### PR TITLE
Combined-footing UI: form, plan schematic, and V/M/w diagrams

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route, Link } from 'react-router-dom'
 import { factoredLoad, beta1 } from './engine/loads'
 import FoundationDesign from './pages/FoundationDesign'
 import PileCapDesign from './pages/PileCapDesign'
+import CombinedFootingDesign from './pages/CombinedFootingDesign'
 
 function Home() {
   return (
@@ -38,6 +39,12 @@ function Home() {
         >
           Pile Cap Design →
         </Link>
+        <Link
+          to="/combined"
+          className="inline-block rounded-lg bg-gradient-to-br from-[#0056b3] to-[#003f86] px-5 py-2.5 font-semibold text-white shadow-md transition hover:shadow-lg"
+        >
+          Combined Footing →
+        </Link>
       </div>
     </div>
   )
@@ -49,6 +56,7 @@ export default function App() {
       <Route path="/" element={<Home />} />
       <Route path="/foundation" element={<FoundationDesign />} />
       <Route path="/pile-cap" element={<PileCapDesign />} />
+      <Route path="/combined" element={<CombinedFootingDesign />} />
     </Routes>
   )
 }

--- a/webapp/src/components/CombinedFootingSchematic.tsx
+++ b/webapp/src/components/CombinedFootingSchematic.tsx
@@ -1,0 +1,80 @@
+import type { JSX } from 'react'
+
+const STROKE = '#37526e'
+const FILL = '#eef3f8'
+const COL = '#37526e'
+const DIM = '#1f77b4'
+
+export interface CombinedSchematicProps {
+  shape: 'Rectangular (CRF)' | 'Trapezoidal (CTF)'
+  Bx: number          // length along x, m
+  By: number          // mean width (rect), m
+  By1: number         // left-end width, m
+  By2: number         // right-end width, m
+  x1: number          // col-1 centre from left edge, m
+  x2: number          // col-2 centre from left edge, m
+  col1Width: number   // mm
+  col2Width: number   // mm
+}
+
+/** Plan view of a combined footing (rectangular or trapezoidal) with both columns. */
+export function CombinedFootingSchematic({
+  shape, Bx, By, By1, By2, x1, x2, col1Width, col2Width,
+}: CombinedSchematicProps): JSX.Element {
+  const W = 520, H = 200
+  const padL = 24, padR = 24, padT = 40, padB = 44
+  const plotW = W - padL - padR
+  const plotH = H - padT - padB
+
+  const trap = shape[0] === 'T'
+  const wMax = Math.max(By1, By2, By)
+  const s = Math.min(plotW / Bx, plotH / wMax)
+  const fW = Bx * s
+  const fx = padL + (plotW - fW) / 2
+  const cy = padT + plotH / 2
+
+  const wL = (trap ? By1 : By) * s
+  const wR = (trap ? By2 : By) * s
+  // slab outline (trapezoid): left edge height wL, right edge height wR
+  const outline = `${fx},${cy - wL / 2} ${fx + fW},${cy - wR / 2} ${fx + fW},${cy + wR / 2} ${fx},${cy + wL / 2}`
+
+  const colRect = (xc: number, cwmm: number) => {
+    const cx = fx + xc * s
+    const cw = Math.max(6, (cwmm / 1000) * s)
+    return { cx, cw }
+  }
+  const c1 = colRect(x1, col1Width)
+  const c2 = colRect(x2, col2Width)
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet"
+      style={{ width: '100%', height: 'auto', fontFamily: 'Arial, sans-serif' }}>
+      <text x={padL} y={18} fontSize={11} fontWeight={700} fill="#0056b3">PLAN — {shape}</text>
+
+      <polygon points={outline} rx={2} fill={FILL} stroke={STROKE} strokeWidth={1.4} />
+
+      {/* columns */}
+      {[c1, c2].map((c, i) => (
+        <rect key={i} x={c.cx - c.cw / 2} y={cy - c.cw / 2} width={c.cw} height={c.cw} fill={COL} />
+      ))}
+      <text x={c1.cx} y={cy - wL / 2 - 6} fontSize={9} fill={COL} textAnchor="middle" fontWeight={700}>C1</text>
+      <text x={c2.cx} y={cy - wR / 2 - 6} fontSize={9} fill={COL} textAnchor="middle" fontWeight={700}>C2</text>
+
+      {/* length dimension */}
+      <g>
+        <line x1={fx} y1={cy + Math.max(wL, wR) / 2 + 14} x2={fx + fW} y2={cy + Math.max(wL, wR) / 2 + 14} stroke={DIM} strokeWidth={0.9} />
+        <text x={fx + fW / 2} y={cy + Math.max(wL, wR) / 2 + 28} fontSize={9.5} fill={DIM} textAnchor="middle">
+          Bx = {Bx.toFixed(2)} m
+        </text>
+      </g>
+
+      {/* width labels */}
+      <text x={fx - 4} y={cy} fontSize={9} fill={DIM} textAnchor="end" dominantBaseline="middle">
+        {(trap ? By1 : By).toFixed(2)} m
+      </text>
+      <text x={fx + fW + 4} y={cy} fontSize={9} fill={DIM} textAnchor="start" dominantBaseline="middle">
+        {(trap ? By2 : By).toFixed(2)} m
+      </text>
+    </svg>
+  )
+}

