### PR TITLE
Add step-by-step worked Solution to the React Foundation page

### DIFF
--- a/webapp/src/components/FoundationSolution.tsx
+++ b/webapp/src/components/FoundationSolution.tsx
@@ -1,0 +1,37 @@
+import { useState, type JSX } from 'react'
+import type { SolutionStep } from '../lib/foundationSolution'
+import { Math } from '../lib/math'
+
+/** Collapsible worked-solution panel — the step-by-step derivation. */
+export function FoundationSolution({ steps }: { steps: SolutionStep[] }): JSX.Element {
+  const [open, setOpen] = useState(true)
+  return (
+    <div className="mt-6 rounded-xl border border-slate-200 bg-white shadow-sm print-avoid-break">
+      <button type="button" onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left">
+        <h2 className="text-[1.02rem] font-bold text-[#0056b3]">Solution — step by step</h2>
+        <span className="no-print text-sm text-slate-400">{open ? 'Hide ▲' : 'Show ▼'}</span>
+      </button>
+
+      {open && (
+        <ol className="space-y-4 border-t border-slate-100 px-4 py-4">
+          {steps.map((s, i) => (
+            <li key={i} className="print-avoid-break">
+              <h3 className="mb-1.5 text-sm font-semibold text-slate-800">
+                <span className="text-slate-400">{i + 1}.</span> {s.title}
+              </h3>
+              <div className="space-y-1.5 overflow-x-auto pl-4">
+                {s.lines.map((ln, j) => (
+                  <div key={j} className="text-[0.95rem] text-slate-700">
+                    <Math block tex={ln.tex} />
+                  </div>
+                ))}
+              </div>
+              {s.note && <p className="mt-1 pl-4 text-xs text-slate-500">{s.note}</p>}
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  )
+}

--- a/webapp/src/lib/foundationSolution.test.ts
+++ b/webapp/src/lib/foundationSolution.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { designSquareFooting } from '../engine/isolatedFooting'
+import { buildFoundationSolution, type SolutionCtx } from './foundationSolution'
+
+const input = {
+  serviceLoad: 1000, ultimateLoad: 1400, columnWidth: 400,
+  fc: 28, fy: 415, qAllow: 200, gammaSoil: 18, gammaConc: 24,
+  H: 1.5, barDia: 20, cover: 75, surcharge: 0, position: 'interior' as const,
+}
+
+function squareCtx(): SolutionCtx {
+  const r = designSquareFooting(input)
+  return {
+    type: 'square', loading: 'concentric',
+    serviceLoad: input.serviceLoad, ultimateLoad: input.ultimateLoad, serviceMoment: 0, ultimateMoment: 0,
+    columnWidth: input.columnWidth, fc: input.fc, fy: input.fy,
+    qAllow: input.qAllow, gammaSoil: input.gammaSoil, gammaConc: input.gammaConc, H: input.H,
+    barDia: input.barDia, cover: input.cover, surcharge: 0, position: 'interior',
+    Bx: r.B, By: r.B, Dc: r.Dc, qNet: r.qNet, qu: r.qu,
+    dPunch: r.dPunch, dBeamLong: r.dBeam, dBeamShort: r.dBeam,
+    long: { As: r.steelArea, rho: r.rho, usedMin: r.usedMinSteel, bars: r.bars, spacing: r.barSpacing },
+    short: null, ecc: null,
+  }
+}
+
+describe('foundation worked solution', () => {
+  it('square: produces the full step sequence ending in bar selection', () => {
+    const steps = buildFoundationSolution(squareCtx())
+    const titles = steps.map((s) => s.title)
+    expect(titles[0]).toMatch(/Net allowable/)
+    expect(titles).toContain('Two-way (punching) shear')
+    expect(titles.some((t) => t.startsWith('Flexural'))).toBe(true)
+    expect(titles[titles.length - 1]).toMatch(/Bar selection/)
+  })
+
+  it('square: flexure As in the solution matches the engine result', () => {
+    const r = designSquareFooting(input)
+    const steps = buildFoundationSolution(squareCtx())
+    const flex = steps.find((s) => s.title.startsWith('Flexural'))!
+    // the As line carries the rounded engine area
+    expect(flex.lines.some((l) => l.tex.includes(`${Math.round(r.steelArea)}`))).toBe(true)
+    const bars = steps.find((s) => s.title.startsWith('Bar selection'))!
+    expect(bars.note).toContain(`${r.bars} ⌀20`)
+  })
+})

--- a/webapp/src/lib/foundationSolution.ts
+++ b/webapp/src/lib/foundationSolution.ts
@@ -1,0 +1,182 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Worked step-by-step solution for the Foundation page — reproduces the
+// legacy app's derivation (loads → net bearing → size → shear → flexure →
+// bars) with substituted numbers, computed with the same engine formulas so
+// the steps stay consistent with the Results panel. Pure & framework-agnostic;
+// returns KaTeX strings the React component renders.
+// ─────────────────────────────────────────────────────────────────────────
+import type { ColumnPosition } from '../engine/shear'
+
+export interface SolutionLine { tex: string }
+export interface SolutionStep { title: string; lines: SolutionLine[]; note?: string }
+
+interface SteelCtx { As: number; rho: number; usedMin: boolean; bars: number; spacing: number }
+
+/** Flattened design context (page maps form + result into this). */
+export interface SolutionCtx {
+  type: 'square' | 'rectangular'
+  loading: 'concentric' | 'eccentric'
+  serviceLoad: number; ultimateLoad: number
+  serviceMoment: number; ultimateMoment: number
+  columnWidth: number; fc: number; fy: number
+  qAllow: number; gammaSoil: number; gammaConc: number; H: number
+  barDia: number; cover: number; surcharge: number; position: ColumnPosition
+  Bx: number; By: number; Dc: number; qNet: number; qu: number
+  dPunch: number; dBeamLong: number; dBeamShort: number
+  long: SteelCtx; short: (SteelCtx & { bandBars: number; bandFraction: number }) | null
+  ecc: { e: number; qMax: number; qMin: number; kernOK: boolean } | null
+}
+
+const n0 = (v: number) => Math.round(v).toString()
+const n1 = (v: number) => v.toFixed(1)
+const n2 = (v: number) => v.toFixed(2)
+const n3 = (v: number) => v.toFixed(3)
+const n4 = (v: number) => v.toFixed(4)
+const ALPHA_S: Record<ColumnPosition, number> = { interior: 40, edge: 30, corner: 20 }
+
+// ── Shared steps ────────────────────────────────────────────────────────
+function bearingStep(c: SolutionCtx): SolutionStep {
+  const DcM = c.Dc / 1000, Ds = c.H - DcM
+  return {
+    title: 'Net allowable soil pressure',
+    lines: [
+      { tex: String.raw`q_{net} = q_a - \gamma_s D_s - \gamma_c D_c - q,\quad D_s = H - D_c` },
+      { tex: String.raw`q_{net} = ${n0(c.qAllow)} - ${n0(c.gammaSoil)}(${n3(Ds)}) - ${n0(c.gammaConc)}(${n3(DcM)}) - ${n0(c.surcharge)} = \mathbf{${n2(c.qNet)}}\ \text{kPa}` },
+    ],
+    note: `Using the converged slab thickness D_c = ${n0(c.Dc)} mm (sizing and thickness are iterated together).`,
+  }
+}
+
+function pressureStep(c: SolutionCtx): SolutionStep {
+  const area = c.Bx * c.By
+  const sizeTex = c.type === 'square'
+    ? String.raw`q_u = \dfrac{P_u}{B^2} = \dfrac{${n0(c.ultimateLoad)}}{${n2(c.Bx)}^2} = \mathbf{${n2(c.qu)}}\ \text{kPa}`
+    : String.raw`q_u = \dfrac{P_u}{B_x B_y} = \dfrac{${n0(c.ultimateLoad)}}{${n2(c.Bx)}\times ${n2(c.By)}} = \mathbf{${n2(c.qu)}}\ \text{kPa}`
+  return { title: 'Factored bearing pressure', lines: [{ tex: `A = ${n3(area)}\\ \\text{m}^2` }, { tex: sizeTex }] }
+}
+
+function punchingStep(c: SolutionCtx): SolutionStep {
+  const cmm = c.columnWidth, d = c.dPunch
+  const crit = cmm + d, bo = 4 * crit, Ao = crit * crit * 1e-6
+  const Vu = c.ultimateLoad - c.qu * Ao
+  const base = (Math.sqrt(c.fc) * bo * d) / 1000
+  const vc = Math.min(base / 3, base / 2, (1 / 12) * (2 + (ALPHA_S[c.position] * d) / bo) * base)
+  const phiVc = 0.75 * vc
+  return {
+    title: 'Two-way (punching) shear',
+    lines: [
+      { tex: String.raw`b_o = 4(c+d) = 4(${n0(cmm)}+${n0(d)}) = ${n0(bo)}\ \text{mm}` },
+      { tex: String.raw`V_u = P_u - q_u(c+d)^2 = ${n0(c.ultimateLoad)} - ${n2(c.qu)}(${n3(Ao)}) = ${n1(Vu)}\ \text{kN}` },
+      { tex: String.raw`\phi V_c = 0.75\,\min(V_{c1},V_{c2},V_{c3}) = ${n1(phiVc)}\ \text{kN} \ge V_u\ \checkmark` },
+    ],
+    note: `Critical perimeter at d/2 from the column face; required d = ${n0(d)} mm.`,
+  }
+}
+
+function oneWayStep(c: SolutionCtx, B: number, d: number, label: string): SolutionStep {
+  const cm = c.columnWidth / 1000
+  const arm = (B - cm) / 2 - d / 1000
+  const Vu = c.qu * B * Math.max(0, arm)
+  const phiVc = (0.75 * (1 / 6) * Math.sqrt(c.fc) * (B * 1000) * d) / 1000
+  return {
+    title: `One-way (beam) shear${label ? ` — ${label}` : ''}`,
+    lines: [
+      { tex: String.raw`a_v = \tfrac{B-c}{2} - d = \tfrac{${n2(B)}-${n3(cm)}}{2} - ${n3(d / 1000)} = ${n3(arm)}\ \text{m}` },
+      { tex: String.raw`V_u = q_u B\,a_v = ${n2(c.qu)}(${n2(B)})(${n3(arm)}) = ${n1(Vu)}\ \text{kN}` },
+      { tex: String.raw`\phi V_c = 0.75\cdot\tfrac{1}{6}\sqrt{f'_c}\,B d = ${n1(phiVc)}\ \text{kN} \ge V_u\ \checkmark` },
+    ],
+    note: `Critical section d = ${n0(d)} mm from the column face.`,
+  }
+}
+
+function thicknessStep(c: SolutionCtx): SolutionStep {
+  const dFlex = c.Dc - c.cover - c.barDia / 2
+  return {
+    title: 'Slab thickness',
+    lines: [
+      { tex: String.raw`D_c = \max(d_{punch},d_{beam}) + cover + d_b = \max(${n0(c.dPunch)},${n0(Math.max(c.dBeamLong, c.dBeamShort))}) + ${n0(c.cover)} + ${n0(c.barDia)} \to \mathbf{${n0(c.Dc)}}\ \text{mm}` },
+      { tex: String.raw`d = D_c - cover - \tfrac{d_b}{2} = ${n0(c.Dc)} - ${n0(c.cover)} - ${n1(c.barDia / 2)} = ${n1(dFlex)}\ \text{mm}` },
+    ],
+  }
+}
+
+function flexureStep(c: SolutionCtx, span: number, width: number, steel: SteelCtx, label: string): SolutionStep {
+  const cm = c.columnWidth / 1000
+  const d = c.Dc - c.cover - c.barDia / 2
+  const arm = (span - cm) / 2
+  const Mu = (c.qu * width * arm * arm) / 2
+  const b = width * 1000
+  const Rn = (Mu * 1e6) / (0.9 * b * d * d)
+  const rhoCalc = (0.85 * c.fc / c.fy) * (1 - Math.sqrt(Math.max(0, 1 - (2 * Rn) / (0.85 * c.fc))))
+  const rMin = Math.max(1.4 / c.fy, Math.sqrt(c.fc) / (4 * c.fy))
+  return {
+    title: `Flexural reinforcement${label ? ` — ${label}` : ''}`,
+    lines: [
+      { tex: String.raw`a = \tfrac{${label === 'short (y)' ? 'B_y' : 'B'}-c}{2} = ${n3(arm)}\ \text{m},\quad M_u = \tfrac{q_u\,b\,a^2}{2} = ${n1(Mu)}\ \text{kN·m}` },
+      { tex: String.raw`R_n = \dfrac{M_u}{\phi b d^2} = ${n3(Rn)}\ \text{MPa}` },
+      { tex: String.raw`\rho = \tfrac{0.85 f'_c}{f_y}\!\left(1-\sqrt{1-\tfrac{2R_n}{0.85 f'_c}}\right) = ${n4(rhoCalc)},\quad \rho_{min} = ${n4(rMin)}` },
+      { tex: String.raw`A_s = \rho\,b\,d = ${n0(steel.As)}\ \text{mm}^2\quad(\rho = ${n4(steel.rho)})` },
+    ],
+    note: steel.usedMin ? 'ρ_min governs.' : 'Computed ρ governs.',
+  }
+}
+
+function barsStep(c: SolutionCtx, steel: SteelCtx, label: string): SolutionStep {
+  const Ab = (Math.PI / 4) * c.barDia * c.barDia
+  return {
+    title: `Bar selection${label ? ` — ${label}` : ''}`,
+    lines: [
+      { tex: String.raw`A_b = \tfrac{\pi}{4}d_b^2 = ${n0(Ab)}\ \text{mm}^2,\quad n = \lceil A_s/A_b \rceil = ${steel.bars}` },
+      { tex: String.raw`s = \dfrac{b - 2\,cover - n d_b}{n-1} = ${n0(steel.spacing)}\ \text{mm}` },
+    ],
+    note: `Provide ${steel.bars} ⌀${c.barDia} mm @ ${n0(steel.spacing)} mm ${label ? `(${label})` : 'each way'}.`,
+  }
+}
+
+function eccentricityStep(c: SolutionCtx): SolutionStep | null {
+  if (!c.ecc) return null
+  const B = c.Bx
+  return {
+    title: 'Eccentricity & pressure distribution',
+    lines: [
+      { tex: String.raw`e = \dfrac{M}{P} = \dfrac{${n0(c.serviceMoment)}}{${n0(c.serviceLoad)}} = ${n3(c.ecc.e)}\ \text{m} \;${c.ecc.kernOK ? '\\le' : '>'}\; \tfrac{B}{6} = ${n3(B / 6)}\ \text{m}` },
+      { tex: String.raw`q_{max,min} = \dfrac{P}{B^2}\!\left(1 \pm \dfrac{6e}{B}\right) = ${n2(c.ecc.qMax)} \,/\, ${n2(c.ecc.qMin)}\ \text{kPa}` },
+    ],
+    note: c.ecc.kernOK
+      ? 'Resultant stays within the kern — full bearing, no uplift. Design uses the factored peak pressure.'
+      : 'Eccentricity exceeds B/6 — partial bearing/uplift; revise the footing.',
+  }
+}
+
+/** Ordered worked-solution steps for the current design. */
+export function buildFoundationSolution(c: SolutionCtx): SolutionStep[] {
+  const steps: SolutionStep[] = [bearingStep(c)]
+  const eccS = eccentricityStep(c)
+  if (eccS) steps.push(eccS)
+  steps.push(pressureStep(c), punchingStep(c))
+
+  if (c.type === 'square') {
+    steps.push(oneWayStep(c, c.Bx, c.dBeamLong, ''), thicknessStep(c))
+    steps.push(flexureStep(c, c.Bx, c.Bx, c.long, ''), barsStep(c, c.long, ''))
+  } else {
+    steps.push(
+      oneWayStep(c, c.Bx, c.dBeamLong, 'long (x)'),
+      oneWayStep(c, c.By, c.dBeamShort, 'short (y)'),
+      thicknessStep(c),
+      flexureStep(c, c.Bx, c.By, c.long, 'long (x)'),
+      barsStep(c, c.long, 'long (x)'),
+    )
+    if (c.short) {
+      steps.push(flexureStep(c, c.By, c.Bx, c.short, 'short (y)'), barsStep(c, c.short, 'short (y)'))
+      steps.push({
+        title: 'Central band (short direction)',
+        lines: [
+          { tex: String.raw`\dfrac{\text{band steel}}{\text{total}} = \dfrac{2}{\beta + 1},\quad \beta = \tfrac{B_x}{B_y} = ${n2(c.Bx / c.By)}` },
+          { tex: String.raw`\Rightarrow ${c.short.bandBars}\ \text{of}\ ${c.short.bars}\ \text{bars in the central band } B_y\ (\approx ${n0(c.short.bandFraction * 100)}\%)` },
+        ],
+        note: 'NSCP 2015 §413.3.3.3 — concentrate the central-band fraction within a width B_y under the column.',
+      })
+    }
+  }
+  return steps
+}

--- a/webapp/src/pages/FoundationDesign.tsx
+++ b/webapp/src/pages/FoundationDesign.tsx
@@ -9,6 +9,8 @@ import { FootingSchematic } from '../components/FootingSchematic'
 import { ReportControls } from '../components/ReportControls'
 import { ExcelImport } from '../components/ExcelImport'
 import type { BatchResult } from '../lib/foundationExcel'
+import { FoundationSolution } from '../components/FoundationSolution'
+import { buildFoundationSolution, type SolutionCtx } from '../lib/foundationSolution'
 import { Math } from '../lib/math'
 import { f0, f2, f3 } from '../lib/format'
 import 'katex/dist/katex.min.css'
@@ -182,6 +184,22 @@ export default function FoundationDesign() {
     }
   }, [form, valid, rect, ecc])
 
+  const solutionSteps = useMemo(() => {
+    if (!view) return null
+    const ctx: SolutionCtx = {
+      type: view.type, loading: view.loading,
+      serviceLoad: form.serviceLoad, ultimateLoad: form.ultimateLoad,
+      serviceMoment: form.serviceMoment, ultimateMoment: form.ultimateMoment,
+      columnWidth: form.columnWidth, fc: form.fc, fy: form.fy,
+      qAllow: form.qAllow, gammaSoil: form.gammaSoil, gammaConc: form.gammaConc, H: form.H,
+      barDia: form.barDia, cover: form.cover, surcharge: form.surcharge, position: form.position,
+      Bx: view.Bx, By: view.By, Dc: view.Dc, qNet: view.qNet, qu: view.qu,
+      dPunch: view.dPunch, dBeamLong: view.dBeamLong, dBeamShort: view.dBeamShort,
+      long: view.long, short: view.short, ecc: view.ecc,
+    }
+    return buildFoundationSolution(ctx)
+  }, [view, form])
+
   return (
     <div className="mx-auto max-w-6xl p-6">
       <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
@@ -333,6 +351,8 @@ export default function FoundationDesign() {
           </div>
         </div>
       </div>
+
+      {solutionSteps && <FoundationSolution steps={solutionSteps} />}
     </div>
   )
 }


### PR DESCRIPTION
Restores the legacy app's **worked solution** in React. The React Foundation page only showed a compact Results panel — the detailed step-by-step derivation engineers rely on (to show/verify their work) was "gone." This adds it back.

## What's new
- **`lib/foundationSolution.ts`** — a pure step generator that reproduces the derivation with substituted numbers, computed with the *same* engine formulas so the steps always agree with the Results panel:
  - Net allowable bearing → required area & size → factored pressure → two-way (punching) shear → one-way (beam) shear → slab thickness → flexure (Rn, ρ, ρ_min, As) → bar selection.
  - **Eccentric** loading adds the `e = M/P`, kern check, and `q_max/q_min` steps.
  - **Rectangular** adds long/short one-way + flexure and the central-band step (NSCP §413.3.3.3).
- **`components/FoundationSolution.tsx`** — a collapsible "Solution — step by step" panel rendering each step's KaTeX with notes; print-friendly so it flows into the PDF report.
- Wired into the Foundation page full-width below the inputs/results grid.

## Verification
- 2 new unit tests (65 total) pin the step sequence and assert the solution's **As and bar count match the engine output** (no drift between the worked steps and Results).
- `npm run build` green.

## Notes
- Covers Isolated **Square**, **Rectangular**, and **Eccentric** (the types the page designs).
- Branches off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)