### PR TITLE
Foundation: circular columns + analyze/approximate for rectangular & eccentric

### DIFF
--- a/webapp/src/engine/eccentricFooting.test.ts
+++ b/webapp/src/engine/eccentricFooting.test.ts
@@ -34,3 +34,26 @@ describe('designEccentricSquareFooting', () => {
     expect(ec.qMinService).toBeGreaterThanOrEqual(-1e-6);
   });
 });
+
+describe('analysis & solution methods', () => {
+  it('approximate gives a one-pass thickness ≥ the iterated one', () => {
+    const it_ = designEccentricSquareFooting({ ...base, serviceMoment: 200, ultimateMoment: 280 });
+    const ap = designEccentricSquareFooting({ ...base, serviceMoment: 200, ultimateMoment: 280, solutionMethod: 'approximate' });
+    expect(ap.method).toBe('approximate');
+    expect(ap.Dc).toBeGreaterThanOrEqual(it_.Dc - 1e-6);
+  });
+
+  it('analyze: adequate section passes; undersized plan fails bearing', () => {
+    const d = designEccentricSquareFooting({ ...base, serviceMoment: 200, ultimateMoment: 280 });
+    const ok = designEccentricSquareFooting({
+      ...base, serviceMoment: 200, ultimateMoment: 280,
+      analysis: 'analyze', givenB: d.B, givenDc: d.Dc,
+    });
+    expect(ok.punchOK && ok.beamOK && ok.bearingOK).toBe(true);
+    const small = designEccentricSquareFooting({
+      ...base, serviceMoment: 200, ultimateMoment: 280,
+      analysis: 'analyze', givenB: d.B - 0.6, givenDc: d.Dc,
+    });
+    expect(small.bearingOK).toBe(false);
+  });
+});

