### PR TITLE
foundationDesign: fix blank-page batch PDF (replace <details> with <div> in html2canvas clone)

### DIFF
--- a/public/assets/js/scriptFoundationDesign6.js
+++ b/public/assets/js/scriptFoundationDesign6.js
@@ -138,7 +138,59 @@ document.addEventListener("DOMContentLoaded", () => {
                 useCORS: true,
                 backgroundColor: '#ffffff',
                 windowWidth: target.scrollWidth,
-                logging: false
+                logging: false,
+                // html2canvas has a long-standing limitation with the
+                // native <details> element: even when the live DOM has
+                // `details[open]`, the captured canvas often renders
+                // only the <summary> (or nothing at all) — which is
+                // why every batch PDF page was coming out blank. The
+                // batch view is built entirely from <details> cards.
+                //
+                // Workaround: in the cloned document html2canvas hands
+                // us via onClone, replace every <details> with a <div>
+                // (preserving classes + children) and turn its
+                // <summary> into a normal <div> so the marker arrow
+                // doesn't leak through. Live DOM is untouched, the
+                // user still sees the regular <details> behaviour.
+                onclone: function (clonedDoc, clonedNode) {
+                    const root = clonedNode || clonedDoc.body;
+                    const detailsList = Array.from(root.querySelectorAll('details'));
+                    for (const det of detailsList) {
+                        const div = clonedDoc.createElement('div');
+                        // Copy attributes (class, id, style, …) onto the div.
+                        for (const attr of det.attributes) {
+                            if (attr.name === 'open') continue;
+                            div.setAttribute(attr.name, attr.value);
+                        }
+                        // Move children across, swapping <summary> for
+                        // an equivalent block <div>.
+                        while (det.firstChild) {
+                            const child = det.firstChild;
+                            if (child.nodeType === 1 && child.tagName === 'SUMMARY') {
+                                const sumDiv = clonedDoc.createElement('div');
+                                for (const attr of child.attributes) sumDiv.setAttribute(attr.name, attr.value);
+                                sumDiv.innerHTML = child.innerHTML;
+                                // Match the look of the original
+                                // <summary> in our batch cards.
+                                sumDiv.style.padding         = '12px 18px';
+                                sumDiv.style.background      = '#eef3f8';
+                                sumDiv.style.color           = '#0056b3';
+                                sumDiv.style.fontWeight      = '600';
+                                sumDiv.style.borderBottom    = '1px solid #e1e4e8';
+                                sumDiv.style.display         = 'flex';
+                                sumDiv.style.alignItems      = 'center';
+                                sumDiv.style.flexWrap        = 'wrap';
+                                sumDiv.style.gap             = '12px';
+                                det.removeChild(child);
+                                div.appendChild(sumDiv);
+                            } else {
+                                det.removeChild(child);
+                                div.appendChild(child);
+                            }
+                        }
+                        det.parentNode.replaceChild(div, det);
+                    }
+                }
             });
 
             // 3) Map the DOM-coordinate break points into canvas


### PR DESCRIPTION
## The bug

Single-foundation PDF looks clean — your screenshots show 8 pages of correctly rendered content with intact chips, no overlap, full step-by-step calc. ✓

Batch PDF: **13 fully blank pages**, 1.2 MB. Nothing visible at all.

## Root cause

**html2canvas has a long-standing limitation with the native \`<details>\` element**. Even when the live DOM has \`details[open]\`, the captured canvas often renders only the \`<summary>\` (or nothing at all). [Known issue thread on the repo.]

The batch view is built **entirely** from \`<details>\` cards — one per foundation — so every page in the captured canvas was blank.

## Fix

Use the \`onclone\` hook html2canvas exposes:

\`\`\`js
onclone: function (clonedDoc, clonedNode) {
    const root = clonedNode || clonedDoc.body;
    for (const det of root.querySelectorAll('details')) {
        const div = clonedDoc.createElement('div');
        // copy attrs (class, id, …), drop \`open\`
        // move children across; <summary> becomes a styled <div>
        // replace <details> with <div>
        det.parentNode.replaceChild(div, det);
    }
}
\`\`\`

The replacement happens **only in the cloned document** html2canvas works with — the user's live DOM still has real \`<details>\` cards (clickable, expandable).

The summary swap-in keeps the visual look (light blue header, foundation label, verdict chip on the right) so the captured PDF reads identical to the on-screen batch.

## Test plan
- [ ] Single foundation PDF still renders cleanly (no regression — onclone only fires once and the replacement is a no-op when there are no \`<details>\` elements)
- [ ] Batch upload → **Download PDF** → all pages have visible content (parameters chips, step banners, formulas, schedule rows)
- [ ] Each foundation card in the PDF shows its label header in the same blue-on-light-blue style as the on-screen card

🤖 Generated with [Claude Code](https://claude.com/claude-code)