### PR TITLE
foundationDesign: parameter chips in batch view + locked to 2 columns

### DIFF
--- a/public/assets/css/styles1.css
+++ b/public/assets/css/styles1.css
@@ -1292,14 +1292,16 @@ nav ul li a:hover {
    `#result.latex-container > p` soft-card so the parameters panel
    reads consistently with the calculation cards underneath. */
 .fd-page #GivenParameters1,
-.fd-page div#GivenParameters1.container2 {
+.fd-page div#GivenParameters1.container2,
+.fd-page .fd-batch-card-body .container2,
+.fd-page .fd-batch-card-body div.container2.latex-container {
     background: transparent !important;
     border: none !important;
     border-radius: 0 !important;
     padding: 0 !important;
     margin: 0 0 20px !important;
     display: grid !important;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)) !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
     gap: 8px 12px !important;
     width: 100% !important;
     max-width: 100% !important;
@@ -1307,7 +1309,8 @@ nav ul li a:hover {
     box-sizing: border-box;
 }
 
-.fd-page #GivenParameters1 h5 {
+.fd-page #GivenParameters1 h5,
+.fd-page .fd-batch-card-body .container2 h5 {
     grid-column: 1 / -1 !important;
     margin: 0 0 6px !important;
     padding: 0 0 8px !important;
@@ -1321,7 +1324,8 @@ nav ul li a:hover {
     display: block !important;
 }
 
-.fd-page #GivenParameters1 h5::before {
+.fd-page #GivenParameters1 h5::before,
+.fd-page .fd-batch-card-body .container2 h5::before {
     /* No step badge in the parameter recap. */
     content: none !important;
     display: none !important;
@@ -1331,9 +1335,14 @@ nav ul li a:hover {
    #result so the two sections read as a single design language.
    The legacy `.container2 h8 { margin-right: 100% }` rule pushed
    every value to a full row even inside the grid; cancelled here
-   with explicit margin-right: 0. */
+   with explicit margin-right: 0. The same selectors target both
+   the standalone single-foundation #GivenParameters1 container AND
+   the batch-card clone (which is wrapped in
+   `<div class="container2 latex-container">` without the id). */
 .fd-page #GivenParameters1 h8,
-.fd-page div#GivenParameters1.container2 h8 {
+.fd-page div#GivenParameters1.container2 h8,
+.fd-page .fd-batch-card-body .container2 h8,
+.fd-page .fd-batch-card-body div.container2.latex-container h8 {
     display: block !important;
     margin: 0 !important;
     margin-right: 0 !important;


### PR DESCRIPTION
## The bug — chip CSS missed the batch view

The previous chip CSS targeted only \`#GivenParameters1\`, but the **batch renderer clones the inner HTML** of that container into a brand-new
\`\`\`html
<div class="container2 latex-container">...</div>
\`\`\`
**without the id**. So in the batch view none of the \`#GivenParameters1\`-scoped rules reached the new wrapper — chips fell back to plain text rows in a single column with no styling.

## Fix

Extend every chip rule to also match the batch wrapper:

- **Grid parent** now also targets \`.fd-batch-card-body .container2\` and \`.fd-batch-card-body div.container2.latex-container\`.
- **Chip body** (the \`h8\` itself): same dual targeting.
- **\`h5\` section header** and the \`h5::before\` badge-suppressor: same.

Also **locked the layout to exactly 2 columns** per your request — \`repeat(2, minmax(0, 1fr))\` — instead of the previous auto-fit.

Chip body still mirrors the soft-card equation paragraph style used in \`#result\`:
- background \`#fcfcfd\`
- 1px \`#e1e4e8\` border
- 2px-left accent
- 4px right-side radius

…so the parameters panel reads as the same design language as the calculation cards underneath, in both the **standalone single-foundation view AND each batch card**.

## Test plan
- [ ] Upload an Excel → each batch card's Parameters Given block lays out as 2 columns of soft-card chips, NOT plain text rows
- [ ] Same chips visually match the formula cards in "Calculation of Dimensions" / "Service Load" beneath them
- [ ] Resize the window narrower → chips stay in 2 columns until the container gets too tight
- [ ] Single-foundation calculate (no Excel) → same 2-column chip layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)