### PR TITLE
Excel batch import on the React Foundation page (icon buttons + format popup)

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -11,7 +11,8 @@
         "katex": "^0.17.0",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
-        "react-router-dom": "^7.17.0"
+        "react-router-dom": "^7.17.0",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -63,6 +64,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1733,6 +1735,7 @@
       "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1743,6 +1746,7 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1802,6 +1806,7 @@
       "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.1",
         "@typescript-eslint/types": "8.60.1",
@@ -2140,6 +2145,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2155,6 +2161,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/ajv": {
@@ -2240,6 +2255,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2275,6 +2291,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2283,6 +2312,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/commander": {
@@ -2312,6 +2350,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -2470,6 +2520,7 @@
       "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2755,6 +2806,15 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -3445,6 +3505,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3506,6 +3567,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3515,6 +3577,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3677,6 +3740,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -3788,6 +3863,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3874,6 +3950,7 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4066,6 +4143,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4074,6 +4169,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/yallist": {
@@ -4102,6 +4218,7 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -14,7 +14,8 @@
     "katex": "^0.17.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "react-router-dom": "^7.17.0"
+    "react-router-dom": "^7.17.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/webapp/src/components/ExcelImport.tsx
+++ b/webapp/src/components/ExcelImport.tsx
@@ -1,0 +1,112 @@
+import { useRef, useState, type JSX } from 'react'
+import { importFoundationWorkbook, downloadFoundationTemplate, TEMPLATE_GUIDE, type BatchResult } from '../lib/foundationExcel'
+
+const UploadIcon = () => (
+  <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><polyline points="17 8 12 3 7 8" /><line x1="12" y1="3" x2="12" y2="15" />
+  </svg>
+)
+const DownloadIcon = () => (
+  <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><polyline points="7 10 12 15 17 10" /><line x1="12" y1="15" x2="12" y2="3" />
+  </svg>
+)
+const InfoIcon = () => (
+  <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+    <circle cx="12" cy="12" r="10" /><line x1="12" y1="16" x2="12" y2="12" /><line x1="12" y1="8" x2="12.01" y2="8" />
+  </svg>
+)
+
+export function ExcelImport({ onResult }: { onResult: (r: BatchResult | null) => void }): JSX.Element {
+  const fileRef = useRef<HTMLInputElement>(null)
+  const [fileName, setFileName] = useState('No file chosen')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [showHelp, setShowHelp] = useState(false)
+
+  async function onPick(e: React.ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0]
+    if (!f) return
+    setFileName(f.name); setError(null); setBusy(true); onResult(null)
+    try {
+      onResult(await importFoundationWorkbook(f))
+    } catch (err) {
+      setError((err as Error).message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="no-print mt-4 rounded-xl border border-slate-200 bg-slate-50 p-3">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+        <span className="text-[0.92rem] font-bold text-slate-800">Import from Excel</span>
+
+        <input ref={fileRef} type="file" accept=".xlsx,.xls" className="sr-only" onChange={onPick} />
+        <button type="button" onClick={() => fileRef.current?.click()} disabled={busy}
+          className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-br from-[#0056b3] to-[#003f86] px-3.5 py-2 text-sm font-semibold text-white shadow-sm transition hover:shadow disabled:opacity-60">
+          <UploadIcon />{busy ? 'Reading…' : 'Choose file'}
+        </button>
+        <span className="text-[0.83rem] text-slate-500">{fileName}</span>
+
+        <button type="button" onClick={() => void downloadFoundationTemplate()}
+          className="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3.5 py-2 text-sm font-semibold text-[#0056b3] transition hover:border-[#0056b3] hover:bg-blue-50">
+          <DownloadIcon />Blank template
+        </button>
+
+        <span className="ml-auto inline-flex items-center gap-2 text-[0.83rem] text-slate-500">
+          One row = one foundation.
+          <button type="button" onClick={() => setShowHelp(true)}
+            className="inline-flex items-center gap-1 font-semibold text-[#0056b3] hover:underline">
+            <InfoIcon />What format?
+          </button>
+        </span>
+      </div>
+
+      {error && <p className="mt-2 text-sm text-red-600">⚠ {error}</p>}
+
+      {showHelp && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/45 p-4"
+          role="dialog" aria-modal="true" aria-label="Excel upload format" onClick={() => setShowHelp(false)}>
+          <div className="max-h-[85vh] w-full max-w-xl overflow-auto rounded-xl bg-white shadow-2xl" onClick={(e) => e.stopPropagation()}>
+            <div className="flex items-center justify-between border-b border-slate-200 px-5 py-3">
+              <h3 className="text-base font-bold text-[#0056b3]">Excel upload format</h3>
+              <button type="button" onClick={() => setShowHelp(false)} aria-label="Close"
+                className="text-2xl leading-none text-slate-400 hover:text-slate-700">×</button>
+            </div>
+            <div className="px-5 py-4 text-sm text-slate-600">
+              <p>
+                The workbook must contain a sheet named <strong>DESIGN PARAMETERS</strong>. Row 1 holds the
+                column headers; each row below is one footing, so you can design many at once. Unknown headers
+                are ignored and listed after import.
+              </p>
+              <p className="mt-2">
+                Use <em>Blank template</em> for a ready-to-fill copy with sample rows and a guide sheet. This
+                React import supports <strong>Isolated Square</strong> and <strong>Isolated Rectangular</strong>
+                (concentric) footings.
+              </p>
+              <table className="mt-3 w-full border-collapse text-[0.82rem]">
+                <thead>
+                  <tr className="border-b border-slate-200 text-left text-slate-500">
+                    <th className="py-1.5 pr-3 font-semibold">Header</th>
+                    <th className="py-1.5 pr-3 font-semibold">Req</th>
+                    <th className="py-1.5 font-semibold">Notes</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {TEMPLATE_GUIDE.map((g) => (
+                    <tr key={g.header} className="border-b border-slate-100 align-top">
+                      <td className="py-1.5 pr-3 font-medium text-slate-700">{g.header}</td>
+                      <td className="py-1.5 pr-3 text-slate-500">{g.required ? '✓' : ''}</td>
+                      <td className="py-1.5 text-slate-500">{g.note}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/webapp/src/lib/foundationExcel.test.ts
+++ b/webapp/src/lib/foundationExcel.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import * as XLSX from 'xlsx'
+import { importFoundationWorkbook } from './foundationExcel'
+
+const HEADERS = [
+  'Label', 'Footing Type', 'P (kN)', 'Pu (kN)', 'Column Width (mm)', 'Position',
+  "f'c (MPa)", 'fy (MPa)', 'qa (kPa)', 'gamma soil (kN/m3)', 'gamma conc (kN/m3)',
+  'H (m)', 'Bar Dia (mm)', 'Cover (mm)', 'Surcharge (kPa)', 'Aspect Bx/By',
+]
+
+function toFile(ws: XLSX.WorkSheet): File {
+  const wb = XLSX.utils.book_new()
+  XLSX.utils.book_append_sheet(wb, ws, 'DESIGN PARAMETERS')
+  const out = XLSX.write(wb, { bookType: 'xlsx', type: 'array' }) as ArrayBuffer
+  return { arrayBuffer: async () => out } as unknown as File
+}
+
+function makeFile(rows: (string | number)[][]): File {
+  return toFile(XLSX.utils.aoa_to_sheet([HEADERS, ...rows]))
+}
+
+describe('foundation Excel import', () => {
+  it('designs square + rectangular rows', async () => {
+    const f = makeFile([
+      ['F-1', 'Isolated Square', 1000, 1400, 400, 'interior', 28, 415, 200, 18, 24, 1.5, 20, 75, 0, ''],
+      ['F-2', 'Isolated Rectangular', 1200, 1680, 450, 'edge', 28, 415, 180, 18, 24, 1.5, 20, 75, 0, 1.5],
+    ])
+    const res = await importFoundationWorkbook(f)
+    expect(res.rows).toHaveLength(2)
+    expect(res.designed).toBe(2)
+    expect(res.rows[0].ok).toBe(true)
+    expect(res.rows[0].size).toMatch(/B = /)
+    expect(res.rows[1].size).toMatch(/×/)
+  })
+
+  it('flags unknown types and missing required fields', async () => {
+    const f = makeFile([
+      ['Bad', 'Mystery', 1000, 1400, 400, 'interior', 28, 415, 200, 18, 24, 1.5, 20, 75, 0, ''],
+      ['Gap', 'Isolated Square', '', '', 400, 'interior', 28, 415, 200, 18, 24, 1.5, 20, 75, 0, ''],
+    ])
+    const res = await importFoundationWorkbook(f)
+    expect(res.designed).toBe(0)
+    expect(res.rows[0].ok).toBe(false)
+    expect(res.rows[0].note).toMatch(/Unknown/)
+    expect(res.rows[1].note).toMatch(/Missing/)
+  })
+
+  it('reports unknown headers', async () => {
+    const file = toFile(XLSX.utils.aoa_to_sheet([
+      [...HEADERS, 'Some Extra Column'],
+      ['F-1', 'Isolated Square', 1000, 1400, 400, 'interior', 28, 415, 200, 18, 24, 1.5, 20, 75, 0, '', 'junk'],
+    ]))
+    const res = await importFoundationWorkbook(file)
+    expect(res.unknownHeaders).toContain('Some Extra Column')
+  })
+})

--- a/webapp/src/lib/foundationExcel.ts
+++ b/webapp/src/lib/foundationExcel.ts
@@ -1,0 +1,174 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Excel batch import for the Foundation page — parse a "DESIGN PARAMETERS"
+// sheet (one row per footing), run each row through the typed engine, and
+// produce a schedule. Also generates a ready-to-fill template. The xlsx
+// library is dynamically imported so it stays out of the main bundle.
+// ─────────────────────────────────────────────────────────────────────────
+import { designSquareFooting } from '../engine/isolatedFooting'
+import { designRectangularFooting } from '../engine/rectangularFooting'
+import type { ColumnPosition } from '../engine/shear'
+import { f0, f2, f3 } from './format'
+
+const SHEET = 'DESIGN PARAMETERS'
+
+interface ColumnSpec {
+  header: string
+  key: string
+  kind: 'num' | 'str'
+  required?: boolean
+  note: string
+}
+
+/** Header → engine field map. Header text is matched case-insensitively. */
+const COLUMNS: ColumnSpec[] = [
+  { header: 'Label', key: 'label', kind: 'str', note: 'Optional name (else auto-numbered).' },
+  { header: 'Footing Type', key: 'type', kind: 'str', required: true, note: '"Isolated Square" or "Isolated Rectangular".' },
+  { header: 'P (kN)', key: 'serviceLoad', kind: 'num', required: true, note: 'Service axial load.' },
+  { header: 'Pu (kN)', key: 'ultimateLoad', kind: 'num', required: true, note: 'Factored axial load.' },
+  { header: 'Column Width (mm)', key: 'columnWidth', kind: 'num', required: true, note: 'Square column side.' },
+  { header: 'Position', key: 'position', kind: 'str', note: 'interior | edge | corner (default interior).' },
+  { header: "f'c (MPa)", key: 'fc', kind: 'num', required: true, note: 'Concrete strength.' },
+  { header: 'fy (MPa)', key: 'fy', kind: 'num', required: true, note: 'Steel yield.' },
+  { header: 'qa (kPa)', key: 'qAllow', kind: 'num', required: true, note: 'Allowable bearing.' },
+  { header: 'gamma soil (kN/m3)', key: 'gammaSoil', kind: 'num', required: true, note: 'Soil unit weight.' },
+  { header: 'gamma conc (kN/m3)', key: 'gammaConc', kind: 'num', required: true, note: 'Concrete unit weight.' },
+  { header: 'H (m)', key: 'H', kind: 'num', required: true, note: 'Total depth to founding level.' },
+  { header: 'Bar Dia (mm)', key: 'barDia', kind: 'num', required: true, note: 'Main bar diameter.' },
+  { header: 'Cover (mm)', key: 'cover', kind: 'num', required: true, note: 'Clear cover.' },
+  { header: 'Surcharge (kPa)', key: 'surcharge', kind: 'num', note: 'Optional, default 0.' },
+  { header: 'Aspect Bx/By', key: 'ratio', kind: 'num', note: 'Rectangular only, default 1.5.' },
+]
+
+export const TEMPLATE_GUIDE = COLUMNS.map((c) => ({
+  header: c.header, required: c.required ? 'yes' : '', note: c.note,
+}))
+
+export interface ScheduleRow {
+  label: string
+  type: string
+  ok: boolean
+  size: string
+  thickness: string
+  steel: string
+  note: string
+}
+
+interface ParsedRow { [k: string]: string | number }
+
+function normalizeType(v: string): 'square' | 'rectangular' | null {
+  const s = v.toLowerCase()
+  if (s.includes('rect')) return 'rectangular'
+  if (s.includes('square') || s.includes('isolated')) return 'square'
+  return null
+}
+
+function pickColumns(raw: Record<string, unknown>): { row: ParsedRow; unknown: string[] } {
+  const lower = new Map<string, ColumnSpec>()
+  COLUMNS.forEach((c) => lower.set(c.header.toLowerCase(), c))
+  const row: ParsedRow = {}
+  const unknown: string[] = []
+  for (const [k, val] of Object.entries(raw)) {
+    const spec = lower.get(k.trim().toLowerCase())
+    if (!spec) { if (String(val).trim() !== '') unknown.push(k); continue }
+    if (spec.kind === 'num') {
+      const n = typeof val === 'number' ? val : parseFloat(String(val))
+      if (Number.isFinite(n)) row[spec.key] = n
+    } else {
+      row[spec.key] = String(val).trim()
+    }
+  }
+  return { row, unknown }
+}
+
+function designRow(r: ParsedRow, index: number): ScheduleRow {
+  const label = (r.label as string) || `F-${index + 1}`
+  const type = normalizeType(String(r.type ?? ''))
+  const base = { label, type: String(r.type ?? '—'), ok: false, size: '—', thickness: '—', steel: '—', note: '' }
+
+  if (!type) return { ...base, note: 'Unknown / unsupported footing type (use Isolated Square or Rectangular).' }
+
+  const required = ['serviceLoad', 'ultimateLoad', 'columnWidth', 'fc', 'fy', 'qAllow', 'gammaSoil', 'gammaConc', 'H', 'barDia', 'cover']
+  const missing = required.filter((k) => !Number.isFinite(r[k] as number))
+  if (missing.length) return { ...base, note: `Missing/invalid: ${missing.join(', ')}` }
+
+  const common = {
+    serviceLoad: r.serviceLoad as number, ultimateLoad: r.ultimateLoad as number,
+    columnWidth: r.columnWidth as number, fc: r.fc as number, fy: r.fy as number,
+    qAllow: r.qAllow as number, gammaSoil: r.gammaSoil as number, gammaConc: r.gammaConc as number,
+    H: r.H as number, barDia: r.barDia as number, cover: r.cover as number,
+    surcharge: (r.surcharge as number) ?? 0,
+    position: (['interior', 'edge', 'corner'].includes(String(r.position)) ? r.position : 'interior') as ColumnPosition,
+  }
+
+  try {
+    if (type === 'square') {
+      const d = designSquareFooting(common)
+      if (!(d.qNet > 0)) return { ...base, type: 'Isolated Square', note: 'Net bearing ≤ 0 — increase qa or reduce depth.' }
+      return {
+        label, type: 'Isolated Square', ok: true,
+        size: `B = ${f2(d.B)} m`,
+        thickness: `${f0(d.Dc)} mm`,
+        steel: `${d.bars}⌀${common.barDia} @ ${f0(d.barSpacing)} mm e.w.`,
+        note: `qNet ${f3(d.qNet)} kPa`,
+      }
+    }
+    const ratio = Number.isFinite(r.ratio as number) && (r.ratio as number) >= 1 ? (r.ratio as number) : 1.5
+    const d = designRectangularFooting({ ...common, sizing: { mode: 'ratio', ratio } })
+    if (!(d.qNet > 0)) return { ...base, type: 'Isolated Rectangular', note: 'Net bearing ≤ 0 — increase qa or reduce depth.' }
+    return {
+      label, type: 'Isolated Rectangular', ok: true,
+      size: `${f2(d.Bx)} × ${f2(d.By)} m`,
+      thickness: `${f0(d.Dc)} mm`,
+      steel: `L ${d.long.bars}⌀${common.barDia}@${f0(d.long.spacing)} · S ${d.short.bars}⌀${common.barDia}@${f0(d.short.spacing)}`,
+      note: `qNet ${f3(d.qNet)} kPa · ratio ${ratio}`,
+    }
+  } catch (e) {
+    return { ...base, type: type === 'square' ? 'Isolated Square' : 'Isolated Rectangular', note: `Error: ${(e as Error).message}` }
+  }
+}
+
+export interface BatchResult { rows: ScheduleRow[]; unknownHeaders: string[]; designed: number }
+
+/** Parse an uploaded .xlsx/.xls and design every row. */
+export async function importFoundationWorkbook(file: File): Promise<BatchResult> {
+  const XLSX = await import('xlsx')
+  const buf = await file.arrayBuffer()
+  const wb = XLSX.read(new Uint8Array(buf), { type: 'array' })
+  const sheetName = wb.SheetNames.includes(SHEET) ? SHEET : wb.SheetNames[0]
+  if (!sheetName) throw new Error('The workbook has no sheets.')
+  const sheet = wb.Sheets[sheetName]
+  const raw = XLSX.utils.sheet_to_json<Record<string, unknown>>(sheet, { defval: '' })
+  if (!raw.length) throw new Error(`Sheet "${sheetName}" has no data rows.`)
+
+  const unknown = new Set<string>()
+  const rows = raw.map((r, i) => {
+    const { row, unknown: u } = pickColumns(r)
+    u.forEach((h) => unknown.add(h))
+    return designRow(row, i)
+  })
+  return { rows, unknownHeaders: [...unknown], designed: rows.filter((r) => r.ok).length }
+}
+
+/** Build and download a ready-to-fill template (.xlsx) with sample rows + a guide. */
+export async function downloadFoundationTemplate(): Promise<void> {
+  const XLSX = await import('xlsx')
+  const headers = COLUMNS.map((c) => c.header)
+  const sampleSquare = ['F-1', 'Isolated Square', 1000, 1400, 400, 'interior', 28, 415, 200, 18, 24, 1.5, 20, 75, 0, '']
+  const sampleRect = ['F-2', 'Isolated Rectangular', 1200, 1680, 450, 'edge', 28, 415, 180, 18, 24, 1.5, 20, 75, 0, 1.5]
+  const ws = XLSX.utils.aoa_to_sheet([headers, sampleSquare, sampleRect])
+  const guide = XLSX.utils.aoa_to_sheet([
+    ['Header', 'Required', 'Notes'],
+    ...TEMPLATE_GUIDE.map((g) => [g.header, g.required, g.note]),
+  ])
+  const wb = XLSX.utils.book_new()
+  XLSX.utils.book_append_sheet(wb, ws, SHEET)
+  XLSX.utils.book_append_sheet(wb, guide, 'PARAMETER GUIDE')
+  const out = XLSX.write(wb, { bookType: 'xlsx', type: 'array' })
+  const blob = new Blob([out], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = 'foundation-template.xlsx'
+  a.click()
+  URL.revokeObjectURL(url)
+}

--- a/webapp/src/pages/FoundationDesign.tsx
+++ b/webapp/src/pages/FoundationDesign.tsx
@@ -7,6 +7,8 @@ import { netBearing } from '../engine/bearing'
 import type { ColumnPosition } from '../engine/shear'
 import { FootingSchematic } from '../components/FootingSchematic'
 import { ReportControls } from '../components/ReportControls'
+import { ExcelImport } from '../components/ExcelImport'
+import type { BatchResult } from '../lib/foundationExcel'
 import { Math } from '../lib/math'
 import { f0, f2, f3 } from '../lib/format'
 import 'katex/dist/katex.min.css'
@@ -131,6 +133,7 @@ function steelRow(label: ReactNode, s: DirSteel, db: number) {
 
 export default function FoundationDesign() {
   const [form, setForm] = useState<FormState>(DEFAULTS)
+  const [batch, setBatch] = useState<BatchResult | null>(null)
   const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) => setForm((s) => ({ ...s, [k]: v }))
   const ecc = form.loadingType === 'eccentric'
   const rect = form.footingType === 'rectangular' && !ecc   // eccentric pilot is square-only
@@ -185,6 +188,49 @@ export default function FoundationDesign() {
       <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Foundation Design</h1>
       <p className="no-print mt-1 text-slate-600">Isolated footing (square / rectangular, concentric / eccentric) — React + typed engine. Results update live.</p>
       <ReportControls title="Foundation Design Report" />
+      <ExcelImport onResult={setBatch} />
+
+      {batch && (
+        <div className="mt-4 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm print-avoid-break">
+          <div className="flex flex-wrap items-baseline justify-between gap-2 border-b border-slate-200 px-4 py-2.5">
+            <h2 className="text-[1.02rem] font-bold text-[#0056b3]">
+              Batch schedule <span className="text-sm font-normal text-slate-500">({batch.designed}/{batch.rows.length} designed)</span>
+            </h2>
+            <button type="button" onClick={() => setBatch(null)} className="no-print text-xs text-slate-500 hover:text-slate-700 hover:underline">Clear</button>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr className="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500">
+                  <th className="px-4 py-2 font-semibold">Label</th>
+                  <th className="px-4 py-2 font-semibold">Type</th>
+                  <th className="px-4 py-2 font-semibold">Plan</th>
+                  <th className="px-4 py-2 font-semibold">Dc</th>
+                  <th className="px-4 py-2 font-semibold">Reinforcement</th>
+                  <th className="px-4 py-2 font-semibold">Note</th>
+                </tr>
+              </thead>
+              <tbody>
+                {batch.rows.map((r, i) => (
+                  <tr key={i} className={`border-t border-slate-100 ${r.ok ? '' : 'bg-red-50/60'}`}>
+                    <td className="px-4 py-2 font-medium text-slate-700">{r.ok ? '✓' : '✗'} {r.label}</td>
+                    <td className="px-4 py-2 text-slate-600">{r.type}</td>
+                    <td className="px-4 py-2 text-slate-800">{r.size}</td>
+                    <td className="px-4 py-2 text-slate-800">{r.thickness}</td>
+                    <td className="px-4 py-2 text-slate-800">{r.steel}</td>
+                    <td className="px-4 py-2 text-xs text-slate-500">{r.note}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          {batch.unknownHeaders.length > 0 && (
+            <p className="border-t border-slate-100 px-4 py-2 text-xs text-slate-400">
+              Ignored headers: {batch.unknownHeaders.join(', ')}
+            </p>
+          )}
+        </div>
+      )}
 
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
         {/* ── Inputs ── */}


### PR DESCRIPTION
Ports the legacy "Import from Excel" feature into the React app (now the production site) with the requested modern UX.

## UX (as requested)
- **Icon buttons** replace the bare file input + text link: a primary **Choose file** (upload icon) and a secondary **Blank template** (download icon), plus a live filename.
- The "What format?" `<details>` block is gone — now a one-line **hint** ("One row = one foundation") with a **What format?** info button that opens a **popup** listing every column and whether it's required.

## Functionality (engine-backed)
- **`lib/foundationExcel.ts`** — parses a `DESIGN PARAMETERS` sheet (one row per footing), maps headers to the typed engine, and designs each row. Supports **Isolated Square** and **Isolated Rectangular** (concentric). Produces a ready-to-fill **template** (sample rows + a `PARAMETER GUIDE` sheet).
- **Schedule table** on the Foundation page: per-row plan size, thickness, reinforcement, status (✓/✗) and notes; unknown headers are reported; failed rows highlighted.
- `xlsx` is **dynamically imported**, so it lands in its own lazy-loaded chunk (`xlsx-*.js`) and doesn't bloat the initial bundle.

## Verification
- 3 new unit tests (63 total). They caught a real bug before it shipped: `File.arrayBuffer()` returns an `ArrayBuffer`, which `XLSX.read` needs wrapped in a `Uint8Array` — fixed.
- `npm run build` green.

## Notes
- Branches off `main` (no stacking).
- Scope vs legacy: the old page accepted ~40 parameter labels across all footing types; this first React pass covers the two isolated concentric types the React engine ships today. Combined-footing / eccentric / pile-cap columns can be added incrementally (the engine functions already exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)