### PR TITLE
beamDesign: surface the silent failure on Design Section click

### DIFF
--- a/public/pages/beamDesign.html
+++ b/public/pages/beamDesign.html
@@ -2072,6 +2072,7 @@
     }
 
     document.getElementById('rc-calc-btn').addEventListener('click', () => {
+      try {
         const Mu   = parseFloat(document.getElementById('rc-Mu').value);
         const Vu   = parseFloat(document.getElementById('rc-Vu').value);
         const b    = parseFloat(document.getElementById('rc-b').value);
@@ -2087,6 +2088,22 @@
         const lam  = parseFloat(document.getElementById('rc-lambda').value);
         const legs = parseInt(document.getElementById('rc-legs').value);
         const Lspan = parseFloat(document.getElementById('rc-L').value);
+
+        // Validate required inputs before running the calculators — designShear()
+        // and designFlexure() return NaN-laden results if any of these are bad,
+        // which made the click look like a no-op on the deployed page.
+        const need = { Mu, Vu, b, h, fc, fyl, fyt, db, ds, cov, lam, legs };
+        const bad = Object.entries(need)
+            .filter(([k, v]) => !Number.isFinite(v))
+            .map(([k]) => k);
+        if (bad.length) {
+            const errBox = document.getElementById('rc-flexure');
+            const msg = `Cannot run the section design — these inputs are blank or invalid: ${bad.join(', ')}. Please fill them in and click Design Section again.`;
+            errBox.innerHTML = `<div class="bd-alert bd-alert-fail">${msg}</div>`;
+            document.getElementById('rc-shear').innerHTML = '';
+            document.getElementById('rc-results').style.display = '';
+            return;
+        }
 
         const fl = designFlexure(Mu, b, h, fc, fyl, db, ds, cov, dPr, dbC);
         const sh = designShear(Vu, b, h, fc, fyt, ds, db, cov, lam, legs, Lspan);
@@ -2367,6 +2384,23 @@
 
         document.getElementById('rc-results').style.display = '';
         renderMath(document.getElementById('rc-results'));
+      } catch (err) {
+        // Make any runtime error visible — previously the click would just
+        // silently abort if anything in the pipeline (designFlexure, designShear,
+        // or HTML assembly) threw, and the user would see no response.
+        console.error('Design Section failed:', err);
+        const errBox = document.getElementById('rc-flexure');
+        if (errBox) {
+            errBox.innerHTML = `<div class="bd-alert bd-alert-fail">
+                <strong>Design Section error:</strong> ${err && err.message ? err.message : err}
+                <br><small style="color:#5c6773;">Check the browser console for the full stack trace.</small>
+            </div>`;
+        }
+        const shrBox = document.getElementById('rc-shear');
+        if (shrBox) shrBox.innerHTML = '';
+        const results = document.getElementById('rc-results');
+        if (results) results.style.display = '';
+      }
     });
 
     // ════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
The Design Section button looked broken on the deployed page — clicking it produced no visible response. My local Node simulation of the handler ran fine and produced ~6 KB of HTML for each panel, so whatever is failing has to be runtime-only in the browser, with the event-loop swallowing the exception silently.

This PR makes the failure visible and recoverable so we (and the user) can actually see what's wrong.

## Up-front input validation
Before calling \`designFlexure()\` and \`designShear()\`, read every required form input (Mu, Vu, b, h, fc, fyl, fyt, db, ds, cover, lambda, legs) and check each with \`Number.isFinite()\`. If any is blank, non-numeric, or otherwise NaN, write a clear alert into the flexure panel:

> Cannot run the section design — these inputs are blank or invalid: X, Y, Z. Please fill them in and click Design Section again.

…and stop. Previously the click would call \`designFlexure()\` with NaN, every downstream formula would propagate NaN, and the user would see Step cards full of "NaN mm" with no hint of the root cause.

## Top-level try/catch around the whole click handler
Wrap the body in \`try { … } catch (err) { … }\`. If anything in the pipeline throws (designFlexure on an out-of-range Mu, a missing DOM node, a KaTeX assembly TypeError on an unexpected result shape, etc.) the catch:
- Logs the full stack to \`console.error\` with the prefix "Design Section failed:"
- Writes a visible **"Design Section error: \<message\>"** red alert into the flexure panel, with a footer telling the user to check the console for the stack trace.
- Still shows the results panel (\`display: ''\`) so the alert is in view; previously a throw mid-handler left the panel \`display:none\` with no UI change at all.

## Test plan
- [ ] After Render redeploys, hard-refresh \`/beamDesign.html\` and switch to Tab 2.
- [ ] Clear the \`Mu\` input and click Design Section. Red validation alert appears with "Mu" listed.
- [ ] Restore Mu, click Design Section. Steps render as before.
- [ ] If the previous bug returns, the catch path now puts the error message + stack trace into the panel and into the console.