### PR TITLE
Worked solutions for Pile Cap and Combined Footing

### DIFF
--- a/webapp/src/lib/combinedSolution.ts
+++ b/webapp/src/lib/combinedSolution.ts
@@ -1,0 +1,63 @@
+// Worked solution for the combined-footing rigid method — mirrors
+// engine/combinedFooting.ts.
+import type { CombinedFootingInput, CombinedFootingResult } from '../engine/combinedFooting'
+import { type SolutionStep, sn0, sn1, sn2 } from './solution'
+
+export function combinedSolution(i: CombinedFootingInput, r: CombinedFootingResult): SolutionStep[] {
+  const Pa1 = i.dl1 + i.ll1, Pa2 = i.dl2 + i.ll2
+
+  const steps: SolutionStep[] = [
+    {
+      title: 'Service & factored column loads',
+      lines: [
+        { tex: `P_{a1} = ${sn0(i.dl1)}+${sn0(i.ll1)} = ${sn0(Pa1)}\\ \\text{kN},\\quad P_{a2} = ${sn0(Pa2)}\\ \\text{kN}` },
+        { tex: `P_{u} = \\max(1.4D,1.2D+1.6L):\\; P_{u1} = ${sn0(r.Pu1)},\\; P_{u2} = ${sn0(r.Pu2)},\\; P_u = ${sn0(r.Pu)}\\ \\text{kN}` },
+      ],
+    },
+    {
+      title: 'Net allowable bearing',
+      lines: [{ tex: `q_{net} = q_a - \\gamma_s D_s - \\gamma_c D_c - q = ${sn2(r.qNet)}\\ \\text{kPa}` }],
+    },
+    {
+      title: `Geometry — ${r.shape}`,
+      lines: r.shape[0] === 'T'
+        ? [
+            { tex: `B_x = ${sn2(r.Bx)}\\ \\text{m},\\quad B_{y1} \\to B_{y2} = ${sn2(r.By1)} \\to ${sn2(r.By2)}\\ \\text{m}` },
+            { tex: `x_1 = ${sn2(r.x1)},\\quad x_2 = ${sn2(r.x2)}\\ \\text{m (column centres from left edge)}` },
+          ]
+        : [
+            { tex: `B_x = ${sn2(r.Bx)}\\ \\text{m},\\quad B_y = ${sn2(r.By)}\\ \\text{m}` },
+            { tex: `x_1 = ${sn2(r.x1)},\\quad x_2 = ${sn2(r.x2)}\\ \\text{m (sized about the service-load resultant)}` },
+          ],
+      note: r.widened ? 'Slab widened so each column sits fully within the footing (containment).' : undefined,
+    },
+    {
+      title: 'Equivalent uniformly-varying line load',
+      lines: [
+        { tex: `w_{sum} = \\dfrac{2P_u}{B_x} = ${sn1(r.wu1 + r.wu2)}\\ \\text{kN/m}` },
+        { tex: `w_{u1} = ${sn1(r.wu1)},\\quad w_{u2} = ${sn1(r.wu2)}\\ \\text{kN/m (linear, resultant matches } P_u)` },
+      ],
+    },
+    {
+      title: 'Peak (hogging) moment',
+      lines: [{ tex: `M_{u,peak} = ${sn0(r.mPeak)}\\ \\text{kN·m at } x = ${sn2(r.xPeak)}\\ \\text{m}` }],
+    },
+    {
+      title: 'Slab thickness',
+      lines: [{ tex: `d_{punch} = ${sn0(r.dPunch)},\\; d_{beam} = ${sn0(r.dBeam)} \\Rightarrow D_c = ${sn0(r.Dc)}\\ \\text{mm}` }],
+    },
+    {
+      title: 'Longitudinal flexure',
+      lines: r.longSections.map((s) => ({
+        tex: `\\text{${s.label}: } M_u = ${sn0(s.Mu)}\\ \\text{kN·m},\\; ${s.bars}\\,⌀${i.barDia}@${sn0(s.spacing)}\\ \\text{mm (${s.top ? 'top' : 'bottom'})}`,
+      })),
+    },
+    {
+      title: 'Transverse flexure (under columns)',
+      lines: r.transverse.map((t) => ({
+        tex: `\\text{${t.label}: } M_u = ${sn1(t.MuPerM)}\\ \\text{kN·m/m},\\; A_s = ${sn0(t.AsPerM)}\\ \\text{mm}^2/\\text{m} \\;@\\; ${sn0(t.spacing)}\\ \\text{mm}`,
+      })),
+    },
+  ]
+  return steps
+}

