### PR TITLE
foundationDesign: compute qact in design mode + native print (no more word-per-line PDF)

### DIFF
--- a/public/assets/css/styles1.css
+++ b/public/assets/css/styles1.css
@@ -1535,3 +1535,56 @@ nav ul li a:hover {
     .fd-schedule-wrap { overflow: visible; }
     .fd-schedule      { font-size: 0.85em; }
 }
+
+/* ============================================================
+   Foundation Design — Download / Print PDF
+   When the user clicks the Save button, scriptFoundationDesign6.js
+   adds .fd-printing-solution (single-foundation mode) or
+   .fd-printing-batch (Excel-batch mode) to <body>. The rules below
+   hide everything except the chosen result panel, so the PDF
+   captures only the design output and not the form / nav / chrome.
+   ============================================================ */
+@media print {
+    body.fd-printing-solution nav,
+    body.fd-printing-solution h1,
+    body.fd-printing-solution form#formFoundation,
+    body.fd-printing-solution .fd-import-row,
+    body.fd-printing-solution #tab,
+    body.fd-printing-solution #summary,
+    body.fd-printing-solution .fd-save-row,
+    body.fd-printing-solution #saveButton,
+    body.fd-printing-batch    nav,
+    body.fd-printing-batch    h1,
+    body.fd-printing-batch    form#formFoundation,
+    body.fd-printing-batch    .fd-import-row,
+    body.fd-printing-batch    #tab,
+    body.fd-printing-batch    #summary,
+    body.fd-printing-batch    .fd-save-row,
+    body.fd-printing-batch    #saveButton {
+        display: none !important;
+    }
+    /* Let the result panel take the full page width. */
+    body.fd-printing-solution #print,
+    body.fd-printing-solution #Solution,
+    body.fd-printing-batch    #print,
+    body.fd-printing-batch    #batchOutput {
+        width: 100% !important;
+        max-width: 100% !important;
+        margin: 0 !important;
+        padding: 0 !important;
+        display: block !important;
+    }
+    /* Avoid awkward page breaks inside the schedule table and the
+       per-foundation card summaries. */
+    body.fd-printing-solution .fd-schedule,
+    body.fd-printing-batch    .fd-batch-card,
+    body.fd-printing-batch    .fd-schedule {
+        break-inside: avoid;
+        page-break-inside: avoid;
+    }
+    /* The batch view normally hides every closed <details> body;
+       force them open on the print sheet so all foundations appear. */
+    body.fd-printing-batch .fd-batch-card > *:not(summary) {
+        display: block !important;
+    }
+}

