### PR TITLE
foundationDesign: hide blank chips + Parameters Given as auto-fit chip grid

### DIFF
--- a/public/assets/css/styles1.css
+++ b/public/assets/css/styles1.css
@@ -1274,20 +1274,22 @@ nav ul li a:hover {
     font-size: 1em !important;
 }
 
-/* Parameter-recap container (#GivenParameters1).
-   The container has class="container2" too, and the legacy rule
-   `.container2 h8 { margin: -0.3em; margin-right: 100%; display: inline-block }`
-   was collapsing every value into a vertical sliver. Defeat all of it. */
+/* Parameter-recap container (#GivenParameters1) — chip grid layout.
+   Each h8 atomic value (P = 800 kN, f'c = 21 MPa, …) becomes its own
+   pill-style chip, and the chips auto-fit into as many columns as the
+   container width allows. Defeats the legacy
+   `.container2 h8 { margin-right: 100%; display: inline-block }` rule
+   that used to collapse every value into a vertical sliver. */
 .fd-page #GivenParameters1.container2,
 .fd-page #GivenParameters1 {
-    background: #f6f8fa !important;
-    border: 1px solid #e1e4e8 !important;
-    border-radius: 8px !important;
-    padding: 16px 20px !important;
+    background: transparent !important;
+    border: none !important;
+    border-radius: 0 !important;
+    padding: 0 !important;
     margin: 0 0 20px !important;
     display: grid !important;
-    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
-    gap: 6px 24px !important;
+    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)) !important;
+    gap: 8px 10px !important;
     width: 100% !important;
     max-width: 100% !important;
     min-width: 0 !important;
