### PR TITLE
Calculation-breakdown solutions for the 5 quantity estimators

### DIFF
--- a/webapp/src/components/qty.tsx
+++ b/webapp/src/components/qty.tsx
@@ -68,9 +68,10 @@ export function Row({ label, value, sub }: { label: ReactNode; value: ReactNode;
   )
 }
 
-/** Standard page shell: back link, title, intro, report bar. */
-export function QtyPage({ title, reportTitle, intro, children }: {
-  title: string; reportTitle: string; intro: ReactNode; children: ReactNode
+/** Standard page shell: back link, title, intro, report bar. `after` renders
+ *  full-width below the two-column grid (e.g. a worked-solution panel). */
+export function QtyPage({ title, reportTitle, intro, children, after }: {
+  title: string; reportTitle: string; intro: ReactNode; children: ReactNode; after?: ReactNode
 }) {
   return (
     <div className="mx-auto max-w-6xl p-6">
@@ -79,6 +80,7 @@ export function QtyPage({ title, reportTitle, intro, children }: {
       <p className="no-print mt-1 text-slate-600">{intro}</p>
       <ReportControls title={reportTitle} />
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">{children}</div>
+      {after}
     </div>
   )
 }

--- a/webapp/src/lib/quantitySolution.ts
+++ b/webapp/src/lib/quantitySolution.ts
@@ -1,0 +1,114 @@
+// Worked solutions for the material-takeoff estimators — mirrors
+// engine/quantities.ts so the steps match the result panels.
+import type {
+  SlabInput, SlabResult, ChbInput, ChbResult, ColumnInput, ColumnResult,
+  BeamInput, BeamResult, BoxCulvertInput, BoxCulvertResult, BarTakeoff, TieTakeoff, TieWire,
+} from '../engine/quantities'
+import { type SolutionStep, sn2, sn3 } from './solution'
+
+const materialsStep = (volExpr: string, m: { volume: number; cement: number; sand: number; gravel: number; factor: number }): SolutionStep => ({
+  title: 'Concrete materials',
+  lines: [
+    { tex: `\\text{Cement} = \\lceil V \\cdot f \\rceil = \\lceil ${sn2(m.volume)}\\times ${m.factor} \\rceil = ${m.cement}\\ \\text{bags}` },
+    { tex: `\\text{Sand} = V\\times 0.5 = ${sn2(m.sand)}\\ \\text{m}^3,\\quad \\text{Gravel} = V\\times 1.0 = ${sn2(m.gravel)}\\ \\text{m}^3` },
+  ],
+  note: `Mix factor f = ${m.factor} bags/m³. ${volExpr}`,
+})
+
+const barStep = (title: string, netExpr: string, b: BarTakeoff): SolutionStep => ({
+  title,
+  lines: [
+    { tex: `L_{net} = ${netExpr} = ${sn2(b.netLength)}\\ \\text{m}` },
+    { tex: `n = \\lceil L_{net} / (6 - splice) \\rceil = ${b.pieces}\\ \\text{pcs of 6 m}` },
+    { tex: `W = n \\cdot 6 \\cdot \\tfrac{\\pi}{4}d_b^2 \\cdot 7850 = ${sn2(b.weight)}\\ \\text{kg}\\ (\\varnothing${b.diaMm})` },
+  ],
+})
+
+const tieStep = (title: string, t: TieTakeoff): SolutionStep => ({
+  title,
+  lines: [
+    { tex: `\\text{cuts}/6m = \\lfloor 6/\\ell \\rfloor = ${t.cutsPer6m},\\quad \\text{total} = ${t.totalCuts}` },
+    { tex: `n = \\lceil ${t.totalCuts}/${t.cutsPer6m} \\rceil = ${t.pieces}\\ \\text{pcs},\\quad W = ${sn2(t.weight)}\\ \\text{kg}\\ (\\varnothing${t.diaMm})` },
+  ],
+})
+
+const tieWireStep = (w: TieWire): SolutionStep => ({
+  title: 'G.I. tie wire',
+  lines: [
+    { tex: `L = \\ell_{cut}\\cdot ${w.intersections}\\ \\text{intersections} = ${sn2(w.netLength)}\\ \\text{m}` },
+    { tex: `\\text{rolls} = \\lceil L/2385 \\rceil = ${w.rolls}` },
+  ],
+})
+
+export function slabSolution(i: SlabInput, r: SlabResult): SolutionStep[] {
+  const volExpr = `V = ${sn2(i.slabArea)}\\times ${sn3(i.thickness)}\\times ${i.numStructures} = ${sn2(r.volume)}\\ \\text{m}^3`
+  return [
+    { title: 'Concrete volume', lines: [{ tex: volExpr }] },
+    materialsStep('', r.materials),
+    barStep('Main steel — long span', `${sn2(i.longSpanLength)}\\times ${i.numLongPieces}\\times ${i.numStructures}`, r.longSteel),
+    barStep('Main steel — short span', `${sn2(i.shortSpanLength)}\\times ${i.numShortPieces}\\times ${i.numStructures}`, r.shortSteel),
+    { title: 'Total steel weight', lines: [{ tex: `W = ${sn2(r.longSteel.weight)} + ${sn2(r.shortSteel.weight)} = ${sn2(r.totalSteelWeight)}\\ \\text{kg}` }] },
+    tieWireStep(r.tieWire),
+  ]
+}
+
+export function chbSolution(i: ChbInput, r: ChbResult): SolutionStep[] {
+  return [
+    { title: 'Net wall area', lines: [{ tex: `A = ${sn2(i.wallArea)} - ${sn2(i.holeArea)} = ${sn2(r.netArea)}\\ \\text{m}^2` }] },
+    { title: 'Number of blocks', lines: [{ tex: `n = \\lceil A\\times 12.5 \\rceil = ${r.pieces}\\ \\text{pcs}\\ (${i.size}")` }] },
+    {
+      title: 'Mortar', lines: [
+        { tex: `\\text{Cement} = \\lceil ${sn2(r.netArea)}\\times f_c \\rceil = ${r.mortar.cement}\\ \\text{bags}` },
+        { tex: `\\text{Sand} = ${sn2(r.netArea)}\\times f_s = ${sn3(r.mortar.sand)}\\ \\text{m}^3` },
+      ],
+    },
+    {
+      title: 'Plaster', lines: [
+        { tex: `\\text{Cement} = \\lceil ${sn2(r.netArea)}\\times 0.3 \\rceil = ${r.plaster.cement}\\ \\text{bags},\\quad \\text{Sand} = ${sn2(r.netArea)}\\times 0.025 = ${sn3(r.plaster.sand)}\\ \\text{m}^3` },
+      ],
+    },
+    { title: 'Totals', lines: [{ tex: `\\text{Cement} = ${r.totalCement}\\ \\text{bags},\\quad \\text{Sand} = ${sn3(r.totalSand)}\\ \\text{m}^3` }] },
+  ]
+}
+
+export function columnSolution(i: ColumnInput, r: ColumnResult): SolutionStep[] {
+  const volExpr = `V = ${sn2(i.length)}\\times ${sn2(i.width)}\\times ${sn2(i.height)}\\times ${i.numStructures} = ${sn2(r.volume)}\\ \\text{m}^3`
+  return [
+    { title: 'Concrete volume', lines: [{ tex: volExpr }] },
+    materialsStep('', r.materials),
+    barStep('Vertical bars', `${sn2(i.barLengthPerPiece)}\\times ${i.numBars}\\times ${i.numStructures}`, r.mainSteel),
+    tieStep('Lateral ties', r.lateralTies),
+    tieWireStep(r.tieWire),
+  ]
+}
+
+export function beamQtySolution(i: BeamInput, r: BeamResult): SolutionStep[] {
+  const volExpr = `V = ${sn2(i.length)}\\times ${sn2(i.width)}\\times ${sn2(i.height)}\\times ${i.numStructures} = ${sn2(r.volume)}\\ \\text{m}^3`
+  const barSteps = r.mainBars.map((b) =>
+    barStep(`Main steel — ${b.label}`, `${sn2(b.takeoff.netLength / i.numStructures)}\\times ${i.numStructures}`, b.takeoff))
+  return [
+    { title: 'Concrete volume', lines: [{ tex: volExpr }] },
+    materialsStep('', r.materials),
+    ...barSteps,
+    { title: 'Total main steel', lines: [{ tex: `W = ${sn2(r.totalMainWeight)}\\ \\text{kg}` }] },
+    tieStep('Stirrups', r.stirrups),
+    tieWireStep(r.tieWire),
+  ]
+}
+
+export function boxCulvertSolution(i: BoxCulvertInput, r: BoxCulvertResult): SolutionStep[] {
+  return [
+    { title: 'Net section & volume', lines: [
+      { tex: `A = ${sn2(i.grossArea)} - ${sn2(i.holeArea)} = ${sn2(r.netArea)}\\ \\text{m}^2` },
+      { tex: `V = A\\times L = ${sn2(r.netArea)}\\times ${sn2(i.length)} = ${sn2(r.volume)}\\ \\text{m}^3` },
+    ] },
+    materialsStep('', r.materials),
+    barStep('Longitudinal — top', `${sn2(i.length)}\\times ${i.numLongTop}`, r.longTop),
+    barStep('Longitudinal — U bars', `${sn2(i.length)}\\times ${i.numLongU}`, r.longU),
+    { title: 'Reinforcing rings (RSB)', lines: [
+      { tex: `n_{RSB} = \\lceil L/s \\rceil + 1 = \\lceil ${sn2(i.length)}/${sn2(i.rsbSpacing)} \\rceil + 1 = ${r.rsb.count}` },
+      { tex: `\\text{Top: } ${r.rsb.top.pieces}\\ \\text{pcs}, ${sn2(r.rsb.top.weight)}\\ \\text{kg};\\quad \\text{U: } ${r.rsb.u.pieces}\\ \\text{pcs}, ${sn2(r.rsb.u.weight)}\\ \\text{kg}` },
+    ] },
+    tieWireStep(r.tieWire),
+  ]
+}

--- a/webapp/src/pages/BeamEstimate.tsx
+++ b/webapp/src/pages/BeamEstimate.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react'
 import { estimateBeam, type BeamInput, type BeamBarGroup, type ConcreteClass } from '../engine/quantities'
 import { Num, ClassPick, Card, ResultCard, Row, QtyPage, kg, m3, m } from '../components/qty'
+import { WorkedSolution } from '../components/WorkedSolution'
+import { beamQtySolution } from '../lib/quantitySolution'
 
 const g = (lengthPerPiece: number, numPieces: number, diaMm: number): BeamBarGroup => ({ lengthPerPiece, numPieces, diaMm })
 
@@ -18,6 +20,7 @@ export default function BeamEstimate() {
   const setG = (grp: 'topSupport' | 'topMidspan' | 'bottomSupport' | 'bottomMidspan', key: keyof BeamBarGroup) =>
     (v: number) => setF((s) => ({ ...s, [grp]: { ...s[grp], [key]: v } }))
   const r = useMemo(() => estimateBeam(f), [f])
+  const solution = useMemo(() => beamQtySolution(f, r), [f, r])
 
   const barCard = (title: string, grp: 'topSupport' | 'topMidspan' | 'bottomSupport' | 'bottomMidspan') => (
     <Card title={title}>
@@ -29,7 +32,8 @@ export default function BeamEstimate() {
 
   return (
     <QtyPage title="Beam — Material Estimate" reportTitle="Beam Material Estimate"
-      intro="Concrete volume, materials, top/bottom bars at support & midspan, stirrups and tie wire for beams.">
+      intro="Concrete volume, materials, top/bottom bars at support & midspan, stirrups and tie wire for beams."
+      after={<WorkedSolution steps={solution} title="Solution — calculation breakdown" />}>
       <div className="space-y-5">
         <Card title="Geometry & mix">
           <Num label="Length" unit="m" value={f.length} onChange={set('length')} />

--- a/webapp/src/pages/BoxCulvertEstimate.tsx
+++ b/webapp/src/pages/BoxCulvertEstimate.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react'
 import { estimateBoxCulvert, type BoxCulvertInput, type ConcreteClass } from '../engine/quantities'
 import { Num, ClassPick, Card, ResultCard, Row, QtyPage, kg, m3, m } from '../components/qty'
+import { WorkedSolution } from '../components/WorkedSolution'
+import { boxCulvertSolution } from '../lib/quantitySolution'
 
 const DEFAULTS: BoxCulvertInput = {
   grossArea: 6, holeArea: 2, length: 5, concreteClass: 'A', customFactor: 9, spliceLength: 0.3,
@@ -14,10 +16,12 @@ export default function BoxCulvertEstimate() {
   const set = <K extends keyof BoxCulvertInput>(k: K) => (v: BoxCulvertInput[K]) => setF((s) => ({ ...s, [k]: v }))
   const r = useMemo(() => estimateBoxCulvert(f), [f])
   const rsbWeight = r.rsb.top.weight + r.rsb.u.weight
+  const solution = useMemo(() => boxCulvertSolution(f, r), [f, r])
 
   return (
     <QtyPage title="Box Culvert — Material Estimate" reportTitle="Box Culvert Material Estimate"
-      intro="Concrete volume from net cross-section, materials, longitudinal bars, reinforcing rings (top + U bars) and tie wire.">
+      intro="Concrete volume from net cross-section, materials, longitudinal bars, reinforcing rings (top + U bars) and tie wire."
+      after={<WorkedSolution steps={solution} title="Solution — calculation breakdown" />}>
       <div className="space-y-5">
         <Card title="Section & mix">
           <Num label="Gross x-section area" unit="m²" value={f.grossArea} onChange={set('grossArea')} />

--- a/webapp/src/pages/ChbEstimate.tsx
+++ b/webapp/src/pages/ChbEstimate.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react'
 import { estimateChb, type ChbInput, type ChbSize } from '../engine/quantities'
 import { Num, Pick, Card, ResultCard, Row, QtyPage, m3 } from '../components/qty'
+import { WorkedSolution } from '../components/WorkedSolution'
+import { chbSolution } from '../lib/quantitySolution'
 
 const DEFAULTS: ChbInput = { wallArea: 30, holeArea: 4, size: '6' }
 
@@ -8,10 +10,12 @@ export default function ChbEstimate() {
   const [f, setF] = useState<ChbInput>(DEFAULTS)
   const set = <K extends keyof ChbInput>(k: K) => (v: ChbInput[K]) => setF((s) => ({ ...s, [k]: v }))
   const r = useMemo(() => estimateChb(f), [f])
+  const solution = useMemo(() => chbSolution(f, r), [f, r])
 
   return (
     <QtyPage title="CHB Wall — Material Estimate" reportTitle="CHB Wall Material Estimate"
-      intro="Concrete hollow block count, mortar and plaster (cement + sand) for a masonry wall.">
+      intro="Concrete hollow block count, mortar and plaster (cement + sand) for a masonry wall."
+      after={<WorkedSolution steps={solution} title="Solution — calculation breakdown" />}>
       <div className="space-y-5">
         <Card title="Wall">
           <Num label="Gross wall area" unit="m²" value={f.wallArea} onChange={set('wallArea')} />

--- a/webapp/src/pages/ColumnEstimate.tsx
+++ b/webapp/src/pages/ColumnEstimate.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react'
 import { estimateColumn, type ColumnInput, type ConcreteClass } from '../engine/quantities'
 import { Num, ClassPick, Card, ResultCard, Row, QtyPage, kg, m3, m } from '../components/qty'
+import { WorkedSolution } from '../components/WorkedSolution'
+import { columnSolution } from '../lib/quantitySolution'
 
 const DEFAULTS: ColumnInput = {
   length: 0.4, width: 0.4, height: 3, numStructures: 4, concreteClass: 'A', customFactor: 9, spliceLength: 0.3,
@@ -13,10 +15,12 @@ export default function ColumnEstimate() {
   const [f, setF] = useState<ColumnInput>(DEFAULTS)
   const set = <K extends keyof ColumnInput>(k: K) => (v: ColumnInput[K]) => setF((s) => ({ ...s, [k]: v }))
   const r = useMemo(() => estimateColumn(f), [f])
+  const solution = useMemo(() => columnSolution(f, r), [f, r])
 
   return (
     <QtyPage title="Column — Material Estimate" reportTitle="Column Material Estimate"
-      intro="Concrete volume, cement / sand / gravel, vertical bars, lateral ties and tie wire for columns.">
+      intro="Concrete volume, cement / sand / gravel, vertical bars, lateral ties and tie wire for columns."
+      after={<WorkedSolution steps={solution} title="Solution — calculation breakdown" />}>
       <div className="space-y-5">
         <Card title="Geometry & mix">
           <Num label="Length" unit="m" value={f.length} onChange={set('length')} />

--- a/webapp/src/pages/SlabEstimate.tsx
+++ b/webapp/src/pages/SlabEstimate.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react'
 import { estimateSlab, type SlabInput, type ConcreteClass } from '../engine/quantities'
 import { Num, ClassPick, Card, ResultCard, Row, QtyPage, kg, m3, m } from '../components/qty'
+import { WorkedSolution } from '../components/WorkedSolution'
+import { slabSolution } from '../lib/quantitySolution'
 
 const DEFAULTS: SlabInput = {
   slabArea: 20, thickness: 0.125, numStructures: 1, concreteClass: 'A', customFactor: 9, spliceLength: 0.3,
@@ -13,10 +15,12 @@ export default function SlabEstimate() {
   const [f, setF] = useState<SlabInput>(DEFAULTS)
   const set = <K extends keyof SlabInput>(k: K) => (v: SlabInput[K]) => setF((s) => ({ ...s, [k]: v }))
   const r = useMemo(() => estimateSlab(f), [f])
+  const solution = useMemo(() => slabSolution(f, r), [f, r])
 
   return (
     <QtyPage title="Slab — Material Estimate" reportTitle="Slab Material Estimate"
-      intro="Concrete volume, cement / sand / gravel, main steel (both spans) and tie wire for a slab.">
+      intro="Concrete volume, cement / sand / gravel, main steel (both spans) and tie wire for a slab."
+      after={<WorkedSolution steps={solution} title="Solution — calculation breakdown" />}>
       <div className="space-y-5">
         <Card title="Geometry & mix">
           <Num label="Slab area" unit="m²" value={f.slabArea} onChange={set('slabArea')} />


### PR DESCRIPTION
Extends the worked-solution pattern to the material-takeoff tools: **slab, CHB, column, beam, box culvert**. Each now shows a step-by-step breakdown — volume → materials → bar/tie take-off → tie wire — mirroring `engine/quantities.ts`.

> Stacked on #123 (reuses its generic `WorkedSolution` + `lib/solution.ts`). Base is `feature/react-beam-design`; retarget to `main` after #123 merges.

## Changes
- **`lib/quantitySolution.ts`** — per-estimator step builders with shared helpers (concrete materials, commercial-bar take-off, lateral ties/stirrups, tie wire).
- **`qty.QtyPage`** gains an `after` slot for full-width content below the input/results grid.
- Wired `WorkedSolution` (collapsible, KaTeX, print-friendly) into all five estimator pages.

## Verification
- `npm run build` green; `npm test` 69 passing.

## Remaining from your request
Worked solutions on **Pile Cap** and **Combined Footing** — next PRs, same renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)