### PR TITLE
Restructure Foundation Design form and fix ACI calculation bugs

### DIFF
--- a/public/assets/css/styles1.css
+++ b/public/assets/css/styles1.css
@@ -421,3 +421,148 @@ ol.summary {
 nav ul li a:hover {
     background: #003f86;
 }
+
+/* ============================================================
+   Foundation Design page (scoped via .fd-page on .container1)
+   Keeps the rigid .container grid out of the way so the form
+   reads as proper sectioned cards. Touches NO existing IDs or
+   classes used by the wired JS.
+   ============================================================ */
+.fd-page {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0 16px;
+}
+
+/* Disable the page-wide rigid grid on the "Parameters Given" card */
+.fd-page #GivenParameters.container {
+    display: block;
+    grid-template-rows: none;
+    grid-template-columns: none;
+    width: auto;
+    max-width: none;
+    min-width: 0;
+    margin: 0;
+    padding: 0;
+    background: transparent;
+    box-shadow: none;
+    border-radius: 0;
+}
+
+.fd-page #GivenParameters > h4.title1 {
+    grid-row: auto;
+    grid-column: auto;
+    text-align: left;
+    margin: 0 0 16px;
+    padding-bottom: 10px;
+    border-bottom: 2px solid #007BFF;
+    color: #0056b3;
+}
+
+.fd-page .fd-section {
+    background: #fff;
+    border: 1px solid #d6d9de;
+    border-radius: 8px;
+    padding: 16px 20px;
+    margin: 0 0 18px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.fd-page .fd-section > legend {
+    padding: 0 8px;
+    font-weight: 700;
+    color: #0056b3;
+    font-size: 1.05em;
+}
+
+.fd-page .fd-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 10px 18px;
+    margin-top: 8px;
+}
+
+.fd-page .fd-field {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.fd-page .fd-field label {
+    display: block;
+    width: auto;
+    margin: 0 0 4px;
+    font-size: 0.9em;
+    color: #2c3e50;
+    line-height: 1.3;
+}
+
+.fd-page .fd-field input,
+.fd-page .fd-field select {
+    width: 100%;
+    margin: 0;
+    padding: 8px 10px;
+    box-sizing: border-box;
+    border: 1px solid #c5c9d0;
+    border-radius: 4px;
+    background: #fff;
+    font-size: 0.95em;
+}
+
+.fd-page .fd-field input:focus,
+.fd-page .fd-field select:focus {
+    outline: none;
+    border-color: #007BFF;
+    box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.15);
+}
+
+/* A full-row field inside the auto-fit grid */
+.fd-page .fd-field--wide {
+    grid-column: 1 / -1;
+}
+
+.fd-page .fd-actions {
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin: 8px 0 0;
+}
+
+.fd-page #calculate {
+    width: auto;
+    min-width: 220px;
+    margin: 0;
+}
+
+.fd-page .fd-import-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    padding: 12px 16px;
+    background: #f6f8fa;
+    border: 1px dashed #c5c9d0;
+    border-radius: 6px;
+    margin: 0 0 16px;
+}
+
+.fd-page .fd-import-row label {
+    width: auto;
+    margin: 0;
+    font-weight: 600;
+    color: #2c3e50;
+}
+
+.fd-page .fd-import-row input[type="file"] {
+    width: auto;
+    flex: 1 1 240px;
+    margin: 0;
+    padding: 6px;
+}
+
+.fd-page .fd-hint {
+    font-size: 0.85em;
+    color: #6a737d;
+    margin: 4px 0 0;
+}

