### PR TITLE
feat(webapp): Phase 3 — rectangular isolated footing (engine + UI)

### DIFF
--- a/webapp/src/components/FootingSchematic.tsx
+++ b/webapp/src/components/FootingSchematic.tsx
@@ -46,8 +46,10 @@ function DimSide({ yA, yB, featX, dX, label, side }: { yA: number; yB: number; f
 }
 
 export interface SchematicProps {
-  /** Footing side, m. */
-  B: number
+  /** Footing length along x, m. */
+  Bx: number
+  /** Footing width along y, m (= Bx for a square footing). */
+  By: number
   /** Slab thickness D_c, mm. */
   Dc: number
   /** Square column width, mm. */
@@ -56,8 +58,8 @@ export interface SchematicProps {
   H: number
 }
 
-/** Plan + section of a designed square footing, drawn to scale. */
-export function FootingSchematic({ B, Dc, columnWidth, H }: SchematicProps): JSX.Element {
+/** Plan + section of a designed footing, drawn to scale. */
+export function FootingSchematic({ Bx, By, Dc, columnWidth, H }: SchematicProps): JSX.Element {
   const W = 360
   const cm = columnWidth / 1000
 
@@ -67,11 +69,12 @@ export function FootingSchematic({ B, Dc, columnWidth, H }: SchematicProps): JSX
   const px0 = 14
   const availW = W - RM - px0
   const availH = 116
-  const s = Math.min(availW / B, availH / B)
-  const fW = B * s
+  const s = Math.min(availW / Bx, availH / By)
+  const fW = Bx * s
+  const fH = By * s
   const fx = px0 + (availW - fW) / 2
   const fyTop = planTop
-  const fyBot = planTop + fW
+  const fyBot = planTop + fH
   const cxc = fx + fW / 2
   const cyc = (fyTop + fyBot) / 2
   const cpx = Math.max(6, cm * s)
@@ -100,10 +103,10 @@ export function FootingSchematic({ B, Dc, columnWidth, H }: SchematicProps): JSX
       style={{ width: '100%', height: 'auto', fontFamily: 'Arial, sans-serif' }}>
       <text x={14} y={20} fontSize={11} fontWeight={700} fill="#0056b3">PLAN</text>
       {/* footing + column */}
-      <rect x={fx} y={fyTop} width={fW} height={fW} rx={2} fill={FILL} stroke={STROKE} strokeWidth={1.4} />
+      <rect x={fx} y={fyTop} width={fW} height={fH} rx={2} fill={FILL} stroke={STROKE} strokeWidth={1.4} />
       <rect x={cxc - cpx / 2} y={cyc - cpx / 2} width={cpx} height={cpx} fill={COL} />
-      <DimBelow xA={fx} xB={fx + fW} featY={fyBot} dY={fyBot + 20} label={`B = ${B.toFixed(2)} m`} />
-      <DimSide yA={fyTop} yB={fyBot} featX={fx + fW} dX={fx + fW + 10} label={`B = ${B.toFixed(2)} m`} side="right" />
+      <DimBelow xA={fx} xB={fx + fW} featY={fyBot} dY={fyBot + 20} label={`Bx = ${Bx.toFixed(2)} m`} />
+      <DimSide yA={fyTop} yB={fyBot} featX={fx + fW} dX={fx + fW + 10} label={`By = ${By.toFixed(2)} m`} side="right" />
 
       <text x={14} y={secTitleY} fontSize={11} fontWeight={700} fill="#0056b3">SECTION</text>
       {/* ground + soil */}

--- a/webapp/src/engine/rectangularFooting.test.ts
+++ b/webapp/src/engine/rectangularFooting.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { designRectangularFooting, type RectFootingInput } from './rectangularFooting';
+import { designSquareFooting } from './isolatedFooting';
+
+const base: Omit<RectFootingInput, 'sizing'> = {
+  serviceLoad: 1200, ultimateLoad: 1680, columnWidth: 400,
+  fc: 28, fy: 415, qAllow: 200, gammaSoil: 18, gammaConc: 24,
+  H: 1.5, barDia: 20, cover: 75, position: 'interior',
+};
+
+describe('designRectangularFooting — ratio mode', () => {
+  const r = designRectangularFooting({ ...base, sizing: { mode: 'ratio', ratio: 1.5 } });
+  it('long side is along x and roughly the target aspect', () => {
+    expect(r.Bx).toBeGreaterThan(r.By);
+    expect(r.Bx / r.By).toBeGreaterThan(1.3);
+    expect(r.Bx / r.By).toBeLessThan(1.7);
+  });
+  it('produces a sane thickness and contains the column both ways', () => {
+    expect(r.Dc).toBeGreaterThan(200);
+    expect(r.By).toBeGreaterThan(base.columnWidth / 1000);
+  });
+  it('short-direction central band: fraction 2/(β+1), bandBars ≤ total', () => {
+    const beta = r.Bx / r.By;
+    expect(r.short.bandFraction).toBeCloseTo(2 / (beta + 1), 6);
+    expect(r.short.bandBars).toBeLessThanOrEqual(r.short.bars);
+    expect(r.short.bandBars).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('designRectangularFooting — fixedWidth mode', () => {
+  it('honours the constrained By and solves Bx for area', () => {
+    const r = designRectangularFooting({ ...base, sizing: { mode: 'fixedWidth', By: 2.0 } });
+    expect(r.By).toBeCloseTo(2.0, 6);
+    expect(r.Bx).toBeGreaterThan(0);
+  });
+});
+
+describe('ratio 1 ≈ square footing', () => {
+  it('matches designSquareFooting for the same inputs', () => {
+    const sq = designSquareFooting(base);
+    const rc = designRectangularFooting({ ...base, sizing: { mode: 'ratio', ratio: 1 } });
+    expect(rc.Bx).toBeCloseTo(rc.By, 6);
+    expect(rc.Bx).toBeCloseTo(sq.B, 1);   // same plan size (within rounding)
+    expect(rc.Dc).toBe(sq.Dc);
+  });
+});

--- a/webapp/src/engine/rectangularFooting.ts
+++ b/webapp/src/engine/rectangularFooting.ts
@@ -1,0 +1,119 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Isolated rectangular footing — concentric load, square column.
+// Sizes Bx × By for bearing, checks punching + one-way shear in both
+// directions, and designs flexure each way (with the short-direction central
+// band per NSCP 2015 §413.3.3.3 / ACI 318-14 §13.3.3.3).
+// ─────────────────────────────────────────────────────────────────────────
+import { netBearing } from './bearing';
+import { punchingDepth, oneWayShearDepth, type ColumnPosition } from './shear';
+import { flexuralSteel, barLayout } from './flexure';
+
+/** How the plan dimensions are determined. */
+export type RectSizing =
+  | { mode: 'ratio'; ratio: number }      // Bx / By aspect ratio (≥ 1 → long along x)
+  | { mode: 'fixedWidth'; By: number };   // By constrained (m); Bx solved for area
+
+export interface RectFootingInput {
+  serviceLoad: number;   // P, kN
+  ultimateLoad: number;  // Pu, kN
+  columnWidth: number;   // square column c, mm
+  fc: number;            // MPa
+  fy: number;            // MPa
+  qAllow: number;        // kPa
+  gammaSoil: number;     // kN/m³
+  gammaConc: number;     // kN/m³
+  H: number;             // m
+  barDia: number;        // mm
+  cover: number;         // mm
+  surcharge?: number;    // kPa
+  position?: ColumnPosition;
+  lambda?: number;
+  sizing: RectSizing;
+}
+
+export interface DirectionSteel {
+  As: number;       // mm² over the design width
+  rho: number;
+  usedMin: boolean;
+  bars: number;
+  spacing: number;  // mm o.c.
+}
+
+export interface RectFootingResult {
+  Bx: number;       // m (long)
+  By: number;       // m (short)
+  Dc: number;       // mm
+  qNet: number;     // kPa
+  qu: number;       // kPa
+  dPunch: number;
+  dBeamLong: number;
+  dBeamShort: number;
+  dFlex: number;
+  long: DirectionSteel;                              // bars along x, spread over By
+  short: DirectionSteel & { bandBars: number; bandFraction: number }; // bars along y + central band
+}
+
+function roundUp(v: number, step: number): number {
+  return Math.ceil(v / step) * step;
+}
+
+function sizePlan(area: number, sizing: RectSizing): { Bx: number; By: number } {
+  if (sizing.mode === 'fixedWidth') {
+    const By = sizing.By;
+    return { Bx: roundUp(area / By, 0.05), By: roundUp(By, 0.05) };
+  }
+  const r = Math.max(1, sizing.ratio);               // long along x
+  const By = Math.sqrt(area / r);
+  return { Bx: roundUp(r * By, 0.05), By: roundUp(By, 0.05) };
+}
+
+export function designRectangularFooting(i: RectFootingInput): RectFootingResult {
+  const cm = i.columnWidth / 1000;
+  const surcharge = i.surcharge ?? 0;
+
+  let Dc = 0.25;
+  let Bx = 0, By = 0, qNet = 0, qu = 0, dPunch = 0, dBeamLong = 0, dBeamShort = 0;
+  for (let k = 0; k < 8; k++) {
+    qNet = netBearing({ qAllow: i.qAllow, gammaSoil: i.gammaSoil, gammaConc: i.gammaConc, H: i.H, Dc, surcharge });
+    ({ Bx, By } = sizePlan(i.serviceLoad / qNet, i.sizing));
+    qu = i.ultimateLoad / (Bx * By);
+    dPunch = punchingDepth({ Pu: i.ultimateLoad, qu, c: i.columnWidth, fc: i.fc, position: i.position, lambda: i.lambda });
+    // One-way shear: d depends on the span dimension only (the perpendicular
+    // width cancels), so pass each plan dimension as the span.
+    dBeamLong = oneWayShearDepth({ qu, B: Bx, c: cm, fc: i.fc, lambda: i.lambda });
+    dBeamShort = oneWayShearDepth({ qu, B: By, c: cm, fc: i.fc, lambda: i.lambda });
+    const newDc = roundUp(Math.max(dPunch, dBeamLong, dBeamShort) + i.cover + i.barDia, 25) / 1000;
+    if (Math.abs(newDc - Dc) < 1e-4) { Dc = newDc; break; }
+    Dc = newDc;
+  }
+
+  const DcMm = Dc * 1000;
+  const dFlex = DcMm - i.cover - i.barDia / 2;
+
+  // Long direction: cantilever in x, bars run along x and spread across By.
+  const armX = (Bx - cm) / 2;
+  const MuLong = qu * By * (armX * armX) / 2;
+  const bLong = By * 1000;
+  const flexLong = flexuralSteel({ Mu: MuLong, b: bLong, d: dFlex, fc: i.fc, fy: i.fy });
+  const layoutLong = barLayout({ As: flexLong.As, db: i.barDia, b: bLong, cover: i.cover });
+
+  // Short direction: cantilever in y, bars run along y and spread across Bx,
+  // with the central-band concentration.
+  const armY = (By - cm) / 2;
+  const MuShort = qu * Bx * (armY * armY) / 2;
+  const bShort = Bx * 1000;
+  const flexShort = flexuralSteel({ Mu: MuShort, b: bShort, d: dFlex, fc: i.fc, fy: i.fy });
+  const layoutShort = barLayout({ As: flexShort.As, db: i.barDia, b: bShort, cover: i.cover });
+  const beta = Bx / By;                               // long / short
+  const bandFraction = 2 / (beta + 1);
+  const bandBars = Math.max(2, Math.ceil(layoutShort.n * bandFraction));
+
+  return {
+    Bx, By, Dc: DcMm, qNet, qu, dPunch, dBeamLong, dBeamShort, dFlex,
+    long: { As: flexLong.As, rho: flexLong.rho, usedMin: flexLong.usedMin, bars: layoutLong.n, spacing: layoutLong.spacing },
+    short: {
+      As: flexShort.As, rho: flexShort.rho, usedMin: flexShort.usedMin,
+      bars: layoutShort.n, spacing: layoutShort.spacing, bandBars, bandFraction,
+    },
+  };
+}

--- a/webapp/src/pages/FoundationDesign.tsx
+++ b/webapp/src/pages/FoundationDesign.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { designSquareFooting } from '../engine/isolatedFooting'
+import { designRectangularFooting } from '../engine/rectangularFooting'
 import { netBearing } from '../engine/bearing'
 import type { ColumnPosition } from '../engine/shear'
 import { FootingSchematic } from '../components/FootingSchematic'
@@ -8,7 +9,14 @@ import { Math } from '../lib/math'
 import { f0, f2, f3 } from '../lib/format'
 import 'katex/dist/katex.min.css'
 
+type FootingType = 'square' | 'rectangular'
+type SizingMode = 'ratio' | 'fixedWidth'
+
 interface FormState {
+  footingType: FootingType
+  sizingMode: SizingMode
+  ratio: number
+  fixedBy: number
   serviceLoad: number
   ultimateLoad: number
   columnWidth: number
@@ -25,6 +33,10 @@ interface FormState {
 }
 
 const DEFAULTS: FormState = {
+  footingType: 'square',
+  sizingMode: 'ratio',
+  ratio: 1.5,
+  fixedBy: 2,
   serviceLoad: 1000,
   ultimateLoad: 1400,
   columnWidth: 400,
@@ -38,6 +50,15 @@ const DEFAULTS: FormState = {
   cover: 75,
   surcharge: 0,
   position: 'interior',
+}
+
+interface DirSteel { As: number; bars: number; spacing: number; usedMin: boolean; rho: number }
+interface View {
+  type: FootingType
+  Bx: number; By: number; Dc: number; qNet: number; qu: number
+  dPunch: number; dBeamLong: number; dBeamShort: number
+  long: DirSteel
+  short: (DirSteel & { bandBars: number; bandFraction: number }) | null
 }
 
 function NumField({ label, unit, value, onChange, step = 'any' }: {
@@ -57,6 +78,20 @@ function NumField({ label, unit, value, onChange, step = 'any' }: {
   )
 }
 
+function Select<T extends string>({ label, value, onChange, options }: {
+  label: string; value: T; onChange: (v: T) => void; options: [T, string][]
+}) {
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="mb-1 font-medium text-slate-600">{label}</span>
+      <select value={value} onChange={(e) => onChange(e.target.value as T)}
+        className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none">
+        {options.map(([v, t]) => <option key={v} value={v}>{t}</option>)}
+      </select>
+    </label>
+  )
+}
+
 function Card({ title, children }: { title: string; children: ReactNode }) {
   return (
     <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
@@ -71,45 +106,87 @@ function Row({ label, value, check }: { label: ReactNode; value: ReactNode; chec
     <div className="flex items-baseline justify-between gap-3 border-b border-slate-100 py-1.5 last:border-0">
       <span className="text-sm text-slate-600">{label}</span>
       <span className="text-right text-sm font-semibold text-slate-800">{value}</span>
-      {check ? <span className="w-28 text-right text-xs text-slate-500">{check}</span> : null}
+      {check ? <span className="w-32 text-right text-xs text-slate-500">{check}</span> : null}
     </div>
+  )
+}
+
+function steelRow(label: ReactNode, s: DirSteel, db: number) {
+  return (
+    <Row label={label} value={`${s.bars} ⌀${db} mm @ ${f0(s.spacing)} mm`}
+      check={`As=${f0(s.As)} mm² · ${s.usedMin ? 'ρ_min' : `ρ=${s.rho.toFixed(4)}`}`} />
   )
 }
 
 export default function FoundationDesign() {
   const [form, setForm] = useState<FormState>(DEFAULTS)
   const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) => setForm((s) => ({ ...s, [k]: v }))
+  const rect = form.footingType === 'rectangular'
 
   const qNetTrial = useMemo(
     () => netBearing({ qAllow: form.qAllow, gammaSoil: form.gammaSoil, gammaConc: form.gammaConc, H: form.H, Dc: 0.25, surcharge: form.surcharge }),
     [form.qAllow, form.gammaSoil, form.gammaConc, form.H, form.surcharge],
   )
+  const sizingOk = !rect || (form.sizingMode === 'ratio' ? form.ratio >= 1 : form.fixedBy > 0)
+  const valid = Object.values(form).every((v) => typeof v === 'string' || Number.isFinite(v as number)) && qNetTrial > 0 && sizingOk
 
-  const valid = Object.values(form).every((v) => typeof v === 'string' || Number.isFinite(v as number)) && qNetTrial > 0
-  const result = useMemo(() => (valid ? designSquareFooting(form) : null), [form, valid])
+  const view: View | null = useMemo(() => {
+    if (!valid) return null
+    const common = {
+      serviceLoad: form.serviceLoad, ultimateLoad: form.ultimateLoad, columnWidth: form.columnWidth,
+      fc: form.fc, fy: form.fy, qAllow: form.qAllow, gammaSoil: form.gammaSoil, gammaConc: form.gammaConc,
+      H: form.H, barDia: form.barDia, cover: form.cover, surcharge: form.surcharge, position: form.position,
+    }
+    if (!rect) {
+      const r = designSquareFooting(common)
+      return {
+        type: 'square', Bx: r.B, By: r.B, Dc: r.Dc, qNet: r.qNet, qu: r.qu,
+        dPunch: r.dPunch, dBeamLong: r.dBeam, dBeamShort: r.dBeam,
+        long: { As: r.steelArea, bars: r.bars, spacing: r.barSpacing, usedMin: r.usedMinSteel, rho: r.rho },
+        short: null,
+      }
+    }
+    const sizing = form.sizingMode === 'ratio'
+      ? { mode: 'ratio' as const, ratio: form.ratio }
+      : { mode: 'fixedWidth' as const, By: form.fixedBy }
+    const r = designRectangularFooting({ ...common, sizing })
+    return {
+      type: 'rectangular', Bx: r.Bx, By: r.By, Dc: r.Dc, qNet: r.qNet, qu: r.qu,
+      dPunch: r.dPunch, dBeamLong: r.dBeamLong, dBeamShort: r.dBeamShort,
+      long: r.long, short: r.short,
+    }
+  }, [form, valid, rect])
 
   return (
     <div className="mx-auto max-w-6xl p-6">
       <Link to="/" className="text-sm text-[#0056b3] hover:underline">← Home</Link>
       <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Foundation Design</h1>
-      <p className="mt-1 text-slate-600">Isolated square footing, concentric load — React + typed engine pilot. Results update live.</p>
+      <p className="mt-1 text-slate-600">Isolated footing, concentric load — React + typed engine. Results update live.</p>
 
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
         {/* ── Inputs ── */}
         <div className="space-y-5">
+          <Card title="Footing">
+            <Select label="Type" value={form.footingType} onChange={set('footingType')}
+              options={[['square', 'Isolated Square'], ['rectangular', 'Isolated Rectangular']]} />
+            {rect && (
+              <Select label="Sizing" value={form.sizingMode} onChange={set('sizingMode')}
+                options={[['ratio', 'By aspect ratio (Bx/By)'], ['fixedWidth', 'Fixed width By']]} />
+            )}
+            {rect && form.sizingMode === 'ratio' && (
+              <NumField label="Aspect Bx/By" value={form.ratio} onChange={set('ratio')} />
+            )}
+            {rect && form.sizingMode === 'fixedWidth' && (
+              <NumField label="Width By" unit="m" value={form.fixedBy} onChange={set('fixedBy')} />
+            )}
+          </Card>
+
           <Card title="Loads & Column">
             <NumField label={<Math tex="P" />} unit="kN" value={form.serviceLoad} onChange={set('serviceLoad')} />
             <NumField label={<Math tex="P_u" />} unit="kN" value={form.ultimateLoad} onChange={set('ultimateLoad')} />
             <NumField label={<>Column <Math tex="c" /> (square)</>} unit="mm" value={form.columnWidth} onChange={set('columnWidth')} />
-            <label className="flex flex-col text-sm">
-              <span className="mb-1 font-medium text-slate-600">Column position</span>
-              <select value={form.position} onChange={(e) => set('position')(e.target.value as FormState['position'])}
-                className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none">
-                <option value="interior">Interior</option>
-                <option value="edge">Edge</option>
-                <option value="corner">Corner</option>
-              </select>
-            </label>
+            <Select label="Column position" value={form.position} onChange={set('position')}
+              options={[['interior', 'Interior'], ['edge', 'Edge'], ['corner', 'Corner']]} />
           </Card>
 
           <Card title="Materials">
@@ -132,31 +209,44 @@ export default function FoundationDesign() {
         <div className="space-y-5">
           <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Design preview</h2>
-            {result ? (
-              <FootingSchematic B={result.B} Dc={result.Dc} columnWidth={form.columnWidth} H={form.H} />
+            {view ? (
+              <FootingSchematic Bx={view.Bx} By={view.By} Dc={view.Dc} columnWidth={form.columnWidth} H={form.H} />
             ) : (
               <p className="py-8 text-center text-sm text-slate-400">Enter valid inputs — net bearing must be positive.</p>
             )}
           </div>
 
-          {result && (
+          {view && (
             <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
               <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Results</h2>
-              <Row label={<Math tex="q_{net}" />} value={`${f3(result.qNet)} kPa`} />
-              <Row label="Footing size B" value={`${f2(result.B)} m`} />
-              <Row label={<Math tex="q_u = P_u/B^2" />} value={`${f3(result.qu)} kPa`} />
-              <Row label="Slab thickness Dc" value={`${f0(result.Dc)} mm`} check={`d≈${f0(result.dFlex)} mm`} />
-              <Row label="d — punching / beam" value={`${f0(result.dPunch)} / ${f0(result.dBeam)} mm`} />
-              <Row label="Steel As" value={`${f0(result.steelArea)} mm²`} check={result.usedMinSteel ? 'ρ_min governs' : `ρ=${result.rho.toFixed(4)}`} />
-              <Row label="Reinforcement" value={`${result.bars} ⌀${form.barDia} mm`} check={`@ ${f0(result.barSpacing)} mm o.c.`} />
+              <Row label={<Math tex="q_{net}" />} value={`${f3(view.qNet)} kPa`} />
+              <Row label="Footing size"
+                value={view.type === 'square' ? `B = ${f2(view.Bx)} m` : `${f2(view.Bx)} × ${f2(view.By)} m`} />
+              <Row label={<Math tex="q_u" />} value={`${f3(view.qu)} kPa`} />
+              <Row label="Slab thickness Dc" value={`${f0(view.Dc)} mm`} />
+              <Row label="d — punching"
+                value={`${f0(view.dPunch)} mm`}
+                check={view.type === 'square' ? `beam ${f0(view.dBeamLong)} mm` : `beam x/y ${f0(view.dBeamLong)}/${f0(view.dBeamShort)} mm`} />
+              {view.type === 'square'
+                ? steelRow('Steel (each way)', view.long, form.barDia)
+                : (
+                  <>
+                    {steelRow('Steel — long (x)', view.long, form.barDia)}
+                    {view.short && steelRow('Steel — short (y)', view.short, form.barDia)}
+                    {view.short && (
+                      <Row label="Central band (short)"
+                        value={`${view.short.bandBars} of ${view.short.bars} bars`}
+                        check={`band ≈ ${(view.short.bandFraction * 100).toFixed(0)}% in By`} />
+                    )}
+                  </>
+                )}
             </div>
           )}
 
           <div className="rounded-xl border border-slate-200 bg-white p-4 text-sm text-slate-600 shadow-sm">
             <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Basis</h2>
-            <Math block tex={String.raw`q_{net} = q_a - \gamma_s D_s - \gamma_c D_c - q`} />
-            <Math block tex={String.raw`P_u = \max(1.4D,\ 1.2D + 1.6L),\quad B = \sqrt{P/q_{net}}`} />
-            <p className="mt-1 text-xs text-slate-400">NSCP 2015 / ACI 318-14. φ: shear 0.75, flexure 0.90.</p>
+            <Math block tex={String.raw`q_{net} = q_a - \gamma_s D_s - \gamma_c D_c - q,\quad P_u = \max(1.4D,\ 1.2D + 1.6L)`} />
+            <p className="mt-1 text-xs text-slate-400">NSCP 2015 / ACI 318-14. φ: shear 0.75, flexure 0.90. Short-direction band per §413.3.3.3.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Phase 3 — Rectangular isolated footing

Extends the React calculator (and the typed engine) to **rectangular** footings, reusing the Phase-2 UI pattern.

### Engine — `rectangularFooting.ts`
- Sizes **Bx × By** for bearing, two ways: by **aspect ratio** (Bx/By) or a **fixed width By**.
- **Punching** shear (square column) + **one-way** shear checked in **both directions** — the one-way depth is independent of the perpendicular width, so each plan dimension is passed as the span (reuses the existing shear helpers cleanly).
- **Flexure each way**, with the short-direction **central band** per NSCP 2015 §413.3.3.3 / ACI 318-14 §13.3.3.3 (band fraction `2/(β+1)`, β = Bx/By).
- **5 new unit tests** (ratio + fixed-width modes, band logic, and a *ratio-1 ≈ square* cross-check against `designSquareFooting`). **24/24 engine tests pass.**

### UI
- **Footing-type toggle** (Square / Rectangular) + sizing controls. Results show `Bx × By`, both-direction shear & steel, and the central band. The square path is unchanged.
- **`FootingSchematic`** now takes `Bx`/`By` and draws rectangular footings to scale (true proportions, architectural-tick dimensions).

### Verified
- `npm run build` clean (tsc + Vite, 53 modules)
- `npm test` → **24/24**
- Legacy pages untouched; this is additive under `/app/foundation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
