### PR TITLE
Foundation Design: restore form show/hide + remaining KaTeX render gaps

### DIFF
--- a/public/assets/css/styles1.css
+++ b/public/assets/css/styles1.css
@@ -648,8 +648,12 @@ nav ul li a:hover {
     flex: 0 0 auto !important;
 }
 
+/* Note: do NOT use `display: block !important` here. The inline show/hide
+   logic toggles `style.display = "none" | "block"` on individual labels and
+   inputs, and !important CSS beats inline style. Keep display unimportant
+   so the JS toggles continue to work. */
 .fd-page .fd-field label {
-    display: block !important;
+    display: block;
     width: auto !important;
     margin: 0 0 6px !important;
     padding: 0;
@@ -660,7 +664,7 @@ nav ul li a:hover {
 
 .fd-page .fd-field input,
 .fd-page .fd-field select {
-    display: block !important;
+    display: block;
     width: 100% !important;
     height: auto;
     margin: 0 !important;
@@ -732,6 +736,15 @@ nav ul li a:hover {
     font-size: 0.85em;
     color: #6a737d;
     margin: 4px 0 0;
+}
+
+/* When the inline show/hide JS sets display:none on EVERY direct child of an
+   .fd-field, hide the wrapper too — otherwise an empty grid cell remains and
+   pushes the next visible field into the wrong slot (the original "dropdown
+   bleed" symptom). This rule was lost during a merge conflict and is being
+   restored here. */
+.fd-page .fd-field:not(:has(> *:not([style*="display: none"]))) {
+    display: none;
 }
 
 /* ============================================================

--- a/public/assets/css/styles1.css
+++ b/public/assets/css/styles1.css
@@ -1026,6 +1026,60 @@ nav ul li a:hover {
     font-size: 1em !important;
 }
 
+/* Parameter-recap container (#GivenParameters1).
+   The container has class="container2" too, and the legacy rule
+   `.container2 h8 { margin: -0.3em; margin-right: 100%; display: inline-block }`
+   was collapsing every value into a vertical sliver. Defeat all of it. */
+.fd-page #GivenParameters1.container2,
+.fd-page #GivenParameters1 {
+    background: #f6f8fa !important;
+    border: 1px solid #e1e4e8 !important;
+    border-radius: 8px !important;
+    padding: 16px 20px !important;
+    margin: 0 0 20px !important;
+    display: grid !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+    gap: 6px 24px !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    min-width: 0 !important;
+    box-sizing: border-box;
+}
+
+.fd-page #GivenParameters1 h5 {
+    grid-column: 1 / -1 !important;
+    margin: 0 0 8px !important;
+    padding: 0 0 8px !important;
+    border: none !important;
+    border-bottom: 2px solid #007BFF !important;
+    color: #0056b3 !important;
+    font-size: 1em !important;
+    background: none !important;
+    text-align: left !important;
+    counter-increment: none !important;
+}
+
+.fd-page #GivenParameters1 h5::before {
+    /* No step badge in the parameter recap. */
+    content: none !important;
+    display: none !important;
+}
+
+.fd-page #GivenParameters1 h8,
+.fd-page .container2 h8 {
+    display: block !important;
+    margin: 0 !important;
+    padding: 3px 0 !important;
+    font-size: 0.95em !important;
+    color: #1f2933 !important;
+    width: auto !important;
+    max-width: 100% !important;
+    text-align: left !important;
+    white-space: normal !important;
+    overflow-wrap: break-word;
+    line-height: 1.4;
+}
+
 .rc-page .rc-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));

