### PR TITLE
Deploy the React app as the production site (served at /)

### DIFF
--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -11,23 +11,43 @@ const app = express();
 const server = http.createServer(app);
 
 app.use(express.json());
+// Legacy assets first so /assets always resolves to the static site's CSS/JS.
 app.use('/assets', express.static(ASSETS_DIR));
 
-// ── React SPA (incremental migration) ──────────────────────────────────
-// The new Vite app builds to public/app and is served under /app so it can
-// coexist with the legacy pages. Mounted only when it has been built, so the
-// legacy site is unaffected if the React build hasn't run.
+// ── React SPA (production site) ─────────────────────────────────────────
+// The Vite app builds to public/app and is the primary site, served at "/".
+// Its hashed assets live under /static (see vite.config assetsDir), so they
+// don't clash with the legacy /assets mount. The old .html pages are still
+// reachable at their own paths, served by pageRoutes below.
 const APP_DIR = path.join(PUBLIC_DIR, 'app');
-if (fs.existsSync(path.join(APP_DIR, 'index.html'))) {
-  app.use('/app', express.static(APP_DIR));
-  // Client-side routing fallback: any /app/* path returns the SPA shell.
-  app.get('/app/*', (_req, res) => res.sendFile(path.join(APP_DIR, 'index.html')));
+const reactBuilt = fs.existsSync(path.join(APP_DIR, 'index.html'));
+if (reactBuilt) {
+  // Serve "/", /static/*, and other built files. A missing file falls through
+  // to the legacy routes (e.g. /foundationDesign.html).
+  app.use(express.static(APP_DIR));
 } else {
-  console.warn('[app] React build not found at public/app — run `npm --prefix webapp run build` to enable /app');
+  console.warn('[app] React build not found at public/app — run `npm --prefix webapp run build`. Falling back to the legacy home page.');
 }
 
 app.use(pageRoutes);
 app.use(downloadRoutes);
+
+// The SPA used to be mounted under /app — keep old links working.
+if (reactBuilt) {
+  app.get(['/app', '/app/*'], (req, res) => {
+    res.redirect(301, req.originalUrl.replace(/^\/app/, '') || '/');
+  });
+}
+
+// SPA fallback: client-side routes (/foundation, /combined, /estimate/*, …)
+// have no file or legacy route, so return the React shell and let the router
+// take over. Registered last so assets and legacy .html pages win first.
+if (reactBuilt) {
+  app.get('*', (req, res, next) => {
+    if (req.method !== 'GET' || req.path.startsWith('/assets/')) return next();
+    res.sendFile(path.join(APP_DIR, 'index.html'));
+  });
+}
 
 server.listen(PORT, () => {
   console.log(`Server listening at http://localhost:${PORT}`);

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,5 +1,4 @@
 import { Routes, Route, Link } from 'react-router-dom'
-import { factoredLoad, beta1 } from './engine/loads'
 import FoundationDesign from './pages/FoundationDesign'
 import PileCapDesign from './pages/PileCapDesign'
 import CombinedFootingDesign from './pages/CombinedFootingDesign'
@@ -22,23 +21,12 @@ function Home() {
   return (
     <div className="mx-auto max-w-4xl p-8">
       <h1 className="text-3xl font-extrabold tracking-tight text-[#0056b3]">
-        Civil Engineering — React preview
+        Civil Engineering Toolkit
       </h1>
       <p className="mt-2 text-slate-600">
-        React&nbsp;+&nbsp;TypeScript app with a typed calculation engine. Structural design tools and
-        material take-off estimators, each with a printable / PDF report.
+        Structural design tools and material take-off estimators built on a typed calculation engine
+        (NSCP&nbsp;2015 / ACI&nbsp;318-14). Every tool computes live and produces a printable / PDF report.
       </p>
-
-      <div className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="text-lg font-semibold text-slate-800">Engine smoke check</h2>
-        <p className="mt-1 text-sm text-slate-600">
-          P<sub>u</sub> = max(1.4D, 1.2D+1.6L), D=150, L=100 →{' '}
-          <b>{factoredLoad({ dead: 150, live: 100 })} kN</b>
-        </p>
-        <p className="text-sm text-slate-600">
-          β₁ at f′c = 35 MPa → <b>{beta1(35)}</b>
-        </p>
-      </div>
 
       <h2 className="mt-8 text-lg font-semibold text-slate-800">Structural design</h2>
       <div className="mt-3 flex flex-wrap gap-3">

--- a/webapp/src/main.tsx
+++ b/webapp/src/main.tsx
@@ -4,11 +4,10 @@ import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
 
-// basename '/app' — the SPA is served by Express under /app, alongside the
-// legacy pages, during the incremental migration.
+// The SPA is served by Express at the site root, so routes live at "/".
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter basename="/app">
+    <BrowserRouter>
       <App />
     </BrowserRouter>
   </StrictMode>,

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -3,15 +3,17 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
-// The React SPA is served by the existing Express server under /app, so it can
-// coexist with the legacy pages while we migrate calculator-by-calculator.
-// It builds into ../public/app (which Express already serves).
+// The React SPA is the production site, served by Express at the root path.
+// It builds into ../public/app; Express serves that directory at "/". Assets
+// go under /static (not /assets) to avoid colliding with the legacy
+// /assets mount, so the old .html pages keep working alongside it.
 // https://vite.dev/config/
 export default defineConfig({
-  base: '/app/',
+  base: '/',
   plugins: [react(), tailwindcss()],
   build: {
     outDir: '../public/app',
+    assetsDir: 'static',
     emptyOutDir: true,
   },
   test: {


### PR DESCRIPTION
Makes the React SPA the primary site at `/`, replacing the legacy static home — while keeping the old `.html` pages reachable so nothing breaks.

## Changes
- **Vite** (`vite.config.ts`): `base '/app/' → '/'`; assets emitted to **`/static`** (via `assetsDir`) instead of `/assets`, so React's hashed files don't collide with the legacy `/assets` mount.
- **Router** (`main.tsx`): dropped the `basename="/app"` — routes are now `/`, `/foundation`, `/combined`, `/estimate/*`.
- **Express** (`server.js`):
  - Serves the React build at `/` with an SPA fallback for client routes.
  - **301-redirects** old `/app/*` links to the new root paths.
  - Legacy `/assets` and every `.html` page (foundationDesign, QuantitySurveying, …) still served. If the React build is absent, it gracefully falls back to the legacy home page.
- **Home** page made production-ready: titled "Civil Engineering Toolkit", removed the dev-only "engine smoke check" card.

## Verified locally
| Request | Result |
|---|---|
| `/` | React app (refs `/static/*`) ✅ |
| `/foundation`, `/combined`, `/estimate/*` | SPA fallback → React ✅ |
| `/static/*.js` | 200 ✅ |
| `/app/foundation` | 301 → `/foundation` ✅ |
| `/foundationDesign.html` + `/assets/*` | legacy still 200 ✅ |

`npm run build` green; `npm test` 60 passing.

## Deploy note
Render's build command must build the webapp so `public/app` exists:
`npm install && npm --prefix webapp install && npm --prefix webapp run build`
(unchanged from the current setup). `public/app` stays gitignored and is produced at build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)