@@ -1296,7 +1298,7 @@ nav ul li a:hover {
 
 .fd-page #GivenParameters1 h5 {
     grid-column: 1 / -1 !important;
-    margin: 0 0 8px !important;
+    margin: 0 0 6px !important;
     padding: 0 0 8px !important;
     border: none !important;
     border-bottom: 2px solid #007BFF !important;
@@ -1313,19 +1315,39 @@ nav ul li a:hover {
     display: none !important;
 }
 
+/* The chip itself — one per parameter value. */
 .fd-page #GivenParameters1 h8,
 .fd-page .container2 h8 {
-    display: block !important;
+    display: flex !important;
+    align-items: center;
     margin: 0 !important;
-    padding: 3px 0 !important;
-    font-size: 0.95em !important;
+    padding: 8px 12px !important;
+    background: #f6f8fa !important;
+    border: 1px solid #d6d9de !important;
+    border-left: 3px solid #0056b3 !important;
+    border-radius: 4px !important;
+    font-size: 0.92em !important;
     color: #1f2933 !important;
     width: auto !important;
     max-width: 100% !important;
+    min-width: 0 !important;
     text-align: left !important;
     white-space: normal !important;
     overflow-wrap: break-word;
-    line-height: 1.4;
+    line-height: 1.35;
+    box-sizing: border-box;
+}
+
+/* Empty-content marker — set by createParagraph / createHeader8 when
+   the call site passes "" / "$$\\ $$". Without this the soft-card
+   <p> styling rendered each empty call as a visible blank chip. */
+.fd-page #result.latex-container > p.fd-empty-p,
+.fd-page #Summary.latex-container > p.fd-empty-p,
+.fd-page #Summary1.latex-container > p.fd-empty-p,
+.fd-page .fd-batch-card-body .latex-container > p.fd-empty-p,
+.fd-page #GivenParameters1 h8.fd-empty-p,
+.fd-page .container2 h8.fd-empty-p {
+    display: none !important;
 }
 
 .rc-page .rc-grid {

--- a/public/assets/js/scriptFoundationDesign6.js
+++ b/public/assets/js/scriptFoundationDesign6.js
@@ -143,14 +143,25 @@ document.addEventListener("DOMContentLoaded", () => {
         return n;
     }
             
+    // Returns true when the content reduces to nothing visible after
+    // stripping LaTeX delimiters / control chars. The DOM helpers below
+    // tag these with the .fd-empty-p class so CSS can hide them — under
+    // the soft-card paragraph styling, an empty <p> rendered as a
+    // visible blank chip with a left border and no content.
+    function _isVisuallyEmpty(content) {
+        return String(content == null ? '' : content)
+            .replace(/[$\\`\s ]/g, '') === '';
+    }
     function createParagraph(content) {
         const p = document.createElement('p');
         p.innerHTML = content;
+        if (_isVisuallyEmpty(content)) p.className = 'fd-empty-p';
         return p;
-    }        
+    }
     function createHeader8(content) {
         const h8 = document.createElement('h8');
         h8.innerHTML = content;
+        if (_isVisuallyEmpty(content)) h8.className = 'fd-empty-p';
         return h8;
     }
     function createHeader7(content) {
@@ -751,7 +762,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 vn3 = 0.75 * (1/12) * (2+(alphaS*d/bo))* lambda * Math.sqrt(fc) *bo*d/1000;
                 vn = Math.min(vn1,vn2,vn3);
                 document.getElementById('result').appendChild(createParagraph(`\\(\\phi V_n = \\phi V_c = \\text{least of}\\left\\{\\begin{array}{l}\\phi \\times \\frac {1}{3} \\times \\lambda \\times \\sqrt{fc'} \\times B_o \\times d  \\,  \\\\\\phi \\times \\frac {1}{6} \\times ( 1 + \\frac{2}{\\beta}) \\times \\lambda \\times \\sqrt{fc'} \\times B_o \\times d \\, \\\\\\phi \\times \\frac {1}{12} \\times ( 2 + \\frac{\\alpha_s \\times d}{B_o}) \\times \\lambda \\times \\sqrt{fc'} \\times B_o \\times d \\, \\end{array}\\right. \\)`));
-                document.getElementById('result').appendChild(createParagraph(``));
+                // Removed an empty createParagraph("") that used to sit
+                // between the symbolic and numeric phi*Vn blocks for
+                // spacing — under the new soft-card paragraph styling
+                // it rendered as a visible blank chip in the user's
+                // screenshots.
                 document.getElementById('result').appendChild(createParagraph(`\\(\\phi V_n = \\left\\{\\begin{array}{l}0.75 \\times \\frac {1}{3} \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times ${bo.toFixed(2)}mm \\times ${d.toFixed(2)}mm = ${(vn1*1000).toFixed(2)}N \\approx ${(vn1).toFixed(2)}kN \\, \\\\0.75 \\times \\frac {1}{6} \\times (1+ \\frac{2}{${beta}}) \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times ${bo.toFixed(2)}mm \\times ${d.toFixed(2)}mm = ${(vn2*1000).toFixed(2)}N \\approx ${(vn2).toFixed(2)}kN \\, \\\\ 0.75 \\times \\frac {1}{12} \\times (2+ \\frac{${alphaS} \\times ${d.toFixed(2)}}{${bo.toFixed(2)}}) \\times ${lambda} \\times \\sqrt{${fc}MPa} \\times ${bo.toFixed(2)}mm \\times ${d}mm = ${(vn3*1000).toFixed(2)}N \\approx ${(vn3).toFixed(2)}kN \\, \\end{array}\\right. = ${vn.toFixed(2)}kN \\, \\)`));
                 document.getElementById('result').appendChild(createParagraph(`$$\\ V_u = ${Vu.toFixed(2)}kN ${Vu<vn ? "< \\phi V_n    \\therefore \\text{SAFE}":"> \\phi V_{n}\\therefore \\text{FAIL}"}\$$`));
                 


### PR DESCRIPTION
## Two fixes from your message

### 1. Blank chip in "Punching Shear Calculation"
The engine has \`createParagraph(\\`\\`)\` / \`createHeader8(\\`$$\\ $$\\`)\` sprinkled through it for vertical spacing. Under the new soft-card paragraph styling those empty elements render as **visible blank chips** (border + padding, no content). One concrete instance sits between the symbolic and numeric \`φVₙ\` blocks in the Punching Shear step; **12+ similar empties** are scattered through the rest of the engine.

**Fix at the helper layer** (not at the call sites):

\`\`\`js
function _isVisuallyEmpty(content) {
    return String(content == null ? '' : content)
        .replace(/[$\\\\`\s ]/g, '') === '';
}
function createParagraph(content) {
    const p = document.createElement('p');
    p.innerHTML = content;
    if (_isVisuallyEmpty(content)) p.className = 'fd-empty-p';
    return p;
}
\`\`\`

Then CSS hides \`.fd-empty-p\` in \`#result\`, \`#Summary\`, \`#Summary1\`, the batch card body, and the parameters block — so every existing AND future empty call becomes a silent no-op. No need to hunt every call site.

### 2. Parameters Given as a chip grid
\`#GivenParameters1\` already had a 2-column grid layout but the \`<h8>\` items rendered as flat text rows.

New CSS turns each \`h8\` into a **pill-style chip** (light background, blue accent left border, rounded corners) and switches the grid to **auto-fit columns**:

\`\`\`css
.fd-page #GivenParameters1 {
    display: grid;
    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
    gap: 8px 10px;
}
.fd-page #GivenParameters1 h8 {
    display: flex; align-items: center;
    padding: 8px 12px;
    background: #f6f8fa;
    border: 1px solid #d6d9de;
    border-left: 3px solid #0056b3;
    border-radius: 4px;
}
\`\`\`

The layout naturally flows to **2 / 3 / 4 columns** depending on container width — solves your "count the items and split into columns" ask via CSS auto-fit instead of JS counting. Same end result, zero JS overhead, scales to any number of parameters. The "Parameters Given:" h5 spans the full row as the section header with no step badge.

## Test plan
- [ ] Single-foundation calculate → Punching Shear Calculation has the two \`φVₙ\` formula blocks back-to-back, no blank chip between them
- [ ] Parameters Given renders as discrete pill chips, 2-4 columns depending on viewport width
- [ ] Resize the window narrower → chips re-flow into fewer columns automatically
- [ ] Batch upload → same behavior inside each foundation's card
- [ ] No other blank chips visible anywhere in the Solution tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)