--- a/public/assets/js/scriptFoundationDesign6.js
+++ b/public/assets/js/scriptFoundationDesign6.js
@@ -406,14 +406,52 @@ document.addEventListener("DOMContentLoaded", () => {
         vn =test.vn;
         dc1 = test.dc;
         console.log(`V,..,.h dc = `,dc1);
+
+        // ACI 318-14 / NSCP 2015 §8.4.4.2 / §22.6.5.4 - Unbalanced moment transfer for eccentric punching
+        // Max shear stress on critical section: v_max = Vu/Ac + gamma_v * Mu * c / Jc <= phi * vc
+        if (method === 1 && centricity === "eccentric" && (Math.abs(mux) > 0 || Math.abs(muy) > 0)) {
+            document.getElementById('result').appendChild(createHeader7(`Unbalanced Moment Transfer (Eccentric Punching)`));
+            if (columnLocation !== 1) {
+                document.getElementById('result').appendChild(createParagraph(`$$\\ \\text{Note: } \\gamma_v \\text{ check below assumes an interior column. Edge/corner critical sections require separate hand check per ACI 318 §8.4.4.}\$$`));
+            }
+            // Critical section dimensions at d/2 from column face (interior column - full perimeter)
+            const b1x = cx + d;                                // perp. to Y-axis bending (shear from Muy)
+            const b2x = cy + d;
+            const b1y = cy + d;                                // perp. to X-axis bending (shear from Mux)
+            const b2y = cx + d;
+            const Ac = (2*(d+cx) + 2*(d+cy)) * d;              // bo * d
+            const JcMuy = (d*Math.pow(b1x,3))/6 + (Math.pow(d,3)*b1x)/6 + (d*b2x*Math.pow(b1x,2))/2;
+            const JcMux = (d*Math.pow(b1y,3))/6 + (Math.pow(d,3)*b1y)/6 + (d*b2y*Math.pow(b1y,2))/2;
+            const gammaF_x = 1 / (1 + (2/3)*Math.sqrt(b1x/b2x));
+            const gammaF_y = 1 / (1 + (2/3)*Math.sqrt(b1y/b2y));
+            const gammaV_x = 1 - gammaF_x;
+            const gammaV_y = 1 - gammaF_y;
+            const cABx = b1x/2;
+            const cABy = b1y/2;
+            // Convert to N and N*mm
+            const Vu_N   = Vu * 1000;
+            const Mux_Nmm = mux * 1e6;
+            const Muy_Nmm = muy * 1e6;
+            const vmax  = Vu_N/Ac + (gammaV_y*Mux_Nmm*cABy)/JcMux + (gammaV_x*Muy_Nmm*cABx)/JcMuy;
+            const phivc = (vn*1000)/Ac;                        // governing phi*Vn / Ac
+
+            document.getElementById('result').appendChild(createParagraph(`$$\\ A_c = B_o \\times d = ${(2*(d+cx)+2*(d+cy)).toFixed(2)}mm \\times ${d.toFixed(2)}mm = ${Ac.toFixed(2)}mm^2 \$$`));
+            document.getElementById('result').appendChild(createParagraph(`$$\\ \\gamma_{v,x} = 1 - \\frac{1}{1 + \\tfrac{2}{3}\\sqrt{b_{1x}/b_{2x}}} = 1 - \\frac{1}{1 + \\tfrac{2}{3}\\sqrt{${b1x.toFixed(1)}/${b2x.toFixed(1)}}} = ${gammaV_x.toFixed(4)} \$$`));
+            document.getElementById('result').appendChild(createParagraph(`$$\\ \\gamma_{v,y} = 1 - \\frac{1}{1 + \\tfrac{2}{3}\\sqrt{b_{1y}/b_{2y}}} = 1 - \\frac{1}{1 + \\tfrac{2}{3}\\sqrt{${b1y.toFixed(1)}/${b2y.toFixed(1)}}} = ${gammaV_y.toFixed(4)} \$$`));
+            document.getElementById('result').appendChild(createParagraph(`$$\\ J_{c,Muy} = \\frac{d\\,b_{1x}^3}{6} + \\frac{d^3 b_{1x}}{6} + \\frac{d\\,b_{2x}\\,b_{1x}^2}{2} = ${JcMuy.toExponential(3)}\\,mm^4 \$$`));
+            document.getElementById('result').appendChild(createParagraph(`$$\\ J_{c,Mux} = \\frac{d\\,b_{1y}^3}{6} + \\frac{d^3 b_{1y}}{6} + \\frac{d\\,b_{2y}\\,b_{1y}^2}{2} = ${JcMux.toExponential(3)}\\,mm^4 \$$`));
+            document.getElementById('result').appendChild(createParagraph(`$$\\ v_{max} = \\frac{V_u}{A_c} + \\frac{\\gamma_{v,y}\\,M_{ux}\\,c_{AB,y}}{J_{c,Mux}} + \\frac{\\gamma_{v,x}\\,M_{uy}\\,c_{AB,x}}{J_{c,Muy}} = ${vmax.toFixed(3)}\\,MPa \$$`));
+            document.getElementById('result').appendChild(createParagraph(`$$\\ \\phi v_c = \\frac{\\phi V_n}{A_c} = ${phivc.toFixed(3)}\\,MPa \$$`));
+            document.getElementById('result').appendChild(createParagraph(`$$\\ v_{max} ${vmax < phivc ? "< \\phi v_c \\therefore \\text{SAFE for combined shear + moment transfer}" : "> \\phi v_c \\therefore \\text{FAIL — increase } D_c \\text{ or column size}"} \$$`));
+        }
         function phiVn(){
            
             let vn1;
             let vn2;
             let vn3;
-            
+
             let beta;
-            let as;
+            let alphaS;
             let bo;
             console.log(`Method = `,method);
 
@@ -439,26 +477,27 @@ document.addEventListener("DOMContentLoaded", () => {
                    
                 }
                 if (columnLocation===1){
-                    as = 40;
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ a_s = ${as} ,(\\text{Interior Column})\$$`));
-                
+                    alphaS = 40;
+                    document.getElementById('result').appendChild(createParagraph(`$$\\ \\alpha_s = ${alphaS} ,(\\text{Interior Column})\$$`));
+
                 } else if (columnLocation===2){
-                    as = 30;
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ a_s = ${as} ,(\\text{Edge Column})\$$`));
+                    alphaS = 30;
+                    document.getElementById('result').appendChild(createParagraph(`$$\\ \\alpha_s = ${alphaS} ,(\\text{Edge Column})\$$`));
 
                 } else if (columnLocation===3){
-                    as = 20;
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ a_s = ${as} ,(\\text{Corner Column})\$$`));
+                    alphaS = 20;
+                    document.getElementById('result').appendChild(createParagraph(`$$\\ \\alpha_s = ${alphaS} ,(\\text{Corner Column})\$$`));
 
                 }
 
+                // ACI 318-14 / NSCP 2015 §422.6.5.2: Vc shall be the least of these three expressions
                 vn1 = 0.75 * (1/3) * lambda * Math.sqrt(fc) *bo*d/1000;
                 vn2 = 0.75 * (1/6) * (1+(2/beta)) * lambda * Math.sqrt(fc) *bo*d/1000;
-                vn3 = 0.75 * (1/12) * (1+(as*d/bo))* lambda * Math.sqrt(fc) *bo*d/1000;
+                vn3 = 0.75 * (1/12) * (2+(alphaS*d/bo))* lambda * Math.sqrt(fc) *bo*d/1000;
                 vn = Math.min(vn1,vn2,vn3);
-                document.getElementById('result').appendChild(createParagraph(`\\(\\phi V_n = \\phi V_c = \\text{least of}\\left\\{\\begin{array}{l}\\phi \\times \\frac {1}{3} \\times \\lambda \\times \\sqrt{fc'} \\times B_o \\times d  \\,  \\\\\\phi \\times \\frac {1}{6} \\times ( 1 + \\frac{2}{\\beta}) \\times \\lambda \\times \\sqrt{fc'} \\times B_o \\times d \\, \\\\\\phi \\times \\frac {1}{12} \\times ( 1 + \\frac{a_s \\times d}{B_o}) \\times \\lambda \\times \\sqrt{fc'} \\times B_o \\times d \\, \\end{array}\\right. \\)`));
+                document.getElementById('result').appendChild(createParagraph(`\\(\\phi V_n = \\phi V_c = \\text{least of}\\left\\{\\begin{array}{l}\\phi \\times \\frac {1}{3} \\times \\lambda \\times \\sqrt{fc'} \\times B_o \\times d  \\,  \\\\\\phi \\times \\frac {1}{6} \\times ( 1 + \\frac{2}{\\beta}) \\times \\lambda \\times \\sqrt{fc'} \\times B_o \\times d \\, \\\\\\phi \\times \\frac {1}{12} \\times ( 2 + \\frac{\\alpha_s \\times d}{B_o}) \\times \\lambda \\times \\sqrt{fc'} \\times B_o \\times d \\, \\end{array}\\right. \\)`));
                 document.getElementById('result').appendChild(createParagraph(``));
-                document.getElementById('result').appendChild(createParagraph(`\\(\\phi V_n = \\left\\{\\begin{array}{l}0.75 \\times \\frac {1}{3} \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times ${bo.toFixed(2)}mm \\times ${d.toFixed(2)}mm = ${(vn1*1000).toFixed(2)}N \\approx ${(vn1).toFixed(2)}kN \\, \\\\0.75 \\times \\frac {1}{6} \\times (1+ \\frac{2}{${beta}}) \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times ${bo.toFixed(2)}mm \\times ${d.toFixed(2)}mm = ${(vn2*1000).toFixed(2)}N \\approx ${(vn2).toFixed(2)}kN \\, \\\\ 0.75 \\times \\frac {1}{12} \\times (1+ \\frac{${as} \\times ${d.toFixed(2)}}{${bo.toFixed(2)}}) \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times ${bo.toFixed(2)}mm \\times ${d}mm = ${(vn3*1000).toFixed(2)}N \\approx ${(vn3).toFixed(2)}kN \\, \\end{array}\\right. = ${vn.toFixed(2)}kN \\, \\)`));
+                document.getElementById('result').appendChild(createParagraph(`\\(\\phi V_n = \\left\\{\\begin{array}{l}0.75 \\times \\frac {1}{3} \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times ${bo.toFixed(2)}mm \\times ${d.toFixed(2)}mm = ${(vn1*1000).toFixed(2)}N \\approx ${(vn1).toFixed(2)}kN \\, \\\\0.75 \\times \\frac {1}{6} \\times (1+ \\frac{2}{${beta}}) \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times ${bo.toFixed(2)}mm \\times ${d.toFixed(2)}mm = ${(vn2*1000).toFixed(2)}N \\approx ${(vn2).toFixed(2)}kN \\, \\\\ 0.75 \\times \\frac {1}{12} \\times (2+ \\frac{${alphaS} \\times ${d.toFixed(2)}}{${bo.toFixed(2)}}) \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times ${bo.toFixed(2)}mm \\times ${d}mm = ${(vn3*1000).toFixed(2)}N \\approx ${(vn3).toFixed(2)}kN \\, \\end{array}\\right. = ${vn.toFixed(2)}kN \\, \\)`));
                 document.getElementById('result').appendChild(createParagraph(`$$\\ V_u = ${Vu.toFixed(2)}kN ${Vu<vn ? "< \\phi V_n    \\therefore \\text{SAFE}":"> \\phi V_{n}\\therefore \\text{FAIL}"}\$$`));
                 
             } else {
@@ -467,7 +506,8 @@ document.addEventListener("DOMContentLoaded", () => {
                 document.getElementById('result').appendChild(createParagraph(`$$\\ ${Vu.toFixed(2)}kN = 0.75 \\times \\frac {1}{3} \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times (2 \\times (d + ${cx.toFixed(2)}mm) + 2 \\times (d + ${cy.toFixed(2)}mm) \\times d  \$$`));
                 d = newtonRaphson(100);
                 document.getElementById('result').appendChild(createParagraph(`$$\\ d = ${d.toFixed(2)} \\approx ${(Math.ceil(d/25)*25).toFixed(2)}\$$`));
-                dc = d + 75 + barDia;
+                document.getElementById('result').appendChild(createParagraph(`$$\\ \\text{(Approximate: V_u held constant at the initial geometry; refine via iteration for a tight design.)}\$$`));
+                dc = d + cc + barDia;
                 document.getElementById('result').appendChild(createParagraph(`$$\\ D_c = ${d.toFixed(2)} + ${cc}mm + ${barDia}mm = ${dc.toFixed(2)}mm \\approx ${(Math.ceil(dc/25)*25).toFixed(2)}mm\$$`));
                 dc = Math.ceil(dc/25)*25;
                 console.log(`V dc method2 = `,dc);
@@ -625,7 +665,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 d = newtonRaphson(100,bx*1000);     
             }
             document.getElementById('result').appendChild(createParagraph(`$$\\ d = ${d.toFixed(2)}mm\$$`));
-            dc1 = d + 75 + (r*barDia);
+            dc1 = d + cc + (r*barDia);
             document.getElementById('result').appendChild(createParagraph(`$$\\ D_c = ${d.toFixed(2)} + ${cc}mm + (${r} \\times ${barDia}mm) = ${dc1.toFixed(2)}mm \\approx ${(Math.ceil(dc1/25)*25).toFixed(2)}mm\$$`));
             dc1 = Math.ceil(dc1/25)*25;
         }
@@ -691,13 +731,14 @@ document.addEventListener("DOMContentLoaded", () => {
         console.log(200);
         document.getElementById('result').appendChild(createHeader5(`Solve Preliminary Values for Design`));       
 
+        // ACI 318-14 / NSCP 2015 §22.2.2.4.3: beta1 step-down coefficient is 0.05/7, not 0.5/7
         let beta1 = 0;
-        if ((0.85-(0.5/7)*(fc-28))>=0.85){
+        if ((0.85-(0.05/7)*(fc-28))>=0.85){
             beta1 = 0.85;
-        } else if ((0.85-(0.5/7)*(fc-28))<0.65) {
+        } else if ((0.85-(0.05/7)*(fc-28))<0.65) {
             beta1 = 0.65;
         } else {
-            beta1 = 0.85-(0.5/7)*(fc-28);
+            beta1 = 0.85-(0.05/7)*(fc-28);
         }
         document.getElementById('result').appendChild(createParagraph(`$$\\ \\beta_1 : 0.65 < [0.85 - (\\frac{0.05}{7})\\times (f'_c - 28)] \\le 0.85 \$$`));
         document.getElementById('result').appendChild(createParagraph(`$$\\ \\beta_1 = 0.85 - (\\frac{0.05}{7})\\times (${fc} - 28) = ${beta1.toFixed(3)} \$$`));
@@ -845,9 +886,12 @@ document.addEventListener("DOMContentLoaded", () => {
         document.getElementById('result').appendChild(createParagraph(`$$\\ \\therefore \\rho = ${rho>rhomin ? rho.toFixed(6):rhomin.toFixed(6)} \$$`));
         rho = Math.max(rho,rhomin);
         let as = rho*b*depth;
-        let asmin = 0.002*dc*b;
+        // ACI 24.4.3.2 / NSCP 425.6.1.1: shrinkage-and-temperature reinforcement
+        //  rhoST = 0.0018 for Grade 414 and higher deformed bars; 0.0020 otherwise.
+        let rhoST = (fy >= 414) ? 0.0018 : 0.0020;
+        let asmin = rhoST*dc*b;
         document.getElementById('result').appendChild(createParagraph(`$$\\ A_s = \\rho \\times B_${text} \\times d = ${rho.toFixed(6)}\\times ${b}mm \\times ${depth.toFixed(2)}mm = ${as.toFixed(2)}mm^2 \$$`));
-        document.getElementById('result').appendChild(createParagraph(`$$\\ A_{smin} = 0.002 \\times A_g = 0.002 \\times B_${text} \\times D_c =  0.002 \\times ${b}mm \\times ${dc}mm = ${asmin.toFixed(2)}mm^2  \$$`));
+        document.getElementById('result').appendChild(createParagraph(`$$\\ A_{s,min} = \\rho_{ST} \\times A_g = ${rhoST.toFixed(4)} \\times B_${text} \\times D_c =  ${rhoST.toFixed(4)} \\times ${b}mm \\times ${dc}mm = ${asmin.toFixed(2)}mm^2  \\, ,\\, \\rho_{ST} = ${rhoST.toFixed(4)} \\text{ (f_y ${fy >= 414 ? "\\ge" : "<"} 414\\,MPa)}\$$`));
         document.getElementById('result').appendChild(createParagraph(`$$\\  ${as>asmin ? "A_s > A_{smin}":"A_s < A_{smin}"} \$$`));
         as = Math.max(as,asmin);
         document.getElementById('result').appendChild(createParagraph(`$$\\ \\therefore A_s = ${as.toFixed(2)}mm^2 \$$`));
@@ -856,9 +900,9 @@ document.addEventListener("DOMContentLoaded", () => {
         document.getElementById('result').appendChild(createParagraph(``));
         document.getElementById('result').appendChild(createParagraph(`$$\\ n = \\frac{A_s}{A_b} = \\frac{${as.toFixed(2)}mm}{\\frac{\\pi}{4} \\times (${barDia}mm)^2} = ${n.toFixed(2)} \\approx ${Math.ceil(n)}pcs \$$`));
         n = Math.ceil(n);
-        sc = (b-150-(n*barDia))/(n-1);
+        sc = (b - 2*cc - (n*barDia))/(n-1);
         let scmin = Math.max(50,barDia,(4/3)*dAgg);
-        document.getElementById('result').appendChild(createParagraph(`$$\\ S_c = \\frac{B_${text} - (2 \\times C_c) - (n \\times d_b)}{n - 1} = \\frac{${b}mm - (2 \\times 75mm) - (${n} \\times ${barDia}mm)}{${n} - 1} = ${sc.toFixed(2)}mm \$$`));
+        document.getElementById('result').appendChild(createParagraph(`$$\\ S_c = \\frac{B_${text} - (2 \\times C_c) - (n \\times d_b)}{n - 1} = \\frac{${b}mm - (2 \\times ${cc}mm) - (${n} \\times ${barDia}mm)}{${n} - 1} = ${sc.toFixed(2)}mm \$$`));
         document.getElementById('result').appendChild(createParagraph(`\\( S_{c(min)} = \\text {Greatest of} \\left\\{\\begin{array}{l} 50mm\\, \\\\  d_b = ${barDia}mm \\, \\\\  d_{agg} = ${dAgg}mm \\,\\end{array}\\right. = ${scmin}mm \\, \\)`));
         document.getElementById('result').appendChild(createParagraph(`$$\\  ${sc>scmin ? "S_c > S_{c(min)} \\therefore \\text{Okay}":"S_c < S_{c(min)} \\therefore \\text{Insufficient Spacing, add layer}"} \$$`));
         let centerbandRatio;
@@ -932,7 +976,10 @@ document.addEventListener("DOMContentLoaded", () => {
     let dc2=0;
     let dc3=0;
     let finalDc=0;
-    let cc = 75;
+    // Concrete cover Cc (mm). Default 75 mm matches ACI 20.6.1.3.1 for concrete cast against earth.
+    let cc = parseFloat(document.getElementById('Cover').value);
+    if (!Number.isFinite(cc) || cc <= 0) { cc = 75; }
+    document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ C_c = ${cc}mm  \$$`));
     let by=0;
     let bx=0;
     if (analysisMethod === "analyze"){

--- a/public/pages/foundationDesign.html
+++ b/public/pages/foundationDesign.html
@@ -37,158 +37,275 @@
     </nav>
     <!--<script type="module" src="https://unpkg.com/@splinetool/viewer@1.9.29/build/spline-viewer.js"></script>
 <spline-viewer url="https://prod.spline.design/yMXK50GKAqpmjpQS/scene.splinecode"></spline-viewer>-->
-    <div class="container1">
+    <div class="container1 fd-page">
         <h1>Foundation Design</h1>
         <div class="form-group">
-           
+
+            <div class="fd-import-row">
+                <label for="uploadExcel">Import from Excel:</label>
+                <input type="file" id="uploadExcel" accept=".xlsx,.xls" />
+                <span class="fd-hint">Optional &mdash; expects a sheet named &ldquo;DESIGN PARAMETERS&rdquo;.</span>
+            </div>
+
             <form id="formFoundation">
-        
+
                 <div id="foundationInputs" class="form-group">
                     <div id="GivenParameters" class="container">
                         <h4 class="title1">Parameters Given</h4>
-                        <label for="analysisMethod">Analysis Method:</label>
 
-                        <select id="analysisMethod" name="analysis">
-		                    <option value="design">Detailed Design</option>
-                            <option value="analyze">Analyze with specified dimensions</option>
-                        </select>
-                        <label for="bx" id="bxL" style="display: none;">\(B_x \,\text{(in Meters)}:\)</label>
-                        <input type="number" id="bx" step="0.1"  style="display: none;">
-                        <label for="by" id="byL" style="display: none;">\(B_y \,\text{(in Meters)}:\)</label>
-                        <input type="number" id="by" step="0.1"  style="display: none;">
-                        <label for="dc" id="dcL" style="display: none;">\(D_c \,\text{(in Millimeters)}:\)</label>
-                        <input type="number" id="dc" step="1"  style="display: none;">
+                        <!-- ============ Analysis &amp; Geometry ============ -->
+                        <fieldset class="fd-section">
+                            <legend>Analysis &amp; Geometry</legend>
+                            <div class="fd-grid">
+                                <div class="fd-field">
+                                    <label for="analysisMethod">Analysis Method</label>
+                                    <select id="analysisMethod" name="analysis">
+                                        <option value="design">Detailed Design</option>
+                                        <option value="analyze">Analyze with specified dimensions</option>
+                                    </select>
+                                </div>
+                                <div class="fd-field">
+                                    <label for="bx" id="bxL" style="display: none;">\(B_x\) (in meters)</label>
+                                    <input type="number" id="bx" step="0.1" inputmode="decimal" style="display: none;">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="by" id="byL" style="display: none;">\(B_y\) (in meters)</label>
+                                    <input type="number" id="by" step="0.1" inputmode="decimal" style="display: none;">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="dc" id="dcL" style="display: none;">\(D_c\) (in millimeters)</label>
+                                    <input type="number" id="dc" step="1" inputmode="numeric" style="display: none;">
+                                </div>
 
+                                <div class="fd-field">
+                                    <label for="structureType" id="strucType">Foundation Type</label>
+                                    <select id="structureType" name="structureType">
+                                        <option value="" disabled>Select the type of footing</option>
+                                        <option value="Isolated Square">Isolated Square</option>
+                                        <option value="Isolated Rectangular">Isolated Rectangular</option>
+                                        <option value="Strip">Combined Footing</option>
+                                    </select>
+                                </div>
+                                <div class="fd-field">
+                                    <label for="LengthRestriction" id="LengthRestriction1" style="display: none;">Restriction</label>
+                                    <select id="LengthRestriction" name="LengthRestriction1" style="display: none;">
+                                        <option value="0">None</option>
+                                        <option value="1">Ratio</option>
+                                        <option value="2">Constricted</option>
+                                    </select>
+                                </div>
+                                <div class="fd-field">
+                                    <label for="RatioL" id="RatioLabelL" style="display: none;">Ratio ( _ ) \(B_y\)</label>
+                                    <input type="number" id="RatioL" step="1" inputmode="numeric" placeholder="L" style="display: none;">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="RatioB" id="RatioLabelB" style="display: none;">Ratio ( _ ) \(B_x\)</label>
+                                    <input type="number" id="RatioB" step="1" inputmode="numeric" placeholder="B" style="display: none;">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="Limitation" id="LimitationLabel" style="display: none;">Length of constriction (in meters)</label>
+                                    <input type="number" id="Limitation" step="0.01" inputmode="decimal" style="display: none;">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="Method" id="methodL">Solution Method</label>
+                                    <select id="Method" name="Method">
+                                        <option value="1">Iteration</option>
+                                        <option value="2">Approximate (Initial \(D_c\))</option>
+                                    </select>
+                                </div>
+                            </div>
+                        </fieldset>
 
-                        <label for="structureType" id="strucType">Select Foundation Type:</label>
-                        <select id="structureType" name="structureType">
-		                    <option value="" disabled>Select The Type Of Footing</option>
-                            <option value="Isolated Square">Isolated Square</option>
-                            <option value="Isolated Rectangular">Isolated Rectangular</option>
-                            <option value="Strip">Combined Footing</option>
-                        </select>
-                        <label for="LengthRestriction" id="LengthRestriction1" style="display: none;">Restriction:</label>
-                        <select id="LengthRestriction" name="LengthRestriction1" style="display: none;">
-                            <option value="0">None</option>
-                            <option value="1">Ratio</option>
-                            <option value="2">Constricted</option>
-                        </select>
-                        <label for="RatioL" id="RatioLabelL" style="display: none;">Ratio ( _ )\(B_y\)</label>
-                        <input type="number" id="RatioL" step="1"  placeholder="L" style="display: none;">
-                        <label for="RatioB" id="RatioLabelB" style="display: none;">Ratio ( _ )\(B_x\)</label>
-                        <input type="number" id="RatioB" step="1"  placeholder="B" style="display: none;">
-                        <label for="Limitation" id="LimitationLabel" style="display: none;">Length of Constriction (in Meters):</label>
-                        <input type="number" id="Limitation" step="0.01"  style="display: none;">
-                        <label for="centricity">Select Type of Centricity:</label>
-                        <select id="centricity">
-                            <option value="" disabled>Select Centricity</option>
-                            <option value="concentric">Concentric</option>
-                            <option value="eccentric">Eccentric</option>
-                        </select>
-                        
-                        <label for="loadType">Select Load Type:</label>
-                        <select id="loadType" name="loadType">
-                            <option value="" disabled selected>Select Load Type</option>
-                            <option value="ultimate">Ultimate and Allowable Load</option>
-                            <option value="individual">Individual Loads (Dead Load & Live Load)</option>
-                        </select>
-                    
-            
-            
-                        <label for="AllowableLoad">Allowable Load P (in KN):</label>
-                        <input type="number" id="AllowableLoad" step="0.001">
-                        <label for="AllowableMx">Allowable Load Mx (in KNm):</label>
-                        <input type="number" id="AllowableMx" step="0.001">
-                        <label for="AllowableMy">Allowable Load My (in KNm):</label>
-                        <input type="number" id="AllowableMy" step="0.001">
-                    
-                        <label for="UltimateLoad">Ultimate Load P<sub>u</sub> (in KN):</label>
-                        <input type="number" id="UltimateLoad" step="0.001">
-                    
-                    
-                        <label for="UltimateMx">Ultimate Load M<sub>ux</sub> (in KNm):</label>
-                        <input type="number" id="UltimateMx" step="0.001">
-                
-                        <label for="UltimateMy">Ultimate Load M<sub>uy</sub> (in KNm):</label>
-                        <input type="number" id="UltimateMy" step="0.001">
-                
-            
-                    
-                        <label for="DeadLoad">P<sub>DL</sub> (in KN):</label>
-                        <input type="number" id="DeadLoad" step="0.001">
-                    
-                        <label for="LiveLoad">P<sub>LL</sub> (in KN):</label>
-                        <input type="number" id="LiveLoad" step="0.001">
-                        <label for="mdlx" id="mdxLabel" style="display: none;">M<sub><sub>x</sub>DL</sub>  (in KNm)</label>
-                        <input type="number" id="mdlx" step="0.001" style="display: none;" >
-                        <label for="mllx" id="mlxLabel" style="display: none;">M<sub><sub>x</sub>LL</sub>  (in KNm)</label>
-                        <input type="number" id="mllx" step="0.001" style="display: none;" >
+                        <!-- ============ Loading ============ -->
+                        <fieldset class="fd-section">
+                            <legend>Loading</legend>
+                            <div class="fd-grid">
+                                <div class="fd-field">
+                                    <label for="loadType">Load Type</label>
+                                    <select id="loadType" name="loadType">
+                                        <option value="" disabled>Select load type</option>
+                                        <option value="ultimate" selected>Ultimate and Allowable Load</option>
+                                        <option value="individual">Individual Loads (DL &amp; LL)</option>
+                                    </select>
+                                </div>
+                                <div class="fd-field">
+                                    <label for="centricity">Centricity</label>
+                                    <select id="centricity">
+                                        <option value="" disabled>Select centricity</option>
+                                        <option value="concentric" selected>Concentric</option>
+                                        <option value="eccentric">Eccentric</option>
+                                    </select>
+                                </div>
 
-                        <label for="mdly" id="mdyLabel" style="display: none;">M<sub><sub>y</sub>DL</sub>  (in KNm)</label>
-                        <input type="number" id="mdly" step="0.001" style="display: none;" >
-                        <label for="mlly" id="mlyLabel" style="display: none;">M<sub><sub>y</sub>LL</sub>  (in KNm)</label>
-                        <input type="number" id="mlly" step="0.001" style="display: none;" >
-                        
-                    
-                        <label for="Depth">Depth (in meters):</label>
-                        <input type="number" id="Depth" step="0.001"  >
-                        <label for="BarDiameter">Bar Diameter (in Millimeters):</label>
-                        <input type="number" id="BarDiameter" step="1"  >
-                        <label for="aggDiameter">Aggregate Diameter (in Millimeters):</label>
-                        <input type="number" id="aggDiameter" step="1"  >
-                        <label for="Method" id="methodL">Method:</label>
-                        <select id="Method" name="Method">
-                            <option value="1">Iteration</option>
-                            <option value="2">Approximate (Initial Dc)</option>
-                            
-                        </select>
-                        <label for="columnShape">Select Shape of column:</label>
-                        <select name="columnShape" id="columnShape">
-                            <option value="" disabled>Select the Shape of Column</option>
-                            <option value="square">Square</option>
-                            <option value="circle">Circular</option>
-                            <option value="rectangular">Rectangular</option>
-                        </select>
-                        <label for="ColumnWidthX" id="cxLabel" style="display: none;">Column Width X (in Millimeters):</label>
-                        <input type="number" id="ColumnWidthX" step="1" style="display: none;" >
-                        <label for="ColumnWidthY" id="cyLabel" style="display: none;">Column Width Y (in Millimeters):</label>
-                        <input type="number" id="ColumnWidthY" step="1" style="display: none;" >
-                        <label for="ColumnWidth" id="cLabel">Column Width (in Millimeters):</label>
-                        <label for="ColumnWidth" id="ccLabel" style="display: none;">Column Diameter (in Millimeters):</label>
-                        <input type="number" id="ColumnWidth" step="1"  >
-                        <label for="ColumnLocation">Column Location:</label>
-                        <select id="ColumnLocation" name="ColumnLocation">
-                            <option value="1">Interior</option>
-                            <option value="2">Edge</option>
-                            <option value="3">Corner</option>
-                        </select>
-                        <label for="SoilBearingCapacity">Soil Bearing Capacity (in KPa):</label>
-                        <input type="number" id="SoilBearingCapacity" step="0.01"  >
-                        <label for="Surcharge">Surcharge (in KPa):</label>
-                        <input type="number" id="Surcharge" step="0.01"  >
-                        <label for="λ">Concrete Modification Factor λ:</label>
-                        <input type="number" id="λ" step="0.01"  >
-                        <label for="fc">Concrete Compressive Strength (in MPa):</label>
-                        <input type="number" id="fc" step="0.01"  >
-                        <label for="fy">Yield Strength of Reinforcement (in MPa):</label>
-                        <input type="number" id="fy" step="0.01"  >
-                        <label for="UnitWeightSoil">Unit Weight of Soil (in KN/m3):</label>
-                        <input type="number" id="UnitWeightSoil" step="0.01"  >
-                        <label for="UnitWeightConcrete">Unit Weight of Concrete (in KN/m3):</label>
-                        <input type="number" id="UnitWeightConcrete" step="0.01"  >
-                        <label for="pu">Consider Weight of Soil?</label>
-                        <select name="considerSoil" id="considerSoil">
-                            <option value="yes">Yes</option>
-                            <option value="no">No</option>
-                        </select>
-                            
+                                <div class="fd-field">
+                                    <label for="AllowableLoad">Allowable Load \(P\) (in kN)</label>
+                                    <input type="number" id="AllowableLoad" step="0.001" inputmode="decimal">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="UltimateLoad">Ultimate Load \(P_u\) (in kN)</label>
+                                    <input type="number" id="UltimateLoad" step="0.001" inputmode="decimal">
+                                </div>
+
+                                <div class="fd-field">
+                                    <label for="AllowableMx">Allowable \(M_x\) (in kN&middot;m)</label>
+                                    <input type="number" id="AllowableMx" step="0.001" inputmode="decimal">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="AllowableMy">Allowable \(M_y\) (in kN&middot;m)</label>
+                                    <input type="number" id="AllowableMy" step="0.001" inputmode="decimal">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="UltimateMx">Ultimate \(M_{ux}\) (in kN&middot;m)</label>
+                                    <input type="number" id="UltimateMx" step="0.001" inputmode="decimal">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="UltimateMy">Ultimate \(M_{uy}\) (in kN&middot;m)</label>
+                                    <input type="number" id="UltimateMy" step="0.001" inputmode="decimal">
+                                </div>
+
+                                <div class="fd-field">
+                                    <label for="DeadLoad">\(P_{DL}\) (in kN)</label>
+                                    <input type="number" id="DeadLoad" step="0.001" inputmode="decimal">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="LiveLoad">\(P_{LL}\) (in kN)</label>
+                                    <input type="number" id="LiveLoad" step="0.001" inputmode="decimal">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="mdlx" id="mdxLabel" style="display: none;">\(M_{x,DL}\) (in kN&middot;m)</label>
+                                    <input type="number" id="mdlx" step="0.001" inputmode="decimal" style="display: none;">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="mllx" id="mlxLabel" style="display: none;">\(M_{x,LL}\) (in kN&middot;m)</label>
+                                    <input type="number" id="mllx" step="0.001" inputmode="decimal" style="display: none;">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="mdly" id="mdyLabel" style="display: none;">\(M_{y,DL}\) (in kN&middot;m)</label>
+                                    <input type="number" id="mdly" step="0.001" inputmode="decimal" style="display: none;">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="mlly" id="mlyLabel" style="display: none;">\(M_{y,LL}\) (in kN&middot;m)</label>
+                                    <input type="number" id="mlly" step="0.001" inputmode="decimal" style="display: none;">
+                                </div>
+                            </div>
+                        </fieldset>
+
+                        <!-- ============ Column ============ -->
+                        <fieldset class="fd-section">
+                            <legend>Column</legend>
+                            <div class="fd-grid">
+                                <div class="fd-field">
+                                    <label for="columnShape">Column Shape</label>
+                                    <select name="columnShape" id="columnShape">
+                                        <option value="" disabled>Select column shape</option>
+                                        <option value="square" selected>Square</option>
+                                        <option value="circle">Circular</option>
+                                        <option value="rectangular">Rectangular</option>
+                                    </select>
+                                </div>
+                                <div class="fd-field">
+                                    <label for="ColumnLocation">Column Location</label>
+                                    <select id="ColumnLocation" name="ColumnLocation">
+                                        <option value="1">Interior</option>
+                                        <option value="2">Edge</option>
+                                        <option value="3">Corner</option>
+                                    </select>
+                                </div>
+                                <div class="fd-field">
+                                    <label for="ColumnWidth" id="cLabel">Column Width (in millimeters)</label>
+                                    <label for="ColumnWidth" id="ccLabel" style="display: none;">Column Diameter (in millimeters)</label>
+                                    <input type="number" id="ColumnWidth" step="1" inputmode="numeric">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="ColumnWidthX" id="cxLabel" style="display: none;">Column Width \(c_x\) (in millimeters)</label>
+                                    <input type="number" id="ColumnWidthX" step="1" inputmode="numeric" style="display: none;">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="ColumnWidthY" id="cyLabel" style="display: none;">Column Width \(c_y\) (in millimeters)</label>
+                                    <input type="number" id="ColumnWidthY" step="1" inputmode="numeric" style="display: none;">
+                                </div>
+                            </div>
+                        </fieldset>
+
+                        <!-- ============ Reinforcement &amp; Footing ============ -->
+                        <fieldset class="fd-section">
+                            <legend>Reinforcement &amp; Footing</legend>
+                            <div class="fd-grid">
+                                <div class="fd-field">
+                                    <label for="Depth">Total Footing Thickness \(H\) (in meters)</label>
+                                    <input type="number" id="Depth" step="0.001" inputmode="decimal">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="BarDiameter">Bar Diameter \(d_b\) (in millimeters)</label>
+                                    <input type="number" id="BarDiameter" step="1" inputmode="numeric">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="aggDiameter">Aggregate Diameter \(d_{agg}\) (in millimeters)</label>
+                                    <input type="number" id="aggDiameter" step="1" inputmode="numeric">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="Cover">Concrete Cover \(C_c\) (in millimeters)</label>
+                                    <input type="number" id="Cover" step="1" inputmode="numeric" value="75">
+                                </div>
+                            </div>
+                        </fieldset>
+
+                        <!-- ============ Materials ============ -->
+                        <fieldset class="fd-section">
+                            <legend>Material Properties</legend>
+                            <div class="fd-grid">
+                                <div class="fd-field">
+                                    <label for="fc">Concrete Compressive Strength \(f'_c\) (in MPa)</label>
+                                    <input type="number" id="fc" step="0.01" inputmode="decimal">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="fy">Steel Yield Strength \(f_y\) (in MPa)</label>
+                                    <input type="number" id="fy" step="0.01" inputmode="decimal">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="λ">Concrete Modification Factor \(\lambda\)</label>
+                                    <input type="number" id="λ" step="0.01" inputmode="decimal">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="UnitWeightConcrete">Unit Weight of Concrete \(\gamma_c\) (in kN/m³)</label>
+                                    <input type="number" id="UnitWeightConcrete" step="0.01" inputmode="decimal">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="UnitWeightSoil">Unit Weight of Soil \(\gamma_s\) (in kN/m³)</label>
+                                    <input type="number" id="UnitWeightSoil" step="0.01" inputmode="decimal">
+                                </div>
+                            </div>
+                        </fieldset>
+
+                        <!-- ============ Soil &amp; Site ============ -->
+                        <fieldset class="fd-section">
+                            <legend>Soil &amp; Site</legend>
+                            <div class="fd-grid">
+                                <div class="fd-field">
+                                    <label for="SoilBearingCapacity">Allowable Soil Bearing \(q_a\) (in kPa)</label>
+                                    <input type="number" id="SoilBearingCapacity" step="0.01" inputmode="decimal">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="Surcharge">Surcharge \(q\) (in kPa)</label>
+                                    <input type="number" id="Surcharge" step="0.01" inputmode="decimal">
+                                </div>
+                                <div class="fd-field">
+                                    <label for="considerSoil">Consider Weight of Soil?</label>
+                                    <select name="considerSoil" id="considerSoil">
+                                        <option value="yes">Yes</option>
+                                        <option value="no">No</option>
+                                    </select>
+                                </div>
+                            </div>
+                        </fieldset>
+
                     </div>
-                   
 
+                    <div class="fd-actions">
                         <button id="calculate" type="submit" onclick="openTab(event, 'summary')">Calculate</button>
                     </div>
 
-                    </div>
+                </div>
             </form>
         
     <div class="tab" id="tab" style="display: none;">
@@ -1020,12 +1137,12 @@ function handleFile(event) {
                 let vn1;
                 let vn2;
                 let vn3;
-                
+
                 let beta;
-                let as;
+                let alphaS;
                 let bo;
                 console.log(`Method = `,method);
-    
+
                 if( method === 1){
                     console.log("phivn Method 1")
                     if (cx<cy){
@@ -1033,50 +1150,52 @@ function handleFile(event) {
                         bo = (2*(d+cx))+(2*(d+cy));
                         document.getElementById('result').appendChild(createParagraph(`$$\\ \\beta = \\frac{c_y}{c_x} = \\frac{${cy.toFixed(2)}mm}{${cx.toFixed(2)}mm} = ${beta.toFixed(3)}\$$`));
                         document.getElementById('result').appendChild(createParagraph(`$$\\ B_o = [2 \\times (d + c_x)]+[2 \\times (d + c_y)] = [2 \\times (${d}mm + ${cx.toFixed(2)}mm)]+[2 \\times (${d}mm + ${cy.toFixed(2)}mm)] = ${bo.toFixed(3)}mm\$$`));
-                        
+
                     } else if (cy<cx){
                         beta = cx/cy;
                         document.getElementById('result').appendChild(createParagraph(`$$\\ \\beta = \\frac{c_x}{c_y} = \\frac{${cx.toFixed(2)}mm}{${cy.toFixed(2)}mm} = ${beta.toFixed(3)}\$$`));
                         bo = (2*(d+cx))+(2*(d+cy));
                         document.getElementById('result').appendChild(createParagraph(`$$\\ B_o = [2 \\times (d + c_x)]+[2 \\times (d + c_y)] = [2 \\times (${d}mm + ${cx.toFixed(2)}mm)]+[2 \\times (${d}mm + ${cy.toFixed(2)}mm)] = ${bo.toFixed(3)}mm\$$`));
-                       
+
                     } else if (cx===cy){
                         beta = 1;
                         document.getElementById('result').appendChild(createParagraph(`$$\\ \\beta = \\frac{c_y}{c_x} = \\frac{${cy.toFixed(2)}mm}{${cx.toFixed(2)}mm} = ${beta}\$$`));
                         bo = (2*(d+cx))+(2*(d+cy));
                         document.getElementById('result').appendChild(createParagraph(`$$\\ B_o = 4 \\times (d + c) = 4 \\times (${d}mm + ${cx.toFixed(2)}mm) = ${bo.toFixed(3)}mm\$$`));
-                       
+
                     }
                     if (columnLocation===1){
-                        as = 40;
-                        document.getElementById('result').appendChild(createParagraph(`$$\\ a_s = ${as} ,(\\text{Interior Column})\$$`));
-                    
+                        alphaS = 40;
+                        document.getElementById('result').appendChild(createParagraph(`$$\\ \\alpha_s = ${alphaS} ,(\\text{Interior Column})\$$`));
+
                     } else if (columnLocation===2){
-                        as = 30;
-                        document.getElementById('result').appendChild(createParagraph(`$$\\ a_s = ${as} ,(\\text{Edge Column})\$$`));
-    
+                        alphaS = 30;
+                        document.getElementById('result').appendChild(createParagraph(`$$\\ \\alpha_s = ${alphaS} ,(\\text{Edge Column})\$$`));
+
                     } else if (columnLocation===3){
-                        as = 20;
-                        document.getElementById('result').appendChild(createParagraph(`$$\\ a_s = ${as} ,(\\text{Corner Column})\$$`));
-    
+                        alphaS = 20;
+                        document.getElementById('result').appendChild(createParagraph(`$$\\ \\alpha_s = ${alphaS} ,(\\text{Corner Column})\$$`));
+
                     }
-    
+
+                    // ACI 318-14 / NSCP 2015 §422.6.5.2: Vc shall be the least of these three expressions
                     vn1 = 0.75 * (1/3) * lambda * Math.sqrt(fc) *bo*d/1000;
                     vn2 = 0.75 * (1/6) * (1+(2/beta)) * lambda * Math.sqrt(fc) *bo*d/1000;
-                    vn3 = 0.75 * (1/12) * (1+(as*d/bo))* lambda * Math.sqrt(fc) *bo*d/1000;
+                    vn3 = 0.75 * (1/12) * (2+(alphaS*d/bo))* lambda * Math.sqrt(fc) *bo*d/1000;
                     vn = Math.min(vn1,vn2,vn3);
-                    document.getElementById('result').appendChild(createParagraph(`\\(\\phi V_n = \\phi V_c = \\text{least of}\\left\\{\\begin{array}{l}\\phi \\times \\frac {1}{3} \\times \\lambda \\times \\sqrt{fc'} \\times B_o \\times d  \\,  \\\\\\phi \\times \\frac {1}{6} \\times ( 1 + \\frac{2}{\\beta}) \\times \\lambda \\times \\sqrt{fc'} \\times B_o \\times d \\, \\\\\\phi \\times \\frac {1}{12} \\times ( 1 + \\frac{a_s \\times d}{B_o}) \\times \\lambda \\times \\sqrt{fc'} \\times B_o \\times d \\, \\end{array}\\right. \\)`));
+                    document.getElementById('result').appendChild(createParagraph(`\\(\\phi V_n = \\phi V_c = \\text{least of}\\left\\{\\begin{array}{l}\\phi \\times \\frac {1}{3} \\times \\lambda \\times \\sqrt{fc'} \\times B_o \\times d  \\,  \\\\\\phi \\times \\frac {1}{6} \\times ( 1 + \\frac{2}{\\beta}) \\times \\lambda \\times \\sqrt{fc'} \\times B_o \\times d \\, \\\\\\phi \\times \\frac {1}{12} \\times ( 2 + \\frac{\\alpha_s \\times d}{B_o}) \\times \\lambda \\times \\sqrt{fc'} \\times B_o \\times d \\, \\end{array}\\right. \\)`));
                     document.getElementById('result').appendChild(createParagraph(``));
-                    document.getElementById('result').appendChild(createParagraph(`\\(\\phi V_n = \\left\\{\\begin{array}{l}0.75 \\times \\frac {1}{3} \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times ${bo.toFixed(2)}mm \\times ${d.toFixed(2)}mm = ${(vn1*1000).toFixed(2)}N \\approx ${(vn1).toFixed(2)}kN \\, \\\\0.75 \\times \\frac {1}{6} \\times (1+ \\frac{2}{${beta}}) \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times ${bo.toFixed(2)}mm \\times ${d.toFixed(2)}mm = ${(vn2*1000).toFixed(2)}N \\approx ${(vn2).toFixed(2)}kN \\, \\\\ 0.75 \\times \\frac {1}{12} \\times (1+ \\frac{${as} \\times ${d.toFixed(2)}}{${bo.toFixed(2)}}) \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times ${bo.toFixed(2)}mm \\times ${d}mm = ${(vn3*1000).toFixed(2)}N \\approx ${(vn3).toFixed(2)}kN \\, \\end{array}\\right. = ${vn.toFixed(2)}kN \\, \\)`));
+                    document.getElementById('result').appendChild(createParagraph(`\\(\\phi V_n = \\left\\{\\begin{array}{l}0.75 \\times \\frac {1}{3} \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times ${bo.toFixed(2)}mm \\times ${d.toFixed(2)}mm = ${(vn1*1000).toFixed(2)}N \\approx ${(vn1).toFixed(2)}kN \\, \\\\0.75 \\times \\frac {1}{6} \\times (1+ \\frac{2}{${beta}}) \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times ${bo.toFixed(2)}mm \\times ${d.toFixed(2)}mm = ${(vn2*1000).toFixed(2)}N \\approx ${(vn2).toFixed(2)}kN \\, \\\\ 0.75 \\times \\frac {1}{12} \\times (2+ \\frac{${alphaS} \\times ${d.toFixed(2)}}{${bo.toFixed(2)}}) \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times ${bo.toFixed(2)}mm \\times ${d}mm = ${(vn3*1000).toFixed(2)}N \\approx ${(vn3).toFixed(2)}kN \\, \\end{array}\\right. = ${vn.toFixed(2)}kN \\, \\)`));
                     document.getElementById('result').appendChild(createParagraph(`$$\\ V_u = ${Vu.toFixed(2)}kN ${Vu<vn ? "< \\phi V_n    \\therefore \\text{SAFE}":"> \\phi V_{n}\\therefore \\text{FAIL}"}\$$`));
-                    
+
                 } else {
                     console.log("phivn Method 2")
                     document.getElementById('result').appendChild(createParagraph(`$$\\ V_{u} = \\phi \\times \\frac {1}{3} \\times \\lambda \\times \\sqrt{fc'} \\times (2 \\times (d + c_x) + 2 \\times (d + c_y) \\times d  \$$`));
                     document.getElementById('result').appendChild(createParagraph(`$$\\ ${Vu.toFixed(2)}kN = 0.75 \\times \\frac {1}{3} \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times (2 \\times (d + ${cx.toFixed(2)}mm) + 2 \\times (d + ${cy.toFixed(2)}mm) \\times d  \$$`));
                     d = newtonRaphson(100);
                     document.getElementById('result').appendChild(createParagraph(`$$\\ d = ${d.toFixed(2)} \\approx ${(Math.ceil(d/25)*25).toFixed(2)}\$$`));
-                    dc = d + 75 + barDia;
+                    document.getElementById('result').appendChild(createParagraph(`$$\\ \\text{(Approximate: V_u held constant at the initial geometry; refine via iteration for a tight design.)}\$$`));
+                    dc = d + cc + barDia;
                     document.getElementById('result').appendChild(createParagraph(`$$\\ D_c = ${d.toFixed(2)} + ${cc}mm + ${barDia}mm = ${dc.toFixed(2)}mm \\approx ${(Math.ceil(dc/25)*25).toFixed(2)}mm\$$`));
                     dc = Math.ceil(dc/25)*25;
                     console.log(`V dc method2 = `,dc);
@@ -1234,7 +1353,7 @@ function handleFile(event) {
                     d = newtonRaphson(100,bx*1000);     
                 }
                 document.getElementById('result').appendChild(createParagraph(`$$\\ d = ${d.toFixed(2)}mm\$$`));
-                dc1 = d + 75 + (r*barDia);
+                dc1 = d + cc + (r*barDia);
                 document.getElementById('result').appendChild(createParagraph(`$$\\ D_c = ${d.toFixed(2)} + ${cc}mm + (${r} \\times ${barDia}mm) = ${dc1.toFixed(2)}mm \\approx ${(Math.ceil(dc1/25)*25).toFixed(2)}mm\$$`));
                 dc1 = Math.ceil(dc1/25)*25;
             }
@@ -1300,13 +1419,14 @@ function handleFile(event) {
             console.log(200);
             document.getElementById('result').appendChild(createHeader5(`Solve Preliminary Values for Design`));       
     
+            // ACI 318-14 / NSCP 2015 §22.2.2.4.3: beta1 step-down coefficient is 0.05/7, not 0.5/7
             let beta1 = 0;
-            if ((0.85-(0.5/7)*(fc-28))>=0.85){
+            if ((0.85-(0.05/7)*(fc-28))>=0.85){
                 beta1 = 0.85;
-            } else if ((0.85-(0.5/7)*(fc-28))<0.65) {
+            } else if ((0.85-(0.05/7)*(fc-28))<0.65) {
                 beta1 = 0.65;
             } else {
-                beta1 = 0.85-(0.5/7)*(fc-28);
+                beta1 = 0.85-(0.05/7)*(fc-28);
             }
             document.getElementById('result').appendChild(createParagraph(`$$\\ \\beta_1 : 0.65 < [0.85 - (\\frac{0.05}{7})\\times (f'_c - 28)] \\le 0.85 \$$`));
             document.getElementById('result').appendChild(createParagraph(`$$\\ \\beta_1 = 0.85 - (\\frac{0.05}{7})\\times (${fc} - 28) = ${beta1.toFixed(3)} \$$`));
@@ -1454,9 +1574,11 @@ function handleFile(event) {
             document.getElementById('result').appendChild(createParagraph(`$$\\ \\therefore \\rho = ${rho>rhomin ? rho.toFixed(6):rhomin.toFixed(6)} \$$`));
             rho = Math.max(rho,rhomin);
             let as = rho*b*depth;
-            let asmin = 0.002*dc*b;
+            // ACI 24.4.3.2 / NSCP 425.6.1.1: rho_ST = 0.0018 for Grade 414+ deformed bars, 0.0020 otherwise.
+            let rhoST = (fy >= 414) ? 0.0018 : 0.0020;
+            let asmin = rhoST*dc*b;
             document.getElementById('result').appendChild(createParagraph(`$$\\ A_s = \\rho \\times B_${text} \\times d = ${rho.toFixed(6)}\\times ${b}mm \\times ${depth.toFixed(2)}mm = ${as.toFixed(2)}mm^2 \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ A_{smin} = 0.002 \\times A_g = 0.002 \\times B_${text} \\times D_c =  0.002 \\times ${b}mm \\times ${dc}mm = ${asmin.toFixed(2)}mm^2  \$$`));
+            document.getElementById('result').appendChild(createParagraph(`$$\\ A_{s,min} = \\rho_{ST} \\times A_g = ${rhoST.toFixed(4)} \\times B_${text} \\times D_c =  ${rhoST.toFixed(4)} \\times ${b}mm \\times ${dc}mm = ${asmin.toFixed(2)}mm^2  \\, ,\\, \\rho_{ST} = ${rhoST.toFixed(4)} \\text{ (f_y ${fy >= 414 ? "\\ge" : "<"} 414\\,MPa)}\$$`));
             document.getElementById('result').appendChild(createParagraph(`$$\\  ${as>asmin ? "A_s > A_{smin}":"A_s < A_{smin}"} \$$`));
             as = Math.max(as,asmin);
             document.getElementById('result').appendChild(createParagraph(`$$\\ \\therefore A_s = ${as.toFixed(2)}mm^2 \$$`));
@@ -1465,9 +1587,9 @@ function handleFile(event) {
             document.getElementById('result').appendChild(createParagraph(``));
             document.getElementById('result').appendChild(createParagraph(`$$\\ n = \\frac{A_s}{A_b} = \\frac{${as.toFixed(2)}mm}{\\frac{\\pi}{4} \\times (${barDia}mm)^2} = ${n.toFixed(2)} \\approx ${Math.ceil(n)}pcs \$$`));
             n = Math.ceil(n);
-            sc = (b-150-(n*barDia))/(n-1);
+            sc = (b - 2*cc - (n*barDia))/(n-1);
             let scmin = Math.max(50,barDia,(4/3)*dAgg);
-            document.getElementById('result').appendChild(createParagraph(`$$\\ S_c = \\frac{B_${text} - (2 \\times C_c) - (n \\times d_b)}{n - 1} = \\frac{${b}mm - (2 \\times 75mm) - (${n} \\times ${barDia}mm)}{${n} - 1} = ${sc.toFixed(2)}mm \$$`));
+            document.getElementById('result').appendChild(createParagraph(`$$\\ S_c = \\frac{B_${text} - (2 \\times C_c) - (n \\times d_b)}{n - 1} = \\frac{${b}mm - (2 \\times ${cc}mm) - (${n} \\times ${barDia}mm)}{${n} - 1} = ${sc.toFixed(2)}mm \$$`));
             document.getElementById('result').appendChild(createParagraph(`\\( S_{c(min)} = \\text {Greatest of} \\left\\{\\begin{array}{l} 50mm\\, \\\\  d_b = ${barDia}mm \\, \\\\  d_{agg} = ${dAgg}mm \\,\\end{array}\\right. = ${scmin}mm \\, \\)`));
             document.getElementById('result').appendChild(createParagraph(`$$\\  ${sc>scmin ? "S_c > S_{c(min)} \\therefore \\text{Okay}":"S_c < S_{c(min)} \\therefore \\text{Insufficient Spacing, add layer}"} \$$`));
             let centerbandRatio;
@@ -1634,7 +1756,9 @@ function handleFile(event) {
             let dc2 = 0;
             let dc3 = 0;
             let finalDc = 0;
-            let cc = 75;
+            // Concrete cover Cc (mm). Default 75 mm per ACI 20.6.1.3.1 (cast against earth).
+            let cc = parseFloat(document.getElementById('Cover').value);
+            if (!Number.isFinite(cc) || cc <= 0) { cc = 75; }
             let by = 0;
             let bx = 0;
             let r = 0;


### PR DESCRIPTION
## Summary
- Regroups the Foundation Design form into six semantic `<fieldset>` cards and gives it a scoped, responsive layout (no impact on Reinforced Concrete or the other Design pages).
- Fixes two real ACI calculation bugs in `scriptFoundationDesign6.js` (β₁ coefficient and punching shear Vn₃), plus three correctness improvements (cover input, grade-aware Asmin, eccentric-punching moment transfer).
- Updates every LaTeX block whose math changed so the displayed derivation matches the new computed value.

## Form HTML / CSS
- 35-input flat dump → 6 semantic `<fieldset>` sections: **Analysis & Geometry / Loading / Column / Reinforcement & Footing / Material Properties / Soil & Site**.
- Scoped via a new `.fd-page` class so the rigid `.container` grid that Reinforced Concrete and the other Design pages depend on is **left untouched**.
- Inputs render in a responsive `repeat(auto-fit, minmax(260px, 1fr))` grid — side-by-side on wide, stacked on narrow.
- Sensible defaults (`loadType=ultimate`, `centricity=concentric`, `columnShape=square`) so the existing show/hide handlers pick a branch on first render instead of leaving every load input visible at once.
- Added the missing `<input id=\"uploadExcel\">` the inline Excel-upload handler was already trying to bind to (previously threw `TypeError` on every page load).
- **Every original element id preserved** — 73 IDs accounted for. The wired external script (`scriptFoundationDesign6.js`) and the inline UI handlers continue to bind identically.

## Calculation bugs fixed

### 🔴 β₁ step-down coefficient (`scriptFoundationDesign6.js` + inline duplicate)
ACI 318-14 §22.2.2.4.3 / NSCP 425.6.1.1:
\`\`\`
β₁ = 0.85 − (0.05/7)·(fc' − 28),  clamped to [0.65, 0.85]
\`\`\`
The code had `0.5/7` — **10× too large**. For any `fc' > 28 MPa` β₁ was getting clamped to 0.65 instead of falling in the correct 0.65–0.85 range. Distorted Mu(max), at, and the SRRB check downstream.

The displayed LaTeX already showed `\frac{0.05}{7}` (the documented formula and the computed value disagreed), so only the JS coefficient needed updating.

### 🔴 Punching shear Vn₃ (`scriptFoundationDesign6.js` + inline duplicate)
ACI 318-14 §422.6.5.2:
\`\`\`
Vc = (1/12)·(α_s·d/B_o + 2)·λ·√fc'·B_o·d
\`\`\`
The code used `(1 + α_s·d/B_o)` — missing the `+1`. LaTeX updated alongside the JS so the displayed math now reads `( 2 + (α_s·d / B_o) )`. Variable also renamed `as` → `alphaS` to avoid collision with the steel-area `As` convention and with module-syntax `as`.

### 🟡 Concrete cover (`scriptFoundationDesign6.js` + inline duplicate)
Was hardcoded `cc = 75` and `+ 75 +` / `- 150 -` constants embedded in arithmetic. Now reads from a new `Cover` form input (default 75 mm, validated to fall back if blank/non-positive). LaTeX denominators in the spacing formula now interpolate `\${cc}` so the displayed math always matches whatever value the user entered. Cc is also printed in the \"Parameters Given\" summary.

### 🟡 Grade-aware Asmin (`scriptFoundationDesign6.js` + inline duplicate)
ACI 24.4.3.2 / NSCP 425.6.1.1: shrinkage-and-temperature ρ_ST is **0.0018** for Grade 414 deformed bars (the common Philippine 60 ksi grade), **0.0020** otherwise. Was hardcoded `0.002`. The LaTeX now shows ρ_ST explicitly with the chosen value and a parenthetical reason `(fy ≥ 414 MPa)` or `(fy < 414 MPa)`.

### 🟡 Approximate-method note
The Newton-Raphson solver in Method 2 holds Vu constant at the initial geometry. Now emits a one-line LaTeX note next to the converged `d` value so the user knows the result is an approximation and to refine via iteration for a tight design.

### 🟡 Eccentric punching — γv moment transfer check (NEW)
ACI 8.4.4.2 / §22.6.5.4. When `centricity === \"eccentric\"` and a moment exists, a new \"Unbalanced Moment Transfer (Eccentric Punching)\" section runs after the basic punching check. Full LaTeX derivation emitted:
- Critical-section dims `b1, b2` for each moment axis
- Ac = Bo·d
- Polar moment `Jc = d·b1³/6 + d³·b1/6 + d·b2·b1²/2`
- `γv = 1 − 1/(1 + ⅔·√(b1/b2))`
- `vmax = Vu/Ac + Σ γv·Mu·cAB/Jc`  vs.  `φvc = φVn/Ac`
- SAFE / FAIL verdict

Edge/corner column locations emit a note recommending a separate hand check, since their critical-section geometry differs and was outside the scope of this pass.

## What I deliberately did NOT change
- The flexural shortcut Muy/Mux formulas inside `dimension()` — complex but no arithmetic bug found.
- The Newton-Raphson root finder for footing width B — no bug found.
- The γv moment-transfer block in the inline (Excel-upload) duplicate. The primary form-submit path gets the full check; the inline path gets only the bug fixes (β₁, Vn₃, alphaS, cover, asmin).

## Test plan
- [ ] `npm install && npm start`, open http://localhost:3000/foundationDesign.html — page renders, no console errors.
- [ ] Form lays out as six labeled card sections, sensible defaults populated.
- [ ] Switch Analysis Method between Detailed Design and Analyze — bx/by/dc and structureType toggle correctly.
- [ ] Switch Load Type between Ultimate and Individual — only the relevant load inputs show.
- [ ] Switch Centricity between Concentric and Eccentric — moment inputs appear/disappear.
- [ ] Switch Column Shape between Square / Rectangular / Circular — ColumnWidth(s)/Diameter swap.
- [ ] Run a calculation with `fc' = 35 MPa`, verify β₁ ≈ 0.80 in the output (was buggy 0.65).
- [ ] Run with eccentric loading and a moment — the new \"Unbalanced Moment Transfer\" block appears with γv, Jc, vmax, φvc.
- [ ] Change Concrete Cover to 50 mm — Dc and bar-spacing formulas in the output use 50 mm.
- [ ] Run with `fy = 414 MPa` vs `fy = 280 MPa` — Asmin shows ρ_ST = 0.0018 and 0.0020 respectively.
- [ ] Reinforced Concrete page, columnDesign, beamDesign, foundationDesign2 — visually unchanged.