### PR TITLE
Restructure landing pages: hero + module-card grid

### DIFF
--- a/public/assets/css/styleMainpage.css
+++ b/public/assets/css/styleMainpage.css
@@ -1,52 +1,229 @@
+/* ============================================================
+   Civil Engineering — main landing page
+   ============================================================ */
+
+:root {
+    --brand-primary: #007BFF;
+    --brand-dark: #0056b3;
+    --brand-darker: #003f86;
+    --surface: #ffffff;
+    --surface-muted: #f6f8fa;
+    --border: #d6d9de;
+    --border-muted: #e1e4e8;
+    --text: #1f2933;
+    --text-muted: #5c6773;
+    --text-disabled: #a0a8b3;
+    --accent-green: #1f8a3a;
+    --accent-amber: #b07700;
+    --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
+    --shadow-md: 0 6px 18px rgba(15, 23, 42, 0.08);
+    --shadow-lg: 0 12px 28px rgba(15, 23, 42, 0.12);
+}
+
+* {
+    box-sizing: border-box;
+}
+
 body {
-    font-family: Arial, sans-serif;
-    background-color: #f0f0f0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    background: #f0f2f5;
     margin: 0;
     padding: 0;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    color: var(--text);
+    line-height: 1.5;
     min-height: 100vh;
-}
-
-.container {
-    width: 90%;
-    max-width: 500px;
-    background: #fff;
-    padding: 30px;
-    border-radius: 10px;
-    box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
-}
-
-h1 {
-    text-align: center;
-    margin-bottom: 30px;
-    color: #333;
-}
-
-.form-group {
     display: flex;
     flex-direction: column;
-    gap: 15px;
 }
 
