### PR TITLE
Flexible (Winkler) combined-footing method + rigid/flexible toggle

### DIFF
--- a/webapp/src/engine/flexibleCombinedFooting.test.ts
+++ b/webapp/src/engine/flexibleCombinedFooting.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { designFlexibleCombinedFooting, type FlexibleCombinedInput } from './flexibleCombinedFooting';
+
+const base: Omit<FlexibleCombinedInput, 'leftRestrict' | 'rightRestrict'> = {
+  col1Width: 400, col2Width: 400, spacing: 4.0,
+  dl1: 600, ll1: 400, dl2: 500, ll2: 300,
+  leftOverhang: 0, rightOverhang: 0,
+  fc: 28, fy: 415, qAllow: 200, gammaSoil: 18, gammaConc: 24, surcharge: 0,
+  H: 1.6, barDia: 20, cover: 75,
+  ksubgrade: 40000,
+};
+
+function endEquilibrium(r: ReturnType<typeof designFlexibleCombinedFooting>) {
+  const n = r.samples.x.length - 1;
+  // free ends: V and M return to ~0 (self-equilibrated on the springs)
+  return Math.abs(r.samples.V[n]) < 0.02 * r.Pu && Math.abs(r.samples.M[n]) < 0.02 * Math.abs(r.mPeak || 1);
+}
+
+describe('flexible (Winkler) combined footing', () => {
+  it('self-equilibrates and settles downward', () => {
+    const r = designFlexibleCombinedFooting({ ...base, leftRestrict: true, rightRestrict: false });
+    expect(endEquilibrium(r)).toBe(true);
+    expect(r.yMax).toBeGreaterThan(0);            // settlement is downward
+    expect(r.EI).toBeGreaterThan(0);
+    expect(r.longSections).toHaveLength(3);
+    expect(r.longSections.every((s) => s.bars >= 2)).toBe(true);
+  });
+
+  it('total soil reaction balances the factored column loads', () => {
+    const r = designFlexibleCombinedFooting({ ...base, leftRestrict: false, rightRestrict: false });
+    const xs = r.samples.x, w = r.samples.w;
+    let R = 0;
+    for (let k = 1; k < xs.length; k++) R += ((w[k] + w[k - 1]) / 2) * (xs[k] - xs[k - 1]);
+    expect(R).toBeCloseTo(r.Pu, 0);               // ∫ k·y dx ≈ ΣPu
+  });
+
+  it('symmetric loads give a symmetric settlement profile', () => {
+    const r = designFlexibleCombinedFooting({
+      ...base, dl1: 600, ll1: 400, dl2: 600, ll2: 400,
+      leftRestrict: false, rightRestrict: false,
+    });
+    const y = r.samples.y, n = y.length - 1;
+    for (let k = 0; k <= n; k++) {
+      expect(Math.abs(y[k] - y[n - k])).toBeLessThan(1e-6 + 0.02 * Math.abs(r.yMax));
+    }
+  });
+
+  it('a stiffer subgrade reduces settlement', () => {
+    const soft = designFlexibleCombinedFooting({ ...base, leftRestrict: false, rightRestrict: false, ksubgrade: 20000 });
+    const hard = designFlexibleCombinedFooting({ ...base, leftRestrict: false, rightRestrict: false, ksubgrade: 80000 });
+    expect(hard.yMax).toBeLessThan(soft.yMax);
+  });
+});

