### PR TITLE
Port Streamlit beam calculator to beamDesign.html

### DIFF
--- a/public/pages/beamDesign.html
+++ b/public/pages/beamDesign.html
@@ -5,25 +5,1248 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Beam Design</title>
     <link rel="stylesheet" href="/assets/css/styles1.css">
+
+    <!-- KaTeX for math typesetting -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" crossorigin="anonymous">
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"></script>
+
+    <style>
+        /* Beam Design scoped layout — disables the rigid .container grid
+           and adopts the same card / grid pattern as foundationDesign. */
+        .container.bd-page {
+            display: block;
+            width: 100%;
+            max-width: 1180px;
+            margin: 1.5em auto;
+            padding: 24px 28px 32px;
+            grid-template-rows: none;
+            grid-template-columns: none;
+        }
+        .bd-page h1 {
+            text-align: center;
+            margin: 0 0 16px;
+            font-size: 1.9em;
+            color: #1f2933;
+        }
+        .bd-page .bd-subtitle {
+            text-align: center;
+            margin: 0 0 24px;
+            color: #5c6773;
+            font-size: 0.95em;
+        }
+        .bd-page .bd-tabs {
+            display: flex;
+            gap: 4px;
+            margin: 0 0 18px;
+            border-bottom: 2px solid #d6d9de;
+        }
+        .bd-page .bd-tab {
+            padding: 10px 20px;
+            background: transparent;
+            border: none;
+            border-bottom: 3px solid transparent;
+            color: #5c6773;
+            font-weight: 600;
+            font-size: 0.95em;
+            cursor: pointer;
+            transition: all 0.18s ease;
+            border-radius: 4px 4px 0 0;
+        }
+        .bd-page .bd-tab:hover {
+            background: #f6f8fa;
+            color: #0056b3;
+        }
+        .bd-page .bd-tab.is-active {
+            color: #0056b3;
+            border-bottom-color: #0056b3;
+            background: #f6f8fa;
+        }
+        .bd-page .bd-panel { display: none; }
+        .bd-page .bd-panel.is-active { display: block; }
+
+        .bd-page .bd-section {
+            background: #fff;
+            border: 1px solid #d6d9de;
+            border-radius: 8px;
+            padding: 16px 20px 18px;
+            margin: 0 0 18px;
+            box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+        }
+        .bd-page .bd-section-title {
+            font-weight: 700;
+            color: #0056b3;
+            font-size: 1.05em;
+            margin: 0 0 12px;
+            padding-bottom: 8px;
+            border-bottom: 1px solid #e1e4e8;
+        }
+        .bd-page .bd-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 14px 18px;
+            align-items: start;
+        }
+        .bd-page .bd-field {
+            display: flex;
+            flex-direction: column;
+            min-width: 0;
+        }
+        .bd-page .bd-field label {
+            display: block;
+            width: auto;
+            margin: 0 0 4px;
+            font-size: 0.85em;
+            color: #2c3e50;
+            line-height: 1.3;
+        }
+        .bd-page .bd-field input,
+        .bd-page .bd-field select {
+            display: block;
+            width: 100%;
+            margin: 0;
+            padding: 8px 10px;
+            box-sizing: border-box;
+            border: 1px solid #c5c9d0;
+            border-radius: 4px;
+            background: #fff;
+            font-size: 0.92em;
+        }
+        .bd-page .bd-field input:focus,
+        .bd-page .bd-field select:focus {
+            outline: none;
+            border-color: #007BFF;
+            box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.15);
+        }
+
+        .bd-page .bd-add-row {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+            margin: 0 0 12px;
+        }
+        .bd-page .bd-add-btn {
+            flex: 1 1 120px;
+            padding: 10px 12px;
+            background: #fff;
+            border: 1px dashed #007BFF;
+            border-radius: 6px;
+            color: #0056b3;
+            font-weight: 600;
+            font-size: 0.9em;
+            cursor: pointer;
+            transition: all 0.18s ease;
+            width: auto;
+            margin: 0;
+        }
+        .bd-page .bd-add-btn:hover {
+            background: #f0f6ff;
+            border-style: solid;
+            transform: none;
+        }
+
+        .bd-page .bd-load-card {
+            background: #fafbfc;
+            border: 1px solid #e1e4e8;
+            border-radius: 6px;
+            padding: 12px 14px;
+            margin: 0 0 10px;
+        }
+        .bd-page .bd-load-card-head {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin: 0 0 10px;
+        }
+        .bd-page .bd-load-type {
+            font-weight: 600;
+            color: #1f2933;
+            font-size: 0.95em;
+        }
+        .bd-page .bd-remove-btn {
+            padding: 4px 10px;
+            background: #fff;
+            border: 1px solid #d6d9de;
+            border-radius: 4px;
+            color: #993C1D;
+            font-size: 0.8em;
+            cursor: pointer;
+            width: auto;
+            margin: 0;
+        }
+        .bd-page .bd-remove-btn:hover {
+            background: #fef0ed;
+            border-color: #993C1D;
+            transform: none;
+        }
+        .bd-page .bd-empty {
+            text-align: center;
+            color: #5c6773;
+            padding: 24px;
+            font-style: italic;
+            font-size: 0.9em;
+        }
+
+        .bd-page .bd-calc-btn {
+            display: block;
+            width: 240px;
+            margin: 16px auto 8px;
+            padding: 12px;
+            background: #007BFF;
+            color: #fff;
+            border: none;
+            border-radius: 6px;
+            font-weight: 700;
+            font-size: 1em;
+            cursor: pointer;
+        }
+        .bd-page .bd-calc-btn:hover {
+            background: #0056b3;
+            transform: translateY(-1px);
+        }
+
+        .bd-page .bd-results-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 14px;
+        }
+        .bd-page .bd-metric {
+            background: #f6f8fa;
+            border: 1px solid #e1e4e8;
+            border-radius: 6px;
+            padding: 12px 16px;
+            text-align: left;
+        }
+        .bd-page .bd-metric-label {
+            font-size: 0.78em;
+            color: #5c6773;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            margin: 0 0 4px;
+        }
+        .bd-page .bd-metric-value {
+            font-size: 1.3em;
+            font-weight: 700;
+            color: #0056b3;
+        }
+
+        .bd-page .bd-diagram {
+            background: #fff;
+            border: 1px solid #e1e4e8;
+            border-radius: 6px;
+            padding: 8px;
+            margin: 12px 0 0;
+        }
+        .bd-page .bd-diagram svg {
+            width: 100%;
+            height: auto;
+            display: block;
+        }
+        .bd-page .bd-diagram-title {
+            font-weight: 600;
+            color: #2c3e50;
+            margin: 0 0 6px;
+            font-size: 0.95em;
+        }
+
+        .bd-page .bd-calc-row {
+            display: flex;
+            font-size: 0.88em;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace;
+            border-bottom: 1px solid #f1f3f5;
+            padding: 4px 0;
+        }
+        .bd-page .bd-calc-row:last-child { border-bottom: none; }
+        .bd-page .bd-calc-row .bd-calc-label {
+            flex: 0 0 260px;
+            color: #495057;
+        }
+        .bd-page .bd-calc-row .bd-calc-value {
+            flex: 1;
+            font-weight: 500;
+            color: #1f2933;
+        }
+        .bd-page .bd-calc-row .bd-calc-note {
+            color: #6c757d;
+            font-size: 0.82em;
+            margin-left: 8px;
+        }
+        .bd-page .bd-calc-value.ok { color: #0F6E56; }
+        .bd-page .bd-calc-value.fail { color: #993C1D; }
+
+        .bd-page .bd-alert {
+            padding: 10px 14px;
+            border-radius: 6px;
+            margin: 12px 0;
+            font-size: 0.92em;
+        }
+        .bd-page .bd-alert-ok {
+            background: #e8f9f1;
+            border: 1px solid #b3e0c9;
+            color: #0F6E56;
+        }
+        .bd-page .bd-alert-fail {
+            background: #fef0ed;
+            border: 1px solid #f0c0b3;
+            color: #993C1D;
+        }
+        .bd-page .bd-alert-info {
+            background: #e7f3ff;
+            border: 1px solid #b3d4f0;
+            color: #0056b3;
+        }
+        .bd-page .bd-alert-warn {
+            background: #fff7e6;
+            border: 1px solid #f0d9a3;
+            color: #b07700;
+        }
+
+        .bd-page .bd-combo-table {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace;
+            font-size: 0.85em;
+        }
+        .bd-page .bd-combo-row {
+            display: flex;
+            padding: 4px 10px;
+            margin: 2px 0;
+            border-radius: 4px;
+        }
+        .bd-page .bd-combo-row.is-gov {
+            background: #e8f9f1;
+            color: #0F6E56;
+            font-weight: 600;
+        }
+        .bd-page .bd-combo-name {
+            flex: 1;
+            color: #495057;
+        }
+        .bd-page .bd-combo-row.is-gov .bd-combo-name { color: #0F6E56; }
+
+        .bd-page details.bd-expander {
+            margin: 0 0 16px;
+            border: 1px solid #e1e4e8;
+            border-radius: 6px;
+            background: #fff;
+        }
+        .bd-page details.bd-expander summary {
+            padding: 10px 16px;
+            cursor: pointer;
+            font-weight: 600;
+            color: #0056b3;
+            list-style: none;
+            user-select: none;
+        }
+        .bd-page details.bd-expander summary::-webkit-details-marker { display: none; }
+        .bd-page details.bd-expander summary::before {
+            content: '▸';
+            display: inline-block;
+            margin-right: 8px;
+            transition: transform 0.18s ease;
+        }
+        .bd-page details.bd-expander[open] summary::before {
+            transform: rotate(90deg);
+        }
+        .bd-page details.bd-expander > div {
+            padding: 0 16px 14px;
+        }
+
+        .bd-page .bd-hint {
+            font-size: 0.8em;
+            color: #6a737d;
+            margin: 4px 0 0;
+            font-style: italic;
+        }
+
+        @media (max-width: 540px) {
+            .container.bd-page { padding: 16px 14px 24px; }
+            .bd-page .bd-grid { grid-template-columns: 1fr; }
+        }
+    </style>
 </head>
 <body>
     <nav>
         <ul>
+            <li><a href="index.html">HOME</a></li>
             <li><a href="QuantitySurveying.html">QUANTITY SURVEYING</a></li>
             <li><a href="ReinforcedConcrete.html">REINFORCED CONCRETE</a></li>
             <li><a href="#">STEEL DESIGN</a></li>
         </ul>
     </nav>
 
-    <div class="container1">
-        <div class="container">
-            <h1 class="title1">Beam Design</h1>
-            <p class="mid1">This Reinforced Concrete sub-page is now available and wired correctly.</p>
-            <p class="mid1">Use Foundation Design for the complete calculation workflow.</p>
-            <div class="mid2">
-                <a href="foundationDesign.html">Go to Foundation Design</a>
-            </div>
+    <div class="container bd-page">
+        <h1>Beam Design</h1>
+        <p class="bd-subtitle">
+            Simply-supported beam analysis with NSCP 2015 reinforced concrete section design
+            (flexure &amp; shear). Units: kN, m, MPa.
+        </p>
+
+        <div class="bd-tabs" role="tablist">
+            <button class="bd-tab is-active" data-tab="analysis" type="button">Beam Analysis</button>
+            <button class="bd-tab" data-tab="rc" type="button">RC Section Design</button>
         </div>
+
+        <!-- ═══════════════════════════ TAB 1 — BEAM ANALYSIS ═══════════════════════════ -->
+        <section class="bd-panel is-active" data-panel="analysis">
+
+            <div class="bd-section">
+                <div class="bd-section-title">Beam Properties</div>
+                <div class="bd-grid">
+                    <div class="bd-field">
+                        <label for="ba-L">Span \(L\) (m)</label>
+                        <input type="number" id="ba-L" value="6" step="0.1" min="0.5" inputmode="decimal">
+                    </div>
+                    <div class="bd-field">
+                        <label for="ba-E">Modulus \(E\) (MPa)</label>
+                        <input type="number" id="ba-E" value="25000" step="500" min="1" inputmode="decimal">
+                        <p class="bd-hint">RC ≈ 4700·√f'c; steel ≈ 200000</p>
+                    </div>
+                    <div class="bd-field">
+                        <label for="ba-I">Inertia \(I\) (mm\(^4\))</label>
+                        <input type="number" id="ba-I" value="3.125e9" step="1e7" min="1" inputmode="decimal">
+                        <p class="bd-hint">Rectangular: b·h³/12</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="bd-section">
+                <div class="bd-section-title">Applied Loads</div>
+                <div class="bd-add-row">
+                    <button type="button" class="bd-add-btn" data-add="point">+ Point Load</button>
+                    <button type="button" class="bd-add-btn" data-add="udl">+ UDL</button>
+                    <button type="button" class="bd-add-btn" data-add="vdl">+ VDL (Trapezoidal)</button>
+                    <button type="button" class="bd-add-btn" data-add="moment">+ Moment</button>
+                </div>
+                <div id="ba-loads-list">
+                    <div class="bd-empty">No loads added yet — click a button above to add one.</div>
+                </div>
+            </div>
+
+            <button type="button" class="bd-calc-btn" id="ba-calc-btn">Analyze Beam</button>
+
+            <section id="ba-results" style="display:none;">
+                <div class="bd-section">
+                    <div class="bd-section-title">Support Reactions</div>
+                    <div class="bd-results-grid" id="ba-reactions"></div>
+                </div>
+
+                <div class="bd-section">
+                    <div class="bd-section-title">Summary</div>
+                    <div class="bd-results-grid" id="ba-summary"></div>
+                    <div id="ba-deflection-check"></div>
+                </div>
+
+                <div class="bd-section">
+                    <div class="bd-section-title">Shear Force Diagram (SFD)</div>
+                    <div class="bd-diagram" id="ba-sfd"></div>
+                </div>
+
+                <div class="bd-section">
+                    <div class="bd-section-title">Bending Moment Diagram (BMD)</div>
+                    <div class="bd-diagram" id="ba-bmd"></div>
+                </div>
+
+                <div class="bd-section">
+                    <div class="bd-section-title">Deflection Diagram</div>
+                    <div class="bd-diagram" id="ba-defl"></div>
+                </div>
+            </section>
+        </section>
+
+        <!-- ═══════════════════════════ TAB 2 — RC SECTION DESIGN ═══════════════════════════ -->
+        <section class="bd-panel" data-panel="rc">
+
+            <div class="bd-section">
+                <div class="bd-section-title">Source of Demands</div>
+                <div class="bd-grid">
+                    <div class="bd-field">
+                        <label for="rc-source">Use values from</label>
+                        <select id="rc-source">
+                            <option value="analysis">Beam Analysis (max |V|, |M|)</option>
+                            <option value="manual" selected>Manual entry</option>
+                        </select>
+                    </div>
+                    <div class="bd-field">
+                        <label for="rc-Mu">\(M_u\) (kN·m)</label>
+                        <input type="number" id="rc-Mu" value="150" step="1" inputmode="decimal">
+                    </div>
+                    <div class="bd-field">
+                        <label for="rc-Vu">\(V_u\) (kN)</label>
+                        <input type="number" id="rc-Vu" value="100" step="1" inputmode="decimal">
+                    </div>
+                </div>
+            </div>
+
+            <div class="bd-section">
+                <div class="bd-section-title">Section &amp; Material</div>
+                <div class="bd-grid">
+                    <div class="bd-field">
+                        <label for="rc-b">\(b\) (mm)</label>
+                        <input type="number" id="rc-b" value="300" step="25" min="100" inputmode="decimal">
+                    </div>
+                    <div class="bd-field">
+                        <label for="rc-h">\(h\) (mm)</label>
+                        <input type="number" id="rc-h" value="500" step="25" min="150" inputmode="decimal">
+                    </div>
+                    <div class="bd-field">
+                        <label for="rc-fc">\(f'_c\) (MPa)</label>
+                        <input type="number" id="rc-fc" value="28" step="1" min="17" inputmode="decimal">
+                    </div>
+                    <div class="bd-field">
+                        <label for="rc-fyl">\(f_y\) longitudinal (MPa)</label>
+                        <input type="number" id="rc-fyl" value="415" step="5" min="200" inputmode="decimal">
+                    </div>
+                    <div class="bd-field">
+                        <label for="rc-fyt">\(f_y\) transverse (MPa)</label>
+                        <input type="number" id="rc-fyt" value="275" step="5" min="200" inputmode="decimal">
+                    </div>
+                    <div class="bd-field">
+                        <label for="rc-db">Main bar \(\varnothing\) (mm)</label>
+                        <input type="number" id="rc-db" value="20" step="2" min="10" inputmode="decimal">
+                    </div>
+                    <div class="bd-field">
+                        <label for="rc-ds">Stirrup \(\varnothing\) (mm)</label>
+                        <input type="number" id="rc-ds" value="10" step="2" min="8" inputmode="decimal">
+                    </div>
+                    <div class="bd-field">
+                        <label for="rc-cover">Cover \(C_c\) (mm)</label>
+                        <input type="number" id="rc-cover" value="40" step="5" min="20" inputmode="decimal">
+                    </div>
+                    <div class="bd-field">
+                        <label for="rc-legs">Stirrup legs</label>
+                        <input type="number" id="rc-legs" value="2" step="1" min="2" max="6" inputmode="numeric">
+                    </div>
+                    <div class="bd-field">
+                        <label for="rc-lambda">\(\lambda\) (concrete weight)</label>
+                        <select id="rc-lambda">
+                            <option value="1.0" selected>1.0 — Normal weight</option>
+                            <option value="0.85">0.85 — Sand-lightweight</option>
+                            <option value="0.75">0.75 — All-lightweight</option>
+                        </select>
+                    </div>
+                </div>
+            </div>
+
+            <details class="bd-expander">
+                <summary>NSCP 2015 Load Combinations (Section 203.3.1)</summary>
+                <div>
+                    <p class="bd-hint">
+                        Enter unfactored service loads (any unit — kN, kN·m, kPa, etc.) to see all
+                        NSCP combinations. The governing combination is highlighted.
+                    </p>
+                    <div class="bd-grid">
+                        <div class="bd-field"><label for="lc-D">D — Dead</label><input type="number" id="lc-D" value="0" step="1" inputmode="decimal"></div>
+                        <div class="bd-field"><label for="lc-L">L — Live</label><input type="number" id="lc-L" value="0" step="1" inputmode="decimal"></div>
+                        <div class="bd-field"><label for="lc-Lr">Lr — Roof Live</label><input type="number" id="lc-Lr" value="0" step="1" inputmode="decimal"></div>
+                        <div class="bd-field"><label for="lc-S">S — Snow</label><input type="number" id="lc-S" value="0" step="1" inputmode="decimal"></div>
+                        <div class="bd-field"><label for="lc-W">W — Wind</label><input type="number" id="lc-W" value="0" step="1" inputmode="decimal"></div>
+                        <div class="bd-field"><label for="lc-E">E — Earthquake</label><input type="number" id="lc-E" value="0" step="1" inputmode="decimal"></div>
+                        <div class="bd-field"><label for="lc-R">R — Rain</label><input type="number" id="lc-R" value="0" step="1" inputmode="decimal"></div>
+                    </div>
+                    <div class="bd-combo-table" id="lc-output" style="margin-top:12px;"></div>
+                </div>
+            </details>
+
+            <button type="button" class="bd-calc-btn" id="rc-calc-btn">Design Section</button>
+
+            <section id="rc-results" style="display:none;">
+                <div class="bd-section">
+                    <div class="bd-section-title">Flexure Design <span style="font-weight:400;font-size:0.85em;color:#5c6773;">— NSCP 2015 §406</span></div>
+                    <div id="rc-flexure"></div>
+                </div>
+
+                <div class="bd-section">
+                    <div class="bd-section-title">Shear Design <span style="font-weight:400;font-size:0.85em;color:#5c6773;">— NSCP 2015 §422</span></div>
+                    <div id="rc-shear"></div>
+                </div>
+            </section>
+        </section>
     </div>
+
+    <!-- ═══════════════════════════════════════════════════════════════════════════════
+         CALCULATION SCRIPTS
+         Ported from C:\Users\raymv\Documents\Structure (Streamlit beam calculator)
+         - calculations/beam.py    -> reactionsSS, shearMomentAt, diagramsSS, deflectionSS
+         - calculations/loads.py   -> nscpLoadCombinations
+         - rc_design.py            -> beta1, rhoBalanced/Min/Max, designFlexure, designShear
+         ═══════════════════════════════════════════════════════════════════════════════ -->
+    <script>
+    'use strict';
+
+    // ─── KaTeX render helper ──────────────────────────────────────────────
+    function renderMath(element) {
+        if (!element) return;
+        if (typeof renderMathInElement === 'undefined') {
+            setTimeout(() => renderMath(element), 80);
+            return;
+        }
+        try {
+            renderMathInElement(element, {
+                delimiters: [
+                    { left: '$$', right: '$$', display: true },
+                    { left: '\\[', right: '\\]', display: true },
+                    { left: '\\(', right: '\\)', display: false }
+                ],
+                throwOnError: false,
+                strict: false,
+                trust: true,
+                ignoredClasses: ['katex']
+            });
+        } catch (e) { console.error('KaTeX render failed:', e); }
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    //  BEAM ANALYSIS  (port of calculations/beam.py)
+    //  Sign convention: forces upward+, sagging moment+, CCW couple+
+    // ════════════════════════════════════════════════════════════════════════
+
+    function loadResultant(ld) {
+        // Returns {W, xc}: total downward force and its centroid.
+        if (ld.type === 'point') return { W: ld.P, xc: ld.x };
+        if (ld.type === 'udl')   return { W: ld.w * (ld.x2 - ld.x1), xc: (ld.x1 + ld.x2) / 2 };
+        if (ld.type === 'vdl') {
+            const t  = ld.x2 - ld.x1;
+            const W  = ld.w1 * t + (ld.w2 - ld.w1) * t / 2;
+            if (Math.abs(W) < 1e-12) return { W: 0, xc: ld.x1 };
+            const num = ld.w1 * t * t / 2 + (ld.w2 - ld.w1) * t * t / 3;
+            return { W, xc: ld.x1 + num / W };
+        }
+        return { W: 0, xc: 0 };  // moment loads have no net vertical force
+    }
+
+    function reactionsSS(L, loads) {
+        // ΣM_A = 0  (CW+):  -Rb·L + Σ(Wi·xi) − Σ(Mj) = 0
+        // ΣFy   = 0      :  Ra + Rb = Σ Wi
+        let sumW = 0, sumMx = 0, sumMc = 0;
+        for (const ld of loads) {
+            if (ld.type === 'moment') {
+                sumMc += ld.M;
+            } else {
+                const { W, xc } = loadResultant(ld);
+                sumW  += W;
+                sumMx += W * xc;
+            }
+        }
+        const Rb = (sumMx - sumMc) / L;
+        const Ra = sumW - Rb;
+        return { Ra, Rb };
+    }
+
+    function shearMomentAt(x, Ra, loads) {
+        // Left-side free-body: sum contributions of loads with their action
+        // point at or to the LEFT of section x.
+        let v = Ra;
+        let m = Ra * x;
+        for (const ld of loads) {
+            if (ld.type === 'point') {
+                if (ld.x <= x) { v -= ld.P; m -= ld.P * (x - ld.x); }
+            } else if (ld.type === 'udl' || ld.type === 'vdl') {
+                if (ld.x1 < x) {
+                    const xEnd = Math.min(x, ld.x2);
+                    const seg  = xEnd - ld.x1;
+                    let W, xc;
+                    if (ld.type === 'udl') {
+                        W  = ld.w * seg;
+                        xc = ld.x1 + seg / 2;
+                    } else {
+                        const t = seg;
+                        W  = ld.w1 * t + (ld.w2 - ld.w1) * t / 2;
+                        const num = ld.w1 * t * t / 2 + (ld.w2 - ld.w1) * t * t / 3;
+                        xc = ld.x1 + (Math.abs(W) > 1e-12 ? num / W : t / 2);
+                    }
+                    v -= W;
+                    m -= W * (x - xc);
+                }
+            } else if (ld.type === 'moment') {
+                if (ld.x <= x) m += ld.M;
+            }
+        }
+        return { V: v, M: m };
+    }
+
+    function diagramsSS(L, loads, nPoints = 400) {
+        const { Ra, Rb } = reactionsSS(L, loads);
+        // Build x-array that includes discontinuity points
+        const xsSet = new Set();
+        for (let i = 0; i <= nPoints; i++) xsSet.add((i * L) / nPoints);
+        for (const ld of loads) {
+            ['x', 'x1', 'x2'].forEach(k => {
+                if (ld[k] !== undefined) xsSet.add(Number(ld[k]));
+            });
+        }
+        const xs = [...xsSet].filter(x => x >= 0 && x <= L).sort((a, b) => a - b);
+        const V  = xs.map(x => shearMomentAt(x, Ra, loads).V);
+        const M  = xs.map(x => shearMomentAt(x, Ra, loads).M);
+        const Vmax = Math.max(...V.map(Math.abs));
+        const Mmax = Math.max(...M.map(Math.abs));
+        return { Ra, Rb, xs, V, M, Vmax, Mmax };
+    }
+
+    function deflectionSS(L, xs, M, E_MPa, I_mm4) {
+        // Double-integrate M(x)/EI with end conditions δ(0) = δ(L) = 0.
+        // Units: M in kN·m = 1e6 N·mm; E in MPa = N/mm²; I in mm⁴ -> EI in N·mm².
+        // Convert x to mm to keep δ in mm.
+        const EI = E_MPa * I_mm4;          // N·mm²
+        if (EI <= 0) return xs.map(() => 0);
+        const n = xs.length;
+        const xMm = xs.map(x => x * 1000); // mm
+        const Mn  = M.map(m => m * 1e6);   // N·mm
+        // Cumulative trapezoidal integration of (M/EI) -> slope
+        const slope_unc = new Array(n).fill(0);
+        for (let i = 1; i < n; i++) {
+            const dx = xMm[i] - xMm[i - 1];
+            slope_unc[i] = slope_unc[i - 1] + 0.5 * (Mn[i] + Mn[i - 1]) / EI * dx;
+        }
+        // Integrate slope to get unc. deflection
+        const defl_unc = new Array(n).fill(0);
+        for (let i = 1; i < n; i++) {
+            const dx = xMm[i] - xMm[i - 1];
+            defl_unc[i] = defl_unc[i - 1] + 0.5 * (slope_unc[i] + slope_unc[i - 1]) * dx;
+        }
+        // Enforce δ(L) = 0 by subtracting a linear ramp
+        const Llocal = xMm[n - 1];
+        const slopeCorr = defl_unc[n - 1] / Llocal;
+        return defl_unc.map((d, i) => d - slopeCorr * xMm[i]);  // mm
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    //  RC SECTION DESIGN  (port of rc_design.py, NSCP 2015 / ACI 318-14)
+    // ════════════════════════════════════════════════════════════════════════
+
+    function beta1(fc) {
+        return fc > 28 ? Math.max(0.65, 0.85 - 0.05 * (fc - 28) / 7) : 0.85;
+    }
+
+    function rhoBalanced(fc, fy) {
+        return (0.85 * beta1(fc) * fc / fy) * (600 / (600 + fy));
+    }
+
+    function rhoMax(fc, fy) { return 0.75 * rhoBalanced(fc, fy); }
+
+    function rhoMin(fc, fy) {
+        return Math.max(Math.sqrt(fc) / (4 * fy), 1.4 / fy);
+    }
+
+    function effDepth(h, cover, ds, db) {
+        return h - cover - ds - db / 2;
+    }
+
+    function designFlexure(Mu_kNm, b, h, fc, fy, db, ds, cover) {
+        const d = effDepth(h, cover, ds, db);
+        if (d <= 0) return { error: 'Effective depth ≤ 0 — check section dimensions and cover.' };
+
+        const phi    = 0.90;
+        const Mu_Nmm = Math.abs(Mu_kNm) * 1e6;
+        const b1     = beta1(fc);
+        const rb     = rhoBalanced(fc, fy);
+        const r_max  = rhoMax(fc, fy);
+        const r_min  = rhoMin(fc, fy);
+        const Ab     = Math.PI / 4 * db * db;
+
+        const Rn   = Mu_Nmm / (phi * b * d * d);
+        const disc = 1 - (2 * Rn) / (0.85 * fc);
+        if (disc < 0) {
+            return {
+                error: `Section is too small — Rn = ${Rn.toFixed(2)} MPa exceeds capacity. Increase b or h.`,
+                d, Rn
+            };
+        }
+        const rho_calc = (0.85 * fc / fy) * (1 - Math.sqrt(disc));
+
+        let rho_use, checks = [];
+        if (rho_calc < r_min) {
+            checks.push(`ρ_calc = ${rho_calc.toFixed(5)} < ρ_min = ${r_min.toFixed(5)} → use ρ_min`);
+            rho_use = r_min;
+        } else if (rho_calc > r_max) {
+            checks.push(`ρ_calc = ${rho_calc.toFixed(5)} > ρ_max = ${r_max.toFixed(5)} → over-reinforced`);
+            checks.push('⚠ Increase beam section. Results below are indicative.');
+            rho_use = r_max;
+        } else {
+            checks.push('ρ_min ≤ ρ_calc ≤ ρ_max  ✓');
+            rho_use = rho_calc;
+        }
+
+        const As_req  = rho_use * b * d;
+        const n_bars  = Math.ceil(As_req / Ab);
+        const As_prov = n_bars * Ab;
+        const a       = As_prov * fy / (0.85 * fc * b);
+        const phi_Mn  = phi * As_prov * fy * (d - a / 2) / 1e6;
+        const cap_ok  = phi_Mn >= Math.abs(Mu_kNm);
+
+        return {
+            d, b, h, cover, fc, fy, db, Ab, beta1: b1,
+            rho_b: rb, rho_max: r_max, rho_min: r_min,
+            phi_flex: phi, Mu_kNm: Math.abs(Mu_kNm), Rn,
+            rho_calc, rho_use, checks,
+            As_req, n_bars, As_prov, a,
+            phi_Mn_kNm: phi_Mn, capacity_ok: cap_ok,
+            over_reinforced: rho_calc > r_max
+        };
+    }
+
+    function roundSpacing(s) {
+        return Math.max(25, Math.floor(s / 25) * 25);
+    }
+
+    function designShear(Vu_kN, b, h, fc, fy_t, ds, db, cover, lam, legs) {
+        const d   = effDepth(h, cover, ds, db);
+        const phi = 0.75;
+        const Vu  = Math.abs(Vu_kN);
+        fy_t = Math.min(fy_t, 420);   // NSCP 2015 §422.5.10.2 cap
+
+        const Vc_N  = 0.17 * lam * Math.sqrt(fc) * b * d;
+        const Vc_kN = Vc_N / 1e3;
+        const phiVc = phi * Vc_kN;
+
+        const Av  = legs * (Math.PI / 4 * ds * ds);
+        const need_min = Vu > phiVc / 2;
+        const need_des = Vu > phiVc;
+
+        const Avs_min = Math.max(0.062 * Math.sqrt(fc) * b / fy_t, 0.35 * b / fy_t);
+        const Vs_lim1 = 0.33 * Math.sqrt(fc) * b * d / 1e3;
+        const Vs_lim2 = 0.66 * Math.sqrt(fc) * b * d / 1e3;
+
+        const base = { d, phi_shear: phi, Vu_kN: Vu, Vc_kN, phiVc, Av_mm2: Av, legs, ds,
+                       Avs_min, Vs_lim1, Vs_lim2, need_min, need_des, fc, fy_t, lam };
+
+        if (!need_min) {
+            return { ...base, mode: 'none', Vs_kN: 0, s_final: null,
+                     note: 'Vu ≤ φVc/2 — stirrups not required by analysis, but provide minimum per good practice.' };
+        }
+        if (!need_des) {
+            const s_from_min = Av / Avs_min;
+            const s_max_spac = roundSpacing(Math.min(d / 2, 600));
+            const s_final    = roundSpacing(Math.min(s_from_min, s_max_spac));
+            return { ...base, mode: 'minimum', Vs_kN: 0,
+                     s_from_min, s_max_spac, s_final,
+                     note: 'φVc/2 < Vu ≤ φVc — minimum stirrups required (NSCP 2015 §409.6.3.1).' };
+        }
+        const Vs_kN = Vu / phi - Vc_kN;
+        if (Vs_kN > Vs_lim2) {
+            return { ...base, mode: 'overloaded', Vs_kN,
+                     error: `Vs = ${Vs_kN.toFixed(2)} kN exceeds Vs_max = ${Vs_lim2.toFixed(2)} kN (0.66√f'c·b·d). Increase beam section.` };
+        }
+        const s_calc = Av * fy_t * d / (Vs_kN * 1e3);
+        let s_max_spac, spac_note;
+        if (Vs_kN <= Vs_lim1) {
+            s_max_spac = roundSpacing(Math.min(d / 2, 600));
+            spac_note  = "Vs ≤ 0.33√f'c·b·d  →  s_max = min(d/2, 600 mm)";
+        } else {
+            s_max_spac = roundSpacing(Math.min(d / 4, 300));
+            spac_note  = "Vs > 0.33√f'c·b·d  →  s_max = min(d/4, 300 mm)";
+        }
+        const s_from_min = Av / Avs_min;
+        let s_final = roundSpacing(Math.min(s_calc, s_max_spac, s_from_min));
+        s_final = Math.max(s_final, 50);
+        const Vs_prov_kN = Av * fy_t * d / (s_final * 1e3);
+        const Vn_prov_kN = Vc_kN + Vs_prov_kN;
+        const phiVn_kN   = phi * Vn_prov_kN;
+        return { ...base, mode: 'designed', Vs_kN, s_calc, s_max_spac, s_from_min, s_final,
+                 spac_note, Vs_prov_kN, Vn_prov_kN, phiVn_kN, capacity_ok: phiVn_kN >= Vu };
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    //  NSCP 2015 LOAD COMBINATIONS  (port of calculations/loads.py)
+    // ════════════════════════════════════════════════════════════════════════
+
+    function nscpLoadCombinations({ D = 0, L = 0, Lr = 0, S = 0, W = 0, E = 0, R = 0 }) {
+        const combos = {
+            '1.4D':                              1.4 * D,
+            '1.2D + 1.6L + 0.5(Lr|S|R)':        1.2 * D + 1.6 * L + 0.5 * Math.max(Lr, S, R),
+            '1.2D + 1.6(Lr|S|R) + (L|0.5W)':    1.2 * D + 1.6 * Math.max(Lr, S, R) + Math.max(L, 0.5 * W),
+            '1.2D + 1.0W + L + 0.5(Lr|S|R)':    1.2 * D + 1.0 * W + L + 0.5 * Math.max(Lr, S, R),
+            '0.9D + 1.0W':                       0.9 * D + 1.0 * W,
+            '1.2D + 1.0E + L + 0.2S':           1.2 * D + 1.0 * E + L + 0.2 * S,
+            '0.9D + 1.0E':                       0.9 * D + 1.0 * E
+        };
+        let govName = null, govVal = -Infinity;
+        for (const [n, v] of Object.entries(combos)) {
+            if (v > govVal) { govVal = v; govName = n; }
+        }
+        return { combos, govName, govVal };
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    //  SVG DIAGRAMS
+    // ════════════════════════════════════════════════════════════════════════
+
+    function drawDiagram(container, xs, ys, opts = {}) {
+        const { color = '#0056b3', fillColor = 'rgba(0, 86, 179, 0.15)',
+                yLabel = '', unit = '', title = '' } = opts;
+        const W = 900, H = 260;
+        const padL = 70, padR = 24, padT = 30, padB = 40;
+        const innerW = W - padL - padR;
+        const innerH = H - padT - padB;
+
+        const xMin = 0, xMax = Math.max(...xs);
+        let yMin = Math.min(...ys, 0), yMax = Math.max(...ys, 0);
+        if (yMin === yMax) { yMin -= 1; yMax += 1; }
+        const yRange = yMax - yMin;
+        // Add a bit of padding
+        yMin -= yRange * 0.08;
+        yMax += yRange * 0.08;
+
+        const sx = x => padL + (x - xMin) / (xMax - xMin) * innerW;
+        const sy = y => padT + (yMax - y) / (yMax - yMin) * innerH;
+
+        const yZero = sy(0);
+
+        // Polygon path filling from zero to curve
+        const pathPoints = xs.map((x, i) => `${sx(x)},${sy(ys[i])}`).join(' ');
+        const fillPath = `${sx(xs[0])},${yZero} ${pathPoints} ${sx(xs[xs.length - 1])},${yZero}`;
+
+        // Critical value markers
+        const maxAbsIdx = ys.reduce((iMax, v, i, arr) =>
+            Math.abs(v) > Math.abs(arr[iMax]) ? i : iMax, 0);
+        const critX = xs[maxAbsIdx], critY = ys[maxAbsIdx];
+
+        // Axis ticks
+        const xTicks = 6, yTicks = 4;
+        let xTickHtml = '';
+        for (let i = 0; i <= xTicks; i++) {
+            const xt = xMin + (xMax - xMin) * i / xTicks;
+            const px = sx(xt);
+            xTickHtml += `<line x1="${px}" y1="${padT + innerH}" x2="${px}" y2="${padT + innerH + 4}" stroke="#5c6773"/>` +
+                         `<text x="${px}" y="${padT + innerH + 18}" font-size="11" fill="#5c6773" text-anchor="middle">${xt.toFixed(2)}</text>`;
+        }
+        let yTickHtml = '';
+        for (let i = 0; i <= yTicks; i++) {
+            const yt = yMin + (yMax - yMin) * i / yTicks;
+            const py = sy(yt);
+            yTickHtml += `<line x1="${padL - 4}" y1="${py}" x2="${padL}" y2="${py}" stroke="#5c6773"/>` +
+                         `<text x="${padL - 8}" y="${py + 4}" font-size="11" fill="#5c6773" text-anchor="end">${yt.toFixed(2)}</text>`;
+        }
+
+        const svg =
+            `<svg viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet">
+                ${title ? `<text x="${W/2}" y="18" font-size="13" font-weight="600" fill="#1f2933" text-anchor="middle">${title}</text>` : ''}
+                <rect x="${padL}" y="${padT}" width="${innerW}" height="${innerH}" fill="#fafbfc" stroke="#e1e4e8"/>
+                <line x1="${padL}" y1="${yZero}" x2="${padL + innerW}" y2="${yZero}" stroke="#adb5bd" stroke-dasharray="3,3"/>
+                <polygon points="${fillPath}" fill="${fillColor}"/>
+                <polyline points="${pathPoints}" stroke="${color}" stroke-width="2" fill="none"/>
+                ${xTickHtml}
+                ${yTickHtml}
+                <text x="${padL + innerW/2}" y="${H - 6}" font-size="11" fill="#5c6773" text-anchor="middle">x (m)</text>
+                <text x="14" y="${padT + innerH/2}" font-size="11" fill="#5c6773" text-anchor="middle" transform="rotate(-90 14 ${padT + innerH/2})">${yLabel}${unit ? ` (${unit})` : ''}</text>
+                <circle cx="${sx(critX)}" cy="${sy(critY)}" r="4" fill="${color}"/>
+                <text x="${sx(critX)}" y="${sy(critY) - 8}" font-size="11" font-weight="600" fill="${color}" text-anchor="middle">${critY.toFixed(2)}</text>
+            </svg>`;
+        container.innerHTML = svg;
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    //  STATE & UI — TAB 1 (BEAM ANALYSIS)
+    // ════════════════════════════════════════════════════════════════════════
+
+    const state = {
+        loads: [],
+        nextId: 1,
+        lastResult: null
+    };
+
+    function newLoad(type) {
+        const L = Number(document.getElementById('ba-L').value) || 6;
+        const id = state.nextId++;
+        const defaults = {
+            point:  { id, type: 'point',  P: 50, x: L / 2 },
+            udl:    { id, type: 'udl',    w: 20, x1: 0, x2: L },
+            vdl:    { id, type: 'vdl',    w1: 0, w2: 30, x1: 0, x2: L },
+            moment: { id, type: 'moment', M: 50, x: L / 2 }
+        };
+        return defaults[type];
+    }
+
+    function renderLoadsList() {
+        const list = document.getElementById('ba-loads-list');
+        if (state.loads.length === 0) {
+            list.innerHTML = '<div class="bd-empty">No loads added yet — click a button above to add one.</div>';
+            return;
+        }
+        const typeNames = { point: '↓ Point Load', udl: '▬ UDL', vdl: '◤ VDL', moment: '↺ Moment' };
+        list.innerHTML = state.loads.map(ld => {
+            const fields = loadFields(ld);
+            return `
+                <div class="bd-load-card" data-id="${ld.id}">
+                    <div class="bd-load-card-head">
+                        <span class="bd-load-type">${typeNames[ld.type]}</span>
+                        <button type="button" class="bd-remove-btn" data-remove="${ld.id}">✕ Remove</button>
+                    </div>
+                    <div class="bd-grid">${fields}</div>
+                </div>`;
+        }).join('');
+    }
+
+    function loadFields(ld) {
+        const num = (key, label, step = 0.1) =>
+            `<div class="bd-field">
+                <label>${label}</label>
+                <input type="number" data-id="${ld.id}" data-key="${key}" value="${ld[key]}" step="${step}" inputmode="decimal">
+             </div>`;
+        if (ld.type === 'point')  return num('P', 'P (kN)', 1) + num('x', 'x (m)');
+        if (ld.type === 'udl')    return num('w', 'w (kN/m)', 1) + num('x1', 'x₁ (m)') + num('x2', 'x₂ (m)');
+        if (ld.type === 'vdl')    return num('w1', 'w₁ (kN/m)', 1) + num('w2', 'w₂ (kN/m)', 1) + num('x1', 'x₁ (m)') + num('x2', 'x₂ (m)');
+        if (ld.type === 'moment') return num('M', 'M (kN·m)  ↺ CCW+', 1) + num('x', 'x (m)');
+        return '';
+    }
+
+    document.querySelectorAll('[data-add]').forEach(btn => {
+        btn.addEventListener('click', () => {
+            state.loads.push(newLoad(btn.dataset.add));
+            renderLoadsList();
+        });
+    });
+
+    document.getElementById('ba-loads-list').addEventListener('input', e => {
+        const t = e.target;
+        if (t.dataset.id && t.dataset.key) {
+            const ld = state.loads.find(l => l.id === Number(t.dataset.id));
+            if (ld) ld[t.dataset.key] = parseFloat(t.value) || 0;
+        }
+    });
+
+    document.getElementById('ba-loads-list').addEventListener('click', e => {
+        const id = e.target.dataset.remove;
+        if (id) {
+            state.loads = state.loads.filter(l => l.id !== Number(id));
+            renderLoadsList();
+        }
+    });
+
+    document.getElementById('ba-calc-btn').addEventListener('click', () => {
+        const L = parseFloat(document.getElementById('ba-L').value);
+        const E = parseFloat(document.getElementById('ba-E').value);
+        const I = parseFloat(document.getElementById('ba-I').value);
+        if (!(L > 0)) { alert('Span L must be > 0.'); return; }
+        if (state.loads.length === 0) { alert('Add at least one load.'); return; }
+
+        const result = diagramsSS(L, state.loads);
+        const D = (E > 0 && I > 0) ? deflectionSS(L, result.xs, result.M, E, I) : null;
+        state.lastResult = { ...result, D, L };
+
+        // Reactions
+        document.getElementById('ba-reactions').innerHTML = `
+            <div class="bd-metric"><div class="bd-metric-label">R<sub>A</sub> @ x = 0</div><div class="bd-metric-value">${result.Ra.toFixed(2)} kN</div></div>
+            <div class="bd-metric"><div class="bd-metric-label">R<sub>B</sub> @ x = ${L.toFixed(2)} m</div><div class="bd-metric-value">${result.Rb.toFixed(2)} kN</div></div>
+            <div class="bd-metric"><div class="bd-metric-label">Sum of reactions</div><div class="bd-metric-value">${(result.Ra + result.Rb).toFixed(2)} kN</div></div>
+        `;
+
+        // Summary
+        const Dmax = D ? Math.max(...D.map(Math.abs)) : NaN;
+        document.getElementById('ba-summary').innerHTML = `
+            <div class="bd-metric"><div class="bd-metric-label">|V|<sub>max</sub></div><div class="bd-metric-value">${result.Vmax.toFixed(2)} kN</div></div>
+            <div class="bd-metric"><div class="bd-metric-label">|M|<sub>max</sub></div><div class="bd-metric-value">${result.Mmax.toFixed(2)} kN·m</div></div>
+            ${D ? `<div class="bd-metric"><div class="bd-metric-label">|δ|<sub>max</sub></div><div class="bd-metric-value">${Dmax.toFixed(2)} mm</div></div>` : ''}
+        `;
+
+        // Deflection check (L/360)
+        const dCheck = document.getElementById('ba-deflection-check');
+        if (D) {
+            const allow = L * 1000 / 360;
+            if (Dmax <= allow) {
+                dCheck.innerHTML = `<div class="bd-alert bd-alert-ok">✓ Deflection OK — ${Dmax.toFixed(2)} mm ≤ L/360 = ${allow.toFixed(2)} mm</div>`;
+            } else {
+                dCheck.innerHTML = `<div class="bd-alert bd-alert-fail">✗ Deflection exceeds L/360 — ${Dmax.toFixed(2)} mm > ${allow.toFixed(2)} mm</div>`;
+            }
+        } else { dCheck.innerHTML = ''; }
+
+        // Diagrams
+        drawDiagram(document.getElementById('ba-sfd'),
+                    result.xs, result.V,
+                    { color: '#1f77b4', fillColor: 'rgba(31, 119, 180, 0.18)', yLabel: 'V', unit: 'kN', title: 'Shear Force' });
+        drawDiagram(document.getElementById('ba-bmd'),
+                    result.xs, result.M,
+                    { color: '#d62728', fillColor: 'rgba(214, 39, 40, 0.18)', yLabel: 'M', unit: 'kN·m', title: 'Bending Moment' });
+        if (D) {
+            drawDiagram(document.getElementById('ba-defl'),
+                        result.xs, D,
+                        { color: '#2ca02c', fillColor: 'rgba(44, 160, 44, 0.18)', yLabel: 'δ', unit: 'mm', title: 'Deflection' });
+        }
+
+        document.getElementById('ba-results').style.display = '';
+        renderMath(document.getElementById('ba-results'));
+    });
+
+    // ════════════════════════════════════════════════════════════════════════
+    //  STATE & UI — TAB 2 (RC SECTION DESIGN)
+    // ════════════════════════════════════════════════════════════════════════
+
+    function row(label, value, note = '', cls = '') {
+        return `<div class="bd-calc-row">
+            <span class="bd-calc-label">${label}</span>
+            <span class="bd-calc-value ${cls}">${value}</span>
+            ${note ? `<span class="bd-calc-note">${note}</span>` : ''}
+        </div>`;
+    }
+
+    // Pre-fill Mu/Vu from beam analysis when user picks that source
+    document.getElementById('rc-source').addEventListener('change', () => {
+        const src = document.getElementById('rc-source').value;
+        if (src === 'analysis') {
+            if (!state.lastResult) {
+                alert('Run a Beam Analysis first, then switch back.');
+                document.getElementById('rc-source').value = 'manual';
+                return;
+            }
+            document.getElementById('rc-Mu').value = state.lastResult.Mmax.toFixed(3);
+            document.getElementById('rc-Vu').value = state.lastResult.Vmax.toFixed(3);
+            document.getElementById('rc-Mu').readOnly = true;
+            document.getElementById('rc-Vu').readOnly = true;
+        } else {
+            document.getElementById('rc-Mu').readOnly = false;
+            document.getElementById('rc-Vu').readOnly = false;
+        }
+    });
+
+    // NSCP load combinations — update live
+    const lcInputs = ['lc-D','lc-L','lc-Lr','lc-S','lc-W','lc-E','lc-R'];
+    function updateLoadCombos() {
+        const vals = {
+            D: +document.getElementById('lc-D').value || 0,
+            L: +document.getElementById('lc-L').value || 0,
+            Lr: +document.getElementById('lc-Lr').value || 0,
+            S: +document.getElementById('lc-S').value || 0,
+            W: +document.getElementById('lc-W').value || 0,
+            E: +document.getElementById('lc-E').value || 0,
+            R: +document.getElementById('lc-R').value || 0
+        };
+        const { combos, govName } = nscpLoadCombinations(vals);
+        const out = document.getElementById('lc-output');
+        out.innerHTML = Object.entries(combos).map(([name, val]) => {
+            const isGov = name === govName && val > 0;
+            return `<div class="bd-combo-row ${isGov ? 'is-gov' : ''}">
+                <span class="bd-combo-name">${name}</span>
+                <span>${val.toFixed(3)}${isGov ? '  ← Governing' : ''}</span>
+            </div>`;
+        }).join('');
+    }
+    lcInputs.forEach(id => document.getElementById(id).addEventListener('input', updateLoadCombos));
+    updateLoadCombos();
+
+    document.getElementById('rc-calc-btn').addEventListener('click', () => {
+        const Mu  = parseFloat(document.getElementById('rc-Mu').value);
+        const Vu  = parseFloat(document.getElementById('rc-Vu').value);
+        const b   = parseFloat(document.getElementById('rc-b').value);
+        const h   = parseFloat(document.getElementById('rc-h').value);
+        const fc  = parseFloat(document.getElementById('rc-fc').value);
+        const fyl = parseFloat(document.getElementById('rc-fyl').value);
+        const fyt = parseFloat(document.getElementById('rc-fyt').value);
+        const db  = parseFloat(document.getElementById('rc-db').value);
+        const ds  = parseFloat(document.getElementById('rc-ds').value);
+        const cov = parseFloat(document.getElementById('rc-cover').value);
+        const lam = parseFloat(document.getElementById('rc-lambda').value);
+        const legs = parseInt(document.getElementById('rc-legs').value);
+
+        const fl = designFlexure(Mu, b, h, fc, fyl, db, ds, cov);
+        const sh = designShear(Vu, b, h, fc, fyt, ds, db, cov, lam, legs);
+
+        // ── Flexure output ─────────────────────────────────────────
+        const flx = document.getElementById('rc-flexure');
+        if (fl.error && fl.d === undefined) {
+            flx.innerHTML = `<div class="bd-alert bd-alert-fail">${fl.error}</div>`;
+        } else {
+            let html = '';
+            if (fl.error) html += `<div class="bd-alert bd-alert-fail">${fl.error}</div>`;
+            html += row('h (total depth)',        `${h.toFixed(0)} mm`);
+            html += row('b (width)',              `${b.toFixed(0)} mm`);
+            html += row('cover',                  `${cov.toFixed(0)} mm`,  'NSCP 2015 Table 420.6.1.3.1');
+            html += row('d (effective depth)',    `${fl.d.toFixed(1)} mm`, 'h − cover − ∅s − ∅b/2');
+            html += row('φ (flexure)',            `${fl.phi_flex}`);
+            html += row('β₁',                     `${fl.beta1.toFixed(4)}`, 'NSCP 2015 §422.2.2.4.3');
+            html += row('Mu',                     `${fl.Mu_kNm.toFixed(3)} kN·m`);
+            html += row('Rn = Mu / (φ·b·d²)',     `${fl.Rn.toFixed(4)} MPa`);
+            html += row('ρ_calc',                 `${fl.rho_calc.toFixed(6)}`);
+            html += row('ρ_min',                  `${fl.rho_min.toFixed(6)}`, 'max(√f\'c / 4fy, 1.4/fy) — §406.3.1');
+            html += row('ρ_max',                  `${fl.rho_max.toFixed(6)}`, '0.75 ρ_b — §406.3.3');
+            fl.checks.forEach(c => { html += row('Check', c); });
+            html += row('ρ_use',                  `${fl.rho_use.toFixed(6)}`);
+            html += row('As_req = ρ·b·d',         `${fl.As_req.toFixed(2)} mm²`);
+            html += row('Ab (1 bar)',             `${fl.Ab.toFixed(2)} mm²`,  `∅${db.toFixed(0)} mm`);
+            html += row('n = ⌈As_req / Ab⌉',     `${fl.n_bars} bars`);
+            html += row('As_prov = n·Ab',         `${fl.As_prov.toFixed(2)} mm²`);
+            html += row('a = As·fy / (0.85·f\'c·b)', `${fl.a.toFixed(2)} mm`);
+            html += row('φMn = φ·As·fy·(d − a/2)',
+                       `${fl.capacity_ok ? '✓' : '✗'} ${fl.phi_Mn_kNm.toFixed(3)} kN·m`,
+                       `${fl.capacity_ok ? '≥' : '<'} Mu = ${fl.Mu_kNm.toFixed(3)} kN·m`,
+                       fl.capacity_ok ? 'ok' : 'fail');
+
+            if (fl.capacity_ok && !fl.over_reinforced) {
+                html += `<div class="bd-alert bd-alert-ok">
+                    ✓ Use <strong>${fl.n_bars} — ∅${db.toFixed(0)} mm</strong> bars
+                    (As<sub>prov</sub> = ${fl.As_prov.toFixed(0)} mm² &nbsp;|&nbsp; φMn = ${fl.phi_Mn_kNm.toFixed(2)} kN·m)
+                </div>`;
+            } else if (fl.over_reinforced) {
+                html += `<div class="bd-alert bd-alert-fail">✗ Over-reinforced — increase beam section.</div>`;
+            } else {
+                html += `<div class="bd-alert bd-alert-fail">✗ Flexural capacity insufficient — check inputs.</div>`;
+            }
+            flx.innerHTML = html;
+        }
+
+        // ── Shear output ───────────────────────────────────────────
+        const shr = document.getElementById('rc-shear');
+        let html = '';
+        html += row('d (effective depth)',          `${sh.d.toFixed(1)} mm`);
+        html += row('φ (shear)',                    `${sh.phi_shear}`);
+        html += row('λ',                            `${lam}`,                     `${lam === 1 ? 'Normal weight' : lam === 0.85 ? 'Sand-lightweight' : 'All-lightweight'}`);
+        html += row('Vc = 0.17λ√f\'c·b·d',          `${sh.Vc_kN.toFixed(3)} kN`,   'NSCP 2015 §422.5.5.1');
+        html += row('φVc',                          `${sh.phiVc.toFixed(3)} kN`);
+        html += row('Vu',                           `${sh.Vu_kN.toFixed(3)} kN`);
+        html += row('Av (stirrup area)',            `${sh.Av_mm2.toFixed(2)} mm²`, `${legs}-leg ∅${ds.toFixed(0)} mm`);
+        html += row("Vs_lim1 (0.33√f'c·b·d)",       `${sh.Vs_lim1.toFixed(2)} kN`, 'controls max spacing');
+        html += row("Vs_lim2 (0.66√f'c·b·d)",       `${sh.Vs_lim2.toFixed(2)} kN`, 'section too small if Vs exceeds');
+
+        if (sh.mode === 'overloaded') {
+            html += `<div class="bd-alert bd-alert-fail">${sh.error}</div>`;
+        } else if (sh.mode === 'none') {
+            html += row("Av/s_min",                  `${sh.Avs_min.toFixed(4)} mm²/mm`, "max(0.062√f'c·b/fyt, 0.35b/fyt)");
+            html += `<div class="bd-alert bd-alert-warn">${sh.note}</div>`;
+        } else {
+            if (sh.mode === 'designed') {
+                html += row("Vs = Vu/φ − Vc",        `${sh.Vs_kN.toFixed(3)} kN`);
+                html += row("s_calc = Av·fyt·d / Vs", `${sh.s_calc.toFixed(1)} mm`);
+                html += row("Spacing rule",          sh.spac_note);
+            }
+            html += row("Av/s_min",                   `${sh.Avs_min.toFixed(4)} mm²/mm`, "max(0.062√f'c·b/fyt, 0.35b/fyt) — §409.6.3.3");
+            html += row("s from Av/s_min",            `${sh.s_from_min.toFixed(1)} mm`);
+            html += row("s_max (spacing)",            `${sh.s_max_spac.toFixed(0)} mm`);
+
+            if (sh.mode === 'designed') {
+                html += row("φVn = φ(Vc + Vs_prov)",
+                           `${sh.capacity_ok ? '✓' : '✗'} ${sh.phiVn_kN.toFixed(3)} kN`,
+                           `${sh.capacity_ok ? '≥' : '<'} Vu = ${sh.Vu_kN.toFixed(3)} kN`,
+                           sh.capacity_ok ? 'ok' : 'fail');
+            }
+
+            const modeLbl = sh.mode === 'minimum' ? 'min. stirrups' : 'designed stirrups';
+            html += `<div class="bd-alert bd-alert-ok">
+                ✓ Use <strong>∅${ds.toFixed(0)} mm stirrups @ ${sh.s_final.toFixed(0)} mm</strong>
+                (${modeLbl})
+            </div>`;
+            if (sh.mode === 'minimum') {
+                html += `<div class="bd-alert bd-alert-info">${sh.note}</div>`;
+            }
+        }
+        shr.innerHTML = html;
+
+        document.getElementById('rc-results').style.display = '';
+        renderMath(document.getElementById('rc-results'));
+    });
+
+    // ════════════════════════════════════════════════════════════════════════
+    //  TAB SWITCHING & INITIAL RENDER
+    // ════════════════════════════════════════════════════════════════════════
+
+    document.querySelectorAll('.bd-tab').forEach(btn => {
+        btn.addEventListener('click', () => {
+            document.querySelectorAll('.bd-tab').forEach(b => b.classList.remove('is-active'));
+            document.querySelectorAll('.bd-panel').forEach(p => p.classList.remove('is-active'));
+            btn.classList.add('is-active');
+            document.querySelector(`[data-panel="${btn.dataset.tab}"]`).classList.add('is-active');
+        });
+    });
+
+    document.addEventListener('DOMContentLoaded', () => {
+        renderMath(document.querySelector('.bd-page'));
+    });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Replace the placeholder redirect at `beamDesign.html` with a working two-tab beam design page, porting the calculation logic from the Streamlit app at `C:/Users/raymv/Documents/Structure` (`calculations/beam.py` + `rc_design.py` + `calculations/loads.py`).

## Tab 1 — Beam Analysis
- **Inputs:** span L (m), modulus E (MPa), inertia I (mm⁴).
- **Loads:** add/remove four types — Point (P, x), UDL (w, x₁, x₂), VDL trapezoidal (w₁, w₂, x₁, x₂), Moment (M, x with CCW+).
- **Analytical solver for simply-supported beam:**
  - `reactionsSS()` — sum forces and moments about A for Rₐ, R_b.
  - `shearMomentAt()` — left-side free-body for V(x) and M(x), handles partial-overlap UDL/VDL truncation correctly.
  - `diagramsSS()` — densely samples with discontinuity points so point-load steps and load endpoints are exact.
  - `deflectionSS()` — double trapezoidal integration of M/EI with δ(0) = δ(L) = 0 enforced via linear ramp subtraction.
- **Output:** support reactions, |V|max, |M|max, |δ|max, plus SVG plots for shear, moment, and deflection diagrams with critical-value markers and the L/360 deflection check.

## Tab 2 — RC Section Design (NSCP 2015 / ACI 318-14)
- **Source of demands:** pull Mu/Vu from Tab 1's max values, or enter manually.
- **Section + materials:** b/h (mm), f'c, fy_longitudinal, fy_transverse, db, ds, cover, stirrup legs, λ (NW / sand-LW / all-LW).
- **Flexure (§406):** β₁, ρ_balanced/min/max, Rn, ρ_calc, As_req, bar count from Ab = π·db²/4, As_prov, a = As·fy/(0.85·f'c·b), φMn = φ·As·fy·(d − a/2). Capacity verdict against Mu.
- **Shear (§422):** Vc = 0.17·λ·√f'c·b·d, three modes:
  - **none** — Vu ≤ φVc/2 (no stirrups needed analytically)
  - **minimum** — φVc/2 < Vu ≤ φVc
  - **designed** — Vu > φVc → Vs = Vu/φ − Vc, s_calc, s_max from Vs ⪌ 0.33·√f'c·b·d, Av/s_min, rounded to 25 mm with a 50 mm floor.
  Verdict: φVn = φ(Vc + Vs_prov) ≥ Vu.
- **NSCP 2015 §203.3.1 load combinations** expandable: all seven strength combos with the governing one highlighted live as you edit unfactored D/L/Lr/S/W/E/R.

## UI / styling
- Scoped `.bd-page` class — no impact on the `.container` grid used elsewhere.
- Reuses the foundation-design visual language: white card sections, responsive auto-fit grid, blue-accent CTAs, green-OK / red-FAIL verdict alerts.
- KaTeX for label math (\(L\), \(f_y\), \(\varnothing\), etc.).
- Plain SVG diagrams — no chart-library dependency.
- HOME link in nav back to the main module grid.

## What's preserved
- `columnDesign.html` and `ReinforcedConcrete.html` are unchanged. The Reinforced Concrete landing card grid still routes here correctly.

## Test plan
- [ ] `npm install && npm start`, open `http://localhost:3000/beamDesign.html` — page renders both tabs, math labels typeset.
- [ ] Tab 1: add a UDL of 20 kN/m over a 6 m span. Click Analyze. Verify Ra = Rb = 60 kN, |M|max ≈ 90 kN·m, |V|max = 60 kN, parabolic moment diagram.
- [ ] Add a centered point load of 50 kN on the same beam. Verify Ra = Rb shift correctly, V step at midspan, triangular addition to the moment diagram.
- [ ] Tab 2: switch source to "Beam Analysis" — Mu / Vu auto-fill from the last analysis. Click Design Section. Verify the full flexure breakdown + shear breakdown print.
- [ ] Toggle source back to "Manual" — inputs become editable again.
- [ ] Open the NSCP load combinations expander, enter D = 10, L = 20. Verify 1.2D + 1.6L + 0.5(...) = 12 + 32 + 0 = 44 highlights as governing.