### PR TITLE
Migrate the 5 legacy quantity calculators (slab, beam, column, CHB, box culvert)

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -3,16 +3,30 @@ import { factoredLoad, beta1 } from './engine/loads'
 import FoundationDesign from './pages/FoundationDesign'
 import PileCapDesign from './pages/PileCapDesign'
 import CombinedFootingDesign from './pages/CombinedFootingDesign'
+import SlabEstimate from './pages/SlabEstimate'
+import ChbEstimate from './pages/ChbEstimate'
+import ColumnEstimate from './pages/ColumnEstimate'
+import BeamEstimate from './pages/BeamEstimate'
+import BoxCulvertEstimate from './pages/BoxCulvertEstimate'
+
+function Tile({ to, children }: { to: string; children: string }) {
+  return (
+    <Link to={to}
+      className="inline-block rounded-lg bg-gradient-to-br from-[#0056b3] to-[#003f86] px-5 py-2.5 font-semibold text-white shadow-md transition hover:shadow-lg">
+      {children} →
+    </Link>
+  )
+}
 
 function Home() {
   return (
-    <div className="mx-auto max-w-3xl p-8">
+    <div className="mx-auto max-w-4xl p-8">
       <h1 className="text-3xl font-extrabold tracking-tight text-[#0056b3]">
         Civil Engineering — React preview
       </h1>
       <p className="mt-2 text-slate-600">
-        New React&nbsp;+&nbsp;TypeScript app (Phase&nbsp;0). The calculation engine is being
-        ported to typed modules; the UI migrates page&nbsp;by&nbsp;page.
+        React&nbsp;+&nbsp;TypeScript app with a typed calculation engine. Structural design tools and
+        material take-off estimators, each with a printable / PDF report.
       </p>
 
       <div className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
@@ -26,25 +40,20 @@ function Home() {
         </p>
       </div>
 
-      <div className="mt-6 flex flex-wrap gap-3">
-        <Link
-          to="/foundation"
-          className="inline-block rounded-lg bg-gradient-to-br from-[#0056b3] to-[#003f86] px-5 py-2.5 font-semibold text-white shadow-md transition hover:shadow-lg"
-        >
-          Foundation Design →
-        </Link>
-        <Link
-          to="/pile-cap"
-          className="inline-block rounded-lg bg-gradient-to-br from-[#0056b3] to-[#003f86] px-5 py-2.5 font-semibold text-white shadow-md transition hover:shadow-lg"
-        >
-          Pile Cap Design →
-        </Link>
-        <Link
-          to="/combined"
-          className="inline-block rounded-lg bg-gradient-to-br from-[#0056b3] to-[#003f86] px-5 py-2.5 font-semibold text-white shadow-md transition hover:shadow-lg"
-        >
-          Combined Footing →
-        </Link>
+      <h2 className="mt-8 text-lg font-semibold text-slate-800">Structural design</h2>
+      <div className="mt-3 flex flex-wrap gap-3">
+        <Tile to="/foundation">Foundation Design</Tile>
+        <Tile to="/pile-cap">Pile Cap Design</Tile>
+        <Tile to="/combined">Combined Footing</Tile>
+      </div>
+
+      <h2 className="mt-8 text-lg font-semibold text-slate-800">Material estimation (quantity take-off)</h2>
+      <div className="mt-3 flex flex-wrap gap-3">
+        <Tile to="/estimate/slab">Slab</Tile>
+        <Tile to="/estimate/beam">Beam</Tile>
+        <Tile to="/estimate/column">Column</Tile>
+        <Tile to="/estimate/chb">CHB Wall</Tile>
+        <Tile to="/estimate/box-culvert">Box Culvert</Tile>
       </div>
     </div>
   )
@@ -57,6 +66,11 @@ export default function App() {
       <Route path="/foundation" element={<FoundationDesign />} />
       <Route path="/pile-cap" element={<PileCapDesign />} />
       <Route path="/combined" element={<CombinedFootingDesign />} />
+      <Route path="/estimate/slab" element={<SlabEstimate />} />
+      <Route path="/estimate/beam" element={<BeamEstimate />} />
+      <Route path="/estimate/column" element={<ColumnEstimate />} />
+      <Route path="/estimate/chb" element={<ChbEstimate />} />
+      <Route path="/estimate/box-culvert" element={<BoxCulvertEstimate />} />
     </Routes>
   )
 }

--- a/webapp/src/components/qty.tsx
+++ b/webapp/src/components/qty.tsx
@@ -1,0 +1,88 @@
+import { Link } from 'react-router-dom'
+import type { ReactNode } from 'react'
+import type { ConcreteClass } from '../engine/quantities'
+import { ReportControls } from './ReportControls'
+
+/** Numeric input. */
+export function Num({ label, unit, value, onChange, step = 'any' }: {
+  label: ReactNode; unit?: string; value: number; onChange: (v: number) => void; step?: string
+}) {
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="mb-1 font-medium text-slate-600">
+        {label}{unit ? <span className="text-slate-400"> ({unit})</span> : null}
+      </span>
+      <input type="number" inputMode="decimal" step={step} value={Number.isFinite(value) ? value : ''}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none focus:ring-1 focus:ring-[#0056b3]" />
+    </label>
+  )
+}
+
+export function Pick<T extends string>({ label, value, onChange, options }: {
+  label: string; value: T; onChange: (v: T) => void; options: [T, string][]
+}) {
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="mb-1 font-medium text-slate-600">{label}</span>
+      <select value={value} onChange={(e) => onChange(e.target.value as T)}
+        className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none">
+        {options.map(([v, t]) => <option key={v} value={v}>{t}</option>)}
+      </select>
+    </label>
+  )
+}
+
+export function ClassPick({ value, onChange }: { value: ConcreteClass; onChange: (v: ConcreteClass) => void }) {
+  return (
+    <Pick label="Concrete class" value={value} onChange={onChange}
+      options={[['AA', 'AA (12 bags/m³)'], ['A', 'A (9)'], ['B', 'B (7.5)'], ['C', 'C (6)'], ['custom', 'Custom factor']]} />
+  )
+}
+
+export function Card({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <fieldset className="print-avoid-break rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">{title}</legend>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">{children}</div>
+    </fieldset>
+  )
+}
+
+export function ResultCard({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className="print-avoid-break rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">{title}</h2>
+      {children}
+    </div>
+  )
+}
+
+export function Row({ label, value, sub }: { label: ReactNode; value: ReactNode; sub?: ReactNode }) {
+  return (
+    <div className="flex items-baseline justify-between gap-3 border-b border-slate-100 py-1.5 last:border-0">
+      <span className="text-sm text-slate-600">{label}</span>
+      <span className="text-right text-sm font-semibold text-slate-800">{value}</span>
+      {sub ? <span className="w-32 text-right text-xs text-slate-500">{sub}</span> : null}
+    </div>
+  )
+}
+
+/** Standard page shell: back link, title, intro, report bar. */
+export function QtyPage({ title, reportTitle, intro, children }: {
+  title: string; reportTitle: string; intro: ReactNode; children: ReactNode
+}) {
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
+      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">{title}</h1>
+      <p className="no-print mt-1 text-slate-600">{intro}</p>
+      <ReportControls title={reportTitle} />
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">{children}</div>
+    </div>
+  )
+}
+
+export const kg = (v: number) => (Number.isFinite(v) ? `${v.toFixed(1)} kg` : '—')
+export const m3 = (v: number) => (Number.isFinite(v) ? `${v.toFixed(2)} m³` : '—')
+export const m = (v: number) => (Number.isFinite(v) ? `${v.toFixed(2)} m` : '—')