--- a/webapp/src/engine/flexibleCombinedFooting.ts
+++ b/webapp/src/engine/flexibleCombinedFooting.ts
@@ -1,0 +1,192 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Combined footing — FLEXIBLE (Winkler) method.
+// Models the footing as a beam on an elastic foundation: the soil reacts in
+// proportion to local settlement, q(x) = k_s·B·y(x), instead of the rigid
+// method's assumed-linear pressure. Solved with 2-node Hermitian beam
+// elements + the consistent Winkler foundation stiffness; the soil springs
+// remove the free-free rigid-body modes, so no external supports are needed.
+//
+// Geometry (Bx, By, Dc, q_net) is taken from the rigid design so the two
+// methods are compared on the same section; only the internal V(x)/M(x)
+// distribution and the resulting longitudinal steel differ.
+// ─────────────────────────────────────────────────────────────────────────
+import { designCombinedFooting, type CombinedFootingInput, type FlexSection } from './combinedFooting';
+import { flexuralSteel, barLayout } from './flexure';
+
+export interface FlexibleCombinedInput extends CombinedFootingInput {
+  /** Modulus of subgrade reaction, kN/m³. */
+  ksubgrade: number;
+  /** Mesh density (beam elements). Default 120. */
+  nElements?: number;
+}
+
+export interface FlexibleCombinedResult {
+  shape: 'Rectangular (CRF)' | 'Trapezoidal (CTF)';
+  Bx: number; By: number;
+  x1: number; x2: number;
+  Pu: number; Pu1: number; Pu2: number; qNet: number;
+  Dc: number;
+  /** Concrete modulus Ec (MPa) and section EI (kN·m²). */
+  Ec: number; EI: number;
+  /** Characteristic length 1/β (m) and the dimensionless rigidity λL = β·Bx. */
+  charLength: number; betaBx: number;
+  /** Settlement extremes (mm, + downward). */
+  yMax: number; yMin: number;
+  /** Peak soil pressure under the footing and whether it stays within q_net. */
+  qSoilMax: number; bearingOK: boolean;
+  xPeak: number; mPeak: number;
+  vMax: number;
+  longSections: FlexSection[];
+  /** Sampled along x: V (kN), M (kN·m), w soil line-load (kN/m), y settlement (mm). */
+  samples: { x: number[]; V: number[]; M: number[]; w: number[]; y: number[] };
+}
+
+// ── Dense linear solver (Gaussian elimination, partial pivot) ──
+function solveLinear(A: number[][], b: number[]): number[] {
+  const n = b.length;
+  const M = A.map((row, i) => [...row, b[i]]);
+  for (let col = 0; col < n; col++) {
+    let piv = col;
+    for (let r = col + 1; r < n; r++) if (Math.abs(M[r][col]) > Math.abs(M[piv][col])) piv = r;
+    [M[col], M[piv]] = [M[piv], M[col]];
+    const d = M[col][col];
+    for (let r = col + 1; r < n; r++) {
+      const f = M[r][col] / d;
+      if (f === 0) continue;
+      for (let c = col; c <= n; c++) M[r][c] -= f * M[col][c];
+    }
+  }
+  const x = new Array(n).fill(0);
+  for (let r = n - 1; r >= 0; r--) {
+    let s = M[r][n];
+    for (let c = r + 1; c < n; c++) s -= M[r][c] * x[c];
+    x[r] = s / M[r][r];
+  }
+  return x;
+}
+
+// Hermite cubic shape functions on a unit element, scaled length L.
+function hermite(xi: number, L: number): [number, number, number, number] {
+  const x2 = xi * xi, x3 = x2 * xi;
+  return [
+    1 - 3 * x2 + 2 * x3,
+    L * (xi - 2 * x2 + x3),
+    3 * x2 - 2 * x3,
+    L * (-x2 + x3),
+  ];
+}
+
+export function designFlexibleCombinedFooting(i: FlexibleCombinedInput): FlexibleCombinedResult {
+  // ── Reuse the rigid design for geometry + thickness ──
+  const rigid = designCombinedFooting(i);
+  const { Bx, By, x1, x2, Pu, Pu1, Pu2, qNet, Dc, shape } = rigid;
+
+  // ── Section stiffness ──
+  const Ec = 4700 * Math.sqrt(i.fc);             // MPa
+  const EcK = Ec * 1000;                          // kPa = kN/m²
+  const Iz = (By * Math.pow(Dc / 1000, 3)) / 12;  // m⁴
+  const EI = EcK * Iz;                            // kN·m²
+  const kf = i.ksubgrade * By;                    // foundation modulus per length, kN/m²
+  const beta = Math.pow(kf / (4 * EI), 0.25);     // 1/m
+
+  // ── Mesh: uniform, with nodes forced at the two column centres ──
+  const nE = Math.max(40, i.nElements ?? 120);
+  const set = new Set<number>();
+  for (let k = 0; k <= nE; k++) set.add(+((Bx * k) / nE).toFixed(6));
+  set.add(+x1.toFixed(6)); set.add(+x2.toFixed(6));
+  const nodes = [...set].sort((a, b) => a - b);
+  const nN = nodes.length, ndof = 2 * nN;
+
+  // ── Assemble global stiffness ──
+  const K: number[][] = Array.from({ length: ndof }, () => new Array(ndof).fill(0));
+  for (let e = 0; e < nN - 1; e++) {
+    const L = nodes[e + 1] - nodes[e];
+    const L2 = L * L, L3 = L2 * L;
+    const eb = EI / L3, ef = (kf * L) / 420;
+    const Kb = [
+      [12 * eb, 6 * L * eb, -12 * eb, 6 * L * eb],
+      [6 * L * eb, 4 * L2 * eb, -6 * L * eb, 2 * L2 * eb],
+      [-12 * eb, -6 * L * eb, 12 * eb, -6 * L * eb],
+      [6 * L * eb, 2 * L2 * eb, -6 * L * eb, 4 * L2 * eb],
+    ];
+    const Kfo = [
+      [156 * ef, 22 * L * ef, 54 * ef, -13 * L * ef],
+      [22 * L * ef, 4 * L2 * ef, 13 * L * ef, -3 * L2 * ef],
+      [54 * ef, 13 * L * ef, 156 * ef, -22 * L * ef],
+      [-13 * L * ef, -3 * L2 * ef, -22 * L * ef, 4 * L2 * ef],
+    ];
+    const map = [2 * e, 2 * e + 1, 2 * e + 2, 2 * e + 3];
+    for (let a = 0; a < 4; a++) for (let b = 0; b < 4; b++) K[map[a]][map[b]] += Kb[a][b] + Kfo[a][b];
+  }
+
+  // ── Load vector: column loads as nodal point forces (downward +) ──
+  const F = new Array(ndof).fill(0);
+  const nodeAt = (x: number) => nodes.findIndex((nx) => Math.abs(nx - x) < 1e-6);
+  F[2 * nodeAt(x1)] += Pu1;
+  F[2 * nodeAt(x2)] += Pu2;
+
+  const d = solveLinear(K, F);
+
+  // ── Sample settlement & soil line-load via Hermite interpolation ──
+  const N = 200;
+  const xs: number[] = [], yLine: number[] = [], wLine: number[] = [];
+  let seg = 0;
+  for (let k = 0; k <= N; k++) {
+    const x = (Bx * k) / N;
+    while (seg < nN - 2 && nodes[seg + 1] < x) seg++;
+    const L = nodes[seg + 1] - nodes[seg];
+    const xi = L > 0 ? (x - nodes[seg]) / L : 0;
+    const [n1, n2, n3, n4] = hermite(xi, L);
+    const y = n1 * d[2 * seg] + n2 * d[2 * seg + 1] + n3 * d[2 * seg + 2] + n4 * d[2 * seg + 3];
+    xs.push(x); yLine.push(y); wLine.push(kf * y);  // kN/m, upward reaction
+  }
+
+  // ── Integrate for V and M (matches the rigid sign convention) ──
+  const V: number[] = [], M: number[] = [];
+  let Vsoil = 0, Macc = 0, prevW = wLine[0], prevV = 0;
+  for (let k = 0; k <= N; k++) {
+    const x = xs[k];
+    if (k > 0) { const dx = x - xs[k - 1]; Vsoil += ((wLine[k] + prevW) / 2) * dx; prevW = wLine[k]; }
+    let v = Vsoil;
+    if (x >= x1 - 1e-9) v -= Pu1;
+    if (x >= x2 - 1e-9) v -= Pu2;
+    if (k > 0) { const dx = x - xs[k - 1]; Macc += ((v + prevV) / 2) * dx; }
+    prevV = v;
+    V.push(v); M.push(Macc);
+  }
+
+  // ── Extremes ──
+  let xPeak = 0, mPeak = 0, vMax = 0, yMax = 0, yMin = 0, qSoilMax = 0;
+  M.forEach((m, k) => { if (Math.abs(m) > Math.abs(mPeak)) { mPeak = m; xPeak = xs[k]; } });
+  V.forEach((v) => { if (Math.abs(v) > vMax) vMax = Math.abs(v); });
+  yLine.forEach((y) => { if (y > yMax) yMax = y; if (y < yMin) yMin = y; });
+  wLine.forEach((w) => { const q = w / By; if (q > qSoilMax) qSoilMax = q; });
+
+  // ── Longitudinal flexure from the BEF moments ──
+  const dFlex = Dc - i.cover - i.barDia / 2;
+  const Mabs = (x: number) => {
+    let lo = 0; for (let k = 0; k < xs.length; k++) if (xs[k] <= x) lo = k;
+    return M[Math.min(lo, M.length - 1)];
+  };
+  const mkSection = (label: string, x: number): FlexSection => {
+    const m = Mabs(x), Mu = Math.abs(m), b = By * 1000;
+    const flex = flexuralSteel({ Mu, b, d: dFlex, fc: i.fc, fy: i.fy });
+    const layout = barLayout({ As: flex.As, db: i.barDia, b, cover: i.cover });
+    return { label, x, Mu, b, As: flex.As, bars: layout.n, spacing: layout.spacing, top: m < 0 };
+  };
+  const cx1m = i.col1Width / 1000, cx2m = i.col2Width / 1000;
+  const longSections = [
+    mkSection('Max |M| (BEF)', xPeak),
+    mkSection('Col 1 inner face', x1 + cx1m / 2),
+    mkSection('Col 2 inner face', x2 - cx2m / 2),
+  ];
+
+  return {
+    shape, Bx, By, x1, x2, Pu, Pu1, Pu2, qNet, Dc, Ec, EI,
+    charLength: 1 / beta, betaBx: beta * Bx,
+    yMax: yMax * 1000, yMin: yMin * 1000,
+    qSoilMax, bearingOK: qSoilMax <= qNet + 1e-6,
+    xPeak, mPeak, vMax, longSections,
+    samples: { x: xs, V, M, w: wLine, y: yLine.map((y) => y * 1000) },
+  };
+}

