### PR TITLE
Beam: compression-bar layering, stirrup hooks, schematic centroid & scale

### DIFF
--- a/webapp/src/components/BeamSchematic.tsx
+++ b/webapp/src/components/BeamSchematic.tsx
@@ -4,76 +4,114 @@ import { DimBelow, DimSide } from './dims'
 const STROKE = '#37526e'
 const FILL = '#eef3f8'
 const BAR = '#37526e'
+const CENTROID = '#dc2626'
 
 export interface BeamSchematicProps {
   b: number; h: number; cover: number; barDia: number; stirrupDia: number
   bars: number; d: number
   /** Tension bars per layer, bottom first (default: one layer of `bars`). */
   layers?: number[]
-  /** Compression bars (drawn along the top when > 0). */
+  /** Compression bars per layer, top first ([] / undefined → none). */
+  comprLayers?: number[]
   comprBars?: number
   comprBarDia?: number
 }
 
-/** Beam cross-section: stirrup outline, layered tension bars and optional
- *  compression bars, drawn to scale. */
+/** Beam cross-section to scale: stirrup drawn at its real thickness with 135°
+ *  hooks, layered tension + compression bars, and a red × on the
+ *  tension-steel centroid (where d is measured). */
 export function BeamSchematic({
-  b, h, cover, barDia, stirrupDia, bars, d, layers, comprBars = 0, comprBarDia,
+  b, h, cover, barDia, stirrupDia, bars, d, layers, comprLayers, comprBars = 0, comprBarDia,
 }: BeamSchematicProps): JSX.Element {
-  const W = 320, H = 300
-  const padL = 60, padT = 24, availW = 150, availH = 210
+  const W = 320, H = 312
+  const padL = 60, padT = 30, availW = 150, availH = 210
   const s = Math.min(availW / b, availH / h)
   const bw = b * s, hh = h * s
   const x0 = padL + (availW - bw) / 2, y0 = padT
-  const inset = (cover + stirrupDia / 2) * s
   const br = Math.max(3, (barDia / 2) * s)
   const dPx = d * s
+
+  // Stirrup centreline rectangle; stroke scaled to the actual bar thickness.
+  const inset = (cover + stirrupDia / 2) * s
+  const stW = Math.max(1, stirrupDia * s)
+  const sx0 = x0 + inset, sy0 = y0 + inset
+  const sw = bw - 2 * inset, sh = hh - 2 * inset
+  const bendR = (2 * stirrupDia) * s            // §407.3.2: inside bend 4ds → centreline radius ≈ 2ds
+  // 135° hooks: from the top corners, into the core at 45°, length max(6ds,75).
+  const hookLen = Math.max(6 * stirrupDia, 75) * s
+  const hk = hookLen / Math.SQRT2
 
   const lay = layers && layers.length > 0 ? layers : [Math.max(2, bars)]
   const n = lay.reduce((a, k) => a + k, 0)
   const x1 = x0 + (cover + stirrupDia + barDia / 2) * s
   const x2 = x0 + bw - (cover + stirrupDia + barDia / 2) * s
   const yBottom = y0 + hh - (cover + stirrupDia + barDia / 2) * s
-  const pitch = (barDia + 25) * s   // layer-to-layer spacing (25 mm clear)
+  const pitch = (barDia + 25) * s
 
   const rowX = (k: number) => Array.from({ length: k }, (_, i) => (k === 1 ? (x1 + x2) / 2 : x1 + ((x2 - x1) * i) / (k - 1)))
 
-  // compression bars along the top
+  // Compression bars, layered downward from the top.
   const dbC = comprBarDia ?? barDia
   const brC = Math.max(3, (dbC / 2) * s)
+  const cLay = comprLayers && comprLayers.length > 0 ? comprLayers : (comprBars > 0 ? [comprBars] : [])
+  const nC = cLay.reduce((a, k) => a + k, 0)
   const yTop = y0 + (cover + stirrupDia + dbC / 2) * s
-  const topX = comprBars > 0 ? rowX(Math.max(2, comprBars)) : []
+  const pitchC = (dbC + 25) * s
+
+  // Tension-steel centroid (where d is measured) — red ×.
+  const cxMid = x0 + bw / 2
+  const cyD = y0 + dPx
+  const X = 6
 
   return (
     <svg viewBox={`0 0 ${W} ${H}`} xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet"
       style={{ width: '100%', height: 'auto', fontFamily: 'Arial, sans-serif' }}>
-      <text x={padL} y={16} fontSize={11} fontWeight={700} fill="#0056b3">SECTION</text>
+      <text x={padL} y={14} fontSize={11} fontWeight={700} fill="#0056b3">SECTION</text>
 
-      {/* concrete + stirrup */}
+      {/* concrete */}
       <rect x={x0} y={y0} width={bw} height={hh} rx={2} fill={FILL} stroke={STROKE} strokeWidth={1.6} />
-      <rect x={x0 + inset} y={y0 + inset} width={bw - 2 * inset} height={hh - 2 * inset} rx={4}
-        fill="none" stroke={BAR} strokeWidth={1.2} />
 
-      {/* tension bars, layered bottom-up */}
+      {/* stirrup at real thickness, rounded bends */}
+      <rect x={sx0} y={sy0} width={sw} height={sh} rx={bendR}
+        fill="none" stroke={BAR} strokeWidth={stW} opacity={0.85} />
+      {/* 135° hooks into the core from the top-left corner pair */}
+      <line x1={sx0 + bendR * 0.3} y1={sy0 + bendR * 0.3} x2={sx0 + bendR * 0.3 + hk} y2={sy0 + bendR * 0.3 + hk}
+        stroke={BAR} strokeWidth={stW} strokeLinecap="round" opacity={0.85} />
+      <line x1={sx0 + bendR * 1.1} y1={sy0 - stW * 0.1} x2={sx0 + bendR * 1.1 + hk * 0.55} y2={sy0 + hk * 0.95}
+        stroke={BAR} strokeWidth={stW} strokeLinecap="round" opacity={0.85} />
+
+      {/* compression bars (hollow), layered downward */}
+      {cLay.map((k, li) =>
+        rowX(k).map((bx, i) => (
+          <circle key={`c${li}-${i}`} cx={bx} cy={yTop + li * pitchC} r={brC} fill="#fff" stroke={BAR} strokeWidth={1.6} />
+        )),
+      )}
+
+      {/* tension bars (solid), layered upward */}
       {lay.map((k, li) =>
         rowX(k).map((bx, i) => (
           <circle key={`t${li}-${i}`} cx={bx} cy={yBottom - li * pitch} r={br} fill={BAR} />
         )),
       )}
 
-      {/* compression bars */}
-      {topX.map((bx, i) => (
-        <circle key={`c${i}`} cx={bx} cy={yTop} r={brC} fill="none" stroke={BAR} strokeWidth={1.6} />
-      ))}
+      {/* red × at the tension-steel centroid */}
+      <line x1={cxMid - X} y1={cyD - X} x2={cxMid + X} y2={cyD + X} stroke={CENTROID} strokeWidth={1.8} />
+      <line x1={cxMid - X} y1={cyD + X} x2={cxMid + X} y2={cyD - X} stroke={CENTROID} strokeWidth={1.8} />
 
-      {/* dimensions: b below, h left, d right (to the tension-steel centroid) */}
-      <DimBelow xA={x0} xB={x0 + bw} featY={y0 + hh} dY={y0 + hh + 18} label={`b = ${Math.round(b)} mm`} />
-      <DimSide yA={y0} yB={y0 + hh} featX={x0} dX={x0 - 16} label={`h = ${Math.round(h)} mm`} side="left" />
-      <DimSide yA={y0} yB={y0 + dPx} featX={x0 + bw} dX={x0 + bw + 16} label={`d = ${Math.round(d)} mm`} side="right" />
-
-      <text x={x0 + bw / 2} y={yBottom + br + 12} fontSize={8.5} fill={BAR} textAnchor="middle">
-        {n} ⌀{barDia} mm{lay.length > 1 ? ` (${lay.join('+')})` : ''}{comprBars > 0 ? ` · ${comprBars} ⌀${dbC} top` : ''}
+      {/* labels: compression on top, tension at the bottom */}
+      {nC > 0 && (
+        <text x={x0 + bw / 2} y={y0 - 6} fontSize={8.5} fill={BAR} textAnchor="middle">
+          {nC} ⌀{dbC} mm{cLay.length > 1 ? ` (${cLay.join('+')})` : ''} top
+        </text>
+      )}
+      <text x={x0 + bw / 2} y={y0 + hh + 12} fontSize={8.5} fill={BAR} textAnchor="middle">
+        {n} ⌀{barDia} mm{lay.length > 1 ? ` (${lay.join('+')})` : ''}
       </text>
+
+      {/* dimensions: b below, h left, d right (to the red centroid) */}
+      <DimBelow xA={x0} xB={x0 + bw} featY={y0 + hh + 14} dY={y0 + hh + 30} label={`b = ${Math.round(b)} mm`} />
+      <DimSide yA={y0} yB={y0 + hh} featX={x0} dX={x0 - 16} label={`h = ${Math.round(h)} mm`} side="left" />
+      <DimSide yA={y0} yB={cyD} featX={x0 + bw} dX={x0 + bw + 16} label={`d = ${Math.round(d)} mm`} side="right" />
     </svg>
   )
 }