--- a/webapp/src/engine/quantities.test.ts
+++ b/webapp/src/engine/quantities.test.ts
@@ -40,11 +40,12 @@ describe('slab estimate', () => {
       slabArea: 20, thickness: 0.1, numStructures: 1, concreteClass: 'A', spliceLength: 0.3,
       longSpanLength: 5, numLongPieces: 10, longDiaMm: 12,
       shortSpanLength: 4, numShortPieces: 12, shortDiaMm: 12,
-      lengthPerCut: 0.3, numIntersections: 120,
+      lengthPerCut: 0.3,
     });
     expect(r.volume).toBeCloseTo(2);              // 20*0.1
     expect(r.totalSteelWeight).toBeCloseTo(r.longSteel.weight + r.shortSteel.weight);
     expect(r.longSteel.netLength).toBeCloseTo(50);
+    expect(r.tieWire.intersections).toBe(120);    // derived: 10 long × 12 short
   });
 });
 
@@ -64,11 +65,12 @@ describe('column / beam / box culvert', () => {
       length: 0.4, width: 0.4, height: 3, numStructures: 4, concreteClass: 'A', spliceLength: 0.3,
       barLengthPerPiece: 3.5, numBars: 8, barDiaMm: 16,
       tieLengthPerSet: 1.4, numTieSets: 15, tieDiaMm: 10,
-      lengthPerCut: 0.3, numIntersections: 60,
+      lengthPerCut: 0.3,
     });
     expect(r.volume).toBeCloseTo(0.4 * 0.4 * 3 * 4);
     expect(r.lateralTies.pieces).toBeGreaterThan(0);
     expect(r.mainSteel.weight).toBeGreaterThan(0);
