### PR TITLE
feat(webapp): Phase 5 — pile cap design (engine + UI)

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -63,7 +63,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1734,7 +1733,6 @@
       "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1745,7 +1743,6 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1805,7 +1802,6 @@
       "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.1",
         "@typescript-eslint/types": "8.60.1",
@@ -2144,7 +2140,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2245,7 +2240,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2476,7 +2470,6 @@
       "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3452,7 +3445,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3514,7 +3506,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3524,7 +3515,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3798,7 +3788,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3885,7 +3874,6 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4114,7 +4102,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route, Link } from 'react-router-dom'
 import { factoredLoad, beta1 } from './engine/loads'
 import FoundationDesign from './pages/FoundationDesign'
+import PileCapDesign from './pages/PileCapDesign'
 
 function Home() {
   return (
@@ -24,12 +25,20 @@ function Home() {
         </p>
       </div>
 
-      <Link
-        to="/foundation"
-        className="mt-6 inline-block rounded-lg bg-gradient-to-br from-[#0056b3] to-[#003f86] px-5 py-2.5 font-semibold text-white shadow-md transition hover:shadow-lg"
-      >
-        Foundation Design →
-      </Link>
+      <div className="mt-6 flex flex-wrap gap-3">
+        <Link
+          to="/foundation"
+          className="inline-block rounded-lg bg-gradient-to-br from-[#0056b3] to-[#003f86] px-5 py-2.5 font-semibold text-white shadow-md transition hover:shadow-lg"
+        >
+          Foundation Design →
+        </Link>
+        <Link
+          to="/pile-cap"
+          className="inline-block rounded-lg bg-gradient-to-br from-[#0056b3] to-[#003f86] px-5 py-2.5 font-semibold text-white shadow-md transition hover:shadow-lg"
+        >
+          Pile Cap Design →
+        </Link>
+      </div>
     </div>
   )
 }
@@ -39,6 +48,7 @@ export default function App() {
     <Routes>
       <Route path="/" element={<Home />} />
       <Route path="/foundation" element={<FoundationDesign />} />
+      <Route path="/pile-cap" element={<PileCapDesign />} />
     </Routes>
   )
 }

--- a/webapp/src/components/PileCapSchematic.tsx
+++ b/webapp/src/components/PileCapSchematic.tsx
@@ -1,0 +1,108 @@
+import type { JSX } from 'react'
+import type { PileCoord } from '../engine/pileCap'
+
+const BLUE  = '#0056b3'
+const STEEL = '#37526e'
+const FILL  = '#eef3f8'
+const PILE  = '#8ab4d8'
+const DIM   = '#1f77b4'
+
+interface Props {
+  capBx: number        // mm
+  capBy: number        // mm
+  coords: PileCoord[]  // pile centres from cap centre, mm
+  pileDia: number      // mm
+  colX: number         // mm
+  colY: number         // mm
+  reactions: number[]  // service, kN
+}
+
+/** Top-view (plan) schematic of the pile cap with pile reactions. */
+export function PileCapSchematic({ capBx, capBy, coords, pileDia, colX, colY, reactions }: Props): JSX.Element {
+  const W = 320
+  const PAD = 40
+  const availW = W - 2 * PAD
+  const availH = 220
+
+  // Scale to fit cap in the available area
+  const s = Math.min(availW / capBx, availH / capBy)
+
+  // Cap corners in SVG coords (cap centre → SVG centre)
+  const cx = W / 2
+  const cy = availH / 2 + PAD / 2
+  const cW = capBx * s
+  const cH = capBy * s
+  const capX = cx - cW / 2
+  const capY = cy - cH / 2
+
+  // Column rectangle
+  const colW = colX * s
+  const colH = colY * s
+
+  // Pile radius in pixels
+  const pr = Math.max(4, pileDia * s / 2)
+
+  const maxR = Math.max(...reactions)
+
+  return (
+    <svg viewBox={`0 0 ${W} ${availH + PAD}`} xmlns="http://www.w3.org/2000/svg"
+      preserveAspectRatio="xMidYMid meet" style={{ width: '100%', height: 'auto', fontFamily: 'Arial, sans-serif' }}>
+
+      {/* Title */}
+      <text x={14} y={16} fontSize={11} fontWeight={700} fill={BLUE}>PLAN (top view)</text>
+
+      {/* Cap outline */}
+      <rect x={capX} y={capY} width={cW} height={cH} rx={2}
+        fill={FILL} stroke={STEEL} strokeWidth={1.4} />
+
+      {/* Piles */}
+      {coords.map((p, i) => {
+        const px = cx + p.x * s
+        const py = cy - p.y * s  // SVG y-down → invert y
+        const intensity = maxR > 0 ? reactions[i] / maxR : 1
+        const fill = `rgba(0, 86, 179, ${(0.25 + 0.65 * intensity).toFixed(2)})`
+        return (
+          <g key={i}>
+            <circle cx={px} cy={py} r={pr} fill={fill} stroke={STEEL} strokeWidth={1} />
+            <text x={px} y={py + pr + 9} fontSize={8} fill={STEEL} textAnchor="middle"
+              paintOrder="stroke" stroke="#fff" strokeWidth={2}>
+              {reactions[i].toFixed(0)} kN
+            </text>
+          </g>
+        )
+      })}
+
+      {/* Column (on top of piles) */}
+      <rect x={cx - colW / 2} y={cy - colH / 2} width={colW} height={colH}
+        fill={STEEL} opacity={0.85} />
+
+      {/* Dimension: cap width Bx */}
+      <line x1={capX} y1={capY + cH + 12} x2={capX + cW} y2={capY + cH + 12}
+        stroke={DIM} strokeWidth={0.9} />
+      <line x1={capX} y1={capY + cH + 6} x2={capX} y2={capY + cH + 18}
+        stroke={DIM} strokeWidth={0.7} />
+      <line x1={capX + cW} y1={capY + cH + 6} x2={capX + cW} y2={capY + cH + 18}
+        stroke={DIM} strokeWidth={0.7} />
+      <text x={cx} y={capY + cH + 24} fontSize={9} fill={DIM} textAnchor="middle">
+        Bx = {(capBx / 1000).toFixed(2)} m
+      </text>
+
+      {/* Dimension: cap height By (right side) */}
+      <line x1={capX + cW + 12} y1={capY} x2={capX + cW + 12} y2={capY + cH}
+        stroke={DIM} strokeWidth={0.9} />
+      <line x1={capX + cW + 6} y1={capY} x2={capX + cW + 18} y2={capY}
+        stroke={DIM} strokeWidth={0.7} />
+      <line x1={capX + cW + 6} y1={capY + cH} x2={capX + cW + 18} y2={capY + cH}
+        stroke={DIM} strokeWidth={0.7} />
+      <text x={capX + cW + 26} y={cy} fontSize={9} fill={DIM} textAnchor="middle"
+        transform={`rotate(90 ${capX + cW + 26} ${cy})`}>
+        By = {(capBy / 1000).toFixed(2)} m
+      </text>
+
+      {/* N-piles label */}
+      <text x={14} y={capY + cH + 44} fontSize={9.5} fill={STEEL}>
+        {coords.length}-pile cap · pile ⌀{pileDia} mm
+      </text>
+    </svg>
+  )
+}

