### PR TITLE
foundationDesign: hide Analysis/Solution Method for Combined Footing, fold layout into Geometry card

### DIFF
--- a/public/pages/foundationDesign.html
+++ b/public/pages/foundationDesign.html
@@ -83,7 +83,7 @@
 
                         <!-- ============ Analysis &amp; Geometry ============ -->
                         <fieldset class="fd-section">
-                            <legend>Analysis &amp; Geometry</legend>
+                            <legend id="ag-legend">Analysis &amp; Geometry</legend>
                             <div class="fd-grid">
                                 <div class="fd-field">
                                     <label for="analysisMethod">Analysis Method</label>
@@ -142,7 +142,39 @@
                                         <option value="2">Approximate (Initial \(D_c\))</option>
                                     </select>
                                 </div>
+                                <!-- Combined-footing layout (shown only for Combined Footing) -->
+                                <div class="fd-field" id="cf-sf-field" style="display: none;">
+                                    <label for="cf-sf">Column spacing \(s_f\) (c/c, in m)</label>
+                                    <input type="number" id="cf-sf" step="0.01" inputmode="decimal">
+                                </div>
+                                <div class="fd-field" id="cf-left-restrict-field" style="display: none;">
+                                    <label for="cf-left-restrict">Left edge</label>
+                                    <select id="cf-left-restrict">
+                                        <option value="0">Free (can extend)</option>
+                                        <option value="1">Property line (restricted)</option>
+                                    </select>
+                                </div>
+                                <div class="fd-field" id="cf-left-oh-field" style="display: none;">
+                                    <label for="cf-left-oh">Left overhang past Col 1 face (in mm)</label>
+                                    <input type="number" id="cf-left-oh" step="1" inputmode="numeric" value="0" placeholder="0 = col face on the line">
+                                </div>
+                                <div class="fd-field" id="cf-right-restrict-field" style="display: none;">
+                                    <label for="cf-right-restrict">Right edge</label>
+                                    <select id="cf-right-restrict">
+                                        <option value="0">Free (can extend)</option>
+                                        <option value="1">Property line (restricted)</option>
+                                    </select>
+                                </div>
+                                <div class="fd-field" id="cf-right-oh-field" style="display: none;">
+                                    <label for="cf-right-oh">Right overhang past Col 2 face (in mm)</label>
+                                    <input type="number" id="cf-right-oh" step="1" inputmode="numeric" value="0" placeholder="0 = col face on the line">
+                                </div>
                             </div>
+                            <p class="fd-hint" id="cf-layout-hint" style="display: none; margin: 8px 4px 0;">
+                                If one edge is a property line and the other is free, a <strong>Rectangular</strong> footing is
+                                used. If both edges are on property lines, a <strong>Trapezoidal</strong> footing is used. The
+                                overhang is the slab projection past the column face toward the property line; a free edge has none.
+                            </p>
                         </fieldset>
 
                         <!-- ============ Loading ============ -->
@@ -276,44 +308,6 @@
                                 </div>
                             </div>
                             <p class="fd-hint" style="margin: 8px 4px 0;">Leave the width blank to reuse Column 1's size.</p>
