### PR TITLE
Beam schematic v3: NA-clipped bars, D_bend hooks, + marks, error highlighting

### DIFF
--- a/webapp/src/components/BeamSchematic.tsx
+++ b/webapp/src/components/BeamSchematic.tsx
@@ -17,27 +17,34 @@ export interface BeamSchematicProps {
   comprLayers?: number[]
   comprBars?: number
   comprBarDia?: number
+  /** Neutral-axis depth c (mm) — used to cap drawn bars when the layout diverges. */
+  naDepth?: number
+  /** When false the section can't fit the steel: bars are clipped at the NA and
+   *  an explicit warning is drawn. */
+  flexOK?: boolean
 }
 
-/** Small thin × with dashed extension lines out to a dimension line. */
+/** Thin + mark with a dashed extension line out to a dimension line. */
 function CentroidMark({ cx, cy, toX }: { cx: number; cy: number; toX: number }) {
-  const X = 3.5
+  const A = 4
   return (
-    <g>
-      <line x1={cx - X} y1={cy - X} x2={cx + X} y2={cy + X} stroke={CENTROID} strokeWidth={1.1} />
-      <line x1={cx - X} y1={cy + X} x2={cx + X} y2={cy - X} stroke={CENTROID} strokeWidth={1.1} />
-      <line x1={cx + X + 2} y1={cy} x2={toX} y2={cy} stroke={CENTROID} strokeWidth={0.7} strokeDasharray="4 3" />
+    <g stroke={CENTROID} strokeWidth={0.7}>
+      <line x1={cx - A} y1={cy} x2={cx + A} y2={cy} />
+      <line x1={cx} y1={cy - A} x2={cx} y2={cy + A} />
+      <line x1={cx + A + 2} y1={cy} x2={toX} y2={cy} strokeDasharray="4 3" />
     </g>
   )
 }
 
