### PR TITLE
Beam: compression NA check + schematic hook/centroid/d′ fixes

### DIFF
--- a/webapp/src/components/BeamSchematic.tsx
+++ b/webapp/src/components/BeamSchematic.tsx
@@ -9,6 +9,8 @@ const CENTROID = '#dc2626'
 export interface BeamSchematicProps {
   b: number; h: number; cover: number; barDia: number; stirrupDia: number
   bars: number; d: number
+  /** Compression-steel centroid depth d′, mm — draws its dim line + cross when set. */
+  dPrime?: number
   /** Tension bars per layer, bottom first (default: one layer of `bars`). */
   layers?: number[]
   /** Compression bars per layer, top first ([] / undefined → none). */
@@ -17,14 +19,26 @@ export interface BeamSchematicProps {
   comprBarDia?: number
 }
 
-/** Beam cross-section to scale: stirrup drawn at its real thickness with 135°
- *  hooks, layered tension + compression bars, and a red × on the
- *  tension-steel centroid (where d is measured). */
+/** Small thin × with dashed extension lines out to a dimension line. */
+function CentroidMark({ cx, cy, toX }: { cx: number; cy: number; toX: number }) {
+  const X = 3.5
+  return (
+    <g>
+      <line x1={cx - X} y1={cy - X} x2={cx + X} y2={cy + X} stroke={CENTROID} strokeWidth={1.1} />
+      <line x1={cx - X} y1={cy + X} x2={cx + X} y2={cy - X} stroke={CENTROID} strokeWidth={1.1} />
+      <line x1={cx + X + 2} y1={cy} x2={toX} y2={cy} stroke={CENTROID} strokeWidth={0.7} strokeDasharray="4 3" />
+    </g>
+  )
+}
+
+/** Beam cross-section to scale: open stirrup with two 135° corner hooks at its
+ *  real thickness, layered tension + compression bars, red × centroid marks
+ *  tied to the d / d′ dimension lines with dashed extensions. */
 export function BeamSchematic({
-  b, h, cover, barDia, stirrupDia, bars, d, layers, comprLayers, comprBars = 0, comprBarDia,
+  b, h, cover, barDia, stirrupDia, bars, d, dPrime, layers, comprLayers, comprBars = 0, comprBarDia,
 }: BeamSchematicProps): JSX.Element {
-  const W = 320, H = 312
-  const padL = 60, padT = 30, availW = 150, availH = 210
+  const W = 330, H = 312
+  const padL = 56, padT = 30, availW = 150, availH = 210
   const s = Math.min(availW / b, availH / h)
   const bw = b * s, hh = h * s
   const x0 = padL + (availW - bw) / 2, y0 = padT
@@ -36,10 +50,27 @@ export function BeamSchematic({
   const stW = Math.max(1, stirrupDia * s)
   const sx0 = x0 + inset, sy0 = y0 + inset
   const sw = bw - 2 * inset, sh = hh - 2 * inset
-  const bendR = (2 * stirrupDia) * s            // §407.3.2: inside bend 4ds → centreline radius ≈ 2ds
-  // 135° hooks: from the top corners, into the core at 45°, length max(6ds,75).
-  const hookLen = Math.max(6 * stirrupDia, 75) * s
-  const hk = hookLen / Math.SQRT2
+  const r = Math.max(2, 2 * stirrupDia * s)     // §407.3.2 bend: centreline radius ≈ 2ds
+  // 135° hook: wraps the corner bar and extends into the core at 45°.
+  const ext = Math.max(6 * stirrupDia, 75) * s
+  const e = ext / Math.SQRT2
+
+  // One open path: tip A → wrap top-left corner → full perimeter → wrap the
+  // same corner from the left leg → tip B. Both tips point into the core at 45°.
+  const stirrupPath = [
+    `M ${sx0 + r * 0.9 + e} ${sy0 + r * 0.1 + e}`,                 // tip A (from the top leg)
+    `L ${sx0 + r * 0.9} ${sy0 + r * 0.1}`,
+    `Q ${sx0 + r * 0.45} ${sy0 - stW * 0.15} ${sx0 + r} ${sy0}`,   // wrap onto the top leg
+    `L ${sx0 + sw - r} ${sy0}`,
+    `Q ${sx0 + sw} ${sy0} ${sx0 + sw} ${sy0 + r}`,
+    `L ${sx0 + sw} ${sy0 + sh - r}`,
+    `Q ${sx0 + sw} ${sy0 + sh} ${sx0 + sw - r} ${sy0 + sh}`,
+    `L ${sx0 + r} ${sy0 + sh}`,
+    `Q ${sx0} ${sy0 + sh} ${sx0} ${sy0 + sh - r}`,
+    `L ${sx0} ${sy0 + r}`,
+    `Q ${sx0 - stW * 0.15} ${sy0 + r * 0.45} ${sx0 + r * 0.1} ${sy0 + r * 0.9}`, // wrap from the left leg
+    `L ${sx0 + r * 0.1 + e} ${sy0 + r * 0.9 + e}`,                 // tip B
+  ].join(' ')
 
   const lay = layers && layers.length > 0 ? layers : [Math.max(2, bars)]
   const n = lay.reduce((a, k) => a + k, 0)
@@ -58,10 +89,13 @@ export function BeamSchematic({
   const yTop = y0 + (cover + stirrupDia + dbC / 2) * s
   const pitchC = (dbC + 25) * s
 
-  // Tension-steel centroid (where d is measured) — red ×.
+  // Dimension-line x positions on the right: d′ inner, d outer.
+  const hasDP = nC > 0 && dPrime !== undefined
+  const dxInner = x0 + bw + 14
+  const dxOuter = x0 + bw + (hasDP ? 38 : 16)
   const cxMid = x0 + bw / 2
   const cyD = y0 + dPx
-  const X = 6
+  const cyDP = hasDP ? y0 + (dPrime as number) * s : 0
 
   return (
     <svg viewBox={`0 0 ${W} ${H}`} xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet"
@@ -71,14 +105,9 @@ export function BeamSchematic({
       {/* concrete */}
       <rect x={x0} y={y0} width={bw} height={hh} rx={2} fill={FILL} stroke={STROKE} strokeWidth={1.6} />
 
-      {/* stirrup at real thickness, rounded bends */}
-      <rect x={sx0} y={sy0} width={sw} height={sh} rx={bendR}
-        fill="none" stroke={BAR} strokeWidth={stW} opacity={0.85} />
-      {/* 135° hooks into the core from the top-left corner pair */}
-      <line x1={sx0 + bendR * 0.3} y1={sy0 + bendR * 0.3} x2={sx0 + bendR * 0.3 + hk} y2={sy0 + bendR * 0.3 + hk}
-        stroke={BAR} strokeWidth={stW} strokeLinecap="round" opacity={0.85} />
-      <line x1={sx0 + bendR * 1.1} y1={sy0 - stW * 0.1} x2={sx0 + bendR * 1.1 + hk * 0.55} y2={sy0 + hk * 0.95}
-        stroke={BAR} strokeWidth={stW} strokeLinecap="round" opacity={0.85} />
+      {/* open stirrup with two 135° hooks at the top-left corner */}
+      <path d={stirrupPath} fill="none" stroke={BAR} strokeWidth={stW}
+        strokeLinecap="round" strokeLinejoin="round" opacity={0.8} />
 
       {/* compression bars (hollow), layered downward */}
       {cLay.map((k, li) =>
@@ -94,9 +123,9 @@ export function BeamSchematic({
         )),
       )}
 
-      {/* red × at the tension-steel centroid */}
-      <line x1={cxMid - X} y1={cyD - X} x2={cxMid + X} y2={cyD + X} stroke={CENTROID} strokeWidth={1.8} />
-      <line x1={cxMid - X} y1={cyD + X} x2={cxMid + X} y2={cyD - X} stroke={CENTROID} strokeWidth={1.8} />
+      {/* centroid marks with dashed ties to their dimension lines */}
+      {hasDP && <CentroidMark cx={cxMid} cy={cyDP} toX={dxInner} />}
+      <CentroidMark cx={cxMid} cy={cyD} toX={dxOuter} />
 
       {/* labels: compression on top, tension at the bottom */}
       {nC > 0 && (
@@ -108,10 +137,13 @@ export function BeamSchematic({
         {n} ⌀{barDia} mm{lay.length > 1 ? ` (${lay.join('+')})` : ''}
       </text>
 
-      {/* dimensions: b below, h left, d right (to the red centroid) */}
+      {/* dimensions: b below, h left, d (and d′ for DRRB) right */}
       <DimBelow xA={x0} xB={x0 + bw} featY={y0 + hh + 14} dY={y0 + hh + 30} label={`b = ${Math.round(b)} mm`} />
       <DimSide yA={y0} yB={y0 + hh} featX={x0} dX={x0 - 16} label={`h = ${Math.round(h)} mm`} side="left" />
-      <DimSide yA={y0} yB={cyD} featX={x0 + bw} dX={x0 + bw + 16} label={`d = ${Math.round(d)} mm`} side="right" />
+      {hasDP && (
+        <DimSide yA={y0} yB={cyDP} featX={x0 + bw} dX={dxInner} label={`d' = ${Math.round(dPrime as number)}`} side="right" />
+      )}
+      <DimSide yA={y0} yB={cyD} featX={x0 + bw} dX={dxOuter} label={`d = ${Math.round(d)} mm`} side="right" />
     </svg>
   )
 }

--- a/webapp/src/engine/beamDesign.test.ts
+++ b/webapp/src/engine/beamDesign.test.ts
@@ -140,3 +140,19 @@ describe('beam design — compression-bar layout & stirrup detailing', () => {
     expect(r16.stirrupHookExt).toBe(96)                   // 6·16 = 96 > 75
   })
 })
+
+describe('beam design — compression NA check', () => {
+  it('deepest layer depth = base + (nLayers−1)·pitch; above NA passes', () => {
+    const r = designBeam({ ...base, Mu: 460, comprBarDia: 16 })   // compr layers [5,4]
+    const expected = (40 + 10 + 8) + (r.comprLayers.length - 1) * (16 + 25)
+    expect(r.dPrimeExtreme).toBeCloseTo(expected, 9)
+    expect(r.dPrimeExtreme).toBeLessThan(r.cNA)
+    expect(r.comprNAOK).toBe(true)
+  })
+
+  it('SRRB: NA check is vacuously OK', () => {
+    const r = designBeam(base)
+    expect(r.comprNAOK).toBe(true)
+    expect(r.dPrimeExtreme).toBe(0)
+  })
+})

--- a/webapp/src/engine/beamDesign.ts
+++ b/webapp/src/engine/beamDesign.ts
@@ -63,6 +63,10 @@ export interface BeamDesignResult {
   comprLayers: number[]    // bars per layer, top (extreme) first; [] when no compression steel
   comprSClear: number
   comprYBar: number        // centroid drop below the extreme top layer (Varignon), mm
+  /** Depth of the DEEPEST compression layer, mm. */
+  dPrimeExtreme: number
+  /** Deepest compression layer stays above the neutral axis (in compression). */
+  comprNAOK: boolean
   // Stirrup detailing (§407.3.2 bend, §425.3.2 hook)
   stirrupBendDia: number   // inside bend diameter = 4·ds (⌀16 and smaller), mm
   stirrupHookExt: number   // 135° hook extension = max(6·ds, 75), mm
@@ -219,6 +223,11 @@ export function designBeam(i: BeamDesignInput): BeamDesignResult {
   const nTop = comprLayers[0] ?? 0
   const comprSClear = nTop > 1 ? (bw - nTop * dbC) / (nTop - 1) : bw
 
+  // NA check (legacy): the DEEPEST compression layer must stay above the
+  // neutral axis c — a bar at or below c is not in compression at all.
+  const dPrimeExtreme = comprLayers.length > 0 ? dPrimeBase + (comprLayers.length - 1) * pitchC : 0
+  const comprNAOK = comprLayers.length === 0 || dPrimeExtreme < cNA
+
   // Stirrup detailing — §407.3.2: inside bend ≥ 4ds for ⌀16 and smaller;
   // §425.3.2: 135° stirrup hook extension = max(6ds, 75 mm).
   const stirrupBendDia = 4 * i.stirrupDia
@@ -260,6 +269,7 @@ export function designBeam(i: BeamDesignInput): BeamDesignResult {
     sMinClear, maxPerLayer, layers, sClear, yBar, layerIters,
     As1, As2, MnResid, cNA, fsPrime, fsYields, AsPrime, comprBars, comprEffective, flexOK,
     comprSMinClear, comprMaxPerLayer, comprLayers, comprSClear, comprYBar,
+    dPrimeExtreme, comprNAOK,
     stirrupBendDia, stirrupHookExt,
     Vc, phiVc, region, Av, VsReq, VsMax, sReq, sMax, sAdopt,
   }

--- a/webapp/src/lib/beamSolution.ts
+++ b/webapp/src/lib/beamSolution.ts
@@ -76,10 +76,16 @@ export function buildBeamSolution(i: BeamDesignInput, r: BeamDesignResult): Solu
         txt('Stress in the compression steel from strain compatibility at c = a_max/β1: f′s = 600(1 − d′/c) ≤ fy. Equating Cs to T2 with the displaced concrete deducted: A′s(f′s − 0.85f′c) = As2·fy.'),
         eq(String.raw`c = \tfrac{a_{max}}{\beta_1} = ${sn1(r.cNA)}\ \text{mm},\quad f_s' = 600\!\left(1 - \tfrac{${sn1(r.dPrime)}}{${sn1(r.cNA)}}\right) = ${sn1(600 * (1 - r.dPrime / r.cNA))} \to ${sn1(r.fsPrime)}\ \text{MPa}\ ${r.fsYields ? '(\\text{yields})' : '(\\text{does not yield})'}`),
         eq(String.raw`A_s' = \dfrac{A_{s2} f_y}{f_s' - 0.85 f'_c} = \dfrac{${sn0(r.As2)}(${sn0(i.fy)})}{${sn1(r.fsPrime)} - ${sn2(0.85 * i.fc)}} = ${sn0(r.AsPrime)}\ \text{mm}^2`),
+        ...(r.comprLayers.length > 0 ? [
+          txt('Neutral-axis check: every compression bar must lie above the NA to actually be in compression — the deepest layer governs.'),
+          eq(String.raw`d'_{deepest} = ${sn0(r.dPrimeExtreme)}\ \text{mm} \;${r.comprNAOK ? '<' : '\\ge'}\; c = ${sn0(r.cNA)}\ \text{mm}\;${r.comprNAOK ? '\\checkmark' : '\\times'}`),
+        ] : []),
       ],
-      note: r.comprEffective
-        ? `Provide ${r.comprBars} ⌀${dbC} mm compression bars.`
-        : 'f′s ≤ 0.85f′c — compression steel is ineffective; enlarge the section.',
+      note: !r.comprEffective
+        ? 'f′s ≤ 0.85f′c — compression steel is ineffective; enlarge the section.'
+        : r.comprNAOK
+          ? `Provide ${r.comprBars} ⌀${dbC} mm compression bars.`
+          : '⚠ The deepest compression layer crosses the neutral axis — those bars are not in compression. Use a larger compression-bar diameter (fewer layers) or enlarge the section.',
     })
   }
 

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -81,7 +81,8 @@ export default function BeamDesign() {
             <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Section preview</h2>
             {r ? (
               <BeamSchematic b={f.b} h={f.h} cover={f.cover} barDia={f.barDia} stirrupDia={f.stirrupDia}
-                bars={r.bars} d={r.d} layers={r.layers} comprLayers={r.comprLayers}
+                bars={r.bars} d={r.d} dPrime={r.comprLayers.length > 0 ? r.dPrime : undefined}
+                layers={r.layers} comprLayers={r.comprLayers}
                 comprBars={r.comprBars} comprBarDia={f.comprBarDia} />
             ) : (
               <p className="py-8 text-center text-sm text-slate-400">Enter a valid section (d must be positive).</p>
@@ -110,6 +111,10 @@ export default function BeamDesign() {
                 <Row label="Compr. layers"
                   value={r.comprLayers.length > 1 ? `${r.comprLayers.length} (${r.comprLayers.join(' + ')})` : '1'}
                   sub={`d'=${f1(r.dPrime)} mm · s'_clear=${f0(r.comprSClear)} ≥ ${f0(r.comprSMinClear)}`} />
+              )}
+              {r.comprLayers.length > 0 && (
+                <Row label="NA check" value={r.comprNAOK ? '✓ above NA' : '✗ crosses NA'}
+                  sub={`deepest d'=${f0(r.dPrimeExtreme)} vs c=${f0(r.cNA)} mm`} />
               )}
               <Row label={<Math tex="\phi V_c" />} value={`${f1(r.phiVc)} kN`} sub={`Vc=${f1(r.Vc)}`} />
               <Row label="Shear" value={REGION[r.region]} />


### PR DESCRIPTION
Implements the follow-up review items.

## Neutral-axis check (the legacy check, as requested)
The **deepest compression layer** must stay above the neutral axis to actually be in compression: `d′_deepest = d′_base + (n_layers−1)(d_b′+25)` vs `c = a_max/β1`. Surfaced three ways: a Results row (✓ above NA / ✗ crosses NA with the numbers), a substituted check line in the compression-steel solution step, and a remedial note when it fails (use a larger compression-bar Ø → fewer layers, or enlarge the section).

## Schematic fixes
- **Hook redrawn**: the stirrup is now a single **open path** whose two ends genuinely wrap the top-left corner bar and extend into the core at 45° — proper 135° hooks at the real (scaled) bar thickness with round caps/joins, replacing the wrong diagonal strokes.
- **Red centroid cross**: thin and small (3.5 px arms, 1.1 stroke) with a **dashed extension line** running from the cross to the d dimension line.
- **DRRB**: a second cross at the **compression-steel centroid** with its own **d′ dimension line** (inner right) and dashed tie; the d line shifts outward to make room.

## Verification
2 new engine tests (92 total): the `d′_deepest` identity + NA pass for the known two-layer case, and the vacuous SRRB case. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)