--- a/webapp/src/lib/pileCapSolution.ts
+++ b/webapp/src/lib/pileCapSolution.ts
@@ -1,0 +1,50 @@
+// Worked solution for the pile-cap design — presents the engine's computed
+// demands and capacities (engine/pileCap.ts) with the governing checks.
+import type { PileCapInput, PileCapResult } from '../engine/pileCap'
+import { type SolutionStep, sn0, sn1 } from './solution'
+
+const ok = (b: boolean) => (b ? '\\checkmark' : '\\times\\ \\text{(revise)}')
+
+export function pileCapSolution(i: PileCapInput, r: PileCapResult): SolutionStep[] {
+  const n = r.coords.length
+  const maxFact = Math.max(...r.factReactions)
+
+  const shearStep = (title: string, Vu: number, phiVc: number, pass: boolean): SolutionStep => ({
+    title,
+    lines: [{ tex: `V_u = ${sn1(Vu)}\\ \\text{kN} \\;\\le\\; \\phi V_c = ${sn1(phiVc)}\\ \\text{kN}\\ ${ok(pass)}` }],
+  })
+
+  const flexStep = (title: string, Mu: number, s: PileCapResult['steelX']): SolutionStep => ({
+    title,
+    lines: [
+      { tex: `M_u = ${sn1(Mu)}\\ \\text{kN·m}` },
+      { tex: `A_s = ${sn0(s.As)}\\ \\text{mm}^2\\ (${s.usedMin ? '\\rho_{min}' : `\\rho = ${s.rho.toFixed(4)}`})` },
+    ],
+    note: `Provide ${s.bars} ⌀${i.barDia} mm @ ${sn0(s.spacing)} mm.`,
+  })
+
+  return [
+    {
+      title: 'Pile reactions (biaxial)',
+      lines: [
+        { tex: `R_i = \\dfrac{P_u}{n} \\pm \\dfrac{M_{ux}\\,y_i}{\\sum y^2} \\pm \\dfrac{M_{uy}\\,x_i}{\\sum x^2}` },
+        { tex: `n = ${n}\\ \\text{piles},\\quad R_{u,max} = ${sn1(maxFact)}\\ \\text{kN}` },
+        { tex: `R_{service,max} = ${sn1(r.maxReaction)}\\ \\text{kN} \\;\\le\\; R_{allow} = ${sn0(i.pileCapacity)}\\ \\text{kN}\\ ${ok(r.capacityOK)}` },
+      ],
+    },
+    {
+      title: 'Cap thickness & effective depth',
+      lines: [{ tex: `D_c = ${sn0(r.Dc)}\\ \\text{mm},\\quad d = D_c - cover - \\tfrac{3}{2}d_b = ${sn0(r.d)}\\ \\text{mm}` }],
+    },
+    shearStep('Two-way (punching) at the column', r.VuPunchCol, r.phiVcPunchCol, r.punchColOK),
+    shearStep('Two-way (punching) at a corner pile', r.VuPunchPile, r.phiVcPunchPile, r.punchPileOK),
+    shearStep('One-way (beam) shear — x', r.VuBeamX, r.phiVcBeamX, r.beamXOK),
+    shearStep('One-way (beam) shear — y', r.VuBeamY, r.phiVcBeamY, r.beamYOK),
+    flexStep('Flexure — x direction', r.MuX, r.steelX),
+    flexStep('Flexure — y direction', r.MuY, r.steelY),
+    {
+      title: 'Development length',
+      lines: [{ tex: `\\ell_{d,req} = ${sn0(r.ldRequired)}\\ \\text{mm} \\;\\le\\; \\ell_{d,avail} = ${sn0(r.ldAvailable)}\\ \\text{mm}\\ ${ok(r.ldOK)}` }],
+    },
+  ]
+}

--- a/webapp/src/pages/CombinedFootingDesign.tsx
+++ b/webapp/src/pages/CombinedFootingDesign.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { designCombinedFooting, type CombinedFootingInput } from '../engine/combinedFooting'
+import { WorkedSolution } from '../components/WorkedSolution'
+import { combinedSolution } from '../lib/combinedSolution'
 import { designFlexibleCombinedFooting } from '../engine/flexibleCombinedFooting'
 import { CombinedFootingSchematic } from '../components/CombinedFootingSchematic'
 import { Diagram } from '../components/Diagram'
@@ -140,6 +142,11 @@ export default function CombinedFootingDesign() {
       return null
     }
   }, [form, valid])
+
+  const solution = useMemo(
+    () => (result ? combinedSolution({ ...form }, result) : null),
+    [form, result],
+  )
 
   const flex = useMemo(() => {
     if (!valid || form.method !== 'flexible' || !(form.ksubgrade > 0)) return null
@@ -341,6 +348,8 @@ export default function CombinedFootingDesign() {
           </p>
         )}
       </div>
+
+      {solution && <WorkedSolution steps={solution} title="Solution — rigid method (step by step)" />}
     </div>
   )
 }

