### PR TITLE
Foundation Design: switch to KaTeX + actually win the form-bleed fight

### DIFF
--- a/public/assets/css/styles1.css
+++ b/public/assets/css/styles1.css
@@ -624,20 +624,35 @@ nav ul li a:hover {
 .fd-page .fd-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 10px 18px;
+    /* row gap must be large enough that the input never visually touches the
+       label of the field below, even if the global `flex: 1 0 100%` leaks. */
+    gap: 22px 20px;
     margin-top: 8px;
+    align-items: start;
 }
 
 .fd-page .fd-field {
     display: flex;
     flex-direction: column;
     min-width: 0;
+    /* Field is content-sized; defeats vertical stretching from grid defaults. */
+    align-self: start;
+}
+
+.fd-page .fd-field > * {
+    /* The global `input, select { flex: 1 0 100% }` would otherwise make the
+       input's flex-basis 100% of the column-flex container's main-axis
+       (= the .fd-field height), causing the input to grow and the label of
+       the NEXT row to render inside the previous row's input. Pin every
+       child to content size. */
+    flex: 0 0 auto !important;
 }
 
 .fd-page .fd-field label {
-    display: block;
-    width: auto;
-    margin: 0 0 4px;
+    display: block !important;
+    width: auto !important;
+    margin: 0 0 6px !important;
+    padding: 0;
     font-size: 0.9em;
     color: #2c3e50;
     line-height: 1.3;
@@ -645,14 +660,20 @@ nav ul li a:hover {
 
 .fd-page .fd-field input,
 .fd-page .fd-field select {
-    width: 100%;
-    margin: 0;
-    padding: 8px 10px;
+    display: block !important;
+    width: 100% !important;
+    height: auto;
+    margin: 0 !important;
+    padding: 9px 11px;
     box-sizing: border-box;
     border: 1px solid #c5c9d0;
     border-radius: 4px;
     background: #fff;
     font-size: 0.95em;
+    line-height: 1.3;
+    /* Keep the select control from stretching beyond a normal control height
+       when the global input rule's flex-basis: 100% would otherwise win. */
+    min-height: auto;
 }
 
 .fd-page .fd-field input:focus,
@@ -777,6 +798,181 @@ nav ul li a:hover {
     border: 1px solid #c5c9d0;
     border-radius: 4px;
     background: #fff;
+}
+
+/* ============================================================
+   Foundation Design — strong overrides for the LaTeX panels.
+   The original .latex-container is { display: inline-block;
+   width: min-content }, which collapses content to its narrowest
+   possible width — that was making citation paragraphs render one
+   word per line. The legacy `.latex-container p` rule also sets
+   `display: inline-block; margin-right: 100%`. Force block layout
+   with full width using !important so neither legacy rule wins.
+   ============================================================ */
+.fd-page #result.latex-container,
+.fd-page #Summary.latex-container,
+.fd-page #Summary1.latex-container {
+    display: block !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    min-width: 0 !important;
+    font-size: 1em;
+    line-height: 1.55;
+    text-align: left;
+    box-sizing: border-box;
+}
+
+.fd-page #result.latex-container p,
+.fd-page #Summary.latex-container p,
+.fd-page #Summary1.latex-container p {
+    display: block !important;
+    width: auto !important;
+    max-width: 100% !important;
+    margin: 0 0 10px !important;
+    padding: 0;
+    text-align: left;
+    overflow-x: auto;
+    overflow-y: hidden;
+    white-space: normal !important;
+    word-break: normal;
+    overflow-wrap: break-word;
+}
+
+/* h3 (Summary title) — section banner */
+.fd-page #Summary.latex-container h3,
+.fd-page #Summary1.latex-container h3,
+.fd-page #result.latex-container h3 {
+    display: block !important;
+    width: 100% !important;
+    box-sizing: border-box;
+    margin: 0 0 18px !important;
+    padding: 14px 18px !important;
+    background: linear-gradient(135deg, #0056b3 0%, #003f86 100%) !important;
+    color: #fff !important;
+    border: none !important;
+    border-radius: 6px !important;
+    font-size: 1.2em !important;
+    font-weight: 700 !important;
+    text-align: left !important;
+}
+
+/* h5 — major calculation step. Render as a card header with a step bar */
+.fd-page #result.latex-container h5 {
+    counter-increment: fd-step;
+    display: block !important;
+    width: 100% !important;
+    box-sizing: border-box;
+    margin: 24px 0 12px !important;
+    padding: 12px 16px 12px 56px !important;
+    background: #f6f8fa !important;
+    border: 1px solid #d6d9de !important;
+    border-left: 4px solid #0056b3 !important;
+    border-radius: 6px !important;
+    color: #0056b3 !important;
+    font-size: 1.1em !important;
+    font-weight: 700 !important;
+    position: relative;
+    page-break-after: avoid;
+    text-align: left !important;
+    line-height: 1.4 !important;
+}
+
+.fd-page #result.latex-container h5::before {
+    content: counter(fd-step);
+    position: absolute;
+    left: 14px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    background: #0056b3;
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.9em;
+    font-weight: 700;
+}
+
+.fd-page #result.latex-container {
+    counter-reset: fd-step;
+}
+
+/* h7 — sub-step header (custom tag the JS uses) */
+.fd-page #result.latex-container h7,
+.fd-page #Summary.latex-container h7,
+.fd-page #Summary1.latex-container h7 {
+    display: block !important;
+    width: 100% !important;
+    box-sizing: border-box;
+    margin: 18px 0 8px 8px !important;
+    padding: 8px 12px !important;
+    background: #e8f1fb !important;
+    border-left: 3px solid #007BFF !important;
+    color: #0056b3 !important;
+    font-size: 1em !important;
+    font-weight: 600 !important;
+    border-radius: 0 4px 4px 0 !important;
+    text-align: left !important;
+}
+
+/* h8 — atomic value line inside the parameters block */
+.fd-page #result.latex-container h8,
+.fd-page #Summary.latex-container h8,
+.fd-page #Summary1.latex-container h8 {
+    display: block;
+    margin: 4px 0;
+    font-size: 0.95em;
+}
+
+/* Soft card treatment for the equation paragraphs that follow a step
+   header. The .fd-clause rule below overrides this with a more specific
+   selector so callouts get the green note styling instead. */
+.fd-page #result.latex-container > p {
+    padding: 10px 14px !important;
+    background: #fcfcfd;
+    border-left: 2px solid #e1e4e8;
+    border-radius: 0 4px 4px 0;
+    margin-left: 8px !important;
+    overflow-x: auto;
+}
+
+/* Code-reference annotation paragraphs the JS appends after each step header.
+   Render as a full-width "callout note" block so the text flows naturally
+   instead of inheriting the LaTeX container's shrink-to-fit width and
+   breaking one-word-per-line. */
+.fd-page #result.latex-container p.fd-clause,
+.fd-page #Summary.latex-container p.fd-clause,
+.fd-page #Summary1.latex-container p.fd-clause {
+    display: block !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    margin: 4px 0 16px 8px !important;
+    padding: 10px 14px !important;
+    background: rgba(31, 138, 58, 0.08) !important;
+    border: 1px solid rgba(31, 138, 58, 0.22) !important;
+    border-left: 3px solid #1f8a3a !important;
+    border-radius: 0 4px 4px 0 !important;
+    color: #1f6f30 !important;
+    font-size: 0.9em !important;
+    font-style: italic !important;
+    text-align: left !important;
+    line-height: 1.55 !important;
+    white-space: normal !important;
+    word-break: normal;
+    overflow-wrap: break-word;
+    box-sizing: border-box;
+}
+
+/* MathJax renders display equations inside the clause as inline pieces so
+   they don't break the paragraph flow. */
+.fd-page #result.latex-container p.fd-clause mjx-container,
+.fd-page #Summary.latex-container p.fd-clause mjx-container,
+.fd-page #Summary1.latex-container p.fd-clause mjx-container {
+    display: inline-block !important;
+    margin: 0 2px !important;
+    vertical-align: middle;
 }
 
 .rc-page .rc-grid {

--- a/public/assets/css/styles1.css
+++ b/public/assets/css/styles1.css
@@ -975,6 +975,57 @@ nav ul li a:hover {
     vertical-align: middle;
 }
 
+/* ============================================================
+   KaTeX output (replaces MathJax). KaTeX wraps display math in
+   <span class="katex-display"><span class="katex">...</span></span>
+   and inline math in <span class="katex">.  Style them to fit the
+   solution-card layout cleanly.
+   ============================================================ */
+.fd-page .katex,
+.fd-page #result.latex-container .katex,
+.fd-page #Summary.latex-container .katex,
+.fd-page #Summary1.latex-container .katex,
+.fd-page #GivenParameters1 .katex {
+    font-size: 1.05em !important;
+    text-rendering: auto;
+    color: #1f2933;
+    line-height: 1.2;
+    white-space: normal !important;
+}
+
+.fd-page .katex-display,
+.fd-page #result.latex-container .katex-display,
+.fd-page #Summary.latex-container .katex-display,
+.fd-page #Summary1.latex-container .katex-display {
+    display: block !important;
+    margin: 6px 0 !important;
+    padding: 4px 2px !important;
+    text-align: left !important;
+    overflow-x: auto;
+    overflow-y: hidden;
+    /* KaTeX's default `.katex-display > .katex` centers — override to left. */
+}
+
+.fd-page .katex-display > .katex {
+    text-align: left !important;
+    display: inline-block;
+}
+
+/* Inside the green clause callout, render inline math without extra spacing. */
+.fd-page #result.latex-container p.fd-clause .katex,
+.fd-page #Summary.latex-container p.fd-clause .katex,
+.fd-page #Summary1.latex-container p.fd-clause .katex {
+    color: #1f6f30 !important;
+    font-size: 0.95em !important;
+    font-style: normal;
+}
+
+/* Parameter-recap atomic value lines (h8 tag — non-standard but used by the JS) */
+.fd-page #GivenParameters1 h8 .katex,
+.fd-page #GivenParameters1 .katex {
+    font-size: 1em !important;
+}
+
 .rc-page .rc-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));

