### PR TITLE
Fix form grid bleed and restyle solution as stepped cards

### DIFF
--- a/public/assets/css/styles1.css
+++ b/public/assets/css/styles1.css
@@ -712,3 +712,215 @@ nav ul li a:hover {
     color: #6a737d;
     margin: 4px 0 0;
 }
+
+/* When the inline show/hide JS sets display:none on BOTH the label and the
+   input/select inside an .fd-field, the wrapper itself stays visible and
+   claims a grid cell — pushing the next visible field into the wrong slot
+   and creating the dropdown-bleed effect. Hide the wrapper when every direct
+   child is hidden via inline style. */
+.fd-page .fd-field:not(:has(> *:not([style*="display: none"]))) {
+    display: none;
+}
+
+/* ============================================================
+   Foundation Design — Solution / Summary card layout
+   The JS appends h5 (major step) / h7 (sub-step) / p (math) into
+   #result and #Solution. Style those tags so the flat list reads
+   as a stepped report.
+   ============================================================ */
+.fd-page #print {
+    margin-top: 24px;
+}
+
+.fd-page .tab {
+    border-radius: 8px 8px 0 0;
+    border: 1px solid #007BFF;
+    border-bottom: none;
+    margin-bottom: 0;
+    overflow: hidden;
+}
+
+.fd-page .tab-button {
+    flex: 1 1 50%;
+    text-align: center;
+    font-weight: 600;
+    border-bottom: 3px solid transparent;
+}
+
+.fd-page .tab-button.active {
+    border-bottom-color: #003f86;
+}
+
+.fd-page #summary,
+.fd-page #Solution {
+    background: #fff;
+    border: 1px solid #007BFF;
+    border-top: none;
+    border-radius: 0 0 8px 8px;
+    padding: 20px 24px;
+    margin: 0 0 24px;
+}
+
+/* Parameter-recap grid at the top of the Solution tab */
+.fd-page #GivenParameters1 {
+    background: #f6f8fa;
+    border: 1px solid #e1e4e8;
+    border-radius: 8px;
+    padding: 16px 20px;
+    margin: 0 0 20px;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px 24px;
+}
+
+.fd-page #GivenParameters1 h5 {
+    grid-column: 1 / -1;
+    margin: 0 0 6px;
+    padding-bottom: 8px;
+    border-bottom: 2px solid #007BFF;
+    color: #0056b3;
+    font-size: 1em;
+}
+
+.fd-page #GivenParameters1 h8 {
+    display: block;
+    margin: 0;
+    font-size: 0.95em;
+    color: #1f2933;
+}
+
+/* Reset the legacy negative-margin hacks on result paragraphs that were
+   making LaTeX bleed sideways. */
+.fd-page #result.latex-container,
+.fd-page #Summary.latex-container,
+.fd-page #Summary1.latex-container {
+    display: block;
+    width: 100%;
+    font-size: 1em;
+    line-height: 1.5;
+}
+
+.fd-page #result.latex-container p,
+.fd-page #Summary.latex-container p,
+.fd-page #Summary1.latex-container p {
+    display: block;
+    margin: 0 0 10px;
+    text-align: left;
+    overflow-x: auto;
+    overflow-y: hidden;
+}
+
+/* h3 (Summary title) — section banner */
+.fd-page #Summary.latex-container h3,
+.fd-page #Summary1.latex-container h3,
+.fd-page #result.latex-container h3 {
+    margin: 0 0 18px;
+    padding: 12px 16px;
+    background: linear-gradient(135deg, #0056b3 0%, #003f86 100%);
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    font-size: 1.15em;
+    text-align: left;
+}
+
+/* h5 — major calculation step. Render as a card header with a step bar */
+.fd-page #result.latex-container h5 {
+    counter-increment: fd-step;
+    margin: 24px 0 12px;
+    padding: 10px 16px 10px 56px;
+    background: #f6f8fa;
+    border: 1px solid #d6d9de;
+    border-left: 4px solid #0056b3;
+    border-radius: 6px;
+    color: #0056b3;
+    font-size: 1.1em;
+    font-weight: 700;
+    position: relative;
+    page-break-after: avoid;
+}
+
+.fd-page #result.latex-container h5::before {
+    content: counter(fd-step);
+    position: absolute;
+    left: 14px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    background: #0056b3;
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.9em;
+    font-weight: 700;
+}
+
+.fd-page #result.latex-container {
+    counter-reset: fd-step;
+}
+
+/* h7 — sub-step header (custom tag the JS uses) */
+.fd-page #result.latex-container h7,
+.fd-page #Summary.latex-container h7,
+.fd-page #Summary1.latex-container h7 {
+    display: block;
+    margin: 16px 0 8px;
+    padding: 6px 12px;
+    background: #e8f1fb;
+    border-left: 3px solid #007BFF;
+    color: #0056b3;
+    font-size: 1em;
+    font-weight: 600;
+    border-radius: 0 4px 4px 0;
+}
+
+/* h8 — atomic value line inside the parameters block */
+.fd-page #result.latex-container h8,
+.fd-page #Summary.latex-container h8,
+.fd-page #Summary1.latex-container h8 {
+    display: block;
+    margin: 4px 0;
+    font-size: 0.95em;
+}
+
+/* Group consecutive math paragraphs under each h5/h7 into a soft card
+   without changing JS. The CSS uses :has() to detect "this h5/h7 is the
+   start of a section" and applies a left border on following <p>. */
+.fd-page #result.latex-container > p {
+    padding: 8px 14px;
+    background: #fcfcfd;
+    border-left: 2px solid #e1e4e8;
+    border-radius: 0 4px 4px 0;
+    margin-left: 8px;
+}
+
+/* Standout style for the code-reference annotation paragraphs the JS
+   appends (they all start with "Per ..."). Uses :has() on the inner span. */
+.fd-page #result.latex-container p.fd-clause,
+.fd-page #Summary.latex-container p.fd-clause,
+.fd-page #Summary1.latex-container p.fd-clause {
+    display: inline-block;
+    margin: 4px 0 14px;
+    padding: 4px 10px;
+    background: rgba(31, 138, 58, 0.10);
+    border: 1px solid rgba(31, 138, 58, 0.25);
+    color: #1f6f30;
+    font-size: 0.85em;
+    border-radius: 4px;
+    font-style: italic;
+    text-align: left;
+    border-left: 3px solid #1f8a3a;
+}
+
+/* Summary block on the Summary tab — keep it tight */
+.fd-page #Summary.latex-container p,
+.fd-page #Summary1.latex-container p {
+    padding: 6px 12px;
+    background: #fcfcfd;
+    border-left: 2px solid #007BFF;
+    border-radius: 0 4px 4px 0;
+    margin: 4px 0;
+}