--- a/webapp/src/engine/beamDesign.test.ts
+++ b/webapp/src/engine/beamDesign.test.ts
@@ -104,3 +104,39 @@ describe('beam design — shear', () => {
     expect(designBeam({ ...base, b: 200, h: 350, Vu: 600 }).region).toBe('inadequate')
   })
 })
+
+describe('beam design — compression-bar layout & stirrup detailing', () => {
+  it("compression bars get the same spacing/layer treatment; d' deepens (Varignon)", () => {
+    // Heavy DRRB → 9 ⌀16 compression bars: two layers [5, 4].
+    const r = designBeam({ ...base, Mu: 460, comprBarDia: 16 })
+    expect(r.mode).toBe('DRRB')
+    expect(r.flexOK).toBe(true)
+    expect(r.comprLayers.length).toBeGreaterThanOrEqual(2)
+    expect(r.comprBars).toBe(r.comprLayers.reduce((s, k) => s + k, 0))
+    expect(r.comprLayers.every((k) => k <= r.comprMaxPerLayer)).toBe(true)
+    expect(r.comprYBar).toBeGreaterThan(0)
+    // d' = base + centroid drop (Varignon on the compression group)
+    expect(r.dPrime).toBeCloseTo(40 + 10 + 16 / 2 + r.comprYBar, 9)
+    expect(r.comprSClear).toBeGreaterThanOrEqual(r.comprSMinClear - 1e-9)
+  })
+
+  it('flags divergence when compression layers run away', () => {
+    const r = designBeam({ ...base, Mu: 520, comprBarDia: 16 })
+    expect(r.flexOK).toBe(false)
+  })
+
+  it('SRRB has no compression layers', () => {
+    const r = designBeam(base)
+    expect(r.comprLayers).toEqual([])
+    expect(r.comprYBar).toBe(0)
+  })
+
+  it('stirrup bend = 4ds and 135° hook extension = max(6ds, 75)', () => {
+    const r10 = designBeam(base)                          // ds = 10
+    expect(r10.stirrupBendDia).toBe(40)
+    expect(r10.stirrupHookExt).toBe(75)                   // 6·10 = 60 < 75
+    const r16 = designBeam({ ...base, stirrupDia: 16 })   // ds = 16
+    expect(r16.stirrupBendDia).toBe(64)
+    expect(r16.stirrupHookExt).toBe(96)                   // 6·16 = 96 > 75
+  })
+})

