### PR TITLE
Beam design: correct ρ_max, displaced-concrete A′s, layered bars (Varignon)

### DIFF
--- a/webapp/src/components/BeamSchematic.tsx
+++ b/webapp/src/components/BeamSchematic.tsx
@@ -6,11 +6,20 @@ const FILL = '#eef3f8'
 const BAR = '#37526e'
 
 export interface BeamSchematicProps {
-  b: number; h: number; cover: number; barDia: number; stirrupDia: number; bars: number; d: number
+  b: number; h: number; cover: number; barDia: number; stirrupDia: number
+  bars: number; d: number
+  /** Tension bars per layer, bottom first (default: one layer of `bars`). */
+  layers?: number[]
+  /** Compression bars (drawn along the top when > 0). */
+  comprBars?: number
+  comprBarDia?: number
 }
 
-/** Beam cross-section: stirrup outline + tension bars, drawn to scale. */
-export function BeamSchematic({ b, h, cover, barDia, stirrupDia, bars, d }: BeamSchematicProps): JSX.Element {
+/** Beam cross-section: stirrup outline, layered tension bars and optional
+ *  compression bars, drawn to scale. */
+export function BeamSchematic({
+  b, h, cover, barDia, stirrupDia, bars, d, layers, comprBars = 0, comprBarDia,
+}: BeamSchematicProps): JSX.Element {
   const W = 320, H = 300
   const padL = 60, padT = 24, availW = 150, availH = 210
   const s = Math.min(availW / b, availH / h)
@@ -20,12 +29,20 @@ export function BeamSchematic({ b, h, cover, barDia, stirrupDia, bars, d }: Beam
   const br = Math.max(3, (barDia / 2) * s)
   const dPx = d * s
 
-  // tension bar centres along the bottom row
-  const barY = y0 + hh - (cover + stirrupDia + barDia / 2) * s
+  const lay = layers && layers.length > 0 ? layers : [Math.max(2, bars)]
+  const n = lay.reduce((a, k) => a + k, 0)
   const x1 = x0 + (cover + stirrupDia + barDia / 2) * s
   const x2 = x0 + bw - (cover + stirrupDia + barDia / 2) * s
-  const n = Math.max(2, bars)
-  const barsX = Array.from({ length: n }, (_, i) => (n === 1 ? (x1 + x2) / 2 : x1 + ((x2 - x1) * i) / (n - 1)))
+  const yBottom = y0 + hh - (cover + stirrupDia + barDia / 2) * s
+  const pitch = (barDia + 25) * s   // layer-to-layer spacing (25 mm clear)
+
+  const rowX = (k: number) => Array.from({ length: k }, (_, i) => (k === 1 ? (x1 + x2) / 2 : x1 + ((x2 - x1) * i) / (k - 1)))
+
+  // compression bars along the top
+  const dbC = comprBarDia ?? barDia
+  const brC = Math.max(3, (dbC / 2) * s)
+  const yTop = y0 + (cover + stirrupDia + dbC / 2) * s
+  const topX = comprBars > 0 ? rowX(Math.max(2, comprBars)) : []
 
   return (
     <svg viewBox={`0 0 ${W} ${H}`} xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet"
@@ -37,15 +54,26 @@ export function BeamSchematic({ b, h, cover, barDia, stirrupDia, bars, d }: Beam
       <rect x={x0 + inset} y={y0 + inset} width={bw - 2 * inset} height={hh - 2 * inset} rx={4}
         fill="none" stroke={BAR} strokeWidth={1.2} />
 
-      {/* tension bars */}
-      {barsX.map((bx, i) => <circle key={i} cx={bx} cy={barY} r={br} fill={BAR} />)}
+      {/* tension bars, layered bottom-up */}
+      {lay.map((k, li) =>
+        rowX(k).map((bx, i) => (
+          <circle key={`t${li}-${i}`} cx={bx} cy={yBottom - li * pitch} r={br} fill={BAR} />
+        )),
+      )}
+
+      {/* compression bars */}
+      {topX.map((bx, i) => (
+        <circle key={`c${i}`} cx={bx} cy={yTop} r={brC} fill="none" stroke={BAR} strokeWidth={1.6} />
+      ))}
 
       {/* dimensions: b below, h left, d right (to the tension-steel centroid) */}
       <DimBelow xA={x0} xB={x0 + bw} featY={y0 + hh} dY={y0 + hh + 18} label={`b = ${Math.round(b)} mm`} />
       <DimSide yA={y0} yB={y0 + hh} featX={x0} dX={x0 - 16} label={`h = ${Math.round(h)} mm`} side="left" />
       <DimSide yA={y0} yB={y0 + dPx} featX={x0 + bw} dX={x0 + bw + 16} label={`d = ${Math.round(d)} mm`} side="right" />
 
-      <text x={x0 + bw / 2} y={barY + br + 12} fontSize={8.5} fill={BAR} textAnchor="middle">{n} ⌀{barDia} mm</text>
+      <text x={x0 + bw / 2} y={yBottom + br + 12} fontSize={8.5} fill={BAR} textAnchor="middle">
+        {n} ⌀{barDia} mm{lay.length > 1 ? ` (${lay.join('+')})` : ''}{comprBars > 0 ? ` · ${comprBars} ⌀${dbC} top` : ''}
+      </text>
     </svg>
   )
 }

--- a/webapp/src/engine/beamDesign.test.ts
+++ b/webapp/src/engine/beamDesign.test.ts
@@ -1,75 +1,106 @@
 import { describe, it, expect } from 'vitest'
 import { designBeam, type BeamDesignInput } from './beamDesign'
+import { beta1 } from './loads'
 
 const base: BeamDesignInput = {
   b: 300, h: 500, cover: 40, barDia: 20, stirrupDia: 10,
   fc: 28, fy: 415, Mu: 180, Vu: 150,
 }
 
+describe('beam design — ρ limits (reference formulas)', () => {
+  it("ρ_max,TC = (0.85 f'c/fy · β1)(3/8)(dt/d)", () => {
+    const r = designBeam(base)
+    const expected = 0.85 * (28 / 415) * beta1(28) * (3 / 8) * (r.dt / r.d)
+    expect(r.rhoMax).toBeCloseTo(expected, 12)
+  })
+
+  it('ρ_b carries the dt/d factor', () => {
+    const r = designBeam(base)
+    const expected = 0.85 * beta1(28) * (28 / 415) * (600 / (600 + 415)) * (r.dt / r.d)
+    expect(r.rhoB).toBeCloseTo(expected, 12)
+  })
+})
+
 describe('beam design — SRRB', () => {
-  it('moderate moment stays singly reinforced', () => {
+  it('moderate moment stays singly reinforced, single layer, d = dt', () => {
     const r = designBeam(base)
     expect(r.mode).toBe('SRRB')
-    expect(r.d).toBeCloseTo(500 - 40 - 10 - 10) // 440
-    expect(r.As).toBeGreaterThan(0)
-    expect(r.bars).toBeGreaterThanOrEqual(2)
+    expect(r.layers).toHaveLength(1)
+    expect(r.d).toBeCloseTo(r.dt)             // one layer → centroid at the layer
+    expect(r.dt).toBeCloseTo(500 - 40 - 10 - 10)
     expect(r.rho).toBeGreaterThanOrEqual(r.rhoMin)
-    expect(r.rho).toBeLessThanOrEqual(r.rhoMax + 1e-9)
-    expect(r.comprBars).toBe(0)
+    expect(r.sClear).toBeGreaterThanOrEqual(r.sMinClear - 1e-9)
   })
 
   it('tiny moment falls back to ρ_min', () => {
     const r = designBeam({ ...base, Mu: 10 })
     expect(r.usedMin).toBe(true)
   })
+})
 
-  it('ρ_max = 0.75 ρ_b (legacy limit)', () => {
+describe('beam design — bar layout & layers (§407.7, Varignon)', () => {
+  it('adds a second layer when one layer cannot fit the bars, lowering d', () => {
+    // Narrow web + big moment → more bars than one layer can hold.
+    const r = designBeam({ ...base, b: 250, h: 600, Mu: 520, barDia: 20 })
+    expect(r.layers.length).toBeGreaterThanOrEqual(2)
+    expect(r.bars).toBe(r.layers.reduce((s, k) => s + k, 0))
+    // Varignon: centroid rises above the extreme layer → d < dt
+    expect(r.yBar).toBeGreaterThan(0)
+    expect(r.d).toBeCloseTo(r.dt - r.yBar, 9)
+    expect(r.layerIters).toBeGreaterThanOrEqual(2)   // re-ran at the new d
+    // every layer respects the per-layer cap
+    expect(r.layers.every((k) => k <= r.maxPerLayer)).toBe(true)
+  })
+
+  it('maxPerLayer honours s_min = max(db, 25): n·db + (n−1)s ≤ b − 2(cover+ds)', () => {
     const r = designBeam(base)
-    expect(r.rhoMax).toBeCloseTo(0.75 * r.rhoB, 12)
+    const bw = 300 - 2 * (40 + 10)
+    const fits = r.maxPerLayer * 20 + (r.maxPerLayer - 1) * r.sMinClear
+    const oneMore = (r.maxPerLayer + 1) * 20 + r.maxPerLayer * r.sMinClear
+    expect(fits).toBeLessThanOrEqual(bw + 1e-9)
+    expect(oneMore).toBeGreaterThan(bw)
   })
 })
 
-describe('beam design — DRRB', () => {
-  it('Mu beyond the singly-reinforced ceiling designs compression steel', () => {
-    const r = designBeam({ ...base, b: 250, h: 400, Mu: 600 })
+describe('beam design — DRRB (compression steel)', () => {
+  it("Mu beyond φMn_max designs A's with the displaced-concrete term", () => {
+    const r = designBeam({ ...base, Mu: 400 })
     expect(r.mode).toBe('DRRB')
-    expect(600).toBeGreaterThan(r.phiMnMax)
+    expect(r.flexOK).toBe(true)
     expect(r.As).toBeCloseTo(r.As1 + r.As2, 6)
-    expect(r.AsPrime).toBeGreaterThan(0)
+    // f's = 600(1 − d'/c) ≤ fy
+    const fsExpect = Math.min(415, 600 * (1 - r.dPrime / r.cNA))
+    expect(r.fsPrime).toBeCloseTo(fsExpect, 9)
+    // A's = As2·fy / (f's − 0.85f'c) > As2 even when the steel yields
+    expect(r.AsPrime).toBeCloseTo((r.As2 * 415) / (r.fsPrime - 0.85 * 28), 6)
+    expect(r.AsPrime).toBeGreaterThan(r.As2)
     expect(r.comprBars).toBeGreaterThanOrEqual(2)
-    // when f's < fy, A's is scaled up from As2
-    if (!r.fsYields) expect(r.AsPrime).toBeGreaterThan(r.As2)
-    else expect(r.AsPrime).toBeCloseTo(r.As2, 6)
   })
 
-  it('the classification boundary is exact at φMn_max', () => {
-    const probe = designBeam(base)
-    const atCeiling = designBeam({ ...base, Mu: probe.phiMnMax - 0.01 })
-    const beyond = designBeam({ ...base, Mu: probe.phiMnMax + 0.01 })
-    expect(atCeiling.mode).toBe('SRRB')
-    expect(beyond.mode).toBe('DRRB')
+  it('classification is consistent with the converged φMn_max', () => {
+    // Layering can shift d (hence φMn_max) between runs, so the invariant is
+    // on each converged result, across a sweep of demands.
+    for (const Mu of [100, 200, 300, 340, 380, 450]) {
+      const r = designBeam({ ...base, Mu })
+      if (r.mode === 'SRRB') expect(Mu).toBeLessThanOrEqual(r.phiMnMax + 1e-9)
+      else expect(Mu).toBeGreaterThan(r.phiMnMax - 1e-9)
+    }
+  })
+
+  it('flags flexOK = false when the layout diverges (over-demanded section)', () => {
+    const r = designBeam({ ...base, b: 250, h: 400, Mu: 450 })
+    expect(r.flexOK).toBe(false)
   })
 })
 
 describe('beam design — shear', () => {
-  it('low shear needs no stirrups, mid shear needs minimum', () => {
+  it('regions: none / minimum / designed / inadequate', () => {
     const r = designBeam(base)
-    const lo = designBeam({ ...base, Vu: r.phiVc * 0.4 })
-    const mid = designBeam({ ...base, Vu: r.phiVc * 0.9 })
-    expect(lo.region).toBe('none')
-    expect(mid.region).toBe('minimum')
-    expect(mid.sAdopt).toBeGreaterThan(0)
-  })
-
-  it('high shear designs stirrups with spacing ≤ s_max', () => {
-    const r = designBeam({ ...base, Vu: 280 })
-    expect(r.region).toBe('designed')
-    expect(r.sAdopt).toBeLessThanOrEqual(r.sMax)
-    expect(r.sAdopt).toBeGreaterThan(0)
-  })
-
-  it('flags an inadequate section when Vs exceeds the cap', () => {
-    const r = designBeam({ ...base, b: 200, h: 350, Vu: 600 })
-    expect(r.region).toBe('inadequate')
+    expect(designBeam({ ...base, Vu: r.phiVc * 0.4 }).region).toBe('none')
+    expect(designBeam({ ...base, Vu: r.phiVc * 0.9 }).region).toBe('minimum')
+    const hi = designBeam({ ...base, Vu: 280 })
+    expect(hi.region).toBe('designed')
+    expect(hi.sAdopt).toBeLessThanOrEqual(hi.sMax)
+    expect(designBeam({ ...base, b: 200, h: 350, Vu: 600 }).region).toBe('inadequate')
   })
 })

--- a/webapp/src/engine/beamDesign.ts
+++ b/webapp/src/engine/beamDesign.ts
@@ -1,8 +1,14 @@
 // ─────────────────────────────────────────────────────────────────────────
 // Rectangular RC beam — SRRB/DRRB flexure + one-way shear (stirrups).
-// NSCP 2015 / ACI 318-14, following the legacy "Reinforced Concrete LAB"
-// sheet: classify against the singly-reinforced ceiling at ρ_max = 0.75ρ_b;
-// beyond it, design compression steel (DRRB) with the f's yield check.
+// NSCP 2015 / ACI 318-14, per the lecture references:
+//   · ρ_max (tension-controlled) = (0.85 f'c/fy · β1)(3/8)(dt/d)
+//   · DRRB compression steel: f's = 600(1 − d'/c) ≤ fy and
+//     A's (f's − 0.85f'c) = As2·fy   (displaced concrete accounted)
+//   · Bars are laid out with the §407.7.1 minimum clear spacing
+//     (max(db, 25 mm)); when one layer can't fit them, layers are added
+//     (25 mm clear, §407.7.2) and d is recomputed from the bar-group
+//     centroid (Varignon) — the design then re-runs at the new d until
+//     the layer arrangement stabilises.
 // Convention: lengths mm, stresses MPa, Mu kN·m, Vu/V_* kN, Es = 200 GPa.
 // ─────────────────────────────────────────────────────────────────────────
 import { rhoMin } from './flexure'
@@ -27,21 +33,33 @@ export type ShearRegion = 'none' | 'minimum' | 'designed' | 'inadequate'
 export type FlexureMode = 'SRRB' | 'DRRB'
 
 export interface BeamDesignResult {
-  d: number            // effective depth (tension), mm
+  d: number            // effective depth to the bar-group centroid, mm
+  dt: number           // depth to the extreme tension layer, mm
   dPrime: number       // compression-steel depth d', mm
-  // ρ limits
+  // ρ limits (both include the dt/d factor)
   rhoB: number; rhoMax: number; rhoMin: number
-  // SRRB ceiling
-  AsMax: number; aMax: number; MnMax: number; phiMnMax: number  // mm², mm, kN·m, kN·m
+  // SRRB ceiling at ρ_max
+  AsMax: number; aMax: number; MnMax: number; phiMnMax: number
   mode: FlexureMode
-  // Flexure (both modes)
+  // Flexure
   As: number; rho: number; usedMin: boolean
-  bars: number; barSpacing: number
-  // DRRB extras (0 / true-yield defaults for SRRB)
-  As1: number; As2: number; MnResid: number       // mm², mm², kN·m
-  cNA: number; epsSp: number; fsPrime: number     // mm, –, MPa
-  fsYields: boolean
-  AsPrime: number; comprBars: number              // mm², count
+  bars: number
+  // Bar layout (§407.7)
+  sMinClear: number    // required clear spacing = max(db, 25), mm
+  maxPerLayer: number  // bars that fit one layer at s_min
+  layers: number[]     // bars per layer, bottom (extreme) first
+  sClear: number       // actual clear spacing in the fullest layer, mm
+  yBar: number         // centroid rise above the extreme layer (Varignon), mm
+  layerIters: number   // d-recompute passes until stable
+  // DRRB extras
+  As1: number; As2: number; MnResid: number
+  cNA: number; fsPrime: number; fsYields: boolean
+  AsPrime: number; comprBars: number
+  /** False when f's ≤ 0.85f'c (compression steel ineffective) — enlarge the section. */
+  comprEffective: boolean
+  /** False when the bar layout diverges (d collapses toward d') — the section
+   *  cannot accommodate the required steel; enlarge it. */
+  flexOK: boolean
   // Shear
   Vc: number; phiVc: number
   region: ShearRegion
@@ -52,66 +70,127 @@ export interface BeamDesignResult {
 
 const PHI_FLEX = 0.90
 const PHI_SHEAR = 0.75
-const ES = 200000
+const LAYER_CLEAR = 25       // §407.7.2 clear distance between layers, mm
 const roundDown = (v: number, step: number) => Math.floor(v / step) * step
+
+/** Split n bars into layers of at most maxPerLayer, fullest at the bottom. */
+function splitLayers(n: number, maxPerLayer: number): number[] {
+  const layers: number[] = []
+  let left = n
+  while (left > 0) {
+    const take = Math.min(left, maxPerLayer)
+    layers.push(take)
+    left -= take
+  }
+  return layers
+}
+
+/** Centroid rise of the bar group above the extreme (bottom) layer — Varignon. */
+function centroidRise(layers: number[], pitch: number): number {
+  const n = layers.reduce((s, k) => s + k, 0)
+  const sum = layers.reduce((s, k, i) => s + k * i * pitch, 0)
+  return n > 0 ? sum / n : 0
+}
 
 export function designBeam(i: BeamDesignInput): BeamDesignResult {
   const fyt = i.fyt ?? i.fy
   const legs = i.legs ?? 2
   const lambda = i.lambda ?? 1
   const dbC = i.comprBarDia ?? i.barDia
-  const d = i.h - i.cover - i.stirrupDia - i.barDia / 2
+  const b1 = beta1(i.fc)
+  const rMin = rhoMin(i.fc, i.fy)
+  const Ab = (Math.PI / 4) * i.barDia * i.barDia
+  const AbC = (Math.PI / 4) * dbC * dbC
+
+  // Extreme tension layer & compression-steel depth — fixed by the section.
+  const dt = i.h - i.cover - i.stirrupDia - i.barDia / 2
   const dPrime = i.cover + i.stirrupDia + dbC / 2
 
-  // ── ρ limits (legacy: ρ_max = 0.75 ρ_balanced) ──
-  const b1 = beta1(i.fc)
-  const rhoB = 0.85 * b1 * (i.fc / i.fy) * (600 / (600 + i.fy))
-  const rhoMaxV = 0.75 * rhoB
-  const rMin = rhoMin(i.fc, i.fy)
+  // §407.7.1 — clear spacing ≥ max(db, 25 mm); bars per layer that fit:
+  // n·db + (n−1)·s_min ≤ b − 2(cover + ds).
+  const bw = i.b - 2 * (i.cover + i.stirrupDia)
+  const sMinClear = Math.max(i.barDia, 25)
+  const maxPerLayer = Math.max(1, Math.floor((bw + sMinClear) / (i.barDia + sMinClear)))
+  const pitch = i.barDia + LAYER_CLEAR     // layer-to-layer centroid distance
 
-  // ── SRRB ceiling: capacity with ρ_max ──
-  const AsMax = rhoMaxV * i.b * d
-  const aMax = (AsMax * i.fy) / (0.85 * i.fc * i.b)
-  const MnMax = (AsMax * i.fy * (d - aMax / 2)) / 1e6        // kN·m
-  const phiMnMax = PHI_FLEX * MnMax
+  // ── Iterate: layout → Varignon d → redesign, until the layers stabilise ──
+  let d = dt
+  let layers: number[] = [0]
+  let layerIters = 0
+  let mode: FlexureMode = 'SRRB'
+  let rhoB = 0, rhoMaxV = 0, AsMax = 0, aMax = 0, MnMax = 0, phiMnMax = 0
+  let As = 0, rho = 0, usedMin = false, bars = 0, yBar = 0
+  let As1 = 0, As2 = 0, MnResid = 0, cNA = 0, fsPrime = i.fy, fsYields = true
+  let AsPrime = 0, comprEffective = true
+  let flexOK = true
 
-  let mode: FlexureMode
-  let As = 0, rho = 0, usedMin = false
-  let As1 = 0, As2 = 0, MnResid = 0, cNA = 0, epsSp = 0, fsPrime = i.fy, fsYields = true, AsPrime = 0
+  for (let iter = 0; iter < 12; iter++) {
+    layerIters = iter + 1
 
-  if (i.Mu <= phiMnMax) {
-    // ── SRRB: ρ from Rn, floored at ρ_min ──
-    mode = 'SRRB'
-    const Rn = (i.Mu * 1e6) / (PHI_FLEX * i.b * d * d)
-    const rhoCalc = (0.85 * i.fc / i.fy) * (1 - Math.sqrt(Math.max(0, 1 - (2 * Rn) / (0.85 * i.fc))))
-    usedMin = rhoCalc < rMin
-    rho = usedMin ? rMin : rhoCalc
-    As = rho * i.b * d
-  } else {
-    // ── DRRB: tension couple at ρ_max + a steel couple for the residual ──
-    mode = 'DRRB'
-    As1 = AsMax
-    MnResid = i.Mu / PHI_FLEX - MnMax                          // kN·m
-    As2 = (MnResid * 1e6) / (i.fy * (d - dPrime))
-    As = As1 + As2
-    rho = As / (i.b * d)
-    // Compression-steel stress check at a = a_max.
-    cNA = aMax / b1
-    epsSp = 0.003 * (cNA - dPrime) / cNA
-    const fsUnc = ES * epsSp
-    fsYields = fsUnc >= i.fy
-    fsPrime = Math.min(i.fy, fsUnc)
-    AsPrime = (As2 * i.fy) / fsPrime
+    // ρ limits at the current d (reference: both carry dt/d).
+    rhoB = 0.85 * b1 * (i.fc / i.fy) * (600 / (600 + i.fy)) * (dt / d)
+    rhoMaxV = 0.85 * (i.fc / i.fy) * b1 * (3 / 8) * (dt / d)
+
+    // Singly-reinforced ceiling at ρ_max (ε_t = 0.005 → φ = 0.90).
+    AsMax = rhoMaxV * i.b * d
+    aMax = (AsMax * i.fy) / (0.85 * i.fc * i.b)
+    MnMax = (AsMax * i.fy * (d - aMax / 2)) / 1e6
+    phiMnMax = PHI_FLEX * MnMax
+
+    if (i.Mu <= phiMnMax) {
+      mode = 'SRRB'
+      const Rn = (i.Mu * 1e6) / (PHI_FLEX * i.b * d * d)
+      const rhoCalc = (0.85 * i.fc / i.fy) * (1 - Math.sqrt(Math.max(0, 1 - (2 * Rn) / (0.85 * i.fc))))
+      usedMin = rhoCalc < rMin
+      rho = usedMin ? rMin : rhoCalc
+      As = rho * i.b * d
+      As1 = 0; As2 = 0; MnResid = 0; cNA = 0; fsPrime = i.fy; fsYields = true; AsPrime = 0
+      comprEffective = true
+    } else {
+      mode = 'DRRB'
+      As1 = AsMax
+      MnResid = i.Mu / PHI_FLEX - MnMax
+      As2 = (MnResid * 1e6) / (i.fy * (d - dPrime))
+      As = As1 + As2
+      rho = As / (i.b * d)
+      usedMin = false
+      // f's = 600(1 − d'/c) ≤ fy at c = a_max/β1; A's accounts for the
+      // concrete displaced by the compression bars.
+      cNA = aMax / b1
+      const fsUnc = 600 * (1 - dPrime / cNA)
+      fsYields = fsUnc >= i.fy
+      fsPrime = Math.min(i.fy, Math.max(0, fsUnc))
+      comprEffective = fsPrime > 0.85 * i.fc
+      AsPrime = comprEffective ? (As2 * i.fy) / (fsPrime - 0.85 * i.fc) : 0
+    }
+
+    bars = Math.max(2, Math.ceil(As / Ab))
+    const newLayers = splitLayers(bars, maxPerLayer)
+    yBar = centroidRise(newLayers, pitch)
+    const dNew = dt - yBar
+
+    // Divergence guard: each added layer lowers d, which demands more steel,
+    // which adds layers — if d collapses toward d' (or the layer stack keeps
+    // growing), the section physically cannot take the steel.
+    if (dNew <= dPrime + i.barDia || newLayers.length > 6) {
+      flexOK = false
+      layers = newLayers
+      d = Math.max(dNew, dPrime + i.barDia)
+      break
+    }
+
+    const stable = newLayers.length === layers.length && newLayers.every((k, j) => k === layers[j])
+    layers = newLayers
+    if (stable && Math.abs(dNew - d) < 1e-9) break
+    d = dNew
   }
 
-  const Ab = (Math.PI / 4) * i.barDia * i.barDia
-  const bars = Math.max(2, Math.ceil(As / Ab))
-  const clearW = i.b - 2 * (i.cover + i.stirrupDia) - bars * i.barDia
-  const barSpacing = bars > 1 ? clearW / (bars - 1) + i.barDia : clearW
-  const AbC = (Math.PI / 4) * dbC * dbC
-  const comprBars = mode === 'DRRB' ? Math.max(2, Math.ceil(AsPrime / AbC)) : 0
+  // Actual clear spacing in the fullest (bottom) layer.
+  const nBot = layers[0]
+  const sClear = nBot > 1 ? (bw - nBot * i.barDia) / (nBot - 1) : bw
+  const comprBars = mode === 'DRRB' && comprEffective ? Math.max(2, Math.ceil(AsPrime / AbC)) : 0
 
-  // ── Shear (unchanged: NSCP 2015 §422.5 / §409.4) ──
+  // ── Shear (NSCP 2015 §422.5 / §409.4) ──
   const Vc = (lambda * Math.sqrt(i.fc) * i.b * d) / 6 / 1000
   const phiVc = PHI_SHEAR * Vc
   const Av = legs * (Math.PI / 4) * i.stirrupDia * i.stirrupDia
@@ -140,11 +219,12 @@ export function designBeam(i: BeamDesignInput): BeamDesignResult {
   }
 
   return {
-    d, dPrime,
+    d, dt, dPrime,
     rhoB, rhoMax: rhoMaxV, rhoMin: rMin,
     AsMax, aMax, MnMax, phiMnMax,
-    mode, As, rho, usedMin, bars, barSpacing,
-    As1, As2, MnResid, cNA, epsSp, fsPrime, fsYields, AsPrime, comprBars,
+    mode, As, rho, usedMin, bars,
+    sMinClear, maxPerLayer, layers, sClear, yBar, layerIters,
+    As1, As2, MnResid, cNA, fsPrime, fsYields, AsPrime, comprBars, comprEffective, flexOK,
     Vc, phiVc, region, Av, VsReq, VsMax, sReq, sMax, sAdopt,
   }
 }

--- a/webapp/src/lib/beamSolution.ts
+++ b/webapp/src/lib/beamSolution.ts
@@ -1,8 +1,9 @@
 // Detailed worked solution for the beam design — legacy-style: each step has
 // an explanation citing the governing provision, then the substituted
-// equations. Mirrors engine/beamDesign.ts (SRRB/DRRB at ρ_max = 0.75ρ_b).
+// equations. Mirrors engine/beamDesign.ts (ρ_max,TC with dt/d, DRRB with
+// displaced concrete, §407.7 bar layout with Varignon d-iteration).
 import type { BeamDesignInput, BeamDesignResult } from '../engine/beamDesign'
-import { type SolutionStep, type SolutionLine, sn0, sn1, sn3, sn4 } from './solution'
+import { type SolutionStep, type SolutionLine, sn0, sn1, sn2, sn3, sn4 } from './solution'
 
 const txt = (text: string): SolutionLine => ({ text })
 const eq = (tex: string): SolutionLine => ({ tex })
@@ -13,31 +14,32 @@ export function buildBeamSolution(i: BeamDesignInput, r: BeamDesignResult): Solu
   const dbC = i.comprBarDia ?? i.barDia
   const d = r.d
   const Ab = (Math.PI / 4) * i.barDia * i.barDia
+  const multiLayer = r.layers.length > 1
 
   const steps: SolutionStep[] = []
 
   steps.push({
     title: 'Effective depths',
     lines: [
-      txt('Tension steel sits inside the stirrup: d = h − cover − dₛ − d_b/2. The compression-steel depth d′ is measured the same way from the top face.'),
-      eq(String.raw`d = ${sn0(i.h)} - ${sn0(i.cover)} - ${sn0(i.stirrupDia)} - ${sn1(i.barDia / 2)} = \mathbf{${sn1(d)}}\ \text{mm}`),
-      eq(String.raw`d' = cover + d_s + \tfrac{d_b'}{2} = ${sn0(i.cover)} + ${sn0(i.stirrupDia)} + ${sn1(dbC / 2)} = ${sn1(r.dPrime)}\ \text{mm}`),
+      txt('d_t is the depth to the extreme (bottom) tension layer; d is the depth to the centroid of the whole bar group — they coincide for a single layer, and d < d_t once the bars need more than one layer (see the bar-layout step).'),
+      eq(String.raw`d_t = h - cover - d_s - \tfrac{d_b}{2} = ${sn0(i.h)} - ${sn0(i.cover)} - ${sn0(i.stirrupDia)} - ${sn1(i.barDia / 2)} = ${sn1(r.dt)}\ \text{mm}`),
+      eq(String.raw`d' = cover + d_s + \tfrac{d_b'}{2} = ${sn1(r.dPrime)}\ \text{mm},\qquad d = \mathbf{${sn1(d)}}\ \text{mm}${multiLayer ? String.raw`\ (\text{after } ${r.layerIters}\ \text{layout passes})` : ''}`),
     ],
   })
 
   steps.push({
     title: 'Reinforcement-ratio limits',
     lines: [
-      txt('The balanced ratio comes from strain compatibility (εcu = 0.003, Es = 200 GPa → the 600/(600+fy) form, NSCP 2015 §422 / ACI 318-14 §21.2). The legacy sheet caps the singly-reinforced design at ρ_max = 0.75ρ_b; ρ_min per §409.6.1.'),
-      eq(String.raw`\rho_b = \tfrac{0.85\beta_1 f'_c}{f_y}\cdot\tfrac{600}{600+f_y} = ${sn4(r.rhoB)}`),
-      eq(String.raw`\rho_{max} = 0.75\rho_b = ${sn4(r.rhoMax)},\qquad \rho_{min} = \max\!\left(\tfrac{1.4}{f_y}, \tfrac{\sqrt{f'_c}}{4f_y}\right) = ${sn4(r.rhoMin)}`),
+      txt('The tension-controlled maximum comes from c = (3/8)d_t (ε_t = 0.005 at the extreme layer): ρ_max = (0.85 f′c/fy · β1)(3/8)(d_t/d). The balanced ratio carries the same d_t/d factor; ρ_min per §409.6.1.'),
+      eq(String.raw`\rho_{max,TC} = \tfrac{0.85 f'_c}{f_y}\beta_1\cdot\tfrac{3}{8}\cdot\tfrac{d_t}{d} = ${sn4(r.rhoMax)}`),
+      eq(String.raw`\rho_b = \tfrac{0.85 f'_c}{f_y}\beta_1\cdot\tfrac{600}{600+f_y}\cdot\tfrac{d_t}{d} = ${sn4(r.rhoB)},\qquad \rho_{min} = ${sn4(r.rhoMin)}`),
     ],
   })
 
   steps.push({
     title: 'SRRB / DRRB classification',
     lines: [
-      txt('Compute the moment capacity of the section if it carried the maximum singly-reinforced steel (ρ_max). If Mu fits under φMn_max the beam is singly reinforced (SRRB); otherwise compression steel is required (DRRB).'),
+      txt('Capacity of the section at ρ_max (the singly-reinforced ceiling, still tension-controlled so φ = 0.90). If Mu fits under φMn_max the beam is singly reinforced; otherwise compression steel carries the excess.'),
       eq(String.raw`A_{s,max} = \rho_{max} b d = ${sn0(r.AsMax)}\ \text{mm}^2,\quad a_{max} = \tfrac{A_{s,max} f_y}{0.85 f'_c b} = ${sn1(r.aMax)}\ \text{mm}`),
       eq(String.raw`\phi M_{n,max} = 0.90\,A_{s,max} f_y (d - \tfrac{a_{max}}{2}) = ${sn1(r.phiMnMax)}\ \text{kN·m}`),
       eq(String.raw`M_u = ${sn1(i.Mu)}\ \text{kN·m} \;${i.Mu <= r.phiMnMax ? '\\le' : '>'}\; \phi M_{n,max} \Rightarrow \textbf{${r.mode}}`),
@@ -61,33 +63,45 @@ export function buildBeamSolution(i: BeamDesignInput, r: BeamDesignResult): Solu
     steps.push({
       title: 'Tension steel (DRRB)',
       lines: [
-        txt('Split the demand into the ρ_max couple (As1, concrete) and a residual steel couple (As2, paired with the compression steel A′s across the lever arm d − d′).'),
+        txt('Split the demand: As1 pairs with the concrete at the ρ_max couple; the excess moment M2 = Mu/φ − Mn,max is carried by a steel couple As2 acting over the lever arm (d − d′).'),
         eq(String.raw`A_{s1} = A_{s,max} = ${sn0(r.As1)}\ \text{mm}^2`),
-        eq(String.raw`M_{n,resid} = \tfrac{M_u}{\phi} - M_{n,max} = \tfrac{${sn1(i.Mu)}}{0.90} - ${sn1(r.MnMax)} = ${sn1(r.MnResid)}\ \text{kN·m}`),
-        eq(String.raw`A_{s2} = \dfrac{M_{n,resid}}{f_y (d - d')} = \dfrac{${sn1(r.MnResid)}\times 10^6}{${sn0(i.fy)}(${sn1(d)} - ${sn1(r.dPrime)})} = ${sn0(r.As2)}\ \text{mm}^2`),
+        eq(String.raw`M_2 = \tfrac{M_u}{\phi} - M_{n,max} = \tfrac{${sn1(i.Mu)}}{0.90} - ${sn1(r.MnMax)} = ${sn1(r.MnResid)}\ \text{kN·m}`),
+        eq(String.raw`A_{s2} = \dfrac{M_2}{f_y (d - d')} = \dfrac{${sn1(r.MnResid)}\times 10^6}{${sn0(i.fy)}(${sn1(d)} - ${sn1(r.dPrime)})} = ${sn0(r.As2)}\ \text{mm}^2`),
         eq(String.raw`A_s = A_{s1} + A_{s2} = \mathbf{${sn0(r.As)}}\ \text{mm}^2`),
       ],
     })
     steps.push({
-      title: 'Compression-steel stress check',
+      title: 'Compression steel',
       lines: [
-        txt('Strain compatibility at a = a_max: if the compression steel has not yielded, A′s is scaled up by fy/f′s so the couple still balances (§422.2.2).'),
-        eq(String.raw`c = \tfrac{a_{max}}{\beta_1} = ${sn1(r.cNA)}\ \text{mm},\quad \varepsilon_s' = 0.003\,\tfrac{c - d'}{c} = ${sn4(r.epsSp)}`),
-        eq(String.raw`f_s' = \min(f_y,\ E_s\varepsilon_s') = ${sn1(r.fsPrime)}\ \text{MPa}\ ${r.fsYields ? '(\\text{yields})' : '(\\text{does not yield})'}`),
-        eq(String.raw`A_s' = A_{s2}\,\tfrac{f_y}{f_s'} = ${sn0(r.AsPrime)}\ \text{mm}^2`),
+        txt('Stress in the compression steel from strain compatibility at c = a_max/β1: f′s = 600(1 − d′/c) ≤ fy. Equating Cs to T2 with the displaced concrete deducted: A′s(f′s − 0.85f′c) = As2·fy.'),
+        eq(String.raw`c = \tfrac{a_{max}}{\beta_1} = ${sn1(r.cNA)}\ \text{mm},\quad f_s' = 600\!\left(1 - \tfrac{${sn1(r.dPrime)}}{${sn1(r.cNA)}}\right) = ${sn1(600 * (1 - r.dPrime / r.cNA))} \to ${sn1(r.fsPrime)}\ \text{MPa}\ ${r.fsYields ? '(\\text{yields})' : '(\\text{does not yield})'}`),
+        eq(String.raw`A_s' = \dfrac{A_{s2} f_y}{f_s' - 0.85 f'_c} = \dfrac{${sn0(r.As2)}(${sn0(i.fy)})}{${sn1(r.fsPrime)} - ${sn2(0.85 * i.fc)}} = ${sn0(r.AsPrime)}\ \text{mm}^2`),
       ],
-      note: `Provide ${r.comprBars} ⌀${dbC} mm compression bars.`,
+      note: r.comprEffective
+        ? `Provide ${r.comprBars} ⌀${dbC} mm compression bars.`
+        : 'f′s ≤ 0.85f′c — compression steel is ineffective; enlarge the section.',
     })
   }
 
+  // ── Bar layout: spacing check → layers → Varignon d ──
+  const bw = i.b - 2 * (i.cover + i.stirrupDia)
   steps.push({
-    title: 'Bar selection (tension)',
+    title: 'Bar layout — spacing check & layers (§407.7)',
     lines: [
-      txt('Choose the bar count from the required area; clear spacing must accommodate the bars inside the stirrup (§425.2).'),
-      eq(String.raw`A_b = \tfrac{\pi}{4}d_b^2 = ${sn0(Ab)}\ \text{mm}^2,\quad n = \lceil A_s/A_b \rceil = ${r.bars}`),
-      eq(String.raw`s = ${sn0(r.barSpacing)}\ \text{mm o.c.}`),
+      txt(`Minimum clear spacing between parallel bars in a layer is max(d_b, 25 mm) = ${sn0(r.sMinClear)} mm (§407.7.1). The clear web width is b − 2(cover + dₛ) = ${sn0(bw)} mm, so at most ${r.maxPerLayer} bars fit per layer.`),
+      eq(String.raw`n = \lceil A_s / A_b \rceil = \lceil ${sn0(r.As)} / ${sn0(Ab)} \rceil = ${r.bars}\ \text{bars} \Rightarrow \text{layers: } [${r.layers.join(',\ ')}]`),
+      eq(String.raw`s_{clear} = \dfrac{${sn0(bw)} - ${r.layers[0]}(${sn0(i.barDia)})}{${Math.max(1, r.layers[0] - 1)}} = ${sn0(r.sClear)}\ \text{mm} \;\ge\; ${sn0(r.sMinClear)}\ \text{mm}\ \checkmark`),
+      ...(multiLayer ? [
+        txt('With more than one layer (25 mm clear between layers, §407.7.2) the bar-group centroid rises above the extreme layer — Varignon: ȳ = Σnᵢyᵢ/Σnᵢ — which reduces d, so the design re-runs at the new d until the layer arrangement stops changing.'),
+        eq(String.raw`\bar{y} = \dfrac{\sum n_i y_i}{\sum n_i} = ${sn1(r.yBar)}\ \text{mm} \Rightarrow d = d_t - \bar{y} = ${sn1(r.dt)} - ${sn1(r.yBar)} = \mathbf{${sn1(r.d)}}\ \text{mm}`),
+        txt(`Converged after ${r.layerIters} passes — the ρ limits, classification, and steel above are already evaluated at this final d.`),
+      ] : [
+        txt('All bars fit in one layer, so d = d_t and no re-iteration is needed.'),
+      ]),
     ],
-    note: `Provide ${r.bars} ⌀${i.barDia} mm tension bars${r.mode === 'DRRB' ? ` + ${r.comprBars} ⌀${dbC} mm compression bars` : ''}.`,
+    note: r.flexOK
+      ? `Provide ${r.bars} ⌀${i.barDia} mm in ${r.layers.length} layer${r.layers.length > 1 ? 's' : ''} (${r.layers.join(' + ')})${r.mode === 'DRRB' && r.comprEffective ? ` + ${r.comprBars} ⌀${dbC} mm compression bars` : ''}.`
+      : '⚠ The layout diverges (d collapses as layers stack up) — the section cannot accommodate the required steel. Enlarge b or h.',
   })
 
   steps.push({

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -48,9 +48,9 @@ export default function BeamDesign() {
       <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
       <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Beam Design</h1>
       <p className="no-print mt-1 text-slate-600">
-        Rectangular RC beam — SRRB/DRRB flexure (compression steel designed automatically when Mu exceeds the
-        singly-reinforced ceiling at ρ_max = 0.75ρ_b) and one-way shear. NSCP 2015 / ACI 318-14.
-        Enter the factored demands; results and the worked solution update live.
+        Rectangular RC beam — SRRB/DRRB flexure (compression steel designed automatically beyond the
+        tension-controlled ceiling at ρ_max = (0.85f′c/fy·β₁)(3/8)(dt/d)), §407.7 bar layout with automatic
+        layering (Varignon d), and one-way shear. NSCP 2015 / ACI 318-14.
       </p>
       <ReportControls title="Beam Design Report" />
 
@@ -80,7 +80,8 @@ export default function BeamDesign() {
           <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Section preview</h2>
             {r ? (
-              <BeamSchematic b={f.b} h={f.h} cover={f.cover} barDia={f.barDia} stirrupDia={f.stirrupDia} bars={r.bars} d={r.d} />
+              <BeamSchematic b={f.b} h={f.h} cover={f.cover} barDia={f.barDia} stirrupDia={f.stirrupDia}
+                bars={r.bars} d={r.d} layers={r.layers} comprBars={r.comprBars} comprBarDia={f.comprBarDia} />
             ) : (
               <p className="py-8 text-center text-sm text-slate-400">Enter a valid section (d must be positive).</p>
             )}
@@ -88,11 +89,18 @@ export default function BeamDesign() {
 
           {r && (
             <ResultCard title="Results">
-              <Row label="Effective depth d" value={`${f1(r.d)} mm`} />
+              {!r.flexOK && (
+                <Row label="⚠ Section" value="too small for the steel"
+                  sub="layout diverges — enlarge b or h" />
+              )}
+              <Row label="Effective depth d" value={`${f1(r.d)} mm`}
+                sub={r.layers.length > 1 ? `dt=${f1(r.dt)} · ȳ=${f1(r.yBar)} mm` : undefined} />
               <Row label="Flexure mode" value={r.mode}
                 sub={`φMn,max=${f1(r.phiMnMax)} kN·m`} />
               <Row label="Tension steel" value={`${r.bars} ⌀${f.barDia} mm`}
                 sub={`As=${f0(r.As)} mm² · ${r.usedMin ? 'ρ_min' : `ρ=${r.rho.toFixed(4)}`}`} />
+              <Row label="Layers" value={r.layers.length > 1 ? `${r.layers.length} (${r.layers.join(' + ')})` : '1'}
+                sub={`s_clear=${f0(r.sClear)} ≥ ${f0(r.sMinClear)} mm`} />
               {r.mode === 'DRRB' && (
                 <Row label="Compression steel" value={`${r.comprBars} ⌀${f.comprBarDia} mm`}
                   sub={`A's=${f0(r.AsPrime)} mm² · f's=${f1(r.fsPrime)} MPa${r.fsYields ? '' : ' (n.y.)'}`} />


### PR DESCRIPTION
Corrects the beam solution per the provided lecture/NSCP references.

## ρ_max — tension-controlled, with dt/d
`ρ_max,TC = (0.85·f′c/fy·β1)(3/8)(dt/d)` (from c = (3/8)dt at εt = 0.005) — replacing the 0.75ρ_b limit. ρ_b also carries the dt/d factor. **dt** (extreme tension layer) and **d** (bar-group centroid) are now distinct quantities throughout.

## DRRB — displaced concrete
- `f′s = 600(1 − d′/c) ≤ fy` at `c = a_max/β1`;
- `A′s(f′s − 0.85f′c) = As2·fy` → **A′s accounts for the concrete displaced by the compression bars** (so A′s > As2 even when the steel yields);
- flags the section when `f′s ≤ 0.85f′c` (compression steel ineffective).

## Bar layout — spacing, layers, Varignon
- §407.7.1 minimum clear spacing `max(db, 25 mm)`; bars per layer limited by `n·db + (n−1)s ≤ b − 2(cover+ds)`.
- When one layer can't fit the bars, **layers are added** (25 mm clear, §407.7.2), the group centroid rises (**Varignon**: ȳ = Σnᵢyᵢ/Σnᵢ), `d = dt − ȳ`, and the whole design **re-runs at the new d** until the layer arrangement stabilises (the solution shows the pass count).
- **Divergence guard**: when each pass demands more steel → more layers → smaller d (runaway), the result flags `flexOK = false` — the section physically cannot take the steel; UI shows "enlarge b or h".

## Solution & UI
The worked solution now derives ρ_max with the (3/8)(dt/d) step, shows the displaced-concrete A′s equation with substituted numbers, and has a new **bar-layout step** (spacing check → layer split → ȳ → new d → iteration count). The section schematic draws layered tension bars and hollow compression bars; Results show layers, s_clear vs s_min, dt/ȳ.

## Verification
10 engine tests pin the reference formulas exactly (ρ_max & ρ_b expressions, f′s, the A′s displaced-concrete identity, layer cap arithmetic, d = dt − ȳ, the converged-classification invariant, and the divergence flag) — **86 total passing**; build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)