-                        </fieldset>
-
-                        <!-- ===== Combined Footing: Footing Layout (shown only for combined footing) ===== -->
-                        <fieldset class="fd-section" id="cf-layout-fieldset" style="display: none;">
-                            <legend>Footing Layout</legend>
-                            <div class="fd-grid">
-                                <div class="fd-field">
-                                    <label for="cf-sf">Column spacing \(s_f\) (c/c, in m)</label>
-                                    <input type="number" id="cf-sf" step="0.01" inputmode="decimal">
-                                </div>
-                                <div class="fd-field">
-                                    <label for="cf-left-restrict">Left edge</label>
-                                    <select id="cf-left-restrict">
-                                        <option value="0">Free (can extend)</option>
-                                        <option value="1">Property line (restricted)</option>
-                                    </select>
-                                </div>
-                                <div class="fd-field" id="cf-left-oh-field" style="display: none;">
-                                    <label for="cf-left-oh">Left overhang past Col 1 face (in mm)</label>
-                                    <input type="number" id="cf-left-oh" step="1" inputmode="numeric" value="0" placeholder="0 = col face on the line">
-                                </div>
-                                <div class="fd-field">
-                                    <label for="cf-right-restrict">Right edge</label>
-                                    <select id="cf-right-restrict">
-                                        <option value="0">Free (can extend)</option>
-                                        <option value="1">Property line (restricted)</option>
-                                    </select>
-                                </div>
-                                <div class="fd-field" id="cf-right-oh-field" style="display: none;">
-                                    <label for="cf-right-oh">Right overhang past Col 2 face (in mm)</label>
-                                    <input type="number" id="cf-right-oh" step="1" inputmode="numeric" value="0" placeholder="0 = col face on the line">
-                                </div>
-                            </div>
-                            <p class="fd-hint" style="margin: 8px 4px 0;">
-                                If one edge is a property line and the other is free, a <strong>Rectangular</strong> footing is
-                                used. If both edges are on property lines, a <strong>Trapezoidal</strong> footing is used. The
-                                overhang is the slab projection past the column face toward the property line; a free edge has none.
-                            </p>
                         </fieldset>
 
                         <!-- ============ Reinforcement &amp; Footing ============ -->
@@ -573,9 +567,19 @@
             //   • rename the "Column" legend to "Column 1".
             // Everything is reverted for the other footing types.
             const cfCol2   = document.getElementById('cf-col2-fieldset');
-            const cfLayout = document.getElementById('cf-layout-fieldset');
             const columnLegend        = document.getElementById('column-legend');
             const loadingFieldset     = document.getElementById('loading-fieldset');
+            // Geometry card: the Analysis Method + Solution Method dropdowns are
+            // hidden for a Combined Footing (they don't affect that engine path),
+            // and the footing-layout fields (spacing + edges) now live in this
+            // same card so it isn't left with just the Foundation Type dropdown.
+            const agLegend            = document.getElementById('ag-legend');
+            const analysisMethodField = analysisMethod.closest('.fd-field');
+            const methodField         = method.closest('.fd-field');
+            const cfSfField     = document.getElementById('cf-sf-field');
+            const cfLeftRField  = document.getElementById('cf-left-restrict-field');
+            const cfRightRField = document.getElementById('cf-right-restrict-field');
+            const cfLayoutHint  = document.getElementById('cf-layout-hint');
             const columnLocationField = document.getElementById('ColumnLocation').closest('.fd-field');
             const colShapeField  = columnShape.closest('.fd-field');
             const colWidthField  = c.closest('.fd-field');
