### PR TITLE
Beam design: SRRB/DRRB + legacy-style provisioned solution

### DIFF
--- a/webapp/src/engine/beamDesign.test.ts
+++ b/webapp/src/engine/beamDesign.test.ts
@@ -6,14 +6,16 @@ const base: BeamDesignInput = {
   fc: 28, fy: 415, Mu: 180, Vu: 150,
 }
 
-describe('beam design — flexure', () => {
-  it('effective depth and a sane steel area', () => {
+describe('beam design — SRRB', () => {
+  it('moderate moment stays singly reinforced', () => {
     const r = designBeam(base)
+    expect(r.mode).toBe('SRRB')
     expect(r.d).toBeCloseTo(500 - 40 - 10 - 10) // 440
     expect(r.As).toBeGreaterThan(0)
     expect(r.bars).toBeGreaterThanOrEqual(2)
     expect(r.rho).toBeGreaterThanOrEqual(r.rhoMin)
-    expect(r.tensionControlled).toBe(true)
+    expect(r.rho).toBeLessThanOrEqual(r.rhoMax + 1e-9)
+    expect(r.comprBars).toBe(0)
   })
 
   it('tiny moment falls back to ρ_min', () => {
@@ -21,9 +23,31 @@ describe('beam design — flexure', () => {
     expect(r.usedMin).toBe(true)
   })
 
-  it('huge moment exceeds the tension-controlled limit', () => {
+  it('ρ_max = 0.75 ρ_b (legacy limit)', () => {
+    const r = designBeam(base)
+    expect(r.rhoMax).toBeCloseTo(0.75 * r.rhoB, 12)
+  })
+})
+
+describe('beam design — DRRB', () => {
+  it('Mu beyond the singly-reinforced ceiling designs compression steel', () => {
     const r = designBeam({ ...base, b: 250, h: 400, Mu: 600 })
-    expect(r.tensionControlled).toBe(false)
+    expect(r.mode).toBe('DRRB')
+    expect(600).toBeGreaterThan(r.phiMnMax)
+    expect(r.As).toBeCloseTo(r.As1 + r.As2, 6)
+    expect(r.AsPrime).toBeGreaterThan(0)
+    expect(r.comprBars).toBeGreaterThanOrEqual(2)
+    // when f's < fy, A's is scaled up from As2
+    if (!r.fsYields) expect(r.AsPrime).toBeGreaterThan(r.As2)
+    else expect(r.AsPrime).toBeCloseTo(r.As2, 6)
+  })
+
+  it('the classification boundary is exact at φMn_max', () => {
+    const probe = designBeam(base)
+    const atCeiling = designBeam({ ...base, Mu: probe.phiMnMax - 0.01 })
+    const beyond = designBeam({ ...base, Mu: probe.phiMnMax + 0.01 })
+    expect(atCeiling.mode).toBe('SRRB')
+    expect(beyond.mode).toBe('DRRB')
   })
 })
 
@@ -40,7 +64,6 @@ describe('beam design — shear', () => {
   it('high shear designs stirrups with spacing ≤ s_max', () => {
     const r = designBeam({ ...base, Vu: 280 })
     expect(r.region).toBe('designed')
-    expect(r.sReq).toBeGreaterThan(0)
     expect(r.sAdopt).toBeLessThanOrEqual(r.sMax)
     expect(r.sAdopt).toBeGreaterThan(0)
   })

--- a/webapp/src/engine/beamDesign.ts
+++ b/webapp/src/engine/beamDesign.ts
@@ -1,17 +1,19 @@
 // ─────────────────────────────────────────────────────────────────────────
-// Rectangular RC beam — singly-reinforced flexure + one-way shear (stirrups).
-// NSCP 2015 / ACI 318-14. Demands Mu (kN·m) and Vu (kN) are given (from
-// analysis); the tool sizes tension steel and vertical stirrups.
-// Convention: lengths mm, stresses MPa, Mu kN·m, Vu/V_* kN.
+// Rectangular RC beam — SRRB/DRRB flexure + one-way shear (stirrups).
+// NSCP 2015 / ACI 318-14, following the legacy "Reinforced Concrete LAB"
+// sheet: classify against the singly-reinforced ceiling at ρ_max = 0.75ρ_b;
+// beyond it, design compression steel (DRRB) with the f's yield check.
+// Convention: lengths mm, stresses MPa, Mu kN·m, Vu/V_* kN, Es = 200 GPa.
 // ─────────────────────────────────────────────────────────────────────────
-import { flexuralSteel, barLayout, rhoMin } from './flexure'
+import { rhoMin } from './flexure'
 import { beta1 } from './loads'
 
 export interface BeamDesignInput {
   b: number            // web width, mm
   h: number            // total depth, mm
   cover: number        // clear cover to stirrup, mm
-  barDia: number       // main bar Ø, mm
+  barDia: number       // main tension bar Ø, mm
+  comprBarDia?: number // compression bar Ø, mm (default barDia)
   stirrupDia: number   // stirrup Ø, mm
   fc: number; fy: number
   fyt?: number         // stirrup yield (default fy)
@@ -22,43 +24,98 @@ export interface BeamDesignInput {
 }
 
 export type ShearRegion = 'none' | 'minimum' | 'designed' | 'inadequate'
+export type FlexureMode = 'SRRB' | 'DRRB'
 
 export interface BeamDesignResult {
-  d: number            // effective depth, mm
-  // Flexure
-  As: number; rho: number; rhoMin: number; rhoMax: number
-  usedMin: boolean; tensionControlled: boolean
+  d: number            // effective depth (tension), mm
+  dPrime: number       // compression-steel depth d', mm
+  // ρ limits
+  rhoB: number; rhoMax: number; rhoMin: number
+  // SRRB ceiling
+  AsMax: number; aMax: number; MnMax: number; phiMnMax: number  // mm², mm, kN·m, kN·m
+  mode: FlexureMode
+  // Flexure (both modes)
+  As: number; rho: number; usedMin: boolean
   bars: number; barSpacing: number
+  // DRRB extras (0 / true-yield defaults for SRRB)
+  As1: number; As2: number; MnResid: number       // mm², mm², kN·m
+  cNA: number; epsSp: number; fsPrime: number     // mm, –, MPa
+  fsYields: boolean
+  AsPrime: number; comprBars: number              // mm², count
   // Shear
-  Vc: number; phiVc: number          // kN
+  Vc: number; phiVc: number
   region: ShearRegion
-  Av: number                          // mm²
-  VsReq: number; VsMax: number        // kN
-  sReq: number; sMax: number; sAdopt: number   // mm
+  Av: number
+  VsReq: number; VsMax: number
+  sReq: number; sMax: number; sAdopt: number
 }
 
+const PHI_FLEX = 0.90
 const PHI_SHEAR = 0.75
+const ES = 200000
 const roundDown = (v: number, step: number) => Math.floor(v / step) * step
 
 export function designBeam(i: BeamDesignInput): BeamDesignResult {
   const fyt = i.fyt ?? i.fy
   const legs = i.legs ?? 2
   const lambda = i.lambda ?? 1
+  const dbC = i.comprBarDia ?? i.barDia
   const d = i.h - i.cover - i.stirrupDia - i.barDia / 2
+  const dPrime = i.cover + i.stirrupDia + dbC / 2
 
-  // ── Flexure (singly reinforced) ──
-  const flex = flexuralSteel({ Mu: i.Mu, b: i.b, d, fc: i.fc, fy: i.fy })
+  // ── ρ limits (legacy: ρ_max = 0.75 ρ_balanced) ──
+  const b1 = beta1(i.fc)
+  const rhoB = 0.85 * b1 * (i.fc / i.fy) * (600 / (600 + i.fy))
+  const rhoMaxV = 0.75 * rhoB
   const rMin = rhoMin(i.fc, i.fy)
-  // Tension-controlled limit (εt = 0.005): ρmax = 0.85β1(f'c/fy)(0.003/0.008).
-  const rhoMax = 0.85 * beta1(i.fc) * (i.fc / i.fy) * (0.003 / 0.008)
-  const layout = barLayout({ As: flex.As, db: i.barDia, b: i.b, cover: i.cover + i.stirrupDia })
 
-  // ── Shear ──
-  const Vc = (lambda * Math.sqrt(i.fc) * i.b * d) / 6 / 1000          // kN
+  // ── SRRB ceiling: capacity with ρ_max ──
+  const AsMax = rhoMaxV * i.b * d
+  const aMax = (AsMax * i.fy) / (0.85 * i.fc * i.b)
+  const MnMax = (AsMax * i.fy * (d - aMax / 2)) / 1e6        // kN·m
+  const phiMnMax = PHI_FLEX * MnMax
+
+  let mode: FlexureMode
+  let As = 0, rho = 0, usedMin = false
+  let As1 = 0, As2 = 0, MnResid = 0, cNA = 0, epsSp = 0, fsPrime = i.fy, fsYields = true, AsPrime = 0
+
+  if (i.Mu <= phiMnMax) {
+    // ── SRRB: ρ from Rn, floored at ρ_min ──
+    mode = 'SRRB'
+    const Rn = (i.Mu * 1e6) / (PHI_FLEX * i.b * d * d)
+    const rhoCalc = (0.85 * i.fc / i.fy) * (1 - Math.sqrt(Math.max(0, 1 - (2 * Rn) / (0.85 * i.fc))))
+    usedMin = rhoCalc < rMin
+    rho = usedMin ? rMin : rhoCalc
+    As = rho * i.b * d
+  } else {
+    // ── DRRB: tension couple at ρ_max + a steel couple for the residual ──
+    mode = 'DRRB'
+    As1 = AsMax
+    MnResid = i.Mu / PHI_FLEX - MnMax                          // kN·m
+    As2 = (MnResid * 1e6) / (i.fy * (d - dPrime))
+    As = As1 + As2
+    rho = As / (i.b * d)
+    // Compression-steel stress check at a = a_max.
+    cNA = aMax / b1
+    epsSp = 0.003 * (cNA - dPrime) / cNA
+    const fsUnc = ES * epsSp
+    fsYields = fsUnc >= i.fy
+    fsPrime = Math.min(i.fy, fsUnc)
+    AsPrime = (As2 * i.fy) / fsPrime
+  }
+
+  const Ab = (Math.PI / 4) * i.barDia * i.barDia
+  const bars = Math.max(2, Math.ceil(As / Ab))
+  const clearW = i.b - 2 * (i.cover + i.stirrupDia) - bars * i.barDia
+  const barSpacing = bars > 1 ? clearW / (bars - 1) + i.barDia : clearW
+  const AbC = (Math.PI / 4) * dbC * dbC
+  const comprBars = mode === 'DRRB' ? Math.max(2, Math.ceil(AsPrime / AbC)) : 0
+
+  // ── Shear (unchanged: NSCP 2015 §422.5 / §409.4) ──
+  const Vc = (lambda * Math.sqrt(i.fc) * i.b * d) / 6 / 1000
   const phiVc = PHI_SHEAR * Vc
-  const Av = legs * (Math.PI / 4) * i.stirrupDia * i.stirrupDia        // mm²
-  const VsMax = (2 / 3) * Math.sqrt(i.fc) * i.b * d / 1000             // kN
-  // Minimum-stirrup spacing cap: Av,min = max(0.062√f'c·b, 0.35·b)·s/fyt.
+  const Av = legs * (Math.PI / 4) * i.stirrupDia * i.stirrupDia
+  const VsMax = (2 / 3) * Math.sqrt(i.fc) * i.b * d / 1000
   const sMinArea = (Av * fyt) / Math.max(0.062 * Math.sqrt(i.fc) * i.b, 0.35 * i.b)
 
   let region: ShearRegion
@@ -72,11 +129,10 @@ export function designBeam(i: BeamDesignInput): BeamDesignResult {
   } else {
     VsReq = i.Vu / PHI_SHEAR - Vc
     if (VsReq > VsMax) {
-      region = 'inadequate'                 // section too small — enlarge or raise f'c
+      region = 'inadequate'
     } else {
       region = 'designed'
       sReq = (Av * fyt * d) / (VsReq * 1000)
-      // tighter spacing cap once Vs exceeds (1/3)√f'c·b·d
       const sCap = VsReq <= Math.sqrt(i.fc) * i.b * d / 3 / 1000 ? Math.min(d / 2, 600) : Math.min(d / 4, 300)
       sMax = sCap
       sAdopt = roundDown(Math.min(sReq, sCap, sMinArea), 10)
@@ -84,10 +140,11 @@ export function designBeam(i: BeamDesignInput): BeamDesignResult {
   }
 
   return {
-    d,
-    As: flex.As, rho: flex.rho, rhoMin: rMin, rhoMax,
-    usedMin: flex.usedMin, tensionControlled: flex.rho <= rhoMax,
-    bars: layout.n, barSpacing: layout.spacing,
+    d, dPrime,
+    rhoB, rhoMax: rhoMaxV, rhoMin: rMin,
+    AsMax, aMax, MnMax, phiMnMax,
+    mode, As, rho, usedMin, bars, barSpacing,
+    As1, As2, MnResid, cNA, epsSp, fsPrime, fsYields, AsPrime, comprBars,
     Vc, phiVc, region, Av, VsReq, VsMax, sReq, sMax, sAdopt,
   }
 }

--- a/webapp/src/lib/beamSolution.ts
+++ b/webapp/src/lib/beamSolution.ts
@@ -1,85 +1,140 @@
-// Worked solution for the beam design — mirrors engine/beamDesign.ts.
+// Detailed worked solution for the beam design — legacy-style: each step has
+// an explanation citing the governing provision, then the substituted
+// equations. Mirrors engine/beamDesign.ts (SRRB/DRRB at ρ_max = 0.75ρ_b).
 import type { BeamDesignInput, BeamDesignResult } from '../engine/beamDesign'
-import { type SolutionStep, sn0, sn1, sn3, sn4 } from './solution'
+import { type SolutionStep, type SolutionLine, sn0, sn1, sn3, sn4 } from './solution'
+
+const txt = (text: string): SolutionLine => ({ text })
+const eq = (tex: string): SolutionLine => ({ tex })
 
 export function buildBeamSolution(i: BeamDesignInput, r: BeamDesignResult): SolutionStep[] {
   const fyt = i.fyt ?? i.fy
   const legs = i.legs ?? 2
+  const dbC = i.comprBarDia ?? i.barDia
   const d = r.d
-  const Rn = (i.Mu * 1e6) / (0.9 * i.b * d * d)
   const Ab = (Math.PI / 4) * i.barDia * i.barDia
 
   const steps: SolutionStep[] = []
 
   steps.push({
-    title: 'Effective depth',
-    lines: [{
-      tex: String.raw`d = h - cover - d_{s} - \tfrac{d_b}{2} = ${sn0(i.h)} - ${sn0(i.cover)} - ${sn0(i.stirrupDia)} - ${sn1(i.barDia / 2)} = \mathbf{${sn1(d)}}\ \text{mm}`,
-    }],
+    title: 'Effective depths',
+    lines: [
+      txt('Tension steel sits inside the stirrup: d = h − cover − dₛ − d_b/2. The compression-steel depth d′ is measured the same way from the top face.'),
+      eq(String.raw`d = ${sn0(i.h)} - ${sn0(i.cover)} - ${sn0(i.stirrupDia)} - ${sn1(i.barDia / 2)} = \mathbf{${sn1(d)}}\ \text{mm}`),
+      eq(String.raw`d' = cover + d_s + \tfrac{d_b'}{2} = ${sn0(i.cover)} + ${sn0(i.stirrupDia)} + ${sn1(dbC / 2)} = ${sn1(r.dPrime)}\ \text{mm}`),
+    ],
   })
 
   steps.push({
-    title: 'Flexural reinforcement',
+    title: 'Reinforcement-ratio limits',
     lines: [
-      { tex: String.raw`R_n = \dfrac{M_u}{\phi b d^2} = \dfrac{${sn0(i.Mu)}\times 10^6}{0.9(${sn0(i.b)})(${sn1(d)})^2} = ${sn3(Rn)}\ \text{MPa}` },
-      { tex: String.raw`\rho = \tfrac{0.85 f'_c}{f_y}\!\left(1-\sqrt{1-\tfrac{2R_n}{0.85 f'_c}}\right) = ${sn4(r.rho)}` },
-      { tex: String.raw`\rho_{min} = ${sn4(r.rhoMin)},\quad \rho_{max} = ${sn4(r.rhoMax)}\ (\varepsilon_t = 0.005)` },
-      { tex: String.raw`A_s = \rho b d = ${sn0(r.As)}\ \text{mm}^2` },
+      txt('The balanced ratio comes from strain compatibility (εcu = 0.003, Es = 200 GPa → the 600/(600+fy) form, NSCP 2015 §422 / ACI 318-14 §21.2). The legacy sheet caps the singly-reinforced design at ρ_max = 0.75ρ_b; ρ_min per §409.6.1.'),
+      eq(String.raw`\rho_b = \tfrac{0.85\beta_1 f'_c}{f_y}\cdot\tfrac{600}{600+f_y} = ${sn4(r.rhoB)}`),
+      eq(String.raw`\rho_{max} = 0.75\rho_b = ${sn4(r.rhoMax)},\qquad \rho_{min} = \max\!\left(\tfrac{1.4}{f_y}, \tfrac{\sqrt{f'_c}}{4f_y}\right) = ${sn4(r.rhoMin)}`),
     ],
-    note: (r.usedMin ? 'ρ_min governs. ' : '') +
-      (r.tensionControlled ? 'ρ ≤ ρ_max → tension-controlled (φ = 0.90).' : 'ρ > ρ_max — section is not tension-controlled; enlarge it or add compression steel.'),
   })
 
   steps.push({
-    title: 'Bar selection',
+    title: 'SRRB / DRRB classification',
     lines: [
-      { tex: String.raw`A_b = \tfrac{\pi}{4}d_b^2 = ${sn0(Ab)}\ \text{mm}^2,\quad n = \lceil A_s/A_b \rceil = ${r.bars}` },
-      { tex: String.raw`\text{clear spacing} = \dfrac{b - 2(cover+d_s) - n d_b}{n-1} = ${sn0(r.barSpacing)}\ \text{mm}` },
+      txt('Compute the moment capacity of the section if it carried the maximum singly-reinforced steel (ρ_max). If Mu fits under φMn_max the beam is singly reinforced (SRRB); otherwise compression steel is required (DRRB).'),
+      eq(String.raw`A_{s,max} = \rho_{max} b d = ${sn0(r.AsMax)}\ \text{mm}^2,\quad a_{max} = \tfrac{A_{s,max} f_y}{0.85 f'_c b} = ${sn1(r.aMax)}\ \text{mm}`),
+      eq(String.raw`\phi M_{n,max} = 0.90\,A_{s,max} f_y (d - \tfrac{a_{max}}{2}) = ${sn1(r.phiMnMax)}\ \text{kN·m}`),
+      eq(String.raw`M_u = ${sn1(i.Mu)}\ \text{kN·m} \;${i.Mu <= r.phiMnMax ? '\\le' : '>'}\; \phi M_{n,max} \Rightarrow \textbf{${r.mode}}`),
     ],
-    note: `Provide ${r.bars} ⌀${i.barDia} mm tension bars.`,
+    note: r.mode === 'SRRB' ? 'Singly reinforced — tension steel only.' : 'Doubly reinforced — add compression steel for the moment beyond the ceiling.',
+  })
+
+  if (r.mode === 'SRRB') {
+    const Rn = (i.Mu * 1e6) / (0.9 * i.b * d * d)
+    steps.push({
+      title: 'Tension steel (SRRB)',
+      lines: [
+        txt('Solve the design strength equation for ρ via the coefficient of resistance Rₙ, then floor at ρ_min (§409.6.1).'),
+        eq(String.raw`R_n = \dfrac{M_u}{\phi b d^2} = \dfrac{${sn0(i.Mu)}\times 10^6}{0.9(${sn0(i.b)})(${sn1(d)})^2} = ${sn3(Rn)}\ \text{MPa}`),
+        eq(String.raw`\rho = \tfrac{0.85 f'_c}{f_y}\!\left(1-\sqrt{1-\tfrac{2R_n}{0.85 f'_c}}\right) = ${sn4(r.rho)}`),
+        eq(String.raw`A_s = \rho b d = ${sn0(r.As)}\ \text{mm}^2`),
+      ],
+      note: r.usedMin ? 'ρ_min governs.' : 'Computed ρ governs.',
+    })
+  } else {
+    steps.push({
+      title: 'Tension steel (DRRB)',
+      lines: [
+        txt('Split the demand into the ρ_max couple (As1, concrete) and a residual steel couple (As2, paired with the compression steel A′s across the lever arm d − d′).'),
+        eq(String.raw`A_{s1} = A_{s,max} = ${sn0(r.As1)}\ \text{mm}^2`),
+        eq(String.raw`M_{n,resid} = \tfrac{M_u}{\phi} - M_{n,max} = \tfrac{${sn1(i.Mu)}}{0.90} - ${sn1(r.MnMax)} = ${sn1(r.MnResid)}\ \text{kN·m}`),
+        eq(String.raw`A_{s2} = \dfrac{M_{n,resid}}{f_y (d - d')} = \dfrac{${sn1(r.MnResid)}\times 10^6}{${sn0(i.fy)}(${sn1(d)} - ${sn1(r.dPrime)})} = ${sn0(r.As2)}\ \text{mm}^2`),
+        eq(String.raw`A_s = A_{s1} + A_{s2} = \mathbf{${sn0(r.As)}}\ \text{mm}^2`),
+      ],
+    })
+    steps.push({
+      title: 'Compression-steel stress check',
+      lines: [
+        txt('Strain compatibility at a = a_max: if the compression steel has not yielded, A′s is scaled up by fy/f′s so the couple still balances (§422.2.2).'),
+        eq(String.raw`c = \tfrac{a_{max}}{\beta_1} = ${sn1(r.cNA)}\ \text{mm},\quad \varepsilon_s' = 0.003\,\tfrac{c - d'}{c} = ${sn4(r.epsSp)}`),
+        eq(String.raw`f_s' = \min(f_y,\ E_s\varepsilon_s') = ${sn1(r.fsPrime)}\ \text{MPa}\ ${r.fsYields ? '(\\text{yields})' : '(\\text{does not yield})'}`),
+        eq(String.raw`A_s' = A_{s2}\,\tfrac{f_y}{f_s'} = ${sn0(r.AsPrime)}\ \text{mm}^2`),
+      ],
+      note: `Provide ${r.comprBars} ⌀${dbC} mm compression bars.`,
+    })
+  }
+
+  steps.push({
+    title: 'Bar selection (tension)',
+    lines: [
+      txt('Choose the bar count from the required area; clear spacing must accommodate the bars inside the stirrup (§425.2).'),
+      eq(String.raw`A_b = \tfrac{\pi}{4}d_b^2 = ${sn0(Ab)}\ \text{mm}^2,\quad n = \lceil A_s/A_b \rceil = ${r.bars}`),
+      eq(String.raw`s = ${sn0(r.barSpacing)}\ \text{mm o.c.}`),
+    ],
+    note: `Provide ${r.bars} ⌀${i.barDia} mm tension bars${r.mode === 'DRRB' ? ` + ${r.comprBars} ⌀${dbC} mm compression bars` : ''}.`,
   })
 
   steps.push({
     title: 'Shear strength of concrete',
     lines: [
-      { tex: String.raw`V_c = \tfrac{1}{6}\lambda\sqrt{f'_c}\,b d = \tfrac{1}{6}\sqrt{${sn0(i.fc)}}(${sn0(i.b)})(${sn1(d)})/1000 = ${sn1(r.Vc)}\ \text{kN}` },
-      { tex: String.raw`\phi V_c = 0.75 V_c = ${sn1(r.phiVc)}\ \text{kN},\quad \tfrac{1}{2}\phi V_c = ${sn1(r.phiVc / 2)}\ \text{kN}` },
+      txt('Concrete one-way shear strength per NSCP 2015 §422.5.5.1 with φ = 0.75 (§421.2). Half of φVc marks the threshold below which no stirrups are required (§409.6.3).'),
+      eq(String.raw`V_c = \tfrac{1}{6}\lambda\sqrt{f'_c}\,b d = \tfrac{1}{6}\sqrt{${sn0(i.fc)}}(${sn0(i.b)})(${sn1(d)})/1000 = ${sn1(r.Vc)}\ \text{kN}`),
+      eq(String.raw`\phi V_c = ${sn1(r.phiVc)}\ \text{kN},\quad \tfrac{1}{2}\phi V_c = ${sn1(r.phiVc / 2)}\ \text{kN}`),
     ],
   })
 
   if (r.region === 'none') {
     steps.push({
       title: 'Stirrup requirement',
-      lines: [{ tex: String.raw`V_u = ${sn1(i.Vu)}\ \text{kN} \le \tfrac{1}{2}\phi V_c = ${sn1(r.phiVc / 2)}\ \text{kN}` }],
-      note: 'No shear reinforcement required (provide nominal stirrups in practice).',
+      lines: [
+        txt('Vu is below half of φVc, so the code does not require shear reinforcement (§409.6.3.1).'),
+        eq(String.raw`V_u = ${sn1(i.Vu)}\ \text{kN} \le \tfrac{1}{2}\phi V_c = ${sn1(r.phiVc / 2)}\ \text{kN}`),
+      ],
+      note: 'Provide nominal stirrups in practice.',
     })
   } else if (r.region === 'minimum') {
     steps.push({
       title: 'Minimum stirrups',
       lines: [
-        { tex: String.raw`\tfrac{1}{2}\phi V_c < V_u = ${sn1(i.Vu)} \le \phi V_c = ${sn1(r.phiVc)}\ \text{kN}` },
-        { tex: String.raw`A_v = ${legs}\cdot\tfrac{\pi}{4}d_s^2 = ${sn0(r.Av)}\ \text{mm}^2,\quad s_{max} = \min(d/2, 600) = ${sn0(r.sMax)}\ \text{mm}` },
+        txt('Vu exceeds ½φVc but not φVc — minimum shear reinforcement applies (§409.6.3.3), with spacing capped at d/2 ≤ 600 mm (§409.7.6.2.2).'),
+        eq(String.raw`A_v = ${legs}\cdot\tfrac{\pi}{4}d_s^2 = ${sn0(r.Av)}\ \text{mm}^2,\quad s_{max} = \min(d/2,\,600) = ${sn0(r.sMax)}\ \text{mm}`),
       ],
-      note: `Provide ⌀${i.stirrupDia} mm, ${legs}-leg stirrups @ ${sn0(r.sAdopt)} mm (minimum area governs).`,
+      note: `Provide ⌀${i.stirrupDia} mm, ${legs}-leg stirrups @ ${sn0(r.sAdopt)} mm.`,
     })
   } else if (r.region === 'designed') {
     steps.push({
       title: 'Stirrup design',
       lines: [
-        { tex: String.raw`V_s = \tfrac{V_u}{\phi} - V_c = \tfrac{${sn1(i.Vu)}}{0.75} - ${sn1(r.Vc)} = ${sn1(r.VsReq)}\ \text{kN} \;(\le V_{s,max} = ${sn1(r.VsMax)})` },
-        { tex: String.raw`A_v = ${legs}\cdot\tfrac{\pi}{4}d_s^2 = ${sn0(r.Av)}\ \text{mm}^2` },
-        { tex: String.raw`s = \dfrac{A_v f_{yt} d}{V_s} = \dfrac{${sn0(r.Av)}(${sn0(fyt)})(${sn1(d)})}{${sn1(r.VsReq)}\times 10^3} = ${sn0(r.sReq)}\ \text{mm}` },
-        { tex: String.raw`s_{max} = ${sn0(r.sMax)}\ \text{mm} \Rightarrow s_{adopt} = ${sn0(r.sAdopt)}\ \text{mm}` },
+        txt('Vu exceeds φVc — design stirrups for Vs = Vu/φ − Vc (§422.5.10.5.3). The spacing cap halves once Vs exceeds ⅓√f′c·b·d (§409.7.6.2.2).'),
+        eq(String.raw`V_s = \tfrac{V_u}{\phi} - V_c = \tfrac{${sn1(i.Vu)}}{0.75} - ${sn1(r.Vc)} = ${sn1(r.VsReq)}\ \text{kN} \;(\le V_{s,max} = \tfrac{2}{3}\sqrt{f'_c}\,bd = ${sn1(r.VsMax)})`),
+        eq(String.raw`s = \dfrac{A_v f_{yt} d}{V_s} = \dfrac{${sn0(r.Av)}(${sn0(fyt)})(${sn1(d)})}{${sn1(r.VsReq)}\times 10^3} = ${sn0(r.sReq)}\ \text{mm},\quad s_{max} = ${sn0(r.sMax)}\ \text{mm}`),
       ],
       note: `Provide ⌀${i.stirrupDia} mm, ${legs}-leg stirrups @ ${sn0(r.sAdopt)} mm.`,
     })
   } else {
     steps.push({
-      title: 'Section check',
+      title: 'Section check (shear)',
       lines: [
-        { tex: String.raw`V_s = \tfrac{V_u}{\phi} - V_c = ${sn1(r.VsReq)}\ \text{kN} > V_{s,max} = \tfrac{2}{3}\sqrt{f'_c}\,b d = ${sn1(r.VsMax)}\ \text{kN}` },
+        txt('The required Vs exceeds the §422.5.1.2 ceiling — the cross-section itself is too small for the shear; no amount of stirrups fixes it.'),
+        eq(String.raw`V_s = ${sn1(r.VsReq)}\ \text{kN} > V_{s,max} = \tfrac{2}{3}\sqrt{f'_c}\,b d = ${sn1(r.VsMax)}\ \text{kN}`),
       ],
-      note: 'Section is inadequate for shear — increase b, d, or f′c.',
+      note: 'Increase b, d, or f′c.',
     })
   }
 

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -10,10 +10,10 @@ import { Math } from '../lib/math'
 import { f0, f1 } from '../lib/format'
 import 'katex/dist/katex.min.css'
 
-interface FormState extends BeamDesignInput { fyt: number; legs: number }
+interface FormState extends BeamDesignInput { fyt: number; legs: number; comprBarDia: number }
 
 const DEFAULTS: FormState = {
-  b: 300, h: 500, cover: 40, barDia: 20, stirrupDia: 10,
+  b: 300, h: 500, cover: 40, barDia: 20, comprBarDia: 16, stirrupDia: 10,
   fc: 28, fy: 415, fyt: 415, Mu: 180, Vu: 150, legs: 2,
 }
 
@@ -48,7 +48,8 @@ export default function BeamDesign() {
       <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
       <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Beam Design</h1>
       <p className="no-print mt-1 text-slate-600">
-        Rectangular RC beam — singly-reinforced flexure and one-way shear (stirrups). NSCP 2015 / ACI 318-14.
+        Rectangular RC beam — SRRB/DRRB flexure (compression steel designed automatically when Mu exceeds the
+        singly-reinforced ceiling at ρ_max = 0.75ρ_b) and one-way shear. NSCP 2015 / ACI 318-14.
         Enter the factored demands; results and the worked solution update live.
       </p>
       <ReportControls title="Beam Design Report" />
@@ -60,6 +61,7 @@ export default function BeamDesign() {
             <Num label="Total depth h" unit="mm" value={f.h} onChange={set('h')} />
             <Num label="Clear cover" unit="mm" value={f.cover} onChange={set('cover')} />
             <Num label={<>Bar <Math tex="d_b" /></>} unit="mm" value={f.barDia} onChange={set('barDia')} />
+            <Num label={<>Compr. bar <Math tex="d_b'" /></>} unit="mm" value={f.comprBarDia} onChange={set('comprBarDia')} />
             <Num label={<>Stirrup <Math tex="d_s" /></>} unit="mm" value={f.stirrupDia} onChange={set('stirrupDia')} />
             <Num label="Stirrup legs" value={f.legs} onChange={set('legs')} />
           </Card>
@@ -87,10 +89,14 @@ export default function BeamDesign() {
           {r && (
             <ResultCard title="Results">
               <Row label="Effective depth d" value={`${f1(r.d)} mm`} />
-              <Row label="Flexural steel" value={`${r.bars} ⌀${f.barDia} mm`}
+              <Row label="Flexure mode" value={r.mode}
+                sub={`φMn,max=${f1(r.phiMnMax)} kN·m`} />
+              <Row label="Tension steel" value={`${r.bars} ⌀${f.barDia} mm`}
                 sub={`As=${f0(r.As)} mm² · ${r.usedMin ? 'ρ_min' : `ρ=${r.rho.toFixed(4)}`}`} />
-              <Row label="Tension-controlled" value={r.tensionControlled ? '✓ yes' : '✗ no'}
-                sub={`ρ_max=${r.rhoMax.toFixed(4)}`} />
+              {r.mode === 'DRRB' && (
+                <Row label="Compression steel" value={`${r.comprBars} ⌀${f.comprBarDia} mm`}
+                  sub={`A's=${f0(r.AsPrime)} mm² · f's=${f1(r.fsPrime)} MPa${r.fsYields ? '' : ' (n.y.)'}`} />
+              )}
               <Row label={<Math tex="\phi V_c" />} value={`${f1(r.phiVc)} kN`} sub={`Vc=${f1(r.Vc)}`} />
               <Row label="Shear" value={REGION[r.region]} />
               <Row label="Stirrups" value={stirrupText}


### PR DESCRIPTION
Expands the React beam tool toward the legacy `beamDesign.html` core, with the foundation-style detailed solution.

## Engine — SRRB/DRRB (legacy sheet logic)
- ρ_b from strain compatibility; **ρ_max = 0.75ρ_b** (the legacy limit — previously the tool only flagged an εt check and gave up).
- **Classification**: compute the singly-reinforced ceiling `φMn_max` at ρ_max; `Mu ≤ φMn_max → SRRB`, else **DRRB**:
  - `As1 = As_max`, residual couple `As2 = Mn_resid / (fy(d−d′))`, total `As = As1 + As2`;
  - strain-compatibility **f′s check** at `a_max` (`c = a_max/β1`, `ε′s = 0.003(c−d′)/c`); when the compression steel doesn't yield, `A′s = As2·fy/f′s`;
  - compression bar selection; `d′` computed from cover + stirrup + compression-bar radius.
- Shear logic unchanged (regions, Vs cap).

## Worked solution — provisioned, legacy style
Every step opens with the governing provision then the substituted equations: ρ_b strain compatibility (§422/§421.2), ρ_min §409.6.1, the **classification step**, separate SRRB (Rn→ρ) / DRRB (As1/As2/f′s) step sets, bar selection §425.2, Vc §422.5.5.1, stirrup thresholds §409.6.3, spacing caps §409.7.6.2.2, and the §422.5.1.2 section ceiling.

## UI
Compression-bar Ø input; **Flexure mode** row (shows φMn_max); compression-steel row for DRRB (A′s, f′s, bar count).

## Verification
8 engine tests including the **exact classification boundary** (`φMn_max ± 0.01 kN·m` flips SRRB↔DRRB) — **83 total passing**; build green.

## Not ported (flagged)
The legacy page also embeds a full **beam analysis** module (span/E/I, load combinations → demands feeding the design). That's a separate tool-sized effort; the React tool takes Mu/Vu directly. Multi-layer bar splitting with Varignon d-recalculation is also out of scope for this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)