### PR TITLE
foundationDesign: alpha_s for combined footing + verdict in schedule + batch styling parity

### DIFF
--- a/public/assets/css/styles1.css
+++ b/public/assets/css/styles1.css
@@ -888,9 +888,10 @@ nav ul li a:hover {
    display:inline-block + width:min-content to keep math snippets
    tight on the standalone Solution tab — so that batch cards lay
    out as normal block flow. Without this the engine output gets
-   squashed into a narrow leftmost column inside each card. */
-.fd-batch-card-body .latex-container,
-.fd-batch-card-body .container2 {
+   squashed into a narrow leftmost column inside each card.
+   NOTE: .container2 keeps its 2-column grid (the parameters-given
+   block uses it) — we do not block-flow that container. */
+.fd-batch-card-body .latex-container {
     display: block !important;
     width: 100% !important;
     max-width: 100% !important;
@@ -900,29 +901,23 @@ nav ul li a:hover {
     font-size: 1em;
     line-height: 1.5;
 }
-/* The .latex-container > p rule has  margin-right: 100%  which
-   forces each paragraph to flush left with effectively zero width.
-   Cancel that here so paragraphs in the batch view fill the card. */
-.fd-batch-card-body .latex-container > p,
-.fd-batch-card-body .container2 > p {
-    display: block !important;
-    margin: 6px 0 !important;
-    width: auto !important;
+.fd-batch-card-body .container2 {
+    width: 100%;
+    max-width: 100%;
+    margin: 10px 0;
 }
-/* Headings inside the engine output were also being forced to
-   inline-block min-content, so a long heading like "Solve for
-   Ultimate Loads Per NSCP 2015 §203.3.1 / ACI 318-14 §5.3.1" was
-   wrapping at every space. Block them out and let them flow. */
+/* Headings inside .latex-container were forced to inline-block
+   min-content, so long headings like "Solve for Ultimate Loads
+   Per NSCP 2015 §203.3.1 / ACI 318-14 §5.3.1" were wrapping at
+   every space. Block them out and let them flow. The pretty
+   step-banner / sub-step styling comes from the existing
+   #result.latex-container h5 / h7 rules which now ALSO target
+   .fd-batch-card-body .latex-container (twin selectors injected
+   above), so we don't redefine padding/background here. */
 .fd-batch-card-body .latex-container > h3,
 .fd-batch-card-body .latex-container > h5,
 .fd-batch-card-body .latex-container > h7,
-.fd-batch-card-body .latex-container > h8,
-.fd-batch-card-body .container2 > h3,
-.fd-batch-card-body .container2 > h5,
-.fd-batch-card-body .container2 > h7,
-.fd-batch-card-body .container2 > h8 {
-    display: block !important;
-    margin: 12px 0 6px !important;
+.fd-batch-card-body .latex-container > h8 {
     width: auto !important;
     white-space: normal;
 }
@@ -1031,6 +1026,8 @@ nav ul li a:hover {
    `display: inline-block; margin-right: 100%`. Force block layout
    with full width using !important so neither legacy rule wins.
    ============================================================ */
+.fd-page .fd-batch-card-body .latex-container,
+
 .fd-page #result.latex-container,
 .fd-page #Summary.latex-container,
 .fd-page #Summary1.latex-container {
@@ -1043,6 +1040,9 @@ nav ul li a:hover {
     text-align: left;
     box-sizing: border-box;
 }
+
+.fd-page .fd-batch-card-body .latex-container p,
+
 
 .fd-page #result.latex-container p,
 .fd-page #Summary.latex-container p,
@@ -1063,6 +1063,8 @@ nav ul li a:hover {
 /* h3 (Summary title) — section banner */
 .fd-page #Summary.latex-container h3,
 .fd-page #Summary1.latex-container h3,
+.fd-page .fd-batch-card-body .latex-container h3 ,
+
 .fd-page #result.latex-container h3 {
     display: block !important;
     width: 100% !important;
@@ -1079,6 +1081,8 @@ nav ul li a:hover {
 }
 
 /* h5 — major calculation step. Render as a card header with a step bar */
+.fd-page .fd-batch-card-body .latex-container h5 ,
+
 .fd-page #result.latex-container h5 {
     counter-increment: fd-step;
     display: block !important;
@@ -1099,6 +1103,9 @@ nav ul li a:hover {
     line-height: 1.4 !important;
 }
 
+.fd-page .fd-batch-card-body .latex-container h5::before ,
+
+
 .fd-page #result.latex-container h5::before {
     content: counter(fd-step);
     position: absolute;
@@ -1117,11 +1124,16 @@ nav ul li a:hover {
     font-weight: 700;
 }
 
+.fd-page .fd-batch-card-body .latex-container ,
+
+
 .fd-page #result.latex-container {
     counter-reset: fd-step;
 }
 
 /* h7 — sub-step header (custom tag the JS uses) */
+.fd-page .fd-batch-card-body .latex-container h7,
+
 .fd-page #result.latex-container h7,
 .fd-page #Summary.latex-container h7,
 .fd-page #Summary1.latex-container h7 {
@@ -1140,6 +1152,8 @@ nav ul li a:hover {
 }
 
 /* h8 — atomic value line inside the parameters block */
+.fd-page .fd-batch-card-body .latex-container h8,
+
 .fd-page #result.latex-container h8,
 .fd-page #Summary.latex-container h8,
 .fd-page #Summary1.latex-container h8 {
@@ -1151,6 +1165,8 @@ nav ul li a:hover {
 /* Soft card treatment for the equation paragraphs that follow a step
    header. The .fd-clause rule below overrides this with a more specific
    selector so callouts get the green note styling instead. */
+.fd-page .fd-batch-card-body .latex-container > p ,
+
 .fd-page #result.latex-container > p {
     padding: 10px 14px !important;
     background: #fcfcfd;
@@ -1164,6 +1180,8 @@ nav ul li a:hover {
    Render as a full-width "callout note" block so the text flows naturally
    instead of inheriting the LaTeX container's shrink-to-fit width and
    breaking one-word-per-line. */
+.fd-page .fd-batch-card-body .latex-container p.fd-clause,
+
 .fd-page #result.latex-container p.fd-clause,
 .fd-page #Summary.latex-container p.fd-clause,
 .fd-page #Summary1.latex-container p.fd-clause {
@@ -1189,6 +1207,8 @@ nav ul li a:hover {
 
 /* MathJax renders display equations inside the clause as inline pieces so
    they don't break the paragraph flow. */
+.fd-page .fd-batch-card-body .latex-container p.fd-clause mjx-container,
+
 .fd-page #result.latex-container p.fd-clause mjx-container,
 .fd-page #Summary.latex-container p.fd-clause mjx-container,
 .fd-page #Summary1.latex-container p.fd-clause mjx-container {
@@ -1204,6 +1224,8 @@ nav ul li a:hover {
    solution-card layout cleanly.
    ============================================================ */
 .fd-page .katex,
+.fd-page .fd-batch-card-body .latex-container .katex,
+
 .fd-page #result.latex-container .katex,
 .fd-page #Summary.latex-container .katex,
 .fd-page #Summary1.latex-container .katex,
@@ -1216,6 +1238,8 @@ nav ul li a:hover {
 }
 
 .fd-page .katex-display,
+.fd-page .fd-batch-card-body .latex-container .katex-display,
+
 .fd-page #result.latex-container .katex-display,
 .fd-page #Summary.latex-container .katex-display,
 .fd-page #Summary1.latex-container .katex-display {
@@ -1234,6 +1258,8 @@ nav ul li a:hover {
 }
 
 /* Inside the green clause callout, render inline math without extra spacing. */
+.fd-page .fd-batch-card-body .latex-container p.fd-clause .katex,
+
 .fd-page #result.latex-container p.fd-clause .katex,
 .fd-page #Summary.latex-container p.fd-clause .katex,
 .fd-page #Summary1.latex-container p.fd-clause .katex {

--- a/public/assets/js/scriptFoundationDesign6.js
+++ b/public/assets/js/scriptFoundationDesign6.js
@@ -1376,9 +1376,22 @@ document.addEventListener("DOMContentLoaded", () => {
         rebarDesign("y");
         const rebarY_size = { n, sc, level };
         if (structureType === "Isolated Rectangular") rebarY_size.m = m;
+        // Even when the foundation is SIZE-CONTROLLED (the while-loop
+        // grew dc until shear passes), we still want the schedule to
+        // show the actual Vu / phi*Vn for transparency — otherwise the
+        // verdict column reads "reported (no SAFE/FAIL)" with no
+        // diagnostic. punchingV / beamShearX / beamShearY hold the
+        // values at the converged dc; surface them.
         renderFoundationSummary({
             method: 1,
             dc, bx, by, barDia,
+            qact, qnet: calc,
+            punching:   punchingV
+                          ? { Vu: punchingV.Vu,  vn: punchingV.vn  } : null,
+            beamShearX: beamShearX
+                          ? { Vu: beamShearX.Vu, vn: beamShearX.vn } : null,
+            beamShearY: beamShearY
+                          ? { Vu: beamShearY.Vu, vn: beamShearY.vn } : null,
             rebarX: rebarX_size, rebarY: rebarY_size,
             isRectangular: structureType === "Isolated Rectangular"
         });
@@ -1423,17 +1436,15 @@ document.addEventListener("DOMContentLoaded", () => {
         rebarDesign("y");
         const rebarY_appr = { n, sc, level };
         if (structureType === "Isolated Rectangular") rebarY_appr.m = m;
-        // Method 2 doesn't compute φVn against Vu in the same way; we
-        // report Vu only (no pass/fail column) by passing vn = +Infinity
-        // so the ✓ always wins. The user sees the magnitudes for
-        // reference but no SAFE/FAIL verdict (matches the original
-        // approximation-method behavior).
+        // Method 2 solves dc from the equality Vu = phi*Vn, so phi*Vn
+        // is real — surface both sides of the comparison instead of
+        // hiding the verdict behind +Infinity.
         renderFoundationSummary({
             method: 2,
             dc, bx, by, barDia,
-            punching:   { Vu: punchingV.Vu,   vn: Number.POSITIVE_INFINITY },
-            beamShearX: { Vu: beamShearX.Vu,  vn: Number.POSITIVE_INFINITY },
-            beamShearY: { Vu: beamShearY.Vu,  vn: Number.POSITIVE_INFINITY },
+            punching:   { Vu: punchingV.Vu,   vn: punchingV.vn   },
+            beamShearX: { Vu: beamShearX.Vu,  vn: beamShearX.vn  },
+            beamShearY: { Vu: beamShearY.Vu,  vn: beamShearY.vn  },
             rebarX: rebarX_appr, rebarY: rebarY_appr,
             isRectangular: structureType === "Isolated Rectangular"
         });

--- a/public/pages/foundationDesign.html
+++ b/public/pages/foundationDesign.html
@@ -900,7 +900,7 @@ function downloadFoundationExcelTemplate() {
         'Load Type':                    'ultimate',
         'Centricity':                   'concentric',
         'Column Shape':                 'square',
-        'Column Location':              'interior',
+        'Column Location':              1,
         'Column Width (mm)':            500,
         'Foundation Depth H (m)':       1.5,
         'Bar Diameter (mm)':            20,
@@ -969,6 +969,7 @@ function downloadFoundationExcelTemplate() {
         'MyDL (kN.m)':                  'individual + eccentric',
         'MyLL (kN.m)':                  'individual + eccentric',
         'Column Shape':                 'square  |  rectangular  |  circle',
+        'Column Location':              '1 (Interior)  |  2 (Edge)  |  3 (Corner) — drives alpha_s in punching shear',
         'Column Width (mm)':            'square / circle (diameter)',
         'Column Width X (mm)':          'rectangular only',
         'Column Width Y (mm)':          'rectangular only',
@@ -1066,6 +1067,36 @@ function handleFile(event) {
 //  by renderFoundationSummary in scriptFoundationDesign6.js), then
 //  hands everything to renderFoundationBatchOutput.
 // ─────────────────────────────────────────────────────────────────
+// Friendly-name aliases for select-type fields whose <option value=…>
+// uses a numeric code. Lets users type "interior" / "edge" / "corner"
+// in the Excel sheet and still drive the right engine branch.
+const FOUNDATION_VALUE_ALIASES = {
+    ColumnLocation: {
+        'interior': 1, 'inner': 1, '1': 1,
+        'edge':     2, 'side':  2, '2': 2,
+        'corner':   3, '3': 3
+    },
+    LengthRestriction: {
+        'none': 0, 'no': 0, '0': 0,
+        'ratio': 1, '1': 1,
+        'constricted': 2, 'limited': 2, '2': 2
+    },
+    Method: {
+        'iteration': 1, 'iterative': 1, '1': 1,
+        'approximate': 2, 'approx': 2, 'approximation': 2, '2': 2
+    },
+    considerSoil: {
+        'yes': 'yes', 'y': 'yes', 'true': 'yes', '1': 'yes',
+        'no':  'no',  'n': 'no',  'false': 'no', '0': 'no'
+    }
+};
+function normalizeExcelValue(fieldId, raw) {
+    const table = FOUNDATION_VALUE_ALIASES[fieldId];
+    if (!table) return raw;
+    const key = String(raw).trim().toLowerCase();
+    return (table[key] !== undefined) ? table[key] : raw;
+}
+
 function runFoundationBatch(headers, dataRows) {
     const map = window.FOUNDATION_EXCEL_PARAM_MAP || {};
     const labelColIdx = headers.findIndex(h => /^(label|id|name)$/i.test(h));
@@ -1088,8 +1119,15 @@ function runFoundationBatch(headers, dataRows) {
             if (!fieldId) continue;
             const el = document.getElementById(fieldId);
             if (!el) continue;
-            const val = row[j];
+            let val = row[j];
             if (val === '' || val === undefined || val === null) continue;
+            // Some <select> fields use numeric option values but humans want
+            // to type the readable label. Normalize a handful of friendly
+            // aliases so the engine sees the right code, NOT a NaN. Without
+            // this, "interior" → parseInt("interior") = NaN → alpha_s
+            // stays undefined and the punching-shear formula prints
+            // "undefined × d/Bo".
+            val = normalizeExcelValue(fieldId, val);
             el.value = String(val);
             el.dispatchEvent(new Event('change', { bubbles: true }));
             el.dispatchEvent(new Event('input',  { bubbles: true }));


### PR DESCRIPTION
## Three problems from the screenshots — all fixed

### 1. alpha_s missing for combined footing
Punching formula printed:
\`0.75 × 1/12 × (2 + undefined × 155 / 2620) × λ × √f'c × Bo × d\`

**Why:** the Excel template sample used \`'interior'\` for **Column Location**. \`parseInt('interior')\` is \`NaN\`, and the engine's \`if/else\` chain only matches numeric \`1\` / \`2\` / \`3\` — none of the branches set \`alphaS\`.

**Fixes:**
- Template sample now uses \`1\` (the actual \`<option value>\`), so downloads work out of the box.
- Template guide row clarifies: \`1 (Interior) | 2 (Edge) | 3 (Corner) — drives alpha_s in punching shear\`.
- New \`FOUNDATION_VALUE_ALIASES\` + \`normalizeExcelValue()\` in the upload handler. Users **can still type** \`interior\` / \`edge\` / \`corner\` (or \`iteration\` vs \`approximate\`, \`ratio\` vs \`constricted\`, \`yes\` vs \`y\` vs \`true\`) and the importer normalizes to the matching numeric option. Same idea for \`LengthRestriction\`, \`Method\`, and \`considerSoil\`.

### 2. Design Schedule verdict column was empty
Two paths in the engine didn't carry shear data into the schedule:
- **Single-foundation, SIZE-CONTROLLED path** passed only \`dc / bx / by / barDia / rebars\` — no \`punching / beamShearX / beamShearY\` — so the Shear Checks section never rendered.
- **METHOD-2 path** passed \`vn = +Infinity\` to suppress the SAFE/FAIL chip, but Method 2 actually solves \`dc\` from \`Vu = φVn\`, so \`φVn\` is real and the chip is meaningful.

**Fix:** both paths now pass the actual \`punchingV / beamShearX / beamShearY\` results, so the schedule's third column shows \`✓ φVn = X kN\` or \`✗ φVn = X kN\` with the proper colour.

### 3. Batch view styling didn't match the single-foundation Solution tab
Every step banner (\`"1  Calculation of Dimensions"\`, \`"Service Load Calculation"\`, ...) and every green code-clause callout rendered as bare bold blue text in the batch view.

**Why:** the step / clause / katex CSS was scoped to \`#result.latex-container\` (a unique ID). The batch cards clone the engine's \`#result\` innerHTML into a generic \`.latex-container\` wrapper without that ID, so none of the styling matched.

**Fix:** extended every
\`\`\`
.fd-page #result.latex-container ...
\`\`\`
selector with a twin
\`\`\`
.fd-page .fd-batch-card-body .latex-container ...
\`\`\`
so the batch cards inherit the same step bar / numbered chip / clause pill / katex sizing. Done via a one-shot Node regex pass on \`styles1.css\`. Also removed an earlier \`.container2\` override that was killing the Parameters-Given 2-column grid in batch.

## Test plan
- [ ] Download a fresh template → Column Location column shows \`1\` in samples, guide sheet documents 1/2/3 mapping
- [ ] Upload the template unchanged → punching formula shows \`α_s = 40\` (Interior column) instead of \`undefined\`
- [ ] Upload an Excel where Column Location is \`'interior'\` (text) → normalized to 1, same result
- [ ] Single-foundation manual calculate (size-controlled or method 2) → Design Schedule shows ✓/✗ verdict per shear row
- [ ] Batch upload → per-foundation cards show numbered step chips, green code-clause callouts, properly typeset KaTeX — visually matching the single-foundation Solution tab
- [ ] Parameters-Given block inside each batch card stays in its 2-column grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)