--- a/webapp/src/engine/eccentricFooting.ts
+++ b/webapp/src/engine/eccentricFooting.ts
@@ -25,6 +25,12 @@ export interface EccentricFootingInput {
   surcharge?: number;
   position?: ColumnPosition;
   lambda?: number;
+  /** Detailed design (size B & D_c) or analyze a given section. Default 'design'. */
+  analysis?: 'design' | 'analyze';
+  givenB?: number;       // m, analyze only
+  givenDc?: number;      // mm, analyze only
+  /** 'iteration' (fixed point) or 'approximate' (one pass from D_c = 250 mm). */
+  solutionMethod?: 'iteration' | 'approximate';
 }
 
 export interface EccentricFootingResult {
@@ -46,6 +52,14 @@ export interface EccentricFootingResult {
   usedMinSteel: boolean;
   bars: number;
   barSpacing: number;
+  analysis: 'design' | 'analyze';
+  method: 'iteration' | 'approximate';
+  /** Provided effective depth for shear (D_c − cover − d_b), mm. */
+  dProvided: number;
+  punchOK: boolean;
+  beamOK: boolean;
+  /** Analyze only: peak service pressure within q_net. */
+  bearingOK: boolean;
 }
 
 function roundUp(v: number, step: number): number {
@@ -58,26 +72,58 @@ export function designEccentricSquareFooting(i: EccentricFootingInput): Eccentri
   const cm = i.columnWidth / 1000;
   const surcharge = i.surcharge ?? 0;
 
-  let Dc = 0.25;
-  let B = 0, qNet = 0, quMax = 0, dPunch = 0, dBeam = 0, qMaxService = 0;
-  for (let k = 0; k < 10; k++) {
-    qNet = netBearing({ qAllow: i.qAllow, gammaSoil: i.gammaSoil, gammaConc: i.gammaConc, H: i.H, Dc, surcharge });
-    // Grow B until the peak service pressure fits AND the load stays in the kern.
-    B = roundUp(Math.max(6 * e, Math.sqrt(i.serviceLoad / qNet)), 0.05);
+  const analysis = i.analysis ?? 'design';
+  const method = i.solutionMethod ?? 'iteration';
+  const qNetAt = (Dc: number) =>
+    netBearing({ qAllow: i.qAllow, gammaSoil: i.gammaSoil, gammaConc: i.gammaConc, H: i.H, Dc, surcharge });
+  // Grow B until the peak service pressure fits AND the load stays in the kern.
+  const sizeB = (qNet: number) => {
+    let B = roundUp(Math.max(6 * e, Math.sqrt(i.serviceLoad / qNet)), 0.05);
     for (let g = 0; g < 600; g++) {
       const qm = (i.serviceLoad / (B * B)) * (1 + (6 * e) / B);
       if (qm <= qNet && B >= 6 * e - 1e-9) break;
       B = roundUp(B + 0.05, 0.05);
     }
+    return B;
+  };
+  // Punching uses the average pressure relief; one-way & flexure use the peak.
+  const shearDepths = (B: number, quMax: number) => ({
+    dPunch: punchingDepth({ Pu: i.ultimateLoad, qu: i.ultimateLoad / (B * B), c: i.columnWidth, fc: i.fc, position: i.position, lambda: i.lambda }),
+    dBeam: oneWayShearDepth({ qu: quMax, B, c: cm, fc: i.fc, lambda: i.lambda }),
+  });
+
+  let Dc = 0.25;
+  let B = 0, qNet = 0, quMax = 0, dPunch = 0, dBeam = 0, qMaxService = 0;
+  let punchOK = true, beamOK = true, bearingOK = true;
+  if (analysis === 'analyze') {
+    B = i.givenB ?? 0;
+    Dc = (i.givenDc ?? 250) / 1000;
+    qNet = qNetAt(Dc);
     qMaxService = (i.serviceLoad / (B * B)) * (1 + (6 * e) / B);
     quMax = (i.ultimateLoad / (B * B)) * (1 + (6 * eU) / B);
-    const quAvg = i.ultimateLoad / (B * B);
-    // Punching uses the average pressure relief; one-way & flexure use the peak.
-    dPunch = punchingDepth({ Pu: i.ultimateLoad, qu: quAvg, c: i.columnWidth, fc: i.fc, position: i.position, lambda: i.lambda });
-    dBeam = oneWayShearDepth({ qu: quMax, B, c: cm, fc: i.fc, lambda: i.lambda });
-    const newDc = roundUp(Math.max(dPunch, dBeam) + i.cover + i.barDia, 25) / 1000;
-    if (Math.abs(newDc - Dc) < 1e-4) { Dc = newDc; break; }
-    Dc = newDc;
+    ({ dPunch, dBeam } = shearDepths(B, quMax));
+    const dProv = Dc * 1000 - i.cover - i.barDia;
+    punchOK = dProv >= dPunch;
+    beamOK = dProv >= dBeam;
+    bearingOK = qMaxService <= qNet + 1e-9;
+  } else if (method === 'approximate') {
+    qNet = qNetAt(Dc);
+    B = sizeB(qNet);
+    qMaxService = (i.serviceLoad / (B * B)) * (1 + (6 * e) / B);
+    quMax = (i.ultimateLoad / (B * B)) * (1 + (6 * eU) / B);
+    ({ dPunch, dBeam } = shearDepths(B, quMax));
+    Dc = roundUp(Math.max(dPunch, dBeam) + i.cover + i.barDia, 25) / 1000;
+  } else {
+    for (let k = 0; k < 10; k++) {
+      qNet = qNetAt(Dc);
+      B = sizeB(qNet);
+      qMaxService = (i.serviceLoad / (B * B)) * (1 + (6 * e) / B);
+      quMax = (i.ultimateLoad / (B * B)) * (1 + (6 * eU) / B);
+      ({ dPunch, dBeam } = shearDepths(B, quMax));
+      const newDc = roundUp(Math.max(dPunch, dBeam) + i.cover + i.barDia, 25) / 1000;
+      if (Math.abs(newDc - Dc) < 1e-4) { Dc = newDc; break; }
+      Dc = newDc;
+    }
   }
 
   const DcMm = Dc * 1000;
@@ -93,5 +139,6 @@ export function designEccentricSquareFooting(i: EccentricFootingInput): Eccentri
     B, Dc: DcMm, e, eU, qNet, qMaxService, qMinService, quMax,
     dPunch, dBeam, dFlex, kernOK: e <= B / 6 + 1e-9,
     steelArea: flex.As, rho: flex.rho, usedMinSteel: flex.usedMin, bars: layout.n, barSpacing: layout.spacing,
+    analysis, method, dProvided: DcMm - i.cover - i.barDia, punchOK, beamOK, bearingOK,
   };
 }

--- a/webapp/src/engine/rectangularFooting.test.ts
+++ b/webapp/src/engine/rectangularFooting.test.ts
@@ -44,3 +44,26 @@ describe('ratio 1 ≈ square footing', () => {
     expect(rc.Dc).toBe(sq.Dc);
   });
 });
