### PR TITLE
Re-apply UI polish to main (#116 merged to wrong base)

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
 
 /* App-wide base. Tailwind v4's preflight is included via the import above.
    This is the NEW React app's stylesheet — independent of the legacy
@@ -10,9 +11,27 @@
 
 body {
   margin: 0;
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
   color: #1f2933;
   background: #f5f7fa;
+}
+
+/* ── Form fields: one global, softer style ───────────────────────────────
+   Unlayered rules override Tailwind's layered utilities, so this lifts every
+   text/number input + select across all pages without editing each component.
+   Checkboxes / buttons are excluded. */
+input:not([type="checkbox"]):not([type="radio"]):not([type="button"]):not([type="submit"]),
+select {
+  border-radius: 8px;
+  border: 1px solid #cbd5e1;
+  padding: 0.5rem 0.75rem;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+input:not([type="checkbox"]):not([type="radio"]):not([type="button"]):not([type="submit"]):focus,
+select:focus {
+  outline: none;
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px rgba(0, 86, 179, 0.16);
 }
 
 /* ── Print / PDF export ──────────────────────────────────────────────
@@ -30,4 +49,6 @@ body {
   .rounded-xl, .shadow-sm { box-shadow: none !important; }
   main, .mx-auto { max-width: 100% !important; }
   a[href]::after { content: ""; }
+  /* don't pin the preview panel when printing */
+  [class*="sticky"] { position: static !important; }
 }

--- a/webapp/src/pages/CombinedFootingDesign.tsx
+++ b/webapp/src/pages/CombinedFootingDesign.tsx
@@ -232,7 +232,7 @@ export default function CombinedFootingDesign() {
         </div>
 
         {/* ── Results ── */}
-        <div className="space-y-5">
+        <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
           <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Plan</h2>
             {result ? (

--- a/webapp/src/pages/FoundationDesign.tsx
+++ b/webapp/src/pages/FoundationDesign.tsx
@@ -236,7 +236,7 @@ export default function FoundationDesign() {
         </div>
 
         {/* ── Results ── */}
-        <div className="space-y-5">
+        <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
           <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Design preview</h2>
             {view ? (

--- a/webapp/src/pages/PileCapDesign.tsx
+++ b/webapp/src/pages/PileCapDesign.tsx
@@ -213,7 +213,7 @@ export default function PileCapDesign() {
         </div>
 
         {/* ── Results ── */}
-        <div className="space-y-5">
+        <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
           {/* Schematic */}
           <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Cap plan</h2>


### PR DESCRIPTION
## Why
PR #116 (UI polish) is labelled *merged*, but its content never reached `main`. It was a stacked PR based on `feature/quantity-estimators`; merging it put the commit into that feature branch, while `main` had already absorbed the quantity work via a different path (`feature/printable-report` → #117). So the single UI-polish commit landed on a dead-end branch.

This re-applies that exact commit (`436e754`) cleanly on top of `main`.

## Contents (unchanged from #116)
- Inter webfont app-wide.
- Global softer input/select style (8px radius, #cbd5e1 border, larger padding, 3px focus ring).
- Sticky preview/results panel on Foundation, Pile Cap, Combined Footing; reset to static in print.

4 files, +25/−4. `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)