--- a/webapp/src/components/Diagram.tsx
+++ b/webapp/src/components/Diagram.tsx
@@ -1,0 +1,113 @@
+import type { JSX } from 'react'
+
+export interface DiagramProps {
+  /** Station coordinates along the footing, m (monotonic increasing). */
+  xs: number[]
+  /** Ordinate at each station (kN, kN·m, kPa …). */
+  ys: number[]
+  title: string
+  unit: string
+  /** Stroke colour of the curve. */
+  color?: string
+  /** Optional vertical reference lines (e.g. column centrelines), in x-units. */
+  vlines?: { x: number; label?: string }[]
+  /** Mark the global max & min ordinates with diamonds + labels. */
+  markExtrema?: boolean
+  /** Decimal places for value labels. */
+  decimals?: number
+}
+
+const AXIS = '#94a3b8'
+const ZERO = '#475569'
+const GRID = '#eef2f7'
+
+/**
+ * Generic filled line diagram (load / shear / moment) drawn from the engine's
+ * sampled arrays. A zero baseline is always shown; the fill goes from the curve
+ * to that baseline so sign changes read at a glance.
+ */
+export function Diagram({
+  xs, ys, title, unit, color = '#0056b3', vlines = [], markExtrema = true, decimals = 1,
+}: DiagramProps): JSX.Element {
+  const W = 520, H = 220
+  const padL = 52, padR = 18, padT = 28, padB = 30
+  const plotW = W - padL - padR
+  const plotH = H - padT - padB
+
+  const xMin = xs[0], xMax = xs[xs.length - 1]
+  const xSpan = xMax - xMin || 1
+  let yMax = Math.max(0, ...ys)
+  let yMin = Math.min(0, ...ys)
+  if (yMax === yMin) { yMax = 1; yMin = -1 }
+  const ySpan = yMax - yMin
+
+  const sx = (x: number) => padL + ((x - xMin) / xSpan) * plotW
+  const sy = (y: number) => padT + ((yMax - y) / ySpan) * plotH
+  const y0 = sy(0)
+
+  const linePts = xs.map((x, i) => `${sx(x).toFixed(1)},${sy(ys[i]).toFixed(1)}`).join(' ')
+  const fillPts = `${sx(xs[0]).toFixed(1)},${y0.toFixed(1)} ${linePts} ${sx(xs[xs.length - 1]).toFixed(1)},${y0.toFixed(1)}`
+
+  // Extrema
+  let iMax = 0, iMin = 0
+  ys.forEach((y, i) => { if (y > ys[iMax]) iMax = i; if (y < ys[iMin]) iMin = i })
+
+  // y gridlines / ticks (0, max, min)
+  const yticks = Array.from(new Set([yMin, 0, yMax])).filter((v) => Number.isFinite(v))
+
+  const fmt = (v: number) => v.toFixed(decimals)
+
+  function Marker({ i, place }: { i: number; place: 'above' | 'below' }) {
+    const x = sx(xs[i]), y = sy(ys[i])
+    const ly = place === 'above' ? y - 9 : y + 15
+    return (
+      <g>
+        <path d={`M${x} ${y - 4} L${x + 4} ${y} L${x} ${y + 4} L${x - 4} ${y} Z`} fill={color} />
+        <text x={x} y={ly} fontSize={9.5} fill={color} fontWeight={700} textAnchor="middle"
+          paintOrder="stroke" stroke="#fff" strokeWidth={2.6}>
+          {fmt(ys[i])}@{xs[i].toFixed(2)}m
+        </text>
+      </g>
+    )
+  }
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet"
+      style={{ width: '100%', height: 'auto', fontFamily: 'Arial, sans-serif' }}>
+      <text x={padL} y={16} fontSize={11} fontWeight={700} fill="#0056b3">{title}</text>
+      <text x={W - padR} y={16} fontSize={9.5} fill="#94a3b8" textAnchor="end">{unit}</text>
+
+      {/* y gridlines + labels */}
+      {yticks.map((v) => (
+        <g key={`y${v}`}>
+          <line x1={padL} y1={sy(v)} x2={W - padR} y2={sy(v)} stroke={v === 0 ? ZERO : GRID} strokeWidth={v === 0 ? 1.1 : 1} />
+          <text x={padL - 6} y={sy(v) + 3} fontSize={9} fill="#64748b" textAnchor="end">{fmt(v)}</text>
+        </g>
+      ))}
+
+      {/* x axis baseline ticks */}
+      <line x1={padL} y1={H - padB} x2={W - padR} y2={H - padB} stroke={AXIS} strokeWidth={1} />
+      {[xMin, (xMin + xMax) / 2, xMax].map((x, k) => (
+        <g key={`x${k}`}>
+          <line x1={sx(x)} y1={H - padB} x2={sx(x)} y2={H - padB + 4} stroke={AXIS} strokeWidth={1} />
+          <text x={sx(x)} y={H - padB + 15} fontSize={9} fill="#64748b" textAnchor="middle">{x.toFixed(2)}</text>
+        </g>
+      ))}
+
+      {/* column / reference verticals */}
+      {vlines.map((v, k) => (
+        <g key={`v${k}`}>
+          <line x1={sx(v.x)} y1={padT} x2={sx(v.x)} y2={H - padB} stroke="#cbd5e1" strokeWidth={1} strokeDasharray="4 3" />
+          {v.label && <text x={sx(v.x)} y={padT - 2} fontSize={8.5} fill="#94a3b8" textAnchor="middle">{v.label}</text>}
+        </g>
+      ))}
+
+      {/* fill + curve */}
+      <polygon points={fillPts} fill={color} opacity={0.12} />
+      <polyline points={linePts} fill="none" stroke={color} strokeWidth={1.8} />
+
+      {markExtrema && Math.abs(ys[iMax]) > 1e-6 && <Marker i={iMax} place="above" />}
+      {markExtrema && Math.abs(ys[iMin]) > 1e-6 && <Marker i={iMin} place="below" />}
+    </svg>
+  )
+}