+
+describe('analysis & solution methods', () => {
+  it('approximate gives a one-pass thickness ≥ the iterated one', () => {
+    const it_ = designRectangularFooting({ ...base, sizing: { mode: 'ratio', ratio: 1.5 } });
+    const ap = designRectangularFooting({ ...base, sizing: { mode: 'ratio', ratio: 1.5 }, solutionMethod: 'approximate' });
+    expect(ap.method).toBe('approximate');
+    expect(ap.Dc).toBeGreaterThanOrEqual(it_.Dc - 1e-6);
+  });
+
+  it('analyze: adequate section passes, thin one fails', () => {
+    const d = designRectangularFooting({ ...base, sizing: { mode: 'ratio', ratio: 1.5 } });
+    const ok = designRectangularFooting({
+      ...base, sizing: { mode: 'ratio', ratio: 1.5 },
+      analysis: 'analyze', givenBx: d.Bx, givenBy: d.By, givenDc: d.Dc,
+    });
+    expect(ok.punchOK && ok.beamOK).toBe(true);
+    const thin = designRectangularFooting({
+      ...base, sizing: { mode: 'ratio', ratio: 1.5 },
+      analysis: 'analyze', givenBx: d.Bx, givenBy: d.By, givenDc: 300,
+    });
+    expect(thin.punchOK && thin.beamOK).toBe(false);
+  });
+});

