### PR TITLE
beamDesign: fix right-support Vu = 0 in auto-detected sections

### DIFF
--- a/public/pages/beamDesign.html
+++ b/public/pages/beamDesign.html
@@ -2301,10 +2301,30 @@
         //    relevant; we still add the support so the user can design for
         //    high shear even when M ≈ 0 (simple supports).
         supps.forEach((s, i) => {
-            const idx     = idxAt(s.x);
-            const idxLeft = idxAt(s.x, -1);
-            const idxRight= idxAt(s.x,  1);
-            const Vu = Math.max(Math.abs(V[idxLeft] || 0), Math.abs(V[idxRight] || 0));
+            const idx = idxAt(s.x);
+            // V has a step at every support (the reaction is added when the
+            // walk reaches x_support). To get the design shear demand we want
+            // the value JUST INSIDE the adjacent span(s) — NOT the post-all-
+            // reactions value at exactly x_support, which can be 0 at the
+            // right end of the beam.
+            //
+            //   idxStrictBefore(x) → last index with xs[i] < x      (left span value)
+            //   idxStrictAfter(x)  → first index with xs[i] > x     (right span value)
+            //
+            // The FEM sampler always seeds xs at x_support ± eps (with
+            // eps = max(L/120, 0.02)), so a sample just inside the span is
+            // guaranteed to exist for non-trivial spans.
+            let iBefore = -1;
+            for (let k = 0; k < xs.length; k++) {
+                if (xs[k] < s.x - 1e-9) iBefore = k; else break;
+            }
+            let iAfter = -1;
+            for (let k = 0; k < xs.length; k++) {
+                if (xs[k] > s.x + 1e-9) { iAfter = k; break; }
+            }
+            const Vleft  = (iBefore >= 0) ? Math.abs(V[iBefore]) : 0;
+            const Vright = (iAfter  >= 0) ? Math.abs(V[iAfter])  : 0;
+            const Vu = Math.max(Vleft, Vright);
             const Mu = M[idx] || 0;
             let label;
             if (i === 0)                    label = `Left support (x = ${s.x.toFixed(2)} m)`;


### PR DESCRIPTION
User report (screenshot): continuous 2-span beam (Pin@0, Roller@3, Roller@6) under 1.4 × 100 kN/m UDL. Reactions panel shows 157.50 / 525.00 / 157.50 kN. **Auto-detect put Vu = 0 on the right-support section** even though the analysis clearly shows 157.5 kN at that face.

## Root cause

The walking-shear reconstruction in `solveFEM()` adds each support reaction the moment x reaches r.x:

```js
for (const r of react) if (r.x <= x) v += r.Rv;
```

So `V(L)` has ALL reactions added and equals the total external load (= 0 after equilibrium). The shear demand the beam has to actually resist is `V(L − ε) ≈ 157.5 kN` — not `V(L)`.

In `rcDetectCriticalSections`, the support shear was extracted via:

```js
idxAt(s.x, -1)  // "snap to index just below x"
idxAt(s.x, +1)  // "snap to index just above x"
```

…but the directional snap had the predicate `xs[best] > x`. The FEM **always** seeds xs at the exact support position, so `xs[best] === x` exactly, the predicate evaluates false, and the snap is a no-op. Both indices returned the index AT the support, where `V = 0` (right end) or `V = post-reaction` (left and interior supports, which happened to equal the in-span demand by coincidence).

Why the bug was invisible elsewhere:
- **Left support**: `V[0] = +R_pin` (reaction added the moment x reaches 0), which numerically matches the in-span demand.
- **Interior supports**: post-reaction value equals demand magnitude (signed flip across the support).
- **Right end**: the only x where all reactions have been summed AND the total equals zero. That's where the bug shows.

## Fix

Replace the nearest-with-snap logic with strict-before / strict-after searches:

```js
iBefore = last  index with xs[i] < s.x − 1e-9   (left  span value)
iAfter  = first index with xs[i] > s.x + 1e-9   (right span value)
```

At end supports one side returns -1, so the corresponding |V| is treated as 0; the other side gives the in-span demand. Interior supports take the larger of the two adjacent-span values, as before.

The FEM seeds xs at `x_support ± eps` (`eps = max(L/120, 0.02)`), so the strict-before / strict-after samples always exist for any practical span length.

## Standalone numerical check

2-span 3 m + 3 m beam under 140 kN/m UDL, supports at 0/3/6:

| Support | Vleft | Vright | Vu |
|---|---|---|---|
| Left (x=0) | 0 | 156.1 | **156.1** |
| Middle (x=3) | 261.1 | 261.1 | **261.1** |
| Right (x=6) | **156.1** | 0 | **156.1** ✓ |

(The standalone test uses 0.01 m resolution; the production FEM uses the support-eps seed points so the actual numbers will read 157.5 to match the reactions panel exactly.)

## Test plan
- [ ] After Render redeploys, in Tab 1 build the same model: Pin@0 + Roller@3 + Roller@6 + UDL Dead 100 kN/m → Analyze.
- [ ] Tab 2: \"Auto-detect from analysis\". The Right support row now shows **Vu = 157.50 kN** (was 0).
- [ ] The other auto-detected sections (Left support, Span 1 V=0, Max −M @ x=3, Span 2 V=0) should be unchanged.