### PR TITLE
Printable / PDF-exportable report on design pages

### DIFF
--- a/webapp/src/components/ReportControls.tsx
+++ b/webapp/src/components/ReportControls.tsx
@@ -1,0 +1,55 @@
+import { useState, type JSX } from 'react'
+
+export interface ReportControlsProps {
+  /** Report heading, also used as the print/PDF document title. */
+  title: string
+}
+
+/**
+ * Reusable report bar: on screen it offers project / prepared-by fields and a
+ * "Print / Save PDF" button; in print it renders a clean letterhead. Pair with
+ * the `.no-print` / `.print-avoid-break` utilities (see index.css). Browser
+ * "Print → Save as PDF" is the export path — no extra dependency needed.
+ */
+export function ReportControls({ title }: ReportControlsProps): JSX.Element {
+  const [project, setProject] = useState('')
+  const [preparedBy, setPreparedBy] = useState('')
+  const today = new Date().toISOString().slice(0, 10)
+
+  const print = () => {
+    const prev = document.title
+    document.title = title + (project ? ` — ${project}` : '')
+    window.print()
+    window.setTimeout(() => { document.title = prev }, 500)
+  }
+
+  const field = (label: string, value: string, set: (v: string) => void, ph: string) => (
+    <label className="flex flex-col text-sm">
+      <span className="mb-1 font-medium text-slate-600">{label}</span>
+      <input value={value} onChange={(e) => set(e.target.value)} placeholder={ph}
+        className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none focus:ring-1 focus:ring-[#0056b3]" />
+    </label>
+  )
+
+  return (
+    <>
+      {/* On-screen controls */}
+      <div className="no-print mt-4 flex flex-wrap items-end gap-3 rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
+        {field('Project / job', project, setProject, 'e.g. Lot 12 Residence')}
+        {field('Prepared by', preparedBy, setPreparedBy, 'Engineer name')}
+        <button type="button" onClick={print}
+          className="ml-auto inline-flex items-center gap-2 rounded-lg bg-gradient-to-br from-[#0056b3] to-[#003f86] px-4 py-2 text-sm font-semibold text-white shadow-md transition hover:shadow-lg">
+          🖨 Print / Save PDF
+        </button>
+      </div>
+
+      {/* Print-only letterhead */}
+      <div className="print-only mb-4 border-b-2 border-[#0056b3] pb-2">
+        <h1 className="text-xl font-extrabold text-[#0056b3]">{title}</h1>
+        <p className="mt-0.5 text-xs text-slate-600">
+          Project: <b>{project || '—'}</b> &nbsp;·&nbsp; Prepared by: <b>{preparedBy || '—'}</b> &nbsp;·&nbsp; Date: <b>{today}</b>
+        </p>
+      </div>
+    </>
+  )
+}

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -14,3 +14,20 @@ body {
   color: #1f2933;
   background: #f5f7fa;
 }
+
+/* ── Print / PDF export ──────────────────────────────────────────────
+   Screen keeps the interactive chrome; print shows a clean report:
+   nav + buttons hidden, white background, cards kept whole across pages. */
+.print-only { display: none; }
+
+@media print {
+  @page { margin: 14mm; }
+  html, body { background: #fff !important; }
+  .no-print { display: none !important; }
+  .print-only { display: block !important; }
+  .print-avoid-break { break-inside: avoid; page-break-inside: avoid; }
+  /* flatten the on-screen panels for ink-friendly output */
+  .rounded-xl, .shadow-sm { box-shadow: none !important; }
+  main, .mx-auto { max-width: 100% !important; }
+  a[href]::after { content: ""; }
+}

--- a/webapp/src/pages/CombinedFootingDesign.tsx
+++ b/webapp/src/pages/CombinedFootingDesign.tsx
@@ -4,6 +4,7 @@ import { designCombinedFooting, type CombinedFootingInput } from '../engine/comb
 import { designFlexibleCombinedFooting } from '../engine/flexibleCombinedFooting'
 import { CombinedFootingSchematic } from '../components/CombinedFootingSchematic'
 import { Diagram } from '../components/Diagram'
+import { ReportControls } from '../components/ReportControls'
 import { Math } from '../lib/math'
 import { f0, f2, f3 } from '../lib/format'
 import 'katex/dist/katex.min.css'
@@ -160,13 +161,14 @@ export default function CombinedFootingDesign() {
 
   return (
     <div className="mx-auto max-w-6xl p-6">
-      <Link to="/" className="text-sm text-[#0056b3] hover:underline">← Home</Link>
+      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
       <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Combined Footing Design</h1>
-      <p className="mt-1 text-slate-600">
+      <p className="no-print mt-1 text-slate-600">
         Two-column combined footing. Rectangular when one edge is free, trapezoidal when both are property-restricted.
         Choose the <b>rigid</b> (linear-pressure) or <b>flexible</b> (Winkler beam-on-elastic-foundation) method —
         geometry is shared; the flexible method recomputes V/M from the settlement field. Results update live.
       </p>
+      <ReportControls title="Combined Footing Design Report" />
 
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
         {/* ── Inputs ── */}

--- a/webapp/src/pages/FoundationDesign.tsx
+++ b/webapp/src/pages/FoundationDesign.tsx
@@ -6,6 +6,7 @@ import { designEccentricSquareFooting } from '../engine/eccentricFooting'
 import { netBearing } from '../engine/bearing'
 import type { ColumnPosition } from '../engine/shear'
 import { FootingSchematic } from '../components/FootingSchematic'
+import { ReportControls } from '../components/ReportControls'
 import { Math } from '../lib/math'
 import { f0, f2, f3 } from '../lib/format'
 import 'katex/dist/katex.min.css'
@@ -180,9 +181,10 @@ export default function FoundationDesign() {
 
   return (
     <div className="mx-auto max-w-6xl p-6">
-      <Link to="/" className="text-sm text-[#0056b3] hover:underline">← Home</Link>
+      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
       <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Foundation Design</h1>
-      <p className="mt-1 text-slate-600">Isolated footing (square / rectangular, concentric / eccentric) — React + typed engine. Results update live.</p>
+      <p className="no-print mt-1 text-slate-600">Isolated footing (square / rectangular, concentric / eccentric) — React + typed engine. Results update live.</p>
+      <ReportControls title="Foundation Design Report" />
 
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
         {/* ── Inputs ── */}

--- a/webapp/src/pages/PileCapDesign.tsx
+++ b/webapp/src/pages/PileCapDesign.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { designPileCap, type PileArrangement } from '../engine/pileCap'
 import { PileCapSchematic } from '../components/PileCapSchematic'
+import { ReportControls } from '../components/ReportControls'
 import { Math as KTex } from '../lib/math'
 import { f0, f2, f3 } from '../lib/format'
 import 'katex/dist/katex.min.css'
@@ -159,11 +160,12 @@ export default function PileCapDesign() {
 
   return (
     <div className="mx-auto max-w-6xl p-6">
-      <Link to="/" className="text-sm text-[#0056b3] hover:underline">← Home</Link>
+      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
       <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Pile Cap Design</h1>
-      <p className="mt-1 text-slate-600">
+      <p className="no-print mt-1 text-slate-600">
         ACI 318-14 / NSCP 2015 — pile reactions, column & pile punching, one-way shear, flexure, development length.
       </p>
+      <ReportControls title="Pile Cap Design Report" />
 
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
         {/* ── Inputs ── */}


### PR DESCRIPTION
Adds a reusable **report / PDF export** to the React design pages. Browser *Print → Save as PDF* is the export path, so no new dependency.

> Stacked on #113 (flexible method). Base is `feature/combined-footing-flexible`; retarget to `main` once #113 merges.

## What's new
- **`ReportControls.tsx`** — on screen: *Project / job* and *Prepared by* fields + a **Print / Save PDF** button (sets a sensible PDF document title). In print: a clean letterhead (title · project · preparer · date).
- **Print stylesheet** (`index.css` `@media print`): hides nav links and the controls bar (`.no-print`), reveals the letterhead (`.print-only`), flattens shadows, lets cards avoid splitting across pages (`.print-avoid-break`), strips URL annotations.
- Wired into **Foundation**, **Pile Cap**, and **Combined Footing** pages (Home link + intro marked `no-print`).

## Verification
- `npm run build` green; existing 50 tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)