--- a/public/assets/js/scriptFoundationDesign6.js
+++ b/public/assets/js/scriptFoundationDesign6.js
@@ -41,12 +41,25 @@ function renderAllMath() {
 }
 
 document.addEventListener("DOMContentLoaded", () => {
-    // printDiv — swap the body for the chosen result block, fire the
-    // browser print dialog, then restore + reload so the page becomes
-    // interactive again. Respects window._foundationPrintTargetId so
-    // the Excel-batch renderer can repoint Save / Print to
-    // #batchOutput (every footing + the consolidated schedule in one
-    // PDF) instead of the hardcoded "Solution" tab.
+    // printDiv — fire the browser's native print dialog and use the
+    // @media print rules in styles1.css to hide the form / nav / save
+    // button so only the chosen result block prints.
+    //
+    // History: the previous implementation swapped document.body.
+    // innerHTML for `target.outerHTML`, called window.print(), then
+    // restored the body and reloaded. That worked semantically but
+    // DESTROYED the styling context — the outer wrapper classes
+    // (.fd-page) were dropped, so every CSS rule scoped to
+    // `.fd-page #result.latex-container ...` stopped matching. The
+    // bare `.latex-container { display: inline-block; width:
+    // min-content; }` rule then took over and the printout came out
+    // with every word on its own line. The user's "print pdf.pdf"
+    // shows exactly that failure mode.
+    //
+    // Native print preserves the entire DOM + cascade. We add a
+    // body class so @media print can decide what to hide based on
+    // single-foundation vs batch mode, and the result panel is the
+    // only thing that ends up on paper.
     function printDiv(divId) {
         const targetId = window._foundationPrintTargetId || divId;
         const target   = document.getElementById(targetId);
@@ -54,14 +67,25 @@ document.addEventListener("DOMContentLoaded", () => {
             alert("Nothing to print yet — click Calculate (or upload an Excel) first.");
             return;
         }
-        const originalContent = document.body.innerHTML;
-        document.body.innerHTML = target.outerHTML;
-        window.print();
-        document.body.innerHTML = originalContent;
-        // Inline event listeners are wiped by the innerHTML swap;
-        // reload so the page becomes interactive again.
-        window.location.reload();
+        const printingClass = (targetId === 'batchOutput')
+                                ? 'fd-printing-batch'
+                                : 'fd-printing-solution';
+        document.body.classList.add(printingClass);
+        try {
+            window.print();
+        } finally {
+            // Remove the class after print so the page is normal
+            // again. Most browsers block on window.print() until the
+            // user dismisses the dialog, so the cleanup runs at the
+            // right time; the afterprint event also fires the same
+            // listener as a defence-in-depth.
+            document.body.classList.remove(printingClass);
+        }
     }
+    window.addEventListener('afterprint', () => {
+        document.body.classList.remove('fd-printing-batch');
+        document.body.classList.remove('fd-printing-solution');
+    });
     // Save / Print PDF — attach ONCE at module load. The previous
     // code re-attached on every form submit, so a 3-row Excel batch
     // ended up with 3 stacked click handlers all racing through
@@ -1440,6 +1464,14 @@ document.addEventListener("DOMContentLoaded", () => {
         }
         recheck += 1;
         calc = dimension(dc+25);
+        // qact is the actual soil pressure that the chosen Bx × By
+        // produces under the (already-summed) service load P. The
+        // engine only assigned qact in the "analyze with specified
+        // dimensions" branch — in DESIGN mode for concentric loads it
+        // stayed at its default 0, which is why the Soil-Bearing row
+        // was reading "0.000 kPa" in the user's PDF. Compute it here
+        // so every design path reports the same number.
+        qact = (p / (bx * by)) * (1 + (6 * (ex || 0) / bx) + (6 * (ey || 0) / by));
         // Run rebar designs (also appends to #result) and capture the
         // per-axis n / spacing / layer values for the schedule.
         rebarDesign("x");
@@ -1449,11 +1481,9 @@ document.addEventListener("DOMContentLoaded", () => {
         const rebarY_size = { n, sc, level };
         if (structureType === "Isolated Rectangular") rebarY_size.m = m;
         // Even when the foundation is SIZE-CONTROLLED (the while-loop
-        // grew dc until shear passes), we still want the schedule to
-        // show the actual Vu / phi*Vn for transparency — otherwise the
-        // verdict column reads "reported (no SAFE/FAIL)" with no
-        // diagnostic. punchingV / beamShearX / beamShearY hold the
-        // values at the converged dc; surface them.
+        // grew dc until shear passes), surface the actual Vu / phi*Vn
+        // for transparency — otherwise the verdict column reads
+        // "reported (no SAFE/FAIL)" with no diagnostic.
         renderFoundationSummary({
             method: 1,
             dc, bx, by, barDia,
@@ -1470,6 +1500,10 @@ document.addEventListener("DOMContentLoaded", () => {
     } else {
         beamShearX = beamShear("x", dc);
         beamShearY = beamShear("y", dc);
+        // Same qact computation as the size-controlled branch above —
+        // the engine never set it for concentric loads in this path
+        // either.
+        qact = (p / (bx * by)) * (1 + (6 * (ex || 0) / bx) + (6 * (ey || 0) / by));
         rebarDesign("x");
         const rebarX_punch = { n, sc, level };
         if (structureType === "Isolated Rectangular") rebarX_punch.m = m;


### PR DESCRIPTION
## Two issues from your PDFs

### 1. \`q_act = 0.000 kPa\` in the Soil Bearing row

The engine only assigned \`qact\` in the "analyze with specified dimensions" branch. In **DESIGN mode with a concentric load**, \`qact\` was never computed — the schedule grabbed the module-scoped default of \`0\`.

Both design branches now compute:
\`\`\`
qact = P/(Bx·By) · [1 + 6·ex/Bx + 6·ey/By]
\`\`\`
right before \`renderFoundationSummary\` is called. \`ex / ey\` default to 0 for concentric, falling through to the simple \`P/A\` form. For your case (P = 220 kN, Bx = By = 1.40 m): \`qact ≈ 112.24 kPa\` instead of 0.

### 2. Download / Print PDF was 15 pages of one-word-per-line text

Compare the two PDFs:
- **\`browser print page.pdf\`** (3 pages, browser's print button) — clean
- **\`print pdf.pdf\`** (15 pages, my Download/Print PDF button) — every word on its own line

**Root cause:** \`printDiv\` was destructive. It did:
\`\`\`js
document.body.innerHTML = target.outerHTML;
window.print();
\`\`\`
That dropped every outer wrapper class (\`.fd-page\` in particular). EVERY usable CSS rule in styles1.css is scoped to \`.fd-page #result.latex-container …\` — with those gone, the bare global rule
\`\`\`css
.latex-container { display: inline-block; width: min-content }
\`\`\`
took over and every word stacked vertically at its minimum intrinsic width. Exactly what your \`print pdf.pdf\` shows.

**New behaviour:** native print only. \`printDiv\` now adds either \`.fd-printing-solution\` or \`.fd-printing-batch\` to \`<body>\`, calls \`window.print()\`, and removes the class on \`afterprint\`. New \`@media print\` rules scoped to those body classes hide nav / form / import row / tabs / save row, so the printout captures ONLY the chosen result block — with the full CSS context intact. Batch-mode rules also force-open every \`<details>\` card so all foundations make it onto paper.

## Test plan
- [ ] Single-foundation calculate → Soil Bearing row reads the real \`q_act\` (≈ 112 kPa for your test inputs), not 0
- [ ] Click **Download / Print PDF** → preview shows the Solution / Schedule formatted exactly like the browser's native print button (clean step banners, paragraphs flow, no word-per-line)
- [ ] No nav / form / import row in the printout
- [ ] Batch upload → **Download / Print PDF** shows EVERY foundation card expanded plus the consolidated table, single coherent layout
- [ ] After the print dialog closes, the page is fully interactive again (no reload needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)