### PR TITLE
foundationDesign: PDF — stop slicing chips + merge batch title into first footing page

### DIFF
--- a/public/assets/js/scriptFoundationDesign6.js
+++ b/public/assets/js/scriptFoundationDesign6.js
@@ -130,9 +130,14 @@ document.addEventListener("DOMContentLoaded", () => {
             if (remainingPx <= sliceHpx) {
                 nextY = canvas.height;
             } else {
+                // Snap the page bottom to the LARGEST whitespace gap
+                // that still fits on this page. No lower floor: a
+                // slightly short page is always better than slicing a
+                // chip / multi-line equation in half. Only when NO gap
+                // fits (a single element taller than a whole page) do
+                // we hard-cut at the page limit.
                 const hardMax = yPx + sliceHpx;
-                const softMin = yPx + Math.floor(sliceHpx * 0.4);
-                const fit = breaks.filter(b => b > softMin && b <= hardMax);
+                const fit = breaks.filter(b => b > yPx && b <= hardMax);
                 nextY = fit.length ? Math.max(...fit) : hardMax;
             }
             const thisSliceH = nextY - yPx;
@@ -215,6 +220,26 @@ document.addEventListener("DOMContentLoaded", () => {
                     else parent.insertBefore(det, nextSibling);
                 });
             }
+
+            // Move the "Batch Foundation Design — N footings" title bar
+            // INTO the first foundation card so it rides on that card's
+            // opening page, instead of getting a near-empty page of its
+            // own (per-block capture would otherwise give the title its
+            // own page). Restored in finally{}.
+            const titleEl   = target.querySelector(':scope > .fd-batch-title');
+            const firstCard = target.querySelector(':scope > .fd-batch-card');
+            if (titleEl && firstCard) {
+                const tParent = titleEl.parentNode;
+                const tNext   = titleEl.nextSibling;
+                titleEl.style.marginBottom = '14px';
+                firstCard.insertBefore(titleEl, firstCard.firstChild);
+                restoreOps.push(() => {
+                    titleEl.style.marginBottom = '';
+                    if (tNext) tParent.insertBefore(titleEl, tNext);
+                    else tParent.appendChild(titleEl);
+                });
+            }
+
             await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
         }
 


### PR DESCRIPTION
## Two issues from the latest batch PDF

### 1. Chips were still sliced at page breaks
The break-picker had a **0.4 "soft floor"** — it only accepted a whitespace gap in the upper 60% of the page (`b > yPx + 0.4·pageHpx`). When a multi-line equation chip spanned the page boundary and the only gap within range sat *below* the 40% mark, the picker rejected it and **hard-cut at the page limit — straight through the chip** (e.g. the `163.62 kPa = 800 kN / B² × (…)` equation split across pages 2→3).

**Fix:** drop the soft floor. Snap the page bottom to the **largest whitespace gap that fits** (`> yPx`, `≤ page limit`). A slightly short page is always preferable to a sliced equation. The hard cut now only triggers when NO gap fits at all (a single element taller than a full page — unavoidable).

Verified: a chip spanning 300→1300 px on an 1108 px page now ends the page at the 300 px gap (short page, intact chip) instead of cutting at 1108.

### 2. Near-empty first page (just the title bar)
Per-block capture gave the *"Batch Foundation Design — 3 footings ✓ 3 OK"* title its own page. You asked to drop it or merge it with the first footing — **merged**.

Before capture (after the `<details>`→`<div>` swap), the `.fd-batch-title` element is moved to be the first child of the first `.fd-batch-card`, so it rides on that footing's opening page. Restored in `finally{}` like the other DOM mutations.

## Test plan
- [ ] Batch PDF → no near-empty title page; the title sits atop footing 1
- [ ] Chips / multi-line equations are never sliced across page breaks (pages may end a little short, which is correct)
- [ ] Single-foundation PDF unchanged
- [ ] After export, the on-screen batch view is intact (title back in place, `<details>` cards restored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)