### PR TITLE
beamDesign: tension/compression bar location from Mu sign + corner-bar minimum spelled out

### DIFF
--- a/public/pages/beamDesign.html
+++ b/public/pages/beamDesign.html
@@ -2220,8 +2220,19 @@
 
     // Per-section flexure rendering — returns an HTML string for ONE section's
     // flexure design panel given the design result object and the materials.
-    function flexureHtmlFor(fl, m) {
+    function flexureHtmlFor(fl, m, signedMu) {
         const { b, h, fc, fyl, db, dbC, cov } = m;
+        // Sagging vs hogging — drives where tension and compression steel sit
+        // in the section. Sagging (positive M) → tension at the BOTTOM of the
+        // beam (typical midspan). Hogging (negative M) → tension at the TOP
+        // (typical at supports of continuous and fixed beams).
+        const isSagging   = (signedMu === undefined) ? true : (signedMu >= 0);
+        const tensionLoc  = isSagging ? 'BOTTOM' : 'TOP';
+        const comprLoc    = isSagging ? 'TOP'    : 'BOTTOM';
+        const momentType  = isSagging ? 'sagging (+M)' : 'hogging (−M)';
+        const tensSubscr  = isSagging ? 'b' : 't';   // bottom or top
+        const comprSubscr = isSagging ? 't' : 'b';
+
         if (fl.error && fl.d === undefined) {
             return `<div class="bd-alert bd-alert-fail">${fl.error}</div>`;
         }
@@ -2236,7 +2247,8 @@
         html += row('\\(d\\) (effective depth)',      `${fl.d.toFixed(1)} mm`, '\\(h - c_c - \\varnothing_s - \\varnothing_b/2\\)');
         html += row('\\(\\phi\\) (flexure)',          `${fl.phi_flex}`);
         html += row('\\(\\beta_1\\)',                 `${fl.beta1.toFixed(4)}`, 'NSCP 2015 §422.2.2.4.3');
-        html += row('\\(M_u\\)',                      `${fl.Mu_kNm.toFixed(3)} kN·m`);
+        html += row('\\(M_u\\)',                      `${fl.Mu_kNm.toFixed(3)} kN·m`,
+                   `${momentType} → tension fiber at the <strong>${tensionLoc}</strong>`);
         html += row('\\(R_n = \\dfrac{M_u}{\\phi \\cdot b \\cdot d^2}\\)', `${fl.Rn.toFixed(4)} MPa`);
 
         html += sectionHeader('Step 2 — ρ limits & singly-reinforced ceiling');
@@ -2270,7 +2282,14 @@
             html += row('\\(\\rho_{use}\\)', `${fl.rho_use.toFixed(6)}`);
             html += row('\\(A_{s,req} = \\rho \\cdot b \\cdot d\\)', `${fl.As_req.toFixed(2)} mm²`);
             html += row('\\(A_b\\) (1 bar)', `${fl.Ab.toFixed(2)} mm²`, `\\(\\varnothing\\,${db.toFixed(0)}\\) mm`);
-            html += row('\\(n = \\lceil A_{s,req} / A_b \\rceil\\)', `${fl.n_bars} bars`);
+            // The "2 bars at the corners" floor — designFlexure already returns
+            // max(2, ceil(As_req/Ab)), so any 1-bar result is rounded up to 2.
+            const ceilRaw = Math.ceil(fl.As_req / fl.Ab);
+            const rawNote = ceilRaw < 2
+                ? `raw \\(\\lceil A_{s,req}/A_b \\rceil = ${ceilRaw}\\) → bumped to <strong>2</strong> (corner-bar minimum)`
+                : '';
+            html += row('\\(n = \\max\\!\\left(2,\\,\\lceil A_{s,req} / A_b \\rceil\\right)\\)',
+                       `${fl.n_bars} bars`, rawNote);
             html += row('\\(A_{s,prov} = n \\cdot A_b\\)', `${fl.As_prov.toFixed(2)} mm²`);
             html += row('\\(a = \\dfrac{A_{s,prov}\\,f_y}{0.85\\,f\'_c\\,b}\\)', `${fl.a.toFixed(2)} mm`);
             if (fl.Sc !== null) {
@@ -2284,7 +2303,7 @@
                        `${fl.capacity_ok ? '≥' : '<'} \\(M_u = ${fl.Mu_kNm.toFixed(3)}\\) kN·m`,
                        fl.capacity_ok ? 'ok' : 'fail');
             html += (fl.capacity_ok)
-                ? `<div class="bd-alert bd-alert-ok">✓ <strong>SRRB</strong> — use <strong>${fl.n_bars} – ∅${db.toFixed(0)} mm</strong> bars (\\(A_{s,prov}\\) = ${fl.As_prov.toFixed(0)} mm² &nbsp;|&nbsp; \\(\\phi M_n\\) = ${fl.phi_Mn_kNm.toFixed(2)} kN·m)</div>`
+                ? `<div class="bd-alert bd-alert-ok">✓ <strong>SRRB</strong> — use <strong>${fl.n_bars} – ∅${db.toFixed(0)} mm</strong> bars at the <strong>${tensionLoc}</strong> of the section <small style="color:#0F6E56;">(${momentType})</small> &nbsp;|&nbsp; \\(A_{s,prov}\\) = ${fl.As_prov.toFixed(0)} mm² &nbsp;|&nbsp; \\(\\phi M_n\\) = ${fl.phi_Mn_kNm.toFixed(2)} kN·m</div>`
                 : `<div class="bd-alert bd-alert-fail">✗ Flexural capacity insufficient — increase section.</div>`;
             return html;
         }
@@ -2325,10 +2344,18 @@
         html += sectionHeader('Step 6 — Bar counts & capacity verification');
         html += row('\\(A_b\\) (tension)',  `${fl.Ab.toFixed(2)} mm²`, `\\(\\varnothing\\,${db.toFixed(0)}\\) mm`);
         html += row('\\(A\'_b\\) (compression)', `${fl.Ab_compr.toFixed(2)} mm²`, `\\(\\varnothing\'\\,${(dbC || db).toFixed(0)}\\) mm`);
-        html += row('\\(n_{tension} = \\lceil A_{s,total} / A_b \\rceil\\)', `${fl.n_tension} bars`);
-        html += row('\\(n_{compr.} = \\lceil A\'_{s,req} / A\'_b \\rceil\\)', `${fl.n_compression} bars`);
-        html += row('\\(A_{s,prov}\\) (tension)', `${fl.As_prov_t.toFixed(2)} mm²`);
-        html += row('\\(A\'_{s,prov}\\) (compression)', `${fl.As_prov_c.toFixed(2)} mm²`);
+        // 2-bar corner-minimum floor for both layers — designFlexure already
+        // returns max(2, ceil), so flag the bump in the note when it kicks in.
+        const ceilTRaw = Math.ceil(fl.As_total / fl.Ab);
+        const ceilCRaw = Math.ceil(fl.As_p_req / fl.Ab_compr);
+        const tNote = (ceilTRaw < 2 ? `raw \\(\\lceil ... \\rceil = ${ceilTRaw}\\) → bumped to <strong>2</strong> (corner-bar minimum). ` : '')
+                    + `at the <strong>${tensionLoc}</strong> of the section (${momentType})`;
+        const cNote = (ceilCRaw < 2 ? `raw \\(\\lceil ... \\rceil = ${ceilCRaw}\\) → bumped to <strong>2</strong> (corner-bar minimum). ` : '')
+                    + `at the <strong>${comprLoc}</strong> of the section`;
+        html += row('\\(n_{tension} = \\max\\!\\left(2,\\,\\lceil A_{s,total} / A_b \\rceil\\right)\\)', `${fl.n_tension} bars`, tNote);
+        html += row('\\(n_{compr.} = \\max\\!\\left(2,\\,\\lceil A\'_{s,req} / A\'_b \\rceil\\right)\\)', `${fl.n_compression} bars`, cNote);
+        html += row('\\(A_{s,prov}\\) (tension)', `${fl.As_prov_t.toFixed(2)} mm²`, `at the <strong>${tensionLoc}</strong>`);
+        html += row('\\(A\'_{s,prov}\\) (compression)', `${fl.As_prov_c.toFixed(2)} mm²`, `at the <strong>${comprLoc}</strong>`);
         html += row('\\(a = \\dfrac{A_s f_y - A\'_s f\'_s}{0.85\\,f\'_c\\,b}\\)', `${fl.a.toFixed(2)} mm`,
                    'force equilibrium with provided steel');
         if (fl.Sc_t !== null) {
@@ -2346,7 +2373,12 @@
                    `${fl.capacity_ok ? '≥' : '<'} \\(M_u = ${fl.Mu_kNm.toFixed(3)}\\) kN·m`,
                    fl.capacity_ok ? 'ok' : 'fail');
         html += (fl.capacity_ok)
-            ? `<div class="bd-alert bd-alert-ok">✓ <strong>DRRB</strong> — use <strong>${fl.n_tension} – ∅${db.toFixed(0)} mm tension</strong> and <strong>${fl.n_compression} – ∅${(dbC||db).toFixed(0)} mm compression</strong> bars (\\(\\phi M_n\\) = ${fl.phi_Mn_kNm.toFixed(2)} kN·m)</div>`
+            ? `<div class="bd-alert bd-alert-ok">
+                 ✓ <strong>DRRB</strong> <small style="color:#0F6E56;">(${momentType})</small>
+                 &nbsp;|&nbsp; <strong>${fl.n_tension} – ∅${db.toFixed(0)} mm</strong> at the <strong>${tensionLoc}</strong> (tension)
+                 &nbsp;|&nbsp; <strong>${fl.n_compression} – ∅${(dbC||db).toFixed(0)} mm</strong> at the <strong>${comprLoc}</strong> (compression)
+                 &nbsp;|&nbsp; \\(\\phi M_n\\) = ${fl.phi_Mn_kNm.toFixed(2)} kN·m
+               </div>`
             : `<div class="bd-alert bd-alert-fail">✗ DRRB capacity insufficient — increase section.</div>`;
         return html;
     }
