### PR TITLE
beamDesign: skip Step 4 spacing rows when stirrups are not required

### DIFF
--- a/public/pages/beamDesign.html
+++ b/public/pages/beamDesign.html
@@ -2318,29 +2318,37 @@
         }
 
         // Step 4 — Spacing
-        html += sectionHeader('Step 4 — Spacing');
-        html += row('\\(A_v / s_{\\min}\\)',
-                   `${sh.Avs_min.toFixed(4)} mm²/mm`,
-                   '\\(\\max\\!\\left(\\dfrac{0.062\\sqrt{f\'_c}\\,b}{f_{yt}},\\;\\dfrac{0.35\\,b}{f_{yt}}\\right)\\) — §409.6.3.3');
-        if (sh.mode === 'designed') {
-            html += row('\\(s_{calc} = \\dfrac{A_v\\,f_{yt}\\,d}{V_s}\\)',
-                       `${sh.s_calc.toFixed(1)} mm`);
-        }
-        html += row('Spacing rule', sh.spac_note);
-        html += row('\\(S_{\\max}\\) (code)',            `${sh.Smax_code.toFixed(1)} mm`);
-        html += row('\\(S_{\\max}\\) floored to 25 mm', `${sh.Smax_floor.toFixed(0)} mm`);
-        html += row('\\(S_{required}\\)',
-                   `${(sh.S_required || sh.Smax_code).toFixed(1)} mm`,
-                   '\\(\\min\\!\\left(s_{calc},\\;S_{\\max},\\;\\dfrac{A_v}{A_v/s_{\\min}}\\right)\\)');
-        html += row('\\(S\\) floored to 25 mm',         `${sh.S_floor.toFixed(0)} mm`);
-        html += row('\\(S_{gov}\\) (50 mm floor)',      `<strong>${sh.S_gov.toFixed(0)} mm</strong>`);
+        // For mode === 'none' the designShear() return only includes the base
+        // values plus `note`. Every spacing field (Smax_code, Smax_floor,
+        // S_required, S_floor, S_gov) is undefined, so we must guard each
+        // toFixed() and short-circuit the section when stirrups aren't needed.
+        if (sh.mode !== 'none') {
+            html += sectionHeader('Step 4 — Spacing');
+            html += row('\\(A_v / s_{\\min}\\)',
+                       `${sh.Avs_min.toFixed(4)} mm²/mm`,
+                       '\\(\\max\\!\\left(\\dfrac{0.062\\sqrt{f\'_c}\\,b}{f_{yt}},\\;\\dfrac{0.35\\,b}{f_{yt}}\\right)\\) — §409.6.3.3');
+            if (sh.mode === 'designed') {
+                html += row('\\(s_{calc} = \\dfrac{A_v\\,f_{yt}\\,d}{V_s}\\)',
+                           `${sh.s_calc.toFixed(1)} mm`);
+            }
+            if (sh.spac_note) html += row('Spacing rule', sh.spac_note);
+            if (sh.Smax_code  !== undefined) html += row('\\(S_{\\max}\\) (code)',           `${sh.Smax_code.toFixed(1)} mm`);
+            if (sh.Smax_floor !== undefined) html += row('\\(S_{\\max}\\) floored to 25 mm', `${sh.Smax_floor.toFixed(0)} mm`);
+            if (sh.S_required !== undefined || sh.Smax_code !== undefined) {
+                html += row('\\(S_{required}\\)',
+                           `${(sh.S_required || sh.Smax_code).toFixed(1)} mm`,
+                           '\\(\\min\\!\\left(s_{calc},\\;S_{\\max},\\;\\dfrac{A_v}{A_v/s_{\\min}}\\right)\\)');
+            }
+            if (sh.S_floor !== undefined) html += row('\\(S\\) floored to 25 mm', `${sh.S_floor.toFixed(0)} mm`);
+            if (sh.S_gov   !== undefined) html += row('\\(S_{gov}\\) (50 mm floor)', `<strong>${sh.S_gov.toFixed(0)} mm</strong>`);
 
-        if (sh.mode === 'designed') {
-            html += row('\\(V_{s,prov} = \\dfrac{A_v\\,f_{yt}\\,d}{S_{gov}}\\)', `${sh.Vs_prov_kN.toFixed(3)} kN`);
-            html += row('\\(\\phi V_n = \\phi (V_c + V_{s,prov})\\)',
-                       `${sh.capacity_ok ? '✓' : '✗'} ${sh.phiVn_kN.toFixed(3)} kN`,
-                       `${sh.capacity_ok ? '≥' : '<'} \\(V_u = ${sh.Vu_kN.toFixed(3)}\\) kN`,
-                       sh.capacity_ok ? 'ok' : 'fail');
+            if (sh.mode === 'designed') {
+                html += row('\\(V_{s,prov} = \\dfrac{A_v\\,f_{yt}\\,d}{S_{gov}}\\)', `${sh.Vs_prov_kN.toFixed(3)} kN`);
+                html += row('\\(\\phi V_n = \\phi (V_c + V_{s,prov})\\)',
+                           `${sh.capacity_ok ? '✓' : '✗'} ${sh.phiVn_kN.toFixed(3)} kN`,
+                           `${sh.capacity_ok ? '≥' : '<'} \\(V_u = ${sh.Vu_kN.toFixed(3)}\\) kN`,
+                           sh.capacity_ok ? 'ok' : 'fail');
+            }
         }
 
         // Step 5 — Stirrup schedule (layout)


### PR DESCRIPTION
Follow-up to PR #50 — the visible-error diagnostic from that PR did its job: the user's screenshot showed exactly which call was crashing, and now we can fix it. PR #50 merged before this fix commit landed, so this PR carries it.

## Root cause
\`designShear()\` has three modes:

| mode | condition | return shape |
|---|---|---|
| \`'none'\` | Vu ≤ 0.5·φVc | **base + note only** |
| \`'minimum'\` | 0.5·φVc < Vu ≤ φVc | base + spacing fields + Smax/S_gov |
| \`'designed'\` | Vu > φVc | base + Vs_kN, s_calc, spacing fields, Vs_prov_kN, phiVn_kN, etc. |

The \`'none'\` return only includes the base values and \`note\`. Every spacing field (\`Smax_code\`, \`Smax_floor\`, \`S_required\`, \`S_floor\`, \`S_gov\`, \`spac_note\`) is undefined.

The **Step 4 — Spacing** render in the click handler was unconditionally calling \`sh.Smax_code.toFixed(1)\`, \`sh.Smax_floor.toFixed(0)\`, etc. So with the user's inputs (Mu = 63 kN·m, Vu = 42 kN — well within φVc/2) the first \`.toFixed()\` on undefined threw \`TypeError: Cannot read properties of undefined (reading 'toFixed')\`. The try/catch from PR #50 caught it and surfaced the message into the UI.

## Fix
- Wrap the entire **Step 4 — Spacing** block in \`if (sh.mode !== 'none')\`. When stirrups aren't required by analysis, just skip the Step 4 table and go straight to the Step 5 schedule (already guarded by \`if (sh.layout)\`, which is set only when Vu > 0.5·φVc) and the verdict alert.
- Defensively guard each individual \`sh.Smax_code\` / \`sh.Smax_floor\` / \`sh.S_required\` / \`sh.S_floor\` / \`sh.S_gov\` / \`sh.spac_note\` access with \`!== undefined\`, so a future \`'minimum'\` return without one of those fields won't crash either.

## Verified
Replayed the user's click in a stubbed DOM with Mu = 63, Vu = 42, b = 300, h = 500, fc = 28, fy = 415, fyt = 275, db = 20, ds = 10, cov = 40, λ = 1, legs = 2, L = 6:
- \`rc-flexure.innerHTML\`: 6 430 chars, no error.
- \`rc-shear.innerHTML\`: 3 253 chars, no Step 4 / Step 5 (correctly skipped), ends with the green \"stirrups not required by analysis\" alert.
- No exceptions thrown.

## Test plan
- [ ] After Render redeploys, hard-refresh \`/beamDesign.html\` → Tab 2.
- [ ] With the defaults from the screenshot (Mu = 63, Vu = 42), click Design Section. Flexure panel shows Steps 1–4 (SRRB path) with the typeset KaTeX rows. Shear panel shows Steps 1–3 plus the green \"Vu ≤ 0.5·φVc — stirrups not required\" alert (no Step 4 / Step 5, no error).
- [ ] Bump Vu to 200 kN (now > φVc) and click again. Shear panel now shows Steps 1–5 with the designed-stirrup schedule.