### PR TITLE
feat(webapp): Phase 2 — Foundation Design (square footing) in React

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -8,6 +8,7 @@
       "name": "webapp",
       "version": "0.0.0",
       "dependencies": {
+        "katex": "^0.17.0",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-router-dom": "^7.17.0"
@@ -15,6 +16,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@tailwindcss/vite": "^4.3.0",
+        "@types/katex": "^0.16.8",
         "@types/node": "^24.12.3",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -1719,6 +1721,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.13.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
@@ -2280,6 +2289,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/convert-source-map": {
@@ -2932,6 +2950,22 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.17.0.tgz",
+      "integrity": "sha512-Vdw0ATsQ9V+LuegM/BTwQqV/6cTl5lbGcIrU+BCgLxyf6bo38ybOr372tuSIxir3CN720flu1meYR6XzNMwQnw==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/keyv": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "katex": "^0.17.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-router-dom": "^7.17.0"
@@ -18,6 +19,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@tailwindcss/vite": "^4.3.0",
+    "@types/katex": "^0.16.8",
     "@types/node": "^24.12.3",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,5 +1,6 @@
 import { Routes, Route, Link } from 'react-router-dom'
 import { factoredLoad, beta1 } from './engine/loads'
+import FoundationDesign from './pages/FoundationDesign'
 
 function Home() {
   return (
@@ -33,26 +34,11 @@ function Home() {
   )
 }
 
-function FoundationPlaceholder() {
-  return (
-    <div className="mx-auto max-w-3xl p-8">
-      <Link to="/" className="text-sm text-[#0056b3] hover:underline">
-        ← Home
-      </Link>
-      <h1 className="mt-2 text-2xl font-bold text-[#0056b3]">Foundation Design</h1>
-      <p className="mt-2 text-slate-600">
-        Pilot migration target (Phase&nbsp;2) — this page will be rebuilt in React on the
-        typed engine.
-      </p>
-    </div>
-  )
-}
-
 export default function App() {
   return (
     <Routes>
       <Route path="/" element={<Home />} />
-      <Route path="/foundation" element={<FoundationPlaceholder />} />
+      <Route path="/foundation" element={<FoundationDesign />} />
     </Routes>
   )
 }

--- a/webapp/src/components/FootingSchematic.tsx
+++ b/webapp/src/components/FootingSchematic.tsx
@@ -1,0 +1,119 @@
+import type { JSX } from 'react'
+
+const DIM = '#1f77b4'
+const STROKE = '#37526e'
+const FILL = '#eef3f8'
+const COL = '#37526e'
+const GAP = 4
+const TK = 4
+
+function Tick({ x, y }: { x: number; y: number }) {
+  // 45° architectural tick
+  return <line x1={x - TK} y1={y + TK} x2={x + TK} y2={y - TK} stroke={DIM} strokeWidth={1.2} />
+}
+
+/** Horizontal dimension below a feature (extension lines + dim line + ticks + label). */
+function DimBelow({ xA, xB, featY, dY, label }: { xA: number; xB: number; featY: number; dY: number; label: string }) {
+  return (
+    <g>
+      <line x1={xA} y1={featY + GAP} x2={xA} y2={dY + 5} stroke={DIM} strokeWidth={0.6} />
+      <line x1={xB} y1={featY + GAP} x2={xB} y2={dY + 5} stroke={DIM} strokeWidth={0.6} />
+      <line x1={xA} y1={dY} x2={xB} y2={dY} stroke={DIM} strokeWidth={0.9} />
+      <Tick x={xA} y={dY} />
+      <Tick x={xB} y={dY} />
+      <text x={(xA + xB) / 2} y={dY - 4} fontSize={9.5} fill={DIM} textAnchor="middle"
+        paintOrder="stroke" stroke="#fff" strokeWidth={2.6}>{label}</text>
+    </g>
+  )
+}
+
+/** Vertical dimension to one side of a feature. side='right' puts it on the right. */
+function DimSide({ yA, yB, featX, dX, label, side }: { yA: number; yB: number; featX: number; dX: number; label: string; side: 'left' | 'right' }) {
+  const ext = side === 'right' ? 5 : -5
+  const lab = side === 'right' ? dX + 11 : dX - 11
+  const e1 = side === 'right' ? featX + GAP : featX - GAP
+  return (
+    <g>
+      <line x1={e1} y1={yA} x2={dX + ext} y2={yA} stroke={DIM} strokeWidth={0.6} />
+      <line x1={e1} y1={yB} x2={dX + ext} y2={yB} stroke={DIM} strokeWidth={0.6} />
+      <line x1={dX} y1={yA} x2={dX} y2={yB} stroke={DIM} strokeWidth={0.9} />
+      <Tick x={dX} y={yA} />
+      <Tick x={dX} y={yB} />
+      <text x={lab} y={(yA + yB) / 2} fontSize={9.5} fill={DIM} textAnchor="middle"
+        transform={`rotate(-90 ${lab} ${(yA + yB) / 2})`} paintOrder="stroke" stroke="#fff" strokeWidth={2.6}>{label}</text>
+    </g>
+  )
+}
+
+export interface SchematicProps {
+  /** Footing side, m. */
+  B: number
+  /** Slab thickness D_c, mm. */
+  Dc: number
+  /** Square column width, mm. */
+  columnWidth: number
+  /** Total depth H, m. */
+  H: number
+}
+
+/** Plan + section of a designed square footing, drawn to scale. */
+export function FootingSchematic({ B, Dc, columnWidth, H }: SchematicProps): JSX.Element {
+  const W = 360
+  const cm = columnWidth / 1000
+
+  // ── PLAN (single scale → true proportions) ──
+  const planTop = 36
+  const RM = 52
+  const px0 = 14
+  const availW = W - RM - px0
+  const availH = 116
+  const s = Math.min(availW / B, availH / B)
+  const fW = B * s
+  const fx = px0 + (availW - fW) / 2
+  const fyTop = planTop
+  const fyBot = planTop + fW
+  const cxc = fx + fW / 2
+  const cyc = (fyTop + fyBot) / 2
+  const cpx = Math.max(6, cm * s)
+
+  // ── SECTION ──
+  const secTitleY = fyBot + 64
+  const secTop = secTitleY + 10
+  const gl = secTop + 6
+  const slabX = 46
+  const sW = W - slabX - 44
+  const sV = 96 / H
+  const Hpx = Math.max(46, H * sV)
+  const slabH = Math.max(8, (Dc / 1000) * sV)
+  const slabY = gl + (Hpx - slabH)
+  const baseY = gl + Hpx
+  const stubW = 28
+  const soilTicks: JSX.Element[] = []
+  for (let x = slabX; x < slabX + sW; x += 12) {
+    soilTicks.push(<line key={`s${x}`} x1={x} y1={gl} x2={x - 6} y2={gl + 6} stroke="#caa472" strokeWidth={0.8} />)
+  }
+
+  const totalH = baseY + 26
+
+  return (
+    <svg viewBox={`0 0 ${W} ${totalH}`} xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet"
+      style={{ width: '100%', height: 'auto', fontFamily: 'Arial, sans-serif' }}>
+      <text x={14} y={20} fontSize={11} fontWeight={700} fill="#0056b3">PLAN</text>
+      {/* footing + column */}
+      <rect x={fx} y={fyTop} width={fW} height={fW} rx={2} fill={FILL} stroke={STROKE} strokeWidth={1.4} />
+      <rect x={cxc - cpx / 2} y={cyc - cpx / 2} width={cpx} height={cpx} fill={COL} />
+      <DimBelow xA={fx} xB={fx + fW} featY={fyBot} dY={fyBot + 20} label={`B = ${B.toFixed(2)} m`} />
+      <DimSide yA={fyTop} yB={fyBot} featX={fx + fW} dX={fx + fW + 10} label={`B = ${B.toFixed(2)} m`} side="right" />
+
+      <text x={14} y={secTitleY} fontSize={11} fontWeight={700} fill="#0056b3">SECTION</text>
+      {/* ground + soil */}
+      <line x1={slabX} y1={gl} x2={slabX + sW} y2={gl} stroke="#8a6d3b" strokeWidth={1.2} />
+      {soilTicks}
+      {/* slab + column stub */}
+      <rect x={slabX} y={slabY} width={sW} height={slabH} fill="#cfe0f1" stroke={STROKE} strokeWidth={1.4} />
+      <rect x={slabX + sW / 2 - stubW / 2} y={gl} width={stubW} height={slabY - gl} fill={COL} />
+      <DimSide yA={gl} yB={baseY} featX={slabX} dX={slabX - 12} label={`H = ${H.toFixed(2)} m`} side="left" />
+      <DimSide yA={slabY} yB={baseY} featX={slabX + sW} dX={slabX + sW + 8} label={`Dc = ${Math.round(Dc)} mm`} side="right" />
+    </svg>
+  )
+}

--- a/webapp/src/lib/format.ts
+++ b/webapp/src/lib/format.ts
@@ -1,0 +1,3 @@
+export const f0 = (v: number) => (Number.isFinite(v) ? Math.round(v).toString() : '—')
+export const f2 = (v: number) => (Number.isFinite(v) ? v.toFixed(2) : '—')
+export const f3 = (v: number) => (Number.isFinite(v) ? v.toFixed(3) : '—')

--- a/webapp/src/lib/math.tsx
+++ b/webapp/src/lib/math.tsx
@@ -1,0 +1,12 @@
+import katex from 'katex'
+
+// Tiny KaTeX wrapper — renders to an HTML string and injects it. Avoids the
+// react-katex peer-dependency friction with React 19 and keeps full control.
+export function Math({ tex, block = false }: { tex: string; block?: boolean }) {
+  const html = katex.renderToString(tex, { throwOnError: false, displayMode: block })
+  return block ? (
+    <div className="my-1 overflow-x-auto" dangerouslySetInnerHTML={{ __html: html }} />
+  ) : (
+    <span dangerouslySetInnerHTML={{ __html: html }} />
+  )
+}

--- a/webapp/src/pages/FoundationDesign.tsx
+++ b/webapp/src/pages/FoundationDesign.tsx
@@ -1,0 +1,165 @@
+import { useMemo, useState, type ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { designSquareFooting } from '../engine/isolatedFooting'
+import { netBearing } from '../engine/bearing'
+import type { ColumnPosition } from '../engine/shear'
+import { FootingSchematic } from '../components/FootingSchematic'
+import { Math } from '../lib/math'
+import { f0, f2, f3 } from '../lib/format'
+import 'katex/dist/katex.min.css'
+
+interface FormState {
+  serviceLoad: number
+  ultimateLoad: number
+  columnWidth: number
+  fc: number
+  fy: number
+  qAllow: number
+  gammaSoil: number
+  gammaConc: number
+  H: number
+  barDia: number
+  cover: number
+  surcharge: number
+  position: ColumnPosition
+}
+
+const DEFAULTS: FormState = {
+  serviceLoad: 1000,
+  ultimateLoad: 1400,
+  columnWidth: 400,
+  fc: 28,
+  fy: 415,
+  qAllow: 200,
+  gammaSoil: 18,
+  gammaConc: 24,
+  H: 1.5,
+  barDia: 20,
+  cover: 75,
+  surcharge: 0,
+  position: 'interior',
+}
+
+function NumField({ label, unit, value, onChange, step = 'any' }: {
+  label: ReactNode; unit?: string; value: number; onChange: (v: number) => void; step?: string
+}) {
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="mb-1 font-medium text-slate-600">
+        {label}{unit ? <span className="text-slate-400"> ({unit})</span> : null}
+      </span>
+      <input
+        type="number" inputMode="decimal" step={step} value={Number.isFinite(value) ? value : ''}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none focus:ring-1 focus:ring-[#0056b3]"
+      />
+    </label>
+  )
+}
+
+function Card({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">{title}</legend>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">{children}</div>
+    </fieldset>
+  )
+}
+
+function Row({ label, value, check }: { label: ReactNode; value: ReactNode; check?: ReactNode }) {
+  return (
+    <div className="flex items-baseline justify-between gap-3 border-b border-slate-100 py-1.5 last:border-0">
+      <span className="text-sm text-slate-600">{label}</span>
+      <span className="text-right text-sm font-semibold text-slate-800">{value}</span>
+      {check ? <span className="w-28 text-right text-xs text-slate-500">{check}</span> : null}
+    </div>
+  )
+}
+
+export default function FoundationDesign() {
+  const [form, setForm] = useState<FormState>(DEFAULTS)
+  const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) => setForm((s) => ({ ...s, [k]: v }))
+
+  const qNetTrial = useMemo(
+    () => netBearing({ qAllow: form.qAllow, gammaSoil: form.gammaSoil, gammaConc: form.gammaConc, H: form.H, Dc: 0.25, surcharge: form.surcharge }),
+    [form.qAllow, form.gammaSoil, form.gammaConc, form.H, form.surcharge],
+  )
+
+  const valid = Object.values(form).every((v) => typeof v === 'string' || Number.isFinite(v as number)) && qNetTrial > 0
+  const result = useMemo(() => (valid ? designSquareFooting(form) : null), [form, valid])
+
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <Link to="/" className="text-sm text-[#0056b3] hover:underline">← Home</Link>
+      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Foundation Design</h1>
+      <p className="mt-1 text-slate-600">Isolated square footing, concentric load — React + typed engine pilot. Results update live.</p>
+
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
+        {/* ── Inputs ── */}
+        <div className="space-y-5">
+          <Card title="Loads & Column">
+            <NumField label={<Math tex="P" />} unit="kN" value={form.serviceLoad} onChange={set('serviceLoad')} />
+            <NumField label={<Math tex="P_u" />} unit="kN" value={form.ultimateLoad} onChange={set('ultimateLoad')} />
+            <NumField label={<>Column <Math tex="c" /> (square)</>} unit="mm" value={form.columnWidth} onChange={set('columnWidth')} />
+            <label className="flex flex-col text-sm">
+              <span className="mb-1 font-medium text-slate-600">Column position</span>
+              <select value={form.position} onChange={(e) => set('position')(e.target.value as FormState['position'])}
+                className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none">
+                <option value="interior">Interior</option>
+                <option value="edge">Edge</option>
+                <option value="corner">Corner</option>
+              </select>
+            </label>
+          </Card>
+
+          <Card title="Materials">
+            <NumField label={<Math tex="f'_c" />} unit="MPa" value={form.fc} onChange={set('fc')} />
+            <NumField label={<Math tex="f_y" />} unit="MPa" value={form.fy} onChange={set('fy')} />
+            <NumField label={<>Bar <Math tex="d_b" /></>} unit="mm" value={form.barDia} onChange={set('barDia')} />
+            <NumField label="Clear cover" unit="mm" value={form.cover} onChange={set('cover')} />
+          </Card>
+
+          <Card title="Soil & Geometry">
+            <NumField label={<Math tex="q_a" />} unit="kPa" value={form.qAllow} onChange={set('qAllow')} />
+            <NumField label={<Math tex="\gamma_{soil}" />} unit="kN/m³" value={form.gammaSoil} onChange={set('gammaSoil')} />
+            <NumField label={<Math tex="\gamma_{conc}" />} unit="kN/m³" value={form.gammaConc} onChange={set('gammaConc')} />
+            <NumField label={<>Total depth <Math tex="H" /></>} unit="m" value={form.H} onChange={set('H')} />
+            <NumField label="Surcharge" unit="kPa" value={form.surcharge} onChange={set('surcharge')} />
+          </Card>
+        </div>
+
+        {/* ── Results ── */}
+        <div className="space-y-5">
+          <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Design preview</h2>
+            {result ? (
+              <FootingSchematic B={result.B} Dc={result.Dc} columnWidth={form.columnWidth} H={form.H} />
+            ) : (
+              <p className="py-8 text-center text-sm text-slate-400">Enter valid inputs — net bearing must be positive.</p>
+            )}
+          </div>
+
+          {result && (
+            <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Results</h2>
+              <Row label={<Math tex="q_{net}" />} value={`${f3(result.qNet)} kPa`} />
+              <Row label="Footing size B" value={`${f2(result.B)} m`} />
+              <Row label={<Math tex="q_u = P_u/B^2" />} value={`${f3(result.qu)} kPa`} />
+              <Row label="Slab thickness Dc" value={`${f0(result.Dc)} mm`} check={`d≈${f0(result.dFlex)} mm`} />
+              <Row label="d — punching / beam" value={`${f0(result.dPunch)} / ${f0(result.dBeam)} mm`} />
+              <Row label="Steel As" value={`${f0(result.steelArea)} mm²`} check={result.usedMinSteel ? 'ρ_min governs' : `ρ=${result.rho.toFixed(4)}`} />
+              <Row label="Reinforcement" value={`${result.bars} ⌀${form.barDia} mm`} check={`@ ${f0(result.barSpacing)} mm o.c.`} />
+            </div>
+          )}
+
+          <div className="rounded-xl border border-slate-200 bg-white p-4 text-sm text-slate-600 shadow-sm">
+            <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Basis</h2>
+            <Math block tex={String.raw`q_{net} = q_a - \gamma_s D_s - \gamma_c D_c - q`} />
+            <Math block tex={String.raw`P_u = \max(1.4D,\ 1.2D + 1.6L),\quad B = \sqrt{P/q_{net}}`} />
+            <p className="mt-1 text-xs text-slate-400">NSCP 2015 / ACI 318-14. φ: shear 0.75, flexure 0.90.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Phase 2 — Foundation Design in React (square footing pilot)

The first calculator migrated to the new stack, live at **`/app/foundation`**, built on the typed engine from Phase 1.

### What it does
- **Live form** (loads, column, materials, soil & geometry) → `designSquareFooting()` from the typed engine. **Results recompute as you type** — the React payoff (no manual DOM sync, no visibility bugs).
- **Results panel:** `q_net`, footing size `B`, `q_u`, slab `D_c`, punching/beam effective depths, steel area + bar count/spacing, with ρ_min / capacity notes.
- **`FootingSchematic.tsx`** — plan + section drawn **to scale as real SVG** (single scale → true proportions, architectural-tick dimension lines). Redraws with the design — and it's clean JSX, not string concatenation.
- **KaTeX** for the notation/formulas, via a tiny direct wrapper (sidesteps `react-katex`'s React-19 peer friction).

### Notes
- **Scope:** isolated **square + concentric** — exactly the engine slice we have. Rectangular, combined footing, and the flexible (Winkler) method come in later phases as the engine grows.
- **Legacy untouched** — the old `/foundationDesign.html` still works; this is additive under `/app`.

### Verified
- `npm run build` → clean (tsc + vite, 52 modules)
- engine tests still **19/19**
- server serves `/app/foundation` (200) with the bundle; defaults produce a sane design (B in range, valid Dc/steel).

> Deploy: already covered by the Render build command from #106 (`npm --prefix webapp run build`). After merge, the page is live at `/app/foundation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