--- a/webapp/src/engine/beamDesign.ts
+++ b/webapp/src/engine/beamDesign.ts
@@ -57,6 +57,15 @@ export interface BeamDesignResult {
   AsPrime: number; comprBars: number
   /** False when f's ≤ 0.85f'c (compression steel ineffective) — enlarge the section. */
   comprEffective: boolean
+  // Compression-bar layout (same §407.7 technique, layered downward from the top)
+  comprSMinClear: number
+  comprMaxPerLayer: number
+  comprLayers: number[]    // bars per layer, top (extreme) first; [] when no compression steel
+  comprSClear: number
+  comprYBar: number        // centroid drop below the extreme top layer (Varignon), mm
+  // Stirrup detailing (§407.3.2 bend, §425.3.2 hook)
+  stirrupBendDia: number   // inside bend diameter = 4·ds (⌀16 and smaller), mm
+  stirrupHookExt: number   // 135° hook extension = max(6·ds, 75), mm
   /** False when the bar layout diverges (d collapses toward d') — the section
    *  cannot accommodate the required steel; enlarge it. */
   flexOK: boolean
@@ -102,26 +111,32 @@ export function designBeam(i: BeamDesignInput): BeamDesignResult {
   const Ab = (Math.PI / 4) * i.barDia * i.barDia
   const AbC = (Math.PI / 4) * dbC * dbC
 
-  // Extreme tension layer & compression-steel depth — fixed by the section.
+  // Extreme tension layer & compression-steel base depth — fixed by the section.
   const dt = i.h - i.cover - i.stirrupDia - i.barDia / 2
-  const dPrime = i.cover + i.stirrupDia + dbC / 2
+  const dPrimeBase = i.cover + i.stirrupDia + dbC / 2
 
   // §407.7.1 — clear spacing ≥ max(db, 25 mm); bars per layer that fit:
-  // n·db + (n−1)·s_min ≤ b − 2(cover + ds).
+  // n·db + (n−1)·s_min ≤ b − 2(cover + ds). Same rule on both faces.
   const bw = i.b - 2 * (i.cover + i.stirrupDia)
   const sMinClear = Math.max(i.barDia, 25)
   const maxPerLayer = Math.max(1, Math.floor((bw + sMinClear) / (i.barDia + sMinClear)))
   const pitch = i.barDia + LAYER_CLEAR     // layer-to-layer centroid distance
+  const comprSMinClear = Math.max(dbC, 25)
+  const comprMaxPerLayer = Math.max(1, Math.floor((bw + comprSMinClear) / (dbC + comprSMinClear)))
+  const pitchC = dbC + LAYER_CLEAR
 
-  // ── Iterate: layout → Varignon d → redesign, until the layers stabilise ──
+  // ── Iterate BOTH faces: layout → Varignon d & d' → redesign, until the
+  //    layer arrangements stabilise ──
   let d = dt
+  let dPrime = dPrimeBase
   let layers: number[] = [0]
+  let comprLayers: number[] = []
   let layerIters = 0
   let mode: FlexureMode = 'SRRB'
   let rhoB = 0, rhoMaxV = 0, AsMax = 0, aMax = 0, MnMax = 0, phiMnMax = 0
-  let As = 0, rho = 0, usedMin = false, bars = 0, yBar = 0
+  let As = 0, rho = 0, usedMin = false, bars = 0, yBar = 0, comprYBar = 0
   let As1 = 0, As2 = 0, MnResid = 0, cNA = 0, fsPrime = i.fy, fsYields = true
-  let AsPrime = 0, comprEffective = true
+  let AsPrime = 0, comprEffective = true, comprBars = 0
   let flexOK = true
 
   for (let iter = 0; iter < 12; iter++) {
@@ -164,31 +179,50 @@ export function designBeam(i: BeamDesignInput): BeamDesignResult {
       AsPrime = comprEffective ? (As2 * i.fy) / (fsPrime - 0.85 * i.fc) : 0
     }
 
+    // Tension side: bars → layers → Varignon → new d.
     bars = Math.max(2, Math.ceil(As / Ab))
     const newLayers = splitLayers(bars, maxPerLayer)
     yBar = centroidRise(newLayers, pitch)
     const dNew = dt - yBar
 
-    // Divergence guard: each added layer lowers d, which demands more steel,
-    // which adds layers — if d collapses toward d' (or the layer stack keeps
-    // growing), the section physically cannot take the steel.
-    if (dNew <= dPrime + i.barDia || newLayers.length > 6) {
+    // Compression side: same technique, layered downward from the top face —
+    // stacking layers DEEPENS d' (centroid drops), which feeds back into As2.
+    comprBars = mode === 'DRRB' && comprEffective ? Math.max(2, Math.ceil(AsPrime / AbC)) : 0
+    const newComprLayers = comprBars > 0 ? splitLayers(comprBars, comprMaxPerLayer) : []
+    comprYBar = centroidRise(newComprLayers, pitchC)
+    const dPrimeNew = dPrimeBase + comprYBar
+
+    // Divergence guard: each added layer lowers d (and raises d'), which
+    // demands more steel, which adds layers — if the two centroids close in
+    // on each other (or a stack keeps growing), the section can't take it.
+    if (dNew <= dPrimeNew + i.barDia || newLayers.length > 6 || newComprLayers.length > 6) {
       flexOK = false
       layers = newLayers
-      d = Math.max(dNew, dPrime + i.barDia)
+      comprLayers = newComprLayers
+      d = Math.max(dNew, dPrimeNew + i.barDia)
+      dPrime = dPrimeNew
       break
     }
 
-    const stable = newLayers.length === layers.length && newLayers.every((k, j) => k === layers[j])
+    const sameVec = (a: number[], b: number[]) => a.length === b.length && a.every((k, j) => k === b[j])
+    const stable = sameVec(newLayers, layers) && sameVec(newComprLayers, comprLayers)
     layers = newLayers
-    if (stable && Math.abs(dNew - d) < 1e-9) break
+    comprLayers = newComprLayers
+    if (stable && Math.abs(dNew - d) < 1e-9 && Math.abs(dPrimeNew - dPrime) < 1e-9) break
     d = dNew
+    dPrime = dPrimeNew
   }
 
-  // Actual clear spacing in the fullest (bottom) layer.
+  // Actual clear spacing in the fullest layer on each face.
   const nBot = layers[0]
   const sClear = nBot > 1 ? (bw - nBot * i.barDia) / (nBot - 1) : bw
-  const comprBars = mode === 'DRRB' && comprEffective ? Math.max(2, Math.ceil(AsPrime / AbC)) : 0
+  const nTop = comprLayers[0] ?? 0
+  const comprSClear = nTop > 1 ? (bw - nTop * dbC) / (nTop - 1) : bw
+
+  // Stirrup detailing — §407.3.2: inside bend ≥ 4ds for ⌀16 and smaller;
+  // §425.3.2: 135° stirrup hook extension = max(6ds, 75 mm).
+  const stirrupBendDia = 4 * i.stirrupDia
+  const stirrupHookExt = Math.max(6 * i.stirrupDia, 75)
 
   // ── Shear (NSCP 2015 §422.5 / §409.4) ──
   const Vc = (lambda * Math.sqrt(i.fc) * i.b * d) / 6 / 1000
@@ -225,6 +259,8 @@ export function designBeam(i: BeamDesignInput): BeamDesignResult {
     mode, As, rho, usedMin, bars,
     sMinClear, maxPerLayer, layers, sClear, yBar, layerIters,
     As1, As2, MnResid, cNA, fsPrime, fsYields, AsPrime, comprBars, comprEffective, flexOK,
+    comprSMinClear, comprMaxPerLayer, comprLayers, comprSClear, comprYBar,
+    stirrupBendDia, stirrupHookExt,
     Vc, phiVc, region, Av, VsReq, VsMax, sReq, sMax, sAdopt,
   }
 }

--- a/webapp/src/lib/beamSolution.ts
+++ b/webapp/src/lib/beamSolution.ts
@@ -94,10 +94,20 @@ export function buildBeamSolution(i: BeamDesignInput, r: BeamDesignResult): Solu
       ...(multiLayer ? [
         txt('With more than one layer (25 mm clear between layers, §407.7.2) the bar-group centroid rises above the extreme layer — Varignon: ȳ = Σnᵢyᵢ/Σnᵢ — which reduces d, so the design re-runs at the new d until the layer arrangement stops changing.'),
         eq(String.raw`\bar{y} = \dfrac{\sum n_i y_i}{\sum n_i} = ${sn1(r.yBar)}\ \text{mm} \Rightarrow d = d_t - \bar{y} = ${sn1(r.dt)} - ${sn1(r.yBar)} = \mathbf{${sn1(r.d)}}\ \text{mm}`),
-        txt(`Converged after ${r.layerIters} passes — the ρ limits, classification, and steel above are already evaluated at this final d.`),
       ] : [
-        txt('All bars fit in one layer, so d = d_t and no re-iteration is needed.'),
+        txt('All tension bars fit in one layer, so d = d_t for the tension side.'),
       ]),
+      ...(r.comprLayers.length > 0 ? [
+        txt(`Compression side — same rule: s_min = max(d_b′, 25) = ${sn0(r.comprSMinClear)} mm, so at most ${r.comprMaxPerLayer} compression bars fit per layer.`),
+        eq(String.raw`n' = ${r.comprBars}\ \text{bars} \Rightarrow \text{layers: } [${r.comprLayers.join(',\ ')}],\quad s_{clear}' = ${sn0(r.comprSClear)}\ \text{mm} \ge ${sn0(r.comprSMinClear)}\ \checkmark`),
+        ...(r.comprLayers.length > 1 ? [
+          txt('Stacking compression layers drops the compression-steel centroid (Varignon), DEEPENING d′ — which reduces the (d − d′) lever arm and feeds back into As2 and A′s.'),
+          eq(String.raw`\bar{y}' = ${sn1(r.comprYBar)}\ \text{mm} \Rightarrow d' = ${sn1(r.dPrime - r.comprYBar)} + ${sn1(r.comprYBar)} = \mathbf{${sn1(r.dPrime)}}\ \text{mm}`),
+        ] : []),
+      ] : []),
+      ...(multiLayer || r.comprLayers.length > 1 ? [
+        txt(`Both faces converged after ${r.layerIters} passes — the ρ limits, classification, and steel above are already evaluated at the final d and d′.`),
+      ] : []),
     ],
     note: r.flexOK
       ? `Provide ${r.bars} ⌀${i.barDia} mm in ${r.layers.length} layer${r.layers.length > 1 ? 's' : ''} (${r.layers.join(' + ')})${r.mode === 'DRRB' && r.comprEffective ? ` + ${r.comprBars} ⌀${dbC} mm compression bars` : ''}.`
@@ -151,6 +161,16 @@ export function buildBeamSolution(i: BeamDesignInput, r: BeamDesignResult): Solu
       note: 'Increase b, d, or f′c.',
     })
   }
