### PR TITLE
foundationDesign: remove grey strip below the nav bar

### DIFF
--- a/public/assets/css/styles1.css
+++ b/public/assets/css/styles1.css
@@ -577,7 +577,9 @@ nav ul li a:hover {
 .fd-page {
     max-width: none;          /* full-bleed white — no grey side strips */
     margin: 0;
-    padding: 0 22px 8px;
+    /* Non-zero top padding stops the <h1> top margin from collapsing out of
+       the card, which otherwise exposed a grey strip below the nav bar. */
+    padding: 14px 22px 8px;
 }
 
 /* Two-column shell: the form/results on the left, a sticky figure rail on


### PR DESCRIPTION
## What

Removes the grey strip showing between the nav bar and the white content.

## Cause

`.fd-page` had `padding-top: 0`, so the `<h1>` (Foundation Design)'s default top margin **collapsed out** through the top of the white card — pushing the card down and revealing the grey body background as a strip under the nav.

## Fix

Gave `.fd-page` a small top padding (`14px`) so the margin can't collapse out; the white card now butts directly against the nav bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)