@@ -591,9 +595,24 @@
             const COL_WIDTH_LABEL_DEFAULT = cLabel.textContent;
             function toggleCombinedFooting() {
                 const isCF = (selectStructure.value === 'Strip');
-                if (cfCol2)   cfCol2.style.display   = isCF ? 'block' : 'none';
-                if (cfLayout) cfLayout.style.display = isCF ? 'block' : 'none';
+                if (cfCol2) cfCol2.style.display = isCF ? 'block' : 'none';
+                // Footing-layout (spacing + edges) fields live in the Geometry card.
+                if (cfSfField)     cfSfField.style.display     = isCF ? '' : 'none';
+                if (cfLeftRField)  cfLeftRField.style.display  = isCF ? '' : 'none';
+                if (cfRightRField) cfRightRField.style.display = isCF ? '' : 'none';
+                if (cfLayoutHint)  cfLayoutHint.style.display  = isCF ? '' : 'none';
                 if (isCF) {
+                    // A Combined Footing is always a detailed design and the
+                    // Analysis/Solution-Method dropdowns don't affect its engine
+                    // path, so force "design" (keeps Foundation Type visible,
+                    // hides the bx/by/dc analyze inputs) and hide both dropdowns.
+                    if (analysisMethod.value !== 'design') {
+                        analysisMethod.value = 'design';
+                        analysisMethod.dispatchEvent(new Event('change'));
+                    }
+                    if (analysisMethodField) analysisMethodField.style.display = 'none';
+                    if (methodField)         methodField.style.display         = 'none';
+                    if (agLegend) agLegend.textContent = 'Geometry';
                     // Force the per-column load model.
                     if (loadType.value !== 'individual') {
                         loadType.value = 'individual';
@@ -621,7 +640,12 @@
                     if (pllLabel)   pllLabel.style.display   = 'none';
                     if (pdlLabelCF) pdlLabelCF.style.display = '';
                     if (pllLabelCF) pllLabelCF.style.display = '';
+                    toggleOverhangs();
                 } else {
+                    // Restore the Analysis/Solution-Method dropdowns + legend.
+                    if (analysisMethodField) analysisMethodField.style.display = '';
+                    if (methodField)         methodField.style.display         = '';
+                    if (agLegend) agLegend.textContent = 'Analysis & Geometry';
                     // Move DL/LL back into the Loading card (original order).
                     loadingGrid.insertBefore(pdlField, mdlxField);
                     loadingGrid.insertBefore(pllField, mdlxField);
@@ -639,6 +663,7 @@
                     if (pllLabel)   pllLabel.style.display   = '';
                     // Re-apply the correct labels/inputs for the chosen shape.
                     columnShape.dispatchEvent(new Event('change'));
+                    toggleOverhangs();
                 }
             }
             selectStructure.addEventListener('change', toggleCombinedFooting);
@@ -650,8 +675,9 @@
             const cfLeftOhF  = document.getElementById('cf-left-oh-field');
             const cfRightOhF = document.getElementById('cf-right-oh-field');
             function toggleOverhangs() {
-                if (cfLeftOhF)  cfLeftOhF.style.display  = (cfLeftR  && cfLeftR.value  === '1') ? 'block' : 'none';
-                if (cfRightOhF) cfRightOhF.style.display = (cfRightR && cfRightR.value === '1') ? 'block' : 'none';
+                const isCF = (selectStructure.value === 'Strip');
+                if (cfLeftOhF)  cfLeftOhF.style.display  = (isCF && cfLeftR  && cfLeftR.value  === '1') ? '' : 'none';
+                if (cfRightOhF) cfRightOhF.style.display = (isCF && cfRightR && cfRightR.value === '1') ? '' : 'none';
             }
             if (cfLeftR)  cfLeftR.addEventListener('change', toggleOverhangs);
             if (cfRightR) cfRightR.addEventListener('change', toggleOverhangs);


### PR DESCRIPTION
## What

Answers the follow-up to the "do these dropdowns matter?" question: the **Analysis Method** and **Solution Method** dropdowns have **no effect on the Combined Footing engine path** (its submit handler intercepts and runs `designCombinedFooting()` before either value is read). So for a Combined Footing they're now hidden, and the card is tidied up.

## Changes (Combined Footing only)

- **Hide Analysis Method + Solution Method.** "design" is forced so the Foundation Type dropdown stays visible and the analyze-only `bx/by/dc` inputs stay hidden.
- **Legend changes** from "Analysis & Geometry" → **"Geometry"**.
- **Footing Layout merged into the Geometry card.** Rather than leave "Geometry" with just the Foundation Type dropdown, the former *Footing Layout* card (column spacing, edge restraints, conditional overhangs, and the rectangular/trapezoidal hint) now lives **inside** the Geometry card. The standalone fieldset is removed; the fields keep the **same IDs**, so the engine reads them unchanged.
- **Overhang visibility is now gated on the footing type** too — a stale "property line" value left over from a previous Combined Footing session can no longer reveal an overhang field under another footing type.

Everything **reverts** for the other footing types: the two method dropdowns and the "Analysis & Geometry" legend return, and the layout fields hide.

## Verification

- Both inline HTML scripts pass `new Function()` syntax checks.
- Each combined-footing field ID (`cf-sf`, `cf-left-restrict`, `cf-right-restrict`, `cf-left-oh`, `cf-right-oh`) appears exactly once after the move — no duplicates, engine wiring intact.
- No stale `cf-layout-fieldset` / `cfLayout` references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
