### PR TITLE
foundationDesign: PDF page-slicing fix + visible batch errors + console diagnostics

### DIFF
--- a/public/assets/js/scriptFoundationDesign6.js
+++ b/public/assets/js/scriptFoundationDesign6.js
@@ -97,53 +97,61 @@ document.addEventListener("DOMContentLoaded", () => {
         }
 
         try {
+            // 1) Snapshot the live DOM with html2canvas. The live
+            //    cascade is intact (no print-media re-evaluation),
+            //    so chips, step banners, KaTeX math all render
+            //    exactly as on screen.
             const canvas = await html2canvas(target, {
-                scale: 2,                 // crisp output on retina
+                scale: 2,
                 useCORS: true,
                 backgroundColor: '#ffffff',
                 windowWidth: target.scrollWidth,
                 logging: false
             });
 
+            // 2) Build the PDF, A4 portrait, 10 mm margins.
             const pdf = new window.jspdf.jsPDF({
                 unit: 'mm', format: 'a4', orientation: 'p',
                 compress: true
             });
-
-            const pageW   = pdf.internal.pageSize.getWidth();
-            const pageH   = pdf.internal.pageSize.getHeight();
-            const margin  = 10;
-            const contentW = pageW - 2 * margin;
+            const pageW    = pdf.internal.pageSize.getWidth();   // 210
+            const pageH    = pdf.internal.pageSize.getHeight();  // 297
+            const margin   = 10;
+            const contentW = pageW - 2 * margin;                 // 190
+            const contentH = pageH - 2 * margin;                 // 277
             const ratio    = contentW / canvas.width;
-            const fullImgH = canvas.height * ratio;
+            const sliceHpx = Math.floor(contentH / ratio);       // canvas-px per page
 
-            const imgData = canvas.toDataURL('image/jpeg', 0.92);
+            // 3) Slice the source canvas into page-height chunks
+            //    on a scratch canvas, then add each as its OWN
+            //    image to the PDF. This avoids the "negative-y
+            //    offset" trick that overlapped page boundaries by
+            //    one margin width in the previous version.
+            const slice    = document.createElement('canvas');
+            const sliceCtx = slice.getContext('2d');
+            slice.width    = canvas.width;
 
-            if (fullImgH <= pageH - 2 * margin) {
-                // Fits one page.
-                pdf.addImage(imgData, 'JPEG', margin, margin, contentW, fullImgH);
-            } else {
-                // Slice across pages — jsPDF's addImage with a
-                // negative-y trick: position the (full-height) image
-                // higher and higher so successive pages show the
-                // next slice.
-                let pageNum = 0;
-                let yShift = margin;
-                let remaining = fullImgH;
-                while (remaining > 0) {
-                    if (pageNum > 0) pdf.addPage();
-                    pdf.addImage(imgData, 'JPEG', margin, yShift, contentW, fullImgH);
-                    // Mask the bottom edge of the previous slice that
-                    // overhangs into the page footer area so it doesn't
-                    // bleed over the page break.
-                    if (remaining > pageH - 2 * margin) {
-                        pdf.setFillColor(255, 255, 255);
-                        pdf.rect(0, pageH - margin, pageW, margin, 'F');
-                    }
-                    pageNum  += 1;
-                    yShift   -= (pageH - 2 * margin);
-                    remaining -= (pageH - 2 * margin);
-                }
+            let yPx = 0;
+            let pageNum = 0;
+            while (yPx < canvas.height) {
+                const remainingPx = canvas.height - yPx;
+                const thisSliceH  = Math.min(sliceHpx, remainingPx);
+                slice.height = thisSliceH;
+                sliceCtx.fillStyle = '#ffffff';
+                sliceCtx.fillRect(0, 0, slice.width, slice.height);
+                sliceCtx.drawImage(
+                    canvas,
+                    0, yPx,             // src x, y
+                    canvas.width, thisSliceH,   // src w, h
+                    0, 0,               // dst x, y
+                    canvas.width, thisSliceH    // dst w, h
+                );
+                const sliceImg = slice.toDataURL('image/jpeg', 0.92);
+                if (pageNum > 0) pdf.addPage();
+                pdf.addImage(sliceImg, 'JPEG', margin, margin,
+                             contentW, thisSliceH * ratio);
+                yPx     += thisSliceH;
+                pageNum += 1;
             }
 
             const fname = (targetId === 'batchOutput')

--- a/public/assets/js/scriptFoundationDesign6.js
+++ b/public/assets/js/scriptFoundationDesign6.js
@@ -1647,8 +1647,19 @@ document.addEventListener("DOMContentLoaded", () => {
     // Excel batch of 3 footings ended up with 3 click handlers all
     // calling printDiv (and the first call's window.location.reload
     // killed the others before they could finish).
-} catch {
-
+} catch (engineErr) {
+    // The submit handler used to bury every exception with bare
+    // `catch {}` — which is exactly why the Excel batch could
+    // "silently not calculate": any failed read of an empty field,
+    // any divide-by-zero, any KaTeX render hiccup would throw,
+    // get swallowed, and leave #result empty with no clue why.
+    //
+    // Log it so the user (or me) can paste it from DevTools, and
+    // re-throw so the batch runner's surrounding try/catch hears
+    // about it and marks that row as failed with the real
+    // message instead of the generic "did not converge".
+    console.error('[foundationDesign engine] threw:', engineErr);
+    throw engineErr;
 }
 
  });

--- a/public/pages/foundationDesign.html
+++ b/public/pages/foundationDesign.html
@@ -1114,6 +1114,28 @@ function runFoundationBatch(headers, dataRows) {
     const labelColIdx = headers.findIndex(h => /^(label|id|name)$/i.test(h));
     const unknownHeaders = headers.filter((h, i) => h && i !== labelColIdx && !map[h]);
 
+    // Hoist console diagnostics — the user couldn't tell whether
+    // the batch was running or silently failing. Now the dev-tools
+    // console shows every step.
+    console.log('[fdBatch] headers:', headers);
+    console.log('[fdBatch] labelColIdx:', labelColIdx);
+    console.log('[fdBatch] unknown headers (ignored):', unknownHeaders);
+    console.log('[fdBatch] data rows:', dataRows.length);
+
+    // Suppress alert() while batching — the engine raises blocking
+    // alerts for validation errors (e.g. Isolated Rectangular without
+    // a Length Restriction) and one bad row would freeze the whole
+    // batch behind N modal dialogs. Capture each alert into a
+    // per-row error string instead and restore the native alert
+    // afterwards.
+    const realAlert = window.alert;
+    const alertsByRow = [];
+    let currentRowAlerts = [];
+    window.alert = function(msg) {
+        currentRowAlerts.push(String(msg));
+        console.warn('[fdBatch] alert suppressed:', msg);
+    };
+
     const captured = [];
     window._foundationBatchCapture = (data) => { captured.push(data); };
 
@@ -1124,7 +1146,11 @@ function runFoundationBatch(headers, dataRows) {
                         ? String(row[labelColIdx]).trim()
                         : ('Foundation ' + (i + 1));
 
+        console.log('[fdBatch] row', i + 1, '/', dataRows.length, '→', label);
+        currentRowAlerts = [];
+
         // Populate the form from this row.
+        let filled = 0;
         for (let j = 0; j < headers.length; j++) {
             if (j === labelColIdx) continue;
             const fieldId = map[headers[j]];
@@ -1133,48 +1159,69 @@ function runFoundationBatch(headers, dataRows) {
             if (!el) continue;
             let val = row[j];
             if (val === '' || val === undefined || val === null) continue;
-            // Some <select> fields use numeric option values but humans want
-            // to type the readable label. Normalize a handful of friendly
-            // aliases so the engine sees the right code, NOT a NaN. Without
-            // this, "interior" → parseInt("interior") = NaN → alpha_s
-            // stays undefined and the punching-shear formula prints
-            // "undefined × d/Bo".
+            // Friendly-name normalization for <select> values that
+            // use numeric codes (e.g. ColumnLocation "interior" → 1).
             val = normalizeExcelValue(fieldId, val);
             el.value = String(val);
             el.dispatchEvent(new Event('change', { bubbles: true }));
             el.dispatchEvent(new Event('input',  { bubbles: true }));
+            filled++;
         }
+        console.log('[fdBatch]   populated', filled, 'fields');
 
-        // Fire the engine. The engine listens to the form's submit
-        // event; dispatching it directly skips the calc-button's
-        // onclick="openTab(...)" so we don't flip tabs mid-batch.
+        // Fire the engine via the form's submit event (skips the
+        // calc-button's onclick="openTab(...)" so we don't flip tabs
+        // mid-batch).
         const before = captured.length;
         try {
             document.getElementById('formFoundation').dispatchEvent(
                 new Event('submit', { bubbles: true, cancelable: true })
             );
         } catch (engineErr) {
-            console.warn('Engine threw for', label, engineErr);
+            console.warn('[fdBatch]   engine threw:', engineErr);
+            currentRowAlerts.push(engineErr && engineErr.message ? engineErr.message : String(engineErr));
         }
         const succeeded = captured.length > before;
         const data = succeeded ? captured[captured.length - 1] : null;
+        console.log('[fdBatch]   succeeded:', succeeded, '— captured.length =', captured.length);
 
-        // Snapshot the rendered HTML so the per-foundation solution
-        // panel survives the next iteration (the engine clears these
-        // divs on the next submit). KaTeX has already typeset by now,
-        // so the cloned innerHTML preserves the math.
+        // Snapshot the rendered HTML — KaTeX has already typeset by
+        // now, so cloned innerHTML preserves the math.
         const resultEl = document.getElementById('result');
         const givenEl  = document.getElementById('GivenParameters1');
+        let errorMsg = null;
+        if (!succeeded) {
+            errorMsg = currentRowAlerts.length
+                ? currentRowAlerts.join(' • ')
+                : 'Engine did not converge — check the row\'s inputs.';
+        }
+        alertsByRow.push(currentRowAlerts.slice());
         results.push({
             label,
             data,
-            error: succeeded ? null : 'Engine did not converge — check the row\'s inputs.',
+            error: errorMsg,
             resultHTML: resultEl ? resultEl.innerHTML : '',
             givenHTML:  givenEl  ? givenEl.innerHTML  : ''
         });
     }
 
+    // Restore the native alert and the batch-capture hook.
+    window.alert = realAlert;
     window._foundationBatchCapture = null;
+
+    const okCount  = results.filter(r => !r.error).length;
+    const badCount = results.length - okCount;
+    console.log('[fdBatch] done —', okCount, 'OK,', badCount, 'failed of', results.length);
+
+    if (okCount === 0 && badCount > 0) {
+        // Every row failed — surface the first error so the user
+        // doesn't see an empty batch panel and wonder what happened.
+        const first = results.find(r => r.error);
+        realAlert('Batch ran but every foundation failed:\n\n' +
+                  (first ? first.error : 'unknown error') +
+                  '\n\nOpen DevTools → Console for the full per-row trace.');
+    }
+
     renderFoundationBatchOutput(results, unknownHeaders);
 }
 


### PR DESCRIPTION
## What was wrong

### 1. PDF page 3 had Schedule + next step overlapping
Multi-page export used a "negative-y offset" trick — placed the FULL-height image on each PDF page and shifted it up by \`(pageH - 2*margin)\` per iteration. That offset was **10 mm shy** of the right value: the bottom margin of page N exposed the same image rows as the top margin of page N+1, so the Design Schedule table and the next Punching Shear Calculation step rendered on top of each other at the boundary.

### 2. Excel batch silently went nowhere
The engine raises **blocking \`alert()\` boxes** for validation errors. A batch with even one bad row froze behind N modal dialogs; the user dismissed them and saw an empty batch panel because the only feedback was a tiny "did not converge" chip on each card. No way to tell which row failed or why.

## Fix

### PDF
Pre-slice the source canvas into one scratch canvas per page (\`drawImage\` with src/dst rects) and \`addImage\` each slice with its own height. **No overlap is geometrically possible** because each PDF page only sees the rows that belong to it.

\`\`\`js
const slice    = document.createElement('canvas');
const sliceCtx = slice.getContext('2d');
slice.width = canvas.width;
while (yPx < canvas.height) {
    const thisSliceH = Math.min(sliceHpx, canvas.height - yPx);
    slice.height = thisSliceH;
    sliceCtx.drawImage(canvas, 0, yPx, canvas.width, thisSliceH, 0, 0, ...);
    pdf.addImage(slice.toDataURL('image/jpeg', 0.92), 'JPEG', margin, margin, contentW, thisSliceH * ratio);
    yPx += thisSliceH;
    pdf.addPage();
}
\`\`\`

### Batch
- While batching, replace \`window.alert\` with a **capturing stub** that pushes each message into a per-row array. Native alert restored afterwards.
- Each failed foundation's card now shows the **actual engine validation message** (e.g. *"Isolated Rectangular footings need a Length Restriction…"*) instead of a generic "did not converge".
- If **every row fails**, surface the first error as a single friendly alert pointing at the console for the full trace.
- \`console.log [fdBatch]\` lines at every stage (headers, per-row fill counts, succeeded y/n, final tally) so the user can paste DevTools output if it still misbehaves.

## Test plan
- [ ] Single foundation → Download PDF → 2-3 pages, **no overlap** between schedule table and any neighboring step
- [ ] Excel batch upload → DevTools console shows \`[fdBatch] row 1/3 → F1\` lines as each row runs
- [ ] Excel row that triggers a validation alert → the corresponding card shows the actual validation message, batch continues to the next row
- [ ] Every-row-fails case → single friendly alert + console trace, batch panel still renders with red verdicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)