--- a/public/assets/js/scriptFoundationDesign6.js
+++ b/public/assets/js/scriptFoundationDesign6.js
@@ -85,6 +85,13 @@ document.addEventListener("DOMContentLoaded", () => {
         h3.innerHTML = content;
         return h3;
     }
+    // Small italic badge under a step header naming the code clause / method
+    function createClause(content) {
+        const p = document.createElement('p');
+        p.className = 'fd-clause';
+        p.innerHTML = content;
+        return p;
+    }
     function dimension(DC){
         let dc = DC;
         let ds = (h*1000) - dc;
@@ -98,7 +105,8 @@ document.addEventListener("DOMContentLoaded", () => {
        
                
         if(recheck===0){
-            document.getElementById('result').appendChild(createHeader5(`Calculation of Dimensions`));       
+            document.getElementById('result').appendChild(createHeader5(`Calculation of Dimensions`));
+            document.getElementById('result').appendChild(createClause(`Per NSCP 2015 §420.6.1.3 / ACI 318-14 §20.6.1.3 — minimum cover 75 mm for concrete cast against and permanently in contact with earth.`));
             document.getElementById('result').appendChild(createParagraph(`$$\\ D_c = ${dc}mm \$$`));
             document.getElementById('result').appendChild(createParagraph(`$$\\ D_s = H - D_c = ${h*1000}mm - ${dc}mm = ${ds}mm \$$`));
             document.getElementById('result').appendChild(createParagraph(`$$\\ q_{net} = q_{all} - (\\gamma_s \\times D_s) - (\\gamma_c \\times D_c) - q =  ${qa}kPa - (${ys}\\frac{kN}{m^3} \\times ${ds/1000}m) - (${yc}\\frac{kN}{m^3} \\times ${dc/1000}m) - ${q}kPa = ${qnet.toFixed(2)}kPa  \$$`));
@@ -178,6 +186,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
             }
             document.getElementById('result').appendChild(createHeader7(`Solve for Ultimate Loads`));
+            document.getElementById('result').appendChild(createClause(`Per NSCP 2015 §203.3.1 / ACI 318-14 §5.3.1 — factored load \\(P_u\\) is the larger of \\(1.4 D\\) and \\(1.2 D + 1.6 L\\).`));
             if(loadType==="ultimate"){
                 document.getElementById('result').appendChild(createParagraph(`$$\\ Pu = ${pu.toFixed(2)}kN \$$`));
                 if  (centricity === "eccentric"){
@@ -309,6 +318,7 @@ document.addEventListener("DOMContentLoaded", () => {
             }
             }
             document.getElementById('result').appendChild(createHeader7(`Solve for Ultimate Load Combinations`));
+                document.getElementById('result').appendChild(createClause(`Per NSCP 2015 §203.3.1 / ACI 318-14 §5.3.1 — factored load \\(P_u\\) is the larger of \\(1.4 D\\) and \\(1.2 D + 1.6 L\\).`));
             if(loadType==="ultimate"){
                 document.getElementById('result').appendChild(createParagraph(`$$\\ Pu = ${pu}kN \$$`));
                 if  (centricity === "eccentric"){
@@ -397,7 +407,8 @@ document.addEventListener("DOMContentLoaded", () => {
         let test;
         console.log(`Ao = `,Ao);
         console.log(`Punching Shear Vu = `,Vu);
-        document.getElementById('result').appendChild(createHeader5(`Punching Shear Calculation`));       
+        document.getElementById('result').appendChild(createHeader5(`Punching Shear Calculation`));
+        document.getElementById('result').appendChild(createClause(`Per NSCP 2015 §422.6.5.2 / ACI 318-14 §22.6.5.2 — two-way (punching) shear; \\(\\phi V_n\\) is the LEAST of three expressions. Strength reduction \\(\\phi = 0.75\\) per §421.2.1.`));
         document.getElementById('result').appendChild(createParagraph(`$$\\ d = D_c - C_c - d_b = ${dc}mm - ${cc}mm - ${barDia}mm = ${d}mm \$$`));
         document.getElementById('result').appendChild(createParagraph(`$$\\ A_o = (d + c_x)\\times (d + c_y) = (${d}mm + ${cx.toFixed(2)}mm)\\times (${d}mm + ${cy.toFixed(2)}mm) = ${Ao.toFixed(2)}mm^2 \$$`));
         document.getElementById('result').appendChild(createParagraph(`$$\\ A_f = B_y \\times B_x = ${by*1000}mm \\times ${bx*1000}mm = ${Af.toFixed(2)}mm^2 \$$`));
@@ -411,6 +422,7 @@ document.addEventListener("DOMContentLoaded", () => {
         // Max shear stress on critical section: v_max = Vu/Ac + gamma_v * Mu * c / Jc <= phi * vc
         if (method === 1 && centricity === "eccentric" && (Math.abs(mux) > 0 || Math.abs(muy) > 0)) {
             document.getElementById('result').appendChild(createHeader7(`Unbalanced Moment Transfer (Eccentric Punching)`));
+            document.getElementById('result').appendChild(createClause(`Per NSCP 2015 §408.4.4.2 / ACI 318-14 §8.4.4.2 — fraction of unbalanced moment transferred by shear: \\(\\gamma_v = 1 - 1/(1 + \\tfrac{2}{3}\\sqrt{b_1/b_2})\\). Stress check: \\(v_{max} = V_u/A_c + \\gamma_v M_u c / J_c \\le \\phi v_c\\).`));
             if (columnLocation !== 1) {
                 document.getElementById('result').appendChild(createParagraph(`$$\\ \\text{Note: } \\gamma_v \\text{ check below assumes an interior column. Edge/corner critical sections require separate hand check per ACI 318 §8.4.4.}\$$`));
             }
@@ -583,7 +595,8 @@ document.addEventListener("DOMContentLoaded", () => {
         y1 = (cy/2)+depth;      console.log(`y1 = `,y1);
         y2 = ((by*1000)/2);            console.log(`y2 = `,y2);
        
-        document.getElementById('result').appendChild(createHeader5(`Beam Shear Calculation Along Y-axis (Cut Across Y-axis)`));       
+        document.getElementById('result').appendChild(createHeader5(`Beam Shear Calculation Along Y-axis (Cut Across Y-axis)`));
+        document.getElementById('result').appendChild(createClause(`Per NSCP 2015 §422.5.5 / ACI 318-14 §22.5.5 — one-way (beam) shear: \\(\\phi V_c = \\phi \\cdot \\tfrac{1}{6}\\lambda\\sqrt{f'_c}\\,b_w\\,d\\) with \\(\\phi = 0.75\\).`));
         if( longer === axis ){
             document.getElementById('result').appendChild(createParagraph(`$$\\ d = D_c - C_c - 0.5d_b = ${dc}mm - ${cc}mm - 0.5(${barDia}mm) = ${depth}mm \$$`));
         } else if ( shorter === axis ){
@@ -616,7 +629,8 @@ document.addEventListener("DOMContentLoaded", () => {
         y2 = (by*1000)/2;              console.log(`y2 = `,y2);
 
         
-        document.getElementById('result').appendChild(createHeader5(`Beam Shear Calculation Along X-axis (Cut Across X-axis)`));       
+        document.getElementById('result').appendChild(createHeader5(`Beam Shear Calculation Along X-axis (Cut Across X-axis)`));
+        document.getElementById('result').appendChild(createClause(`Per NSCP 2015 §422.5.5 / ACI 318-14 §22.5.5 — one-way (beam) shear: \\(\\phi V_c = \\phi \\cdot \\tfrac{1}{6}\\lambda\\sqrt{f'_c}\\,b_w\\,d\\) with \\(\\phi = 0.75\\).`));
         if( longer === axis ){
             document.getElementById('result').appendChild(createParagraph(`$$\\ d = D_c - C_c - 0.5d_b = ${dc}mm - ${cc}mm - 0.5(${barDia}mm) = ${depth}mm \$$`));
         } else if ( shorter === axis ){
@@ -729,7 +743,8 @@ document.addEventListener("DOMContentLoaded", () => {
             shorter="y";
         } 
         console.log(200);
-        document.getElementById('result').appendChild(createHeader5(`Solve Preliminary Values for Design`));       
+        document.getElementById('result').appendChild(createHeader5(`Solve Preliminary Values for Design`));
+        document.getElementById('result').appendChild(createClause(`Per NSCP 2015 §422.2.2.4.3 / ACI 318-14 §22.2.2.4.3 — Whitney stress-block factor \\(\\beta_1\\): \\(0.85\\) for \\(f'_c \\le 28\\,\\text{MPa}\\), reduces by \\(0.05/7\\) per MPa above 28, with a floor of \\(0.65\\).`));
 
         // ACI 318-14 / NSCP 2015 §22.2.2.4.3: beta1 step-down coefficient is 0.05/7, not 0.5/7
         let beta1 = 0;
@@ -868,7 +883,8 @@ document.addEventListener("DOMContentLoaded", () => {
         let ct = 3*depth/8;
         let at = ct*beta1;
         let muMax = 0.9 * 0.85 * fc * at * b *(depth-(at/2))/1000000;
-        document.getElementById('result').appendChild(createHeader7(`Check if SRRB`));       
+        document.getElementById('result').appendChild(createHeader7(`Check if SRRB`));
+        document.getElementById('result').appendChild(createClause(`Per NSCP 2015 §421.2.2 / ACI 318-14 §21.2.2 — tension-controlled limit \\(c_t = 3d/8\\) gives steel strain \\(\\varepsilon_t = 0.005\\) and \\(\\phi = 0.90\\); below this, the section is Singly-Reinforced (SRRB), above it requires compression steel (DRRB).`));
         document.getElementById('result').appendChild(createParagraph(`$$\\ c_t = 3 \\times \\frac{d}{8} = 3 \\times \\frac{${depth}}{8} = ${ct.toFixed(2)}mm \$$`));
         document.getElementById('result').appendChild(createParagraph(`$$\\ a_t = \\beta_1 \\times  c_t   = ${beta1} \\times ${ct.toFixed(2)}mm = ${at.toFixed(2)}mm \$$`));
         document.getElementById('result').appendChild(createParagraph(`$$\\ M_{u(max)} = \\phi \\times 0.85 \\times f'c \\times a_t \\times b \\times (d - \\frac{a_t}{2}) \$$`));
@@ -882,6 +898,7 @@ document.addEventListener("DOMContentLoaded", () => {
         let rhomin1 = 1.4/fy;
         let rhomin2 = Math.sqrt(fc)/(4*fy);
         let rhomin = Math.max(rhomin1,rhomin2);
+        document.getElementById('result').appendChild(createClause(`Per NSCP 2015 §409.6.1.2 / ACI 318-14 §9.6.1.2 — minimum flexural reinforcement ratio \\(\\rho_{min}\\) is the larger of \\(1.4/f_y\\) and \\(\\sqrt{f'_c}/(4 f_y)\\).`));
         document.getElementById('result').appendChild(createParagraph(`\\( \\rho_{min} = \\text {Greatest of} \\left\\{\\begin{array}{l} \\frac{1.4}{fy} = \\frac{1.4}{${fy}MPa} = ${rhomin1.toFixed(6)}\\, \\\\ \\frac{f'c}{4 \\times fy} = \\frac{${fc}MPa}{4 \\times ${fy}MPa} = ${rhomin2.toFixed(6)} \\, \\end{array}\\right. = ${rhomin.toFixed(6)} \\, \\)`));
         document.getElementById('result').appendChild(createParagraph(`$$\\ \\therefore \\rho = ${rho>rhomin ? rho.toFixed(6):rhomin.toFixed(6)} \$$`));
         rho = Math.max(rho,rhomin);
@@ -891,6 +908,7 @@ document.addEventListener("DOMContentLoaded", () => {
         let rhoST = (fy >= 414) ? 0.0018 : 0.0020;
         let asmin = rhoST*dc*b;
         document.getElementById('result').appendChild(createParagraph(`$$\\ A_s = \\rho \\times B_${text} \\times d = ${rho.toFixed(6)}\\times ${b}mm \\times ${depth.toFixed(2)}mm = ${as.toFixed(2)}mm^2 \$$`));
+        document.getElementById('result').appendChild(createClause(`Per NSCP 2015 §425.6.1.1 / ACI 318-14 §24.4.3.2 — shrinkage-and-temperature ratio \\(\\rho_{ST}\\): \\(0.0018\\) for Grade 414+ deformed bars, \\(0.0020\\) otherwise. Selected here based on the entered \\(f_y\\).`));
         document.getElementById('result').appendChild(createParagraph(`$$\\ A_{s,min} = \\rho_{ST} \\times A_g = ${rhoST.toFixed(4)} \\times B_${text} \\times D_c =  ${rhoST.toFixed(4)} \\times ${b}mm \\times ${dc}mm = ${asmin.toFixed(2)}mm^2  \\, ,\\, \\rho_{ST} = ${rhoST.toFixed(4)} \\text{ (f_y ${fy >= 414 ? "\\ge" : "<"} 414\\,MPa)}\$$`));
         document.getElementById('result').appendChild(createParagraph(`$$\\  ${as>asmin ? "A_s > A_{smin}":"A_s < A_{smin}"} \$$`));
         as = Math.max(as,asmin);
@@ -916,6 +934,7 @@ document.addEventListener("DOMContentLoaded", () => {
         }
         centerbandRatio = 2 / (beta+1);
         m = Math.ceil(n*centerbandRatio);
+        document.getElementById('result').appendChild(createClause(`Per NSCP 2015 §413.3.3.3 / ACI 318-14 §13.3.3.3 — in rectangular footings, a portion \\(\\Upsilon_s = 2/(\\beta+1)\\) of the short-direction reinforcement is concentrated in a center band of width equal to the short side, where \\(\\beta\\) = long / short.`));
         document.getElementById('result').appendChild(createParagraph(`$$\\ \\Upsilon_s = \\frac{2}{\\beta + 1} = \\frac{2}{${beta.toFixed(2)} + 1} = ${centerbandRatio.toFixed(2)}\$$`));
         document.getElementById('result').appendChild(createParagraph(`$$\\ n_{centerband} = n \\times \\Upsilon_s = ${n} \\times ${centerbandRatio.toFixed(2)} = ${(n*centerbandRatio).toFixed(2)}pcs \\approx ${Math.ceil(n*centerbandRatio)}pcs \$$`));
         


### PR DESCRIPTION
Form layout
- Empty .fd-field wrappers around hidden labels/inputs were claiming grid cells, pushing visible fields into wrong slots and producing the dropdown-bleed seen on the deployed page. Add a CSS :has() rule that hides any .fd-field whose every direct child is display:none. No JS change required.

Solution display
- Reset the legacy negative-margin styling on .latex-container paragraphs (it was making LaTeX bleed sideways) for #result, #Summary, and #Summary1. Restore normal block flow.
- Render the Solution h3 ("Summary:") as a gradient banner.
- Render each h5 (major calculation step) as a numbered card-style header using CSS counters and a circular step badge. The flat list of equations now reads as a stepped report.
- Render each h7 (sub-step) as a light-blue pill banner.
- Cluster consecutive math paragraphs under a soft left border so each step visually owns its derivation block.
- Lay out the parameter recap (#GivenParameters1) as a 2-column grid instead of a single column, matching the form's density.

Code references (NSCP 2015 / ACI 318-14 citations)
- Add a createClause() helper that emits a small italic green pill paragraph after each step header.
- Cite the governing clause at every key step: cover (§420.6.1.3), load combinations (§203.3.1), punching shear (§422.6.5.2), unbalanced moment transfer (§408.4.4.2), beam shear (§422.5.5), beta1 (§422.2.2.4.3), tension-controlled SRRB limit (§421.2.2), rho_min (§409.6.1.2), shrinkage/temperature As,min (§425.6.1.1), and the long-direction band-width ratio for rectangular footings (§413.3.3.3).
- Every clause line is purely additive — no existing calculation, equation, or display ID changed.