+
+  steps.push({
+    title: 'Stirrup detailing — bend & hooks (§407.3.2, §425.3.2)',
+    lines: [
+      txt('Inside diameter of bend for stirrups and ties shall not be less than 4d_b for ⌀16 mm bars and smaller (§407.3.2.2). Stirrups close with 135° hooks around a longitudinal bar; the hook extension beyond the bend is 6d_b but not less than 75 mm (§425.3.2).'),
+      eq(String.raw`D_{bend} = 4 d_s = 4(${sn0(i.stirrupDia)}) = ${sn0(r.stirrupBendDia)}\ \text{mm}`),
+      eq(String.raw`\ell_{hook} = \max(6 d_s,\ 75) = \max(${sn0(6 * i.stirrupDia)},\ 75) = ${sn0(r.stirrupHookExt)}\ \text{mm}`),
+    ],
+    note: `Provide 135° seismic hooks, ${sn0(r.stirrupHookExt)} mm extension, bent around a corner bar.`,
+  })
 
   return steps
 }

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -81,7 +81,8 @@ export default function BeamDesign() {
             <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Section preview</h2>
             {r ? (
               <BeamSchematic b={f.b} h={f.h} cover={f.cover} barDia={f.barDia} stirrupDia={f.stirrupDia}
-                bars={r.bars} d={r.d} layers={r.layers} comprBars={r.comprBars} comprBarDia={f.comprBarDia} />
+                bars={r.bars} d={r.d} layers={r.layers} comprLayers={r.comprLayers}
+                comprBars={r.comprBars} comprBarDia={f.comprBarDia} />
             ) : (
               <p className="py-8 text-center text-sm text-slate-400">Enter a valid section (d must be positive).</p>
             )}
@@ -105,10 +106,17 @@ export default function BeamDesign() {
                 <Row label="Compression steel" value={`${r.comprBars} ⌀${f.comprBarDia} mm`}
                   sub={`A's=${f0(r.AsPrime)} mm² · f's=${f1(r.fsPrime)} MPa${r.fsYields ? '' : ' (n.y.)'}`} />
               )}