--- a/webapp/src/pages/CombinedFootingDesign.tsx
+++ b/webapp/src/pages/CombinedFootingDesign.tsx
@@ -1,13 +1,18 @@
 import { useMemo, useState, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { designCombinedFooting, type CombinedFootingInput } from '../engine/combinedFooting'
+import { designFlexibleCombinedFooting } from '../engine/flexibleCombinedFooting'
 import { CombinedFootingSchematic } from '../components/CombinedFootingSchematic'
 import { Diagram } from '../components/Diagram'
 import { Math } from '../lib/math'
 import { f0, f2, f3 } from '../lib/format'
 import 'katex/dist/katex.min.css'
 
+type Method = 'rigid' | 'flexible'
+
 interface FormState {
+  method: Method
+  ksubgrade: number
   col1Width: number
   col2Width: number
   spacing: number
@@ -29,6 +34,8 @@ interface FormState {
 }
 
 const DEFAULTS: FormState = {
+  method: 'rigid',
+  ksubgrade: 40000,
   col1Width: 400,
   col2Width: 400,
   spacing: 4.0,
@@ -76,6 +83,20 @@ function Toggle({ label, value, onChange }: { label: ReactNode; value: boolean; 
   )
 }
 
+function Select<T extends string>({ label, value, onChange, options }: {
+  label: string; value: T; onChange: (v: T) => void; options: [T, string][]
+}) {
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="mb-1 font-medium text-slate-600">{label}</span>
+      <select value={value} onChange={(e) => onChange(e.target.value as T)}
+        className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none">
+        {options.map(([v, t]) => <option key={v} value={v}>{t}</option>)}
+      </select>
+    </label>
+  )
+}
+
 function Card({ title, children }: { title: string; children: ReactNode }) {
   return (
     <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
@@ -119,6 +140,20 @@ export default function CombinedFootingDesign() {
     }
   }, [form, valid])
 
+  const flex = useMemo(() => {
+    if (!valid || form.method !== 'flexible' || !(form.ksubgrade > 0)) return null
+    try {
+      const r = designFlexibleCombinedFooting({ ...form, ksubgrade: form.ksubgrade })
+      return r.qNet > 0 ? r : null
+    } catch {
+      return null
+    }
+  }, [form, valid])
+
+  const flexible = form.method === 'flexible'
+  // Diagrams & longitudinal steel come from the active method; geometry/plan/transverse from rigid.
+  const samples = flexible && flex ? flex.samples : result?.samples
+  const longSections = flexible && flex ? flex.longSections : result?.longSections
   const vlines = result
     ? [{ x: result.x1, label: 'C1' }, { x: result.x2, label: 'C2' }]
     : []
@@ -128,13 +163,28 @@ export default function CombinedFootingDesign() {
       <Link to="/" className="text-sm text-[#0056b3] hover:underline">← Home</Link>
       <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Combined Footing Design</h1>
       <p className="mt-1 text-slate-600">
-        Two-column combined footing (rigid / conventional method). Rectangular when one edge is free, trapezoidal
-        when both are property-restricted. Results update live.
+        Two-column combined footing. Rectangular when one edge is free, trapezoidal when both are property-restricted.
+        Choose the <b>rigid</b> (linear-pressure) or <b>flexible</b> (Winkler beam-on-elastic-foundation) method —
+        geometry is shared; the flexible method recomputes V/M from the settlement field. Results update live.
       </p>
 
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
         {/* ── Inputs ── */}
         <div className="space-y-5">
+          <Card title="Analysis method">
+            <Select label="Method" value={form.method} onChange={set('method')}
+              options={[['rigid', 'Rigid (conventional)'], ['flexible', 'Flexible (Winkler)']]} />
+            {flexible && (
+              <NumField label={<>Subgrade <Math tex="k_s" /></>} unit="kN/m³" value={form.ksubgrade} onChange={set('ksubgrade')} />
+            )}
+            {flexible && (
+              <p className="col-span-full text-xs text-slate-400">
+                Beam-on-elastic-foundation FEM (Hermitian elements + consistent Winkler springs). Soil reaction
+                q(x) = k_s·B·y(x). Typical k_s: loose sand ~10–25, dense sand / stiff clay ~40–120 MN/m³.
+              </p>
+            )}
+          </Card>
+
           <Card title="Geometry">
             <NumField label={<>Column 1 <Math tex="c_1" /></>} unit="mm" value={form.col1Width} onChange={set('col1Width')} />
             <NumField label={<>Column 2 <Math tex="c_2" /></>} unit="mm" value={form.col2Width} onChange={set('col2Width')} />
@@ -206,14 +256,33 @@ export default function CombinedFootingDesign() {
               <Row label={<>Factored loads <Math tex="P_{u1}/P_{u2}" /></>} value={`${f0(result.Pu1)} / ${f0(result.Pu2)} kN`} />
               <Row label="Slab thickness Dc" value={`${f0(result.Dc)} mm`}
                 check={`d punch ${f0(result.dPunch)} · beam ${f0(result.dBeam)} mm`} />
-              <Row label={<>Peak +M <Math tex="M_u" /></>} value={`${f0(result.mPeak)} kN·m`} check={`at x = ${f2(result.xPeak)} m`} />
+              {!flexible && (
+                <Row label={<>Peak +M <Math tex="M_u" /></>} value={`${f0(result.mPeak)} kN·m`} check={`at x = ${f2(result.xPeak)} m`} />
+              )}
+              {flexible && flex && (
+                <>
+                  <Row label={<>Section <Math tex="EI" /></>} value={`${f0(flex.EI / 1000)}×10³ kN·m²`} check={`Ec ${f0(flex.Ec)} MPa`} />
+                  <Row label={<>Rigidity <Math tex="\beta B_x" /></>} value={f2(flex.betaBx)}
+                    check={flex.betaBx < 1 ? 'short → ~rigid' : flex.betaBx > 3 ? 'long → flexible' : 'intermediate'} />
+                  <Row label="Max settlement" value={`${f2(flex.yMax)} mm`}
+                    check={flex.yMin < -1e-3 ? `uplift ${f2(flex.yMin)} mm` : 'full contact'} />
+                  <Row label={<Math tex="q_{soil,max}" />} value={`${f3(flex.qSoilMax)} kPa`}
+                    check={flex.bearingOK ? '✓ ≤ q_net' : '✗ > q_net'} />
+                  <Row label={<>Peak |M| <Math tex="M_u" /></>} value={`${f0(flex.mPeak)} kN·m`} check={`at x = ${f2(flex.xPeak)} m`} />
+                </>
+              )}
+              {flexible && !flex && (
+                <Row label="Flexible solve" value="—" check="check k_s > 0" />
+              )}
             </div>
           )}
 
           {result && (
             <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-              <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Longitudinal flexure</h2>
-              {result.longSections.map((s) => (
+              <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">
+                Longitudinal flexure {flexible && <span className="text-xs font-normal text-slate-400">(from BEF moments)</span>}
+              </h2>
+              {(longSections ?? result.longSections).map((s) => (
                 <Row key={s.label} label={s.label}
                   value={`${s.bars} ⌀${form.barDia} @ ${f0(s.spacing)} mm`}
                   check={`Mu=${f0(s.Mu)} kN·m · ${s.top ? 'top' : 'bottom'}`} />
@@ -230,31 +299,45 @@ export default function CombinedFootingDesign() {
       </div>
 
       {/* ── Diagrams (full width) ── */}
-      {result && (
-        <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
+      {samples && (
+        <div className={`mt-6 grid grid-cols-1 gap-6 ${flexible && flex ? 'lg:grid-cols-2' : 'lg:grid-cols-3'}`}>
           <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-            <Diagram xs={result.samples.x} ys={result.samples.w} title="SOIL REACTION (w)" unit="kN/m"
-              color="#16a34a" vlines={vlines} markExtrema={false} decimals={1} />
+            <Diagram xs={samples.x} ys={samples.w} title="SOIL REACTION (w)" unit="kN/m"
+              color="#16a34a" vlines={vlines} markExtrema={!flexible} decimals={1} />
           </div>
           <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-            <Diagram xs={result.samples.x} ys={result.samples.V} title="SHEAR (Vu)" unit="kN"
+            <Diagram xs={samples.x} ys={samples.V} title="SHEAR (Vu)" unit="kN"
               color="#dc2626" vlines={vlines} decimals={0} />
           </div>
           <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-            <Diagram xs={result.samples.x} ys={result.samples.M} title="MOMENT (Mu)" unit="kN·m"
+            <Diagram xs={samples.x} ys={samples.M} title="MOMENT (Mu)" unit="kN·m"
               color="#0056b3" vlines={vlines} decimals={0} />
           </div>
+          {flexible && flex && (
+            <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <Diagram xs={flex.samples.x} ys={flex.samples.y} title="SETTLEMENT (y, + down)" unit="mm"
+                color="#7c3aed" vlines={vlines} decimals={2} />
+            </div>
+          )}
         </div>
       )}
 
       <div className="mt-6 rounded-xl border border-slate-200 bg-white p-4 text-sm text-slate-600 shadow-sm">
         <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Basis</h2>
         <Math block tex={String.raw`q_{net} = q_a - \gamma_s D_s - \gamma_c D_c - q,\qquad P_u = \max(1.4D,\ 1.2D + 1.6L)`} />
-        <p className="mt-1 text-xs text-slate-400">
-          Rigid (conventional) method: equivalent line load varies linearly so its resultant matches the factored
-          column loads; V(x)/M(x) integrated along the footing. NSCP 2015 / ACI 318-14. φ: shear 0.75, flexure 0.90.
-          The Winkler (flexible) method is a planned follow-up.
-        </p>
+        {flexible ? (
+          <p className="mt-1 text-xs text-slate-400">
+            Flexible (Winkler) method: footing modelled as a beam on elastic foundation, EI·y'''' + k_s·B·y = column
+            loads, solved with Hermitian beam elements and consistent foundation springs. Soil pressure and internal
+            V/M follow the settlement field rather than an assumed linear pressure. Geometry/thickness are inherited
+            from the rigid sizing. NSCP 2015 / ACI 318-14. φ: shear 0.75, flexure 0.90.
+          </p>
+        ) : (
+          <p className="mt-1 text-xs text-slate-400">
+            Rigid (conventional) method: equivalent line load varies linearly so its resultant matches the factored
+            column loads; V(x)/M(x) integrated along the footing. NSCP 2015 / ACI 318-14. φ: shear 0.75, flexure 0.90.
+          </p>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
Adds the planned **flexible method** for combined footings as a sibling to the merged rigid engine (#110/#112), with a method toggle so the two are compared on identical inputs.

## Engine — `flexibleCombinedFooting.ts`
Beam-on-elastic-foundation (Winkler) FEM:
- 2-node **Hermitian beam elements** + the **consistent Winkler foundation stiffness** matrix. The soil springs supply stiffness in every DOF, so the free-free footing has no rigid-body modes — no external supports needed.
- Dense Gaussian solve (partial pivot); mesh forces nodes at both column centres so column loads are pure nodal forces.
- Soil reaction `q(x) = k_s·B·y(x)`; settlement field interpolated with the Hermite shape functions, then V(x)/M(x) integrated from it (same sign convention as the rigid `samples`).
- **Reuses the rigid design** for geometry (Bx, By) and thickness (Dc, hence EI), so only the internal-force distribution and the resulting longitudinal steel differ.
- Reports `Ec`/`EI`, characteristic length `1/β`, the **`βBx` rigidity index** (short→rigid, long→flexible), settlement extremes (incl. uplift flag), and **peak soil pressure vs `q_net`**.

## UI — `CombinedFootingDesign`
- **Method** toggle (Rigid / Flexible) + `k_s` subgrade field (flexible only).
- Flexible adds EI / rigidity / settlement / bearing-check rows, BEF-derived longitudinal steel, and a fourth **settlement diagram**. Diagrams and steel switch to the active method; plan + transverse steel stay shared.

## Verification
- 4 new unit tests (50 total passing): end equilibrium (V,M→0 at free ends), `∫k·y dx ≈ ΣPu`, symmetric load → symmetric settlement, stiffer subgrade → less settlement.
- `npm run build` green (tsc + vite).

Closes the combined-footing work: rigid + flexible methods both available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)