### PR TITLE
foundationDesign: collapse hidden fields' empty grid cells (blank-fields bug)

### DIFF
--- a/public/pages/foundationDesign.html
+++ b/public/pages/foundationDesign.html
@@ -1078,12 +1078,33 @@ handleLoadTypeChange(); // This ensures the display is set correctly on page loa
         // first run, and the restored values must re-fire their visibility
         // handlers (otherwise restored fields render but in the wrong show/hide
         // state — the "invisible field" bug).
+        // Collapse any .fd-field whose CONTROL is hidden, so a hidden input no
+        // longer leaves an empty cell in the grid (the "blank fields" bug —
+        // e.g. P_DL getting pushed to the far column past the hidden Ultimate
+        // Load / moment fields). We key off the control's own inline display,
+        // so wrapper-level toggles (combined-footing cards, analysis method)
+        // are never disturbed; and we only un-collapse fields WE collapsed.
+        function fdCollapseEmptyFields() {
+            document.querySelectorAll('.fd-page .fd-field').forEach(field => {
+                const ctrl = field.querySelector('input, select, textarea');
+                if (!ctrl) return;
+                if (ctrl.style.display === 'none') {
+                    field.dataset.fdCollapsed = '1';
+                    field.style.display = 'none';
+                } else if (field.dataset.fdCollapsed === '1') {
+                    delete field.dataset.fdCollapsed;
+                    field.style.display = '';
+                }
+            });
+        }
+
         function fdResyncVisibility() {
             ['analysisMethod','structureType','loadType','centricity','columnShape',
              'LengthRestriction','cf-method','cf-left-restrict','cf-right-restrict'].forEach(id => {
                 const el = document.getElementById(id);
                 if (el && el.value !== 'PileCap') el.dispatchEvent(new Event('change', { bubbles: true }));
             });
+            fdCollapseEmptyFields();
             drawFoundationSchematic();
         }
 
@@ -1097,8 +1118,12 @@ handleLoadTypeChange(); // This ensures the display is set correctly on page loa
                 f.addEventListener('input', onEdit);
                 f.addEventListener('change', onEdit);
             });
+            // After every change, collapse the cells of any newly-hidden fields.
+            const fdPage = document.querySelector('.fd-page');
+            if (fdPage) fdPage.addEventListener('change', fdCollapseEmptyFields);
 
             fdResyncVisibility();
+            fdCollapseEmptyFields();   // also fix the blanks present on first load
             renderFormMath();
         });
         window.addEventListener('load', fdResyncVisibility);


### PR DESCRIPTION
## What

Finally fixes the blank/"invisible" fields — and your screenshot pinned it down: it happens **even on first load**.

## Root cause

The conditional fields hide their **input + label** with `display:none`, but the wrapping `.fd-field` div stays in the CSS grid as an **empty cell**. With "Individual Loads", the hidden Ultimate-Load and moment fields left blank cells that pushed `P_DL` into the far-right column and wrapped `P_LL` onto the next row.

My previous re-sync fixed *which controls* hide, but not the leftover empty wrappers — that's why blanks remained.

## Fix

Added `fdCollapseEmptyFields()`:
- Hides a `.fd-field` wrapper whenever its control's **own inline `display`** is `none`.
- Un-hides only the wrappers **it** collapsed (tracked via a data-attribute).

Because it keys off the *control's* inline display (not the wrapper), it **never fights** the wrapper-level toggles already used by the combined-footing cards or the Analysis/Solution-Method hiding.

It runs:
- after every change (delegated on `.fd-page`),
- inside the `load`/`pageshow` re-sync,
- once on `DOMContentLoaded` — clearing the blanks present on first load.

## Verification

- Both inline scripts parse.
- Collapse/expand logic unit-tested with a mock DOM: hidden-control fields collapse (no empty cells), and re-expand when shown again, without disturbing wrapper-toggled fields.

So with Individual + Concentric, the Loading card now reads cleanly: **Load Type · Centricity · P_DL · P_LL** with no gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