+              {r.comprLayers.length > 0 && (
+                <Row label="Compr. layers"
+                  value={r.comprLayers.length > 1 ? `${r.comprLayers.length} (${r.comprLayers.join(' + ')})` : '1'}
+                  sub={`d'=${f1(r.dPrime)} mm · s'_clear=${f0(r.comprSClear)} ≥ ${f0(r.comprSMinClear)}`} />
+              )}
               <Row label={<Math tex="\phi V_c" />} value={`${f1(r.phiVc)} kN`} sub={`Vc=${f1(r.Vc)}`} />
               <Row label="Shear" value={REGION[r.region]} />
               <Row label="Stirrups" value={stirrupText}
                 sub={r.region === 'designed' ? `s_req=${f0(r.sReq)} · s_max=${f0(r.sMax)} mm` : undefined} />
+              <Row label="Hooks (135°)" value={`ext ${f0(r.stirrupHookExt)} mm`}
+                sub={`bend Ø ${f0(r.stirrupBendDia)} mm (4ds)`} />
             </ResultCard>
           )}
         </div>


### PR DESCRIPTION
Implements the review feedback on the beam tool.

## Compression-bar spacing & layering (same technique as tension)
- §407.7.1 minimum clear spacing `max(d_b′, 25)` and the per-layer fit cap now apply to the **compression face**; excess bars layer **downward from the top** (25 mm clear, §407.7.2).
- Stacking compression layers **deepens d′** (Varignon: ȳ′ = Σnᵢyᵢ/Σnᵢ, `d′ = d′_base + ȳ′`), which shrinks the (d − d′) lever arm and feeds back into As2/A′s — so the engine now iterates **both d and d′** until both layer vectors stabilise. The divergence guard covers the compression stack too (a runaway compression demand flags `flexOK = false`).

## Stirrup hooks (continued to the provisions)
- Inside bend diameter `= 4d_s` for ⌀16 and smaller (§407.3.2.2) and **135° hook extension `= max(6d_s, 75 mm)`** (§425.3.2) — computed in the engine, shown in Results, and walked through as a new **"Stirrup detailing — bend & hooks"** solution step with substituted numbers.

## Schematic
- Stirrup stroke **scaled to the actual d_s** at the drawing scale, rounded bends (~2d_s centreline radius), and **135° hooks** drawn into the core at the top corner.
- Compression bars drawn **layered** (hollow) with their label **on top** of the section; the tension label stays below — no longer side-by-side.
- **Red ×** on the tension-steel centroid (where d is measured); the d dimension line now terminates at it.

## Solution
The bar-layout step covers both faces: compression spacing check, layer split, ȳ′ → new d′, and the joint convergence pass count.

## Verification
4 new engine tests (90 total): the compression layer split + `d′ = base + ȳ′` Varignon identity, SRRB → no compression layers, the compression-side divergence flag, and the bend/hook values at d_s = 10 (75 governs) and 16 (6d_s governs). Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)