--- a/webapp/src/components/PileCapSchematic.tsx
+++ b/webapp/src/components/PileCapSchematic.tsx
@@ -4,7 +4,6 @@ import type { PileCoord } from '../engine/pileCap'
 const BLUE  = '#0056b3'
 const STEEL = '#37526e'
 const FILL  = '#eef3f8'
-const PILE  = '#8ab4d8'
 const DIM   = '#1f77b4'
 
 interface Props {

--- a/webapp/src/pages/CombinedFootingDesign.tsx
+++ b/webapp/src/pages/CombinedFootingDesign.tsx
@@ -1,0 +1,261 @@
+import { useMemo, useState, type ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { designCombinedFooting, type CombinedFootingInput } from '../engine/combinedFooting'
+import { CombinedFootingSchematic } from '../components/CombinedFootingSchematic'
+import { Diagram } from '../components/Diagram'
+import { Math } from '../lib/math'
+import { f0, f2, f3 } from '../lib/format'
+import 'katex/dist/katex.min.css'
+
+interface FormState {
+  col1Width: number
+  col2Width: number
+  spacing: number
+  dl1: number; ll1: number
+  dl2: number; ll2: number
+  leftRestrict: boolean
+  rightRestrict: boolean
+  leftOverhang: number
+  rightOverhang: number
+  fc: number
+  fy: number
+  qAllow: number
+  gammaSoil: number
+  gammaConc: number
+  surcharge: number
+  H: number
+  barDia: number
+  cover: number
+}
+
+const DEFAULTS: FormState = {
+  col1Width: 400,
+  col2Width: 400,
+  spacing: 4.0,
+  dl1: 600, ll1: 400,
+  dl2: 500, ll2: 300,
+  leftRestrict: true,
+  rightRestrict: false,
+  leftOverhang: 0,
+  rightOverhang: 0,
+  fc: 28,
+  fy: 415,
+  qAllow: 200,
+  gammaSoil: 18,
+  gammaConc: 24,
+  surcharge: 0,
+  H: 1.6,
+  barDia: 20,
+  cover: 75,
+}
+
+function NumField({ label, unit, value, onChange, step = 'any' }: {
+  label: ReactNode; unit?: string; value: number; onChange: (v: number) => void; step?: string
+}) {
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="mb-1 font-medium text-slate-600">
+        {label}{unit ? <span className="text-slate-400"> ({unit})</span> : null}
+      </span>
+      <input
+        type="number" inputMode="decimal" step={step} value={Number.isFinite(value) ? value : ''}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none focus:ring-1 focus:ring-[#0056b3]"
+      />
+    </label>
+  )
+}
+
+function Toggle({ label, value, onChange }: { label: ReactNode; value: boolean; onChange: (v: boolean) => void }) {
+  return (
+    <label className="flex cursor-pointer items-center gap-2 text-sm">
+      <input type="checkbox" checked={value} onChange={(e) => onChange(e.target.checked)}
+        className="h-4 w-4 rounded border-slate-300 text-[#0056b3] focus:ring-[#0056b3]" />
+      <span className="font-medium text-slate-600">{label}</span>
+    </label>
+  )
+}
+
+function Card({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">{title}</legend>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">{children}</div>
+    </fieldset>
+  )
+}
+
+function Row({ label, value, check }: { label: ReactNode; value: ReactNode; check?: ReactNode }) {
+  return (
+    <div className="flex items-baseline justify-between gap-3 border-b border-slate-100 py-1.5 last:border-0">
+      <span className="text-sm text-slate-600">{label}</span>
+      <span className="text-right text-sm font-semibold text-slate-800">{value}</span>
+      {check ? <span className="w-36 text-right text-xs text-slate-500">{check}</span> : null}
+    </div>
+  )
+}
+
+export default function CombinedFootingDesign() {
+  const [form, setForm] = useState<FormState>(DEFAULTS)
+  const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) => setForm((s) => ({ ...s, [k]: v }))
+
+  const valid = useMemo(() => {
+    const nums: (keyof FormState)[] = [
+      'col1Width', 'col2Width', 'spacing', 'dl1', 'll1', 'dl2', 'll2',
+      'leftOverhang', 'rightOverhang', 'fc', 'fy', 'qAllow', 'gammaSoil', 'gammaConc', 'surcharge', 'H', 'barDia', 'cover',
+    ]
+    if (!nums.every((k) => Number.isFinite(form[k] as number))) return false
+    return form.spacing > 0 && form.qAllow > 0 && form.fc > 0 && form.fy > 0
+  }, [form])
+
+  const result = useMemo(() => {
+    if (!valid) return null
+    const input: CombinedFootingInput = { ...form }
+    try {
+      const r = designCombinedFooting(input)
+      return r.qNet > 0 ? r : null
+    } catch {
+      return null
+    }
+  }, [form, valid])
+
+  const vlines = result
+    ? [{ x: result.x1, label: 'C1' }, { x: result.x2, label: 'C2' }]
+    : []
+
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <Link to="/" className="text-sm text-[#0056b3] hover:underline">← Home</Link>
+      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Combined Footing Design</h1>
+      <p className="mt-1 text-slate-600">
+        Two-column combined footing (rigid / conventional method). Rectangular when one edge is free, trapezoidal
+        when both are property-restricted. Results update live.
+      </p>
+
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
+        {/* ── Inputs ── */}
+        <div className="space-y-5">
+          <Card title="Geometry">
+            <NumField label={<>Column 1 <Math tex="c_1" /></>} unit="mm" value={form.col1Width} onChange={set('col1Width')} />
+            <NumField label={<>Column 2 <Math tex="c_2" /></>} unit="mm" value={form.col2Width} onChange={set('col2Width')} />
+            <NumField label="C/C spacing" unit="m" value={form.spacing} onChange={set('spacing')} />
+            <div className="col-span-full grid grid-cols-2 gap-4">
+              <Toggle label="Left edge restricted" value={form.leftRestrict} onChange={set('leftRestrict')} />
+              <Toggle label="Right edge restricted" value={form.rightRestrict} onChange={set('rightRestrict')} />
+            </div>
+            {form.leftRestrict && (
+              <NumField label="Left overhang" unit="mm" value={form.leftOverhang} onChange={set('leftOverhang')} />
+            )}
+            {form.rightRestrict && (
+              <NumField label="Right overhang" unit="mm" value={form.rightOverhang} onChange={set('rightOverhang')} />
+            )}
+            <p className="col-span-full text-xs text-slate-400">
+              Both edges restricted → trapezoidal (CTF). Otherwise the slab is rectangular (CRF) and sized about the
+              service-load resultant so bearing is uniform.
+            </p>
+          </Card>
+
+          <Card title="Loads">
+            <NumField label={<>Col 1 dead <Math tex="D_1" /></>} unit="kN" value={form.dl1} onChange={set('dl1')} />
+            <NumField label={<>Col 1 live <Math tex="L_1" /></>} unit="kN" value={form.ll1} onChange={set('ll1')} />
+            <div className="hidden lg:block" />
+            <NumField label={<>Col 2 dead <Math tex="D_2" /></>} unit="kN" value={form.dl2} onChange={set('dl2')} />
+            <NumField label={<>Col 2 live <Math tex="L_2" /></>} unit="kN" value={form.ll2} onChange={set('ll2')} />
+          </Card>
+
+          <Card title="Materials">
+            <NumField label={<Math tex="f'_c" />} unit="MPa" value={form.fc} onChange={set('fc')} />
+            <NumField label={<Math tex="f_y" />} unit="MPa" value={form.fy} onChange={set('fy')} />
+            <NumField label={<>Bar <Math tex="d_b" /></>} unit="mm" value={form.barDia} onChange={set('barDia')} />
+            <NumField label="Clear cover" unit="mm" value={form.cover} onChange={set('cover')} />
+          </Card>
+
+          <Card title="Soil & Geometry">
+            <NumField label={<Math tex="q_a" />} unit="kPa" value={form.qAllow} onChange={set('qAllow')} />
+            <NumField label={<Math tex="\gamma_{soil}" />} unit="kN/m³" value={form.gammaSoil} onChange={set('gammaSoil')} />
+            <NumField label={<Math tex="\gamma_{conc}" />} unit="kN/m³" value={form.gammaConc} onChange={set('gammaConc')} />
+            <NumField label={<>Total depth <Math tex="H" /></>} unit="m" value={form.H} onChange={set('H')} />
+            <NumField label="Surcharge" unit="kPa" value={form.surcharge} onChange={set('surcharge')} />
+          </Card>
+        </div>
+
+        {/* ── Results ── */}
+        <div className="space-y-5">
+          <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Plan</h2>
+            {result ? (
+              <CombinedFootingSchematic
+                shape={result.shape} Bx={result.Bx} By={result.By} By1={result.By1} By2={result.By2}
+                x1={result.x1} x2={result.x2} col1Width={form.col1Width} col2Width={form.col2Width}
+              />
+            ) : (
+              <p className="py-8 text-center text-sm text-slate-400">Enter valid inputs — net bearing must be positive.</p>
+            )}
+          </div>
+
+          {result && (
+            <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Results</h2>
+              <Row label="Shape" value={result.shape} />
+              <Row label={<Math tex="q_{net}" />} value={`${f3(result.qNet)} kPa`} />
+              <Row label="Plan size"
+                value={result.shape[0] === 'T'
+                  ? `${f2(result.Bx)} m × (${f2(result.By1)}→${f2(result.By2)}) m`
+                  : `${f2(result.Bx)} × ${f2(result.By)} m`}
+                check={result.widened ? 'widened for containment' : undefined} />
+              <Row label={<>Factored loads <Math tex="P_{u1}/P_{u2}" /></>} value={`${f0(result.Pu1)} / ${f0(result.Pu2)} kN`} />
+              <Row label="Slab thickness Dc" value={`${f0(result.Dc)} mm`}
+                check={`d punch ${f0(result.dPunch)} · beam ${f0(result.dBeam)} mm`} />
+              <Row label={<>Peak +M <Math tex="M_u" /></>} value={`${f0(result.mPeak)} kN·m`} check={`at x = ${f2(result.xPeak)} m`} />
+            </div>
+          )}
+
+          {result && (
+            <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Longitudinal flexure</h2>
+              {result.longSections.map((s) => (
+                <Row key={s.label} label={s.label}
+                  value={`${s.bars} ⌀${form.barDia} @ ${f0(s.spacing)} mm`}
+                  check={`Mu=${f0(s.Mu)} kN·m · ${s.top ? 'top' : 'bottom'}`} />
+              ))}
+              <h2 className="mb-2 mt-4 text-[1.02rem] font-bold text-[#0056b3]">Transverse (under columns)</h2>
+              {result.transverse.map((t) => (
+                <Row key={t.label} label={t.label}
+                  value={`⌀${form.barDia} @ ${f0(t.spacing)} mm`}
+                  check={`As=${f0(t.AsPerM)} mm²/m`} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ── Diagrams (full width) ── */}
+      {result && (
+        <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
+          <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <Diagram xs={result.samples.x} ys={result.samples.w} title="SOIL REACTION (w)" unit="kN/m"
+              color="#16a34a" vlines={vlines} markExtrema={false} decimals={1} />
+          </div>
+          <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <Diagram xs={result.samples.x} ys={result.samples.V} title="SHEAR (Vu)" unit="kN"
+              color="#dc2626" vlines={vlines} decimals={0} />
+          </div>
+          <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <Diagram xs={result.samples.x} ys={result.samples.M} title="MOMENT (Mu)" unit="kN·m"
+              color="#0056b3" vlines={vlines} decimals={0} />
+          </div>
+        </div>
+      )}
+
+      <div className="mt-6 rounded-xl border border-slate-200 bg-white p-4 text-sm text-slate-600 shadow-sm">
+        <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Basis</h2>
+        <Math block tex={String.raw`q_{net} = q_a - \gamma_s D_s - \gamma_c D_c - q,\qquad P_u = \max(1.4D,\ 1.2D + 1.6L)`} />
+        <p className="mt-1 text-xs text-slate-400">
+          Rigid (conventional) method: equivalent line load varies linearly so its resultant matches the factored
+          column loads; V(x)/M(x) integrated along the footing. NSCP 2015 / ACI 318-14. φ: shear 0.75, flexure 0.90.
+          The Winkler (flexible) method is a planned follow-up.
+        </p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Builds the visible UI on top of the merged `designCombinedFooting` rigid engine (#110).

## What's new
- **`Diagram.tsx`** — generic SVG line chart driven by the engine's `samples` arrays. Zero baseline, signed fill, global max/min diamond markers with value@station labels, and dashed column verticals. Reused for the soil-reaction, shear, and moment plots.
- **`CombinedFootingSchematic.tsx`** — plan view that renders both columns on either a rectangular (CRF) or trapezoidal (CTF) slab outline.
- **`CombinedFootingDesign.tsx`** — two-column form (per-column D/L, c/c spacing, edge restraints + overhangs, materials, soil). Live `useMemo` compute → shape, `q_net`, plan size (flags containment widening), factored loads, slab thickness (punching + beam `d`), peak `M_u`, longitudinal flexure at the three critical sections, and per-metre transverse steel under each column. Soil-reaction / shear / moment diagrams below.
- Wired `/combined` route + a Home-page button.
- Removed an unused `PILE` const in `PileCapSchematic.tsx` that was breaking `tsc -b`.

## Method
Rigid (conventional) method — equivalent linearly-varying line load whose resultant matches the factored column loads; V(x)/M(x) integrated along the footing. NSCP 2015 / ACI 318-14, φ shear 0.75 / flexure 0.90. The Winkler (flexible) method is the planned follow-up.

## Verification
- `npm run build` green (tsc + vite).
- `npm test` — 46 passing (incl. combined-footing equilibrium + containment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)