### PR TITLE
Foundation: rectangular columns (cx × cy)

### DIFF
--- a/webapp/src/engine/eccentricFooting.ts
+++ b/webapp/src/engine/eccentricFooting.ts
@@ -13,7 +13,8 @@ export interface EccentricFootingInput {
   ultimateLoad: number;   // Pu, kN
   serviceMoment: number;  // M, kN·m (service, about one axis)
   ultimateMoment: number; // Mu, kN·m (factored)
-  columnWidth: number;    // square column c, mm
+  columnWidth: number;    // column x-dimension (along the eccentricity), mm
+  columnWidthY?: number;  // column y-dimension, mm (default columnWidth)
   fc: number;
   fy: number;
   qAllow: number;
@@ -69,7 +70,9 @@ function roundUp(v: number, step: number): number {
 export function designEccentricSquareFooting(i: EccentricFootingInput): EccentricFootingResult {
   const e = i.serviceLoad > 0 ? Math.abs(i.serviceMoment) / i.serviceLoad : 0;
   const eU = i.ultimateLoad > 0 ? Math.abs(i.ultimateMoment) / i.ultimateLoad : 0;
-  const cm = i.columnWidth / 1000;
+  const cy = i.columnWidthY ?? i.columnWidth;
+  // The smaller column dimension gives the longer (governing) cantilever.
+  const cm = Math.min(i.columnWidth, cy) / 1000;
   const surcharge = i.surcharge ?? 0;
 
   const analysis = i.analysis ?? 'design';
@@ -88,7 +91,7 @@ export function designEccentricSquareFooting(i: EccentricFootingInput): Eccentri
   };
   // Punching uses the average pressure relief; one-way & flexure use the peak.
   const shearDepths = (B: number, quMax: number) => ({
-    dPunch: punchingDepth({ Pu: i.ultimateLoad, qu: i.ultimateLoad / (B * B), c: i.columnWidth, fc: i.fc, position: i.position, lambda: i.lambda }),
+    dPunch: punchingDepth({ Pu: i.ultimateLoad, qu: i.ultimateLoad / (B * B), c: i.columnWidth, cy, fc: i.fc, position: i.position, lambda: i.lambda }),
     dBeam: oneWayShearDepth({ qu: quMax, B, c: cm, fc: i.fc, lambda: i.lambda }),
   });
 

--- a/webapp/src/engine/isolatedFooting.test.ts
+++ b/webapp/src/engine/isolatedFooting.test.ts
@@ -66,3 +66,20 @@ describe('designSquareFooting (integration)', () => {
     expect(thin.punchOK && thin.beamOK).toBe(false);
   });
 });
+
+describe('rectangular columns', () => {
+  const input = {
+    serviceLoad: 1000, ultimateLoad: 1400, columnWidth: 400,
+    fc: 28, fy: 415, qAllow: 200, gammaSoil: 18, gammaConc: 24,
+    H: 1.5, barDia: 20, cover: 75, position: 'interior' as const,
+  };
+  it('punching uses the cx × cy perimeter; one-way uses the smaller dim', () => {
+    const sq600 = designSquareFooting({ ...input, columnWidth: 600 });
+    const r = designSquareFooting({ ...input, columnWidth: 600, columnWidthY: 300 });
+    expect(r.Dc % 25).toBe(0);
+    // smaller cy → longer cantilever → one-way demand can only grow
+    expect(r.dBeam).toBeGreaterThanOrEqual(sq600.dBeam);
+    // smaller perimeter + beta penalty → punching depth can only grow
+    expect(r.dPunch).toBeGreaterThanOrEqual(sq600.dPunch);
+  });
+});