--- a/webapp/src/pages/PileCapDesign.tsx
+++ b/webapp/src/pages/PileCapDesign.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
-import { designPileCap, type PileArrangement } from '../engine/pileCap'
+import { designPileCap, type PileArrangement, type PileCapInput } from '../engine/pileCap'
+import { WorkedSolution } from '../components/WorkedSolution'
+import { pileCapSolution } from '../lib/pileCapSolution'
 import { PileCapSchematic } from '../components/PileCapSchematic'
 import { ReportControls } from '../components/ReportControls'
 import { Math as KTex } from '../lib/math'
@@ -131,29 +133,29 @@ export default function PileCapDesign() {
     && form.serviceLoad > 0 && form.ultimateLoad > 0
     && form.pileCapacity > 0 && form.spacing > 0 && form.edgeDist > 0
 
-  const result = useMemo(() => {
-    if (!valid) return null
-    return designPileCap({
-      serviceLoad: form.serviceLoad,
-      serviceMomX: form.serviceMomX,
-      serviceMomY: form.serviceMomY,
-      ultimateLoad: form.ultimateLoad,
-      ultimateMomX: form.ultimateMomX,
-      ultimateMomY: form.ultimateMomY,
-      nPiles: form.nPiles,
-      pileDia: form.pileDia,
-      pileCapacity: form.pileCapacity,
-      spacing: form.spacing,
-      edgeDist: form.edgeDist,
-      colX: form.colX,
-      colY: form.colY,
-      fc: form.fc,
-      fy: form.fy,
-      cover: form.cover,
-      barDia: form.barDia,
-      pileEmbed: form.pileEmbed,
-    })
-  }, [form, valid])
+  const input = useMemo<PileCapInput>(() => ({
+    serviceLoad: form.serviceLoad,
+    serviceMomX: form.serviceMomX,
+    serviceMomY: form.serviceMomY,
+    ultimateLoad: form.ultimateLoad,
+    ultimateMomX: form.ultimateMomX,
+    ultimateMomY: form.ultimateMomY,
+    nPiles: form.nPiles,
+    pileDia: form.pileDia,
+    pileCapacity: form.pileCapacity,
+    spacing: form.spacing,
+    edgeDist: form.edgeDist,
+    colX: form.colX,
+    colY: form.colY,
+    fc: form.fc,
+    fy: form.fy,
+    cover: form.cover,
+    barDia: form.barDia,
+    pileEmbed: form.pileEmbed,
+  }), [form])
+
+  const result = useMemo(() => (valid ? designPileCap(input) : null), [input, valid])
+  const solution = useMemo(() => (result ? pileCapSolution(input, result) : null), [input, result])
 
   const allOK = result && result.capacityOK && result.punchColOK && result.punchPileOK
     && result.beamXOK && result.beamYOK && result.ldOK
@@ -317,6 +319,8 @@ export default function PileCapDesign() {
           )}
         </div>
       </div>
+
+      {solution && <WorkedSolution steps={solution} />}
     </div>
   )
 }


### PR DESCRIPTION
Completes the "extend the worked-solution pattern" request — the last two structural tools now have step-by-step solutions, reusing the generic `WorkedSolution` renderer.

> Stacked on #123 (for the shared renderer). Base is `feature/react-beam-design`; retarget to `main` after #123 merges. Parallel to #124 (estimator solutions) — no overlapping files.

## Pile Cap — `lib/pileCapSolution.ts`
Pile reactions (biaxial `R = Pu/n ± Mx·y/Σy² ± My·x/Σx²`, max vs allowable) → cap thickness/d → two-way punching at the **column** and at a **corner pile** → one-way shear **x/y** → flexure **x/y** (As, bars) → **development length** — each with its φ-capacity check (✓/✗). Presents the engine's computed demands so the steps always match the result panel.

## Combined Footing — `lib/combinedSolution.ts` (rigid method)
Service & factored loads → net bearing → geometry (rectangular CRF / trapezoidal CTF, sized about the resultant, containment note) → equivalent uniformly-varying line load (`w_u1 → w_u2`) → peak moment → slab thickness → longitudinal flexure sections → transverse (per-metre) strips.

Wired into both pages (Pile Cap input extracted to a memo; Combined uses the rigid result).

## Verification
- `npm run build` green; `npm test` 69 passing.

## Status of your full request
- ✅ #123 New React **Beam Design** tool (+ solution)
- ✅ #124 **Estimator** solutions (slab, CHB, column, beam, box culvert)
- ✅ this PR: **Pile Cap** + **Combined Footing** solutions

🤖 Generated with [Claude Code](https://claude.com/claude-code)