### PR TITLE
New React Beam Design tool (flexure + shear) with worked solution

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route, Link } from 'react-router-dom'
 import FoundationDesign from './pages/FoundationDesign'
 import PileCapDesign from './pages/PileCapDesign'
 import CombinedFootingDesign from './pages/CombinedFootingDesign'
+import BeamDesign from './pages/BeamDesign'
 import SlabEstimate from './pages/SlabEstimate'
 import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
@@ -33,6 +34,7 @@ function Home() {
         <Tile to="/foundation">Foundation Design</Tile>
         <Tile to="/pile-cap">Pile Cap Design</Tile>
         <Tile to="/combined">Combined Footing</Tile>
+        <Tile to="/beam-design">Beam Design</Tile>
       </div>
 
       <h2 className="mt-8 text-lg font-semibold text-slate-800">Material estimation (quantity take-off)</h2>
@@ -54,6 +56,7 @@ export default function App() {
       <Route path="/foundation" element={<FoundationDesign />} />
       <Route path="/pile-cap" element={<PileCapDesign />} />
       <Route path="/combined" element={<CombinedFootingDesign />} />
+      <Route path="/beam-design" element={<BeamDesign />} />
       <Route path="/estimate/slab" element={<SlabEstimate />} />
       <Route path="/estimate/beam" element={<BeamEstimate />} />
       <Route path="/estimate/column" element={<ColumnEstimate />} />

--- a/webapp/src/components/BeamSchematic.tsx
+++ b/webapp/src/components/BeamSchematic.tsx
@@ -1,0 +1,60 @@
+import type { JSX } from 'react'
+
+const STROKE = '#37526e'
+const FILL = '#eef3f8'
+const BAR = '#37526e'
+const DIM = '#1f77b4'
+
+export interface BeamSchematicProps {
+  b: number; h: number; cover: number; barDia: number; stirrupDia: number; bars: number; d: number
+}
+
+/** Beam cross-section: stirrup outline + tension bars, drawn to scale. */
+export function BeamSchematic({ b, h, cover, barDia, stirrupDia, bars, d }: BeamSchematicProps): JSX.Element {
+  const W = 320, H = 300
+  const padL = 60, padT = 24, availW = 150, availH = 210
+  const s = Math.min(availW / b, availH / h)
+  const bw = b * s, hh = h * s
+  const x0 = padL + (availW - bw) / 2, y0 = padT
+  const inset = (cover + stirrupDia / 2) * s
+  const br = Math.max(3, (barDia / 2) * s)
+  const dPx = d * s
+
+  // tension bar centres along the bottom row
+  const barY = y0 + hh - (cover + stirrupDia + barDia / 2) * s
+  const x1 = x0 + (cover + stirrupDia + barDia / 2) * s
+  const x2 = x0 + bw - (cover + stirrupDia + barDia / 2) * s
+  const n = Math.max(2, bars)
+  const barsX = Array.from({ length: n }, (_, i) => (n === 1 ? (x1 + x2) / 2 : x1 + ((x2 - x1) * i) / (n - 1)))
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet"
+      style={{ width: '100%', height: 'auto', fontFamily: 'Arial, sans-serif' }}>
+      <text x={padL} y={16} fontSize={11} fontWeight={700} fill="#0056b3">SECTION</text>
+
+      {/* concrete + stirrup */}
+      <rect x={x0} y={y0} width={bw} height={hh} rx={2} fill={FILL} stroke={STROKE} strokeWidth={1.6} />
+      <rect x={x0 + inset} y={y0 + inset} width={bw - 2 * inset} height={hh - 2 * inset} rx={4}
+        fill="none" stroke={BAR} strokeWidth={1.2} />
+
+      {/* tension bars */}
+      {barsX.map((bx, i) => <circle key={i} cx={bx} cy={barY} r={br} fill={BAR} />)}
+
+      {/* width dim (below) */}
+      <line x1={x0} y1={y0 + hh + 14} x2={x0 + bw} y2={y0 + hh + 14} stroke={DIM} strokeWidth={0.9} />
+      <text x={x0 + bw / 2} y={y0 + hh + 28} fontSize={9.5} fill={DIM} textAnchor="middle">b = {Math.round(b)} mm</text>
+
+      {/* height dim (left) */}
+      <line x1={x0 - 14} y1={y0} x2={x0 - 14} y2={y0 + hh} stroke={DIM} strokeWidth={0.9} />
+      <text x={x0 - 24} y={y0 + hh / 2} fontSize={9.5} fill={DIM} textAnchor="middle"
+        transform={`rotate(-90 ${x0 - 24} ${y0 + hh / 2})`}>h = {Math.round(h)} mm</text>
+
+      {/* d dim (right) */}
+      <line x1={x0 + bw + 14} y1={y0} x2={x0 + bw + 14} y2={y0 + dPx} stroke={DIM} strokeWidth={0.9} strokeDasharray="3 2" />
+      <text x={x0 + bw + 24} y={y0 + dPx / 2} fontSize={9} fill={DIM} textAnchor="middle"
+        transform={`rotate(-90 ${x0 + bw + 24} ${y0 + dPx / 2})`}>d = {Math.round(d)} mm</text>
+
+      <text x={x0 + bw / 2} y={barY + br + 12} fontSize={8.5} fill={BAR} textAnchor="middle">{n} ⌀{barDia} mm</text>
+    </svg>
+  )
+}

--- a/webapp/src/components/WorkedSolution.tsx
+++ b/webapp/src/components/WorkedSolution.tsx
@@ -1,0 +1,39 @@
+import { useState, type JSX } from 'react'
+import type { SolutionStep } from '../lib/solution'
+import { Math } from '../lib/math'
+
+/** Collapsible step-by-step worked-solution panel (KaTeX, print-friendly). */
+export function WorkedSolution({ steps, title = 'Solution — step by step' }: {
+  steps: SolutionStep[]; title?: string
+}): JSX.Element {
+  const [open, setOpen] = useState(true)
+  return (
+    <div className="mt-6 rounded-xl border border-slate-200 bg-white shadow-sm print-avoid-break">
+      <button type="button" onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left">
+        <h2 className="text-[1.02rem] font-bold text-[#0056b3]">{title}</h2>
+        <span className="no-print text-sm text-slate-400">{open ? 'Hide ▲' : 'Show ▼'}</span>
+      </button>
+
+      {open && (
+        <ol className="space-y-4 border-t border-slate-100 px-4 py-4">
+          {steps.map((s, i) => (
+            <li key={i} className="print-avoid-break">
+              <h3 className="mb-1.5 text-sm font-semibold text-slate-800">
+                <span className="text-slate-400">{i + 1}.</span> {s.title}
+              </h3>
+              <div className="space-y-1.5 overflow-x-auto pl-4">
+                {s.lines.map((ln, j) => (
+                  <div key={j} className="text-[0.95rem] text-slate-700">
+                    <Math block tex={ln.tex} />
+                  </div>
+                ))}
+              </div>
+              {s.note && <p className="mt-1 pl-4 text-xs text-slate-500">{s.note}</p>}
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  )
+}

--- a/webapp/src/engine/beamDesign.test.ts
+++ b/webapp/src/engine/beamDesign.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { designBeam, type BeamDesignInput } from './beamDesign'
+
+const base: BeamDesignInput = {
+  b: 300, h: 500, cover: 40, barDia: 20, stirrupDia: 10,
+  fc: 28, fy: 415, Mu: 180, Vu: 150,
+}
+
+describe('beam design — flexure', () => {
+  it('effective depth and a sane steel area', () => {
+    const r = designBeam(base)
+    expect(r.d).toBeCloseTo(500 - 40 - 10 - 10) // 440
+    expect(r.As).toBeGreaterThan(0)
+    expect(r.bars).toBeGreaterThanOrEqual(2)
+    expect(r.rho).toBeGreaterThanOrEqual(r.rhoMin)
+    expect(r.tensionControlled).toBe(true)
+  })
+
+  it('tiny moment falls back to ρ_min', () => {
+    const r = designBeam({ ...base, Mu: 10 })
+    expect(r.usedMin).toBe(true)
+  })
+
+  it('huge moment exceeds the tension-controlled limit', () => {
+    const r = designBeam({ ...base, b: 250, h: 400, Mu: 600 })
+    expect(r.tensionControlled).toBe(false)
+  })
+})
+
+describe('beam design — shear', () => {
+  it('low shear needs no stirrups, mid shear needs minimum', () => {
+    const r = designBeam(base)
+    const lo = designBeam({ ...base, Vu: r.phiVc * 0.4 })
+    const mid = designBeam({ ...base, Vu: r.phiVc * 0.9 })
+    expect(lo.region).toBe('none')
+    expect(mid.region).toBe('minimum')
+    expect(mid.sAdopt).toBeGreaterThan(0)
+  })
+
+  it('high shear designs stirrups with spacing ≤ s_max', () => {
+    const r = designBeam({ ...base, Vu: 280 })
+    expect(r.region).toBe('designed')
+    expect(r.sReq).toBeGreaterThan(0)
+    expect(r.sAdopt).toBeLessThanOrEqual(r.sMax)
+    expect(r.sAdopt).toBeGreaterThan(0)
+  })
+
+  it('flags an inadequate section when Vs exceeds the cap', () => {
+    const r = designBeam({ ...base, b: 200, h: 350, Vu: 600 })
+    expect(r.region).toBe('inadequate')
+  })
+})

--- a/webapp/src/engine/beamDesign.ts
+++ b/webapp/src/engine/beamDesign.ts
@@ -1,0 +1,93 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Rectangular RC beam — singly-reinforced flexure + one-way shear (stirrups).
+// NSCP 2015 / ACI 318-14. Demands Mu (kN·m) and Vu (kN) are given (from
+// analysis); the tool sizes tension steel and vertical stirrups.
+// Convention: lengths mm, stresses MPa, Mu kN·m, Vu/V_* kN.
+// ─────────────────────────────────────────────────────────────────────────
+import { flexuralSteel, barLayout, rhoMin } from './flexure'
+import { beta1 } from './loads'
+
+export interface BeamDesignInput {
+  b: number            // web width, mm
+  h: number            // total depth, mm
+  cover: number        // clear cover to stirrup, mm
+  barDia: number       // main bar Ø, mm
+  stirrupDia: number   // stirrup Ø, mm
+  fc: number; fy: number
+  fyt?: number         // stirrup yield (default fy)
+  Mu: number           // factored moment, kN·m
+  Vu: number           // factored shear, kN
+  legs?: number        // stirrup legs (default 2)
+  lambda?: number      // lightweight factor (default 1)
+}
+
+export type ShearRegion = 'none' | 'minimum' | 'designed' | 'inadequate'
+
+export interface BeamDesignResult {
+  d: number            // effective depth, mm
+  // Flexure
+  As: number; rho: number; rhoMin: number; rhoMax: number
+  usedMin: boolean; tensionControlled: boolean
+  bars: number; barSpacing: number
+  // Shear
+  Vc: number; phiVc: number          // kN
+  region: ShearRegion
+  Av: number                          // mm²
+  VsReq: number; VsMax: number        // kN
+  sReq: number; sMax: number; sAdopt: number   // mm
+}
+
+const PHI_SHEAR = 0.75
+const roundDown = (v: number, step: number) => Math.floor(v / step) * step
+
+export function designBeam(i: BeamDesignInput): BeamDesignResult {
+  const fyt = i.fyt ?? i.fy
+  const legs = i.legs ?? 2
+  const lambda = i.lambda ?? 1
+  const d = i.h - i.cover - i.stirrupDia - i.barDia / 2
+
+  // ── Flexure (singly reinforced) ──
+  const flex = flexuralSteel({ Mu: i.Mu, b: i.b, d, fc: i.fc, fy: i.fy })
+  const rMin = rhoMin(i.fc, i.fy)
+  // Tension-controlled limit (εt = 0.005): ρmax = 0.85β1(f'c/fy)(0.003/0.008).
+  const rhoMax = 0.85 * beta1(i.fc) * (i.fc / i.fy) * (0.003 / 0.008)
+  const layout = barLayout({ As: flex.As, db: i.barDia, b: i.b, cover: i.cover + i.stirrupDia })
+
+  // ── Shear ──
+  const Vc = (lambda * Math.sqrt(i.fc) * i.b * d) / 6 / 1000          // kN
+  const phiVc = PHI_SHEAR * Vc
+  const Av = legs * (Math.PI / 4) * i.stirrupDia * i.stirrupDia        // mm²
+  const VsMax = (2 / 3) * Math.sqrt(i.fc) * i.b * d / 1000             // kN
+  // Minimum-stirrup spacing cap: Av,min = max(0.062√f'c·b, 0.35·b)·s/fyt.
+  const sMinArea = (Av * fyt) / Math.max(0.062 * Math.sqrt(i.fc) * i.b, 0.35 * i.b)
+
+  let region: ShearRegion
+  let VsReq = 0, sReq = 0, sMax = 0, sAdopt = 0
+  if (i.Vu <= 0.5 * phiVc) {
+    region = 'none'
+  } else if (i.Vu <= phiVc) {
+    region = 'minimum'
+    sMax = Math.min(d / 2, 600)
+    sAdopt = roundDown(Math.min(sMinArea, sMax), 10)
+  } else {
+    VsReq = i.Vu / PHI_SHEAR - Vc
+    if (VsReq > VsMax) {
+      region = 'inadequate'                 // section too small — enlarge or raise f'c
+    } else {
+      region = 'designed'
+      sReq = (Av * fyt * d) / (VsReq * 1000)
+      // tighter spacing cap once Vs exceeds (1/3)√f'c·b·d
+      const sCap = VsReq <= Math.sqrt(i.fc) * i.b * d / 3 / 1000 ? Math.min(d / 2, 600) : Math.min(d / 4, 300)
+      sMax = sCap
+      sAdopt = roundDown(Math.min(sReq, sCap, sMinArea), 10)
+    }
+  }
+
+  return {
+    d,
+    As: flex.As, rho: flex.rho, rhoMin: rMin, rhoMax,
+    usedMin: flex.usedMin, tensionControlled: flex.rho <= rhoMax,
+    bars: layout.n, barSpacing: layout.spacing,
+    Vc, phiVc, region, Av, VsReq, VsMax, sReq, sMax, sAdopt,
+  }
+}

--- a/webapp/src/lib/beamSolution.ts
+++ b/webapp/src/lib/beamSolution.ts
@@ -1,0 +1,87 @@
+// Worked solution for the beam design — mirrors engine/beamDesign.ts.
+import type { BeamDesignInput, BeamDesignResult } from '../engine/beamDesign'
+import { type SolutionStep, sn0, sn1, sn3, sn4 } from './solution'
+
+export function buildBeamSolution(i: BeamDesignInput, r: BeamDesignResult): SolutionStep[] {
+  const fyt = i.fyt ?? i.fy
+  const legs = i.legs ?? 2
+  const d = r.d
+  const Rn = (i.Mu * 1e6) / (0.9 * i.b * d * d)
+  const Ab = (Math.PI / 4) * i.barDia * i.barDia
+
+  const steps: SolutionStep[] = []
+
+  steps.push({
+    title: 'Effective depth',
+    lines: [{
+      tex: String.raw`d = h - cover - d_{s} - \tfrac{d_b}{2} = ${sn0(i.h)} - ${sn0(i.cover)} - ${sn0(i.stirrupDia)} - ${sn1(i.barDia / 2)} = \mathbf{${sn1(d)}}\ \text{mm}`,
+    }],
+  })
+
+  steps.push({
+    title: 'Flexural reinforcement',
+    lines: [
+      { tex: String.raw`R_n = \dfrac{M_u}{\phi b d^2} = \dfrac{${sn0(i.Mu)}\times 10^6}{0.9(${sn0(i.b)})(${sn1(d)})^2} = ${sn3(Rn)}\ \text{MPa}` },
+      { tex: String.raw`\rho = \tfrac{0.85 f'_c}{f_y}\!\left(1-\sqrt{1-\tfrac{2R_n}{0.85 f'_c}}\right) = ${sn4(r.rho)}` },
+      { tex: String.raw`\rho_{min} = ${sn4(r.rhoMin)},\quad \rho_{max} = ${sn4(r.rhoMax)}\ (\varepsilon_t = 0.005)` },
+      { tex: String.raw`A_s = \rho b d = ${sn0(r.As)}\ \text{mm}^2` },
+    ],
+    note: (r.usedMin ? 'ρ_min governs. ' : '') +
+      (r.tensionControlled ? 'ρ ≤ ρ_max → tension-controlled (φ = 0.90).' : 'ρ > ρ_max — section is not tension-controlled; enlarge it or add compression steel.'),
+  })
+
+  steps.push({
+    title: 'Bar selection',
+    lines: [
+      { tex: String.raw`A_b = \tfrac{\pi}{4}d_b^2 = ${sn0(Ab)}\ \text{mm}^2,\quad n = \lceil A_s/A_b \rceil = ${r.bars}` },
+      { tex: String.raw`\text{clear spacing} = \dfrac{b - 2(cover+d_s) - n d_b}{n-1} = ${sn0(r.barSpacing)}\ \text{mm}` },
+    ],
+    note: `Provide ${r.bars} ⌀${i.barDia} mm tension bars.`,
+  })
+
+  steps.push({
+    title: 'Shear strength of concrete',
+    lines: [
+      { tex: String.raw`V_c = \tfrac{1}{6}\lambda\sqrt{f'_c}\,b d = \tfrac{1}{6}\sqrt{${sn0(i.fc)}}(${sn0(i.b)})(${sn1(d)})/1000 = ${sn1(r.Vc)}\ \text{kN}` },
+      { tex: String.raw`\phi V_c = 0.75 V_c = ${sn1(r.phiVc)}\ \text{kN},\quad \tfrac{1}{2}\phi V_c = ${sn1(r.phiVc / 2)}\ \text{kN}` },
+    ],
+  })
+
+  if (r.region === 'none') {
+    steps.push({
+      title: 'Stirrup requirement',
+      lines: [{ tex: String.raw`V_u = ${sn1(i.Vu)}\ \text{kN} \le \tfrac{1}{2}\phi V_c = ${sn1(r.phiVc / 2)}\ \text{kN}` }],
+      note: 'No shear reinforcement required (provide nominal stirrups in practice).',
+    })
+  } else if (r.region === 'minimum') {
+    steps.push({
+      title: 'Minimum stirrups',
+      lines: [
+        { tex: String.raw`\tfrac{1}{2}\phi V_c < V_u = ${sn1(i.Vu)} \le \phi V_c = ${sn1(r.phiVc)}\ \text{kN}` },
+        { tex: String.raw`A_v = ${legs}\cdot\tfrac{\pi}{4}d_s^2 = ${sn0(r.Av)}\ \text{mm}^2,\quad s_{max} = \min(d/2, 600) = ${sn0(r.sMax)}\ \text{mm}` },
+      ],
+      note: `Provide ⌀${i.stirrupDia} mm, ${legs}-leg stirrups @ ${sn0(r.sAdopt)} mm (minimum area governs).`,
+    })
+  } else if (r.region === 'designed') {
+    steps.push({
+      title: 'Stirrup design',
+      lines: [
+        { tex: String.raw`V_s = \tfrac{V_u}{\phi} - V_c = \tfrac{${sn1(i.Vu)}}{0.75} - ${sn1(r.Vc)} = ${sn1(r.VsReq)}\ \text{kN} \;(\le V_{s,max} = ${sn1(r.VsMax)})` },
+        { tex: String.raw`A_v = ${legs}\cdot\tfrac{\pi}{4}d_s^2 = ${sn0(r.Av)}\ \text{mm}^2` },
+        { tex: String.raw`s = \dfrac{A_v f_{yt} d}{V_s} = \dfrac{${sn0(r.Av)}(${sn0(fyt)})(${sn1(d)})}{${sn1(r.VsReq)}\times 10^3} = ${sn0(r.sReq)}\ \text{mm}` },
+        { tex: String.raw`s_{max} = ${sn0(r.sMax)}\ \text{mm} \Rightarrow s_{adopt} = ${sn0(r.sAdopt)}\ \text{mm}` },
+      ],
+      note: `Provide ⌀${i.stirrupDia} mm, ${legs}-leg stirrups @ ${sn0(r.sAdopt)} mm.`,
+    })
+  } else {
+    steps.push({
+      title: 'Section check',
+      lines: [
+        { tex: String.raw`V_s = \tfrac{V_u}{\phi} - V_c = ${sn1(r.VsReq)}\ \text{kN} > V_{s,max} = \tfrac{2}{3}\sqrt{f'_c}\,b d = ${sn1(r.VsMax)}\ \text{kN}` },
+      ],
+      note: 'Section is inadequate for shear — increase b, d, or f′c.',
+    })
+  }
+
+  return steps
+}

--- a/webapp/src/lib/format.ts
+++ b/webapp/src/lib/format.ts
@@ -1,3 +1,4 @@
 export const f0 = (v: number) => (Number.isFinite(v) ? Math.round(v).toString() : '—')
+export const f1 = (v: number) => (Number.isFinite(v) ? v.toFixed(1) : '—')
 export const f2 = (v: number) => (Number.isFinite(v) ? v.toFixed(2) : '—')
 export const f3 = (v: number) => (Number.isFinite(v) ? v.toFixed(3) : '—')

--- a/webapp/src/lib/solution.ts
+++ b/webapp/src/lib/solution.ts
@@ -1,0 +1,11 @@
+// Shared worked-solution types — a step is a titled list of KaTeX lines with
+// an optional plain-text note. Used by the per-tool solution generators and
+// rendered by <WorkedSolution>.
+export interface SolutionLine { tex: string }
+export interface SolutionStep { title: string; lines: SolutionLine[]; note?: string }
+
+export const sn0 = (v: number) => Math.round(v).toString()
+export const sn1 = (v: number) => v.toFixed(1)
+export const sn2 = (v: number) => v.toFixed(2)
+export const sn3 = (v: number) => v.toFixed(3)
+export const sn4 = (v: number) => v.toFixed(4)

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -1,0 +1,106 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { designBeam, type BeamDesignInput } from '../engine/beamDesign'
+import { BeamSchematic } from '../components/BeamSchematic'
+import { ReportControls } from '../components/ReportControls'
+import { WorkedSolution } from '../components/WorkedSolution'
+import { buildBeamSolution } from '../lib/beamSolution'
+import { Num, Card, ResultCard, Row } from '../components/qty'
+import { Math } from '../lib/math'
+import { f0, f1 } from '../lib/format'
+import 'katex/dist/katex.min.css'
+
+interface FormState extends BeamDesignInput { fyt: number; legs: number }
+
+const DEFAULTS: FormState = {
+  b: 300, h: 500, cover: 40, barDia: 20, stirrupDia: 10,
+  fc: 28, fy: 415, fyt: 415, Mu: 180, Vu: 150, legs: 2,
+}
+
+const REGION: Record<string, string> = {
+  none: 'No stirrups required',
+  minimum: 'Minimum stirrups',
+  designed: 'Stirrups designed',
+  inadequate: '⚠ Section inadequate',
+}
+
+export default function BeamDesign() {
+  const [f, setF] = useState<FormState>(DEFAULTS)
+  const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) => setF((s) => ({ ...s, [k]: v }))
+
+  const valid = useMemo(() => {
+    const keys: (keyof FormState)[] = ['b', 'h', 'cover', 'barDia', 'stirrupDia', 'fc', 'fy', 'fyt', 'Mu', 'Vu', 'legs']
+    return keys.every((k) => Number.isFinite(f[k] as number)) && f.b > 0 && f.h > 0 && f.fc > 0 && f.fy > 0
+      && f.h - f.cover - f.stirrupDia - f.barDia / 2 > 0
+  }, [f])
+
+  const r = useMemo(() => (valid ? designBeam(f) : null), [f, valid])
+  const solution = useMemo(() => (r ? buildBeamSolution(f, r) : null), [f, r])
+
+  const stirrupText = r
+    ? r.region === 'designed' || r.region === 'minimum'
+      ? `⌀${f.stirrupDia} ${f.legs}-leg @ ${f0(r.sAdopt)} mm`
+      : r.region === 'none' ? '— none' : '⚠ enlarge'
+    : '—'
+
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
+      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Beam Design</h1>
+      <p className="no-print mt-1 text-slate-600">
+        Rectangular RC beam — singly-reinforced flexure and one-way shear (stirrups). NSCP 2015 / ACI 318-14.
+        Enter the factored demands; results and the worked solution update live.
+      </p>
+      <ReportControls title="Beam Design Report" />
+
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
+        <div className="space-y-5">
+          <Card title="Section">
+            <Num label="Width b" unit="mm" value={f.b} onChange={set('b')} />
+            <Num label="Total depth h" unit="mm" value={f.h} onChange={set('h')} />
+            <Num label="Clear cover" unit="mm" value={f.cover} onChange={set('cover')} />
+            <Num label={<>Bar <Math tex="d_b" /></>} unit="mm" value={f.barDia} onChange={set('barDia')} />
+            <Num label={<>Stirrup <Math tex="d_s" /></>} unit="mm" value={f.stirrupDia} onChange={set('stirrupDia')} />
+            <Num label="Stirrup legs" value={f.legs} onChange={set('legs')} />
+          </Card>
+          <Card title="Materials">
+            <Num label={<Math tex="f'_c" />} unit="MPa" value={f.fc} onChange={set('fc')} />
+            <Num label={<Math tex="f_y" />} unit="MPa" value={f.fy} onChange={set('fy')} />
+            <Num label={<Math tex="f_{yt}" />} unit="MPa" value={f.fyt} onChange={set('fyt')} />
+          </Card>
+          <Card title="Factored demands">
+            <Num label={<Math tex="M_u" />} unit="kN·m" value={f.Mu} onChange={set('Mu')} />
+            <Num label={<Math tex="V_u" />} unit="kN" value={f.Vu} onChange={set('Vu')} />
+          </Card>
+        </div>
+
+        <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
+          <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Section preview</h2>
+            {r ? (
+              <BeamSchematic b={f.b} h={f.h} cover={f.cover} barDia={f.barDia} stirrupDia={f.stirrupDia} bars={r.bars} d={r.d} />
+            ) : (
+              <p className="py-8 text-center text-sm text-slate-400">Enter a valid section (d must be positive).</p>
+            )}
+          </div>
+
+          {r && (
+            <ResultCard title="Results">
+              <Row label="Effective depth d" value={`${f1(r.d)} mm`} />
+              <Row label="Flexural steel" value={`${r.bars} ⌀${f.barDia} mm`}
+                sub={`As=${f0(r.As)} mm² · ${r.usedMin ? 'ρ_min' : `ρ=${r.rho.toFixed(4)}`}`} />
+              <Row label="Tension-controlled" value={r.tensionControlled ? '✓ yes' : '✗ no'}
+                sub={`ρ_max=${r.rhoMax.toFixed(4)}`} />
+              <Row label={<Math tex="\phi V_c" />} value={`${f1(r.phiVc)} kN`} sub={`Vc=${f1(r.Vc)}`} />
+              <Row label="Shear" value={REGION[r.region]} />
+              <Row label="Stirrups" value={stirrupText}
+                sub={r.region === 'designed' ? `s_req=${f0(r.sReq)} · s_max=${f0(r.sMax)} mm` : undefined} />
+            </ResultCard>
+          )}
+        </div>
+      </div>
+
+      {solution && <WorkedSolution steps={solution} />}
+    </div>
+  )
+}


### PR DESCRIPTION
The first **structural beam design** in the React app (previously there was only a beam material-takeoff estimator). Rectangular, singly-reinforced — flexure + one-way shear — with a full worked solution.

## Engine — `beamDesign.ts` (NSCP 2015 / ACI 318-14)
- **Flexure:** effective depth, required steel via the shared `flexuralSteel` (Rn → ρ), ρ_min floor, **tension-controlled ρ_max check** (εt = 0.005), bar count + clear spacing.
- **Shear:** `Vc`, `φVc`; classifies into **no stirrups** (Vu ≤ ½φVc), **minimum** (≤ φVc), or **designed** (Vs = Vu/φ − Vc) with spacing `s = Av·fyt·d/Vs`, s_max caps, and an **inadequate-section flag** when Vs exceeds ⅔√f′c·b·d.
- 6 unit tests.

## UI — `BeamDesign` page
Section / materials / factored-demand inputs; live results; **cross-section schematic** (stirrup + tension bars to scale); sticky preview; report/PDF bar.

## Worked solution (reusable)
Introduces a **generic** `lib/solution.ts` + `components/WorkedSolution.tsx` renderer (so Pile Cap / Combined / estimators can reuse it next), and `lib/beamSolution.ts` — d → flexure (Rn, ρ, ρ_min/ρ_max, As, bars) → shear (Vc, φVc, region, Vs, Av, s, s_max) with substituted numbers.

Home gains a **Beam Design** tile; route `/beam-design`.

## Verification
- `npm run build` green; `npm test` **69 passing**.

## Remaining from your request (separate PRs to follow)
Worked solutions on **Pile Cap**, **Combined Footing**, and the **5 quantity estimators** — I'll reuse the new `WorkedSolution` renderer for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)