--- a/public/assets/js/scriptFoundationDesign6.js
+++ b/public/assets/js/scriptFoundationDesign6.js
@@ -1,10 +1,63 @@
 import { SaveFile } from './script.js';
 
+// Render KaTeX math in an element after the JS has appended its content.
+// KaTeX is synchronous (unlike MathJax) so this just works without promises.
+// Falls back gracefully if KaTeX auto-render hasn't finished loading.
+function renderMath(element) {
+    if (!element) return;
+    if (typeof renderMathInElement === 'undefined') {
+        setTimeout(() => renderMath(element), 80);
+        return;
+    }
+    try {
+        renderMathInElement(element, {
+            delimiters: [
+                { left: '$$', right: '$$', display: true },
+                { left: '\\[', right: '\\]', display: true },
+                { left: '\\(', right: '\\)', display: false }
+            ],
+            throwOnError: false,
+            errorColor: '#cc0000',
+            strict: false,
+            trust: true,
+            macros: {
+                "\\kN":  "\\,\\text{kN}",
+                "\\kNm": "\\,\\text{kN·m}",
+                "\\mm":  "\\,\\text{mm}",
+                "\\MPa": "\\,\\text{MPa}",
+                "\\kPa": "\\,\\text{kPa}"
+            }
+        });
+    } catch (e) {
+        console.error('KaTeX render failed:', e);
+    }
+}
+
+// Render math in every output panel after the calculation has appended content.
+function renderAllMath() {
+    ['result', 'Summary', 'Summary1', 'GivenParameters1'].forEach(id => {
+        renderMath(document.getElementById(id));
+    });
+}
+
 document.addEventListener("DOMContentLoaded", () => {
     document.getElementById('formFoundation').addEventListener('submit',function(event){
         event.preventDefault();
-       
-        
+
+        // Validate critical combinations before running the calculator.
+        // (Isolated Rectangular without a Length Restriction makes dimension()
+        //  skip its solver, leaving B_x and B_y at 0 and cascading NaN through
+        //  every downstream check.)
+        const _structureType = document.getElementById('structureType').value;
+        const _restrictionType = document.getElementById('LengthRestriction').value;
+        if (_structureType === 'Isolated Rectangular' && (_restrictionType === '0' || _restrictionType === '')) {
+            alert(
+                'Isolated Rectangular footings need a Length Restriction.\n\n' +
+                'Pick "Ratio" (and enter the ratio L:B) or "Constricted" (and enter the constraint length).\n' +
+                'Without it the solver cannot determine both B_x and B_y.'
+            );
+            return;
+        }
 
     try {
         const resultDiv = document.getElementById("result");
@@ -1315,7 +1368,8 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     document.getElementById('saveButton').style.display = 'block';
     document.getElementById('tab').style.display = 'flex';
-    MathJax.typesetPromise(); 
+    // Render all math now that every paragraph has been appended.
+    renderAllMath();
     const saveButtonElement = document.getElementById("saveButton");
     saveButtonElement.addEventListener("click", function() {
         printDiv("Solution");

--- a/public/pages/foundationDesign.html
+++ b/public/pages/foundationDesign.html
@@ -12,14 +12,16 @@
     color: #fff;}
     </style>
     <script src="/assets/js/layout_script.js" defer></script>
-    
-    <script type="text/javascript" async
-        src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
-</script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.16.9/xlsx.full.min.js"></script>
 
-<script type="module" src="/assets/js/scriptFoundationDesign6.js" defer></script>
+    <!-- KaTeX: synchronous, deterministic math typesetting (replaces MathJax) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" crossorigin="anonymous">
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"></script>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.16.9/xlsx.full.min.js"></script>
+
+    <script type="module" src="/assets/js/scriptFoundationDesign6.js" defer></script>
     
 <style>
     canvas {
@@ -713,6 +715,38 @@ handleLoadTypeChange(); // This ensures the display is set correctly on page loa
 
     
  document.getElementById('uploadExcel').addEventListener('change', handleFile);
+
+// Shared KaTeX renderer for the Excel-upload code path (the inline script
+// below mirrors the same calculation engine and needs the same renderer).
+function renderMathHere(element) {
+    if (!element) return;
+    if (typeof renderMathInElement === 'undefined') {
+        setTimeout(() => renderMathHere(element), 80);
+        return;
+    }
+    try {
+        renderMathInElement(element, {
+            delimiters: [
+                { left: '$$', right: '$$', display: true },
+                { left: '\\[', right: '\\]', display: true },
+                { left: '\\(', right: '\\)', display: false }
+            ],
+            throwOnError: false,
+            errorColor: '#cc0000',
+            strict: false,
+            trust: true,
+            macros: {
+                "\\kN":  "\\,\\text{kN}",
+                "\\kNm": "\\,\\text{kN·m}",
+                "\\mm":  "\\,\\text{mm}",
+                "\\MPa": "\\,\\text{MPa}",
+                "\\kPa": "\\,\\text{kPa}"
+            }
+        });
+    } catch (e) {
+        console.error('KaTeX render failed:', e);
+    }
+}
 
 function handleFile(event) {
     const file = event.target.files[0];
@@ -1870,7 +1904,9 @@ function handleFile(event) {
     }
     document.getElementById('saveButton').style.display = 'block';
     document.getElementById('tab').style.display = 'flex';
-    MathJax.typesetPromise(); 
+    ['result', 'Summary', 'Summary1', 'GivenParameters1'].forEach(id => {
+        renderMathHere(document.getElementById(id));
+    });
     const saveButtonElement = document.getElementById("saveButton");
     saveButtonElement.addEventListener("click", function() {
         printDiv("Solution");


### PR DESCRIPTION
## Why this PR exists
PR #42 merged the foundation branch into main when it was at commit \`7809b2e\` — which had the *first attempt* at the form-bleed fix and the solution-display restyling. After that merge I pushed two more commits to the same branch, but PR #42 was already closed, so neither commit reached main. The deployed site on Render is still running the pre-fix version and the user is reporting that the dropdown label of row N+1 still visually overlaps the dropdown of row N, plus the Summary panel is showing raw \`\$\$\ D_c = NaNmm \$\$\` text.

This PR ships those two outstanding commits.

## Commit 1 — \`9c494cd\` Defeat global flex / min-content rules
The first form-bleed attempt used specificity-only overrides. The legacy global \`input, select { flex: 1 0 100% }\` was still winning. In a column flex container that rule makes the input's flex-basis 100% of the parent's height, so the input grew to fill the grid cell and the next row's label rendered *inside* the previous row's input. Same story for \`.latex-container { width: min-content }\` making the Summary text break one word per line.

The fix uses \`!important\` plus higher-specificity selectors:
- \`.fd-page .fd-field > * { flex: 0 0 auto !important }\` — pin every direct child to content size.
- \`.fd-page .fd-grid { align-items: start }\` + \`.fd-page .fd-field { align-self: start }\` — disable grid's default \`align-items: stretch\` so cells stop stretching to the tallest neighbour.
- Row gap bumped \`10px → 22px\`, column gap \`18px → 20px\` so even at minimum widths the label of each row clears the field above it.
- \`.fd-page #result.latex-container { display: block !important; width: 100% !important }\` and the same for \`#Summary\` / \`#Summary1\` — defeat \`width: min-content\`.
- Paragraph children get \`display: block; white-space: normal !important; overflow-wrap: break-word\` so citation text wraps naturally instead of one-word-per-line.
- \`.fd-clause\` redone as a full-width green callout block instead of an inline-block pill.

## Commit 2 — \`e51fcfa\` Replace MathJax with KaTeX + fix the NaN cascade
The user's PDF showed Summary content as raw TeX source like \`\$\$\ D_c = NaNmm \$\$\` with each word on its own line.

**Math rendering** — MathJax 3 was loaded \`async\` and the script called \`MathJax.typesetPromise()\` synchronously after appending content. Either the async load hadn't completed or the default config didn't recognize \`\$\$...\$\$\` delimiters, so MathJax never ran and the raw TeX source rendered as plain text.

Fix:
- Remove the MathJax CDN script. Add KaTeX (\`katex.min.css\` + \`katex.min.js\` + \`auto-render.min.js\` from jsDelivr). **KaTeX is synchronous** — no async race.
- New \`renderMath(element)\` helper calls \`renderMathInElement()\` with the existing \`\$\$...\$\$\` and \`\(...\)\` delimiters that every template string in the JS already uses. No template strings rewritten.
- Helper gracefully retries if KaTeX hasn't finished loading.
- Macros for \`\kN\`, \`\kNm\`, \`\mm\`, \`\MPa\`, \`\kPa\` so units render upright in \`\text{}\`.
- Replace the single \`MathJax.typesetPromise()\` call with \`renderAllMath()\` that walks \`result\` / \`Summary\` / \`Summary1\` / \`GivenParameters1\`.
- Mirror the same renderer into the Excel-upload inline script.

**NaN cascade** — the PDF showed every value as NaN. Diagnosed: user picked Isolated Rectangular with default LengthRestriction = "None" (value \`\"0\"\`). The \`if (structureType === \"Isolated Rectangular\")\` block in \`dimension()\` only branches on restrictionType \`\"1\"\` (Ratio) or \`\"2\"\` (Constricted); with \`\"0\"\` neither branch runs, so \`B_x\` and \`B_y\` stay at 0 and every downstream \`q_net = P / (B_y · B_x)\` division returns Infinity / NaN.

Fix: validation at the top of the submit handler. If structureType is Isolated Rectangular and restrictionType is None, alert the user to pick Ratio or Constricted and abort cleanly.

**CSS for KaTeX output** — new \`.fd-page .katex\` and \`.fd-page .katex-display\` rules: left-aligned display math (KaTeX defaults to centred), \`overflow-x: auto\` so wide equations scroll within their card. Inline math inside green clause callouts inherits the callout colour.

## Test plan
- [ ] Pull / wait for Render redeploy, hard-refresh.
- [ ] On Foundation Design, fill the form with Isolated Square (any concrete-class / load setup) and click Calculate. The Summary and Solution tabs render proper math — no raw \`\$\$\` text anywhere.
- [ ] Switch Foundation Type to Isolated Rectangular without picking a Restriction and click Calculate. Alert pops up with instructions, no NaN.
- [ ] Pick Ratio (e.g. 3 B_y = 2 B_x) and recalculate — Summary shows numeric values.
- [ ] In every fieldset row, the label of row N+1 clears the input of row N at all viewport widths (resize to ~480px and re-check).