-/** Beam cross-section to scale: open stirrup with two 135° corner hooks at its
- *  real thickness, layered tension + compression bars, red × centroid marks
- *  tied to the d / d′ dimension lines with dashed extensions. */
+/** Beam cross-section to scale: stirrup with 135° hooks that bend smoothly
+ *  around the corner bar at the D_bend radius, layered bars (clipped at the
+ *  NA when the section is over-full), and thin + centroid marks tied to the
+ *  d / d′ dimension lines. */
 export function BeamSchematic({
-  b, h, cover, barDia, stirrupDia, bars, d, dPrime, layers, comprLayers, comprBars = 0, comprBarDia,
+  b, h, cover, barDia, stirrupDia, bars, d, dPrime, layers, comprLayers,
+  comprBars = 0, comprBarDia, naDepth = 0, flexOK = true,
 }: BeamSchematicProps): JSX.Element {
-  const W = 330, H = 312
+  const W = 330, H = 322
   const padL = 56, padT = 30, availW = 150, availH = 210
   const s = Math.min(availW / b, availH / h)
   const bw = b * s, hh = h * s
@@ -45,57 +52,63 @@ export function BeamSchematic({
   const br = Math.max(3, (barDia / 2) * s)
   const dPx = d * s
 
-  // Stirrup centreline rectangle; stroke scaled to the actual bar thickness.
+  // Stirrup centreline; stroke scaled to the actual bar thickness. The bend
+  // radius is the §407.3.2 D_bend centreline: inside Ø 4ds → r = (4/2 + 1/2)ds.
   const inset = (cover + stirrupDia / 2) * s
   const stW = Math.max(1, stirrupDia * s)
   const sx0 = x0 + inset, sy0 = y0 + inset
   const sw = bw - 2 * inset, sh = hh - 2 * inset
-  const r = Math.max(2, 2 * stirrupDia * s)     // §407.3.2 bend: centreline radius ≈ 2ds
-  // 135° hook: wraps the corner bar and extends into the core at 45°.
+  const r = Math.max(3, 2.5 * stirrupDia * s)
   const ext = Math.max(6 * stirrupDia, 75) * s
   const e = ext / Math.SQRT2
 
-  // One open path: tip A → wrap top-left corner → full perimeter → wrap the
-  // same corner from the left leg → tip B. Both tips point into the core at 45°.
-  const stirrupPath = [
-    `M ${sx0 + r * 0.9 + e} ${sy0 + r * 0.1 + e}`,                 // tip A (from the top leg)
-    `L ${sx0 + r * 0.9} ${sy0 + r * 0.1}`,
-    `Q ${sx0 + r * 0.45} ${sy0 - stW * 0.15} ${sx0 + r} ${sy0}`,   // wrap onto the top leg
-    `L ${sx0 + sw - r} ${sy0}`,
-    `Q ${sx0 + sw} ${sy0} ${sx0 + sw} ${sy0 + r}`,
-    `L ${sx0 + sw} ${sy0 + sh - r}`,
-    `Q ${sx0 + sw} ${sy0 + sh} ${sx0 + sw - r} ${sy0 + sh}`,
-    `L ${sx0 + r} ${sy0 + sh}`,
-    `Q ${sx0} ${sy0 + sh} ${sx0} ${sy0 + sh - r}`,
-    `L ${sx0} ${sy0 + r}`,
-    `Q ${sx0 - stW * 0.15} ${sy0 + r * 0.45} ${sx0 + r * 0.1} ${sy0 + r * 0.9}`, // wrap from the left leg
-    `L ${sx0 + r * 0.1 + e} ${sy0 + r * 0.9 + e}`,                 // tip B
-  ].join(' ')
+  // 135° hooks around the top-left corner bar (centre O, radius r = D_bend).
+  // Hook 1 comes off the TOP leg: arc T(12:00) → L(9:00) → E1(7:30), then a
+  // straight 45° extension into the core. Hook 2 comes off the LEFT leg:
+  // arc L(9:00) → T(12:00) → E2(1:30), extension parallel to hook 1's.
+  const Ox = sx0 + r, Oy = sy0 + r
+  const k = Math.SQRT1_2 * r
+  const T = { x: Ox, y: Oy - r }
+  const L = { x: Ox - r, y: Oy }
+  const E1 = { x: Ox - k, y: Oy + k }
+  const E2 = { x: Ox + k, y: Oy - k }
+  const hook1 = `M ${T.x} ${T.y} A ${r} ${r} 0 0 0 ${E1.x} ${E1.y} L ${E1.x + e} ${E1.y + e}`
+  const hook2 = `M ${L.x} ${L.y} A ${r} ${r} 0 0 1 ${E2.x} ${E2.y} L ${E2.x + e} ${E2.y + e}`
 
   const lay = layers && layers.length > 0 ? layers : [Math.max(2, bars)]
-  const n = lay.reduce((a, k) => a + k, 0)
+  const n = lay.reduce((a, q) => a + q, 0)
   const x1 = x0 + (cover + stirrupDia + barDia / 2) * s
   const x2 = x0 + bw - (cover + stirrupDia + barDia / 2) * s
   const yBottom = y0 + hh - (cover + stirrupDia + barDia / 2) * s
   const pitch = (barDia + 25) * s
 
-  const rowX = (k: number) => Array.from({ length: k }, (_, i) => (k === 1 ? (x1 + x2) / 2 : x1 + ((x2 - x1) * i) / (k - 1)))
+  const rowX = (q: number) => Array.from({ length: q }, (_, i) => (q === 1 ? (x1 + x2) / 2 : x1 + ((x2 - x1) * i) / (q - 1)))
 
-  // Compression bars, layered downward from the top.
   const dbC = comprBarDia ?? barDia
   const brC = Math.max(3, (dbC / 2) * s)
   const cLay = comprLayers && comprLayers.length > 0 ? comprLayers : (comprBars > 0 ? [comprBars] : [])
-  const nC = cLay.reduce((a, k) => a + k, 0)
+  const nC = cLay.reduce((a, q) => a + q, 0)
   const yTop = y0 + (cover + stirrupDia + dbC / 2) * s
   const pitchC = (dbC + 25) * s
 
-  // Dimension-line x positions on the right: d′ inner, d outer.
+  // When the layout diverges, clip the drawing at the neutral axis: tension
+  // layers stay below it, compression layers above it.
+  const yNA = naDepth > 0 ? y0 + naDepth * s : sy0 + r
+  const maxTen = flexOK ? lay.length : Math.max(1, Math.floor((yBottom - yNA - br) / pitch) + 1)
+  const maxCom = flexOK ? cLay.length : Math.max(nC > 0 ? 1 : 0, Math.floor((yNA - brC - yTop) / pitchC) + 1)
+  const layDrawn = lay.slice(0, maxTen)
+  const cLayDrawn = cLay.slice(0, maxCom)
+
   const hasDP = nC > 0 && dPrime !== undefined
   const dxInner = x0 + bw + 14
   const dxOuter = x0 + bw + (hasDP ? 38 : 16)
   const cxMid = x0 + bw / 2
   const cyD = y0 + dPx
   const cyDP = hasDP ? y0 + (dPrime as number) * s : 0
+
+  const tenLabel = lay.length > 3
+    ? `${n} ⌀${barDia} mm — ${lay.length} layers`
+    : `${n} ⌀${barDia} mm${lay.length > 1 ? ` (${lay.join('+')})` : ''}`
 
   return (
     <svg viewBox={`0 0 ${W} ${H}`} xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet"
@@ -105,22 +118,36 @@ export function BeamSchematic({
       {/* concrete */}
       <rect x={x0} y={y0} width={bw} height={hh} rx={2} fill={FILL} stroke={STROKE} strokeWidth={1.6} />
 
-      {/* open stirrup with two 135° hooks at the top-left corner */}
-      <path d={stirrupPath} fill="none" stroke={BAR} strokeWidth={stW}
-        strokeLinecap="round" strokeLinejoin="round" opacity={0.8} />
+      {/* stirrup body + the two 135° corner hooks (smooth D_bend arcs) */}
+      <rect x={sx0} y={sy0} width={sw} height={sh} rx={r}
+        fill="none" stroke={BAR} strokeWidth={stW} opacity={0.8} />
+      <path d={hook1} fill="none" stroke={BAR} strokeWidth={stW} strokeLinecap="round" opacity={0.8} />
+      <path d={hook2} fill="none" stroke={BAR} strokeWidth={stW} strokeLinecap="round" opacity={0.8} />
 
       {/* compression bars (hollow), layered downward */}
-      {cLay.map((k, li) =>
-        rowX(k).map((bx, i) => (
+      {cLayDrawn.map((q, li) =>
+        rowX(q).map((bx, i) => (
           <circle key={`c${li}-${i}`} cx={bx} cy={yTop + li * pitchC} r={brC} fill="#fff" stroke={BAR} strokeWidth={1.6} />
         )),
       )}
 
       {/* tension bars (solid), layered upward */}
-      {lay.map((k, li) =>
-        rowX(k).map((bx, i) => (
+      {layDrawn.map((q, li) =>
+        rowX(q).map((bx, i) => (
           <circle key={`t${li}-${i}`} cx={bx} cy={yBottom - li * pitch} r={br} fill={BAR} />
         )),
+      )}
+
+      {/* over-full section: NA line + explicit warning */}
+      {!flexOK && (
+        <g>
+          <line x1={x0 - 4} y1={yNA} x2={x0 + bw + 4} y2={yNA} stroke={CENTROID} strokeWidth={0.8} strokeDasharray="6 4" />
+          <text x={x0 + bw - 4} y={yNA - 4} fontSize={8} fill={CENTROID} textAnchor="end">N.A.</text>
+          <text x={x0 + bw / 2} y={y0 + hh / 2} fontSize={9.5} fontWeight={700} fill={CENTROID} textAnchor="middle"
+            paintOrder="stroke" stroke="#fff" strokeWidth={3}>
+            ⚠ n = {bars} bars cannot fit in the section
+          </text>
+        </g>
       )}
 
       {/* centroid marks with dashed ties to their dimension lines */}
@@ -130,18 +157,16 @@ export function BeamSchematic({
       {/* labels: compression on top, tension at the bottom */}
       {nC > 0 && (
         <text x={x0 + bw / 2} y={y0 - 6} fontSize={8.5} fill={BAR} textAnchor="middle">
-          {nC} ⌀{dbC} mm{cLay.length > 1 ? ` (${cLay.join('+')})` : ''} top
+          {nC} ⌀{dbC} mm{cLay.length > 1 ? (cLay.length > 3 ? ` — ${cLay.length} layers` : ` (${cLay.join('+')})`) : ''} top
         </text>
       )}
-      <text x={x0 + bw / 2} y={y0 + hh + 12} fontSize={8.5} fill={BAR} textAnchor="middle">
-        {n} ⌀{barDia} mm{lay.length > 1 ? ` (${lay.join('+')})` : ''}
-      </text>
+      <text x={x0 + bw / 2} y={y0 + hh + 12} fontSize={8.5} fill={BAR} textAnchor="middle">{tenLabel}</text>
 
       {/* dimensions: b below, h left, d (and d′ for DRRB) right */}
       <DimBelow xA={x0} xB={x0 + bw} featY={y0 + hh + 14} dY={y0 + hh + 30} label={`b = ${Math.round(b)} mm`} />
       <DimSide yA={y0} yB={y0 + hh} featX={x0} dX={x0 - 16} label={`h = ${Math.round(h)} mm`} side="left" />
       {hasDP && (
-        <DimSide yA={y0} yB={cyDP} featX={x0 + bw} dX={dxInner} label={`d' = ${Math.round(dPrime as number)}`} side="right" />
+        <DimSide yA={y0} yB={cyDP} featX={x0 + bw} dX={dxInner} label={`d' = ${Math.round(dPrime as number)} mm`} side="right" />
       )}
       <DimSide yA={y0} yB={cyD} featX={x0 + bw} dX={dxOuter} label={`d = ${Math.round(d)} mm`} side="right" />
     </svg>

--- a/webapp/src/components/qty.tsx
+++ b/webapp/src/components/qty.tsx
@@ -58,12 +58,15 @@ export function ResultCard({ title, children }: { title: string; children: React
   )
 }
 
-export function Row({ label, value, sub }: { label: ReactNode; value: ReactNode; sub?: ReactNode }) {
+export function Row({ label, value, sub, alert }: {
+  label: ReactNode; value: ReactNode; sub?: ReactNode; alert?: boolean
+}) {
   return (
-    <div className="flex items-baseline justify-between gap-3 border-b border-slate-100 py-1.5 last:border-0">
-      <span className="text-sm text-slate-600">{label}</span>
-      <span className="text-right text-sm font-semibold text-slate-800">{value}</span>
-      {sub ? <span className="w-32 text-right text-xs text-slate-500">{sub}</span> : null}
+    <div className={`flex items-baseline justify-between gap-3 border-b py-1.5 last:border-0 ${
+      alert ? 'border-red-100 bg-red-50 px-2 -mx-2 rounded' : 'border-slate-100'}`}>
+      <span className={`text-sm ${alert ? 'text-red-700' : 'text-slate-600'}`}>{label}</span>
+      <span className={`text-right text-sm font-semibold ${alert ? 'text-red-700' : 'text-slate-800'}`}>{value}</span>
+      {sub ? <span className={`w-32 text-right text-xs ${alert ? 'text-red-500' : 'text-slate-500'}`}>{sub}</span> : null}
     </div>
   )
 }

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -83,7 +83,8 @@ export default function BeamDesign() {
               <BeamSchematic b={f.b} h={f.h} cover={f.cover} barDia={f.barDia} stirrupDia={f.stirrupDia}
                 bars={r.bars} d={r.d} dPrime={r.comprLayers.length > 0 ? r.dPrime : undefined}
                 layers={r.layers} comprLayers={r.comprLayers}
-                comprBars={r.comprBars} comprBarDia={f.comprBarDia} />
+                comprBars={r.comprBars} comprBarDia={f.comprBarDia}
+                naDepth={r.cNA} flexOK={r.flexOK} />
             ) : (
               <p className="py-8 text-center text-sm text-slate-400">Enter a valid section (d must be positive).</p>
             )}
@@ -92,7 +93,7 @@ export default function BeamDesign() {
           {r && (
             <ResultCard title="Results">
               {!r.flexOK && (
-                <Row label="⚠ Section" value="too small for the steel"
+                <Row alert label="⚠ Section" value={`${r.bars} bars cannot fit`}
                   sub="layout diverges — enlarge b or h" />
               )}
               <Row label="Effective depth d" value={`${f1(r.d)} mm`}
@@ -104,8 +105,11 @@ export default function BeamDesign() {
               <Row label="Layers" value={r.layers.length > 1 ? `${r.layers.length} (${r.layers.join(' + ')})` : '1'}
                 sub={`s_clear=${f0(r.sClear)} ≥ ${f0(r.sMinClear)} mm`} />
               {r.mode === 'DRRB' && (
-                <Row label="Compression steel" value={`${r.comprBars} ⌀${f.comprBarDia} mm`}
-                  sub={`A's=${f0(r.AsPrime)} mm² · f's=${f1(r.fsPrime)} MPa${r.fsYields ? '' : ' (n.y.)'}`} />
+                <Row alert={!r.comprEffective} label="Compression steel"
+                  value={r.comprEffective ? `${r.comprBars} ⌀${f.comprBarDia} mm` : '✗ ineffective'}
+                  sub={r.comprEffective
+                    ? `A's=${f0(r.AsPrime)} mm² · f's=${f1(r.fsPrime)} MPa${r.fsYields ? '' : ' (n.y.)'}`
+                    : `f's=${f1(r.fsPrime)} ≤ 0.85f'c`} />
               )}
               {r.comprLayers.length > 0 && (
                 <Row label="Compr. layers"
@@ -113,11 +117,11 @@ export default function BeamDesign() {
                   sub={`d'=${f1(r.dPrime)} mm · s'_clear=${f0(r.comprSClear)} ≥ ${f0(r.comprSMinClear)}`} />
               )}
               {r.comprLayers.length > 0 && (
-                <Row label="NA check" value={r.comprNAOK ? '✓ above NA' : '✗ crosses NA'}
+                <Row alert={!r.comprNAOK} label="NA check" value={r.comprNAOK ? '✓ above NA' : '✗ crosses NA'}
                   sub={`deepest d'=${f0(r.dPrimeExtreme)} vs c=${f0(r.cNA)} mm`} />
               )}
               <Row label={<Math tex="\phi V_c" />} value={`${f1(r.phiVc)} kN`} sub={`Vc=${f1(r.Vc)}`} />
-              <Row label="Shear" value={REGION[r.region]} />
+              <Row alert={r.region === 'inadequate'} label="Shear" value={REGION[r.region]} />
               <Row label="Stirrups" value={stirrupText}
                 sub={r.region === 'designed' ? `s_req=${f0(r.sReq)} · s_max=${f0(r.sMax)} mm` : undefined} />
               <Row label="Hooks (135°)" value={`ext ${f0(r.stirrupHookExt)} mm`}


### PR DESCRIPTION
Implements the latest review on the beam section drawing & results.

## Over-full section
- When the layout diverges (`flexOK = false`), drawn bars are **clipped at the neutral axis** — tension layers stop below it, compression layers above it — instead of flooding past the section. The NA is shown as a dashed red line, and the drawing says explicitly **"⚠ n = X bars cannot fit in the section"**. The Results row now reads "X bars cannot fit" too.
- The bottom label compacts to `161 ⌀20 mm — 6 layers` instead of the `(9+9+9+…)` string explosion.

## Error highlighting
Shared `Row` gains an `alert` prop (light-red background, red text). Applied to: section-too-small, **NA-check failure**, **ineffective compression steel** (now displayed as "✗ ineffective · f′s ≤ 0.85f′c" instead of "0 bars"), and inadequate shear.

## Drawing corrections
- **Hooks**: every stirrup corner now bends at the **D_bend centreline radius** (2.5·d_s, from the §407.3.2 inside Ø = 4d_s), and the two 135° hook ends are smooth **arcs around the top-left corner bar** (T→L→7:30 and L→T→1:30) with tangent 45° extensions into the core — replacing the straight diagonal stubs.
- **Centroid marks**: thin **+** (0.7 stroke — same weight as the dashed tie line) instead of the fat ×.
- **d′ dimension** now carries its `mm` unit.

## Verification
Build green; 92 tests passing (rendering-only changes — engine untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)