### PR TITLE
foundationDesign: fix kN·m rendering + tidy combined-footing load labels

### DIFF
--- a/public/assets/js/scriptFoundationDesign6.js
+++ b/public/assets/js/scriptFoundationDesign6.js
@@ -22,7 +22,7 @@ function renderMath(element) {
             trust: true,
             macros: {
                 "\\kN":  "\\,\\text{kN}",
-                "\\kNm": "\\,\\text{kN·m}",
+                "\\kNm": "\\,\\text{kN}\\cdot\\text{m}",
                 "\\mm":  "\\,\\text{mm}",
                 "\\MPa": "\\,\\text{MPa}",
                 "\\kPa": "\\,\\text{kPa}"
@@ -632,7 +632,7 @@ document.addEventListener("DOMContentLoaded", () => {
             return { ...s, Rn, rho, rhoUse, As: Asf, n, sc };
         });
         flexRows.forEach(fr => {
-            P(`$$\\ \\textbf{${fr.label}: } M_u = ${fr.Mu.toFixed(1)}\\text{ kN·m}, \\; b = ${fr.bmm.toFixed(0)}\\text{ mm}, \\; d = ${dFlex.toFixed(0)}\\text{ mm} \$$`);
+            P(`$$\\ \\textbf{${fr.label}: } M_u = ${fr.Mu.toFixed(1)}\\text{ kN}\\cdot\\text{m}, \\; b = ${fr.bmm.toFixed(0)}\\text{ mm}, \\; d = ${dFlex.toFixed(0)}\\text{ mm} \$$`);
             P(`$$\\ R_n = \\frac{M_u}{\\phi b d^2} = ${fr.Rn.toFixed(3)}\\text{ MPa}, \\; \\rho = ${fr.rhoUse.toFixed(6)} \\;\\Rightarrow\\; A_s = ${fr.As.toFixed(0)}\\text{ mm}^2 \$$`);
             P(`$$\\ n = \\lceil A_s/A_b \\rceil = ${fr.n}\\text{ bars } \\varnothing${db}\\text{ mm}, \\; s_c = ${fr.sc ? fr.sc.toFixed(0) : '—'}\\text{ mm}${fr.sc && fr.sc >= scMin ? '\\;✓' : ''} \$$`);
         });
@@ -655,7 +655,7 @@ document.addEventListener("DOMContentLoaded", () => {
             const As_perm = rhoUse * 1000 * dT;
             const sBar = Ab / As_perm * 1000;                           // spacing mm for 1 m
             P(`$$\\ \\textbf{${lbl}: } B_y = ${(Byloc*1000).toFixed(0)}\\text{ mm}, \\; \\text{arm} = \\tfrac{B_y - c_y}{2} = ${(arm*1000).toFixed(0)}\\text{ mm} \$$`);
-            P(`$$\\ q_{strip} = \\frac{P_u}{B_x B_y} = ${qStrip.toFixed(2)}\\text{ kPa}, \\; M_u = \\tfrac{q\\,arm^2}{2} = ${Mu_perm.toFixed(2)}\\text{ kN·m/m} \$$`);
+            P(`$$\\ q_{strip} = \\frac{P_u}{B_x B_y} = ${qStrip.toFixed(2)}\\text{ kPa}, \\; M_u = \\tfrac{q\\,arm^2}{2} = ${Mu_perm.toFixed(2)}\\text{ kN}\\cdot\\text{m/m} \$$`);
             P(`$$\\ \\rho = ${rhoUse.toFixed(6)}, \\; A_s = ${As_perm.toFixed(0)}\\text{ mm}^2/m \\;\\Rightarrow\\; \\varnothing${db}\\text{ @ } ${sBar.toFixed(0)}\\text{ mm o.c.} \$$`);
         });
 

--- a/public/pages/foundationDesign.html
+++ b/public/pages/foundationDesign.html
@@ -193,11 +193,13 @@
                                 </div>
 
                                 <div class="fd-field">
-                                    <label for="DeadLoad">\(P_{DL}\) (in kN)</label>
+                                    <label for="DeadLoad" id="pdlLabel">\(P_{DL}\) (in kN)</label>
+                                    <label for="DeadLoad" id="pdlLabelCF" style="display: none;">\(P_{DL,1}\) (in kN)</label>
                                     <input type="number" id="DeadLoad" step="0.001" inputmode="decimal">
                                 </div>
                                 <div class="fd-field">
-                                    <label for="LiveLoad">\(P_{LL}\) (in kN)</label>
+                                    <label for="LiveLoad" id="pllLabel">\(P_{LL}\) (in kN)</label>
+                                    <label for="LiveLoad" id="pllLabelCF" style="display: none;">\(P_{LL,1}\) (in kN)</label>
                                     <input type="number" id="LiveLoad" step="0.001" inputmode="decimal">
                                 </div>
                                 <div class="fd-field">
@@ -265,11 +267,11 @@
                                     <input type="number" id="cf-col2-width" step="1" inputmode="numeric" placeholder="defaults to Column 1">
                                 </div>
                                 <div class="fd-field">
-                                    <label for="cf-pdl2">Column 2 \(P_{DL,2}\) (in kN)</label>
+                                    <label for="cf-pdl2">\(P_{DL,2}\) (in kN)</label>
                                     <input type="number" id="cf-pdl2" step="0.01" inputmode="decimal">
                                 </div>
                                 <div class="fd-field">
-                                    <label for="cf-pll2">Column 2 \(P_{LL,2}\) (in kN)</label>
+                                    <label for="cf-pll2">\(P_{LL,2}\) (in kN)</label>
                                     <input type="number" id="cf-pll2" step="0.01" inputmode="decimal">
                                 </div>
                             </div>
@@ -584,6 +586,8 @@
             const pllField       = pll.closest('.fd-field');
             const loadingGrid    = pdlField.parentElement;
             const mdlxField      = document.getElementById('mdlx').closest('.fd-field');
+            const pdlLabelCF     = document.getElementById('pdlLabelCF');
+            const pllLabelCF     = document.getElementById('pllLabelCF');
             const COL_WIDTH_LABEL_DEFAULT = cLabel.textContent;
             function toggleCombinedFooting() {
                 const isCF = (selectStructure.value === 'Strip');
@@ -612,6 +616,11 @@
                     cLabel.style.display = ''; ccLabel.style.display = 'none'; c.style.display = '';
                     cLabel.textContent = 'Column 1 Width (square, in mm)';
                     columnLegend.textContent = 'Column 1';
+                    // Show the ",1"-subscripted Column 1 load labels.
+                    if (pdlLabel)   pdlLabel.style.display   = 'none';
+                    if (pllLabel)   pllLabel.style.display   = 'none';
+                    if (pdlLabelCF) pdlLabelCF.style.display = '';
+                    if (pllLabelCF) pllLabelCF.style.display = '';
                 } else {
                     // Move DL/LL back into the Loading card (original order).
                     loadingGrid.insertBefore(pdlField, mdlxField);
@@ -623,6 +632,11 @@
                     colWidthYField.style.display = '';
                     cLabel.textContent = COL_WIDTH_LABEL_DEFAULT;
                     columnLegend.textContent = 'Column';
+                    // Restore the default (unsubscripted) Column 1 load labels.
+                    if (pdlLabelCF) pdlLabelCF.style.display = 'none';
+                    if (pllLabelCF) pllLabelCF.style.display = 'none';
+                    if (pdlLabel)   pdlLabel.style.display   = '';
+                    if (pllLabel)   pllLabel.style.display   = '';
                     // Re-apply the correct labels/inputs for the chosen shape.
                     columnShape.dispatchEvent(new Event('change'));
                 }


### PR DESCRIPTION
## What

Two small fixes to the combined-footing flow.

### 1. `kN·m` rendered as literal `\cdotp`

The longitudinal & transverse flexure steps printed the unit as `277.3 kN\cdotpm`. The cause: a raw `·` (U+00B7) character placed **inside** a KaTeX `\text{}` group — KaTeX has no text-mode mapping for it, so it emitted the raw command name.

Fix: switch to math-mode `\cdot` between text chunks — `\text{ kN}\cdot\text{m}` (also for `kN·m/m` and the `\kNm` macro). Now renders as a proper `kN·m`.

### 2. Combined-footing load labels

- **Column 2** loads dropped the redundant **"Column 2"** prefix (the card legend already says *Column 2*) → now `\(P_{DL,2}\)` / `\(P_{LL,2}\)`.
- **Column 1** loads gain a **",1"** subscript while a combined footing is selected → `\(P_{DL,1}\)` / `\(P_{LL,1}\)`. Implemented as hidden, KaTeX-pre-rendered label variants that are toggled in/out, so they **revert to plain `\(P_{DL}\)` / `\(P_{LL}\)`** for every other footing type.

## Verification

- `node --check` passes on the engine; both inline HTML scripts pass `new Function()` checks.
- The `,1` label variants live inside `.fd-page`, so the existing `renderFormMath()` pass renders them on load even while hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
