### PR TITLE
Restyle the legacy Foundation Design Excel-import banner

### DIFF
--- a/public/assets/css/styles1.css
+++ b/public/assets/css/styles1.css
@@ -754,27 +754,48 @@ nav ul li a:hover {
 .fd-page .fd-import-row {
     display: flex;
     align-items: center;
-    gap: 12px;
+    gap: 10px 14px;
     flex-wrap: wrap;
-    padding: 12px 16px;
-    background: #f6f8fa;
-    border: 1px dashed #c5c9d0;
-    border-radius: 6px;
-    margin: 0 0 16px;
+    padding: 10px 14px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    margin: 0 0 18px;
 }
 
 .fd-page .fd-import-row label {
     width: auto;
     margin: 0;
     font-weight: 600;
-    color: #2c3e50;
+    color: #1e293b;
+    font-size: 0.92rem;
 }
 
+/* Compact native file input with a styled picker button. */
 .fd-page .fd-import-row input[type="file"] {
     width: auto;
-    flex: 1 1 240px;
+    flex: 0 1 auto;
     margin: 0;
-    padding: 6px;
+    padding: 0;
+    font-size: 0.85rem;
+    color: #64748b;
+}
+.fd-page .fd-import-row input[type="file"]::file-selector-button {
+    appearance: none;
+    margin-right: 10px;
+    padding: 7px 14px;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    background: #fff;
+    color: #0056b3;
+    font-weight: 600;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease;
+}
+.fd-page .fd-import-row input[type="file"]::file-selector-button:hover {
+    background: #eff6ff;
+    border-color: #0056b3;
 }
 
 .fd-page .fd-hint {
@@ -783,27 +804,34 @@ nav ul li a:hover {
     margin: 4px 0 0;
 }
 
-/* "Download blank template" link-button next to the upload field */
+/* "Download blank template" — compact secondary button, pushed to the right.
+   Width/padding/margin explicitly reset the global `button { width:80% }` rule. */
 .fd-page .fd-link-btn {
     appearance: none;
+    width: auto;
+    flex: 0 0 auto;
+    margin: 0 0 0 auto;
     background: #fff;
-    border: 1px solid #b3d4f0;
+    border: 1px solid #cbd5e1;
     color: #0056b3;
-    padding: 6px 12px;
-    border-radius: 4px;
-    font-size: 0.9em;
+    padding: 7px 14px;
+    border-radius: 8px;
+    font-size: 0.85rem;
+    line-height: 1.2;
     cursor: pointer;
     font-weight: 600;
+    transition: background 0.15s ease, border-color 0.15s ease;
 }
 .fd-page .fd-link-btn:hover {
-    background: #e7f3ff;
+    background: #eff6ff;
     border-color: #0056b3;
 }
 
-/* Expandable "What format?" help block */
+/* Expandable "What format?" help block — on its own line under the banner. */
 .fd-page .fd-import-help {
+    flex: 1 0 100%;
     width: 100%;
-    margin-top: 6px;
+    margin-top: 2px;
     font-size: 0.85em;
 }
 .fd-page .fd-import-help > summary {


### PR DESCRIPTION
Fixes the ugly **Import from Excel** area on the deployed legacy page (`foundationDesign.html`).

## Problem
- The row was a dashed gray box that ate vertical space.
- The **Download blank template** button rendered as a big centered, ~80%-width box on its own line — because the global `button { width: 80%; padding: 15px; margin: 0 auto }` rule was never overridden for it.
- The native file input was bloated by the global `input { width:90%; flex:1 0 100% }` rule.

## Fix (CSS only — `styles1.css`, `.fd-import-row`)
- Lighter, compact banner: solid `#e2e8f0` border, 10px radius, tighter padding.
- File input keeps the native control but gets a clean `::file-selector-button` (white, blue text, rounded, hover) and is no longer forced full-width.
- **Download blank template** → auto-width secondary button explicitly resetting the global width/margin, pushed to the right end of the row.
- **What format?** disclosure drops to its own line beneath the banner.

No JS/markup changes; the upload + template behaviour is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)