--- a/webapp/src/engine/rectangularFooting.ts
+++ b/webapp/src/engine/rectangularFooting.ts
@@ -29,6 +29,13 @@ export interface RectFootingInput {
   position?: ColumnPosition;
   lambda?: number;
   sizing: RectSizing;
+  /** Detailed design (size plan & D_c) or analyze a given section. Default 'design'. */
+  analysis?: 'design' | 'analyze';
+  givenBx?: number;      // m, analyze only
+  givenBy?: number;      // m, analyze only
+  givenDc?: number;      // mm, analyze only
+  /** 'iteration' (fixed point) or 'approximate' (one pass from D_c = 250 mm). */
+  solutionMethod?: 'iteration' | 'approximate';
 }
 
 export interface DirectionSteel {
@@ -51,6 +58,12 @@ export interface RectFootingResult {
   dFlex: number;
   long: DirectionSteel;                              // bars along x, spread over By
   short: DirectionSteel & { bandBars: number; bandFraction: number }; // bars along y + central band
+  analysis: 'design' | 'analyze';
+  method: 'iteration' | 'approximate';
+  /** Provided effective depth for shear (D_c − cover − d_b), mm. */
+  dProvided: number;
+  punchOK: boolean;
+  beamOK: boolean;
 }
 
 function roundUp(v: number, step: number): number {
@@ -70,21 +83,48 @@ function sizePlan(area: number, sizing: RectSizing): { Bx: number; By: number } 
 export function designRectangularFooting(i: RectFootingInput): RectFootingResult {
   const cm = i.columnWidth / 1000;
   const surcharge = i.surcharge ?? 0;
+  const analysis = i.analysis ?? 'design';
+  const method = i.solutionMethod ?? 'iteration';
+  const qNetAt = (Dc: number) =>
+    netBearing({ qAllow: i.qAllow, gammaSoil: i.gammaSoil, gammaConc: i.gammaConc, H: i.H, Dc, surcharge });
+  const shearDepths = (qu: number, Bx: number, By: number) => ({
+    dPunch: punchingDepth({ Pu: i.ultimateLoad, qu, c: i.columnWidth, fc: i.fc, position: i.position, lambda: i.lambda }),
+    // One-way shear: d depends on the span dimension only (the perpendicular
+    // width cancels), so pass each plan dimension as the span.
+    dBeamLong: oneWayShearDepth({ qu, B: Bx, c: cm, fc: i.fc, lambda: i.lambda }),
+    dBeamShort: oneWayShearDepth({ qu, B: By, c: cm, fc: i.fc, lambda: i.lambda }),
+  });
 
   let Dc = 0.25;
   let Bx = 0, By = 0, qNet = 0, qu = 0, dPunch = 0, dBeamLong = 0, dBeamShort = 0;
-  for (let k = 0; k < 8; k++) {
-    qNet = netBearing({ qAllow: i.qAllow, gammaSoil: i.gammaSoil, gammaConc: i.gammaConc, H: i.H, Dc, surcharge });
+  let punchOK = true, beamOK = true;
+  if (analysis === 'analyze') {
+    // Given plan & thickness — compute pressures, check shear adequacy.
+    Bx = i.givenBx ?? 0; By = i.givenBy ?? 0;
+    Dc = (i.givenDc ?? 250) / 1000;
+    qNet = qNetAt(Dc);
+    qu = i.ultimateLoad / (Bx * By);
+    ({ dPunch, dBeamLong, dBeamShort } = shearDepths(qu, Bx, By));
+    const dProv = Dc * 1000 - i.cover - i.barDia;
+    punchOK = dProv >= dPunch;
+    beamOK = dProv >= Math.max(dBeamLong, dBeamShort);
+  } else if (method === 'approximate') {
+    // One pass from the assumed D_c = 250 mm.
+    qNet = qNetAt(Dc);
     ({ Bx, By } = sizePlan(i.serviceLoad / qNet, i.sizing));
     qu = i.ultimateLoad / (Bx * By);
-    dPunch = punchingDepth({ Pu: i.ultimateLoad, qu, c: i.columnWidth, fc: i.fc, position: i.position, lambda: i.lambda });
-    // One-way shear: d depends on the span dimension only (the perpendicular
-    // width cancels), so pass each plan dimension as the span.
-    dBeamLong = oneWayShearDepth({ qu, B: Bx, c: cm, fc: i.fc, lambda: i.lambda });
-    dBeamShort = oneWayShearDepth({ qu, B: By, c: cm, fc: i.fc, lambda: i.lambda });
-    const newDc = roundUp(Math.max(dPunch, dBeamLong, dBeamShort) + i.cover + i.barDia, 25) / 1000;
-    if (Math.abs(newDc - Dc) < 1e-4) { Dc = newDc; break; }
-    Dc = newDc;
+    ({ dPunch, dBeamLong, dBeamShort } = shearDepths(qu, Bx, By));
+    Dc = roundUp(Math.max(dPunch, dBeamLong, dBeamShort) + i.cover + i.barDia, 25) / 1000;
+  } else {
+    for (let k = 0; k < 8; k++) {
+      qNet = qNetAt(Dc);
+      ({ Bx, By } = sizePlan(i.serviceLoad / qNet, i.sizing));
+      qu = i.ultimateLoad / (Bx * By);
+      ({ dPunch, dBeamLong, dBeamShort } = shearDepths(qu, Bx, By));
+      const newDc = roundUp(Math.max(dPunch, dBeamLong, dBeamShort) + i.cover + i.barDia, 25) / 1000;
+      if (Math.abs(newDc - Dc) < 1e-4) { Dc = newDc; break; }
+      Dc = newDc;
+    }
   }
 
   const DcMm = Dc * 1000;
@@ -115,5 +155,6 @@ export function designRectangularFooting(i: RectFootingInput): RectFootingResult
       As: flexShort.As, rho: flexShort.rho, usedMin: flexShort.usedMin,
       bars: layoutShort.n, spacing: layoutShort.spacing, bandBars, bandFraction,
     },
+    analysis, method, dProvided: DcMm - i.cover - i.barDia, punchOK, beamOK,
   };
 }

--- a/webapp/src/lib/foundationSolution.ts
+++ b/webapp/src/lib/foundationSolution.ts
@@ -21,6 +21,8 @@ export interface SolutionCtx {
   loads?: { dead: number; live: number } | null
   serviceMoment: number; ultimateMoment: number
   columnWidth: number; fc: number; fy: number
+  /** Present when the column is circular (columnWidth is the equivalent square). */
+  column?: { shape: 'circular'; dia: number } | null
   qAllow: number; gammaSoil: number; gammaConc: number; H: number
   barDia: number; cover: number; surcharge: number; position: ColumnPosition
   Bx: number; By: number; Dc: number; qNet: number; qu: number
@@ -75,13 +77,26 @@ function bearingStep(c: SolutionCtx): SolutionStep {
   }
 }
 
+function columnStep(c: SolutionCtx): SolutionStep | null {
+  if (!c.column) return null
+  return {
+    title: 'Equivalent square column',
+    lines: [
+      txt('A circular (spiral) column is replaced by an equal-area square for the shear and flexure checks — the legacy convention.'),
+      eq(String.raw`c = D\sqrt{\tfrac{\pi}{4}} = ${sn0(c.column.dia)}\times ${sn4(Math.sqrt(Math.PI / 4))} = \mathbf{${sn1(c.columnWidth)}}\ \text{mm}`),
+    ],
+  }
+}
+
 function sizeOrGivenStep(c: SolutionCtx): SolutionStep {
   if (c.analysis === 'analyze') {
     return {
       title: 'Given section',
       lines: [
         txt('Analyze mode — the plan size and thickness are provided; the remaining steps check the section rather than size it.'),
-        eq(String.raw`B = ${sn2(c.Bx)}\ \text{m},\qquad D_c = ${sn0(c.Dc)}\ \text{mm}`),
+        eq(c.type === 'rectangular'
+          ? String.raw`B_x = ${sn2(c.Bx)}\ \text{m},\quad B_y = ${sn2(c.By)}\ \text{m},\qquad D_c = ${sn0(c.Dc)}\ \text{mm}`
+          : String.raw`B = ${sn2(c.Bx)}\ \text{m},\qquad D_c = ${sn0(c.Dc)}\ \text{mm}`),
       ],
     }
   }
@@ -239,7 +254,10 @@ function eccentricityStep(c: SolutionCtx): SolutionStep | null {
 }
 
 export function buildFoundationSolution(c: SolutionCtx): SolutionStep[] {
-  const steps: SolutionStep[] = [loadsStep(c), bearingStep(c)]
+  const steps: SolutionStep[] = [loadsStep(c)]
+  const colS = columnStep(c)
+  if (colS) steps.push(colS)
+  steps.push(bearingStep(c))
   const eccS = eccentricityStep(c)
   if (eccS) steps.push(eccS)
   steps.push(sizeOrGivenStep(c), pressureStep(c), punchingStep(c))

--- a/webapp/src/pages/FoundationDesign.tsx
+++ b/webapp/src/pages/FoundationDesign.tsx
@@ -22,6 +22,7 @@ type LoadingType = 'concentric' | 'eccentric'
 type AnalysisMethod = 'design' | 'analyze'
 type SolutionMethod = 'iteration' | 'approximate'
 type LoadInput = 'direct' | 'individual'
+type ColumnShape = 'square' | 'circular'
 
 interface FormState {
   footingType: FootingType
@@ -29,7 +30,9 @@ interface FormState {
   analysisMethod: AnalysisMethod
   solutionMethod: SolutionMethod
   givenB: number
+  givenBy: number
   givenDc: number
+  columnShape: ColumnShape
   sizingMode: SizingMode
   ratio: number
   fixedBy: number
@@ -59,7 +62,9 @@ const DEFAULTS: FormState = {
   analysisMethod: 'design',
   solutionMethod: 'iteration',
   givenB: 2,
+  givenBy: 2,
   givenDc: 500,
+  columnShape: 'square',
   sizingMode: 'ratio',
   ratio: 1.5,
   fixedBy: 2,
@@ -96,7 +101,6 @@ interface View {
   ecc: { e: number; qMax: number; qMin: number; kernOK: boolean } | null
 }
 
-const designDefaults = { analysis: 'design' as const, method: 'iteration' as const, punchOK: true, beamOK: true }
 
 function NumField({ label, unit, value, onChange, step = 'any' }: {
   label: ReactNode; unit?: string; value: number; onChange: (v: number) => void; step?: string
@@ -161,15 +165,18 @@ export default function FoundationDesign() {
   const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) => setForm((s) => ({ ...s, [k]: v }))
   const ecc = form.loadingType === 'eccentric'
   const rect = form.footingType === 'rectangular' && !ecc   // eccentric pilot is square-only
-  const sq = form.footingType === 'square' && !ecc          // analysis/solution methods apply here
-  const analyze = sq && form.analysisMethod === 'analyze'
+  const analyze = form.analysisMethod === 'analyze'
+  // Circular columns use the legacy equivalent-square width c_eq = D·√(π/4).
+  // (globalThis.Math: the KaTeX <Math> import shadows the global in this file.)
+  const circular = form.columnShape === 'circular'
+  const colWidth = circular ? form.columnWidth * globalThis.Math.sqrt(globalThis.Math.PI / 4) : form.columnWidth
 
   const qNetTrial = useMemo(
     () => netBearing({ qAllow: form.qAllow, gammaSoil: form.gammaSoil, gammaConc: form.gammaConc, H: form.H, Dc: 0.25, surcharge: form.surcharge }),
     [form.qAllow, form.gammaSoil, form.gammaConc, form.H, form.surcharge],
   )
-  const sizingOk = !rect || (form.sizingMode === 'ratio' ? form.ratio >= 1 : form.fixedBy > 0)
-  const analyzeOk = !analyze || (form.givenB > 0 && form.givenDc > 0)
+  const sizingOk = analyze || !rect || (form.sizingMode === 'ratio' ? form.ratio >= 1 : form.fixedBy > 0)
+  const analyzeOk = !analyze || (form.givenB > 0 && form.givenDc > 0 && (!rect || form.givenBy > 0))
   const valid = Object.values(form).every((v) => typeof v === 'string' || Number.isFinite(v as number)) && qNetTrial > 0 && sizingOk && analyzeOk
 
   // Effective loads: entered directly, or derived from DL & LL
@@ -181,25 +188,30 @@ export default function FoundationDesign() {
   const view: View | null = useMemo(() => {
     if (!valid) return null
     const common = {
-      serviceLoad, ultimateLoad, columnWidth: form.columnWidth,
+      serviceLoad, ultimateLoad, columnWidth: colWidth,
       fc: form.fc, fy: form.fy, qAllow: form.qAllow, gammaSoil: form.gammaSoil, gammaConc: form.gammaConc,
       H: form.H, barDia: form.barDia, cover: form.cover, surcharge: form.surcharge, position: form.position,
     }
+    const methods = {
+      analysis: form.analysisMethod, solutionMethod: form.solutionMethod,
+      givenB: form.givenB, givenDc: form.givenDc,
+    }
     if (ecc) {
-      const r = designEccentricSquareFooting({ ...common, serviceMoment: form.serviceMoment, ultimateMoment: form.ultimateMoment })
+      const r = designEccentricSquareFooting({
+        ...common, ...methods, serviceMoment: form.serviceMoment, ultimateMoment: form.ultimateMoment,
+      })
       return {
-        type: 'square', loading: 'eccentric', ...designDefaults, Bx: r.B, By: r.B, Dc: r.Dc, qNet: r.qNet, qu: r.quMax,
-        dPunch: r.dPunch, dBeamLong: r.dBeam, dBeamShort: r.dBeam, dProvided: r.Dc - form.cover - form.barDia,
+        type: 'square', loading: 'eccentric', analysis: r.analysis, method: r.method,
+        Bx: r.B, By: r.B, Dc: r.Dc, qNet: r.qNet, qu: r.quMax,
+        dPunch: r.dPunch, dBeamLong: r.dBeam, dBeamShort: r.dBeam, dProvided: r.dProvided,
+        punchOK: r.punchOK, beamOK: r.beamOK && r.bearingOK,
         long: { As: r.steelArea, bars: r.bars, spacing: r.barSpacing, usedMin: r.usedMinSteel, rho: r.rho },
         short: null,
         ecc: { e: r.e, qMax: r.qMaxService, qMin: r.qMinService, kernOK: r.kernOK },
       }
     }
     if (!rect) {
-      const r = designSquareFooting({
-        ...common, analysis: form.analysisMethod, solutionMethod: form.solutionMethod,
-        givenB: form.givenB, givenDc: form.givenDc,
-      })
+      const r = designSquareFooting({ ...common, ...methods })
       return {
         type: 'square', loading: 'concentric', analysis: r.analysis, method: r.method,
         Bx: r.B, By: r.B, Dc: r.Dc, qNet: r.qNet, qu: r.qu,
@@ -212,13 +224,17 @@ export default function FoundationDesign() {
     const sizing = form.sizingMode === 'ratio'
       ? { mode: 'ratio' as const, ratio: form.ratio }
       : { mode: 'fixedWidth' as const, By: form.fixedBy }
-    const r = designRectangularFooting({ ...common, sizing })
+    const r = designRectangularFooting({
+      ...common, sizing, ...methods, givenBx: form.givenB, givenBy: form.givenBy,
+    })
     return {
-      type: 'rectangular', loading: 'concentric', ...designDefaults, Bx: r.Bx, By: r.By, Dc: r.Dc, qNet: r.qNet, qu: r.qu,
-      dPunch: r.dPunch, dBeamLong: r.dBeamLong, dBeamShort: r.dBeamShort, dProvided: r.Dc - form.cover - form.barDia,
+      type: 'rectangular', loading: 'concentric', analysis: r.analysis, method: r.method,
+      Bx: r.Bx, By: r.By, Dc: r.Dc, qNet: r.qNet, qu: r.qu,
+      dPunch: r.dPunch, dBeamLong: r.dBeamLong, dBeamShort: r.dBeamShort, dProvided: r.dProvided,
+      punchOK: r.punchOK, beamOK: r.beamOK,
       long: r.long, short: r.short, ecc: null,
     }
-  }, [form, valid, rect, ecc, serviceLoad, ultimateLoad])
+  }, [form, valid, rect, ecc, serviceLoad, ultimateLoad, colWidth])
 
   const solutionSteps = useMemo(() => {
     if (!view) return null
@@ -227,7 +243,8 @@ export default function FoundationDesign() {
       serviceLoad, ultimateLoad,
       loads: individual ? { dead: form.deadLoad, live: form.liveLoad } : null,
       serviceMoment: form.serviceMoment, ultimateMoment: form.ultimateMoment,
-      columnWidth: form.columnWidth, fc: form.fc, fy: form.fy,
+      columnWidth: colWidth, fc: form.fc, fy: form.fy,
+      column: circular ? { shape: 'circular' as const, dia: form.columnWidth } : null,
       qAllow: form.qAllow, gammaSoil: form.gammaSoil, gammaConc: form.gammaConc, H: form.H,
       barDia: form.barDia, cover: form.cover, surcharge: form.surcharge, position: form.position,
       Bx: view.Bx, By: view.By, Dc: view.Dc, qNet: view.qNet, qu: view.qu,
@@ -296,28 +313,29 @@ export default function FoundationDesign() {
               options={[['square', 'Isolated Square'], ['rectangular', 'Isolated Rectangular']]} />
             <Select label="Loading" value={form.loadingType} onChange={set('loadingType')}
               options={[['concentric', 'Concentric'], ['eccentric', 'Eccentric (uniaxial)']]} />
-            {sq && (
-              <Select label="Analysis method" value={form.analysisMethod} onChange={set('analysisMethod')}
-                options={[['design', 'Detailed design'], ['analyze', 'Analyze given dimensions']]} />
-            )}
-            {sq && !analyze && (
+            <Select label="Analysis method" value={form.analysisMethod} onChange={set('analysisMethod')}
+              options={[['design', 'Detailed design'], ['analyze', 'Analyze given dimensions']]} />
+            {!analyze && (
               <Select label="Solution method" value={form.solutionMethod} onChange={set('solutionMethod')}
                 options={[['iteration', 'Iteration'], ['approximate', 'Approximate (initial Dc)']]} />
             )}
             {analyze && (
-              <NumField label="Given B" unit="m" value={form.givenB} onChange={set('givenB')} />
+              <NumField label={rect ? 'Given Bx' : 'Given B'} unit="m" value={form.givenB} onChange={set('givenB')} />
+            )}
+            {analyze && rect && (
+              <NumField label="Given By" unit="m" value={form.givenBy} onChange={set('givenBy')} />
             )}
             {analyze && (
               <NumField label="Given Dc" unit="mm" value={form.givenDc} onChange={set('givenDc')} />
             )}
-            {rect && (
+            {rect && !analyze && (
               <Select label="Sizing" value={form.sizingMode} onChange={set('sizingMode')}
                 options={[['ratio', 'By aspect ratio (Bx/By)'], ['fixedWidth', 'Fixed width By']]} />
             )}
-            {rect && form.sizingMode === 'ratio' && (
+            {rect && !analyze && form.sizingMode === 'ratio' && (
               <NumField label="Aspect Bx/By" value={form.ratio} onChange={set('ratio')} />
             )}
-            {rect && form.sizingMode === 'fixedWidth' && (
+            {rect && !analyze && form.sizingMode === 'fixedWidth' && (
               <NumField label="Width By" unit="m" value={form.fixedBy} onChange={set('fixedBy')} />
             )}
             {ecc && (
@@ -344,9 +362,17 @@ export default function FoundationDesign() {
             )}
             {ecc && <NumField label={<Math tex="M" />} unit="kN·m" value={form.serviceMoment} onChange={set('serviceMoment')} />}
             {ecc && <NumField label={<Math tex="M_u" />} unit="kN·m" value={form.ultimateMoment} onChange={set('ultimateMoment')} />}
-            <NumField label={<>Column <Math tex="c" /> (square)</>} unit="mm" value={form.columnWidth} onChange={set('columnWidth')} />
+            <Select label="Column shape" value={form.columnShape} onChange={set('columnShape')}
+              options={[['square', 'Square'], ['circular', 'Circular (spiral)']]} />
+            <NumField label={circular ? <>Column Ø <Math tex="D" /></> : <>Column <Math tex="c" /> (square)</>}
+              unit="mm" value={form.columnWidth} onChange={set('columnWidth')} />
             <Select label="Column position" value={form.position} onChange={set('position')}
               options={[['interior', 'Interior'], ['edge', 'Edge'], ['corner', 'Corner']]} />
+            {circular && (
+              <p className="col-span-full text-xs text-slate-400">
+                Circular column → equivalent square c = D·√(π/4) = {f0(colWidth)} mm (equal area, legacy convention).
+              </p>
+            )}
           </Card>
 
           <Card title="Materials">
@@ -370,7 +396,7 @@ export default function FoundationDesign() {
           <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Design preview</h2>
             {view ? (
-              <FootingSchematic Bx={view.Bx} By={view.By} Dc={view.Dc} columnWidth={form.columnWidth} H={form.H} />
+              <FootingSchematic Bx={view.Bx} By={view.By} Dc={view.Dc} columnWidth={colWidth} H={form.H} />
             ) : (
               <p className="py-8 text-center text-sm text-slate-400">Enter valid inputs — net bearing must be positive.</p>
             )}
@@ -383,7 +409,7 @@ export default function FoundationDesign() {
                 <Row label="Adequacy" value={view.punchOK && view.beamOK ? '✓ section OK' : '✗ inadequate in shear'}
                   check={`punching ${view.punchOK ? '✓' : '✗'} · beam ${view.beamOK ? '✓' : '✗'}`} />
               )}
-              {view.analysis === 'design' && view.type === 'square' && view.loading === 'concentric' && (
+              {view.analysis === 'design' && (
                 <Row label="Method" value={view.method === 'iteration' ? 'Iteration' : 'Approximate'} />
               )}
               <Row label={<Math tex="q_{net}" />} value={`${f3(view.qNet)} kPa`} />


### PR DESCRIPTION
Ports the **remaining unported legacy foundation options**.

## Circular (spiral) columns
- Column **shape** select (Square / Circular). Circular uses the legacy **equivalent-square** conversion `c = D·√(π/4)` (equal area); the input becomes a diameter Ø.
- The conversion is shown inline under the form and as its own **worked-solution step**; the schematic and all engines consume the equivalent width.

## Analyze / Approximate everywhere
Previously square-only (#126); now on all three types:
- **Rectangular**: `analyze` takes `givenBx/givenBy/givenDc`, checks punching + both-direction one-way shear (`punchOK`/`beamOK`); `approximate` is the one-pass D_c = 250 mm sizing.
- **Eccentric**: `analyze` takes `givenB/givenDc`, checks punching, one-way, **and peak service pressure vs q_net** (`bearingOK`); `approximate` one-pass.
- UI: method selects shown for every footing type; Given Bx/By/Dc inputs as applicable; sizing controls hidden in analyze mode; the Results Method/Adequacy rows generalised.
- Worked solution: the given-section step shows `Bx × By` for rectangular; all method-aware commentary from #126 applies.

## Verification
- 4 new engine tests — rectangular & eccentric: approximate ≥ iterated thickness; analyze pass/fail (incl. the eccentric bearing failure). **81 total passing**; build green.

With this, the legacy Foundation Design options are fully represented in the React app (square/rectangular/eccentric × design/analyze × iteration/approximate, square/circular columns, direct or DL&LL loads, Excel batch, worked solutions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)