--- a/public/assets/js/scriptFoundationDesign6.js
+++ b/public/assets/js/scriptFoundationDesign6.js
@@ -962,7 +962,10 @@ document.addEventListener("DOMContentLoaded", () => {
         let asmin = rhoST*dc*b;
         document.getElementById('result').appendChild(createParagraph(`$$\\ A_s = \\rho \\times B_${text} \\times d = ${rho.toFixed(6)}\\times ${b}mm \\times ${depth.toFixed(2)}mm = ${as.toFixed(2)}mm^2 \$$`));
         document.getElementById('result').appendChild(createClause(`Per NSCP 2015 §425.6.1.1 / ACI 318-14 §24.4.3.2 — shrinkage-and-temperature ratio \\(\\rho_{ST}\\): \\(0.0018\\) for Grade 414+ deformed bars, \\(0.0020\\) otherwise. Selected here based on the entered \\(f_y\\).`));
-        document.getElementById('result').appendChild(createParagraph(`$$\\ A_{s,min} = \\rho_{ST} \\times A_g = ${rhoST.toFixed(4)} \\times B_${text} \\times D_c =  ${rhoST.toFixed(4)} \\times ${b}mm \\times ${dc}mm = ${asmin.toFixed(2)}mm^2  \\, ,\\, \\rho_{ST} = ${rhoST.toFixed(4)} \\text{ (f_y ${fy >= 414 ? "\\ge" : "<"} 414\\,MPa)}\$$`));
+        // Note: keep \geq / < OUTSIDE any \text{} — math operators don't parse
+        // inside text mode in KaTeX, which was causing this line to fall back
+        // to raw markup on the deployed page.
+        document.getElementById('result').appendChild(createParagraph(`$$\\ A_{s,min} = \\rho_{ST} \\times A_g = ${rhoST.toFixed(4)} \\times B_${text} \\times D_c = ${rhoST.toFixed(4)} \\times ${b}\\,\\text{mm} \\times ${dc}\\,\\text{mm} = ${asmin.toFixed(2)}\\,\\text{mm}^2 \\quad (\\rho_{ST} = ${rhoST.toFixed(4)},\\; f_y ${fy >= 414 ? "\\geq" : "<"} 414\\,\\mathrm{MPa}) \$$`));
         document.getElementById('result').appendChild(createParagraph(`$$\\  ${as>asmin ? "A_s > A_{smin}":"A_s < A_{smin}"} \$$`));
         as = Math.max(as,asmin);
         document.getElementById('result').appendChild(createParagraph(`$$\\ \\therefore A_s = ${as.toFixed(2)}mm^2 \$$`));

--- a/public/pages/foundationDesign.html
+++ b/public/pages/foundationDesign.html
@@ -686,10 +686,39 @@ handleLoadTypeChange(); // This ensures the display is set correctly on page loa
             document.querySelectorAll('input, select').forEach(field => {
                 field.addEventListener('input', saveFieldValues);
                 field.addEventListener('change', saveFieldValues);
-             
+
             });
-    
-            
+
+            // Render KaTeX in the form labels (e.g. \(B_x\), \(P_u\), \(\gamma_c\)).
+            // Without this, labels show raw "\(B_x\) (in meters)" text because
+            // KaTeX auto-render only runs when explicitly invoked.
+            function renderFormMath() {
+                if (typeof renderMathInElement === 'undefined') {
+                    setTimeout(renderFormMath, 80);
+                    return;
+                }
+                const target = document.querySelector('.fd-page') || document.body;
+                try {
+                    renderMathInElement(target, {
+                        delimiters: [
+                            { left: '$$', right: '$$', display: true },
+                            { left: '\\[', right: '\\]', display: true },
+                            { left: '\\(', right: '\\)', display: false }
+                        ],
+                        throwOnError: false,
+                        errorColor: '#cc0000',
+                        strict: false,
+                        trust: true,
+                        // Skip elements that would break if we touched their text
+                        // nodes (the calculator's output panels handle their own
+                        // rendering after Calculate runs).
+                        ignoredClasses: ['katex', 'fd-clause']
+                    });
+                } catch (e) {
+                    console.error('KaTeX render (form) failed:', e);
+                }
+            }
+            renderFormMath();
         });
         function openTab(evt, tabName) {
         // Get all elements with class="tab-content" and hide them
@@ -1612,7 +1641,7 @@ function handleFile(event) {
             let rhoST = (fy >= 414) ? 0.0018 : 0.0020;
             let asmin = rhoST*dc*b;
             document.getElementById('result').appendChild(createParagraph(`$$\\ A_s = \\rho \\times B_${text} \\times d = ${rho.toFixed(6)}\\times ${b}mm \\times ${depth.toFixed(2)}mm = ${as.toFixed(2)}mm^2 \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ A_{s,min} = \\rho_{ST} \\times A_g = ${rhoST.toFixed(4)} \\times B_${text} \\times D_c =  ${rhoST.toFixed(4)} \\times ${b}mm \\times ${dc}mm = ${asmin.toFixed(2)}mm^2  \\, ,\\, \\rho_{ST} = ${rhoST.toFixed(4)} \\text{ (f_y ${fy >= 414 ? "\\ge" : "<"} 414\\,MPa)}\$$`));
+            document.getElementById('result').appendChild(createParagraph(`$$\\ A_{s,min} = \\rho_{ST} \\times A_g = ${rhoST.toFixed(4)} \\times B_${text} \\times D_c = ${rhoST.toFixed(4)} \\times ${b}\\,\\text{mm} \\times ${dc}\\,\\text{mm} = ${asmin.toFixed(2)}\\,\\text{mm}^2 \\quad (\\rho_{ST} = ${rhoST.toFixed(4)},\\; f_y ${fy >= 414 ? "\\geq" : "<"} 414\\,\\mathrm{MPa}) \$$`));
             document.getElementById('result').appendChild(createParagraph(`$$\\  ${as>asmin ? "A_s > A_{smin}":"A_s < A_{smin}"} \$$`));
             as = Math.max(as,asmin);
             document.getElementById('result').appendChild(createParagraph(`$$\\ \\therefore A_s = ${as.toFixed(2)}mm^2 \$$`));


### PR DESCRIPTION
PR #43 merged at \`e51fcfa\` but left two follow-up commits behind, plus the form show/hide quietly regressed. This PR ships them.

## Commit \`8515167\` — three KaTeX render gaps after the Render redeploy

**Form labels still showed raw \`\(B_x\)\` / \`\(P_u\)\` / \`\(\gamma_c\)\`**
\`renderAllMath()\` only walks the *output* panels (\`#result\`, \`#Summary\`, \`#Summary1\`, \`#GivenParameters1\`). The form area was never typeset, so every label with embedded LaTeX rendered as raw markup. Added a \`renderFormMath()\` pass on \`DOMContentLoaded\` that walks the whole \`.fd-page\` subtree once, with \`throwOnError: false\` and graceful retry if KaTeX hasn't finished loading.

**Asmin / ρ_ST equation rendered as raw red text**
The template string ended with \`\text{ (f_y \ge 414\,MPa)}\` — \`\ge\` doesn't parse inside \`\text{}\` (math commands aren't valid in text mode). Rewrote as \`\quad (\rho_{ST} = X,\; f_y \geq 414\,\mathrm{MPa})\` so the operator stays in math mode and only the unit wraps in \`\mathrm{}\`. Same fix in the inline Excel-upload duplicate.

**\"Parameters Given:\" recap collapsed to a sliver of dots**
The recap div has \`class=\"container2\"\` and the legacy \`.container2 h8 { margin: -0.3em; margin-right: 100%; display: inline-block }\` was winning over my CSS, pushing every h8 to content-only width on the far left. Hard-overrode \`#GivenParameters1.container2\` and every \`h8\` inside it (\`display: block\`, full width, sane margins, reset margin-right).

## Commit \`7cc5b88\` — restore form show/hide

The user reported that on the deployed page every conditional form field was visible: analyze-mode B_x/B_y/D_c, the Restriction selector and its Ratio/Constricted inputs, and every moment field for both centricities — even though the dropdown state should have hidden most. Two related regressions:

**\`!important\` on \`display\` defeated the inline show/hide**
In an earlier defensive pass \`.fd-page .fd-field label\` and \`.fd-page .fd-field input, .fd-page .fd-field select\` got \`display: block !important\`, meant to defeat the legacy \`label { display: inline }\` and \`input, select { display: block }\` rules. But \`!important\` CSS beats the inline \`style=\"display: none\"\` that the show/hide handlers (\`analysisMethod.change\`, \`centricity.change\`, \`loadType.change\`, \`columnShape.change\`, \`LengthRestriction.change\`) toggle on labels and inputs. Every field the JS tried to hide was being force-shown by my CSS. Dropped the \`!important\` — my rule still wins over the legacy ones by specificity (0,2,1 vs 0,0,1), and the JS's inline style now wins over my CSS as it should.

**The \`:has()\` wrapper-hide rule was lost during a merge resolution**
\`.fd-page .fd-field:not(:has(> *:not([style*=\"display: none\"]))) { display: none }\` was originally added in commit \`cd183f6\` to hide the EMPTY \`.fd-field\` wrapper when both its label and input are hidden inline. Without it, hidden fields leave empty grid cells that push neighbours into wrong slots — that's the original \"dropdown bleed\" symptom. The rule went missing in the rebase chain that followed PR #41/#42. Re-added with a comment explaining its purpose so it doesn't get dropped again.

## Test plan
- [ ] Hard refresh (\`Ctrl+F5\`) after Render redeploys.
- [ ] Foundation Design page: every form label renders proper math (\`B_x\`, \`P_u\`, \`\gamma_c\` etc.), no raw \`\(...\)\`.
- [ ] **Detailed Design** mode: B_x / B_y / D_c inputs absent. **Analyze** mode: they appear.
- [ ] **Isolated Square**: Restriction selector absent. **Isolated Rectangular**: Restriction appears, then Ratio inputs (or Constriction input) appear based on the choice.
- [ ] **Concentric**: every M_x / M_y / M_ux / M_uy / M_{x,DL} / M_{x,LL} input absent. **Eccentric**: they appear.
- [ ] **Circular** column: Width X / Width Y absent, label shows \"Column Diameter\".
- [ ] Click Calculate on a valid Isolated Square setup: Summary tab shows proper math (no raw \`\$\$\\\` text), the A_smin clause renders with \`f_y \geq 414 MPa\` in proper math, the Parameters Given recap is a two-column block of readable values (not a column of dots).