--- a/webapp/src/engine/pileCap.test.ts
+++ b/webapp/src/engine/pileCap.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { designPileCap, pileCentres } from './pileCap';
+
+// Shared base inputs — 4-pile square cap, concentric load
+const BASE = {
+  serviceLoad: 2000, serviceMomX: 0, serviceMomY: 0,
+  ultimateLoad: 2800, ultimateMomX: 0, ultimateMomY: 0,
+  nPiles: 4 as const,
+  pileDia: 400, pileCapacity: 600, spacing: 1200, edgeDist: 500,
+  colX: 500, colY: 500,
+  fc: 28, fy: 415, cover: 75, barDia: 20, pileEmbed: 150,
+};
+
+describe('pileCentres', () => {
+  it('returns N piles for each arrangement', () => {
+    ([2, 3, 4, 6, 9] as const).forEach(n => {
+      expect(pileCentres(n, 1200)).toHaveLength(n);
+    });
+  });
+
+  it('pile group centroid is at origin for all arrangements', () => {
+    ([2, 3, 4, 6, 9] as const).forEach(n => {
+      const coords = pileCentres(n, 1200);
+      const cx = coords.reduce((s, p) => s + p.x, 0) / n;
+      const cy = coords.reduce((s, p) => s + p.y, 0) / n;
+      expect(cx).toBeCloseTo(0, 8);
+      expect(cy).toBeCloseTo(0, 8);
+    });
+  });
+
+  it('4-pile group has correct coordinates', () => {
+    const coords = pileCentres(4, 1200);
+    expect(coords.map(p => p.x).sort()).toEqual([-600, -600, 600, 600]);
+    expect(coords.map(p => p.y).sort()).toEqual([-600, -600, 600, 600]);
+  });
+});
+
+describe('designPileCap — concentric 4-pile', () => {
+  it('produces a valid design', () => {
+    const r = designPileCap(BASE);
+    expect(r.Dc).toBeGreaterThan(0);
+    expect(r.d).toBeGreaterThan(0);
+    expect(r.capBx).toBeGreaterThan(0);
+  });
+
+  it('cap covers all piles with edge distance', () => {
+    const r = designPileCap(BASE);
+    // Each pile is at ±600mm; cap half-width = capBx/2; must be ≥ 600 + 500 = 1100 mm
+    expect(r.capBx / 2).toBeGreaterThanOrEqual(BASE.spacing / 2 + BASE.edgeDist);
+  });
+
+  it('equal service reactions for concentric load', () => {
+    const r = designPileCap(BASE);
+    const expected = BASE.serviceLoad / 4;
+    r.reactions.forEach(ri => expect(ri).toBeCloseTo(expected, 5));
+  });
+
+  it('pile capacity check passes', () => {
+    const r = designPileCap(BASE);
+    // 2000/4 = 500 kN ≤ 600 kN pileCapacity
+    expect(r.capacityOK).toBe(true);
+    expect(r.maxReaction).toBeCloseTo(500, 3);
+  });
+
+  it('all shear checks pass', () => {
+    const r = designPileCap(BASE);
+    expect(r.punchColOK).toBe(true);
+    expect(r.punchPileOK).toBe(true);
+    expect(r.beamXOK).toBe(true);
+    expect(r.beamYOK).toBe(true);
+  });
+
+  it('reported φVc > Vu for each check', () => {
+    const r = designPileCap(BASE);
+    expect(r.phiVcPunchCol).toBeGreaterThanOrEqual(r.VuPunchCol);
+    expect(r.phiVcPunchPile).toBeGreaterThanOrEqual(r.VuPunchPile);
+    expect(r.phiVcBeamX).toBeGreaterThanOrEqual(r.VuBeamX);
+    expect(r.phiVcBeamY).toBeGreaterThanOrEqual(r.VuBeamY);
+  });
+
+  it('Dc is a multiple of 25 mm', () => {
+    const r = designPileCap(BASE);
+    expect(r.Dc % 25).toBe(0);
+  });
+
+  it('effective depth = Dc − cover − db/2', () => {
+    const r = designPileCap(BASE);
+    expect(r.d).toBeCloseTo(r.Dc - BASE.cover - BASE.barDia / 2, 5);
+  });
+
+  it('steel area is positive and bars ≥ 2', () => {
+    const r = designPileCap(BASE);
+    expect(r.steelX.As).toBeGreaterThan(0);
+    expect(r.steelX.bars).toBeGreaterThanOrEqual(2);
+    expect(r.steelY.As).toBeGreaterThan(0);
+    expect(r.steelY.bars).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('designPileCap — eccentric load (uniaxial Y)', () => {
+  const ECC = { ...BASE, serviceMomY: 200, ultimateMomY: 280 };
+
+  it('piles on +x side have higher reaction than −x side', () => {
+    const r = designPileCap(ECC);
+    // Piles at x = +600: higher load; x = -600: lower load
+    const posR = r.reactions.filter((_, i) => r.coords[i].x > 0);
+    const negR = r.reactions.filter((_, i) => r.coords[i].x < 0);
+    expect(Math.min(...posR)).toBeGreaterThan(Math.max(...negR));
+  });
+
+  it('all shear checks still pass', () => {
+    const r = designPileCap(ECC);
+    expect(r.punchColOK).toBe(true);
+    expect(r.punchPileOK).toBe(true);
+    expect(r.beamXOK).toBe(true);
+    expect(r.beamYOK).toBe(true);
+  });
+});
+
+describe('designPileCap — 9-pile cap', () => {
+  const NINE = {
+    ...BASE,
+    serviceLoad: 5400, ultimateLoad: 7560,
+    nPiles: 9 as const,
+    pileCapacity: 700, spacing: 1400, edgeDist: 600,
+    colX: 600, colY: 600,
+  };
+
+  it('produces valid design for 9 piles', () => {
+    const r = designPileCap(NINE);
+    expect(r.coords).toHaveLength(9);
+    expect(r.Dc).toBeGreaterThan(0);
+    expect(r.capacityOK).toBe(true);
+  });
+});

--- a/webapp/src/engine/pileCap.ts
+++ b/webapp/src/engine/pileCap.ts
@@ -1,0 +1,268 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Pile cap design — ACI 318-14 / NSCP 2015
+// Supports 2-pile (linear), 3-pile (triangular), 4-pile (square),
+// 6-pile (2×3 rectangular), and 9-pile (3×3 square) standard arrangements.
+// Convention: lengths in mm, forces in kN, moments in kN·m.
+// ─────────────────────────────────────────────────────────────────────────
+
+import { twoWayVc, oneWayVc } from './shear';
+import { flexuralSteel, barLayout } from './flexure';
+
+const PHI_V = 0.75;
+
+export type PileArrangement = 2 | 3 | 4 | 6 | 9;
+
+export interface PileCapInput {
+  // Service loads — pile capacity check
+  serviceLoad: number;    // P_service, kN
+  serviceMomX: number;    // M_x service (about x-axis), kN·m
+  serviceMomY: number;    // M_y service (about y-axis), kN·m
+  // Factored loads — shear & flexure design
+  ultimateLoad: number;   // Pu, kN
+  ultimateMomX: number;   // Mux, kN·m
+  ultimateMomY: number;   // Muy, kN·m
+  // Pile geometry
+  nPiles: PileArrangement;
+  pileDia: number;        // circular pile diameter, mm
+  pileCapacity: number;   // allowable service load per pile, kN
+  spacing: number;        // c/c pile spacing, mm
+  edgeDist: number;       // pile centre to nearest cap edge, mm
+  // Column (rectangular)
+  colX: number;           // column dimension in x, mm
+  colY: number;           // column dimension in y, mm
+  // Materials & detailing
+  fc: number;
+  fy: number;
+  cover: number;          // clear cover, mm
+  barDia: number;
+  pileEmbed: number;      // pile embedment into cap, mm
+  lambda?: number;        // lightweight concrete factor (default 1)
+}
+
+export interface PileCoord { x: number; y: number }
+
+export interface SteelDetail {
+  As: number; rho: number; bars: number; spacing: number; usedMin: boolean;
+}
+
+export interface PileCapResult {
+  capBx: number; capBy: number;       // cap plan dimensions, mm
+  Dc: number;                          // cap thickness, mm
+  d: number;                           // effective depth, mm
+  coords: PileCoord[];                 // pile centres from cap centre, mm
+  reactions: number[];                 // service pile reactions, kN
+  factReactions: number[];             // factored pile reactions, kN
+  maxReaction: number;                 // max service reaction, kN
+  capacityOK: boolean;                 // max ≤ pileCapacity
+
+  VuPunchCol: number;  phiVcPunchCol: number;  punchColOK: boolean;
+  VuPunchPile: number; phiVcPunchPile: number; punchPileOK: boolean;
+  VuBeamX: number;     phiVcBeamX: number;     beamXOK: boolean;
+  VuBeamY: number;     phiVcBeamY: number;     beamYOK: boolean;
+
+  MuX: number; MuY: number;
+  steelX: SteelDetail;
+  steelY: SteelDetail;
+
+  ldRequired: number; ldAvailable: number; ldOK: boolean;
+}
+
+/** Returns pile centres in the cap coordinate system (cap centroid = pile group centroid = origin). */
+export function pileCentres(n: PileArrangement, s: number): PileCoord[] {
+  const s2 = s / 2;
+  const r = s / Math.sqrt(3); // circumradius of equilateral triangle with side s
+  switch (n) {
+    case 2: return [{ x: -s2, y: 0 }, { x: s2, y: 0 }];
+    case 3: return [
+      { x: 0,   y:  r     },
+      { x: -s2, y: -r / 2 },
+      { x:  s2, y: -r / 2 },
+    ];
+    case 4: return [
+      { x: -s2, y: -s2 }, { x: s2, y: -s2 },
+      { x: -s2, y:  s2 }, { x: s2, y:  s2 },
+    ];
+    case 6: return [
+      { x:  -s, y: -s2 }, { x: 0, y: -s2 }, { x: s, y: -s2 },
+      { x:  -s, y:  s2 }, { x: 0, y:  s2 }, { x: s, y:  s2 },
+    ];
+    case 9: return [
+      { x: -s, y: -s }, { x: 0, y: -s }, { x: s, y: -s },
+      { x: -s, y:  0 }, { x: 0, y:  0 }, { x: s, y:  0 },
+      { x: -s, y:  s }, { x: 0, y:  s }, { x: s, y:  s },
+    ];
+  }
+}
+
+function roundUp(v: number, step: number) { return Math.ceil(v / step) * step; }
+
+/**
+ * Pile reactions — elastic analysis: Ri = P/N + Mx·yi/Σyi² + My·xi/Σxi²
+ * Mx/My in kN·m, coords in mm → Ri in kN.
+ */
+function calcReactions(
+  coords: PileCoord[], P: number, Mx_kNm: number, My_kNm: number,
+): number[] {
+  const Sxx = coords.reduce((s, p) => s + p.y * p.y, 0); // Σyi², mm²
+  const Syy = coords.reduce((s, p) => s + p.x * p.x, 0); // Σxi², mm²
+  const N = coords.length;
+  return coords.map(p => {
+    let R = P / N;
+    if (Sxx > 0) R += (Mx_kNm * 1e3 * p.y) / Sxx;
+    if (Syy > 0) R += (My_kNm * 1e3 * p.x) / Syy;
+    return R;
+  });
+}
+
+/**
+ * ACI 318-14 §25.5.1 development length (straight bar, bottom, uncoated,
+ * normal weight unless lambda < 1). Returns mm.
+ */
+function devLength(db: number, fc: number, fy: number, cover: number, lambda: number): number {
+  const cb = cover + db / 2;                           // centre-to-surface distance
+  const ratio = Math.min(cb / db, 2.5);               // (cb + Ktr)/db, Ktr = 0
+  return Math.ceil((3 * fy) / (40 * lambda * Math.sqrt(fc) * ratio) * db);
+}
+
+export function designPileCap(inp: PileCapInput): PileCapResult {
+  const lambda = inp.lambda ?? 1;
+  const coords = pileCentres(inp.nPiles, inp.spacing);
+  const N = coords.length;
+
+  // ── Cap plan dimensions ──────────────────────────────────────────────────
+  const maxX = Math.max(...coords.map(p => Math.abs(p.x)));
+  const maxY = Math.max(...coords.map(p => Math.abs(p.y)));
+  const capBx = roundUp(2 * (maxX + inp.edgeDist), 25);
+  const capBy = roundUp(2 * (maxY + inp.edgeDist), 25);
+
+  // ── Pile reactions ───────────────────────────────────────────────────────
+  const reactions     = calcReactions(coords, inp.serviceLoad,  inp.serviceMomX,  inp.serviceMomY);
+  const factReactions = calcReactions(coords, inp.ultimateLoad, inp.ultimateMomX, inp.ultimateMomY);
+  const maxReaction     = Math.max(...reactions);
+  const maxFactReaction = Math.max(...factReactions);
+  const capacityOK = maxReaction <= inp.pileCapacity;
+
+  const betaC = Math.max(inp.colX, inp.colY) / Math.min(inp.colX, inp.colY);
+
+  // ── Find minimum effective depth satisfying all shear checks ─────────────
+  let dMin = 3000;
+  outer: for (let dTry = 50; dTry <= 3000; dTry++) {
+    // 1 · Column punching (critical section at d/2 from column face)
+    const boCol = 2 * (inp.colX + dTry) + 2 * (inp.colY + dTry);
+    let VuCol = inp.ultimateLoad;
+    for (let i = 0; i < N; i++) {
+      if (Math.abs(coords[i].x) <= inp.colX / 2 + dTry / 2 &&
+          Math.abs(coords[i].y) <= inp.colY / 2 + dTry / 2) {
+        VuCol -= factReactions[i];
+      }
+    }
+    VuCol = Math.max(0, VuCol);
+    if (PHI_V * twoWayVc({ fc: inp.fc, bo: boCol, d: dTry, betaC, lambda }) < VuCol) continue;
+
+    // 2 · Pile punching (worst pile reaction, critical perimeter π(dp+d))
+    const boPile = Math.PI * (inp.pileDia + dTry);
+    if (PHI_V * twoWayVc({ fc: inp.fc, bo: boPile, d: dTry, betaC: 1, lambda }) < maxFactReaction) continue;
+
+    // 3 · One-way shear in x (critical section at cx/2 + d from cap centre)
+    const critX = inp.colX / 2 + dTry;
+    let bxPos = 0, bxNeg = 0;
+    for (let i = 0; i < N; i++) {
+      if (coords[i].x  >  critX) bxPos += factReactions[i];
+      if (coords[i].x  < -critX) bxNeg += factReactions[i];
+    }
+    if (PHI_V * oneWayVc({ fc: inp.fc, b: capBy, d: dTry, lambda }) < Math.max(bxPos, bxNeg)) continue;
+
+    // 4 · One-way shear in y
+    const critY = inp.colY / 2 + dTry;
+    let byPos = 0, byNeg = 0;
+    for (let i = 0; i < N; i++) {
+      if (coords[i].y  >  critY) byPos += factReactions[i];
+      if (coords[i].y  < -critY) byNeg += factReactions[i];
+    }
+    if (PHI_V * oneWayVc({ fc: inp.fc, b: capBx, d: dTry, lambda }) < Math.max(byPos, byNeg)) continue;
+
+    dMin = dTry;
+    break outer;
+  }
+
+  // Minimum depth also must accommodate pile embedment + cover + bar
+  const dcFromEmbed = roundUp(inp.pileEmbed + inp.cover + inp.barDia, 25);
+  const Dc = Math.max(roundUp(dMin + inp.cover + inp.barDia, 25), dcFromEmbed);
+  const d  = Dc - inp.cover - inp.barDia / 2;
+
+  // ── Final check values at adopted d ─────────────────────────────────────
+  const boColF = 2 * (inp.colX + d) + 2 * (inp.colY + d);
+  let VuPunchCol = inp.ultimateLoad;
+  for (let i = 0; i < N; i++) {
+    if (Math.abs(coords[i].x) <= inp.colX / 2 + d / 2 &&
+        Math.abs(coords[i].y) <= inp.colY / 2 + d / 2) {
+      VuPunchCol -= factReactions[i];
+    }
+  }
+  VuPunchCol = Math.max(0, VuPunchCol);
+  const phiVcPunchCol  = PHI_V * twoWayVc({ fc: inp.fc, bo: boColF, d, betaC, lambda });
+
+  const boPileF = Math.PI * (inp.pileDia + d);
+  const VuPunchPile   = maxFactReaction;
+  const phiVcPunchPile = PHI_V * twoWayVc({ fc: inp.fc, bo: boPileF, d, betaC: 1, lambda });
+
+  const critXF = inp.colX / 2 + d;
+  let bxPosF = 0, bxNegF = 0;
+  for (let i = 0; i < N; i++) {
+    if (coords[i].x  >  critXF) bxPosF += factReactions[i];
+    if (coords[i].x  < -critXF) bxNegF += factReactions[i];
+  }
+  const VuBeamX    = Math.max(bxPosF, bxNegF);
+  const phiVcBeamX = PHI_V * oneWayVc({ fc: inp.fc, b: capBy, d, lambda });
+
+  const critYF = inp.colY / 2 + d;
+  let byPosF = 0, byNegF = 0;
+  for (let i = 0; i < N; i++) {
+    if (coords[i].y  >  critYF) byPosF += factReactions[i];
+    if (coords[i].y  < -critYF) byNegF += factReactions[i];
+  }
+  const VuBeamY    = Math.max(byPosF, byNegF);
+  const phiVcBeamY = PHI_V * oneWayVc({ fc: inp.fc, b: capBx, d, lambda });
+
+  // ── Flexure — critical section at column face ────────────────────────────
+  let MuXpos = 0, MuXneg = 0, MuYpos = 0, MuYneg = 0;
+  for (let i = 0; i < N; i++) {
+    const armX = Math.abs(coords[i].x) - inp.colX / 2;
+    if (armX > 0) {
+      (coords[i].x > 0 ? (MuXpos += factReactions[i] * armX) : (MuXneg += factReactions[i] * armX));
+    }
+    const armY = Math.abs(coords[i].y) - inp.colY / 2;
+    if (armY > 0) {
+      (coords[i].y > 0 ? (MuYpos += factReactions[i] * armY) : (MuYneg += factReactions[i] * armY));
+    }
+  }
+  const MuX = Math.max(MuXpos, MuXneg) / 1e3; // kN·mm → kN·m
+  const MuY = Math.max(MuYpos, MuYneg) / 1e3;
+
+  // x-direction bars (running in x, moment about y, width = capBy)
+  const flexX   = flexuralSteel({ Mu: MuX, b: capBy, d, fc: inp.fc, fy: inp.fy });
+  const layoutX = barLayout({ As: flexX.As, db: inp.barDia, b: capBy, cover: inp.cover });
+
+  // y-direction bars (running in y, moment about x, width = capBx)
+  const flexY   = flexuralSteel({ Mu: MuY, b: capBx, d, fc: inp.fc, fy: inp.fy });
+  const layoutY = barLayout({ As: flexY.As, db: inp.barDia, b: capBx, cover: inp.cover });
+
+  // ── Development length ───────────────────────────────────────────────────
+  const ldReq    = devLength(inp.barDia, inp.fc, inp.fy, inp.cover, lambda);
+  const ldAvailX = capBx / 2 - inp.colX / 2 - inp.cover;
+  const ldAvailY = capBy / 2 - inp.colY / 2 - inp.cover;
+  const ldAvail  = Math.min(ldAvailX, ldAvailY);
+
+  return {
+    capBx, capBy, Dc, d,
+    coords, reactions, factReactions, maxReaction, capacityOK,
+    VuPunchCol,  phiVcPunchCol,  punchColOK:  phiVcPunchCol  >= VuPunchCol,
+    VuPunchPile, phiVcPunchPile, punchPileOK: phiVcPunchPile >= VuPunchPile,
+    VuBeamX,     phiVcBeamX,     beamXOK:     phiVcBeamX     >= VuBeamX,
+    VuBeamY,     phiVcBeamY,     beamYOK:     phiVcBeamY     >= VuBeamY,
+    MuX, MuY,
+    steelX: { As: flexX.As, rho: flexX.rho, bars: layoutX.n, spacing: layoutX.spacing, usedMin: flexX.usedMin },
+    steelY: { As: flexY.As, rho: flexY.rho, bars: layoutY.n, spacing: layoutY.spacing, usedMin: flexY.usedMin },
+    ldRequired: ldReq, ldAvailable: ldAvail, ldOK: ldAvail >= ldReq,
+  };
+}

--- a/webapp/src/pages/PileCapDesign.tsx
+++ b/webapp/src/pages/PileCapDesign.tsx
@@ -1,0 +1,320 @@
+import { useMemo, useState, type ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { designPileCap, type PileArrangement } from '../engine/pileCap'
+import { PileCapSchematic } from '../components/PileCapSchematic'
+import { Math as KTex } from '../lib/math'
+import { f0, f2, f3 } from '../lib/format'
+import 'katex/dist/katex.min.css'
+
+interface FormState {
+  serviceLoad: number
+  serviceMomX: number
+  serviceMomY: number
+  ultimateLoad: number
+  ultimateMomX: number
+  ultimateMomY: number
+  nPiles: PileArrangement
+  pileDia: number
+  pileCapacity: number
+  spacing: number
+  edgeDist: number
+  colX: number
+  colY: number
+  fc: number
+  fy: number
+  cover: number
+  barDia: number
+  pileEmbed: number
+}
+
+const DEFAULTS: FormState = {
+  serviceLoad: 2000,
+  serviceMomX: 0,
+  serviceMomY: 0,
+  ultimateLoad: 2800,
+  ultimateMomX: 0,
+  ultimateMomY: 0,
+  nPiles: 4,
+  pileDia: 400,
+  pileCapacity: 600,
+  spacing: 1200,
+  edgeDist: 500,
+  colX: 500,
+  colY: 500,
+  fc: 28,
+  fy: 415,
+  cover: 75,
+  barDia: 20,
+  pileEmbed: 150,
+}
+
+function NumField({ label, unit, value, onChange, step = 'any' }: {
+  label: ReactNode; unit?: string; value: number; onChange: (v: number) => void; step?: string
+}) {
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="mb-1 font-medium text-slate-600">
+        {label}{unit ? <span className="text-slate-400"> ({unit})</span> : null}
+      </span>
+      <input
+        type="number" inputMode="decimal" step={step} value={Number.isFinite(value) ? value : ''}
+        onChange={e => onChange(parseFloat(e.target.value))}
+        className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none focus:ring-1 focus:ring-[#0056b3]"
+      />
+    </label>
+  )
+}
+
+function SelectField<T extends string | number>({ label, value, onChange, options }: {
+  label: string; value: T; onChange: (v: T) => void; options: [T, string][]
+}) {
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="mb-1 font-medium text-slate-600">{label}</span>
+      <select value={String(value)} onChange={e => onChange(e.target.value as T)}
+        className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none">
+        {options.map(([v, t]) => <option key={String(v)} value={String(v)}>{t}</option>)}
+      </select>
+    </label>
+  )
+}
+
+function Card({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">{title}</legend>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">{children}</div>
+    </fieldset>
+  )
+}
+
+function Row({ label, value, check }: { label: ReactNode; value: ReactNode; check?: ReactNode }) {
+  return (
+    <div className="flex items-baseline justify-between gap-3 border-b border-slate-100 py-1.5 last:border-0">
+      <span className="text-sm text-slate-600">{label}</span>
+      <span className="text-right text-sm font-semibold text-slate-800">{value}</span>
+      {check ? <span className="w-36 text-right text-xs text-slate-500">{check}</span> : null}
+    </div>
+  )
+}
+
+function CheckRow({ label, Vu, phiVc, ok }: { label: ReactNode; Vu: number; phiVc: number; ok: boolean }) {
+  return (
+    <Row
+      label={label}
+      value={`${f2(Vu)} kN`}
+      check={
+        <span className={ok ? 'text-emerald-600' : 'text-rose-600'}>
+          φVc = {f2(phiVc)} kN {ok ? '✓' : '✗'}
+        </span>
+      }
+    />
+  )
+}
+
+function steelRow(label: ReactNode, s: { bars: number; spacing: number; As: number; usedMin: boolean; rho: number }, db: number) {
+  return (
+    <Row
+      label={label}
+      value={`${s.bars} ⌀${db} mm @ ${f0(s.spacing)} mm`}
+      check={`As=${f0(s.As)} mm² · ${s.usedMin ? 'ρ_min' : `ρ=${s.rho.toFixed(4)}`}`}
+    />
+  )
+}
+
+export default function PileCapDesign() {
+  const [form, setForm] = useState<FormState>(DEFAULTS)
+  const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) => setForm(s => ({ ...s, [k]: v }))
+
+  const valid = Object.values(form).every(v => typeof v === 'string' || Number.isFinite(v as number))
+    && form.serviceLoad > 0 && form.ultimateLoad > 0
+    && form.pileCapacity > 0 && form.spacing > 0 && form.edgeDist > 0
+
+  const result = useMemo(() => {
+    if (!valid) return null
+    return designPileCap({
+      serviceLoad: form.serviceLoad,
+      serviceMomX: form.serviceMomX,
+      serviceMomY: form.serviceMomY,
+      ultimateLoad: form.ultimateLoad,
+      ultimateMomX: form.ultimateMomX,
+      ultimateMomY: form.ultimateMomY,
+      nPiles: form.nPiles,
+      pileDia: form.pileDia,
+      pileCapacity: form.pileCapacity,
+      spacing: form.spacing,
+      edgeDist: form.edgeDist,
+      colX: form.colX,
+      colY: form.colY,
+      fc: form.fc,
+      fy: form.fy,
+      cover: form.cover,
+      barDia: form.barDia,
+      pileEmbed: form.pileEmbed,
+    })
+  }, [form, valid])
+
+  const allOK = result && result.capacityOK && result.punchColOK && result.punchPileOK
+    && result.beamXOK && result.beamYOK && result.ldOK
+
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <Link to="/" className="text-sm text-[#0056b3] hover:underline">← Home</Link>
+      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Pile Cap Design</h1>
+      <p className="mt-1 text-slate-600">
+        ACI 318-14 / NSCP 2015 — pile reactions, column & pile punching, one-way shear, flexure, development length.
+      </p>
+
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
+        {/* ── Inputs ── */}
+        <div className="space-y-5">
+          <Card title="Column Loads">
+            <NumField label={<>Service <KTex tex="P" /></>} unit="kN" value={form.serviceLoad} onChange={set('serviceLoad')} />
+            <NumField label={<>Service <KTex tex="M_x" /></>} unit="kN·m" value={form.serviceMomX} onChange={set('serviceMomX')} />
+            <NumField label={<>Service <KTex tex="M_y" /></>} unit="kN·m" value={form.serviceMomY} onChange={set('serviceMomY')} />
+            <NumField label={<>Factored <KTex tex="P_u" /></>} unit="kN" value={form.ultimateLoad} onChange={set('ultimateLoad')} />
+            <NumField label={<>Factored <KTex tex="M_{ux}" /></>} unit="kN·m" value={form.ultimateMomX} onChange={set('ultimateMomX')} />
+            <NumField label={<>Factored <KTex tex="M_{uy}" /></>} unit="kN·m" value={form.ultimateMomY} onChange={set('ultimateMomY')} />
+          </Card>
+
+          <Card title="Pile & Cap Geometry">
+            <SelectField<PileArrangement>
+              label="Number of piles"
+              value={form.nPiles}
+              onChange={v => set('nPiles')(Number(v) as PileArrangement)}
+              options={[
+                [2, '2 piles (linear)'],
+                [3, '3 piles (triangular)'],
+                [4, '4 piles (square)'],
+                [6, '6 piles (2 × 3)'],
+                [9, '9 piles (3 × 3)'],
+              ]}
+            />
+            <NumField label="Pile diameter" unit="mm" value={form.pileDia} onChange={set('pileDia')} step="50" />
+            <NumField label="Pile capacity (service)" unit="kN" value={form.pileCapacity} onChange={set('pileCapacity')} />
+            <NumField label="Pile spacing (c/c)" unit="mm" value={form.spacing} onChange={set('spacing')} step="50" />
+            <NumField label="Edge distance" unit="mm" value={form.edgeDist} onChange={set('edgeDist')} step="25" />
+            <NumField label="Pile embedment" unit="mm" value={form.pileEmbed} onChange={set('pileEmbed')} step="25" />
+          </Card>
+
+          <Card title="Column">
+            <NumField label={<>Width <KTex tex="c_x" /></>} unit="mm" value={form.colX} onChange={set('colX')} step="25" />
+            <NumField label={<>Width <KTex tex="c_y" /></>} unit="mm" value={form.colY} onChange={set('colY')} step="25" />
+          </Card>
+
+          <Card title="Materials & Detailing">
+            <NumField label={<KTex tex="f'_c" />} unit="MPa" value={form.fc} onChange={set('fc')} />
+            <NumField label={<KTex tex="f_y" />} unit="MPa" value={form.fy} onChange={set('fy')} />
+            <NumField label={<>Bar <KTex tex="d_b" /></>} unit="mm" value={form.barDia} onChange={set('barDia')} />
+            <NumField label="Clear cover" unit="mm" value={form.cover} onChange={set('cover')} />
+          </Card>
+        </div>
+
+        {/* ── Results ── */}
+        <div className="space-y-5">
+          {/* Schematic */}
+          <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Cap plan</h2>
+            {result ? (
+              <PileCapSchematic
+                capBx={result.capBx}
+                capBy={result.capBy}
+                coords={result.coords}
+                pileDia={form.pileDia}
+                colX={form.colX}
+                colY={form.colY}
+                reactions={result.reactions}
+              />
+            ) : (
+              <p className="py-8 text-center text-sm text-slate-400">Enter valid inputs to preview.</p>
+            )}
+          </div>
+
+          {result && (
+            <>
+              {/* Summary banner */}
+              <div className={`rounded-xl border p-3 text-center text-sm font-semibold shadow-sm ${
+                allOK ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-rose-200 bg-rose-50 text-rose-700'
+              }`}>
+                {allOK ? '✓ All checks pass' : '✗ One or more checks fail — review results below'}
+              </div>
+
+              {/* Cap geometry */}
+              <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Cap geometry</h2>
+                <Row label="Plan (Bx × By)"
+                  value={`${f2(result.capBx / 1000)} × ${f2(result.capBy / 1000)} m`} />
+                <Row label={<>Thickness <KTex tex="D_c" /></>} value={`${f0(result.Dc)} mm`} />
+                <Row label={<>Effective depth <KTex tex="d" /></>} value={`${f0(result.d)} mm`} />
+              </div>
+
+              {/* Pile reactions */}
+              <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Pile reactions (service)</h2>
+                {result.reactions.map((r, i) => (
+                  <Row key={i}
+                    label={`Pile ${i + 1} (${(result.coords[i].x / 1000).toFixed(2)}, ${(result.coords[i].y / 1000).toFixed(2)}) m`}
+                    value={`${f2(r)} kN`}
+                    check={
+                      <span className={r <= form.pileCapacity ? 'text-emerald-600' : 'text-rose-600'}>
+                        ≤ {form.pileCapacity} kN {r <= form.pileCapacity ? '✓' : '✗'}
+                      </span>
+                    }
+                  />
+                ))}
+              </div>
+
+              {/* Shear checks */}
+              <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Shear checks (factored)</h2>
+                <CheckRow label="Column punching" Vu={result.VuPunchCol} phiVc={result.phiVcPunchCol} ok={result.punchColOK} />
+                <CheckRow label="Pile punching (worst)" Vu={result.VuPunchPile} phiVc={result.phiVcPunchPile} ok={result.punchPileOK} />
+                <CheckRow label={<>Beam shear — <KTex tex="x" /></>} Vu={result.VuBeamX} phiVc={result.phiVcBeamX} ok={result.beamXOK} />
+                <CheckRow label={<>Beam shear — <KTex tex="y" /></>} Vu={result.VuBeamY} phiVc={result.phiVcBeamY} ok={result.beamYOK} />
+              </div>
+
+              {/* Flexure & steel */}
+              <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Flexure & reinforcement</h2>
+                <Row label={<>Design moment <KTex tex="M_{u,x}" /></>} value={`${f3(result.MuX)} kN·m`} />
+                <Row label={<>Design moment <KTex tex="M_{u,y}" /></>} value={`${f3(result.MuY)} kN·m`} />
+                {steelRow(<>Bars — <KTex tex="x" />-direction (bottom)</>, result.steelX, form.barDia)}
+                {steelRow(<>Bars — <KTex tex="y" />-direction (bottom)</>, result.steelY, form.barDia)}
+              </div>
+
+              {/* Development length */}
+              <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Development length</h2>
+                <Row
+                  label={<>Required <KTex tex="\ell_d" /></>}
+                  value={`${f0(result.ldRequired)} mm`}
+                />
+                <Row
+                  label="Available (column face to bar end)"
+                  value={`${f0(result.ldAvailable)} mm`}
+                  check={
+                    <span className={result.ldOK ? 'text-emerald-600' : 'text-rose-600'}>
+                      {result.ldOK ? '✓ OK' : '✗ Hooks required'}
+                    </span>
+                  }
+                />
+              </div>
+
+              {/* Basis */}
+              <div className="rounded-xl border border-slate-200 bg-white p-4 text-sm text-slate-600 shadow-sm">
+                <h2 className="mb-1 text-[1.02rem] font-bold text-[#0056b3]">Basis</h2>
+                <KTex block tex={String.raw`R_i = \frac{P}{N} + \frac{M_x \cdot y_i}{\sum y_i^2} + \frac{M_y \cdot x_i}{\sum x_i^2}`} />
+                <p className="mt-1 text-xs text-slate-400">
+                  NSCP 2015 / ACI 318-14. φ_v = 0.75, φ_f = 0.90.
+                  Column punching at d/2 from column face; pile punching at d/2 from pile perimeter (§13.4.6).
+                  One-way shear critical section at d from column face.
+                  Development length per §25.5.1 (straight bar, no Ktr).
+                </p>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
ACI 318-14 / NSCP 2015 pile cap design module covering:
- Elastic pile reactions under biaxial moments (Ri = P/N + Mx·yi/Σyi² + My·xi/Σxi²)
- Supports 2, 3 (triangular), 4 (square), 6 (2×3) and 9 (3×3) pile arrangements
- Column two-way punching shear (ACI §22.6.5)
- Individual pile punching check (ACI §13.4.6, circular perimeter π(dp+d))
- One-way beam shear in both directions
- Flexural steel design and bar layout in x and y
- Development length check per ACI §25.5.1
- Cap thickness sized to satisfy all checks + pile embedment
- React UI with live plan-view schematic, per-pile reaction table, all check rows
- 42 tests, all passing; zero TypeScript errors

https://claude.ai/code/session_01RU7XQEuScseJCc63Ekbz3d