--- a/webapp/src/engine/isolatedFooting.ts
+++ b/webapp/src/engine/isolatedFooting.ts
@@ -11,8 +11,10 @@ export interface SquareFootingInput {
   serviceLoad: number;
   /** Ultimate (factored) axial load Pu, kN. */
   ultimateLoad: number;
-  /** Square column width c, mm. */
+  /** Column width c (x-dimension for a rectangular column), mm. */
   columnWidth: number;
+  /** Column y-dimension, mm — defaults to columnWidth (square). */
+  columnWidthY?: number;
   /** f′c, MPa. */
   fc: number;
   /** fy, MPa. */
@@ -82,14 +84,17 @@ function roundUp(v: number, step: number): number {
 }
 
 export function designSquareFooting(i: SquareFootingInput): SquareFootingResult {
-  const cm = i.columnWidth / 1000; // column width, m
+  const cy = i.columnWidthY ?? i.columnWidth;
+  // One-way shear & flexure act both ways on a square footing; the smaller
+  // column dimension gives the longer cantilever, so it governs both.
+  const cm = Math.min(i.columnWidth, cy) / 1000;
   const surcharge = i.surcharge ?? 0;
   const analysis = i.analysis ?? 'design';
   const method = i.solutionMethod ?? 'iteration';
   const qNetAt = (Dc: number) =>
     netBearing({ qAllow: i.qAllow, gammaSoil: i.gammaSoil, gammaConc: i.gammaConc, H: i.H, Dc, surcharge });
   const reqPunch = (qu: number) =>
-    punchingDepth({ Pu: i.ultimateLoad, qu, c: i.columnWidth, fc: i.fc, position: i.position, lambda: i.lambda });
+    punchingDepth({ Pu: i.ultimateLoad, qu, c: i.columnWidth, cy, fc: i.fc, position: i.position, lambda: i.lambda });
   const reqBeam = (qu: number, B: number) =>
     oneWayShearDepth({ qu, B, c: cm, fc: i.fc, lambda: i.lambda });
 

--- a/webapp/src/engine/rectangularFooting.ts
+++ b/webapp/src/engine/rectangularFooting.ts
@@ -16,7 +16,8 @@ export type RectSizing =
 export interface RectFootingInput {
   serviceLoad: number;   // P, kN
   ultimateLoad: number;  // Pu, kN
-  columnWidth: number;   // square column c, mm
+  columnWidth: number;   // column x-dimension cx, mm
+  columnWidthY?: number; // column y-dimension cy, mm (default cx → square)
   fc: number;            // MPa
   fy: number;            // MPa
   qAllow: number;        // kPa
@@ -81,18 +82,20 @@ function sizePlan(area: number, sizing: RectSizing): { Bx: number; By: number } 
 }
 
 export function designRectangularFooting(i: RectFootingInput): RectFootingResult {
-  const cm = i.columnWidth / 1000;
+  const cyMm = i.columnWidthY ?? i.columnWidth;
+  const cxm = i.columnWidth / 1000;   // column dim along x (long cantilever)
+  const cym = cyMm / 1000;            // column dim along y (short cantilever)
   const surcharge = i.surcharge ?? 0;
   const analysis = i.analysis ?? 'design';
   const method = i.solutionMethod ?? 'iteration';
   const qNetAt = (Dc: number) =>
     netBearing({ qAllow: i.qAllow, gammaSoil: i.gammaSoil, gammaConc: i.gammaConc, H: i.H, Dc, surcharge });
   const shearDepths = (qu: number, Bx: number, By: number) => ({
-    dPunch: punchingDepth({ Pu: i.ultimateLoad, qu, c: i.columnWidth, fc: i.fc, position: i.position, lambda: i.lambda }),
+    dPunch: punchingDepth({ Pu: i.ultimateLoad, qu, c: i.columnWidth, cy: cyMm, fc: i.fc, position: i.position, lambda: i.lambda }),
     // One-way shear: d depends on the span dimension only (the perpendicular
     // width cancels), so pass each plan dimension as the span.
-    dBeamLong: oneWayShearDepth({ qu, B: Bx, c: cm, fc: i.fc, lambda: i.lambda }),
-    dBeamShort: oneWayShearDepth({ qu, B: By, c: cm, fc: i.fc, lambda: i.lambda }),
+    dBeamLong: oneWayShearDepth({ qu, B: Bx, c: cxm, fc: i.fc, lambda: i.lambda }),
+    dBeamShort: oneWayShearDepth({ qu, B: By, c: cym, fc: i.fc, lambda: i.lambda }),
   });
 
   let Dc = 0.25;
@@ -131,7 +134,7 @@ export function designRectangularFooting(i: RectFootingInput): RectFootingResult
   const dFlex = DcMm - i.cover - i.barDia / 2;
 
   // Long direction: cantilever in x, bars run along x and spread across By.
-  const armX = (Bx - cm) / 2;
+  const armX = (Bx - cxm) / 2;
   const MuLong = qu * By * (armX * armX) / 2;
   const bLong = By * 1000;
   const flexLong = flexuralSteel({ Mu: MuLong, b: bLong, d: dFlex, fc: i.fc, fy: i.fy });
@@ -139,7 +142,7 @@ export function designRectangularFooting(i: RectFootingInput): RectFootingResult
 
   // Short direction: cantilever in y, bars run along y and spread across Bx,
   // with the central-band concentration.
-  const armY = (By - cm) / 2;
+  const armY = (By - cym) / 2;
   const MuShort = qu * Bx * (armY * armY) / 2;
   const bShort = Bx * 1000;
   const flexShort = flexuralSteel({ Mu: MuShort, b: bShort, d: dFlex, fc: i.fc, fy: i.fy });

--- a/webapp/src/engine/shear.ts
+++ b/webapp/src/engine/shear.ts
@@ -34,20 +34,23 @@ export function twoWayVc(params: {
 }
 
 /**
- * Smallest effective depth d (mm) that satisfies punching shear for a square
- * column c (mm) under factored column load Pu (kN) on net pressure qu (kPa).
+ * Smallest effective depth d (mm) that satisfies punching shear for a
+ * rectangular column cx × cy (mm; cy defaults to cx → square) under factored
+ * column load Pu (kN) on net pressure qu (kPa).
  */
 export function punchingDepth(params: {
-  Pu: number; qu: number; c: number; fc: number;
+  Pu: number; qu: number; c: number; cy?: number; fc: number;
   position?: ColumnPosition; lambda?: number; phi?: number;
 }): number {
   const phi = params.phi ?? PHI_SHEAR;
+  const cx = params.c, cy = params.cy ?? params.c;
+  const betaC = Math.max(cx, cy) / Math.min(cx, cy);
   for (let d = 50; d <= 3000; d += 1) {
-    const crit = params.c + d;                 // mm (square column → side of critical square)
-    const Ao = crit * crit * 1e-6;             // m²
+    const critX = cx + d, critY = cy + d;       // mm
+    const Ao = critX * critY * 1e-6;            // m²
     const Vu = params.Pu - params.qu * Ao;      // kN
     const cap = phi * twoWayVc({
-      fc: params.fc, bo: 4 * crit, d, betaC: 1,
+      fc: params.fc, bo: 2 * (critX + critY), d, betaC,
       position: params.position, lambda: params.lambda,
     });
     if (cap >= Vu) return d;

--- a/webapp/src/lib/foundationSolution.ts
+++ b/webapp/src/lib/foundationSolution.ts
@@ -21,6 +21,8 @@ export interface SolutionCtx {
   loads?: { dead: number; live: number } | null
   serviceMoment: number; ultimateMoment: number
   columnWidth: number; fc: number; fy: number
+  /** Column y-dimension, mm — equals columnWidth unless rectangular. */
+  columnWidthY?: number
   /** Present when the column is circular (columnWidth is the equivalent square). */
   column?: { shape: 'circular'; dia: number } | null
   qAllow: number; gammaSoil: number; gammaConc: number; H: number
@@ -122,20 +124,28 @@ function pressureStep(c: SolutionCtx): SolutionStep {
 }
 
 function punchingStep(c: SolutionCtx): SolutionStep {
-  const cmm = c.columnWidth, d = c.analysis === 'analyze' ? c.dProvided : c.dPunch
-  const crit = cmm + d, bo = 4 * crit, Ao = crit * crit * 1e-6
+  const cx = c.columnWidth, cyDim = c.columnWidthY ?? c.columnWidth
+  const rectCol = Math.abs(cx - cyDim) > 1e-9
+  const d = c.analysis === 'analyze' ? c.dProvided : c.dPunch
+  const critX = cx + d, critY = cyDim + d
+  const bo = 2 * (critX + critY), Ao = critX * critY * 1e-6
+  const betaC = Math.max(cx, cyDim) / Math.min(cx, cyDim)
   const Vu = c.ultimateLoad - c.qu * Ao
   const base = (Math.sqrt(c.fc) * bo * d) / 1000
-  const vc1 = base / 3, vc2 = base / 2, vc3 = (1 / 12) * (2 + (ALPHA_S[c.position] * d) / bo) * base
+  const vc1 = base / 3, vc2 = (1 / 6) * (1 + 2 / betaC) * base, vc3 = (1 / 12) * (2 + (ALPHA_S[c.position] * d) / bo) * base
   const vc = Math.min(vc1, vc2, vc3)
   const phiVc = 0.75 * vc
   const pass = phiVc >= Vu
   return {
     title: 'Two-way (punching) shear',
     lines: [
-      txt(`Two-way (punching) shear acts on a critical perimeter b₀ at d/2 from the column face (ACI §22.6). V_c is the least of three expressions; α_s = ${ALPHA_S[c.position]} for an ${c.position} column.`),
-      eq(String.raw`b_o = 4(c + d) = 4(${sn0(cmm)} + ${sn0(d)}) = ${sn0(bo)}\ \text{mm},\quad d = ${sn0(d)}\ \text{mm}`),
-      eq(String.raw`V_u = P_u - q_u(c+d)^2 = ${sn0(c.ultimateLoad)} - ${sn2(c.qu)}(${sn3(Ao)}) = ${sn1(Vu)}\ \text{kN}`),
+      txt(`Two-way (punching) shear acts on a critical perimeter b₀ at d/2 from the column face (ACI §22.6). V_c is the least of three expressions; α_s = ${ALPHA_S[c.position]} for an ${c.position} column${rectCol ? `; β = ${betaC.toFixed(2)} for the ${cx}×${cyDim} mm column` : ''}.`),
+      eq(rectCol
+        ? String.raw`b_o = 2(c_x + d) + 2(c_y + d) = 2(${sn0(critX)}) + 2(${sn0(critY)}) = ${sn0(bo)}\ \text{mm},\quad d = ${sn0(d)}\ \text{mm}`
+        : String.raw`b_o = 4(c + d) = 4(${sn0(cx)} + ${sn0(d)}) = ${sn0(bo)}\ \text{mm},\quad d = ${sn0(d)}\ \text{mm}`),
+      eq(rectCol
+        ? String.raw`V_u = P_u - q_u(c_x+d)(c_y+d) = ${sn0(c.ultimateLoad)} - ${sn2(c.qu)}(${sn3(Ao)}) = ${sn1(Vu)}\ \text{kN}`
+        : String.raw`V_u = P_u - q_u(c+d)^2 = ${sn0(c.ultimateLoad)} - ${sn2(c.qu)}(${sn3(Ao)}) = ${sn1(Vu)}\ \text{kN}`),
       eq(String.raw`V_{c} = \min\!\left(\tfrac{1}{3}, \tfrac{1}{6}(1{+}\tfrac{2}{\beta}), \tfrac{1}{12}(2{+}\tfrac{\alpha_s d}{b_o})\right)\sqrt{f'_c}\,b_o d`),
       eq(String.raw`= \min(${sn1(vc1)},\ ${sn1(vc2)},\ ${sn1(vc3)}) = ${sn1(vc)}\ \text{kN}`),
       eq(String.raw`\phi V_c = 0.75 V_c = ${sn1(phiVc)}\ \text{kN} \;${pass ? '\\ge' : '<'}\; V_u = ${sn1(Vu)}\ \text{kN}\;${pass ? '\\checkmark' : '\\times'}`),
@@ -146,8 +156,8 @@ function punchingStep(c: SolutionCtx): SolutionStep {
   }
 }
 
-function oneWayStep(c: SolutionCtx, B: number, dReq: number, label: string): SolutionStep {
-  const cm = c.columnWidth / 1000
+function oneWayStep(c: SolutionCtx, B: number, dReq: number, label: string, cDimMm?: number): SolutionStep {
+  const cm = (cDimMm ?? Math.min(c.columnWidth, c.columnWidthY ?? c.columnWidth)) / 1000
   const d = c.analysis === 'analyze' ? c.dProvided : dReq
   const arm = (B - cm) / 2 - d / 1000
   const Vu = c.qu * B * Math.max(0, arm)
@@ -188,8 +198,8 @@ function thicknessStep(c: SolutionCtx): SolutionStep {
   }
 }
 
-function flexureStep(c: SolutionCtx, span: number, width: number, steel: SteelCtx, label: string): SolutionStep {
-  const cm = c.columnWidth / 1000
+function flexureStep(c: SolutionCtx, span: number, width: number, steel: SteelCtx, label: string, cDimMm?: number): SolutionStep {
+  const cm = (cDimMm ?? Math.min(c.columnWidth, c.columnWidthY ?? c.columnWidth)) / 1000
   const d = c.Dc - c.cover - c.barDia / 2
   const arm = (span - cm) / 2
   const Mu = (c.qu * width * arm * arm) / 2
@@ -226,7 +236,8 @@ function devLengthStep(c: SolutionCtx): SolutionStep {
   // Simplified tension development length (NSCP 425.4.2.3 with ψ = 1,
   // (c_b+K_tr)/d_b = 2.5): l_d = f_y d_b / (1.1 λ √f'c · 2.5), ≥ 300 mm.
   const ld = Math.max(300, (c.fy * c.barDia) / (1.1 * Math.sqrt(c.fc) * 2.5))
-  const avail = ((c.Bx - c.columnWidth / 1000) / 2) * 1000 - 75
+  const cGov = Math.min(c.columnWidth, c.columnWidthY ?? c.columnWidth)
+  const avail = ((c.Bx - cGov / 1000) / 2) * 1000 - 75
   const ok = avail >= ld
   return {
     title: 'Development length (simplified)',
@@ -266,15 +277,16 @@ export function buildFoundationSolution(c: SolutionCtx): SolutionStep[] {
     steps.push(oneWayStep(c, c.Bx, c.dBeamLong, ''), thicknessStep(c))
     steps.push(flexureStep(c, c.Bx, c.Bx, c.long, ''), barsStep(c, c.long, ''), devLengthStep(c))
   } else {
+    const cy = c.columnWidthY ?? c.columnWidth
     steps.push(
-      oneWayStep(c, c.Bx, c.dBeamLong, 'long (x)'),
-      oneWayStep(c, c.By, c.dBeamShort, 'short (y)'),
+      oneWayStep(c, c.Bx, c.dBeamLong, 'long (x)', c.columnWidth),
+      oneWayStep(c, c.By, c.dBeamShort, 'short (y)', cy),
       thicknessStep(c),
-      flexureStep(c, c.Bx, c.By, c.long, 'long (x)'),
+      flexureStep(c, c.Bx, c.By, c.long, 'long (x)', c.columnWidth),
       barsStep(c, c.long, 'long (x)'),
     )
     if (c.short) {
-      steps.push(flexureStep(c, c.By, c.Bx, c.short, 'short (y)'), barsStep(c, c.short, 'short (y)'))
+      steps.push(flexureStep(c, c.By, c.Bx, c.short, 'short (y)', cy), barsStep(c, c.short, 'short (y)'))
       steps.push({
         title: 'Central band (short direction)',
         lines: [

--- a/webapp/src/pages/FoundationDesign.tsx
+++ b/webapp/src/pages/FoundationDesign.tsx
@@ -22,7 +22,7 @@ type LoadingType = 'concentric' | 'eccentric'
 type AnalysisMethod = 'design' | 'analyze'
 type SolutionMethod = 'iteration' | 'approximate'
 type LoadInput = 'direct' | 'individual'
-type ColumnShape = 'square' | 'circular'
+type ColumnShape = 'square' | 'rectangular' | 'circular'
 
 interface FormState {
   footingType: FootingType
@@ -44,6 +44,7 @@ interface FormState {
   serviceMoment: number
   ultimateMoment: number
   columnWidth: number
+  columnWidthY: number
   fc: number
   fy: number
   qAllow: number
@@ -76,6 +77,7 @@ const DEFAULTS: FormState = {
   serviceMoment: 150,
   ultimateMoment: 210,
   columnWidth: 400,
+  columnWidthY: 400,
   fc: 28,
   fy: 415,
   qAllow: 200,
@@ -169,7 +171,9 @@ export default function FoundationDesign() {
   // Circular columns use the legacy equivalent-square width c_eq = D·√(π/4).
   // (globalThis.Math: the KaTeX <Math> import shadows the global in this file.)
   const circular = form.columnShape === 'circular'
+  const rectCol = form.columnShape === 'rectangular'
   const colWidth = circular ? form.columnWidth * globalThis.Math.sqrt(globalThis.Math.PI / 4) : form.columnWidth
+  const colWidthY = rectCol ? form.columnWidthY : colWidth
 
   const qNetTrial = useMemo(
     () => netBearing({ qAllow: form.qAllow, gammaSoil: form.gammaSoil, gammaConc: form.gammaConc, H: form.H, Dc: 0.25, surcharge: form.surcharge }),
@@ -188,7 +192,7 @@ export default function FoundationDesign() {
   const view: View | null = useMemo(() => {
     if (!valid) return null
     const common = {
-      serviceLoad, ultimateLoad, columnWidth: colWidth,
+      serviceLoad, ultimateLoad, columnWidth: colWidth, columnWidthY: colWidthY,
       fc: form.fc, fy: form.fy, qAllow: form.qAllow, gammaSoil: form.gammaSoil, gammaConc: form.gammaConc,
       H: form.H, barDia: form.barDia, cover: form.cover, surcharge: form.surcharge, position: form.position,
     }
@@ -234,7 +238,7 @@ export default function FoundationDesign() {
       punchOK: r.punchOK, beamOK: r.beamOK,
       long: r.long, short: r.short, ecc: null,
     }
-  }, [form, valid, rect, ecc, serviceLoad, ultimateLoad, colWidth])
+  }, [form, valid, rect, ecc, serviceLoad, ultimateLoad, colWidth, colWidthY])
 
   const solutionSteps = useMemo(() => {
     if (!view) return null
@@ -243,7 +247,7 @@ export default function FoundationDesign() {
       serviceLoad, ultimateLoad,
       loads: individual ? { dead: form.deadLoad, live: form.liveLoad } : null,
       serviceMoment: form.serviceMoment, ultimateMoment: form.ultimateMoment,
-      columnWidth: colWidth, fc: form.fc, fy: form.fy,
+      columnWidth: colWidth, columnWidthY: colWidthY, fc: form.fc, fy: form.fy,
       column: circular ? { shape: 'circular' as const, dia: form.columnWidth } : null,
       qAllow: form.qAllow, gammaSoil: form.gammaSoil, gammaConc: form.gammaConc, H: form.H,
       barDia: form.barDia, cover: form.cover, surcharge: form.surcharge, position: form.position,
@@ -363,14 +367,24 @@ export default function FoundationDesign() {
             {ecc && <NumField label={<Math tex="M" />} unit="kN·m" value={form.serviceMoment} onChange={set('serviceMoment')} />}
             {ecc && <NumField label={<Math tex="M_u" />} unit="kN·m" value={form.ultimateMoment} onChange={set('ultimateMoment')} />}
             <Select label="Column shape" value={form.columnShape} onChange={set('columnShape')}
-              options={[['square', 'Square'], ['circular', 'Circular (spiral)']]} />
-            <NumField label={circular ? <>Column Ø <Math tex="D" /></> : <>Column <Math tex="c" /> (square)</>}
+              options={[['square', 'Square'], ['rectangular', 'Rectangular'], ['circular', 'Circular (spiral)']]} />
+            <NumField
+              label={circular ? <>Column Ø <Math tex="D" /></> : rectCol ? <>Column <Math tex="c_x" /></> : <>Column <Math tex="c" /> (square)</>}
               unit="mm" value={form.columnWidth} onChange={set('columnWidth')} />
+            {rectCol && (
+              <NumField label={<>Column <Math tex="c_y" /></>} unit="mm" value={form.columnWidthY} onChange={set('columnWidthY')} />
+            )}
             <Select label="Column position" value={form.position} onChange={set('position')}
               options={[['interior', 'Interior'], ['edge', 'Edge'], ['corner', 'Corner']]} />
             {circular && (
               <p className="col-span-full text-xs text-slate-400">
                 Circular column → equivalent square c = D·√(π/4) = {f0(colWidth)} mm (equal area, legacy convention).
+              </p>
+            )}
+            {rectCol && !rect && (
+              <p className="col-span-full text-xs text-slate-400">
+                Punching uses the full cx × cy perimeter (β = max/min); one-way shear & flexure use the smaller
+                dimension (longer cantilever governs both ways on a square footing).
               </p>
             )}
           </Card>


### PR DESCRIPTION
Answers "is there no rectangular column?" — there wasn't; now there is, completing the legacy column shapes (square / rectangular / circular).

## Engine
- **`punchingDepth`** now takes `cy`: critical perimeter `b₀ = 2(cx+d) + 2(cy+d)`, relieved area `(cx+d)(cy+d)`, and **β = max/min** feeding the second ACI 318-14 §22.6.5.2 expression `(1/6)(1+2/β)√f'c·b₀d`.
- **Square & eccentric** footings: `columnWidthY` input; punching uses the true cx × cy; one-way shear & flexure use the **smaller** dimension (longer cantilever governs both ways on a square plan) — noted in the UI.
- **Rectangular** footing is direction-correct: long (x) uses cx, short (y) uses cy for the one-way arms and flexure cantilevers.

## UI + solution
- Column shape select gains **Rectangular** (cx, cy inputs).
- The worked solution's punching step switches to the rectangular `b₀`/`V_u`/β forms with substituted numbers; one-way/flexure/development steps use the governing (direction-specific) dimension.

## Verification
- New engine test: vs a 600-square column, a 600×300 column needs ≥ one-way depth (longer cantilever) and ≥ punching depth (smaller perimeter + β penalty). **82 total passing**; build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)