-button {
-    width: 100%;
-    padding: 15px;
-    background: #007BFF;
+a {
+    color: var(--brand-dark);
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+/* ---------- Hero ---------- */
+
+.hero {
+    background: linear-gradient(135deg, #0056b3 0%, #003f86 100%);
     color: #fff;
-    border: none;
-    border-radius: 5px;
-    font-size: 16px;
+    padding: 56px 24px 48px;
+    text-align: center;
+    border-bottom: 4px solid var(--brand-primary);
+}
+
+.hero h1 {
+    margin: 0 0 12px;
+    font-size: clamp(1.8rem, 4vw, 2.6rem);
+    font-weight: 700;
+    letter-spacing: -0.02em;
+}
+
+.hero .tagline {
+    margin: 0 auto;
+    max-width: 640px;
+    font-size: 1.05rem;
+    color: rgba(255, 255, 255, 0.88);
+}
+
+/* ---------- Page container ---------- */
+
+.page {
+    width: 100%;
+    max-width: 1080px;
+    margin: 0 auto;
+    padding: 40px 24px 56px;
+    flex: 1;
+}
+
+.section-heading {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin: 0 0 18px;
+}
+
+/* ---------- Module grid ---------- */
+
+.module-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 18px;
+}
+
+.module-card {
+    display: flex;
+    flex-direction: column;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 22px 22px 18px;
+    box-shadow: var(--shadow-sm);
+    transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+    text-decoration: none;
+    color: inherit;
+    min-height: 180px;
+    position: relative;
+}
+
+.module-card:hover {
+    text-decoration: none;
+}
+
+.module-card.is-available {
     cursor: pointer;
-    transition: background-color 0.3s, transform 0.2s;
 }
 
-button:hover {
-    background-color: #0056b3;
-    transform: translateY(-2px);
+.module-card.is-available:hover,
+.module-card.is-available:focus-visible {
+    transform: translateY(-3px);
+    box-shadow: var(--shadow-md);
+    border-color: var(--brand-primary);
+    outline: none;
 }
 
-button:active {
-    transform: translateY(0);
+.module-card.is-coming-soon {
+    background: var(--surface-muted);
+    border-style: dashed;
+    color: var(--text-disabled);
+    cursor: not-allowed;
+}
+
+.module-card__title {
+    font-size: 1.15rem;
+    font-weight: 700;
+    margin: 0 0 6px;
+    color: var(--text);
+}
+
+.module-card.is-coming-soon .module-card__title {
+    color: var(--text-disabled);
+}
+
+.module-card__subtitle {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    margin: 0 0 14px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.module-card__description {
+    font-size: 0.95rem;
+    color: var(--text-muted);
+    margin: 0 0 18px;
+    flex: 1;
+}
+
+.module-card__footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: auto;
+    font-size: 0.9rem;
+}
+
+.module-card__cta {
+    color: var(--brand-dark);
+    font-weight: 600;
+}
+
+.module-card.is-available:hover .module-card__cta {
+    color: var(--brand-darker);
+}
+
+.badge {
+    display: inline-block;
+    padding: 3px 10px;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.badge--available {
+    background: rgba(31, 138, 58, 0.12);
+    color: var(--accent-green);
+}
+
+.badge--coming-soon {
+    background: rgba(176, 119, 0, 0.12);
+    color: var(--accent-amber);
+}
+
+/* ---------- Footer ---------- */
+
+.site-footer {
+    background: var(--surface);
+    border-top: 1px solid var(--border-muted);
+    padding: 16px 24px;
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 0.85rem;
+}
+
+.site-footer a {
+    color: var(--brand-dark);
+    font-weight: 500;
+}
+
+@media (max-width: 520px) {
+    .hero {
+        padding: 40px 18px 32px;
+    }
+
+    .page {
+        padding: 28px 14px 36px;
+    }
+
+    .module-card {
+        padding: 18px;
+        min-height: 160px;
+    }
 }

--- a/public/assets/css/styles1.css
+++ b/public/assets/css/styles1.css
@@ -421,3 +421,142 @@ ol.summary {
 nav ul li a:hover {
     background: #003f86;
 }
+
+/* ============================================================
+   Reinforced Concrete landing page (scoped via .rc-page)
+   Disables the rigid .container grid only for this page.
+   ============================================================ */
+
+.container.rc-page {
+    display: block;
+    width: 100%;
+    max-width: 960px;
+    margin: 1.5em auto;
+    padding: 28px 28px 32px;
+    grid-template-rows: none;
+    grid-template-columns: none;
+}
+
+.rc-page .rc-hero {
+    text-align: center;
+    margin: 0 0 24px;
+    padding: 0 8px 18px;
+    border-bottom: 1px solid #e1e4e8;
+}
+
+.rc-page .rc-hero h1 {
+    margin: 0 0 8px;
+    font-size: 1.7em;
+    color: #1f2933;
+}
+
+.rc-page .rc-hero p {
+    margin: 0;
+    color: #5c6773;
+    font-size: 0.95em;
+    max-width: 580px;
+    margin: 0 auto;
+}
+
+.rc-page .rc-quickselect {
+    margin: 0 0 28px;
+    padding: 14px 16px;
+    background: #f6f8fa;
+    border: 1px solid #e1e4e8;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.rc-page .rc-quickselect label {
+    width: auto;
+    margin: 0;
+    font-weight: 600;
+    color: #2c3e50;
+    white-space: nowrap;
+}
+
+.rc-page .rc-quickselect select {
+    width: auto;
+    flex: 1 1 220px;
+    margin: 0;
+    padding: 8px 10px;
+    border: 1px solid #c5c9d0;
+    border-radius: 4px;
+    background: #fff;
+}
+
+.rc-page .rc-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 16px;
+}
+
+.rc-page .rc-card {
+    display: flex;
+    flex-direction: column;
+    background: #fff;
+    border: 1px solid #d6d9de;
+    border-radius: 10px;
+    padding: 18px 20px 16px;
+    text-decoration: none;
+    color: inherit;
+    transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+    min-height: 170px;
+}
+
+.rc-page .rc-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+    border-color: #007BFF;
+    text-decoration: none;
+}
+
+.rc-page .rc-card__title {
+    margin: 0 0 6px;
+    font-size: 1.1em;
+    font-weight: 700;
+    color: #1f2933;
+}
+
+.rc-page .rc-card__description {
+    margin: 0 0 14px;
+    color: #5c6773;
+    font-size: 0.92em;
+    flex: 1;
+}
+
+.rc-page .rc-card__footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: auto;
+    font-size: 0.85em;
+}
+
+.rc-page .rc-card__cta {
+    color: #0056b3;
+    font-weight: 600;
+}
+
+.rc-page .rc-badge {
+    display: inline-block;
+    padding: 3px 10px;
+    border-radius: 999px;
+    font-size: 0.7em;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.rc-page .rc-badge--full {
+    background: rgba(31, 138, 58, 0.12);
+    color: #1f8a3a;
+}
+
+.rc-page .rc-badge--stub {
+    background: rgba(176, 119, 0, 0.12);
+    color: #b07700;
+}

--- a/public/pages/ReinforcedConcrete.html
+++ b/public/pages/ReinforcedConcrete.html
@@ -7,29 +7,82 @@
 
     <link rel="stylesheet" href="/assets/css/styles1.css">
     <script src="/assets/js/layout_script.js" defer></script>
-    <script src="/assets/js/script.js" defer></script>
 </head>
 <body>
     <nav>
         <ul>
+            <li><a href="index.html">HOME</a></li>
             <li><a href="QuantitySurveying.html">QUANTITY SURVEYING</a></li>
             <li><a href="ReinforcedConcrete.html">REINFORCED CONCRETE</a></li>
             <li><a href="#">STEEL DESIGN</a></li>
         </ul>
     </nav>
-    <div class="container1">
-        <div class="container">
-        <h1 class="title1">Reinforced Concrete Design</h1>
-        <div>
-            <label for="structureType" class="mid1">Select Structure Type:</label>
-            <select id="structureType" name="structureType" class="mid2">
-		        <option value="" disabled selected>Select The Type Of Structure</option>
-                <option value="beamDesign">Beam</option>
-                <option value="columnDesign">Column</option>
-                <option value="foundationDesign">Foundation</option>
+
+    <div class="container rc-page">
+
+        <header class="rc-hero">
+            <h1>Reinforced Concrete Design</h1>
+            <p>
+                Choose a structural element below. Foundation Design is the full ACI 318 / NSCP 2015
+                workflow with iterative shear and flexural checks. Beam and Column are placeholder
+                pages for now.
+            </p>
+        </header>
+
+        <div class="rc-quickselect">
+            <label for="structureType">Quick select:</label>
+            <select id="structureType" name="structureType">
+                <option value="" disabled selected>Jump to a calculator&hellip;</option>
+                <option value="beamDesign">Beam Design</option>
+                <option value="columnDesign">Column Design</option>
+                <option value="foundationDesign">Foundation Design</option>
             </select>
         </div>
+
+        <div class="rc-grid">
+
+            <a href="foundationDesign.html" class="rc-card">
+                <h3 class="rc-card__title">Foundation Design</h3>
+                <p class="rc-card__description">
+                    Isolated square, isolated rectangular, and combined footings. Solves
+                    dimensions, punching shear, beam shear, and flexural reinforcement
+                    iteratively. Supports eccentric loads with moment-transfer check.
+                </p>
+                <div class="rc-card__footer">
+                    <span class="rc-badge rc-badge--full">Full calculator</span>
+                    <span class="rc-card__cta">Open &rarr;</span>
+                </div>
+            </a>
+
+            <a href="beamDesign.html" class="rc-card">
+                <h3 class="rc-card__title">Beam Design</h3>
+                <p class="rc-card__description">
+                    Singly and doubly reinforced beam design with shear stirrup spacing.
+                    Currently a placeholder &mdash; the page redirects you to the foundation
+                    workflow.
+                </p>
+                <div class="rc-card__footer">
+                    <span class="rc-badge rc-badge--stub">Placeholder</span>
+                    <span class="rc-card__cta">Open &rarr;</span>
+                </div>
+            </a>
+
+            <a href="columnDesign.html" class="rc-card">
+                <h3 class="rc-card__title">Column Design</h3>
+                <p class="rc-card__description">
+                    Axially loaded and uniaxial-bending column design with tie spacing.
+                    Currently a placeholder &mdash; the page redirects you to the foundation
+                    workflow.
+                </p>
+                <div class="rc-card__footer">
+                    <span class="rc-badge rc-badge--stub">Placeholder</span>
+                    <span class="rc-card__cta">Open &rarr;</span>
+                </div>
+            </a>
+
+        </div>
+
     </div>
-    </div>
+
 </body>
 </html>

--- a/public/pages/index.html
+++ b/public/pages/index.html
@@ -3,59 +3,129 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Civil Engineering</title>
+    <title>Civil Engineering Toolkit</title>
 
     <link rel="stylesheet" href="/assets/css/styleMainpage.css">
 </head>
 <body>
-    <div class="container">
-        <h1>Civil Engineering</h1>
-        <div class="form-group">
-            
-            <script>try{</script>
-            <form action="QuantitySurveying.html">
-                <button value="quantitySurveying">Quantity Surveying</button>
-            </form>
-            <form action="ReinforcedConcrete.html">
-                <button value="reinforcedConcrete">Reinforced Concrete</button>
-            </form>
-            <form action="SteelDesign.html">
-                <button value="steelDesign">Steel Design</button>
-            </form>
-            <form action="Geotechnical.html">
-                <button value="geotechnical">Geothechnical</button>
-            </form>
-            <form action="ConstructionProjectManagement.html">
-                <button value="cepm">Construction Project Management</button>
-            </form>
-            <form action="Utilities.html">
-                <button value="utilities">Utilities</button>
-            </form>
-            <script type="module">
-  // Import the functions you need from the SDKs you need
-  import { initializeApp } from "https://www.gstatic.com/firebasejs/10.13.1/firebase-app.js";
-  import { getAnalytics } from "https://www.gstatic.com/firebasejs/10.13.1/firebase-analytics.js";
-  // TODO: Add SDKs for Firebase products that you want to use
-  // https://firebase.google.com/docs/web/setup#available-libraries
 
-  // Your web app's Firebase configuration
-  // For Firebase JS SDK v7.20.0 and later, measurementId is optional
-  const firebaseConfig = {
-    apiKey: "AIzaSyAy98I8VJnrP2GF451pACvYKT28R377Pvk",
-    authDomain: "civilengineering-306c3.firebaseapp.com",
-    projectId: "civilengineering-306c3",
-    storageBucket: "civilengineering-306c3.appspot.com",
-    messagingSenderId: "30055218619",
-    appId: "1:30055218619:web:5588cb4fd1f1737fbcd89e",
-    measurementId: "G-MXJVLJ8RWV"
-  };
+    <header class="hero">
+        <h1>Civil Engineering Toolkit</h1>
+        <p class="tagline">
+            A collection of quantity surveying estimators and reinforced concrete design routines
+            following ACI 318 / NSCP 2015 conventions.
+        </p>
+    </header>
 
-  // Initialize Firebase
-  const app = initializeApp(firebaseConfig);
-  const analytics = getAnalytics(app);
-</script>
-            <script>} catch (error) {console.log(`error:${error}`)}</script>
+    <main class="page">
+
+        <h2 class="section-heading">Available Modules</h2>
+        <div class="module-grid">
+
+            <a href="QuantitySurveying.html" class="module-card is-available">
+                <h3 class="module-card__title">Quantity Surveying</h3>
+                <p class="module-card__subtitle">Material Quantity Estimator</p>
+                <p class="module-card__description">
+                    Estimate concrete, steel, and masonry quantities for slabs, columns, beams,
+                    foundations, CHB walls, and box culverts.
+                </p>
+                <div class="module-card__footer">
+                    <span class="badge badge--available">Available</span>
+                    <span class="module-card__cta">Open &rarr;</span>
+                </div>
+            </a>
+
+            <a href="ReinforcedConcrete.html" class="module-card is-available">
+                <h3 class="module-card__title">Reinforced Concrete</h3>
+                <p class="module-card__subtitle">Structural Design</p>
+                <p class="module-card__description">
+                    Detailed foundation design with iterative shear and flexural checks per ACI 318.
+                    Beam and column workflows are placeholder stubs &mdash; foundation is the full
+                    calculator.
+                </p>
+                <div class="module-card__footer">
+                    <span class="badge badge--available">Available</span>
+                    <span class="module-card__cta">Open &rarr;</span>
+                </div>
+            </a>
+
         </div>
-    </div>
+
+        <h2 class="section-heading" style="margin-top: 36px;">Coming Soon</h2>
+        <div class="module-grid">
+
+            <div class="module-card is-coming-soon" aria-disabled="true">
+                <h3 class="module-card__title">Steel Design</h3>
+                <p class="module-card__subtitle">Member Sizing &amp; Connections</p>
+                <p class="module-card__description">
+                    Tension, compression, beam, and connection design.
+                </p>
+                <div class="module-card__footer">
+                    <span class="badge badge--coming-soon">Planned</span>
+                </div>
+            </div>
+
+            <div class="module-card is-coming-soon" aria-disabled="true">
+                <h3 class="module-card__title">Geotechnical</h3>
+                <p class="module-card__subtitle">Soil &amp; Foundation</p>
+                <p class="module-card__description">
+                    Bearing capacity, settlement, retaining walls, and slope stability.
+                </p>
+                <div class="module-card__footer">
+                    <span class="badge badge--coming-soon">Planned</span>
+                </div>
+            </div>
+
+            <div class="module-card is-coming-soon" aria-disabled="true">
+                <h3 class="module-card__title">Construction Project Management</h3>
+                <p class="module-card__subtitle">Scheduling &amp; Costing</p>
+                <p class="module-card__description">
+                    CPM, S-curves, cash flow, and project cost estimating.
+                </p>
+                <div class="module-card__footer">
+                    <span class="badge badge--coming-soon">Planned</span>
+                </div>
+            </div>
+
+            <div class="module-card is-coming-soon" aria-disabled="true">
+                <h3 class="module-card__title">Utilities</h3>
+                <p class="module-card__subtitle">Helpers &amp; References</p>
+                <p class="module-card__description">
+                    Unit converters, rebar tables, and quick references.
+                </p>
+                <div class="module-card__footer">
+                    <span class="badge badge--coming-soon">Planned</span>
+                </div>
+            </div>
+
+        </div>
+
+    </main>
+
+    <footer class="site-footer">
+        Built by Raymart Valdepe&ntilde;as &middot;
+        <a href="https://github.com/BitLess246/civilEngineering" target="_blank" rel="noopener">View source</a>
+    </footer>
+
+    <script type="module">
+        try {
+            const { initializeApp } = await import("https://www.gstatic.com/firebasejs/10.13.1/firebase-app.js");
+            const { getAnalytics } = await import("https://www.gstatic.com/firebasejs/10.13.1/firebase-analytics.js");
+            const firebaseConfig = {
+                apiKey: "AIzaSyAy98I8VJnrP2GF451pACvYKT28R377Pvk",
+                authDomain: "civilengineering-306c3.firebaseapp.com",
+                projectId: "civilengineering-306c3",
+                storageBucket: "civilengineering-306c3.appspot.com",
+                messagingSenderId: "30055218619",
+                appId: "1:30055218619:web:5588cb4fd1f1737fbcd89e",
+                measurementId: "G-MXJVLJ8RWV"
+            };
+            const app = initializeApp(firebaseConfig);
+            getAnalytics(app);
+        } catch (error) {
+            console.log(`Firebase init skipped: ${error}`);
+        }
+    </script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- **Main page (`index.html` + `styleMainpage.css`)** — replace the six stacked plain buttons with a hero header and a responsive module-card grid. Available modules (Quantity Surveying, Reinforced Concrete) are clickable cards with a green Available badge and an Open arrow; the four planned modules (Steel Design, Geotechnical, CPM, Utilities) get dashed-border Coming Soon cards so users see the roadmap instead of hitting 404s.
- **Reinforced Concrete page** — add a hero block, a HOME nav link back to index, a quick-select pill that preserves the original `<select id=\"structureType\">` so `layout_script.js` still binds and navigates, and a 3-card grid for Beam / Column / Foundation Design with status badges making it clear that Foundation is the full calculator and the other two are placeholders.
- Scoped layout fixes via new `.fd-page` / `.rc-page` classes so the rigid `.container` grid that Reinforced Concrete and the other Design pages depend on stays untouched on the rest of the site.

## Why
Both landing pages were skeletal. The main page was a stack of six plain buttons, four of which led to 404s (`SteelDesign.html`, `Geotechnical.html`, `ConstructionProjectManagement.html`, `Utilities.html`). The Reinforced Concrete page was a single dropdown with no description of what each option does. New users had no way to know which modules were actually wired and which were aspirational. This restructures both as scannable card grids with explicit status indicators.

The main page also had a parser-fragile `<script>try{</script>...<script>}catch{</script>` pattern straddling a module script. Replaced with a single proper `<script type=\"module\">` block using dynamic `import()` inside one try/catch. Firebase analytics init preserved.

## What reviewers should know
- The `<select id=\"structureType\">` element is preserved on the Reinforced Concrete page (repositioned and restyled as a quick-select pill) specifically so `layout_script.js`'s change-handler still binds. No JS file changed.
- The four Coming Soon cards on the main page are non-clickable `<div>`s with `aria-disabled=\"true\"` and dashed borders, not broken `<a>` tags. Users can see the planned modules without landing on a 404.
- Foundation Design / Column Design / Beam Design / Reinforced Concrete subpage routes are unchanged. No new pages added.
- Scoped via new `.rc-page` class so the rigid `.container` grid that the Design pages depend on (placement via `.title1`/`.mid1`/`.mid2`) stays available where it's needed.

## Test plan
- [ ] `npm install && npm start`, open http://localhost:3000/index.html — hero renders, two Available cards (QS, RC) are clickable with hover-lift; four Coming Soon cards visible but unclickable.
- [ ] Resize to ~480px wide — cards stack to single column cleanly.
- [ ] Click Quantity Surveying → lands on `QuantitySurveying.html`. Click Reinforced Concrete → lands on `ReinforcedConcrete.html`.
- [ ] On `ReinforcedConcrete.html`, click the HOME link in the nav → returns to `index.html`.
- [ ] Use the quick-select dropdown → still navigates to the chosen sub-page (Beam / Column / Foundation Design) via `layout_script.js`.
- [ ] Click each of the three module cards directly → navigates correctly.
- [ ] Reinforced Concrete page, Quantity Surveying subpages, Foundation Design / Column Design / Beam Design — visually unchanged from before this PR.