### PR TITLE
feat(webapp): eccentric (uniaxial) isolated footing — engine + UI

### DIFF
--- a/webapp/src/engine/eccentricFooting.test.ts
+++ b/webapp/src/engine/eccentricFooting.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { designEccentricSquareFooting, type EccentricFootingInput } from './eccentricFooting';
+import { designSquareFooting } from './isolatedFooting';
+
+const base: Omit<EccentricFootingInput, 'serviceMoment' | 'ultimateMoment'> = {
+  serviceLoad: 1000, ultimateLoad: 1400, columnWidth: 400,
+  fc: 28, fy: 415, qAllow: 200, gammaSoil: 18, gammaConc: 24,
+  H: 1.5, barDia: 20, cover: 75, position: 'interior',
+};
+
+describe('designEccentricSquareFooting', () => {
+  it('reduces to the concentric square footing when M = 0', () => {
+    const ec = designEccentricSquareFooting({ ...base, serviceMoment: 0, ultimateMoment: 0 });
+    const sq = designSquareFooting(base);
+    expect(ec.e).toBe(0);
+    expect(ec.B).toBeCloseTo(sq.B, 6);
+    expect(ec.Dc).toBe(sq.Dc);
+    expect(ec.qMaxService).toBeCloseTo(ec.qMinService, 6);
+  });
+
+  it('eccentricity raises q_max above q_min and enlarges the footing', () => {
+    const ec = designEccentricSquareFooting({ ...base, serviceMoment: 200, ultimateMoment: 280 });
+    const sq = designSquareFooting(base);
+    expect(ec.e).toBeCloseTo(0.2, 6);          // 200/1000
+    expect(ec.qMaxService).toBeGreaterThan(ec.qMinService);
+    expect(ec.B).toBeGreaterThanOrEqual(sq.B);  // needs more area / kern
+    expect(ec.qMaxService).toBeLessThanOrEqual(ec.qNet + 1e-6);
+  });
+
+  it('keeps the load in the kern (no uplift): e ≤ B/6, q_min ≥ 0', () => {
+    const ec = designEccentricSquareFooting({ ...base, serviceMoment: 400, ultimateMoment: 560 });
+    expect(ec.kernOK).toBe(true);
+    expect(ec.B).toBeGreaterThanOrEqual(6 * ec.e - 1e-9);
+    expect(ec.qMinService).toBeGreaterThanOrEqual(-1e-6);
+  });
+});

