### PR TITLE
foundationDesign: fix Excel upload + template download + redesigned save button + Pile Cap scaffold

### DIFF
--- a/public/assets/css/styles1.css
+++ b/public/assets/css/styles1.css
@@ -738,6 +738,91 @@ nav ul li a:hover {
     margin: 4px 0 0;
 }
 
+/* "Download blank template" link-button next to the upload field */
+.fd-page .fd-link-btn {
+    appearance: none;
+    background: #fff;
+    border: 1px solid #b3d4f0;
+    color: #0056b3;
+    padding: 6px 12px;
+    border-radius: 4px;
+    font-size: 0.9em;
+    cursor: pointer;
+    font-weight: 600;
+}
+.fd-page .fd-link-btn:hover {
+    background: #e7f3ff;
+    border-color: #0056b3;
+}
+
+/* Expandable "What format?" help block */
+.fd-page .fd-import-help {
+    width: 100%;
+    margin-top: 6px;
+    font-size: 0.85em;
+}
+.fd-page .fd-import-help > summary {
+    cursor: pointer;
+    color: #0056b3;
+    font-weight: 600;
+    list-style: revert;
+}
+.fd-page .fd-import-help-body {
+    margin-top: 8px;
+    padding: 10px 14px;
+    background: #fff;
+    border: 1px solid #e1e4e8;
+    border-radius: 6px;
+    color: #495057;
+    line-height: 1.5;
+}
+.fd-page .fd-import-help-body ul { margin: 6px 0; padding-left: 22px; }
+.fd-page .fd-import-help-body code {
+    background: #f6f8fa;
+    border: 1px solid #e1e4e8;
+    border-radius: 3px;
+    padding: 1px 5px;
+    font-size: 0.92em;
+}
+
+/* Save + Pile Cap row at the bottom of the page */
+.fd-page .fd-save-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+    margin: 18px 0 0;
+}
+.fd-page .fd-save-btn {
+    background: linear-gradient(135deg, #1f6f30, #0F6E56);
+    color: #fff;
+    border: 0;
+    padding: 10px 22px;
+    border-radius: 6px;
+    font-size: 1em;
+    font-weight: 700;
+    cursor: pointer;
+    transition: filter 0.15s;
+}
+.fd-page .fd-save-btn:hover { filter: brightness(1.08); }
+
+.fd-page .fd-pilecap-link {
+    display: inline-block;
+    background: rgba(0, 86, 179, 0.08);
+    color: #0056b3;
+    padding: 10px 18px;
+    border-radius: 6px;
+    border: 1px solid #b3d4f0;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background 0.15s;
+}
+.fd-page .fd-pilecap-link:hover {
+    background: rgba(0, 86, 179, 0.16);
+    text-decoration: none;
+}
+
 /* When the inline show/hide JS sets display:none on EVERY direct child of an
    .fd-field, hide the wrapper too — otherwise an empty grid cell remains and
    pushes the next visible field into the wrong slot (the original "dropdown

--- a/public/assets/js/layout_script.js
+++ b/public/assets/js/layout_script.js
@@ -18,8 +18,11 @@ document.addEventListener("DOMContentLoaded", () => {
             window.location.href = 'columnDesign.html';
         } else if (selectedOption === 'beamDesign') {
             window.location.href = 'beamDesign.html';
-        } else if (selectedOption === 'foundationDesign')
+        } else if (selectedOption === 'foundationDesign') {
             window.location.href = 'foundationDesign.html';
+        } else if (selectedOption === 'pileCapDesign') {
+            window.location.href = 'pileCapDesign.html';
+        }
         }catch (error)
         {console.error('Error loading content:', error)}
         

--- a/public/pages/ReinforcedConcrete.html
+++ b/public/pages/ReinforcedConcrete.html
@@ -36,6 +36,7 @@
                 <option value="beamDesign">Beam Design</option>
                 <option value="columnDesign">Column Design</option>
                 <option value="foundationDesign">Foundation Design</option>
+                <option value="pileCapDesign">Pile Cap Design</option>
             </select>
         </div>
 
@@ -78,6 +79,19 @@
                 </p>
                 <div class="rc-card__footer">
                     <span class="rc-badge rc-badge--stub">Placeholder</span>
+                    <span class="rc-card__cta">Open &rarr;</span>
+                </div>
+            </a>
+
+            <a href="pileCapDesign.html" class="rc-card">
+                <h3 class="rc-card__title">Pile Cap Design</h3>
+                <p class="rc-card__description">
+                    ACI 318-14 / NSCP 2015 deep-foundation workflow &mdash; pile reactions,
+                    two-way / one-way shear, flexure, and pile-head anchorage. The form is
+                    scaffolded; calculation routines land next.
+                </p>
+                <div class="rc-card__footer">
+                    <span class="rc-badge rc-badge--stub">In progress</span>
                     <span class="rc-card__cta">Open &rarr;</span>
                 </div>
             </a>

--- a/public/pages/foundationDesign.html
+++ b/public/pages/foundationDesign.html
@@ -46,7 +46,22 @@
             <div class="fd-import-row">
                 <label for="uploadExcel">Import from Excel:</label>
                 <input type="file" id="uploadExcel" accept=".xlsx,.xls" />
-                <span class="fd-hint">Optional &mdash; expects a sheet named &ldquo;DESIGN PARAMETERS&rdquo;.</span>
+                <button type="button" id="downloadTemplate" class="fd-link-btn" onclick="downloadFoundationExcelTemplate()">
+                    &#8595; Download blank template
+                </button>
+                <details class="fd-import-help">
+                    <summary>What format?</summary>
+                    <div class="fd-import-help-body">
+                        The uploaded file must contain a sheet named <strong>DESIGN PARAMETERS</strong> with two columns:
+                        <ul>
+                            <li><strong>Column A</strong> &mdash; parameter label (e.g. <code>Allowable Load P (kN)</code>)</li>
+                            <li><strong>Column B</strong> &mdash; numeric value or text option</li>
+                        </ul>
+                        Row 1 is treated as a header. Unknown labels are ignored. Hit the
+                        <em>Download blank template</em> link above to get a ready-to-fill copy
+                        with every supported label and a Notes column explaining allowed values.
+                    </div>
+                </details>
             </div>
 
             <form id="formFoundation">
@@ -328,7 +343,14 @@
     </div>
     
 </div>     
-            <button id="saveButton" style="display: none;">Save</button>
+            <div class="fd-save-row">
+                <button id="saveButton" type="button" class="fd-save-btn" style="display: none;">
+                    <span aria-hidden="true">&#8595;</span>&nbsp; Download / Print PDF
+                </button>
+                <a href="pileCapDesign.html" class="fd-pilecap-link">
+                    Pile Cap Design &rarr;
+                </a>
+            </div>
         </div>
         
 
@@ -777,1180 +799,206 @@ function renderMathHere(element) {
     }
 }
 
-function handleFile(event) {
-    const file = event.target.files[0];
-    const reader = new FileReader();
-    
-    reader.onload = function(e) {try {
-    const data = new Uint8Array(e.target.result);
-    const workbook = XLSX.read(data, { type: 'array' });
-    const worksheet = workbook.Sheets["DESIGN PARAMETERS"]; // Specify your sheet name
-    if (!worksheet) {
-        console.error("Sheet not found");
+// ─────────────────────────────────────────────────────────────────
+//  Excel parameter map — label (in column A of the DESIGN PARAMETERS
+//  sheet) → form-field id. Single source of truth for both the
+//  upload handler and the template-download helper.
+// ─────────────────────────────────────────────────────────────────
+window.FOUNDATION_EXCEL_PARAM_MAP = {
+    // Analysis & Geometry
+    'Analysis Method':              'analysisMethod',
+    'Structure Type':               'structureType',
+    'Solution Method':              'Method',
+    'Bx (m)':                       'bx',
+    'By (m)':                       'by',
+    'Dc (mm)':                      'dc',
+    'Length Restriction':           'LengthRestriction',
+    'Ratio L':                      'RatioL',
+    'Ratio B':                      'RatioB',
+    'Constriction Length (m)':      'Limitation',
+    // Loading
+    'Load Type':                    'loadType',
+    'Centricity':                   'centricity',
+    'Allowable Load P (kN)':        'AllowableLoad',
+    'Ultimate Load Pu (kN)':        'UltimateLoad',
+    'Allowable Mx (kN.m)':          'AllowableMx',
+    'Allowable My (kN.m)':          'AllowableMy',
+    'Ultimate Mux (kN.m)':          'UltimateMx',
+    'Ultimate Muy (kN.m)':          'UltimateMy',
+    'Dead Load PDL (kN)':           'DeadLoad',
+    'Live Load PLL (kN)':           'LiveLoad',
+    'MxDL (kN.m)':                  'mdlx',
+    'MxLL (kN.m)':                  'mllx',
+    'MyDL (kN.m)':                  'mdly',
+    'MyLL (kN.m)':                  'mlly',
+    // Column
+    'Column Shape':                 'columnShape',
+    'Column Location':              'ColumnLocation',
+    'Column Width (mm)':            'ColumnWidth',
+    'Column Width X (mm)':          'ColumnWidthX',
+    'Column Width Y (mm)':          'ColumnWidthY',
+    // Concrete & detailing
+    'Foundation Depth H (m)':       'Depth',
+    'Bar Diameter (mm)':            'BarDiameter',
+    'Aggregate Diameter (mm)':      'aggDiameter',
+    'Clear Cover (mm)':             'Cover',
+    "f'c (MPa)":                    'fc',
+    'fy (MPa)':                     'fy',
+    'Concrete Unit Weight (kN/m3)': 'UnitWeightConcrete',
+    'Soil Unit Weight (kN/m3)':     'UnitWeightSoil',
+    'Allowable Soil Bearing (kPa)': 'SoilBearingCapacity',
+    'Surcharge (kPa)':              'Surcharge',
+    'Consider Soil Weight':         'considerSoil'
+};
+
+// ─────────────────────────────────────────────────────────────────
+//  Generate a ready-to-fill Excel template that exactly matches the
+//  parameter map. User clicks the button, gets the XLSX, fills in
+//  column B, uploads it back — values land in the right form fields
+//  with no need to memorize internal ids.
+// ─────────────────────────────────────────────────────────────────
+function downloadFoundationExcelTemplate() {
+    if (typeof XLSX === 'undefined') {
+        alert('XLSX library has not loaded yet — refresh the page and try again.');
         return;
     }
-    const jsonSheet = XLSX.utils.sheet_to_json(worksheet, { header: 1 }); // Converting to a 2D array
-    jsonSheet.forEach((row, index) => {
-        if (index === 0) return; // Skip header row
-        // Use Excel column data
-    });
-
-
-        const resultDiv = document.getElementById("result");
-        resultDiv.innerHTML = ''; // Clear previous results
-        const summaryDiv = document.getElementById("Summary");
-        summaryDiv.innerHTML = ''; // Clear previous results
-        const summary1Div = document.getElementById("Summary1");
-        summary1Div.innerHTML = ''; // Clear previous results
-
-
-
-    
-     
-    
-
-
-
-
-        jsonSheet.forEach((row, index) => {
-            if (index === 0) return; // Skip header row
-            
-
-        function determineMethod(structureType, loadType, columnShape, centricity, method) {
-            let n = "";  // Initialize the variable
-            
-            // Mapping structure type
-            if (structureType === "Isolated Square") {
-                n += "IS";
-            } else if (structureType === "Isolated Rectangular") {
-                n += "IR";
-            } else if (structureType === "Strip") {
-                n += "ST";
-            }
-        
-            // Mapping load type
-            if (loadType === "ultimate") {
-                n += "-UL";
-            } else {
-                n += "-SW";  // Assuming "SW" is for Service Load
-            }
-        
-            // Mapping column shape
-            if (columnShape === "square") {
-                n += "-SQ";
-            } else if (columnShape === "rectangular") {
-                n += "-RC";
-            } else if (columnShape === "circle") {
-                n += "-CR";
-            }
-        
-            // Mapping centricity
-            if (centricity === "concentric") {
-                n += "-CC";
-            } else if (centricity === "eccentric") {
-                n += "-EC";
-            }
-        
-            // Adding method as the final number
-            n += `-${method}`;
-        
-            return n;
-        }
-                
-        function createParagraph(content) {
-            const p = document.createElement('p');
-            p.innerHTML = content;
-            return p;
-        }        
-        function createHeader8(content) {
-            const h8 = document.createElement('h8');
-            h8.innerHTML = content;
-            return h8;
-        }
-        function createHeader7(content) {
-            const h7 = document.createElement('h7');
-            h7.innerHTML = content;
-            return h7;
-        }
-        function createHeader5(content) {
-            const h5 = document.createElement('h5');
-            h5.innerHTML = content;
-            return h5;
-        }
-        function createHeader3(content) {
-            const h3 = document.createElement('h3');
-            h3.innerHTML = content;
-            return h3;
-        }
-        function dimension(DC){
-            let dc = DC;
-            let ds = (h*1000) - dc;
-            let qnet = qa - (ys*(ds/1000)) -(yc*(dc/1000)) - q;
-            let pu1;
-            let pu2;
-            let mux1;
-            let mux2;
-            let muy1;
-            let muy2;
-           
-                   
-            if(recheck===0){
-                document.getElementById('result').appendChild(createHeader5(`Calculation of Dimensions`));       
-                document.getElementById('result').appendChild(createParagraph(`$$\\ D_c = ${dc}mm \$$`));
-                document.getElementById('result').appendChild(createParagraph(`$$\\ D_s = H - D_c = ${h*1000}mm - ${dc}mm = ${ds}mm \$$`));
-                document.getElementById('result').appendChild(createParagraph(`$$\\ q_{net} = q_{all} - (\\gamma_s \\times D_s) - (\\gamma_c \\times D_c) - q =  ${qa}kPa - (${ys}\\frac{kN}{m^3} \\times ${ds/1000}m) - (${yc}\\frac{kN}{m^3} \\times ${dc/1000}m) - ${q}kPa = ${qnet.toFixed(2)}kPa  \$$`));
-                console.log(`qnet = ${qnet}`);
-                document.getElementById('result').appendChild(createHeader7(`Service Load Calculation`));
-                if(loadType==="ultimate"){
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ P = ${p}kN \$$`));
-                    if (centricity === "eccentric"){
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ M_x = ${mx}kNm \$$`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ M_y = ${my}kNm   \$$`));
-                    }
-                } else if (loadType==="individual"){
-                    p = pdl + pll;
-                    if (centricity === "eccentric"){
-                    mx = mdlx + mllx;
-                    my = mdly + mlly;
-                }
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ P = P_{DL} + P{LL} = ${pdl}kN + ${pll}kN = ${p}kN \$$`));
-                    if (centricity === "eccentric"){
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ M_x = M_{xDL} + M_{xLL} = ${mdlx}kNm + ${mllx}kNm = ${mx}kNm \$$`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ M_y = M_{yDL} + M_{yLL} = ${mdly}kNm + ${mlly}kNm = ${my}kNm   \$$`));
-                    }
-                } if (centricity === "eccentric"){
-                document.getElementById('result').appendChild(createHeader7(`Solve Service Eccentricity`));       
-                
-                ey = mx / p;
-                ex = my / p;
-                document.getElementById('result').appendChild(createParagraph(`$$\\ e_x = \\frac {M_y}{P} = \\frac {${my}kNm}{${p}kN} = ${(ex*1000).toFixed(2)}mm   \$$`));
-                document.getElementById('result').appendChild(createParagraph(`$$\\ e_y = \\frac {M_x}{P} = \\frac {${mx}kNm}{${p}kN} = ${(ey*1000).toFixed(2)}mm   \$$`));
-                document.getElementById('result').appendChild(createParagraph(`$$\\ q_{net} = \\frac {P}{B_y\\times B_x}\\times (1 + \\frac{6\\times e_x}{B_x} + \\frac{6\\times e_y}{B_y}) \$$`));
-                } else if (centricity === "concentric"){
-                document.getElementById('result').appendChild(createParagraph(`$$\\ q_{net} = \\frac {P}{B_y\\times B_x} \$$`));
-    
-                }
-                document.getElementById('result').appendChild(createHeader7(`Solve for \\( B\\)`)); 
-                if (structureType==="Isolated Square"){
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ q_{net} = \\frac {P}{B^2}\\times (1 + \\frac{6\\times (e_x + e_y)}{B}) \$$`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ ${qnet.toFixed(2)}kPa = \\frac {${p}kN}{B^2}\\times (1 + \\frac{6\\times (${ex.toFixed(3)}m+${ey.toFixed(3)}m)}{B})  \$$`));
-                    let Bx_solution = newtonRaphson(0, 0, 1,0,qnet,by,p,ex,ey);
-                    console.log(`Solution for B: ${Bx_solution}`);
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ B = ${(Bx_solution*1000).toFixed(2)}mm \\approx ${Math.ceil(Bx_solution*10)/10}m \$$`));
-                    bx = Math.ceil(Bx_solution*10)/10;
-                    by = bx;
-                } else if (structureType==="Isolated Rectangular"){
-                if (restrictionType === "1"){
-                    //Ratio
-                    let k = ratioLengthB/ratioLengthL;
-                    let A = qnet*k/p;
-                    let C = (6*ex)+((6*ey)/k);   
-                    let initialGuess = 1000; 
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ q_{net} = \\frac {P}{k \\times B_x^2}\\times (1 + \\frac{6\\times e_x}{B_x} + \\frac{6\\times e_y}{k \\times B_x}) \$$`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ ${qnet.toFixed(2)}kPa = \\frac {${p}kN}{${k.toFixed(3)} \\times B_x^2}\\times (1 + \\frac{6\\times ${ex.toFixed(3)}m}{B_x} + \\frac{6\\times ${ey.toFixed(3)}m}{${k.toFixed(3)} \\times B_x}) \$$`));
-                    let Bx_solution = newtonRaphson(A, C, initialGuess,"1");
-                    console.log(`Solution for B_x: ${Bx_solution}`);
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ B_x = ${(Bx_solution*1000).toFixed(2)}mm \\approx ${Math.ceil(Bx_solution*10)/10}m \$$`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ B_y = k \\times B_x = ${k.toFixed(3)} \\times ${(Bx_solution*1000).toFixed(2)}mm \\approx ${Math.ceil(k*Bx_solution*10)/10}m \$$`));
-                    bx = Math.ceil(Bx_solution*10)/10;
-                    by = Math.ceil(k*Bx_solution*10)/10;
-                } else if ( restrictionType === "2"){
-                    //Limited
-                    by = limitLength;
-                    let initialGuess = 100; 
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ ${qnet.toFixed(2)}kPa = \\frac {${p}kN}{${by.toFixed(2)}m \\times B_x}\\times (1 + \\frac{6\\times ${ex.toFixed(3)}m}{B_x} + \\frac{6\\times ${ey.toFixed(3)}m}{${by.toFixed(2)}m}) \$$`));
-                    let Bx_solution = newtonRaphson(0, 0, initialGuess,"2",qnet,by,p,ex,ey);
-                    console.log(`Solution for B_x: ${Bx_solution}`);
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ B_x = ${(Bx_solution*1000).toFixed(2)}mm \\approx ${Math.ceil(Bx_solution*10)/10}m \$$`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ B_y = ${by}m \$$`));
-                    bx = Math.ceil(Bx_solution*10)/10;
-                }
-                }
-                document.getElementById('result').appendChild(createHeader7(`Solve for Ultimate Loads`));
-                if(loadType==="ultimate"){
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ Pu = ${pu.toFixed(2)}kN \$$`));
-                    if  (centricity === "eccentric"){
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ M_{ux} = ${mux.toFixed(2)}kNm \$$`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ M_{uy} = ${muy.toFixed(2)}kNm   \$$`));
-                    }
-                } else if (loadType==="individual"){
-                    if (considerSoil==="yes"){
-                        pu1 = 1.4*(pdl)+1.4*(ys*(ds/1000)+yc*(dc/1000)+q)*bx*by;
-                        pu2 = 1.2*pdl +1.6*pll + 1.2*(ys*(ds/1000)+yc*(dc/1000)+q)*bx*by;
-                        document.getElementById('result').appendChild(createParagraph(``));
-                        document.getElementById('result').appendChild(createParagraph(``));
-                        document.getElementById('result').appendChild(createParagraph(`\\( P_u = \\text{Greatest of}\\left\\{\\begin{array}{l}1.4 \\times P_{DL} + 1.4 \\times [(\\gamma_s \\times D_s) + (\\gamma_c \\times D_c) + q] \\times B_y \\times B_x \\,  \\\\ 1.2 \\times P_{DL} + 1.6 \\times P_{LL} + 1.2 \\times [(\\gamma_s \\times D_s) + (\\gamma_c \\times D_c) + q] \\times B_y \\times B_x \\,  \\end{array}\\right. \\)`));
-                        document.getElementById('result').appendChild(createParagraph(``));
-                        document.getElementById('result').appendChild(createParagraph(``));
-    
-                        document.getElementById('result').appendChild(createParagraph(`\\( P_u = \\text{Greatest of}\\left\\{\\begin{array}{l}1.4 \\times ${pdl}kN + 1.4 \\times [(${ys} \\frac{kN}{m^3} \\times ${ds/1000}m) + (${yc} \\frac{kN}{m^3} \\times ${dc/1000}m) + ${q}kPa] \\times ${by}m \\times ${bx}m = ${pu1.toFixed(2)}kN \\,  \\\\  1.2 \\times ${pdl}kN + 1.6 \\times ${pll}kN + 1.2 \\times [(${ys} \\frac{kN}{m^3} \\times ${ds/1000}m) + (${yc} \\frac{kN}{m^3} \\times ${dc/1000}m) + ${q}kPa] \\times ${by}m \\times ${bx}m  = ${pu2.toFixed(2)}kN \\,  \\end{array}\\right. = ${Math.max(pu1,pu2).toFixed(2)}kN \\)`));
-                        
-                        pu = Math.max(pu1,pu2); 
-                    } else {
-                        pu1 = 1.4*pdl;
-                        pu2 = 1.2*pdl +1.6*pll;
-                        document.getElementById('result').appendChild(createParagraph(``));
-                        document.getElementById('result').appendChild(createParagraph(`\\( P_u = \\text{Greatest of}\\left\\{\\begin{array}{l}1.4 \\times P_{DL}\\ = 1.4 \\times ${pdl}kN = ${pu1.toFixed(2)}kN\\,  \\\\ 1.2 \\times P_{DL} + 1.6 \\times P_{LL} = 1.2 \\times ${pdl}kN + 1.6 \\times ${pll}kN = ${pu2.toFixed(2)}kN  \\,  \\end{array}\\right. = ${Math.max(pu1,pu2).toFixed(2)}kN \\)`));
-                        
-                        pu = Math.max(pu1,pu2); 
-                        }
-                        if  (centricity === "eccentric"){
-                    mux1 = 1.4*(mdlx);
-                    mux2 = 1.2*mdlx +1.6*mllx;
-                    muy1 = 1.4*(mdly);
-                    muy2 = 1.2*mdly +1.6*mlly;
-                    document.getElementById('result').appendChild(createParagraph(``));
-                    document.getElementById('result').appendChild(createParagraph(``));
-    
-                    document.getElementById('result').appendChild(createParagraph(`\\( M_{ux} = \\text{Greatest of}\\left\\{\\begin{array}{l}1.4 \\times M_{xDL} = 1.4 \\times ${mdlx}kNm = ${mux1.toFixed(2)}kNm \\,  \\\\ 1.2 \\times M_{xDL} + 1.6 \\times M_{xLL} = 1.2 \\times ${mdlx}kNm + 1.6 \\times ${mllx}kNm = ${mux2.toFixed(2)}kNm \\,  \\end{array}\\right. = ${Math.max(mux1,mux2).toFixed(2)}kNm \\)`));
-                    document.getElementById('result').appendChild(createParagraph(``));
-                    document.getElementById('result').appendChild(createParagraph(``));
-    
-                    document.getElementById('result').appendChild(createParagraph(`\\( M_{uy} = \\text{Greatest of}\\left\\{\\begin{array}{l}1.4 \\times M_{yDL} = 1.4 \\times ${mdly}kNm = ${muy1.toFixed(2)}kNm \\,  \\\\ 1.2 \\times M_{yDL} + 1.6 \\times M_{yLL} = 1.2 \\times ${mdly}kNm + 1.6 \\times ${mlly}kNm = ${muy2.toFixed(2)}kNm \\,  \\end{array}\\right. = ${Math.max(muy1,muy2).toFixed(2)}kNm \\)`));
-                    document.getElementById('result').appendChild(createParagraph(``));
-                    document.getElementById('result').appendChild(createParagraph(``));
-    
-                    
-                    document.getElementById('result').appendChild(createHeader7(`Solve for Ultimate Eccentricity`));
-                    muy = Math.max(muy1,muy2);
-                    mux = Math.max(mux1,mux2);
-                    euy = mux/pu;
-                    eux = muy/pu;
-                    con = (6*euy/by)+(6*eux/bx);
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ e_{ux} = \\frac{M_{uy}}{P} = \\frac{${muy.toFixed(2)}kNm}{${pu.toFixed(2)}kN} = ${(eux*1000).toFixed(2)}mm\$$`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ e_{uy} = \\frac{M_{ux}}{P} = \\frac{${mux.toFixed(2)}kNm}{${pu.toFixed(2)}kN} = ${(euy*1000).toFixed(2)}mm\$$`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ 6 \\times \\frac{e_{ux}}{B_x} + 6 \\times \\frac{e_{uy}}{B_y} \\le 1 \$$`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ 6 \\times \\frac{${(eux*1000).toFixed(2)}mm}{${(bx*1000).toFixed(2)}mm} + 6 \\times \\frac {${(euy*1000).toFixed(2)}mm}{${(by*1000).toFixed(2)}mm} \\le 1 \$$`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ ${con.toFixed(6)} ${con > 1 ? "> 1 \\therefore \\text{Case 1, With Tension}":"< 1 \\therefore \\text{Case 2, Without Tension}"} \$$`));
-                    }
-                    
-    
-                }
-            } else if (recheck===1){
-                document.getElementById('result').appendChild(createHeader5(`Recompute Dimensions`));       
-                document.getElementById('result').appendChild(createParagraph(`$$\\ D_c = ${dc}mm \$$`));
-                document.getElementById('result').appendChild(createParagraph(`$$\\ D_s = H - D_c = ${h*1000}mm - ${dc}mm = ${ds}mm \$$`));
-                document.getElementById('result').appendChild(createParagraph(`$$\\ q_{net} = q_{all} - (\\gamma_s \\times D_s) - (\\gamma_c \\times D_c) - q =  ${qa}kPa - (${ys}\\frac{kN}{m^3} \\times ${ds/1000}m) - (${yc}\\frac{kN}{m^3} \\times ${dc/1000}m) - ${q}kPa = ${qnet.toFixed(2)}kPa  \$$`));
-                console.log(`qnet = ${qnet}`);
-                document.getElementById('result').appendChild(createHeader7(`Service Load Calculation`));
-                if(loadType==="ultimate"){
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ P = ${p}kN \$$`));
-                    if (centricity === "eccentric"){
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ M_x = ${mx}kNm \$$`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ M_y = ${my}kNm   \$$`));
-                    }
-                } else if (loadType==="individual"){
-                    p = pdl + pll;
-                    if (centricity === "eccentric"){
-                    mx = mdlx + mllx;
-                    my = mdly + mlly;
-                }
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ P = ${p}kN \$$`));
-                    if (centricity === "eccentric"){
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ M_x = ${mx}kNm \$$`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ M_y = ${my}kNm \$$`));
-                    }
-                } if (centricity === "eccentric"){
-                document.getElementById('result').appendChild(createHeader7(`Solve Service Eccentricity`));       
-                
-                ey = mx / p;
-                ex = my / p;
-                document.getElementById('result').appendChild(createParagraph(`$$\\ e_x = \\frac {M_y}{P} = ${(ex*1000).toFixed(2)}mm   \$$`));
-                document.getElementById('result').appendChild(createParagraph(`$$\\ e_y = \\frac {M_x}{P} = ${(ey*1000).toFixed(2)}mm   \$$`));
-                } else if (centricity === "concentric"){
-                document.getElementById('result').appendChild(createParagraph(`$$\\ q_{net} = \\frac {P}{B_y\\times B_x} \$$`));
-    
-                }
-                document.getElementById('result').appendChild(createHeader7(`Solve for \\( B\\)`)); 
-                if (structureType==="Isolated Square"){
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ q_{net} = \\frac {P}{B^2}\\times (1 + \\frac{6\\times (e_x + e_y)}{B}) \$$`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ ${qnet.toFixed(2)}kPa = \\frac {${p}kN}{B^2}\\times (1 + \\frac{6\\times (${ex.toFixed(3)}m+${ey.toFixed(3)}m)}{B})  \$$`));
-                    let Bx_solution = newtonRaphson(0, 0, 1,0,qnet,by,p,ex,ey);
-                    console.log(`Solution for B: ${Bx_solution}`);
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ B = ${(Bx_solution*1000).toFixed(2)}mm \\approx ${Math.ceil(Bx_solution*10)/10}m \$$`));
-                    bx = Math.ceil(Bx_solution*10)/10;
-                    by = bx;
-                } else if (structureType==="Isolated Rectangular"){
-                if (restrictionType === "1"){
-                    //Ratio
-                    let k = ratioLengthB/ratioLengthL;
-                    let A = qnet*k/p;
-                    let C = (6*ex)+((6*ey)/k);   
-                    let initialGuess = 1000; 
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ q_{net} = \\frac {P}{k \\times B_x^2}\\times (1 + \\frac{6\\times e_x}{B_x} + \\frac{6\\times e_y}{k \\times B_x}) \$$`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ ${qnet.toFixed(2)}kPa = \\frac {${p}kN}{${k.toFixed(3)} \\times B_x^2}\\times (1 + \\frac{6\\times ${ex.toFixed(3)}m}{B_x} + \\frac{6\\times ${ey.toFixed(3)}m}{${k.toFixed(3)} \\times B_x}) \$$`));
-                    let Bx_solution = newtonRaphson(A, C, initialGuess,"1");
-                    console.log(`Solution for B_x: ${Bx_solution}`);
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ B_x = ${(Bx_solution*1000).toFixed(2)}mm \\approx ${Math.ceil(Bx_solution*10)/10}m \$$`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ B_y = k \\times B_x = ${k.toFixed(3)} \\times ${(Bx_solution*1000).toFixed(2)}mm \\approx ${Math.ceil(k*Bx_solution*10)/10}m \$$`));
-                    bx = Math.ceil(Bx_solution*10)/10;
-                    by = Math.ceil(k*Bx_solution*10)/10;
-                } else if ( restrictionType === "2"){
-                    //Limited
-                    by = limitLength;
-                    let initialGuess = 100; 
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ ${qnet.toFixed(2)}kPa = \\frac {${p}kN}{${by.toFixed(2)}m \\times B_x}\\times (1 + \\frac{6\\times ${ex.toFixed(3)}m}{B_x} + \\frac{6\\times ${ey.toFixed(3)}m}{${by.toFixed(2)}m}) \$$`));
-                    let Bx_solution = newtonRaphson(0, 0, initialGuess,"2",qnet,by,p,ex,ey);
-                    console.log(`Solution for B_x: ${Bx_solution}`);
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ B_x = ${(Bx_solution*1000).toFixed(2)}mm \\approx ${Math.ceil(Bx_solution*10)/10}m \$$`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ B_y = ${by}m \$$`));
-                    bx = Math.ceil(Bx_solution*10)/10;
-                }
-                }
-                document.getElementById('result').appendChild(createHeader7(`Solve for Ultimate Load Combinations`));
-                if(loadType==="ultimate"){
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ Pu = ${pu}kN \$$`));
-                    if  (centricity === "eccentric"){
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ M_{ux} = ${mux.toFixed(2)}kNm \$$`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ M_{uy} = ${muy.toFixed(2)}kNm   \$$`));
-                    }
-                } else if (loadType==="individual"){
-                    if (considerSoil==="yes"){
-                        pu1 = 1.4*(pdl)+1.4*(ys*(ds/1000)+yc*(dc/1000)+q)*bx*by;
-                        pu2 = 1.2*pdl +1.6*pll + 1.2*(ys*(ds/1000)+yc*(dc/1000)+q)*bx*by;
-                        document.getElementById('result').appendChild(createParagraph(`$$\\ P_{u} = ${Math.max(pu1,pu2).toFixed(2)}kN\$$`));
-                        pu = Math.max(pu1,pu2); 
-                        if (centricity === "eccentric"){
-                        document.getElementById('result').appendChild(createParagraph(`$$\\ M_{ux} = ${mux.toFixed(2)}kNm \$$`));
-                        document.getElementById('result').appendChild(createParagraph(`$$\\ M_{uy} = ${muy.toFixed(2)}kNm   \$$`));
-                        }
-                    } else {
-                        pu1 = 1.4*pdl;
-                        pu2 = 1.2*pdl +1.6*pll;
-                        
-                        document.getElementById('result').appendChild(createParagraph(`$$\\ P_{u} = ${Math.max(pu1,pu2).toFixed(2)}kN\$$`));
-                        pu = Math.max(pu1,pu2);
-                        if (centricity === "eccentric"){
-                        document.getElementById('result').appendChild(createParagraph(`$$\\ M_{ux} = ${mux.toFixed(2)}kNm \$$`));
-                        document.getElementById('result').appendChild(createParagraph(`$$\\ M_{uy} = ${muy.toFixed(2)}kNm   \$$`));
-                        }
-                        }
-    
-                }
-    
-            }
-            function newtonRaphson(A, C, initialGuess, restrictionType, q_a_max, by, p, ex, ey, tolerance = 1e-6, maxIterations = 1000000) {
-                let Bx = initialGuess; // Initial guess for Bx
-                let f_Bx;
-                let f_prime_Bx;
-                const factor = 6 * (ex + ey);
-                for (let i = 0; i < maxIterations; i++) {
-                    if (structureType==="Isolated Square"){
-                        // f(Bx) = (P / Bx^2) * (1 + (6 * (ex + ey) / Bx)) - qa_max
-                        // f(Bx) = (P / Bx^2) * (1 + (factor / Bx)) - qa_max
-                        f_Bx = (p / Math.pow(Bx, 2)) * (1 + (factor / Bx)) - q_a_max;
-        
-                        // f'(Bx) = -2 * (P / Bx^3) * (1 + (factor / Bx)) + (factor * P / Bx^4)
-                        f_prime_Bx = (-2 * (p / Math.pow(Bx, 3))) * (1 + (factor / Bx)) + (factor * p / Math.pow(Bx, 4));
-    
-    
-                    } else if (structureType==="Isolated Rectangular"){
-                    if (restrictionType === "1" ){
-                        f_Bx = A * Math.pow(Bx, 3) - Bx - C;
-                        f_prime_Bx = 3 * A * Math.pow(Bx, 2) - 1;
-                    } else if (restrictionType === "2"){
-                        f_Bx = (q_a_max * by * Bx) - (p * (1 + (6 * ex / Bx))) - (p * 6 * ey / by);
-                        f_prime_Bx = (q_a_max * by) + (p * 6 * ex / Math.pow(Bx, 2));
-                    }}
-                    // Update Bx using Newton-Raphson formula
-                    let next_Bx = Bx - f_Bx / f_prime_Bx;
-            
-                    // Check if the approximation is within tolerance
-                    if (Math.abs(next_Bx - Bx) < tolerance) {
-                        console.log(`Converged to ${next_Bx} after ${i+1} iterations.`);
-                        return next_Bx;
-                    }
-            
-                    // Update Bx for the next iteration
-                    Bx = next_Bx;
-                }
-            
-                console.log("Did not converge within the maximum number of iterations.");
-                return Bx; // Return the last approximation if not converged
-    
-            }
-            
-               
-            
-            
-        }
-    
-        function punchingShear(){
-            let d = dc - cc - barDia;
-            let Ao = (d + cx)*(d+cy);
-            let Af = (by*1000)*(bx*1000);
-            let Vu = pu - pu *(Ao/Af);
-            let print = "";
-            let vn=0;
-            let dc1=0;
-            let test;
-            console.log(`Ao = `,Ao);
-            console.log(`Punching Shear Vu = `,Vu);
-            document.getElementById('result').appendChild(createHeader5(`Punching Shear Calculation`));       
-            document.getElementById('result').appendChild(createParagraph(`$$\\ d = D_c - C_c - d_b = ${dc}mm - ${cc}mm - ${barDia}mm = ${d}mm \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ A_o = (d + c_x)\\times (d + c_y) = (${d}mm + ${cx.toFixed(2)}mm)\\times (${d}mm + ${cy.toFixed(2)}mm) = ${Ao.toFixed(2)}mm^2 \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ A_f = B_y \\times B_x = ${by*1000}mm \\times ${bx*1000}mm = ${Af.toFixed(2)}mm^2 \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ V_u = P_u - P_u \\times (\\frac{A_o}{A_f} ) = ${pu.toFixed(2)}kN - ${pu.toFixed(2)}kN \\times (\\frac{${Ao.toFixed(2)}mm^2}{${Af.toFixed(2)}mm^2} ) = ${Vu.toFixed(2)}kN \$$`));
-            test = phiVn();
-            vn =test.vn;
-            dc1 = test.dc;
-            console.log(`V,..,.h dc = `,dc1);
-            function phiVn(){
-               
-                let vn1;
-                let vn2;
-                let vn3;
-
-                let beta;
-                let alphaS;
-                let bo;
-                console.log(`Method = `,method);
-
-                if( method === 1){
-                    console.log("phivn Method 1")
-                    if (cx<cy){
-                        beta = cy/cx;
-                        bo = (2*(d+cx))+(2*(d+cy));
-                        document.getElementById('result').appendChild(createParagraph(`$$\\ \\beta = \\frac{c_y}{c_x} = \\frac{${cy.toFixed(2)}mm}{${cx.toFixed(2)}mm} = ${beta.toFixed(3)}\$$`));
-                        document.getElementById('result').appendChild(createParagraph(`$$\\ B_o = [2 \\times (d + c_x)]+[2 \\times (d + c_y)] = [2 \\times (${d}mm + ${cx.toFixed(2)}mm)]+[2 \\times (${d}mm + ${cy.toFixed(2)}mm)] = ${bo.toFixed(3)}mm\$$`));
-
-                    } else if (cy<cx){
-                        beta = cx/cy;
-                        document.getElementById('result').appendChild(createParagraph(`$$\\ \\beta = \\frac{c_x}{c_y} = \\frac{${cx.toFixed(2)}mm}{${cy.toFixed(2)}mm} = ${beta.toFixed(3)}\$$`));
-                        bo = (2*(d+cx))+(2*(d+cy));
-                        document.getElementById('result').appendChild(createParagraph(`$$\\ B_o = [2 \\times (d + c_x)]+[2 \\times (d + c_y)] = [2 \\times (${d}mm + ${cx.toFixed(2)}mm)]+[2 \\times (${d}mm + ${cy.toFixed(2)}mm)] = ${bo.toFixed(3)}mm\$$`));
-
-                    } else if (cx===cy){
-                        beta = 1;
-                        document.getElementById('result').appendChild(createParagraph(`$$\\ \\beta = \\frac{c_y}{c_x} = \\frac{${cy.toFixed(2)}mm}{${cx.toFixed(2)}mm} = ${beta}\$$`));
-                        bo = (2*(d+cx))+(2*(d+cy));
-                        document.getElementById('result').appendChild(createParagraph(`$$\\ B_o = 4 \\times (d + c) = 4 \\times (${d}mm + ${cx.toFixed(2)}mm) = ${bo.toFixed(3)}mm\$$`));
-
-                    }
-                    if (columnLocation===1){
-                        alphaS = 40;
-                        document.getElementById('result').appendChild(createParagraph(`$$\\ \\alpha_s = ${alphaS} ,(\\text{Interior Column})\$$`));
-
-                    } else if (columnLocation===2){
-                        alphaS = 30;
-                        document.getElementById('result').appendChild(createParagraph(`$$\\ \\alpha_s = ${alphaS} ,(\\text{Edge Column})\$$`));
-
-                    } else if (columnLocation===3){
-                        alphaS = 20;
-                        document.getElementById('result').appendChild(createParagraph(`$$\\ \\alpha_s = ${alphaS} ,(\\text{Corner Column})\$$`));
-
-                    }
-
-                    // ACI 318-14 / NSCP 2015 §422.6.5.2: Vc shall be the least of these three expressions
-                    vn1 = 0.75 * (1/3) * lambda * Math.sqrt(fc) *bo*d/1000;
-                    vn2 = 0.75 * (1/6) * (1+(2/beta)) * lambda * Math.sqrt(fc) *bo*d/1000;
-                    vn3 = 0.75 * (1/12) * (2+(alphaS*d/bo))* lambda * Math.sqrt(fc) *bo*d/1000;
-                    vn = Math.min(vn1,vn2,vn3);
-                    document.getElementById('result').appendChild(createParagraph(`\\(\\phi V_n = \\phi V_c = \\text{least of}\\left\\{\\begin{array}{l}\\phi \\times \\frac {1}{3} \\times \\lambda \\times \\sqrt{fc'} \\times B_o \\times d  \\,  \\\\\\phi \\times \\frac {1}{6} \\times ( 1 + \\frac{2}{\\beta}) \\times \\lambda \\times \\sqrt{fc'} \\times B_o \\times d \\, \\\\\\phi \\times \\frac {1}{12} \\times ( 2 + \\frac{\\alpha_s \\times d}{B_o}) \\times \\lambda \\times \\sqrt{fc'} \\times B_o \\times d \\, \\end{array}\\right. \\)`));
-                    document.getElementById('result').appendChild(createParagraph(``));
-                    document.getElementById('result').appendChild(createParagraph(`\\(\\phi V_n = \\left\\{\\begin{array}{l}0.75 \\times \\frac {1}{3} \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times ${bo.toFixed(2)}mm \\times ${d.toFixed(2)}mm = ${(vn1*1000).toFixed(2)}N \\approx ${(vn1).toFixed(2)}kN \\, \\\\0.75 \\times \\frac {1}{6} \\times (1+ \\frac{2}{${beta}}) \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times ${bo.toFixed(2)}mm \\times ${d.toFixed(2)}mm = ${(vn2*1000).toFixed(2)}N \\approx ${(vn2).toFixed(2)}kN \\, \\\\ 0.75 \\times \\frac {1}{12} \\times (2+ \\frac{${alphaS} \\times ${d.toFixed(2)}}{${bo.toFixed(2)}}) \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times ${bo.toFixed(2)}mm \\times ${d}mm = ${(vn3*1000).toFixed(2)}N \\approx ${(vn3).toFixed(2)}kN \\, \\end{array}\\right. = ${vn.toFixed(2)}kN \\, \\)`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ V_u = ${Vu.toFixed(2)}kN ${Vu<vn ? "< \\phi V_n    \\therefore \\text{SAFE}":"> \\phi V_{n}\\therefore \\text{FAIL}"}\$$`));
-
-                } else {
-                    console.log("phivn Method 2")
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ V_{u} = \\phi \\times \\frac {1}{3} \\times \\lambda \\times \\sqrt{fc'} \\times (2 \\times (d + c_x) + 2 \\times (d + c_y) \\times d  \$$`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ ${Vu.toFixed(2)}kN = 0.75 \\times \\frac {1}{3} \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times (2 \\times (d + ${cx.toFixed(2)}mm) + 2 \\times (d + ${cy.toFixed(2)}mm) \\times d  \$$`));
-                    d = newtonRaphson(100);
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ d = ${d.toFixed(2)} \\approx ${(Math.ceil(d/25)*25).toFixed(2)}\$$`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ \\text{(Approximate: V_u held constant at the initial geometry; refine via iteration for a tight design.)}\$$`));
-                    dc = d + cc + barDia;
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ D_c = ${d.toFixed(2)} + ${cc}mm + ${barDia}mm = ${dc.toFixed(2)}mm \\approx ${(Math.ceil(dc/25)*25).toFixed(2)}mm\$$`));
-                    dc = Math.ceil(dc/25)*25;
-                    console.log(`V dc method2 = `,dc);
-                }
-                function newtonRaphson(initialGuess, tolerance = 1e-6, maxIterations = 100000) {
-                    let d = initialGuess; // Initial guess for d
-                    let f_d, f_prime_d;
-                
-                    for (let i = 0; i < maxIterations; i++) {
-                        // Calculate the function f(d)
-                        f_d = 0.75 * (1 / 3) * lambda * Math.sqrt(fc) * (2 * (d + cx) + 2 * (d + cy)) * d - (Vu*1000);
-                
-                        // Calculate the derivative f'(d)
-                        f_prime_d = 0.75 * (1 / 3) * lambda * Math.sqrt(fc) * (4 * d + 2 * (d + cx) + 2 * (d + cy));
-                
-                        // Newton-Raphson formula to update d
-                        let next_d = d - f_d / f_prime_d;
-                
-                        // Check if the difference is within tolerance
-                        if (Math.abs(next_d - d) < tolerance) {
-                            console.log(`Converged to d = ${next_d} after ${i+1} iterations.`);
-                            return next_d; // Return the result when converged
-                        }
-                
-                        // Update d for the next iteration
-                        d = next_d;
-                    }
-                
-                    console.log(`Did not converge within the maximum number of iterations.`, d);
-                    return d; // Return the last approximation if not converged
-                }
-                console.log(`Vm2 dc = `,dc);
-                return {vn,dc} ;
-    
-            }
-            
-            return {dc,dc1,vn,Vu};
-        }
-        function beamShear(axis,dc){
-            let x1;
-            let x2;
-            let y1;
-            let y2;
-            let vn;
-            let longer;
-            let shorter;
-            let depth;
-            if(bx<by){
-                longer ="y";
-                shorter ="x";
-            } else if (bx>by){
-                longer ="x";
-                shorter="y";
-            } 
-            if(axis === "y"){
-            //ACROSS X AXIS or ALONG Y AXIS
-            if( longer === axis ){
-                console.log(`y is longer`);
-                r = 0.5;
-                depth = dc - cc - (0.5*barDia);
-            } else if ( shorter === axis ){
-                console.log(`y is shorter`);
-                depth = dc - cc - (1.5*barDia);
-                r = 1.5;
-            } else if ( bx === by){
-                console.log(`y is equal to x`);
-                depth = dc - cc - (1.5*barDia);
-                r = 1.5;
-            }
-            
-            x1 = -((bx*1000)/2);           console.log(`x1 = `,x1);
-            x2 = (bx*1000)/2;              console.log(`x2 = `,x2);
-            y1 = (cy/2)+depth;      console.log(`y1 = `,y1);
-            y2 = ((by*1000)/2);            console.log(`y2 = `,y2);
-           
-            document.getElementById('result').appendChild(createHeader5(`Beam Shear Calculation Along Y-axis (Cut Across Y-axis)`));       
-            if( longer === axis ){
-                document.getElementById('result').appendChild(createParagraph(`$$\\ d = D_c - C_c - 0.5d_b = ${dc}mm - ${cc}mm - 0.5(${barDia}mm) = ${depth}mm \$$`));
-            } else if ( shorter === axis ){
-                document.getElementById('result').appendChild(createParagraph(`$$\\ d = D_c - C_c - 1.5d_b = ${dc}mm - ${cc}mm - 1.5(${barDia}mm) = ${depth}mm \$$`));
-            } else {
-                document.getElementById('result').appendChild(createParagraph(`$$\\ d = D_c - C_c - 1.5d_b = ${dc}mm - ${cc}mm - 1.5(${barDia}mm) = ${depth}mm \$$`));
-            }     
-            
-            document.getElementById('result').appendChild(createParagraph(`$$\\ x_1 = \\frac {-B_x}{2} = \\frac {${-bx*1000}mm}{2} = ${x1}mm \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ x_2 = \\frac {B_x}{2} = \\frac {${bx*1000}mm}{2} = ${x2}mm \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ y_1 = \\frac {c_y}{2} + d = \\frac {${cy.toFixed(2)}mm}{2} + ${depth}mm = ${y1.toFixed(2)}mm \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ y_2 = \\frac {B_y}{2} = \\frac {${by*1000}mm}{2} = ${y2}mm\$$`));
-           
-            } else if (axis === "x"){
-            //ACROSS X AXIS or ALONG Y AXIS
-            if( longer === axis ){
-                depth = dc - cc - (0.5*barDia);
-                r = 0.5;
-            } else if ( shorter === axis ){
-                depth = dc - cc - (1.5*barDia);
-                r = 1.5;
-            } else if ( bx === by){
-                console.log(`y is equal to x`);
-                depth = dc - cc - (0.5*barDia);
-                r = 0.5;
-            }
-            x1 = (cx/2)+depth;      console.log(`x1 = `,x1);
-            x2 = ((bx*1000)/2);            console.log(`x2 = `,x2);
-            y1 = -((by*1000)/2);           console.log(`y1 = `,y1);
-            y2 = (by*1000)/2;              console.log(`y2 = `,y2);
-    
-            
-            document.getElementById('result').appendChild(createHeader5(`Beam Shear Calculation Along X-axis (Cut Across X-axis)`));       
-            if( longer === axis ){
-                document.getElementById('result').appendChild(createParagraph(`$$\\ d = D_c - C_c - 0.5d_b = ${dc}mm - ${cc}mm - 0.5(${barDia}mm) = ${depth}mm \$$`));
-            } else if ( shorter === axis ){
-                document.getElementById('result').appendChild(createParagraph(`$$\\ d = D_c - C_c - 1.5d_b = ${dc}mm - ${cc}mm - 1.5(${barDia}mm) = ${depth}mm \$$`));
-            } else {
-                document.getElementById('result').appendChild(createParagraph(`$$\\ d = D_c - C_c - 0.5d_b = ${dc}mm - ${cc}mm - 0.5(${barDia}mm) = ${depth}mm \$$`));
-            }
-            
-            document.getElementById('result').appendChild(createParagraph(`$$\\ x_1 = \\frac {c_x}{2} + d = \\frac {${cx.toFixed(2)}mm}{2} + {${depth}mm} = ${x1.toFixed(2)}mm \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ x_2 = \\frac {B_x}{2} = \\frac {${bx*1000}mm}{2} = ${x2}mm \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ y_1 = \\frac {-B_y}{2} = \\frac {${-by*1000}mm}{2} = ${y1}mm \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ y_2 = \\frac {B_y}{2} = \\frac {${by*1000}mm}{2} = ${y2}mm\$$`));
-             
-            }
-            let a = x2 - x1;            console.log(`a = `,a);
-            let b = y2 - y1;            console.log(`b = `,b);    
-            let c = x2 + x1;            console.log(`c = `,c);
-            let d = y2 + y1;            console.log(`d = `,d);
-            let Vu = ((a*b)/(by*bx*1000*1000))*(pu+((6*c*muy*1000)/Math.pow(bx*1000,2))+((6*d*mux*1000)/Math.pow(by*1000,2)));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ x_2 - x_1 = ${x2.toFixed(2)}mm - (${x1.toFixed(2)})mm = ${a.toFixed(2)}mm\$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ y_2 - y_1 = ${y2.toFixed(2)}mm - (${y1.toFixed(2)})mm = ${b.toFixed(2)}mm\$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ x_2 + x_1 = ${x2.toFixed(2)}mm + (${x1.toFixed(2)})mm = ${c.toFixed(2)}mm\$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ y_2 + y_1 = ${y2.toFixed(2)}mm + (${y1.toFixed(2)})mm = ${d.toFixed(2)}mm\$$`));
-            if (method === 1){
-                if (axis === "x"){
-                vn = phiVn(by*1000,"B_y");
-                } else if (axis === "y"){
-                vn = phiVn(bx*1000,"B_x"); 
-                }
-            } 
-            document.getElementById('result').appendChild(createParagraph(`$$\\ V_u = \\frac{(x_2 - x_1)\\times(y_2 - y_1)}{B_y \\times B_x}\\times (P_u + \\frac{6 \\times (x_2 + x_1) \\times M_{uy}}{B_x^2} + \\frac{6 \\times (y_2 + y_1) \\times M_{ux}}{B_y^2} ) \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ V_u = \\frac{(${a.toFixed(2)}mm)\\times(${b.toFixed(2)}mm)}{${by*1000}mm \\times ${bx*1000}mm}\\times (${pu.toFixed(2)}kN + \\frac{6 \\times (${c.toFixed(2)}mm) \\times ${muy.toFixed(2)}kNm}{(${bx*1000}mm)^2} + \\frac{6 \\times (${d.toFixed(2)}mm) \\times ${mux.toFixed(2)}kNm}{(${by*1000}mm)^2} ) \$$`));
-            if (method === 1){
-                document.getElementById('result').appendChild(createParagraph(`$$\\ V_u = ${Vu.toFixed(2)}kN ${Vu<vn ? "< \\phi V_n    \\therefore \\text{SAFE}":"> \\phi V_{n}\\therefore \\text{FAIL}"}\$$`));
-                
-            } else if (method === 2){
-                document.getElementById('result').appendChild(createParagraph(`$$\\ V_u = ${Vu.toFixed(2)}kN\$$`));
-    
-                if (axis === "x"){
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ V_u = \\phi \\times \\frac {1}{6} \\times \\lambda \\times \\sqrt{fc'} \\times B_y \\times d \$$`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ ${(Vu*1000).toFixed(2)}N = 0.75 \\times \\frac {1}{6} \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times ${by*1000}mm \\times d \$$`));
-                    d = newtonRaphson(100,by*1000);  
-                } else if (axis === "y"){
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ V_u = \\phi \\times \\frac {1}{6} \\times \\lambda \\times \\sqrt{fc'} \\times B_x \\times d \$$`));
-                    document.getElementById('result').appendChild(createParagraph(`$$\\ ${(Vu*1000).toFixed(2)}N = 0.75 \\times \\frac {1}{6} \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times ${bx*1000}mm \\times d \$$`));
-                    d = newtonRaphson(100,bx*1000);     
-                }
-                document.getElementById('result').appendChild(createParagraph(`$$\\ d = ${d.toFixed(2)}mm\$$`));
-                dc1 = d + cc + (r*barDia);
-                document.getElementById('result').appendChild(createParagraph(`$$\\ D_c = ${d.toFixed(2)} + ${cc}mm + (${r} \\times ${barDia}mm) = ${dc1.toFixed(2)}mm \\approx ${(Math.ceil(dc1/25)*25).toFixed(2)}mm\$$`));
-                dc1 = Math.ceil(dc1/25)*25;
-            }
-            function phiVn(B,text){
-                console.log(fc)
-                let vn = 0.75 * (1/6) * lambda * Math.sqrt(fc) *B *depth/1000;
-                document.getElementById('result').appendChild(createParagraph(`$$\\phi V_n = \\phi \\times \\frac {1}{6} \\times \\lambda \\times \\sqrt{fc'} \\times ${text} \\times d = 0.75 \\times \\frac {1}{6} \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times ${B}mm \\times ${depth}mm = ${(vn*1000).toFixed(2)}N \\approx ${(vn).toFixed(2)}kN\$$`));
-            
-                return vn;
-            }
-           
-            
-            function newtonRaphson(initialGuess,B, tolerance = 1e-6, maxIterations = 100000000) {
-                const K = 0.75 * (1/6) * lambda * Math.sqrt(fc) * B;
-                console.log(`k = `,K);
-                let d = initialGuess; // Initial guess for d
-                let f_d, f_prime_d;
-                let i = 0;
-                while (i < maxIterations) {
-                    // Calculate the function f(d)
-                    f_d =  (Vu*1000) - K * d;
-                    // Calculate the derivative f'(d)
-                    f_prime_d = -K;
-                    // Newton-Raphson formula to update d
-                    let next_d = d - f_d / f_prime_d;
-            
-                    // Check if the difference is within tolerance
-                    if (Math.abs(next_d - d) < tolerance) {
-                        console.log(`Converged to d = ${next_d} after ${i+1} iterations.`);
-                        return next_d; // Return the result when converged
-                    }
-                    i++;
-                    // Update d for the next iteration
-                    d = next_d;
-                    
-                }
-            
-                console.log("Did not converge within the maximum number of iterations.");
-                return d; // Return the last approximation if not converged
-            }
-            console.log(`Beam Shear Vu = `,Vu);
-            console.log(`Beam Shear phi Vn = `,vn);
-            return {vn,Vu,d,dc1};
-        }
-        function rebarDesign(axis){
-            console.log(100);
-            let x1;
-            let x2;
-            let y1;
-            let y2;
-            let longer;
-            let shorter;
-            let depth;
-            
-    
-            if(bx<by){
-                longer ="y";
-                shorter ="x";
-            } else if (bx>by){
-                longer ="x";
-                shorter="y";
-            } 
-            console.log(200);
-            document.getElementById('result').appendChild(createHeader5(`Solve Preliminary Values for Design`));       
-    
-            // ACI 318-14 / NSCP 2015 §22.2.2.4.3: beta1 step-down coefficient is 0.05/7, not 0.5/7
-            let beta1 = 0;
-            if ((0.85-(0.05/7)*(fc-28))>=0.85){
-                beta1 = 0.85;
-            } else if ((0.85-(0.05/7)*(fc-28))<0.65) {
-                beta1 = 0.65;
-            } else {
-                beta1 = 0.85-(0.05/7)*(fc-28);
-            }
-            document.getElementById('result').appendChild(createParagraph(`$$\\ \\beta_1 : 0.65 < [0.85 - (\\frac{0.05}{7})\\times (f'_c - 28)] \\le 0.85 \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ \\beta_1 = 0.85 - (\\frac{0.05}{7})\\times (${fc} - 28) = ${beta1.toFixed(3)} \$$`));
-            
-            
-            if(axis === "y"){
-            //ACROSS X AXIS or ALONG Y AXIS
-            if( longer === axis ){
-                console.log(`y is longer`);
-                r = 0.5;
-                depth = dc - cc - (0.5*barDia);
-                level = "lower";
-            } else if ( shorter === axis ){
-                console.log(`y is shorter`);
-                depth = dc - cc - (1.5*barDia);
-                r = 1.5;
-                level = "upper";
-            } else if ( bx === by){
-                console.log(`y is equal to x`);
-                depth = dc - cc - (1.5*barDia);
-                r = 1.5;
-                level = "upper";
-            }
-            document.getElementById('result').appendChild(createHeader5(`Rebar Design Calculation Along Y-axis (Cut Across Y-axis)`));       
-            
-            x1 = -(bx*1000/2);             console.log(`x1 = `,x1);
-            x2 = ((bx*1000)/2);            console.log(`x2 = `,x2);
-            y1 = ((cy)/2);           console.log(`y1 = `,y1);
-            y2 = (by*1000)/2;              console.log(`y2 = `,y2);
-            
-            document.getElementById('result').appendChild(createParagraph(`$$\\ x_1 = \\frac {-B_x}{2} = \\frac {${-bx*1000}mm}{2} = ${x1}mm \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ x_2 = \\frac {B_x}{2} = \\frac {${bx*1000}mm}{2} = ${x2}mm \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ y_1 = \\frac {c_y}{2} = \\frac {${cy.toFixed(2)}mm}{2} = ${y1.toFixed(2)}mm \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ y_2 = \\frac {B_y}{2} = \\frac {${by*1000}mm}{2} = ${y2}mm\$$`));
-           
-            
-            document.getElementById('result').appendChild(createParagraph(`$$\\ d = D_c - C_c - ${r}d_b = ${dc}mm - ${cc}mm - ${r}(${barDia}mm) = ${depth}mm \$$`));
-            
-    
-            let a = x2 - x1;            console.log(`a = `,a);
-            let b = y2 - y1;            console.log(`b = `,b);    
-            let c = x2 + x1;            console.log(`c = `,c);
-            let d = y2 + y1;            console.log(`d = `,d);
-            
-            console.log(`by = `,by);
-            console.log(`bx = `,bx);
-            console.log(`pu = `,pu);
-            console.log(`muy = `,muy);
-            console.log(`mux = `,mux);
-            let muyShortcut;
-            if (centricity === "eccentric"){
-                muyShortcut = (((x2/1000)-(x1/1000))*Math.pow(((y2/1000)-(y1/1000)),2)/(2*by*bx))*(pu+(6*((x2/1000)+(x1/1000))*muy/Math.pow(bx,2))+(4*((2*y2/1000)+(y1/1000))*mux/Math.pow(by,2)));
-                console.log(`Muy(shortcut) = `,muyShortcut);
-                document.getElementById('result').appendChild(createParagraph(`$$\\ M_{uy(shortcut)} = \\frac{(x_2-x_1) \\times (y_2-y_1)^2}{2 \\times A_f} \\times (P_u + \\frac{6 \\times (x_2 + x_1 ) \\times M_{uy}}{B_x^2} + \\frac{4 \\times (2 \\times y_2 + y_1) \\times M_{ux}}{B_y^2})  \$$`));
-                document.getElementById('result').appendChild(createParagraph(`$$\\ M_{uy(shortcut)} = \\frac{(${a/1000}m) \\times (${b.toFixed(2)/1000}m)^2}{2 \\times ${by}m\\times${bx}m} \\times (${pu}kN +  \\frac{4 \\times (2 \\times ${y2/1000}m + (${(y1/1000).toFixed(2)}m)) \\times ${mux.toFixed(2)}kNm}{(${by}m)^2}) = ${muyShortcut.toFixed(2)}kNm  \$$`));
-            } else {
-                muyShortcut = (((x2/1000)-(x1/1000))*Math.pow(((y2/1000)-(y1/1000)),2)/(2*by*bx))*(pu);
-                console.log(`Muy(shortcut) = `,muyShortcut);
-                document.getElementById('result').appendChild(createParagraph(`$$\\ M_{uy(shortcut)} = \\frac{(x_2-x_1) \\times (y_2-y_1)^2}{2 \\times A_f} \\times (P_u)\$$`));
-                document.getElementById('result').appendChild(createParagraph(`$$\\ M_{uy(shortcut)} = \\frac{(${a/1000}m) \\times (${b.toFixed(2)/1000}m)^2}{2 \\times ${by}m\\times${bx}m} \\times (${pu}kN) = ${muyShortcut.toFixed(2)}kNm  \$$`));           
-            }
-            checkSRRB(bx*1000,muyShortcut,"x");
-    
-            
-        } else if(axis === "x"){
-            //ACROSS Y AXIS or ALONG X AXIS
-            if( longer === axis ){
-                console.log(`x is longer`);
-                r = 0.5;
-                depth = dc - cc - (0.5*barDia);
-                level = "lower";
-            } else if ( shorter === axis ){
-                console.log(`x is shorter`);
-                depth = dc - cc - (1.5*barDia);
-                r = 1.5;
-                level = "upper";
-            } else if ( bx === by){
-                console.log(`x is equal to y`);
-                depth = dc - cc - (0.5*barDia);
-                r = 0.5;
-                level = "lower";
-            }
-            document.getElementById('result').appendChild(createHeader5(`Rebar Design Calculation Along X-axis (Cut Across X-axis)`));       
-            
-            x1 = cx/2;             console.log(`x1 = `,x1);
-            x2 = ((bx*1000)/2);            console.log(`x2 = `,x2);
-            y1 = -(by*1000/2);           console.log(`y1 = `,y1);
-            y2 = (by*1000)/2;              console.log(`y2 = `,y2);
-            
-            document.getElementById('result').appendChild(createParagraph(`$$\\ x_1 = \\frac {c_x}{2} = \\frac {${cx.toFixed(2)}mm}{2} = ${x1.toFixed(2)}mm \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ x_2 = \\frac {B_x}{2} = \\frac {${bx*1000}mm}{2} = ${x2}mm \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ y_1 = \\frac {-B_y}{2} = \\frac {${(-by*1000)}mm}{2} = ${y1}mm \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ y_2 = \\frac {B_y}{2} = \\frac {${by*1000}mm}{2} = ${y2}mm\$$`));
-           
-            
-            document.getElementById('result').appendChild(createParagraph(`$$\\ d = D_c - C_c - ${r}d_b = ${dc}mm - ${cc}mm - ${r}(${barDia}mm) = ${depth}mm \$$`));
-            
-    
-            let a = x2 - x1;            console.log(`a = `,a);
-            let b = y2 - y1;            console.log(`b = `,b);    
-            let c = x2 + x1;            console.log(`c = `,c);
-            let d = y2 + y1;            console.log(`d = `,d);
-            
-            console.log(`by = `,by);
-            console.log(`bx = `,bx);
-            console.log(`pu = `,pu);
-            console.log(`muy = `,muy);
-            console.log(`mux = `,mux);
-            let muxShortcut;
-            if (centricity === "eccentric"){
-            muxShortcut = (Math.pow(((x2/1000)-(x1/1000)),2)*((y2/1000)-(y1/1000))/(2*by*bx))*(pu+(4*((2*x2/1000)+(x1/1000))*muy/Math.pow(bx,2))+(6*((y2/1000)+(y1/1000))*mux/Math.pow(by,2)));
-            console.log(`Mux(shortcut) = `,muxShortcut);
-            document.getElementById('result').appendChild(createParagraph(`$$\\ M_{ux(shortcut)} = \\frac{(x_2-x_1)^2 \\times (y_2-y_1)}{2 \\times A_f} \\times (P_u + \\frac{4 \\times (2 \\times x_2 + x_1 ) \\times M_{uy}}{B_x^2} + \\frac{6 \\times (y_2 + y_1) \\times M_{ux}}{B_y^2})  \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ M_{ux(shortcut)} = \\frac{(${a.toFixed(2)/1000}m)^2 \\times (${b/1000}m)}{2 \\times ${by}m\\times${bx}m} \\times (${pu}kN + \\frac{4 \\times (2 \\times ${(x2/1000).toFixed(2)}m +${(x1/1000).toFixed(2)}m) \\times ${muy.toFixed(2)}kNm}{(${bx}m)^2}) = ${muxShortcut.toFixed(2)}kNm  \$$`));
-            } else {
-                muxShortcut = (Math.pow(((x2/1000)-(x1/1000)),2)*((y2/1000)-(y1/1000))/(2*by*bx))*(pu) ;
-                console.log(`Mux(shortcut) = `,muxShortcut);
-                document.getElementById('result').appendChild(createParagraph(`$$\\ M_{ux(shortcut)} = \\frac{(x_2-x_1)^2 \\times (y_2-y_1)}{2 \\times A_f} \\times (P_u) \$$`));
-                document.getElementById('result').appendChild(createParagraph(`$$\\ M_{ux(shortcut)} = \\frac{(${a.toFixed(2)/1000}m)^2 \\times (${b/1000}m)}{2 \\times ${by}m\\times${bx}m} \\times (${pu}kN) = ${muxShortcut.toFixed(2)}kNm  \$$`));
-            
-            }
-            checkSRRB(by*1000,muxShortcut,"y");
-    
-            
-        }
-        function checkSRRB (b,mu,text){
-            let ct = 3*depth/8;
-            let at = ct*beta1;
-            let muMax = 0.9 * 0.85 * fc * at * b *(depth-(at/2))/1000000;
-            document.getElementById('result').appendChild(createHeader7(`Check if SRRB`));       
-            document.getElementById('result').appendChild(createParagraph(`$$\\ c_t = 3 \\times \\frac{d}{8} = 3 \\times \\frac{${depth}}{8} = ${ct.toFixed(2)}mm \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ a_t = \\beta_1 \\times  c_t   = ${beta1} \\times ${ct.toFixed(2)}mm = ${at.toFixed(2)}mm \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ M_{u(max)} = \\phi \\times 0.85 \\times f'c \\times a_t \\times b \\times (d - \\frac{a_t}{2}) \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ M_{u(max)} = 0.9 \\times 0.85 \\times ${fc}MPa \\times ${at.toFixed(2)}mm \\times ${b}mm \\times (${depth}mm - \\frac{${at.toFixed(2)}mm}{2}) = ${muMax.toFixed(2)}kNm \$$`));
-            
-            document.getElementById('result').appendChild(createParagraph(`$$\\ M_u ${mu < muMax ? "< M_{u(max)} \\therefore \\text{ SRRB}":"> M_{u(max)} \\therefore  \\text{ DRRB}"} \$$`));
-            let rn = (mu*1000000)/(0.9*b*Math.pow(depth,2));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ R_{n} = \\frac{M_{uy}}{\\phi B_${text} d^2} = \\frac{${(mu*1000).toFixed(2)}Nm}{${0.9}\\times  ${b}m \\times  (${depth}mm)^2}  = ${rn.toFixed(3)}\\frac{N}{mm^2} \$$`));
-            let rho = 0.85 * (fc/fy)*(1-Math.sqrt(1-(2*rn/(0.85*fc))));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ \\rho = 0.85 \\times (\\frac{f'c}{fy}) \\times (1- \\sqrt{1 - 2 \\times \\frac{R_n}{0.85 \\times f'c} }) = 0.85 \\times (\\frac{${fc}MPa}{${fy}MPa}) \\times (1- \\sqrt{1 - 2 \\times \\frac{${rn.toFixed(3)}MPa}{0.85 \\times ${fc}MPa} }) = ${rho.toFixed(6)} \$$`));
-            let rhomin1 = 1.4/fy;
-            let rhomin2 = Math.sqrt(fc)/(4*fy);
-            let rhomin = Math.max(rhomin1,rhomin2);
-            document.getElementById('result').appendChild(createParagraph(`\\( \\rho_{min} = \\text {Greatest of} \\left\\{\\begin{array}{l} \\frac{1.4}{fy} = \\frac{1.4}{${fy}MPa} = ${rhomin1.toFixed(6)}\\, \\\\ \\frac{f'c}{4 \\times fy} = \\frac{${fc}MPa}{4 \\times ${fy}MPa} = ${rhomin2.toFixed(6)} \\, \\end{array}\\right. = ${rhomin.toFixed(6)} \\, \\)`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ \\therefore \\rho = ${rho>rhomin ? rho.toFixed(6):rhomin.toFixed(6)} \$$`));
-            rho = Math.max(rho,rhomin);
-            let as = rho*b*depth;
-            // ACI 24.4.3.2 / NSCP 425.6.1.1: rho_ST = 0.0018 for Grade 414+ deformed bars, 0.0020 otherwise.
-            let rhoST = (fy >= 414) ? 0.0018 : 0.0020;
-            let asmin = rhoST*dc*b;
-            document.getElementById('result').appendChild(createParagraph(`$$\\ A_s = \\rho \\times B_${text} \\times d = ${rho.toFixed(6)}\\times ${b}mm \\times ${depth.toFixed(2)}mm = ${as.toFixed(2)}mm^2 \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ A_{s,min} = \\rho_{ST} \\times A_g = ${rhoST.toFixed(4)} \\times B_${text} \\times D_c = ${rhoST.toFixed(4)} \\times ${b}\\,\\text{mm} \\times ${dc}\\,\\text{mm} = ${asmin.toFixed(2)}\\,\\text{mm}^2 \\quad (\\rho_{ST} = ${rhoST.toFixed(4)},\\; f_y ${fy >= 414 ? "\\geq" : "<"} 414\\,\\mathrm{MPa}) \$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\  ${as>asmin ? "A_s > A_{smin}":"A_s < A_{smin}"} \$$`));
-            as = Math.max(as,asmin);
-            document.getElementById('result').appendChild(createParagraph(`$$\\ \\therefore A_s = ${as.toFixed(2)}mm^2 \$$`));
-            let ab = (Math.PI/4)*Math.pow(barDia,2);
-            n = as/ab;
-            document.getElementById('result').appendChild(createParagraph(``));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ n = \\frac{A_s}{A_b} = \\frac{${as.toFixed(2)}mm}{\\frac{\\pi}{4} \\times (${barDia}mm)^2} = ${n.toFixed(2)} \\approx ${Math.ceil(n)}pcs \$$`));
-            n = Math.ceil(n);
-            sc = (b - 2*cc - (n*barDia))/(n-1);
-            let scmin = Math.max(50,barDia,(4/3)*dAgg);
-            document.getElementById('result').appendChild(createParagraph(`$$\\ S_c = \\frac{B_${text} - (2 \\times C_c) - (n \\times d_b)}{n - 1} = \\frac{${b}mm - (2 \\times ${cc}mm) - (${n} \\times ${barDia}mm)}{${n} - 1} = ${sc.toFixed(2)}mm \$$`));
-            document.getElementById('result').appendChild(createParagraph(`\\( S_{c(min)} = \\text {Greatest of} \\left\\{\\begin{array}{l} 50mm\\, \\\\  d_b = ${barDia}mm \\, \\\\  d_{agg} = ${dAgg}mm \\,\\end{array}\\right. = ${scmin}mm \\, \\)`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\  ${sc>scmin ? "S_c > S_{c(min)} \\therefore \\text{Okay}":"S_c < S_{c(min)} \\therefore \\text{Insufficient Spacing, add layer}"} \$$`));
-            let centerbandRatio;
-            let beta;
-            if (by>bx){
-                beta = by/bx;
-            } else if (bx>by){
-                beta = bx/by;
-            } else {
-                beta = 1;
-            }
-            centerbandRatio = 2 / (beta+1);
-            m = Math.ceil(n*centerbandRatio);
-            document.getElementById('result').appendChild(createParagraph(`$$\\ \\Upsilon_s = \\frac{2}{\\beta + 1} = \\frac{2}{${beta.toFixed(2)} + 1} = ${centerbandRatio.toFixed(2)}\$$`));
-            document.getElementById('result').appendChild(createParagraph(`$$\\ n_{centerband} = n \\times \\Upsilon_s = ${n} \\times ${centerbandRatio.toFixed(2)} = ${(n*centerbandRatio).toFixed(2)}pcs \\approx ${Math.ceil(n*centerbandRatio)}pcs \$$`));
-            
-        }
-        
-        }
-        function printDiv(divId) {
-            const originalContent = document.body.innerHTML;
-            const printContent = document.getElementById(divId).outerHTML;
-    
-            document.body.innerHTML = printContent;
-            window.print();
-            document.body.innerHTML = originalContent;
-        }
-            // Use Excel column data
-            document.getElementById('GivenParameters1').appendChild(createHeader5(`Parameters Given:`));       
-            document.getElementById('GivenParameters1').appendChild(createHeader5(``));       
-
-            const structureType = row[0]; // First column in the sheet
-            const restrictionType = row[1]; // Second column
-            const ratioLengthL = parseFloat(row[2]);
-            const ratioLengthB = parseFloat(row[3]);
-            const limitLength = parseFloat(row[4]);
-            const centricity = row[5];
-
-            if (structureType==="Isolated Rectangular"){
-                if (restrictionType === "1"){
-                        //Ratio
-                        document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ ${ratioLengthL}B_{y} = ${ratioLengthB}B_x  \$$`));
-            
-                    }else{
-                        //limited
-                        document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ B_y = ${limitLength}m  \$$`));
-                        document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ \$$`));
-                        
-                        
-                    }
-                }
-
-            let loadType = row[6];
-            let muy = 0;
-            let mux = 0;
-            let p = 0;
-            let pu = 0;
-            let mx = 0;
-            let my = 0;
-            let ey = 0;
-            let ex = 0;
-            let mdlx = 0;
-            let mdly = 0;
-            let mllx = 0;
-            let mlly = 0;
-            let recheck = 0;
-            let pdl = 0;
-            let pll = 0;
-
-            if (loadType === "ultimate") {
-                p = parseFloat(row[7]);
-                document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ P = ${p}kN \$$`));
-                pu = parseFloat(row[8]);
-                document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ P_{u} = ${pu}kN  \$$`));
-                
-
-                if (centricity === "eccentric") {
-                    mx = parseFloat(row[9]);
-                    my = parseFloat(row[10]);
-                    mux = parseFloat(row[11]);
-                    muy = parseFloat(row[12]);
-                    document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ M_{x} = ${mx}kNm  \$$`));
-                    document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ M_{y} = ${my}kNm  \$$`));
-                    document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ M_{ux} = ${mux}kNm \$$`));
-                    document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ M_{uy} = ${muy}kNm  \$$`));
-        
-                   
-                }
-            } else {
-                pdl = parseFloat(row[13]);
-                document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ P_{dl} = ${pdl}kN  \$$`));
-
-                pll = parseFloat(row[14]);
-                document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ P_{ll} = ${pll}kN  \$$`));
-
-                if (centricity === "eccentric") {
-                    mdlx = parseFloat(row[15]);
-                    mllx = parseFloat(row[16]);
-                    mdly = parseFloat(row[17]);
-                    mlly = parseFloat(row[18]);
-
-                    document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ M_{dlx} = ${mdlx}kNm  \$$`));
-                    document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ M_{llx} = ${mllx}kNm  \$$`));
-                    document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ M_{dly} = ${mdly}kNm \$$`));
-                    document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ M_{lly} = ${mlly}kNm  \$$`));
-
-                }
-            }
-
-            const h = parseFloat(row[19]);
-            const barDia = parseInt(row[20]);
-            const dAgg = parseInt(row[21]);
-            const method = parseInt(row[22]);
-
-            document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ H = ${h*1000}mm  \$$`));
-            document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ d_b = ${barDia}mm  \$$`));
-            document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ d_{agg} = ${dAgg}mm  \$$`));
-
-
-            const columnShape = row[23];
-            let cx = 0;
-            let cy = 0;
-
-            if (columnShape === "square") {
-                cx = parseInt(row[24]);
-                cy = cx;
-                document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ c = ${cx}mm , \\text{Square Column} \$$`));
-
-            } else if (columnShape === "rectangular") {
-                cx = parseInt(row[24]);
-                cy = parseInt(row[25]);
-                document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ c_x = ${cx}mm  \$$`));
-                document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ c_y = ${cy}mm , \\text{Rectangular Column} \$$`));
-        
-            } else if (columnShape === "circle") {
-                cx = parseInt(row[24]) * Math.sqrt(Math.PI / 4);
-                cy = cx;
-                document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ c = ${(cx/Math.sqrt(Math.PI/4)).toFixed(0)}mm \\times \\sqrt{\\frac{\\pi}{4}} = ${cx.toFixed(2)}mm , \\text{Spiral Column} \$$`));
-        
-            }
-
-            let columnLocation = parseInt(row[26]);
-            const qa = parseFloat(row[27]);
-            const q = parseFloat(row[28]);
-            const lambda = parseInt(row[29]);
-            const fc = parseFloat(row[30]);
-            const fy = parseFloat(row[31]);
-            const ys = parseFloat(row[32]);
-            const yc = parseFloat(row[33]);
-            const considerSoil = row[34];
-
-            document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ q_a = ${qa}kPa  \$$`));
-            document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ q = ${q}kPa  \$$`));
-            document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ \\lambda = ${lambda}  \$$`));
-            document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ f'c = ${fc}MPa  \$$`));
-            document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ fy = ${fy}MPa  \$$`));
-            document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ f'c = ${fc}MPa  \$$`));
-            document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ \\gamma_s = ${ys}\\frac{kN}{m^3}  \$$`));
-            document.getElementById('GivenParameters1').appendChild(createHeader8(`$$\\ \\gamma_c = ${yc}\\frac{kN}{m^3}  \$$`));
-
-
-            let dc = 250;
-            let dc1 = 0;
-            let dc2 = 0;
-            let dc3 = 0;
-            let finalDc = 0;
-            // Concrete cover Cc (mm). Default 75 mm per ACI 20.6.1.3.1 (cast against earth).
-            let cc = parseFloat(document.getElementById('Cover').value);
-            if (!Number.isFinite(cc) || cc <= 0) { cc = 75; }
-            let by = 0;
-            let bx = 0;
-            let r = 0;
-            let calc;
-            let beamShearX;
-            let beamShearY;
-            let punchingV;
-            let euy = 0;
-            let eux = 0;
-            let con = 0;
-            let m;
-            let n;
-            let sc;
-            let level;
-
-    let logic = determineMethod(structureType,loadType,columnShape,centricity,method);
-    console.log(`logic: `, logic);
-    calc = dimension(dc);
-    punchingV = punchingShear ();
-    
-    if(method === 1){
-        //ITERATION METHOD
-        console.log(`Punching Vu = `,punchingV.Vu);
-        console.log(`Punching Vn = `,punchingV.vn);
-        while(punchingV.vn<punchingV.Vu){
-            console.log("iterating Punching Shear");    
-            dc+=25;
-            punchingV =punchingShear ();
-        }
-        beamShearX=beamShear ("x",dc+25);
-        beamShearY=beamShear ("y",dc+25);
-        while (beamShearX.Vu>beamShearX.vn ||beamShearY.Vu>beamShearY.vn  ){
-            dc += 25;
-            beamShearX=beamShear ("x",dc+25);
-            beamShearY=beamShear ("y",dc+25);
-        }
-        recheck += 1;
-        calc = dimension(dc+25);
-        document.getElementById('Summary').appendChild(createHeader3(`Summary:`));
-        document.getElementById('Summary').appendChild(createParagraph(`$$\\ D_c = ${dc}mm \$$`));
-        document.getElementById('Summary').appendChild(createParagraph(`$$\\ B_x = ${bx}m \$$`));
-        document.getElementById('Summary').appendChild(createParagraph(`$$\\ B_y = ${by}m \$$`));
-
-        document.getElementById('Summary1').appendChild(createHeader3(`Summary:`));
-        document.getElementById('Summary1').appendChild(createParagraph(`$$\\ D_c = ${dc}mm \$$`));
-        document.getElementById('Summary1').appendChild(createParagraph(`$$\\ B_x = ${bx}m \$$`));
-        document.getElementById('Summary1').appendChild(createParagraph(`$$\\ B_y = ${by}m \$$`));
-        rebarDesign("x");
-        document.getElementById('Summary').appendChild(createParagraph(`$$\\ \\text{No. of Rebars Along X-axis (${level})} = ${n}pcs \\text{  @  }${sc.toFixed(2)}mm \$$`));
-        document.getElementById('Summary1').appendChild(createParagraph(`$$\\ \\text{No. of Rebars Along X-axis (${level})} = ${n}pcs \\text{  @  }${sc.toFixed(2)}mm \$$`));
-
-        if (structureType==="Isolated Rectangular"){            
-        document.getElementById('Summary').appendChild(createParagraph(`$$\\ n_{centerband} = ${m}pcs \$$`));
-        document.getElementById('Summary1').appendChild(createParagraph(`$$\\ n_{centerband} = ${m}pcs \$$`));
-
-        }
-        rebarDesign("y");
-        document.getElementById('Summary').appendChild(createParagraph(`$$\\ \\text{No. of Rebars Along Y-axis (${level})} = ${n}pcs \\text{  @  }${sc.toFixed(2)}mm \$$`));
-        document.getElementById('Summary1').appendChild(createParagraph(`$$\\ \\text{No. of Rebars Along Y-axis (${level})} = ${n}pcs \\text{  @  }${sc.toFixed(2)}mm \$$`));
-
-        if (structureType==="Isolated Rectangular"){ 
-        document.getElementById('Summary').appendChild(createParagraph(`$$\\ n_{centerband} = ${m}pcs \$$`));
-        document.getElementById('Summary1').appendChild(createParagraph(`$$\\ n_{centerband} = ${m}pcs \$$`));
-
-        }
-
-    } else if (method === 2){
-        //APPROXIMATION METHOD
-        beamShearX=beamShear ("x",dc+25);
-        dc2=beamShearX.dc1;
-        beamShearY=beamShear ("y",dc+25);
-        dc3=beamShearY.dc1;
-        finalDc = Math.max(punchingV.dc1,dc2,dc3);
-        console.log(`dc: ${punchingV.dc1}, ${dc2}, ${dc3}  `);
-        console.log(`final dc: ${finalDc}mm  `);
-        document.getElementById('result').appendChild(createParagraph(`\\( D_c = \\text {Greatest of} \\left\\{\\begin{array}{l} ${punchingV.dc1}mm \\, \\\\ ${dc2}mm \\, \\\\ ${dc3}mm \\, \\end{array}\\right. = ${finalDc}mm \\, \\)`));
-        recheck += 1;
-        calc = dimension(finalDc);
-        dc = finalDc;
-        
-        document.getElementById('Summary').appendChild(createHeader3(`Summary:`));            
-        document.getElementById('Summary').appendChild(createParagraph(`$$\\ D_c = ${dc}mm \$$`));
-        document.getElementById('Summary').appendChild(createParagraph(`$$\\ B_x = ${bx}m \$$`));
-        document.getElementById('Summary').appendChild(createParagraph(`$$\\ B_y = ${by}m \$$`));
-
-        document.getElementById('Summary1').appendChild(createHeader3(`Summary:`));            
-        document.getElementById('Summary1').appendChild(createParagraph(`$$\\ D_c = ${dc}mm \$$`));
-        document.getElementById('Summary1').appendChild(createParagraph(`$$\\ B_x = ${bx}m \$$`));
-        document.getElementById('Summary1').appendChild(createParagraph(`$$\\ B_y = ${by}m \$$`));
-        
-        rebarDesign("x");
-        document.getElementById('Summary').appendChild(createParagraph(`$$\\ \\text{No. of Rebars Along X-axis (${level})} = ${n}pcs \\text{  @  }${sc.toFixed(2)}mm \$$`));
-        document.getElementById('Summary1').appendChild(createParagraph(`$$\\ \\text{No. of Rebars Along X-axis (${level})} = ${n}pcs \\text{  @  }${sc.toFixed(2)}mm \$$`));
-        
-        if (structureType==="Isolated Rectangular"){ 
-            document.getElementById('Summary').appendChild(createParagraph(`$$\\ n_{centerband} = ${m}pcs \$$`));
-            document.getElementById('Summary1').appendChild(createParagraph(`$$\\ n_{centerband} = ${m}pcs \$$`));
-
-            }
-        rebarDesign("y");
-        document.getElementById('Summary').appendChild(createParagraph(`$$\\ \\text{No. of Rebars Along Y-axis (${level})} = ${n}pcs \\text{  @  }${sc.toFixed(2)}mm \$$`));
-        document.getElementById('Summary1').appendChild(createParagraph(`$$\\ \\text{No. of Rebars Along Y-axis (${level})} = ${n}pcs \\text{  @  }${sc.toFixed(2)}mm \$$`));
-
-        if (structureType==="Isolated Rectangular"){ 
-            document.getElementById('Summary').appendChild(createParagraph(`$$\\ n_{centerband} = ${m}pcs \$$`));
-            document.getElementById('Summary1').appendChild(createParagraph(`$$\\ n_{centerband} = ${m}pcs \$$`));
-
-            }
-    }
-    document.getElementById('saveButton').style.display = 'block';
-    document.getElementById('tab').style.display = 'flex';
-    ['result', 'Summary', 'Summary1', 'GivenParameters1'].forEach(id => {
-        renderMathHere(document.getElementById(id));
-    });
-    const saveButtonElement = document.getElementById("saveButton");
-    saveButtonElement.addEventListener("click", function() {
-        printDiv("Solution");
-        
-
-
-
-
-    });  
-        });
-    } catch (error) {
-    console.error("Error reading the file:", error);
-}
+    const M = window.FOUNDATION_EXCEL_PARAM_MAP || {};
+    const sampleValues = {
+        'Analysis Method':              'design',
+        'Structure Type':               'Isolated Rectangular',
+        'Solution Method':              1,
+        'Length Restriction':           0,
+        'Load Type':                    'ultimate',
+        'Centricity':                   'concentric',
+        'Allowable Load P (kN)':        800,
+        'Ultimate Load Pu (kN)':        1200,
+        'Column Shape':                 'square',
+        'Column Location':              'interior',
+        'Column Width (mm)':            500,
+        'Foundation Depth H (m)':       1.5,
+        'Bar Diameter (mm)':            20,
+        'Aggregate Diameter (mm)':      20,
+        'Clear Cover (mm)':             75,
+        "f'c (MPa)":                    21,
+        'fy (MPa)':                     415,
+        'Concrete Unit Weight (kN/m3)': 23.54,
+        'Soil Unit Weight (kN/m3)':     18,
+        'Allowable Soil Bearing (kPa)': 192,
+        'Surcharge (kPa)':              0,
+        'Consider Soil Weight':         'yes'
     };
-    
+    const guidance = {
+        'Analysis Method':              'design  |  analyze',
+        'Structure Type':               'Isolated Square  |  Isolated Rectangular  |  Strip',
+        'Solution Method':              '1 (Iteration)  |  2 (Approximate from initial Dc)',
+        'Bx (m)':                       'only when Analysis Method = analyze',
+        'By (m)':                       'only when Analysis Method = analyze',
+        'Dc (mm)':                      'only when Analysis Method = analyze',
+        'Length Restriction':           '0 (None)  |  1 (Ratio)  |  2 (Constricted)',
+        'Ratio L':                      'Isolated Rectangular + Restriction = 1',
+        'Ratio B':                      'Isolated Rectangular + Restriction = 1',
+        'Constriction Length (m)':      'Isolated Rectangular + Restriction = 2',
+        'Load Type':                    'ultimate  |  individual',
+        'Centricity':                   'concentric  |  eccentric',
+        'Allowable Mx (kN.m)':          'eccentric only',
+        'Allowable My (kN.m)':          'eccentric only',
+        'Ultimate Mux (kN.m)':          'eccentric only',
+        'Ultimate Muy (kN.m)':          'eccentric only',
+        'Dead Load PDL (kN)':           'individual only',
+        'Live Load PLL (kN)':           'individual only',
+        'MxDL (kN.m)':                  'individual + eccentric',
+        'MxLL (kN.m)':                  'individual + eccentric',
+        'MyDL (kN.m)':                  'individual + eccentric',
+        'MyLL (kN.m)':                  'individual + eccentric',
+        'Column Shape':                 'square  |  rectangular  |  circle',
+        'Column Width (mm)':            'square / circle (diameter)',
+        'Column Width X (mm)':          'rectangular only',
+        'Column Width Y (mm)':          'rectangular only',
+        'Consider Soil Weight':         'yes  |  no'
+    };
+    const rows = [['Parameter', 'Value', 'Notes / units / allowed values']];
+    for (const label of Object.keys(M)) {
+        rows.push([label, sampleValues[label] !== undefined ? sampleValues[label] : '', guidance[label] || '']);
+    }
+    const ws = XLSX.utils.aoa_to_sheet(rows);
+    ws['!cols'] = [{ wch: 32 }, { wch: 22 }, { wch: 58 }];
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'DESIGN PARAMETERS');
+    XLSX.writeFile(wb, 'foundation-design-template.xlsx');
+}
+
+// printDiv — used by the "Download / Print PDF" button. Swaps the body
+// for the chosen result block, fires the browser print dialog (which
+// users can route to "Save as PDF"), and restores the original body.
+// Defined here at top-level so scriptFoundationDesign6.js (an ES
+// module) can still reach it via the global scope.
+function printDiv(divId) {
+    const target = document.getElementById(divId);
+    if (!target) {
+        alert("Nothing to print yet — click Calculate first.");
+        return;
+    }
+    const originalContent = document.body.innerHTML;
+    document.body.innerHTML = target.outerHTML;
+    window.print();
+    document.body.innerHTML = originalContent;
+    // After restore, the inline event listeners are gone — reload so
+    // the page is interactive again. (Cheap; matches the original
+    // post-print behavior users were used to.)
+    window.location.reload();
+}
+
+function handleFile(event) {
+    // Clean, label-driven Excel import. The DESIGN PARAMETERS sheet
+    // should be a 2-column table  [Parameter, Value]; the loader maps
+    // each Parameter to its form-field id and writes the value into
+    // the matching input/select, then dispatches change so the
+    // existing show/hide handlers fire. The user reviews the form and
+    // clicks Calculate — the engine is exactly the same code path as
+    // a manually filled form, so there's no duplicated logic to drift.
+    const file = event.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = function(e) {
+        try {
+            const data = new Uint8Array(e.target.result);
+            const workbook = XLSX.read(data, { type: 'array' });
+            const worksheet = workbook.Sheets['DESIGN PARAMETERS'];
+            if (!worksheet) {
+                alert("The uploaded file has no 'DESIGN PARAMETERS' sheet. Download the template with the button next to the upload control and fill it in.");
+                return;
+            }
+            const rows = XLSX.utils.sheet_to_json(worksheet, { header: 1, defval: '' });
+            const map = window.FOUNDATION_EXCEL_PARAM_MAP || {};
+            let filled = 0, skipped = [];
+            for (let i = 0; i < rows.length; i++) {
+                const row = rows[i];
+                if (!row || row.length < 2) continue;
+                const label = String(row[0] || '').trim();
+                const value = row[1];
+                if (!label || value === '' || value === undefined || value === null) continue;
+                const fieldId = map[label];
+                if (!fieldId) { skipped.push(label); continue; }
+                const el = document.getElementById(fieldId);
+                if (!el) { skipped.push(label); continue; }
+                el.value = String(value);
+                // Fire both change AND input so the listener-driven UI
+                // (hide/show of conditional fields) refreshes the same
+                // way a human-edited field would.
+                el.dispatchEvent(new Event('change',  { bubbles: true }));
+                el.dispatchEvent(new Event('input',   { bubbles: true }));
+                filled++;
+            }
+            const tail = skipped.length
+                ? "\n\nIgnored labels (no matching field): " + skipped.slice(0, 10).join(', ')
+                  + (skipped.length > 10 ? ", ..." : '')
+                : '';
+            alert("Filled " + filled + " field" + (filled === 1 ? '' : 's') + " from the Excel sheet. Review the form and click Calculate." + tail);
+        } catch (err) {
+            console.error('Excel import failed:', err);
+            alert('Could not read the Excel file: ' + (err && err.message ? err.message : err));
+        }
+    };
     reader.readAsArrayBuffer(file);
 }
 

--- a/public/pages/pileCapDesign.html
+++ b/public/pages/pileCapDesign.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pile Cap Design</title>
+    <link rel="stylesheet" href="/assets/css/styles1.css">
+    <script src="/assets/js/layout_script.js" defer></script>
+
+    <!-- KaTeX (synchronous, deterministic) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" crossorigin="anonymous">
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" crossorigin="anonymous"></script>
+
+    <style>
+        /* Scoped page styles — short stub for the placeholder UI. */
+        .pc-page {
+            max-width: 1080px;
+            margin: 0 auto;
+            padding: 16px 20px 40px;
+        }
+        .pc-page h1 {
+            color: #0056b3;
+            font-size: 2em;
+            margin: 0 0 4px;
+        }
+        .pc-page .pc-sub {
+            color: #5c6773;
+            margin: 0 0 24px;
+            font-size: 0.96em;
+        }
+        .pc-page .pc-section {
+            background: #fff;
+            border: 1px solid #d6d9de;
+            border-radius: 8px;
+            padding: 20px 22px;
+            margin-bottom: 20px;
+            box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+        }
+        .pc-page .pc-section h2 {
+            color: #0056b3;
+            font-size: 1.12em;
+            margin: 0 0 12px;
+            padding-bottom: 8px;
+            border-bottom: 1px solid #e1e4e8;
+        }
+        .pc-page .pc-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 14px;
+        }
+        .pc-page .pc-field { display: flex; flex-direction: column; }
+        .pc-page .pc-field label {
+            font-size: 0.85em;
+            color: #495057;
+            font-weight: 600;
+            margin-bottom: 4px;
+        }
+        .pc-page .pc-field input,
+        .pc-page .pc-field select {
+            padding: 8px 10px;
+            border: 1px solid #c5c9d0;
+            border-radius: 4px;
+            font-size: 0.95em;
+        }
+        .pc-page .pc-banner {
+            background: linear-gradient(135deg, #fff7e6, #fff1d6);
+            border: 1px solid #f0d9a3;
+            color: #b07700;
+            padding: 14px 18px;
+            border-radius: 6px;
+            font-size: 0.95em;
+            margin: 20px 0 0;
+        }
+        .pc-page .pc-roadmap {
+            font-size: 0.92em;
+            color: #495057;
+            line-height: 1.6;
+        }
+        .pc-page .pc-roadmap ul { padding-left: 20px; margin: 8px 0; }
+        .pc-page .pc-actions {
+            display: flex;
+            gap: 12px;
+            justify-content: center;
+            flex-wrap: wrap;
+            margin: 12px 0 0;
+        }
+        .pc-page .pc-actions button {
+            background: linear-gradient(135deg, #0070cc, #0056b3);
+            color: #fff;
+            border: 0;
+            padding: 10px 22px;
+            border-radius: 6px;
+            font-size: 1em;
+            font-weight: 600;
+            cursor: not-allowed;
+            opacity: 0.6;
+        }
+        .pc-page .pc-back {
+            display: inline-block;
+            margin-bottom: 14px;
+            color: #0056b3;
+            text-decoration: none;
+            font-size: 0.95em;
+        }
+        .pc-page .pc-back:hover { text-decoration: underline; }
+    </style>
+</head>
+<body>
+    <nav>
+        <ul>
+            <li><a href="index.html">HOME</a></li>
+            <li><a href="QuantitySurveying.html">QUANTITY SURVEYING</a></li>
+            <li><a href="ReinforcedConcrete.html">REINFORCED CONCRETE</a></li>
+            <li><a href="#">STEEL DESIGN</a></li>
+        </ul>
+    </nav>
+
+    <div class="pc-page">
+        <a href="foundationDesign.html" class="pc-back">&larr; Back to Foundation Design</a>
+        <h1>Pile Cap Design</h1>
+        <p class="pc-sub">
+            ACI 318-14 / NSCP 2015 deep-foundation workflow &mdash; pile cap thickness, pile reactions,
+            two-way / one-way shear, flexure, and pile-head anchorage check.
+        </p>
+
+        <!-- ============ Loading & cap layout ============ -->
+        <section class="pc-section">
+            <h2>Column &amp; Pile Layout</h2>
+            <div class="pc-grid">
+                <div class="pc-field">
+                    <label for="pc-pu">Ultimate column load \(P_u\) (kN)</label>
+                    <input type="number" id="pc-pu" step="0.01" inputmode="decimal" placeholder="e.g. 2400" disabled>
+                </div>
+                <div class="pc-field">
+                    <label for="pc-mux">Column moment \(M_{ux}\) (kN&middot;m)</label>
+                    <input type="number" id="pc-mux" step="0.01" inputmode="decimal" placeholder="0" disabled>
+                </div>
+                <div class="pc-field">
+                    <label for="pc-muy">Column moment \(M_{uy}\) (kN&middot;m)</label>
+                    <input type="number" id="pc-muy" step="0.01" inputmode="decimal" placeholder="0" disabled>
+                </div>
+                <div class="pc-field">
+                    <label for="pc-n">Number of piles</label>
+                    <select id="pc-n" disabled>
+                        <option value="2">2 piles (linear)</option>
+                        <option value="3">3 piles (triangular)</option>
+                        <option value="4" selected>4 piles (square)</option>
+                        <option value="6">6 piles (rectangular)</option>
+                        <option value="9">9 piles (3 &times; 3)</option>
+                    </select>
+                </div>
+                <div class="pc-field">
+                    <label for="pc-pile-d">Pile diameter (mm)</label>
+                    <input type="number" id="pc-pile-d" step="50" inputmode="numeric" value="400" disabled>
+                </div>
+                <div class="pc-field">
+                    <label for="pc-pile-cap">Pile capacity (kN/pile)</label>
+                    <input type="number" id="pc-pile-cap" step="10" inputmode="decimal" value="600" disabled>
+                </div>
+                <div class="pc-field">
+                    <label for="pc-pile-spacing">Pile spacing (mm)</label>
+                    <input type="number" id="pc-pile-spacing" step="50" inputmode="numeric" value="1200" disabled>
+                </div>
+                <div class="pc-field">
+                    <label for="pc-edge-dist">Edge distance (mm)</label>
+                    <input type="number" id="pc-edge-dist" step="25" inputmode="numeric" value="400" disabled>
+                </div>
+            </div>
+        </section>
+
+        <!-- ============ Cap geometry & materials ============ -->
+        <section class="pc-section">
+            <h2>Cap Geometry &amp; Materials</h2>
+            <div class="pc-grid">
+                <div class="pc-field">
+                    <label for="pc-cap-d">Cap thickness \(D_c\) (mm)</label>
+                    <input type="number" id="pc-cap-d" step="25" inputmode="numeric" placeholder="solved" disabled>
+                </div>
+                <div class="pc-field">
+                    <label for="pc-col-x">Column width X (mm)</label>
+                    <input type="number" id="pc-col-x" step="25" inputmode="numeric" value="500" disabled>
+                </div>
+                <div class="pc-field">
+                    <label for="pc-col-y">Column width Y (mm)</label>
+                    <input type="number" id="pc-col-y" step="25" inputmode="numeric" value="500" disabled>
+                </div>
+                <div class="pc-field">
+                    <label for="pc-fc">\(f'_c\) (MPa)</label>
+                    <input type="number" id="pc-fc" step="1" inputmode="decimal" value="28" disabled>
+                </div>
+                <div class="pc-field">
+                    <label for="pc-fy">\(f_y\) (MPa)</label>
+                    <input type="number" id="pc-fy" step="5" inputmode="decimal" value="415" disabled>
+                </div>
+                <div class="pc-field">
+                    <label for="pc-cover">Clear cover (mm)</label>
+                    <input type="number" id="pc-cover" step="5" inputmode="numeric" value="75" disabled>
+                </div>
+                <div class="pc-field">
+                    <label for="pc-bar">Main bar \(\varnothing\) (mm)</label>
+                    <input type="number" id="pc-bar" step="2" inputmode="numeric" value="20" disabled>
+                </div>
+                <div class="pc-field">
+                    <label for="pc-emb">Pile embedment (mm)</label>
+                    <input type="number" id="pc-emb" step="25" inputmode="numeric" value="150" disabled>
+                </div>
+            </div>
+        </section>
+
+        <div class="pc-actions">
+            <button type="button" disabled>Design Pile Cap (coming soon)</button>
+        </div>
+
+        <div class="pc-banner">
+            <strong>Pile Cap Design is under construction.</strong>
+            The form above is scaffolded so the inputs and labels are ready for the design engine;
+            the calculation routines themselves are next on the roadmap.
+        </div>
+
+        <section class="pc-section" style="margin-top: 18px;">
+            <h2>Roadmap</h2>
+            <div class="pc-roadmap">
+                Planned design steps once the engine lands &mdash;
+                <ul>
+                    <li><strong>Pile reactions</strong> &mdash; equilibrium under \(P_u + M_{ux} + M_{uy}\) and check
+                        each pile against its allowable load.</li>
+                    <li><strong>Cap thickness</strong> &mdash; iterate \(D_c\) until both
+                        <strong>punching shear</strong> (around the column + around individual piles per
+                        ACI 318-14 &sect;13.4.6) and <strong>one-way shear</strong> pass with adequate margin.</li>
+                    <li><strong>Flexure</strong> &mdash; bending at the critical section (face of column),
+                        same SRRB / DRRB classification as Beam &amp; Foundation.</li>
+                    <li><strong>Reinforcement schedule</strong> &mdash; bar count + spacing in both directions,
+                        development length, hook geometry per NSCP 2015 &sect;425.</li>
+                    <li><strong>Pile anchorage</strong> &mdash; verify the embedment + bend / hook against the
+                        tension demand from any uplift / moment-induced uplift case.</li>
+                    <li><strong>Design Schedule</strong> &mdash; same tabular summary format as the Foundation
+                        and Beam calculators so the deliverable is consistent across modules.</li>
+                </ul>
+            </div>
+        </section>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## TL;DR

| ask | result |
|-----|--------|
| **Is the Excel upload working?** | **No.** Found ~1175 lines of dead handler code that read the sheet, iterated rows, then never extracted any cell values. Replaced with a clean label-driven importer. |
| **What format does the Excel need?** | New format documented in-page (expandable "What format?" block) and shipped as a downloadable template. |
| **Ready-made fill-in Excel file?** | "Download blank template" button next to the upload field generates a pre-filled XLSX on click. |
| **Update / change the save button** | Renamed "Save" → "Download / Print PDF" with a real green button and download arrow. Also restored \`printDiv\` (lost with the deleted handler) and made it surface a friendly alert when there's nothing to print yet. |
| **Add pile cap design on a new tab** | New \`pileCapDesign.html\` with scaffolded form + roadmap + cross-nav from Foundation Design, Reinforced Concrete landing card, and the RC quick-select dropdown. |

## Excel — the fix

### Old behavior (broken)
```js
jsonSheet.forEach((row, index) => {
    if (index === 0) return; // Skip header row
    // Use Excel column data       ← never actually used anything
});
// ...1175 lines of duplicated calc engine running on undefined vars...
```

### New behavior (works)
- Single source of truth: \`window.FOUNDATION_EXCEL_PARAM_MAP\` — label → form-field id, 40 entries covering every input on the page.
- \`handleFile\` reads the **DESIGN PARAMETERS** sheet, looks up each label in the map, writes the value into the matching input/select, and dispatches \`change\` + \`input\` so the existing show/hide handlers fire. User reviews the form and clicks **Calculate** — the same code path as a manually filled form runs, so there's no duplicated logic to drift.
- Unknown labels are listed (up to 10) in the success toast.

### New sheet format

| Column A — Parameter   | Column B — Value          | Column C — Notes |
|------------------------|---------------------------|-----------------|
| Analysis Method        | design                    | design \| analyze |
| Structure Type         | Isolated Rectangular      | Isolated Square \| Isolated Rectangular \| Strip |
| Solution Method        | 1                         | 1 (Iteration) \| 2 (Approximate from initial Dc) |
| Allowable Load P (kN)  | 800                       |                 |
| Foundation Depth H (m) | 1.5                       |                 |
| Bar Diameter (mm)      | 20                        |                 |
| ...                    | ...                       | ...             |

Row 1 is the header. Column C is ignored on upload — it's just there to explain allowed values.

### Template download
The **Download blank template** button next to the upload control generates a fresh XLSX at click time, using \`XLSX.utils.aoa_to_sheet\` + \`XLSX.writeFile\` from the SheetJS library that was already loaded. The template has every supported label, sensible sample values, and the Notes column auto-filled.

## Save button

Renamed **Save** → **Download / Print PDF** with a download-arrow icon and a real green button (matches the Beam Design step banners). Hits \`window.print()\` after swapping in the Solution block — users can route to "Save as PDF" from the browser print dialog.

\`printDiv()\` was lost when I deleted the broken handler (it was buried inside it). Restored at top level so the saveButton click handler in \`scriptFoundationDesign6.js\` can still call it, and added a friendly alert when there's nothing to print yet.

## Pile Cap Design — new tab

New \`pileCapDesign.html\` is a scaffold:
- Scoped \`.pc-page\` styling
- Two form sections (**Column & Pile Layout**, **Cap Geometry & Materials**) with all the inputs disabled so the user can see what's coming without trying to calculate
- A "Coming soon" banner and a **Roadmap** section listing the planned design steps (pile reactions → cap thickness via punching + one-way shear → flexure → reinforcement schedule → pile anchorage → Design Schedule)
- Cross-nav: "← Back to Foundation Design" link at the top

Touchpoints across the app:
- \`ReinforcedConcrete.html\` — new Pile Cap card (badge "In progress") + quick-select option
- \`layout_script.js\` — routes \`pileCapDesign\` selection
- \`foundationDesign.html\` footer — "Pile Cap Design →" link next to the save button so the cross-flow is obvious

## Test plan
- [ ] **Foundation Design** → click **Download blank template** → opens \`foundation-design-template.xlsx\` with 40 labeled rows
- [ ] Fill in a few values in the template → upload → form fields populate, toast confirms count
- [ ] Run **Calculate** with the imported values → solution + schedule render as if hand-filled
- [ ] Click **Download / Print PDF** → browser print dialog opens with the Solution block
- [ ] **Reinforced Concrete** landing → new **Pile Cap Design** card appears with "In progress" badge
- [ ] Quick-select dropdown → selecting **Pile Cap Design** navigates to the new page
- [ ] **Pile Cap Design** page renders the scaffolded form with disabled inputs and the roadmap section

🤖 Generated with [Claude Code](https://claude.com/claude-code)