@@ -2512,7 +2544,7 @@
                     <span>${i + 1}. ${sec.label || `Section ${i + 1}`}${xLbl}${dem}</span>
                 </div>
                 <div class="bd-step-banner" style="background:linear-gradient(135deg,#1f6f30,#0F6E56);">Flexure Design — NSCP 2015 §406</div>
-                ${flexureHtmlFor(fl, materials)}
+                ${flexureHtmlFor(fl, materials, Mu)}
                 <div class="bd-step-banner" style="background:linear-gradient(135deg,#b07700,#8a5a00);">Shear Design — NSCP 2015 §422</div>
                 ${shearHtmlFor(sh, materials)}
             </div>`;


### PR DESCRIPTION
The flexural design output now states explicitly **where** the tension and compression bars go in the section — driven by the sign of Mu — and the rounding rule that bumps any 1-bar result to 2 (\"corner-bar minimum\") is now spelled out where it applies.

## Bar position from Mu sign

- **Positive Mu → sagging (+M)** → tension at the **BOTTOM**, compression at the **TOP** (typical midspan).
- **Negative Mu → hogging (−M)** → tension at the **TOP**, compression at the **BOTTOM** (typical at supports of continuous and fixed beams).

`flexureHtmlFor(fl, m, signedMu)` now accepts the signed Mu directly from the section input — `designFlexure` previously dropped the sign with `Math.abs(Mu_kNm)` so the position couldn't be recovered downstream. The caller in the per-section loop already had the signed value; this PR just threads it through one more argument.

### Where the position now appears

- **Step 1 — Mu row** right-column note: *\"sagging (+M) → tension fiber at the BOTTOM\"* or *\"hogging (−M) → tension fiber at the TOP\"*.
- **Step 4 (SRRB) success alert**: *\"Use 3 – ∅20 mm bars at the **BOTTOM** of the section (sagging (+M)) | As_prov = ... | φMn = ... kN·m\"*.
- **Step 6 (DRRB)** — both `n_tension` and `n_compr` rows carry the location in their right-column notes; the As_prov rows also annotate the side. The success alert becomes:

> ✓ **DRRB** *(hogging (−M))* &nbsp;|&nbsp; **4 – ∅25 mm** at the **TOP** (tension) &nbsp;|&nbsp; **2 – ∅20 mm** at the **BOTTOM** (compression) &nbsp;|&nbsp; φMn = ... kN·m

## Corner-bar minimum made explicit

`designFlexure` already returns `max(2, ceil(As_req/Ab))` for SRRB and the same for both DRRB layers — so the 1-bar case was already being bumped to 2 in the math. The output didn't say so.

- The `n`-row labels are now written as **`n = max(2, ⌈...⌉)`** instead of just `⌈...⌉`.
- When the raw ceil is < 2, the right-column note prints *\"raw ⌈...⌉ = 1 → bumped to **2** (corner-bar minimum)\"* so the user can see why the bar count is higher than the bare `As_req / Ab` ratio would suggest.

## Verified
Smoke-tested in a stubbed DOM with the default section (Mu = 150 kN·m, sagging): the output now contains \"BOTTOM\", \"sagging\", and \"tension fiber at the BOTTOM\". The other branches (negative Mu → \"TOP\" / \"hogging\", tiny Mu → corner-bar bump note) follow the same path with the only differences being the resolved strings.

## Test plan
- [ ] After Render redeploys, hard-refresh `/beamDesign.html` → Tab 2.
- [ ] Default section (Mu = 150, Vu = 100) → Design All Sections. The Mu row now says \"sagging (+M) → tension fiber at the BOTTOM\" and the green alert reads \"Use N – ∅XX mm bars at the **BOTTOM** of the section\".
- [ ] Edit the section to Mu = −150. Re-run. Now it says \"hogging (−M) → tension fiber at the TOP\" and the green alert puts the bars at the **TOP**.
- [ ] Bump Mu to ±400 to trigger DRRB. Verify both tension and compression rows in Step 6 carry their side annotations, and the success alert shows both sides correctly (tension at TOP, compression at BOTTOM for hogging; reversed for sagging).
- [ ] Set Mu very small (e.g. Mu = 10). The SRRB n row should display \"raw ⌈...⌉ = 1 → bumped to **2** (corner-bar minimum)\".