+    expect(r.tieWire.intersections).toBe(120);    // derived: 8 bars × 15 ties
   });
   it('beam: four bar groups sum to total', () => {
     const g = (d: number) => ({ lengthPerPiece: 6, numPieces: 2, diaMm: d });
@@ -76,10 +78,12 @@ describe('column / beam / box culvert', () => {
       length: 6, width: 0.25, height: 0.5, numStructures: 1, concreteClass: 'B', spliceLength: 0.3,
       topSupport: g(16), topMidspan: g(12), bottomSupport: g(12), bottomMidspan: g(20),
       stirrupLengthPerSet: 1.2, numStirrupSets: 30, stirrupDiaMm: 10,
-      lengthPerCut: 0.3, numIntersections: 120,
+      lengthPerCut: 0.3,
     });
     expect(r.mainBars).toHaveLength(4);
     expect(r.totalMainWeight).toBeCloseTo(r.mainBars.reduce((s, b) => s + b.takeoff.weight, 0));
+    // intersections = (max top 2 + max bottom 2) × 30 stirrups = 120
+    expect(r.tieWire.intersections).toBe(120);
   });
   it('box culvert RSB count = ceil(L/s)+1', () => {
     const r = estimateBoxCulvert({

--- a/webapp/src/engine/quantities.test.ts
+++ b/webapp/src/engine/quantities.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import {
+  concreteMaterials, barTakeoff, lateralTieTakeoff, tieWire,
+  estimateSlab, estimateChb, estimateColumn, estimateBeam, estimateBoxCulvert,
+} from './quantities';
+
+describe('shared helpers', () => {
+  it('concrete materials by mix class', () => {
+    const m = concreteMaterials(10, 'A');
+    expect(m.factor).toBe(9);
+    expect(m.cement).toBe(90);      // ceil(10*9)
+    expect(m.sand).toBeCloseTo(5);  // 10*0.5
+    expect(m.gravel).toBeCloseTo(10);
+  });
+  it('custom cement factor falls through', () => {
+    expect(concreteMaterials(10, 'custom', 8).cement).toBe(80);
+  });
+  it('bar take-off: 6 m bars less splice', () => {
+    const b = barTakeoff(20, 12, 0.3);            // splice usable = 5.7 m
+    expect(b.splice).toBeCloseTo(5.7);
+    expect(b.pieces).toBe(Math.ceil(20 / 5.7));   // 4
+    // 12 mm 6 m bar ≈ 5.33 kg → 4 bars ≈ 21.3 kg
+    expect(b.weight).toBeGreaterThan(20);
+    expect(b.weight).toBeLessThan(23);
+  });
+  it('lateral ties cut from 6 m bars', () => {
+    const t = lateralTieTakeoff(1.5, 40, 10, 2);  // 4 cuts/6m, 80 ties → 20 bars
+    expect(t.cutsPer6m).toBe(4);
+    expect(t.totalCuts).toBe(80);
+    expect(t.pieces).toBe(20);
+  });
+  it('tie wire rolls', () => {
+    expect(tieWire(0.3, 100, 5).rolls).toBe(1);   // 150 m < 2385
+  });
+});
+
+describe('slab estimate', () => {
+  it('volume + both-span steel + total', () => {
+    const r = estimateSlab({
+      slabArea: 20, thickness: 0.1, numStructures: 1, concreteClass: 'A', spliceLength: 0.3,
+      longSpanLength: 5, numLongPieces: 10, longDiaMm: 12,
+      shortSpanLength: 4, numShortPieces: 12, shortDiaMm: 12,
+      lengthPerCut: 0.3, numIntersections: 120,
+    });
+    expect(r.volume).toBeCloseTo(2);              // 20*0.1
+    expect(r.totalSteelWeight).toBeCloseTo(r.longSteel.weight + r.shortSteel.weight);
+    expect(r.longSteel.netLength).toBeCloseTo(50);
+  });
+});
+
+describe('chb estimate', () => {
+  it('net area, block count, mortar + plaster', () => {
+    const r = estimateChb({ wallArea: 30, holeArea: 4, size: '6' });
+    expect(r.netArea).toBe(26);
+    expect(r.pieces).toBe(Math.ceil(26 * 12.5)); // 325
+    expect(r.mortar.cement).toBe(Math.ceil(26 * 1.018));
+    expect(r.totalCement).toBe(r.mortar.cement + r.plaster.cement);
+  });
+});
+
+describe('column / beam / box culvert', () => {
+  it('column volume + ties', () => {
+    const r = estimateColumn({
+      length: 0.4, width: 0.4, height: 3, numStructures: 4, concreteClass: 'A', spliceLength: 0.3,
+      barLengthPerPiece: 3.5, numBars: 8, barDiaMm: 16,
+      tieLengthPerSet: 1.4, numTieSets: 15, tieDiaMm: 10,
+      lengthPerCut: 0.3, numIntersections: 60,
+    });
+    expect(r.volume).toBeCloseTo(0.4 * 0.4 * 3 * 4);
+    expect(r.lateralTies.pieces).toBeGreaterThan(0);
+    expect(r.mainSteel.weight).toBeGreaterThan(0);
+  });
+  it('beam: four bar groups sum to total', () => {
+    const g = (d: number) => ({ lengthPerPiece: 6, numPieces: 2, diaMm: d });
+    const r = estimateBeam({
+      length: 6, width: 0.25, height: 0.5, numStructures: 1, concreteClass: 'B', spliceLength: 0.3,
+      topSupport: g(16), topMidspan: g(12), bottomSupport: g(12), bottomMidspan: g(20),
+      stirrupLengthPerSet: 1.2, numStirrupSets: 30, stirrupDiaMm: 10,
+      lengthPerCut: 0.3, numIntersections: 120,
+    });
+    expect(r.mainBars).toHaveLength(4);
+    expect(r.totalMainWeight).toBeCloseTo(r.mainBars.reduce((s, b) => s + b.takeoff.weight, 0));
+  });
+  it('box culvert RSB count = ceil(L/s)+1', () => {
+    const r = estimateBoxCulvert({
+      grossArea: 6, holeArea: 2, length: 5, concreteClass: 'A', spliceLength: 0.3,
+      numLongTop: 6, longTopDiaMm: 16, numLongU: 6, longUDiaMm: 16,
+      rsbSpacing: 0.2, topBarLength: 2.5, topBarDiaMm: 12, uBarLength: 3.5, uBarDiaMm: 12,
+      lengthPerCut: 0.3,
+    });
+    expect(r.netArea).toBe(4);
+    expect(r.volume).toBeCloseTo(20);
+    expect(r.rsb.count).toBe(Math.ceil(5 / 0.2) + 1); // 26
+  });
+});

--- a/webapp/src/engine/quantities.ts
+++ b/webapp/src/engine/quantities.ts
@@ -69,7 +69,8 @@ export interface SlabInput {
   spliceLength: number;
   longSpanLength: number; numLongPieces: number; longDiaMm: number;
   shortSpanLength: number; numShortPieces: number; shortDiaMm: number;
-  lengthPerCut: number; numIntersections: number;
+  /** Wire used per bar crossing (m). Intersections are derived from the bar grid. */
+  lengthPerCut: number;
 }
 export interface SlabResult {
   volume: number; materials: ConcreteMaterials;
@@ -81,10 +82,12 @@ export function estimateSlab(i: SlabInput): SlabResult {
   const materials = concreteMaterials(volume, i.concreteClass, i.customFactor);
   const longSteel = barTakeoff(i.longSpanLength * i.numLongPieces * i.numStructures, i.longDiaMm, i.spliceLength);
   const shortSteel = barTakeoff(i.shortSpanLength * i.numShortPieces * i.numStructures, i.shortDiaMm, i.spliceLength);
+  // Tie wire ties every long×short bar crossing of the orthogonal mat.
+  const intersections = i.numLongPieces * i.numShortPieces;
   return {
     volume, materials, longSteel, shortSteel,
     totalSteelWeight: longSteel.weight + shortSteel.weight,
-    tieWire: tieWire(i.lengthPerCut, i.numIntersections, i.numStructures),
+    tieWire: tieWire(i.lengthPerCut, intersections, i.numStructures),
   };
 }
 
@@ -117,7 +120,8 @@ export interface ColumnInput {
   concreteClass: ConcreteClass; customFactor?: number; spliceLength: number;
   barLengthPerPiece: number; numBars: number; barDiaMm: number;
   tieLengthPerSet: number; numTieSets: number; tieDiaMm: number;
-  lengthPerCut: number; numIntersections: number;
+  /** Wire used per bar crossing (m). Intersections = vertical bars × ties. */
+  lengthPerCut: number;
 }
 export interface ColumnResult {
   volume: number; materials: ConcreteMaterials;
@@ -125,12 +129,14 @@ export interface ColumnResult {
 }
 export function estimateColumn(i: ColumnInput): ColumnResult {
   const volume = i.length * i.width * i.height * i.numStructures;
+  // Each vertical bar is tied to each lateral tie.
+  const intersections = i.numBars * i.numTieSets;
   return {
     volume,
     materials: concreteMaterials(volume, i.concreteClass, i.customFactor),
     mainSteel: barTakeoff(i.barLengthPerPiece * i.numBars * i.numStructures, i.barDiaMm, i.spliceLength),
     lateralTies: lateralTieTakeoff(i.tieLengthPerSet, i.numTieSets, i.tieDiaMm, i.numStructures),
-    tieWire: tieWire(i.lengthPerCut, i.numIntersections, i.numStructures),
+    tieWire: tieWire(i.lengthPerCut, intersections, i.numStructures),
   };
 }
 
@@ -142,7 +148,8 @@ export interface BeamInput {
   topSupport: BeamBarGroup; topMidspan: BeamBarGroup;
   bottomSupport: BeamBarGroup; bottomMidspan: BeamBarGroup;
   stirrupLengthPerSet: number; numStirrupSets: number; stirrupDiaMm: number;
-  lengthPerCut: number; numIntersections: number;
+  /** Wire used per bar crossing (m). Intersections = longitudinal bars × stirrups. */
+  lengthPerCut: number;
 }
 export interface BeamResult {
   volume: number; materials: ConcreteMaterials;
@@ -160,13 +167,18 @@ export function estimateBeam(i: BeamInput): BeamResult {
     grp('Bottom bars @ support', i.bottomSupport),
     grp('Bottom bars @ midspan', i.bottomMidspan),
   ];
+  // Each stirrup ties the longitudinal bars running through it; use the
+  // governing section count (max top + max bottom) crossing each stirrup.
+  const topBars = Math.max(i.topSupport.numPieces, i.topMidspan.numPieces);
+  const bottomBars = Math.max(i.bottomSupport.numPieces, i.bottomMidspan.numPieces);
+  const intersections = (topBars + bottomBars) * i.numStirrupSets;
   return {
     volume,
     materials: concreteMaterials(volume, i.concreteClass, i.customFactor),
     mainBars,
     totalMainWeight: mainBars.reduce((s, b) => s + b.takeoff.weight, 0),
     stirrups: lateralTieTakeoff(i.stirrupLengthPerSet, i.numStirrupSets, i.stirrupDiaMm, i.numStructures),
-    tieWire: tieWire(i.lengthPerCut, i.numIntersections, i.numStructures),
+    tieWire: tieWire(i.lengthPerCut, intersections, i.numStructures),
   };
 }
 

--- a/webapp/src/engine/quantities.ts
+++ b/webapp/src/engine/quantities.ts
@@ -1,0 +1,213 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Material take-off / quantity estimation — typed port of the legacy
+// scriptSlab / scriptChb / scriptColumn / scriptBeam / scriptBoxCulvert.
+// Lengths/areas/volumes are in metres; bar diameters are in MILLIMETRES
+// (the legacy forms used metres — converted here for a saner UI). Steel uses
+// 7850 kg/m³ and is bought in 6 m lengths; splices shorten the usable length.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type ConcreteClass = 'AA' | 'A' | 'B' | 'C' | 'custom';
+
+/** Cement bags per m³ by NSCP mix class (sand 0.5, gravel 1.0 m³ per m³). */
+export const CONCRETE_CLASS_FACTORS: Record<Exclude<ConcreteClass, 'custom'>, number> = {
+  AA: 12, A: 9, B: 7.5, C: 6,
+};
+const STEEL_DENSITY = 7850;   // kg/m³
+const BAR_LENGTH = 6;         // m, commercial length
+const TIE_WIRE_ROLL = 2385;   // m per roll
+
+const barAreaM2 = (diaMm: number) => (Math.PI / 4) * (diaMm / 1000) ** 2;
+
+export interface ConcreteMaterials {
+  volume: number; cement: number; sand: number; gravel: number; factor: number;
+}
+/** Cement (bags, rounded up), sand & gravel (m³) for a concrete volume. */
+export function concreteMaterials(volume: number, klass: ConcreteClass, customFactor = 0): ConcreteMaterials {
+  const factor = klass === 'custom' ? customFactor : CONCRETE_CLASS_FACTORS[klass];
+  return {
+    volume,
+    cement: Math.ceil(volume * factor),
+    sand: volume * 0.5,
+    gravel: volume * 1.0,
+    factor,
+  };
+}
+
+export interface BarTakeoff {
+  netLength: number; diaMm: number; area: number; splice: number; pieces: number; weight: number;
+}
+/** Commercial-bar take-off for a required net length (splice = usable bar length). */
+export function barTakeoff(netLength: number, diaMm: number, spliceLength: number): BarTakeoff {
+  const area = barAreaM2(diaMm);
+  const splice = BAR_LENGTH - spliceLength;
+  const pieces = splice > 0 ? Math.ceil(netLength / splice) : 0;
+  return { netLength, diaMm, area, splice, pieces, weight: pieces * BAR_LENGTH * area * STEEL_DENSITY };
+}
+
+export interface TieTakeoff {
+  cutsPer6m: number; totalCuts: number; diaMm: number; area: number; pieces: number; weight: number;
+}
+/** Stirrups / lateral ties cut from 6 m bars. */
+export function lateralTieTakeoff(lengthPerSet: number, noSets: number, diaMm: number, numStructures: number): TieTakeoff {
+  const cutsPer6m = Math.floor(BAR_LENGTH / lengthPerSet);
+  const totalCuts = noSets * numStructures;
+  const area = barAreaM2(diaMm);
+  const pieces = cutsPer6m > 0 ? Math.ceil(totalCuts / cutsPer6m) : 0;
+  return { cutsPer6m, totalCuts, diaMm, area, pieces, weight: pieces * BAR_LENGTH * area * STEEL_DENSITY };
+}
+
+export interface TieWire { netLength: number; intersections: number; rolls: number; }
+export function tieWire(lengthPerCut: number, intersections: number, numStructures: number): TieWire {
+  const netLength = lengthPerCut * intersections * numStructures;
+  return { netLength, intersections, rolls: Math.ceil(netLength / TIE_WIRE_ROLL) };
+}
+
+// ── Slab ──────────────────────────────────────────────────────────────────
+export interface SlabInput {
+  slabArea: number; thickness: number; numStructures: number;
+  concreteClass: ConcreteClass; customFactor?: number;
+  spliceLength: number;
+  longSpanLength: number; numLongPieces: number; longDiaMm: number;
+  shortSpanLength: number; numShortPieces: number; shortDiaMm: number;
+  lengthPerCut: number; numIntersections: number;
+}
+export interface SlabResult {
+  volume: number; materials: ConcreteMaterials;
+  longSteel: BarTakeoff; shortSteel: BarTakeoff; totalSteelWeight: number;
+  tieWire: TieWire;
+}
+export function estimateSlab(i: SlabInput): SlabResult {
+  const volume = i.slabArea * i.thickness * i.numStructures;
+  const materials = concreteMaterials(volume, i.concreteClass, i.customFactor);
+  const longSteel = barTakeoff(i.longSpanLength * i.numLongPieces * i.numStructures, i.longDiaMm, i.spliceLength);
+  const shortSteel = barTakeoff(i.shortSpanLength * i.numShortPieces * i.numStructures, i.shortDiaMm, i.spliceLength);
+  return {
+    volume, materials, longSteel, shortSteel,
+    totalSteelWeight: longSteel.weight + shortSteel.weight,
+    tieWire: tieWire(i.lengthPerCut, i.numIntersections, i.numStructures),
+  };
+}
+
+// ── CHB (masonry) ───────────────────────────────────────────────────────────
+export type ChbSize = '4' | '6' | '8';
+const MORTAR_CEMENT: Record<ChbSize, number> = { '4': 0.522, '6': 1.018, '8': 1.5 };
+const MORTAR_SAND: Record<ChbSize, number> = { '4': 0.0435, '6': 0.0844, '8': 0.125 };
+export interface ChbInput { wallArea: number; holeArea: number; size: ChbSize; }
+export interface ChbResult {
+  netArea: number; pieces: number;
+  mortar: { cement: number; sand: number };
+  plaster: { cement: number; sand: number };
+  totalCement: number; totalSand: number;
+}
+export function estimateChb(i: ChbInput): ChbResult {
+  const netArea = i.wallArea - i.holeArea;
+  const pieces = Math.ceil(netArea * 12.5);
+  const mortar = { cement: Math.ceil(netArea * MORTAR_CEMENT[i.size]), sand: netArea * MORTAR_SAND[i.size] };
+  const plaster = { cement: Math.ceil(netArea * 0.3), sand: netArea * 0.025 };
+  return {
+    netArea, pieces, mortar, plaster,
+    totalCement: mortar.cement + plaster.cement,
+    totalSand: mortar.sand + plaster.sand,
+  };
+}
+
+// ── Column ──────────────────────────────────────────────────────────────────
+export interface ColumnInput {
+  length: number; width: number; height: number; numStructures: number;
+  concreteClass: ConcreteClass; customFactor?: number; spliceLength: number;
+  barLengthPerPiece: number; numBars: number; barDiaMm: number;
+  tieLengthPerSet: number; numTieSets: number; tieDiaMm: number;
+  lengthPerCut: number; numIntersections: number;
+}
+export interface ColumnResult {
+  volume: number; materials: ConcreteMaterials;
+  mainSteel: BarTakeoff; lateralTies: TieTakeoff; tieWire: TieWire;
+}
+export function estimateColumn(i: ColumnInput): ColumnResult {
+  const volume = i.length * i.width * i.height * i.numStructures;
+  return {
+    volume,
+    materials: concreteMaterials(volume, i.concreteClass, i.customFactor),
+    mainSteel: barTakeoff(i.barLengthPerPiece * i.numBars * i.numStructures, i.barDiaMm, i.spliceLength),
+    lateralTies: lateralTieTakeoff(i.tieLengthPerSet, i.numTieSets, i.tieDiaMm, i.numStructures),
+    tieWire: tieWire(i.lengthPerCut, i.numIntersections, i.numStructures),
+  };
+}
+
+// ── Beam ─────────────────────────────────────────────────────────────────────
+export interface BeamBarGroup { lengthPerPiece: number; numPieces: number; diaMm: number; }
+export interface BeamInput {
+  length: number; width: number; height: number; numStructures: number;
+  concreteClass: ConcreteClass; customFactor?: number; spliceLength: number;
+  topSupport: BeamBarGroup; topMidspan: BeamBarGroup;
+  bottomSupport: BeamBarGroup; bottomMidspan: BeamBarGroup;
+  stirrupLengthPerSet: number; numStirrupSets: number; stirrupDiaMm: number;
+  lengthPerCut: number; numIntersections: number;
+}
+export interface BeamResult {
+  volume: number; materials: ConcreteMaterials;
+  mainBars: { label: string; takeoff: BarTakeoff }[];
+  totalMainWeight: number; stirrups: TieTakeoff; tieWire: TieWire;
+}
+export function estimateBeam(i: BeamInput): BeamResult {
+  const volume = i.length * i.width * i.height * i.numStructures;
+  const grp = (label: string, g: BeamBarGroup) => ({
+    label, takeoff: barTakeoff(g.lengthPerPiece * g.numPieces * i.numStructures, g.diaMm, i.spliceLength),
+  });
+  const mainBars = [
+    grp('Top bars @ support', i.topSupport),
+    grp('Top bars @ midspan', i.topMidspan),
+    grp('Bottom bars @ support', i.bottomSupport),
+    grp('Bottom bars @ midspan', i.bottomMidspan),
+  ];
+  return {
+    volume,
+    materials: concreteMaterials(volume, i.concreteClass, i.customFactor),
+    mainBars,
+    totalMainWeight: mainBars.reduce((s, b) => s + b.takeoff.weight, 0),
+    stirrups: lateralTieTakeoff(i.stirrupLengthPerSet, i.numStirrupSets, i.stirrupDiaMm, i.numStructures),
+    tieWire: tieWire(i.lengthPerCut, i.numIntersections, i.numStructures),
+  };
+}
+
+// ── Box culvert ───────────────────────────────────────────────────────────────
+export interface BoxCulvertInput {
+  grossArea: number; holeArea: number; length: number;
+  concreteClass: ConcreteClass; customFactor?: number; spliceLength: number;
+  numLongTop: number; longTopDiaMm: number;
+  numLongU: number; longUDiaMm: number;
+  rsbSpacing: number; topBarLength: number; topBarDiaMm: number; uBarLength: number; uBarDiaMm: number;
+  lengthPerCut: number;
+}
+export interface BoxCulvertResult {
+  netArea: number; volume: number; materials: ConcreteMaterials;
+  longTop: BarTakeoff; longU: BarTakeoff;
+  rsb: {
+    count: number;
+    top: { netLength: number; pieces: number; weight: number };
+    u: { netLength: number; pieces: number; weight: number };
+  };
+  tieWire: TieWire;
+}
+export function estimateBoxCulvert(i: BoxCulvertInput): BoxCulvertResult {
+  const netArea = i.grossArea - i.holeArea;
+  const volume = netArea * i.length;
+  // Longitudinal bars run the culvert length.
+  const longTop = barTakeoff(i.length * i.numLongTop, i.longTopDiaMm, i.spliceLength);
+  const longU = barTakeoff(i.length * i.numLongU, i.longUDiaMm, i.spliceLength);
+  // Reinforcing steel bars (transverse rings) repeat at the spacing.
+  const count = Math.ceil(i.length / i.rsbSpacing) + 1;
+  const rsbBar = (perBarLen: number, diaMm: number) => {
+    const netLength = count * perBarLen;
+    const pieces = Math.ceil(netLength / BAR_LENGTH);
+    return { netLength, pieces, weight: pieces * BAR_LENGTH * barAreaM2(diaMm) * STEEL_DENSITY };
+  };
+  const numLongitudinal = i.numLongTop + i.numLongU;
+  return {
+    netArea, volume,
+    materials: concreteMaterials(volume, i.concreteClass, i.customFactor),
+    longTop, longU,
+    rsb: { count, top: rsbBar(i.topBarLength, i.topBarDiaMm), u: rsbBar(i.uBarLength, i.uBarDiaMm) },
+    tieWire: tieWire(i.lengthPerCut, count * numLongitudinal, 1),
+  };
+}

--- a/webapp/src/pages/BeamEstimate.tsx
+++ b/webapp/src/pages/BeamEstimate.tsx
@@ -9,7 +9,7 @@ const DEFAULTS: BeamInput = {
   topSupport: g(3, 2, 16), topMidspan: g(6, 2, 12),
   bottomSupport: g(3, 2, 12), bottomMidspan: g(6, 3, 20),
   stirrupLengthPerSet: 1.2, numStirrupSets: 30, stirrupDiaMm: 10,
-  lengthPerCut: 0.3, numIntersections: 120,
+  lengthPerCut: 0.3,
 }
 
 export default function BeamEstimate() {
@@ -49,7 +49,6 @@ export default function BeamEstimate() {
           <Num label="Stirrups / beam" value={f.numStirrupSets} onChange={set('numStirrupSets')} />
           <Num label="Stirrup Ø" unit="mm" value={f.stirrupDiaMm} onChange={set('stirrupDiaMm')} />
           <Num label="Tie wire length / cut" unit="m" value={f.lengthPerCut} onChange={set('lengthPerCut')} />
-          <Num label="Tie wire intersections" value={f.numIntersections} onChange={set('numIntersections')} />
         </Card>
       </div>
 
@@ -69,6 +68,7 @@ export default function BeamEstimate() {
         </ResultCard>
         <ResultCard title="Stirrups & tie wire">
           <Row label={`Stirrups (Ø${f.stirrupDiaMm})`} value={kg(r.stirrups.weight)} sub={`${r.stirrups.pieces} bars · ${r.stirrups.totalCuts} ties`} />
+          <Row label="Tie wire intersections" value={`${r.tieWire.intersections}`} sub="long. bars × stirrups" />
           <Row label="Tie wire" value={`${r.tieWire.rolls} roll/s`} sub={m(r.tieWire.netLength)} />
         </ResultCard>
       </div>

--- a/webapp/src/pages/BeamEstimate.tsx
+++ b/webapp/src/pages/BeamEstimate.tsx
@@ -1,0 +1,77 @@
+import { useMemo, useState } from 'react'
+import { estimateBeam, type BeamInput, type BeamBarGroup, type ConcreteClass } from '../engine/quantities'
+import { Num, ClassPick, Card, ResultCard, Row, QtyPage, kg, m3, m } from '../components/qty'
+
+const g = (lengthPerPiece: number, numPieces: number, diaMm: number): BeamBarGroup => ({ lengthPerPiece, numPieces, diaMm })
+
+const DEFAULTS: BeamInput = {
+  length: 6, width: 0.25, height: 0.5, numStructures: 1, concreteClass: 'B', customFactor: 7.5, spliceLength: 0.3,
+  topSupport: g(3, 2, 16), topMidspan: g(6, 2, 12),
+  bottomSupport: g(3, 2, 12), bottomMidspan: g(6, 3, 20),
+  stirrupLengthPerSet: 1.2, numStirrupSets: 30, stirrupDiaMm: 10,
+  lengthPerCut: 0.3, numIntersections: 120,
+}
+
+export default function BeamEstimate() {
+  const [f, setF] = useState<BeamInput>(DEFAULTS)
+  const set = <K extends keyof BeamInput>(k: K) => (v: BeamInput[K]) => setF((s) => ({ ...s, [k]: v }))
+  const setG = (grp: 'topSupport' | 'topMidspan' | 'bottomSupport' | 'bottomMidspan', key: keyof BeamBarGroup) =>
+    (v: number) => setF((s) => ({ ...s, [grp]: { ...s[grp], [key]: v } }))
+  const r = useMemo(() => estimateBeam(f), [f])
+
+  const barCard = (title: string, grp: 'topSupport' | 'topMidspan' | 'bottomSupport' | 'bottomMidspan') => (
+    <Card title={title}>
+      <Num label="Length / piece" unit="m" value={f[grp].lengthPerPiece} onChange={setG(grp, 'lengthPerPiece')} />
+      <Num label="No. of pieces" value={f[grp].numPieces} onChange={setG(grp, 'numPieces')} />
+      <Num label="Bar Ø" unit="mm" value={f[grp].diaMm} onChange={setG(grp, 'diaMm')} />
+    </Card>
+  )
+
+  return (
+    <QtyPage title="Beam — Material Estimate" reportTitle="Beam Material Estimate"
+      intro="Concrete volume, materials, top/bottom bars at support & midspan, stirrups and tie wire for beams.">
+      <div className="space-y-5">
+        <Card title="Geometry & mix">
+          <Num label="Length" unit="m" value={f.length} onChange={set('length')} />
+          <Num label="Width" unit="m" value={f.width} onChange={set('width')} />
+          <Num label="Height" unit="m" value={f.height} onChange={set('height')} />
+          <Num label="No. of beams" value={f.numStructures} onChange={set('numStructures')} />
+          <ClassPick value={f.concreteClass} onChange={set('concreteClass') as (v: ConcreteClass) => void} />
+          {f.concreteClass === 'custom' && <Num label="Cement factor" unit="bags/m³" value={f.customFactor ?? 0} onChange={set('customFactor')} />}
+          <Num label="Splice length" unit="m" value={f.spliceLength} onChange={set('spliceLength')} />
+        </Card>
+        {barCard('Top bars @ support', 'topSupport')}
+        {barCard('Top bars @ midspan', 'topMidspan')}
+        {barCard('Bottom bars @ support', 'bottomSupport')}
+        {barCard('Bottom bars @ midspan', 'bottomMidspan')}
+        <Card title="Stirrups & tie wire">
+          <Num label="Length / stirrup" unit="m" value={f.stirrupLengthPerSet} onChange={set('stirrupLengthPerSet')} />
+          <Num label="Stirrups / beam" value={f.numStirrupSets} onChange={set('numStirrupSets')} />
+          <Num label="Stirrup Ø" unit="mm" value={f.stirrupDiaMm} onChange={set('stirrupDiaMm')} />
+          <Num label="Tie wire length / cut" unit="m" value={f.lengthPerCut} onChange={set('lengthPerCut')} />
+          <Num label="Tie wire intersections" value={f.numIntersections} onChange={set('numIntersections')} />
+        </Card>
+      </div>
+
+      <div className="space-y-5">
+        <ResultCard title="Concrete">
+          <Row label="Volume" value={m3(r.volume)} />
+          <Row label="Cement" value={`${r.materials.cement} bags`} sub={`factor ${r.materials.factor}`} />
+          <Row label="Sand" value={m3(r.materials.sand)} />
+          <Row label="Gravel" value={m3(r.materials.gravel)} />
+        </ResultCard>
+        <ResultCard title="Main reinforcement">
+          {r.mainBars.map((b) => (
+            <Row key={b.label} label={`${b.label} (Ø${b.takeoff.diaMm})`} value={kg(b.takeoff.weight)}
+              sub={`${b.takeoff.pieces} bars · ${m(b.takeoff.netLength)}`} />
+          ))}
+          <Row label="Total main steel" value={kg(r.totalMainWeight)} />
+        </ResultCard>
+        <ResultCard title="Stirrups & tie wire">
+          <Row label={`Stirrups (Ø${f.stirrupDiaMm})`} value={kg(r.stirrups.weight)} sub={`${r.stirrups.pieces} bars · ${r.stirrups.totalCuts} ties`} />
+          <Row label="Tie wire" value={`${r.tieWire.rolls} roll/s`} sub={m(r.tieWire.netLength)} />
+        </ResultCard>
+      </div>
+    </QtyPage>
+  )
+}

--- a/webapp/src/pages/BoxCulvertEstimate.tsx
+++ b/webapp/src/pages/BoxCulvertEstimate.tsx
@@ -1,0 +1,72 @@
+import { useMemo, useState } from 'react'
+import { estimateBoxCulvert, type BoxCulvertInput, type ConcreteClass } from '../engine/quantities'
+import { Num, ClassPick, Card, ResultCard, Row, QtyPage, kg, m3, m } from '../components/qty'
+
+const DEFAULTS: BoxCulvertInput = {
+  grossArea: 6, holeArea: 2, length: 5, concreteClass: 'A', customFactor: 9, spliceLength: 0.3,
+  numLongTop: 6, longTopDiaMm: 16, numLongU: 6, longUDiaMm: 16,
+  rsbSpacing: 0.2, topBarLength: 2.5, topBarDiaMm: 12, uBarLength: 3.5, uBarDiaMm: 12,
+  lengthPerCut: 0.3,
+}
+
+export default function BoxCulvertEstimate() {
+  const [f, setF] = useState<BoxCulvertInput>(DEFAULTS)
+  const set = <K extends keyof BoxCulvertInput>(k: K) => (v: BoxCulvertInput[K]) => setF((s) => ({ ...s, [k]: v }))
+  const r = useMemo(() => estimateBoxCulvert(f), [f])
+  const rsbWeight = r.rsb.top.weight + r.rsb.u.weight
+
+  return (
+    <QtyPage title="Box Culvert — Material Estimate" reportTitle="Box Culvert Material Estimate"
+      intro="Concrete volume from net cross-section, materials, longitudinal bars, reinforcing rings (top + U bars) and tie wire.">
+      <div className="space-y-5">
+        <Card title="Section & mix">
+          <Num label="Gross x-section area" unit="m²" value={f.grossArea} onChange={set('grossArea')} />
+          <Num label="Opening area" unit="m²" value={f.holeArea} onChange={set('holeArea')} />
+          <Num label="Length" unit="m" value={f.length} onChange={set('length')} />
+          <ClassPick value={f.concreteClass} onChange={set('concreteClass') as (v: ConcreteClass) => void} />
+          {f.concreteClass === 'custom' && <Num label="Cement factor" unit="bags/m³" value={f.customFactor ?? 0} onChange={set('customFactor')} />}
+          <Num label="Splice length" unit="m" value={f.spliceLength} onChange={set('spliceLength')} />
+        </Card>
+        <Card title="Longitudinal bars">
+          <Num label="No. top bars" value={f.numLongTop} onChange={set('numLongTop')} />
+          <Num label="Top bar Ø" unit="mm" value={f.longTopDiaMm} onChange={set('longTopDiaMm')} />
+          <Num label="No. U-bars" value={f.numLongU} onChange={set('numLongU')} />
+          <Num label="U-bar Ø" unit="mm" value={f.longUDiaMm} onChange={set('longUDiaMm')} />
+        </Card>
+        <Card title="Reinforcing rings (RSB)">
+          <Num label="Spacing" unit="m" value={f.rsbSpacing} onChange={set('rsbSpacing')} />
+          <Num label="Top bar length" unit="m" value={f.topBarLength} onChange={set('topBarLength')} />
+          <Num label="Top bar Ø" unit="mm" value={f.topBarDiaMm} onChange={set('topBarDiaMm')} />
+          <Num label="U-bar length" unit="m" value={f.uBarLength} onChange={set('uBarLength')} />
+          <Num label="U-bar Ø" unit="mm" value={f.uBarDiaMm} onChange={set('uBarDiaMm')} />
+          <Num label="Tie wire length / cut" unit="m" value={f.lengthPerCut} onChange={set('lengthPerCut')} />
+        </Card>
+      </div>
+
+      <div className="space-y-5">
+        <ResultCard title="Concrete">
+          <Row label="Net x-section" value={m3(r.netArea).replace('m³', 'm²')} />
+          <Row label="Volume" value={m3(r.volume)} />
+          <Row label="Cement" value={`${r.materials.cement} bags`} sub={`factor ${r.materials.factor}`} />
+          <Row label="Sand" value={m3(r.materials.sand)} />
+          <Row label="Gravel" value={m3(r.materials.gravel)} />
+        </ResultCard>
+        <ResultCard title="Longitudinal steel">
+          <Row label={`Top bars (Ø${f.longTopDiaMm})`} value={kg(r.longTop.weight)} sub={`${r.longTop.pieces} bars`} />
+          <Row label={`U-bars (Ø${f.longUDiaMm})`} value={kg(r.longU.weight)} sub={`${r.longU.pieces} bars`} />
+        </ResultCard>
+        <ResultCard title="Reinforcing rings">
+          <Row label="No. of RSB" value={`${r.rsb.count} pcs`} />
+          <Row label={`Top bars (Ø${f.topBarDiaMm})`} value={kg(r.rsb.top.weight)} sub={`${r.rsb.top.pieces} bars · ${m(r.rsb.top.netLength)}`} />
+          <Row label={`U-bars (Ø${f.uBarDiaMm})`} value={kg(r.rsb.u.weight)} sub={`${r.rsb.u.pieces} bars · ${m(r.rsb.u.netLength)}`} />
+          <Row label="RSB total" value={kg(rsbWeight)} />
+        </ResultCard>
+        <ResultCard title="Tie wire">
+          <Row label="Intersections" value={`${r.tieWire.intersections}`} />
+          <Row label="Net length" value={m(r.tieWire.netLength)} />
+          <Row label="Rolls" value={`${r.tieWire.rolls} roll/s`} />
+        </ResultCard>
+      </div>
+    </QtyPage>
+  )
+}

--- a/webapp/src/pages/ChbEstimate.tsx
+++ b/webapp/src/pages/ChbEstimate.tsx
@@ -1,0 +1,44 @@
+import { useMemo, useState } from 'react'
+import { estimateChb, type ChbInput, type ChbSize } from '../engine/quantities'
+import { Num, Pick, Card, ResultCard, Row, QtyPage, m3 } from '../components/qty'
+
+const DEFAULTS: ChbInput = { wallArea: 30, holeArea: 4, size: '6' }
+
+export default function ChbEstimate() {
+  const [f, setF] = useState<ChbInput>(DEFAULTS)
+  const set = <K extends keyof ChbInput>(k: K) => (v: ChbInput[K]) => setF((s) => ({ ...s, [k]: v }))
+  const r = useMemo(() => estimateChb(f), [f])
+
+  return (
+    <QtyPage title="CHB Wall — Material Estimate" reportTitle="CHB Wall Material Estimate"
+      intro="Concrete hollow block count, mortar and plaster (cement + sand) for a masonry wall.">
+      <div className="space-y-5">
+        <Card title="Wall">
+          <Num label="Gross wall area" unit="m²" value={f.wallArea} onChange={set('wallArea')} />
+          <Num label="Openings area" unit="m²" value={f.holeArea} onChange={set('holeArea')} />
+          <Pick label="CHB size" value={f.size} onChange={set('size') as (v: ChbSize) => void}
+            options={[['4', '4 in'], ['6', '6 in'], ['8', '8 in']]} />
+        </Card>
+      </div>
+
+      <div className="space-y-5">
+        <ResultCard title="Blocks">
+          <Row label="Net area" value={m3(r.netArea).replace('m³', 'm²')} />
+          <Row label={`No. of CHB (${f.size}")`} value={`${r.pieces} pcs`} />
+        </ResultCard>
+        <ResultCard title="Mortar">
+          <Row label="Cement" value={`${r.mortar.cement} bags`} />
+          <Row label="Sand" value={m3(r.mortar.sand)} />
+        </ResultCard>
+        <ResultCard title="Plaster">
+          <Row label="Cement" value={`${r.plaster.cement} bags`} />
+          <Row label="Sand" value={m3(r.plaster.sand)} />
+        </ResultCard>
+        <ResultCard title="Total cement & sand">
+          <Row label="Cement" value={`${r.totalCement} bags`} />
+          <Row label="Sand" value={m3(r.totalSand)} />
+        </ResultCard>
+      </div>
+    </QtyPage>
+  )
+}

--- a/webapp/src/pages/ColumnEstimate.tsx
+++ b/webapp/src/pages/ColumnEstimate.tsx
@@ -1,0 +1,64 @@
+import { useMemo, useState } from 'react'
+import { estimateColumn, type ColumnInput, type ConcreteClass } from '../engine/quantities'
+import { Num, ClassPick, Card, ResultCard, Row, QtyPage, kg, m3, m } from '../components/qty'
+
+const DEFAULTS: ColumnInput = {
+  length: 0.4, width: 0.4, height: 3, numStructures: 4, concreteClass: 'A', customFactor: 9, spliceLength: 0.3,
+  barLengthPerPiece: 3.5, numBars: 8, barDiaMm: 16,
+  tieLengthPerSet: 1.4, numTieSets: 16, tieDiaMm: 10,
+  lengthPerCut: 0.3, numIntersections: 64,
+}
+
+export default function ColumnEstimate() {
+  const [f, setF] = useState<ColumnInput>(DEFAULTS)
+  const set = <K extends keyof ColumnInput>(k: K) => (v: ColumnInput[K]) => setF((s) => ({ ...s, [k]: v }))
+  const r = useMemo(() => estimateColumn(f), [f])
+
+  return (
+    <QtyPage title="Column — Material Estimate" reportTitle="Column Material Estimate"
+      intro="Concrete volume, cement / sand / gravel, vertical bars, lateral ties and tie wire for columns.">
+      <div className="space-y-5">
+        <Card title="Geometry & mix">
+          <Num label="Length" unit="m" value={f.length} onChange={set('length')} />
+          <Num label="Width" unit="m" value={f.width} onChange={set('width')} />
+          <Num label="Height" unit="m" value={f.height} onChange={set('height')} />
+          <Num label="No. of columns" value={f.numStructures} onChange={set('numStructures')} />
+          <ClassPick value={f.concreteClass} onChange={set('concreteClass') as (v: ConcreteClass) => void} />
+          {f.concreteClass === 'custom' && <Num label="Cement factor" unit="bags/m³" value={f.customFactor ?? 0} onChange={set('customFactor')} />}
+          <Num label="Splice length" unit="m" value={f.spliceLength} onChange={set('spliceLength')} />
+        </Card>
+        <Card title="Vertical bars">
+          <Num label="Length / piece" unit="m" value={f.barLengthPerPiece} onChange={set('barLengthPerPiece')} />
+          <Num label="Bars / column" value={f.numBars} onChange={set('numBars')} />
+          <Num label="Bar Ø" unit="mm" value={f.barDiaMm} onChange={set('barDiaMm')} />
+        </Card>
+        <Card title="Lateral ties">
+          <Num label="Length / tie" unit="m" value={f.tieLengthPerSet} onChange={set('tieLengthPerSet')} />
+          <Num label="Ties / column" value={f.numTieSets} onChange={set('numTieSets')} />
+          <Num label="Tie Ø" unit="mm" value={f.tieDiaMm} onChange={set('tieDiaMm')} />
+        </Card>
+        <Card title="Tie wire">
+          <Num label="Length / cut" unit="m" value={f.lengthPerCut} onChange={set('lengthPerCut')} />
+          <Num label="No. of intersections" value={f.numIntersections} onChange={set('numIntersections')} />
+        </Card>
+      </div>
+
+      <div className="space-y-5">
+        <ResultCard title="Concrete">
+          <Row label="Volume" value={m3(r.volume)} />
+          <Row label="Cement" value={`${r.materials.cement} bags`} sub={`factor ${r.materials.factor}`} />
+          <Row label="Sand" value={m3(r.materials.sand)} />
+          <Row label="Gravel" value={m3(r.materials.gravel)} />
+        </ResultCard>
+        <ResultCard title="Reinforcing steel">
+          <Row label={`Vertical bars (Ø${f.barDiaMm})`} value={kg(r.mainSteel.weight)} sub={`${r.mainSteel.pieces} bars · ${m(r.mainSteel.netLength)}`} />
+          <Row label={`Lateral ties (Ø${f.tieDiaMm})`} value={kg(r.lateralTies.weight)} sub={`${r.lateralTies.pieces} bars · ${r.lateralTies.totalCuts} ties`} />
+        </ResultCard>
+        <ResultCard title="Tie wire">
+          <Row label="Net length" value={m(r.tieWire.netLength)} />
+          <Row label="Rolls" value={`${r.tieWire.rolls} roll/s`} />
+        </ResultCard>
+      </div>
+    </QtyPage>
+  )
+}

--- a/webapp/src/pages/ColumnEstimate.tsx
+++ b/webapp/src/pages/ColumnEstimate.tsx
@@ -6,7 +6,7 @@ const DEFAULTS: ColumnInput = {
   length: 0.4, width: 0.4, height: 3, numStructures: 4, concreteClass: 'A', customFactor: 9, spliceLength: 0.3,
   barLengthPerPiece: 3.5, numBars: 8, barDiaMm: 16,
   tieLengthPerSet: 1.4, numTieSets: 16, tieDiaMm: 10,
-  lengthPerCut: 0.3, numIntersections: 64,
+  lengthPerCut: 0.3,
 }
 
 export default function ColumnEstimate() {
@@ -39,7 +39,6 @@ export default function ColumnEstimate() {
         </Card>
         <Card title="Tie wire">
           <Num label="Length / cut" unit="m" value={f.lengthPerCut} onChange={set('lengthPerCut')} />
-          <Num label="No. of intersections" value={f.numIntersections} onChange={set('numIntersections')} />
         </Card>
       </div>
 
@@ -55,6 +54,7 @@ export default function ColumnEstimate() {
           <Row label={`Lateral ties (Ø${f.tieDiaMm})`} value={kg(r.lateralTies.weight)} sub={`${r.lateralTies.pieces} bars · ${r.lateralTies.totalCuts} ties`} />
         </ResultCard>
         <ResultCard title="Tie wire">
+          <Row label="Intersections" value={`${r.tieWire.intersections}`} sub={`${f.numBars} bars × ${f.numTieSets} ties`} />
           <Row label="Net length" value={m(r.tieWire.netLength)} />
           <Row label="Rolls" value={`${r.tieWire.rolls} roll/s`} />
         </ResultCard>

--- a/webapp/src/pages/SlabEstimate.tsx
+++ b/webapp/src/pages/SlabEstimate.tsx
@@ -6,7 +6,7 @@ const DEFAULTS: SlabInput = {
   slabArea: 20, thickness: 0.125, numStructures: 1, concreteClass: 'A', customFactor: 9, spliceLength: 0.3,
   longSpanLength: 5, numLongPieces: 12, longDiaMm: 12,
   shortSpanLength: 4, numShortPieces: 14, shortDiaMm: 12,
-  lengthPerCut: 0.3, numIntersections: 150,
+  lengthPerCut: 0.3,
 }
 
 export default function SlabEstimate() {
@@ -38,7 +38,6 @@ export default function SlabEstimate() {
         </Card>
         <Card title="Tie wire">
           <Num label="Length / cut" unit="m" value={f.lengthPerCut} onChange={set('lengthPerCut')} />
-          <Num label="No. of intersections" value={f.numIntersections} onChange={set('numIntersections')} />
         </Card>
       </div>
 
@@ -55,6 +54,7 @@ export default function SlabEstimate() {
           <Row label="Total steel weight" value={kg(r.totalSteelWeight)} />
         </ResultCard>
         <ResultCard title="Tie wire">
+          <Row label="Intersections" value={`${r.tieWire.intersections}`} sub={`${f.numLongPieces}×${f.numShortPieces} grid`} />
           <Row label="Net length" value={m(r.tieWire.netLength)} />
           <Row label="Rolls" value={`${r.tieWire.rolls} roll/s`} />
         </ResultCard>

--- a/webapp/src/pages/SlabEstimate.tsx
+++ b/webapp/src/pages/SlabEstimate.tsx
@@ -1,0 +1,64 @@
+import { useMemo, useState } from 'react'
+import { estimateSlab, type SlabInput, type ConcreteClass } from '../engine/quantities'
+import { Num, ClassPick, Card, ResultCard, Row, QtyPage, kg, m3, m } from '../components/qty'
+
+const DEFAULTS: SlabInput = {
+  slabArea: 20, thickness: 0.125, numStructures: 1, concreteClass: 'A', customFactor: 9, spliceLength: 0.3,
+  longSpanLength: 5, numLongPieces: 12, longDiaMm: 12,
+  shortSpanLength: 4, numShortPieces: 14, shortDiaMm: 12,
+  lengthPerCut: 0.3, numIntersections: 150,
+}
+
+export default function SlabEstimate() {
+  const [f, setF] = useState<SlabInput>(DEFAULTS)
+  const set = <K extends keyof SlabInput>(k: K) => (v: SlabInput[K]) => setF((s) => ({ ...s, [k]: v }))
+  const r = useMemo(() => estimateSlab(f), [f])
+
+  return (
+    <QtyPage title="Slab — Material Estimate" reportTitle="Slab Material Estimate"
+      intro="Concrete volume, cement / sand / gravel, main steel (both spans) and tie wire for a slab.">
+      <div className="space-y-5">
+        <Card title="Geometry & mix">
+          <Num label="Slab area" unit="m²" value={f.slabArea} onChange={set('slabArea')} />
+          <Num label="Thickness" unit="m" value={f.thickness} onChange={set('thickness')} />
+          <Num label="No. of structures" value={f.numStructures} onChange={set('numStructures')} />
+          <ClassPick value={f.concreteClass} onChange={set('concreteClass') as (v: ConcreteClass) => void} />
+          {f.concreteClass === 'custom' && <Num label="Cement factor" unit="bags/m³" value={f.customFactor ?? 0} onChange={set('customFactor')} />}
+          <Num label="Splice length" unit="m" value={f.spliceLength} onChange={set('spliceLength')} />
+        </Card>
+        <Card title="Long-span bars">
+          <Num label="Length / piece" unit="m" value={f.longSpanLength} onChange={set('longSpanLength')} />
+          <Num label="No. of pieces" value={f.numLongPieces} onChange={set('numLongPieces')} />
+          <Num label="Bar Ø" unit="mm" value={f.longDiaMm} onChange={set('longDiaMm')} />
+        </Card>
+        <Card title="Short-span bars">
+          <Num label="Length / piece" unit="m" value={f.shortSpanLength} onChange={set('shortSpanLength')} />
+          <Num label="No. of pieces" value={f.numShortPieces} onChange={set('numShortPieces')} />
+          <Num label="Bar Ø" unit="mm" value={f.shortDiaMm} onChange={set('shortDiaMm')} />
+        </Card>
+        <Card title="Tie wire">
+          <Num label="Length / cut" unit="m" value={f.lengthPerCut} onChange={set('lengthPerCut')} />
+          <Num label="No. of intersections" value={f.numIntersections} onChange={set('numIntersections')} />
+        </Card>
+      </div>
+
+      <div className="space-y-5">
+        <ResultCard title="Concrete">
+          <Row label="Volume" value={m3(r.volume)} />
+          <Row label="Cement" value={`${r.materials.cement} bags`} sub={`factor ${r.materials.factor}`} />
+          <Row label="Sand" value={m3(r.materials.sand)} />
+          <Row label="Gravel" value={m3(r.materials.gravel)} />
+        </ResultCard>
+        <ResultCard title="Reinforcing steel">
+          <Row label={`Long span (Ø${f.longDiaMm})`} value={kg(r.longSteel.weight)} sub={`${r.longSteel.pieces} bars · ${m(r.longSteel.netLength)}`} />
+          <Row label={`Short span (Ø${f.shortDiaMm})`} value={kg(r.shortSteel.weight)} sub={`${r.shortSteel.pieces} bars · ${m(r.shortSteel.netLength)}`} />
+          <Row label="Total steel weight" value={kg(r.totalSteelWeight)} />
+        </ResultCard>
+        <ResultCard title="Tie wire">
+          <Row label="Net length" value={m(r.tieWire.netLength)} />
+          <Row label="Rolls" value={`${r.tieWire.rolls} roll/s`} />
+        </ResultCard>
+      </div>
+    </QtyPage>
+  )
+}


### PR DESCRIPTION
Ports the remaining legacy calculators — all **material take-off / quantity** tools — to the React app as a typed engine + pages.

> Stacked on #114 → #113. Base is `feature/printable-report`; retarget to `main` after the parents merge.

## Engine — `quantities.ts`
Faithful typed port of `scriptSlab/scriptChb/scriptColumn/scriptBeam/scriptBoxCulvert`, with shared primitives so the rules live in one place:
- `concreteMaterials` — cement bags by NSCP mix class (AA 12 / A 9 / B 7.5 / C 6, or custom factor), sand 0.5 / gravel 1.0 m³ per m³.
- `barTakeoff` — commercial 6 m bars less splice; `lateralTieTakeoff` — stirrups/ties cut from 6 m; `tieWire` — rolls of 2385 m.
- `estimateSlab / estimateChb / estimateColumn / estimateBeam / estimateBoxCulvert`.
- Bar diameters are entered in **mm** (the legacy forms awkwardly used metres) and converted internally.
- **10 unit tests** (60 total) pinning the helper formulas + each calculator.

## Pages
Slab, Beam, Column, CHB Wall, Box Culvert — live results via a shared `qty` UI kit, each with the **printable report bar** from #114. Home is reorganised into **Structural design** and **Material estimation** sections; `/estimate/*` routes added.

## Verification
- `npm run build` green; `npm test` 60 passing.

With this, every legacy calculator now has a React equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)