--- a/webapp/src/engine/eccentricFooting.ts
+++ b/webapp/src/engine/eccentricFooting.ts
@@ -1,0 +1,97 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Isolated square footing — uniaxial eccentric load (axial + moment about one
+// axis). Sizes B so the peak SERVICE pressure stays within q_net with NO
+// uplift (e ≤ B/6, full bearing); designs shear & flexure on the FACTORED
+// peak pressure (conservative), punching on the average pressure.
+// ─────────────────────────────────────────────────────────────────────────
+import { netBearing } from './bearing';
+import { punchingDepth, oneWayShearDepth, type ColumnPosition } from './shear';
+import { flexuralSteel, barLayout } from './flexure';
+
+export interface EccentricFootingInput {
+  serviceLoad: number;    // P, kN
+  ultimateLoad: number;   // Pu, kN
+  serviceMoment: number;  // M, kN·m (service, about one axis)
+  ultimateMoment: number; // Mu, kN·m (factored)
+  columnWidth: number;    // square column c, mm
+  fc: number;
+  fy: number;
+  qAllow: number;
+  gammaSoil: number;
+  gammaConc: number;
+  H: number;
+  barDia: number;
+  cover: number;
+  surcharge?: number;
+  position?: ColumnPosition;
+  lambda?: number;
+}
+
+export interface EccentricFootingResult {
+  B: number;            // m
+  Dc: number;           // mm
+  e: number;            // service eccentricity M/P, m
+  eU: number;           // factored eccentricity Mu/Pu, m
+  qNet: number;         // kPa
+  qMaxService: number;  // kPa
+  qMinService: number;  // kPa (≥ 0 when full bearing)
+  quMax: number;        // factored peak pressure, kPa
+  dPunch: number;
+  dBeam: number;
+  dFlex: number;
+  /** e ≤ B/6 — pressure trapezoid stays positive (no uplift). */
+  kernOK: boolean;
+  steelArea: number;
+  rho: number;
+  usedMinSteel: boolean;
+  bars: number;
+  barSpacing: number;
+}
+
+function roundUp(v: number, step: number): number {
+  return Math.ceil(v / step) * step;
+}
+
+export function designEccentricSquareFooting(i: EccentricFootingInput): EccentricFootingResult {
+  const e = i.serviceLoad > 0 ? Math.abs(i.serviceMoment) / i.serviceLoad : 0;
+  const eU = i.ultimateLoad > 0 ? Math.abs(i.ultimateMoment) / i.ultimateLoad : 0;
+  const cm = i.columnWidth / 1000;
+  const surcharge = i.surcharge ?? 0;
+
+  let Dc = 0.25;
+  let B = 0, qNet = 0, quMax = 0, dPunch = 0, dBeam = 0, qMaxService = 0;
+  for (let k = 0; k < 10; k++) {
+    qNet = netBearing({ qAllow: i.qAllow, gammaSoil: i.gammaSoil, gammaConc: i.gammaConc, H: i.H, Dc, surcharge });
+    // Grow B until the peak service pressure fits AND the load stays in the kern.
+    B = roundUp(Math.max(6 * e, Math.sqrt(i.serviceLoad / qNet)), 0.05);
+    for (let g = 0; g < 600; g++) {
+      const qm = (i.serviceLoad / (B * B)) * (1 + (6 * e) / B);
+      if (qm <= qNet && B >= 6 * e - 1e-9) break;
+      B = roundUp(B + 0.05, 0.05);
+    }
+    qMaxService = (i.serviceLoad / (B * B)) * (1 + (6 * e) / B);
+    quMax = (i.ultimateLoad / (B * B)) * (1 + (6 * eU) / B);
+    const quAvg = i.ultimateLoad / (B * B);
+    // Punching uses the average pressure relief; one-way & flexure use the peak.
+    dPunch = punchingDepth({ Pu: i.ultimateLoad, qu: quAvg, c: i.columnWidth, fc: i.fc, position: i.position, lambda: i.lambda });
+    dBeam = oneWayShearDepth({ qu: quMax, B, c: cm, fc: i.fc, lambda: i.lambda });
+    const newDc = roundUp(Math.max(dPunch, dBeam) + i.cover + i.barDia, 25) / 1000;
+    if (Math.abs(newDc - Dc) < 1e-4) { Dc = newDc; break; }
+    Dc = newDc;
+  }
+
+  const DcMm = Dc * 1000;
+  const dFlex = DcMm - i.cover - i.barDia / 2;
+  const arm = (B - cm) / 2;
+  const Mu = quMax * B * (arm * arm) / 2;   // conservative: peak pressure across the width
+  const b = B * 1000;
+  const flex = flexuralSteel({ Mu, b, d: dFlex, fc: i.fc, fy: i.fy });
+  const layout = barLayout({ As: flex.As, db: i.barDia, b, cover: i.cover });
+  const qMinService = (i.serviceLoad / (B * B)) * (1 - (6 * e) / B);
+
+  return {
+    B, Dc: DcMm, e, eU, qNet, qMaxService, qMinService, quMax,
+    dPunch, dBeam, dFlex, kernOK: e <= B / 6 + 1e-9,
+    steelArea: flex.As, rho: flex.rho, usedMinSteel: flex.usedMin, bars: layout.n, barSpacing: layout.spacing,
+  };
+}

--- a/webapp/src/pages/FoundationDesign.tsx
+++ b/webapp/src/pages/FoundationDesign.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { designSquareFooting } from '../engine/isolatedFooting'
 import { designRectangularFooting } from '../engine/rectangularFooting'
+import { designEccentricSquareFooting } from '../engine/eccentricFooting'
 import { netBearing } from '../engine/bearing'
 import type { ColumnPosition } from '../engine/shear'
 import { FootingSchematic } from '../components/FootingSchematic'
@@ -11,14 +12,18 @@ import 'katex/dist/katex.min.css'
 
 type FootingType = 'square' | 'rectangular'
 type SizingMode = 'ratio' | 'fixedWidth'
+type LoadingType = 'concentric' | 'eccentric'
 
 interface FormState {
   footingType: FootingType
+  loadingType: LoadingType
   sizingMode: SizingMode
   ratio: number
   fixedBy: number
   serviceLoad: number
   ultimateLoad: number
+  serviceMoment: number
+  ultimateMoment: number
   columnWidth: number
   fc: number
   fy: number
@@ -34,11 +39,14 @@ interface FormState {
 
 const DEFAULTS: FormState = {
   footingType: 'square',
+  loadingType: 'concentric',
   sizingMode: 'ratio',
   ratio: 1.5,
   fixedBy: 2,
   serviceLoad: 1000,
   ultimateLoad: 1400,
+  serviceMoment: 150,
+  ultimateMoment: 210,
   columnWidth: 400,
   fc: 28,
   fy: 415,
@@ -55,10 +63,12 @@ const DEFAULTS: FormState = {
 interface DirSteel { As: number; bars: number; spacing: number; usedMin: boolean; rho: number }
 interface View {
   type: FootingType
+  loading: LoadingType
   Bx: number; By: number; Dc: number; qNet: number; qu: number
   dPunch: number; dBeamLong: number; dBeamShort: number
   long: DirSteel
   short: (DirSteel & { bandBars: number; bandFraction: number }) | null
+  ecc: { e: number; qMax: number; qMin: number; kernOK: boolean } | null
 }
 
 function NumField({ label, unit, value, onChange, step = 'any' }: {
@@ -121,7 +131,8 @@ function steelRow(label: ReactNode, s: DirSteel, db: number) {
 export default function FoundationDesign() {
   const [form, setForm] = useState<FormState>(DEFAULTS)
   const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) => setForm((s) => ({ ...s, [k]: v }))
-  const rect = form.footingType === 'rectangular'
+  const ecc = form.loadingType === 'eccentric'
+  const rect = form.footingType === 'rectangular' && !ecc   // eccentric pilot is square-only
 
   const qNetTrial = useMemo(
     () => netBearing({ qAllow: form.qAllow, gammaSoil: form.gammaSoil, gammaConc: form.gammaConc, H: form.H, Dc: 0.25, surcharge: form.surcharge }),
@@ -137,13 +148,23 @@ export default function FoundationDesign() {
       fc: form.fc, fy: form.fy, qAllow: form.qAllow, gammaSoil: form.gammaSoil, gammaConc: form.gammaConc,
       H: form.H, barDia: form.barDia, cover: form.cover, surcharge: form.surcharge, position: form.position,
     }
-    if (!rect) {
-      const r = designSquareFooting(common)
+    if (ecc) {
+      const r = designEccentricSquareFooting({ ...common, serviceMoment: form.serviceMoment, ultimateMoment: form.ultimateMoment })
       return {
-        type: 'square', Bx: r.B, By: r.B, Dc: r.Dc, qNet: r.qNet, qu: r.qu,
+        type: 'square', loading: 'eccentric', Bx: r.B, By: r.B, Dc: r.Dc, qNet: r.qNet, qu: r.quMax,
         dPunch: r.dPunch, dBeamLong: r.dBeam, dBeamShort: r.dBeam,
         long: { As: r.steelArea, bars: r.bars, spacing: r.barSpacing, usedMin: r.usedMinSteel, rho: r.rho },
         short: null,
+        ecc: { e: r.e, qMax: r.qMaxService, qMin: r.qMinService, kernOK: r.kernOK },
+      }
+    }
+    if (!rect) {
+      const r = designSquareFooting(common)
+      return {
+        type: 'square', loading: 'concentric', Bx: r.B, By: r.B, Dc: r.Dc, qNet: r.qNet, qu: r.qu,
+        dPunch: r.dPunch, dBeamLong: r.dBeam, dBeamShort: r.dBeam,
+        long: { As: r.steelArea, bars: r.bars, spacing: r.barSpacing, usedMin: r.usedMinSteel, rho: r.rho },
+        short: null, ecc: null,
       }
     }
     const sizing = form.sizingMode === 'ratio'
@@ -151,17 +172,17 @@ export default function FoundationDesign() {
       : { mode: 'fixedWidth' as const, By: form.fixedBy }
     const r = designRectangularFooting({ ...common, sizing })
     return {
-      type: 'rectangular', Bx: r.Bx, By: r.By, Dc: r.Dc, qNet: r.qNet, qu: r.qu,
+      type: 'rectangular', loading: 'concentric', Bx: r.Bx, By: r.By, Dc: r.Dc, qNet: r.qNet, qu: r.qu,
       dPunch: r.dPunch, dBeamLong: r.dBeamLong, dBeamShort: r.dBeamShort,
-      long: r.long, short: r.short,
+      long: r.long, short: r.short, ecc: null,
     }
-  }, [form, valid, rect])
+  }, [form, valid, rect, ecc])
 
   return (
     <div className="mx-auto max-w-6xl p-6">
       <Link to="/" className="text-sm text-[#0056b3] hover:underline">← Home</Link>
       <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Foundation Design</h1>
-      <p className="mt-1 text-slate-600">Isolated footing, concentric load — React + typed engine. Results update live.</p>
+      <p className="mt-1 text-slate-600">Isolated footing (square / rectangular, concentric / eccentric) — React + typed engine. Results update live.</p>
 
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
         {/* ── Inputs ── */}
@@ -169,6 +190,8 @@ export default function FoundationDesign() {
           <Card title="Footing">
             <Select label="Type" value={form.footingType} onChange={set('footingType')}
               options={[['square', 'Isolated Square'], ['rectangular', 'Isolated Rectangular']]} />
+            <Select label="Loading" value={form.loadingType} onChange={set('loadingType')}
+              options={[['concentric', 'Concentric'], ['eccentric', 'Eccentric (uniaxial)']]} />
             {rect && (
               <Select label="Sizing" value={form.sizingMode} onChange={set('sizingMode')}
                 options={[['ratio', 'By aspect ratio (Bx/By)'], ['fixedWidth', 'Fixed width By']]} />
@@ -179,11 +202,16 @@ export default function FoundationDesign() {
             {rect && form.sizingMode === 'fixedWidth' && (
               <NumField label="Width By" unit="m" value={form.fixedBy} onChange={set('fixedBy')} />
             )}
+            {ecc && (
+              <p className="col-span-full text-xs text-slate-400">Eccentric is square-only in this pilot; the footing is sized to keep the load in the kern (no uplift).</p>
+            )}
           </Card>
 
           <Card title="Loads & Column">
             <NumField label={<Math tex="P" />} unit="kN" value={form.serviceLoad} onChange={set('serviceLoad')} />
             <NumField label={<Math tex="P_u" />} unit="kN" value={form.ultimateLoad} onChange={set('ultimateLoad')} />
+            {ecc && <NumField label={<Math tex="M" />} unit="kN·m" value={form.serviceMoment} onChange={set('serviceMoment')} />}
+            {ecc && <NumField label={<Math tex="M_u" />} unit="kN·m" value={form.ultimateMoment} onChange={set('ultimateMoment')} />}
             <NumField label={<>Column <Math tex="c" /> (square)</>} unit="mm" value={form.columnWidth} onChange={set('columnWidth')} />
             <Select label="Column position" value={form.position} onChange={set('position')}
               options={[['interior', 'Interior'], ['edge', 'Edge'], ['corner', 'Corner']]} />
@@ -222,7 +250,14 @@ export default function FoundationDesign() {
               <Row label={<Math tex="q_{net}" />} value={`${f3(view.qNet)} kPa`} />
               <Row label="Footing size"
                 value={view.type === 'square' ? `B = ${f2(view.Bx)} m` : `${f2(view.Bx)} × ${f2(view.By)} m`} />
-              <Row label={<Math tex="q_u" />} value={`${f3(view.qu)} kPa`} />
+              {view.ecc && (
+                <>
+                  <Row label={<>Eccentricity <Math tex="e = M/P" /></>} value={`${f3(view.ecc.e)} m`} check={`kern B/6 = ${f3(view.Bx / 6)} m`} />
+                  <Row label={<Math tex="q_{max}/q_{min}" />} value={`${f2(view.ecc.qMax)} / ${f2(view.ecc.qMin)} kPa`}
+                    check={view.ecc.kernOK ? '✓ no uplift, ≤ q_net' : '✗ check uplift'} />
+                </>
+              )}
+              <Row label={view.ecc ? <Math tex="q_{u,max}" /> : <Math tex="q_u" />} value={`${f3(view.qu)} kPa`} />
               <Row label="Slab thickness Dc" value={`${f0(view.Dc)} mm`} />
               <Row label="d — punching"
                 value={`${f0(view.dPunch)} mm`}


### PR DESCRIPTION
## Eccentric (uniaxial) isolated footing

Adds **eccentric loading** (axial + a uniaxial moment) to the React calculator.

### Engine — `eccentricFooting.ts`
- Service eccentricity `e = M/P`. Sizes **B** so the **peak service pressure** `q_max = (P/B²)(1 + 6e/B) ≤ q_net` **and** the load stays in the **kern** (`B ≥ 6e` → no uplift, `q_min ≥ 0`).
- Structural design on the **factored peak pressure** (conservative) for one-way shear & flexure; **punching uses the average pressure** relief (the physically correct choice — peak pressure would *under*-estimate punching demand).
- **Reduces exactly to the concentric square footing when M = 0** (cross-checked in a test).
- **3 unit tests** (M=0 ≡ square, q_max>q_min + enlargement, kern/no-uplift). **27/27 engine tests pass.**

### UI
- **"Loading" toggle** (Concentric / Eccentric). Eccentric reveals `M` and `Mu` inputs and reports **e**, **q_max / q_min**, the **B/6 kern limit**, and a **no-uplift verdict** — live, like the rest of the page.
- Eccentric is **square-only** in this pilot (noted in the UI).

### Verified
- `npm run build` clean (tsc + Vite, 54 modules)
- `npm test` → **27/27**
- Square + rectangular concentric paths unchanged; legacy pages untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
