### PR TITLE
UI polish: Inter font, softer inputs, sticky preview panel

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
 
 /* App-wide base. Tailwind v4's preflight is included via the import above.
    This is the NEW React app's stylesheet — independent of the legacy
@@ -10,9 +11,27 @@
 
 body {
   margin: 0;
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
   color: #1f2933;
   background: #f5f7fa;
+}
+
+/* ── Form fields: one global, softer style ───────────────────────────────
+   Unlayered rules override Tailwind's layered utilities, so this lifts every
+   text/number input + select across all pages without editing each component.
+   Checkboxes / buttons are excluded. */
+input:not([type="checkbox"]):not([type="radio"]):not([type="button"]):not([type="submit"]),
+select {
+  border-radius: 8px;
+  border: 1px solid #cbd5e1;
+  padding: 0.5rem 0.75rem;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+input:not([type="checkbox"]):not([type="radio"]):not([type="button"]):not([type="submit"]):focus,
+select:focus {
+  outline: none;
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px rgba(0, 86, 179, 0.16);
 }
 
 /* ── Print / PDF export ──────────────────────────────────────────────
@@ -30,4 +49,6 @@ body {
   .rounded-xl, .shadow-sm { box-shadow: none !important; }
   main, .mx-auto { max-width: 100% !important; }
   a[href]::after { content: ""; }
+  /* don't pin the preview panel when printing */
+  [class*="sticky"] { position: static !important; }
 }

--- a/webapp/src/pages/CombinedFootingDesign.tsx
+++ b/webapp/src/pages/CombinedFootingDesign.tsx
@@ -232,7 +232,7 @@ export default function CombinedFootingDesign() {
         </div>
 
         {/* ── Results ── */}
-        <div className="space-y-5">
+        <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
           <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Plan</h2>
             {result ? (

--- a/webapp/src/pages/FoundationDesign.tsx
+++ b/webapp/src/pages/FoundationDesign.tsx
@@ -236,7 +236,7 @@ export default function FoundationDesign() {
         </div>
 
         {/* ── Results ── */}
-        <div className="space-y-5">
+        <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
           <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Design preview</h2>
             {view ? (

--- a/webapp/src/pages/PileCapDesign.tsx
+++ b/webapp/src/pages/PileCapDesign.tsx
@@ -213,7 +213,7 @@ export default function PileCapDesign() {
         </div>
 
         {/* ── Results ── */}
-        <div className="space-y-5">
+        <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
           {/* Schematic */}
           <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Cap plan</h2>


### PR DESCRIPTION
Applies the **valid subset** of an external UI review. The reviewer was looking at the *legacy* static page (it references "Import from Excel", a "Parameters Given" outer card, and "Solution Method/Iteration" — none of which exist in the React app), so those points are N/A. Adopted the changes that genuinely apply:

> Stacked on #115 → #114 → #113. Base is `feature/quantity-estimators`; retarget to `main` as parents merge.

## Adopted
- **Inter webfont** app-wide (was Arial/Helvetica) via a single `@import` in `index.css`.
- **Global input/select restyle** — 8px radius, softer `#cbd5e1` border, larger padding, and a 3px focus ring. Done as one *unlayered* CSS rule that overrides Tailwind's layered utilities, so every text/number field + select across all pages is lifted without editing each component (checkboxes/buttons excluded).
- **Sticky preview/results panel** on Foundation, Pile Cap, and Combined Footing — the diagram/results stay in view while scrolling the long input column (`lg:sticky lg:top-6 lg:self-start`); reset to `static` in print so the report layout is unaffected.

## Rejected (with reason)
- *Excel-import banner / remove "Parameters Given" outer border* — legacy-only; the React app already uses clean cards on a light-gray background with no nested outer wrapper.
- *Switch brand to `#2563eb`/`#0284c7` and hardcode a 450px right column* — the app has a consistent `#0056b3` brand and a responsive `1.4fr/1fr` split; kept both to avoid fragmenting the design.

## Verification
- `npm run build` green; `npm test` 60 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)