### PR TITLE
Beam Analysis (FEM): modular supports/loads, NSCP combos, three-moment check

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -3,6 +3,7 @@ import FoundationDesign from './pages/FoundationDesign'
 import PileCapDesign from './pages/PileCapDesign'
 import CombinedFootingDesign from './pages/CombinedFootingDesign'
 import BeamDesign from './pages/BeamDesign'
+import BeamAnalysis from './pages/BeamAnalysis'
 import SlabEstimate from './pages/SlabEstimate'
 import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
@@ -35,6 +36,7 @@ function Home() {
         <Tile to="/pile-cap">Pile Cap Design</Tile>
         <Tile to="/combined">Combined Footing</Tile>
         <Tile to="/beam-design">Beam Design</Tile>
+        <Tile to="/beam-analysis">Beam Analysis (FEM)</Tile>
       </div>
 
       <h2 className="mt-8 text-lg font-semibold text-slate-800">Material estimation (quantity take-off)</h2>
@@ -57,6 +59,7 @@ export default function App() {
       <Route path="/pile-cap" element={<PileCapDesign />} />
       <Route path="/combined" element={<CombinedFootingDesign />} />
       <Route path="/beam-design" element={<BeamDesign />} />
+      <Route path="/beam-analysis" element={<BeamAnalysis />} />
       <Route path="/estimate/slab" element={<SlabEstimate />} />
       <Route path="/estimate/beam" element={<BeamEstimate />} />
       <Route path="/estimate/column" element={<ColumnEstimate />} />

--- a/webapp/src/components/BeamElevation.tsx
+++ b/webapp/src/components/BeamElevation.tsx
@@ -1,0 +1,111 @@
+import type { JSX } from 'react'
+import type { Support, BeamLoad } from '../engine/beamAnalysis'
+
+const BEAM = '#37526e'
+const LOAD = '#dc2626'
+const MOM = '#7c3aed'
+const SUP = '#0056b3'
+
+/** Elevation sketch of the analysis model: beam line, support symbols
+ *  (pin / roller / fixed / spring) and load glyphs (point, UDL/VDL, moment). */
+export function BeamElevation({ L, supports, loads }: {
+  L: number; supports: Support[]; loads: BeamLoad[]
+}): JSX.Element {
+  const W = 560, H = 150
+  const padL = 30, padR = 30
+  const bx0 = padL, bx1 = W - padR
+  const sx = (x: number) => bx0 + ((bx1 - bx0) * Math.max(0, Math.min(L, x))) / Math.max(L, 1e-9)
+  const by = 92
+
+  const supSym = (s: Support, i: number) => {
+    const x = sx(s.x)
+    if (s.type === 'fixed') {
+      const dir = s.x < L / 2 ? -1 : 1
+      return (
+        <g key={`s${i}`} stroke={SUP} strokeWidth={1.6}>
+          <line x1={x} y1={by - 18} x2={x} y2={by + 18} />
+          {[-14, -7, 0, 7, 14].map((dy) => (
+            <line key={dy} x1={x} y1={by + dy} x2={x + dir * 7} y2={by + dy + 6} strokeWidth={1} />
+          ))}
+        </g>
+      )
+    }
+    if (s.type === 'spring') {
+      const zig = `M ${x} ${by + 2} l 0 4 l 5 3 l -10 5 l 10 5 l -10 5 l 5 3 l 0 4`
+      return (
+        <g key={`s${i}`} stroke={SUP} strokeWidth={1.4} fill="none">
+          <path d={zig} />
+          <line x1={x - 9} y1={by + 31} x2={x + 9} y2={by + 31} />
+          <text x={x} y={by + 43} fontSize={8} fill={SUP} textAnchor="middle" stroke="none">k={s.k ?? 1000}</text>
+        </g>
+      )
+    }
+    return (
+      <g key={`s${i}`} stroke={SUP} strokeWidth={1.4} fill="none">
+        <path d={`M ${x} ${by + 1} L ${x - 8} ${by + 15} L ${x + 8} ${by + 15} Z`} fill="#fff" />
+        {s.type === 'roller'
+          ? <g>{[-5, 0, 5].map((dx) => <circle key={dx} cx={x + dx} cy={by + 19} r={2.6} />)}</g>
+          : <g>{[-8, -3, 2, 7].map((dx) => <line key={dx} x1={x + dx} y1={by + 15} x2={x + dx - 4} y2={by + 21} strokeWidth={1} />)}</g>}
+        <text x={x} y={by + 32} fontSize={8} fill={SUP} textAnchor="middle" stroke="none">{s.type}</text>
+      </g>
+    )
+  }
+
+  const arrow = (x: number, y0: number, y1: number, color: string) => (
+    <g stroke={color} strokeWidth={1.4}>
+      <line x1={x} y1={y0} x2={x} y2={y1} />
+      <path d={`M ${x - 3.5} ${y1 - 6} L ${x} ${y1} L ${x + 3.5} ${y1 - 6}`} fill="none" />
+    </g>
+  )
+
+  const loadGlyph = (ld: BeamLoad, i: number) => {
+    if (ld.type === 'point') {
+      const x = sx(ld.x)
+      return (
+        <g key={`l${i}`}>
+          {arrow(x, by - 44, by - 3, LOAD)}
+          <text x={x} y={by - 48} fontSize={8.5} fill={LOAD} textAnchor="middle">{ld.P} kN ({ld.cat})</text>
+        </g>
+      )
+    }
+    if (ld.type === 'moment') {
+      const x = sx(ld.x)
+      const ccw = ld.M >= 0
+      return (
+        <g key={`l${i}`} stroke={MOM} fill="none" strokeWidth={1.4}>
+          <path d={`M ${x - 8} ${by - 12} A 9 9 0 1 ${ccw ? 0 : 1} ${x + 8} ${by - 12}`} />
+          <path d={ccw ? `M ${x + 8} ${by - 12} l -5 -4 m 5 4 l -6 2` : `M ${x - 8} ${by - 12} l 5 -4 m -5 4 l 6 2`} strokeWidth={1.2} />
+          <text x={x} y={by - 26} fontSize={8.5} fill={MOM} textAnchor="middle" stroke="none">{ld.M} kN·m ({ld.cat})</text>
+        </g>
+      )
+    }
+    const xa = sx(ld.x1), xb = sx(ld.x2)
+    const h1 = ld.type === 'udl' ? 26 : Math.max(8, 26 * (Math.abs(ld.w1) / Math.max(Math.abs(ld.w1), Math.abs(ld.w2), 1e-9)))
+    const h2 = ld.type === 'udl' ? 26 : Math.max(8, 26 * (Math.abs(ld.w2) / Math.max(Math.abs(ld.w1), Math.abs(ld.w2), 1e-9)))
+    const nA = Math.max(3, Math.floor((xb - xa) / 26))
+    const label = ld.type === 'udl' ? `${ld.w} kN/m (${ld.cat})` : `${ld.w1}→${ld.w2} kN/m (${ld.cat})`
+    return (
+      <g key={`l${i}`}>
+        <line x1={xa} y1={by - 4 - h1} x2={xb} y2={by - 4 - h2} stroke={LOAD} strokeWidth={1.2} />
+        {Array.from({ length: nA + 1 }, (_, j) => {
+          const t = j / nA
+          const x = xa + (xb - xa) * t
+          const hh = h1 + (h2 - h1) * t
+          return arrow(x, by - 4 - hh, by - 3, LOAD)
+        })}
+        <text x={(xa + xb) / 2} y={by - 10 - Math.max(h1, h2)} fontSize={8.5} fill={LOAD} textAnchor="middle">{label}</text>
+      </g>
+    )
+  }
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet"
+      style={{ width: '100%', height: 'auto', fontFamily: 'Arial, sans-serif' }}>
+      <line x1={bx0} y1={by} x2={bx1} y2={by} stroke={BEAM} strokeWidth={4} strokeLinecap="round" />
+      {supports.map(supSym)}
+      {loads.map(loadGlyph)}
+      <text x={bx0} y={by + 56} fontSize={9} fill={BEAM}>0</text>
+      <text x={bx1} y={by + 56} fontSize={9} fill={BEAM} textAnchor="end">L = {L} m</text>
+    </svg>
+  )
+}

--- a/webapp/src/engine/beamAnalysis.test.ts
+++ b/webapp/src/engine/beamAnalysis.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import { solveFEM, analyzeBeam, threeMoment, type Support, type BeamLoad } from './beamAnalysis'
+
+const E = 25000      // MPa
+const I = 3.125e9    // mm⁴ (≈ 250×500 gross)
+const EI = E * I * 1e-9  // kN·m²
+
+describe('FEM — closed-form checks', () => {
+  it('simply supported + UDL: R = wL/2, Mmax = wL²/8, δmax = 5wL⁴/384EI', () => {
+    const L = 6, w = 10
+    const supports: Support[] = [{ type: 'pin', x: 0 }, { type: 'roller', x: L }]
+    const loads: BeamLoad[] = [{ type: 'udl', x1: 0, x2: L, w, cat: 'D' }]
+    const r = solveFEM(supports, loads, L, E, I)!
+    expect(r.reactions[0].Rv).toBeCloseTo((w * L) / 2, 3)
+    expect(r.reactions[1].Rv).toBeCloseTo((w * L) / 2, 3)
+    expect(r.Mmax).toBeCloseTo((w * L * L) / 8, 2)
+    expect(r.Dmax).toBeCloseTo(((5 * w * L ** 4) / (384 * EI)) * 1000, 2)  // mm
+  })
+
+  it('simply supported + midspan point: Mmax = PL/4, δmax = PL³/48EI', () => {
+    const L = 6, P = 50
+    const r = solveFEM(
+      [{ type: 'pin', x: 0 }, { type: 'roller', x: L }],
+      [{ type: 'point', x: L / 2, P, cat: 'D' }], L, E, I)!
+    expect(r.Mmax).toBeCloseTo((P * L) / 4, 2)
+    expect(r.Dmax).toBeCloseTo(((P * L ** 3) / (48 * EI)) * 1000, 2)
+  })
+
+  it('cantilever + tip point: R = P, Mfix = −PL, δtip = PL³/3EI', () => {
+    const L = 3, P = 20
+    const r = solveFEM([{ type: 'fixed', x: 0 }], [{ type: 'point', x: L, P, cat: 'D' }], L, E, I)!
+    expect(r.reactions[0].Rv).toBeCloseTo(P, 3)
+    expect(Math.abs(r.reactions[0].Rm)).toBeCloseTo(P * L, 2)
+    expect(r.Dmax).toBeCloseTo(((P * L ** 3) / (3 * EI)) * 1000, 1)
+  })
+
+  it('spring support: R = k·δ at the spring', () => {
+    const L = 6, P = 50, k = 5000
+    const r = solveFEM(
+      [{ type: 'pin', x: 0 }, { type: 'spring', x: L, k }],
+      [{ type: 'point', x: L / 2, P, cat: 'D' }], L, E, I)!
+    const spring = r.reactions.find((s) => s.type === 'spring')!
+    const delta = -r.D[r.xs.length - 1] / 1000   // m, downward positive load → negative D
+    expect(spring.Rv).toBeCloseTo(k * -delta * -1, 1) // R = k·d (sign convention of solver)
+    // equilibrium: ΣR = P
+    expect(r.reactions.reduce((a, s) => a + s.Rv, 0)).toBeCloseTo(P, 3)
+  })
+
+  it('VDL (triangular 0→w): W = wL/2, Ra = wL/6 (resultant at 2L/3)', () => {
+    const L = 6, w = 12
+    const r = solveFEM(
+      [{ type: 'pin', x: 0 }, { type: 'roller', x: L }],
+      [{ type: 'vdl', x1: 0, x2: L, w1: 0, w2: w, cat: 'D' }], L, E, I)!
+    expect(r.reactions[0].Rv).toBeCloseTo((w * L) / 6, 2)
+    expect(r.reactions[1].Rv).toBeCloseTo((w * L) / 3, 2)
+  })
+})
+
+describe('three-moment theorem', () => {
+  it('two equal spans, UDL: interior moment = −wL²/8', () => {
+    const L = 4, w = 10
+    const lds: BeamLoad[] = [{ type: 'udl', x1: 0, x2: L, w, cat: 'D' }]
+    const r = threeMoment([L, L], [lds, lds])!
+    expect(r.supportMoments[1]).toBeCloseTo((-w * L * L) / 8, 1)
+    // total reactions balance the load
+    expect(r.reactions.reduce((a, v) => a + v, 0)).toBeCloseTo(2 * w * L, 3)
+  })
+})
+
+describe('analyzeBeam — NSCP combinations', () => {
+  const supports: Support[] = [{ type: 'pin', x: 0 }, { type: 'roller', x: 6 }]
+  const loads: BeamLoad[] = [
+    { type: 'udl', x1: 0, x2: 6, w: 8, cat: 'D' },
+    { type: 'udl', x1: 0, x2: 6, w: 5, cat: 'L' },
+  ]
+
+  it('runs all 7 combos; 1.2D+1.6L governs for D+L loading', () => {
+    const res = analyzeBeam(supports, loads, 6, E, I)!
+    expect(res.perCombo).toHaveLength(7)
+    expect(res.perCombo[res.govIdx].combo.name).toContain('1.2D + 1.6L')
+    const wu = 1.2 * 8 + 1.6 * 5    // 17.6
+    expect(res.perCombo[res.govIdx].result!.Mmax).toBeCloseTo((wu * 36) / 8, 1)
+  })
+
+  it('TMT check appears for a 3-support continuous beam and matches FEM', () => {
+    const cont: Support[] = [{ type: 'pin', x: 0 }, { type: 'roller', x: 3 }, { type: 'roller', x: 6 }]
+    const res = analyzeBeam(cont, [{ type: 'udl', x1: 0, x2: 6, w: 10, cat: 'D' }], 6, E, I)!
+    expect(res.tmt).not.toBeNull()
+    const gov = res.perCombo[res.govIdx].result!
+    // FEM reactions ≈ TMT reactions
+    res.tmt!.reactions.forEach((R, i) => expect(gov.reactions[i].Rv).toBeCloseTo(R, 1))
+    // interior support moment ≈ −wu·l²/8 with l = 3 (equal spans, w = 14)
+    const wu = 1.4 * 10
+    expect(res.tmt!.supportMoments[1]).toBeCloseTo((-wu * 9) / 8, 1)
+  })
+
+  it('TMT is suppressed when a fixed or spring support exists', () => {
+    const withFixed: Support[] = [{ type: 'fixed', x: 0 }, { type: 'roller', x: 3 }, { type: 'roller', x: 6 }]
+    const res = analyzeBeam(withFixed, [{ type: 'udl', x1: 0, x2: 6, w: 10, cat: 'D' }], 6, E, I)!
+    expect(res.tmt).toBeNull()
+  })
+})

--- a/webapp/src/engine/beamAnalysis.ts
+++ b/webapp/src/engine/beamAnalysis.ts
@@ -1,0 +1,466 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Beam analysis — Euler-Bernoulli FEM (Hermite cubic elements, Gauss-5
+// consistent load vectors) with modular supports (pin / roller / fixed /
+// spring at any position) and categorised loads (point / UDL / VDL / applied
+// moment) run through the NSCP 2015 load combinations. Includes the
+// three-moment (Clapeyron) cross-check for continuous pin/roller beams.
+// Faithful port of the legacy beamDesign.html analysis module.
+// Units: m, kN, kN·m; E in MPa; I in mm⁴; deflection returned in mm.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type SupportType = 'pin' | 'roller' | 'fixed' | 'spring'
+export interface Support { type: SupportType; x: number; k?: number /* kN/m, spring */ }
+
+export type LoadCategory = 'D' | 'L' | 'Lr' | 'S' | 'R' | 'W' | 'E'
+export type BeamLoad =
+  | { type: 'point'; x: number; P: number; cat: LoadCategory }
+  | { type: 'udl'; x1: number; x2: number; w: number; cat: LoadCategory }
+  | { type: 'vdl'; x1: number; x2: number; w1: number; w2: number; cat: LoadCategory }
+  | { type: 'moment'; x: number; M: number; cat: LoadCategory }
+
+export interface Reaction { type: SupportType; x: number; Rv: number; Rm: number; k?: number }
+export interface FemResult {
+  xs: number[]; V: number[]; M: number[]; D: number[]   // D in mm
+  reactions: Reaction[]
+  Vmax: number; Mmax: number; Dmax: number
+}
+
+export interface Combo { name: string; f: Partial<Record<LoadCategory, number>> }
+export const NSCP_COMBOS: Combo[] = [
+  { name: '1.4D', f: { D: 1.4 } },
+  { name: '1.2D + 1.6L + 0.5(Lr|S|R)', f: { D: 1.2, L: 1.6, Lr: 0.5, S: 0.5, R: 0.5 } },
+  { name: '1.2D + 1.6(Lr|S|R) + (L|0.5W)', f: { D: 1.2, Lr: 1.6, S: 1.6, R: 1.6, L: 1.0, W: 0.5 } },
+  { name: '1.2D + 1.0W + L + 0.5(Lr|S|R)', f: { D: 1.2, W: 1.0, L: 1.0, Lr: 0.5, S: 0.5, R: 0.5 } },
+  { name: '0.9D + 1.0W', f: { D: 0.9, W: 1.0 } },
+  { name: '1.2D + 1.0E + L + 0.2S', f: { D: 1.2, E: 1.0, L: 1.0, S: 0.2 } },
+  { name: '0.9D + 1.0E', f: { D: 0.9, E: 1.0 } },
+]
+
+const roundX = (x: number, dec = 8) => Math.round(x * 10 ** dec) / 10 ** dec
+const clamp = (x: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, x))
+
+// ── Linear algebra ────────────────────────────────────────────────────────
+function solveLinear(A: number[][], b: number[]): number[] | null {
+  const n = b.length
+  const M = A.map((row, i) => [...row, b[i]])
+  for (let k = 0; k < n; k++) {
+    let piv = k
+    for (let i = k + 1; i < n; i++) if (Math.abs(M[i][k]) > Math.abs(M[piv][k])) piv = i
+    if (piv !== k) [M[k], M[piv]] = [M[piv], M[k]]
+    if (Math.abs(M[k][k]) < 1e-14) return null
+    for (let i = k + 1; i < n; i++) {
+      const f = M[i][k] / M[k][k]
+      for (let j = k; j <= n; j++) M[i][j] -= f * M[k][j]
+    }
+  }
+  const x = new Array(n).fill(0)
+  for (let i = n - 1; i >= 0; i--) {
+    let s = M[i][n]
+    for (let j = i + 1; j < n; j++) s -= M[i][j] * x[j]
+    x[i] = s / M[i][i]
+  }
+  return x
+}
+
+// ── Load helpers ──────────────────────────────────────────────────────────
+export function loadResultant(ld: BeamLoad): { W: number; xc: number } {
+  if (ld.type === 'point') return { W: ld.P, xc: ld.x }
+  if (ld.type === 'udl') return { W: ld.w * (ld.x2 - ld.x1), xc: (ld.x1 + ld.x2) / 2 }
+  if (ld.type === 'vdl') {
+    const t = ld.x2 - ld.x1
+    const W = ld.w1 * t + ((ld.w2 - ld.w1) * t) / 2
+    if (Math.abs(W) < 1e-12) return { W: 0, xc: ld.x1 }
+    const num = (ld.w1 * t * t) / 2 + ((ld.w2 - ld.w1) * t * t) / 3
+    return { W, xc: ld.x1 + num / W }
+  }
+  return { W: 0, xc: 0 }
+}
+
+export function scaleLoad(ld: BeamLoad, f: number): BeamLoad {
+  if (ld.type === 'point') return { ...ld, P: ld.P * f }
+  if (ld.type === 'udl') return { ...ld, w: ld.w * f }
+  if (ld.type === 'vdl') return { ...ld, w1: ld.w1 * f, w2: ld.w2 * f }
+  return { ...ld, M: ld.M * f }
+}
+
+export function applyCombo(loads: BeamLoad[], factors: Partial<Record<LoadCategory, number>>): BeamLoad[] {
+  return loads
+    .map((ld) => scaleLoad(ld, factors[ld.cat] ?? 0))
+    .filter((ld) => {
+      if (ld.type === 'point') return Math.abs(ld.P) > 1e-9
+      if (ld.type === 'udl') return Math.abs(ld.w) > 1e-9
+      if (ld.type === 'vdl') return Math.abs(ld.w1) + Math.abs(ld.w2) > 1e-9
+      return Math.abs(ld.M) > 1e-9
+    })
+}
+
+function loadIntensity(ld: BeamLoad, x: number): number {
+  if (ld.type === 'udl') return ld.x1 <= x && x <= ld.x2 ? ld.w : 0
+  if (ld.type === 'vdl') {
+    if (!(ld.x1 <= x && x <= ld.x2)) return 0
+    const span = Math.max(ld.x2 - ld.x1, 1e-9)
+    return ld.w1 + ((ld.w2 - ld.w1) * (x - ld.x1)) / span
+  }
+  return 0
+}
+
+function hermite(xi: number, le: number): [number, number, number, number] {
+  return [
+    1 - 3 * xi * xi + 2 * xi * xi * xi,
+    le * xi * (1 - xi) * (1 - xi),
+    3 * xi * xi - 2 * xi * xi * xi,
+    le * xi * xi * (xi - 1),
+  ]
+}
+
+function gauss5Vec(f: (x: number) => number[], a: number, b: number): number[] {
+  const gp = [-0.90618, -0.53847, 0, 0.53847, 0.90618]
+  const gw = [0.23693, 0.47863, 0.56889, 0.47863, 0.23693]
+  const mid = (a + b) / 2, half = (b - a) / 2
+  const acc = [0, 0, 0, 0]
+  for (let i = 0; i < 5; i++) {
+    const fi = f(mid + half * gp[i])
+    for (let j = 0; j < 4; j++) acc[j] += gw[i] * fi[j]
+  }
+  return acc.map((v) => half * v)
+}
+
+// ── FEM solver ────────────────────────────────────────────────────────────
+export function solveFEM(supports: Support[], loads: BeamLoad[], L: number, E_MPa: number, I_mm4: number): FemResult | null {
+  const EI = E_MPa * I_mm4 * 1e-9 // kN·m²
+
+  // Node set: ends, supports, load anchors, then N_INT subdivisions per span.
+  const nodeSet = new Set<number>([roundX(0), roundX(L)])
+  supports.forEach((s) => nodeSet.add(roundX(clamp(s.x, 0, L))))
+  loads.forEach((ld) => {
+    if (ld.type === 'point' || ld.type === 'moment') nodeSet.add(roundX(clamp(ld.x, 0, L)))
+    else { nodeSet.add(roundX(clamp(ld.x1, 0, L))); nodeSet.add(roundX(clamp(ld.x2, 0, L))) }
+  })
+  const anchor = [...nodeSet].sort((a, b) => a - b)
+  const N_INT = 25
+  for (let i = 0; i < anchor.length - 1; i++) {
+    const xa = anchor[i], xb = anchor[i + 1]
+    for (let j = 1; j < N_INT; j++) nodeSet.add(roundX(xa + ((xb - xa) * j) / N_INT))
+  }
+  const nodes = [...nodeSet].sort((a, b) => a - b)
+  const n = nodes.length
+  const ndof = 2 * n
+  const nm = new Map<number, number>()
+  nodes.forEach((x, i) => nm.set(x, i))
+
+  // Assemble K, F.
+  const K: number[][] = Array.from({ length: ndof }, () => new Array(ndof).fill(0))
+  const F = new Array(ndof).fill(0)
+  for (let e = 0; e < n - 1; e++) {
+    const x1n = nodes[e], x2n = nodes[e + 1]
+    const le = x2n - x1n
+    if (le < 1e-10) continue
+    const c = EI / (le * le * le)
+    const ke = [
+      [12 * c, 6 * le * c, -12 * c, 6 * le * c],
+      [6 * le * c, 4 * le * le * c, -6 * le * c, 2 * le * le * c],
+      [-12 * c, -6 * le * c, 12 * c, -6 * le * c],
+      [6 * le * c, 2 * le * le * c, -6 * le * c, 4 * le * le * c],
+    ]
+    const i1 = nm.get(x1n)!, i2 = nm.get(x2n)!
+    const dofs = [2 * i1, 2 * i1 + 1, 2 * i2, 2 * i2 + 1]
+    for (let a = 0; a < 4; a++) for (let b = 0; b < 4; b++) K[dofs[a]][dofs[b]] += ke[a][b]
+
+    for (const ld of loads) {
+      if (ld.type !== 'udl' && ld.type !== 'vdl') continue
+      const la = Math.max(x1n, roundX(ld.x1))
+      const lb = Math.min(x2n, roundX(ld.x2))
+      if (lb <= la) continue
+      const fe = gauss5Vec((xg) => {
+        const w = loadIntensity(ld, xg)
+        return hermite((xg - x1n) / le, le).map((v) => -w * v)
+      }, la, lb)
+      for (let j = 0; j < 4; j++) F[dofs[j]] += fe[j]
+    }
+  }
+  for (const ld of loads) {
+    if (ld.type === 'point') {
+      const i = nm.get(roundX(clamp(ld.x, 0, L)))
+      if (i !== undefined) F[2 * i] -= ld.P
+    } else if (ld.type === 'moment') {
+      const i = nm.get(roundX(clamp(ld.x, 0, L)))
+      if (i !== undefined) F[2 * i + 1] += ld.M
+    }
+  }
+
+  // Boundary conditions (springs add stiffness; pins/rollers fix v; fixed also θ).
+  const constrained = new Set<number>()
+  for (const s of supports) {
+    const i = nm.get(roundX(clamp(s.x, 0, L)))
+    if (i === undefined) continue
+    if (s.type === 'spring') K[2 * i][2 * i] += Math.max(s.k ?? 1000, 1e-3)
+    else {
+      constrained.add(2 * i)
+      if (s.type === 'fixed') constrained.add(2 * i + 1)
+    }
+  }
+  const free: number[] = []
+  for (let dof = 0; dof < ndof; dof++) if (!constrained.has(dof)) free.push(dof)
+
+  const d = new Array(ndof).fill(0)
+  if (free.length > 0) {
+    const Kff = free.map((i) => free.map((j) => K[i][j]))
+    const dFree = solveLinear(Kff, free.map((i) => F[i]))
+    if (dFree === null) return null
+    free.forEach((dof, idx) => (d[dof] = dFree[idx]))
+  }
+
+  // Reactions.
+  const Kd = new Array(ndof).fill(0)
+  for (let i = 0; i < ndof; i++) for (let j = 0; j < ndof; j++) Kd[i] += K[i][j] * d[j]
+  const Rfull = Kd.map((v, i) => v - F[i])
+  const react: Reaction[] = []
+  for (const s of supports) {
+    const sx = roundX(clamp(s.x, 0, L))
+    const i = nm.get(sx)
+    if (i === undefined) continue
+    if (s.type === 'spring') react.push({ ...s, x: sx, Rv: Math.max(s.k ?? 1000, 1e-3) * d[2 * i], Rm: 0 })
+    else react.push({ ...s, x: sx, Rv: Rfull[2 * i], Rm: s.type === 'fixed' ? -Rfull[2 * i + 1] : 0 })
+  }
+
+  // Equilibrium correction — distribute the tiny cubic-FEM residual to the
+  // two outermost supports so statics-based V/M close exactly.
+  let Wtot = 0, Mw = 0
+  for (const ld of loads) {
+    if (ld.type === 'moment') Mw -= ld.M
+    else { const { W, xc } = loadResultant(ld); Wtot += W; Mw += W * xc }
+  }
+  const Rvsum = react.reduce((a, r) => a + r.Rv, 0)
+  const RMsum = react.reduce((a, r) => a + r.Rv * r.x - r.Rm, 0)
+  const resV = Wtot - Rvsum, resM = Mw - RMsum
+  if (react.length >= 2) {
+    const x0 = react[0].x, xN = react[react.length - 1].x
+    const dx = xN - x0
+    if (Math.abs(dx) > 1e-6) {
+      const dN = (resM - resV * x0) / dx
+      react[0].Rv += resV - dN
+      react[react.length - 1].Rv += dN
+    }
+  }
+
+  // Diagram sampling (extra points hugging supports & point loads).
+  const xsSet = new Set<number>()
+  const Nsample = 500
+  for (let i = 0; i <= Nsample; i++) xsSet.add(roundX((i * L) / Nsample))
+  const eps = Math.max(L / 120, 0.02)
+  for (const s of supports) {
+    const sx = roundX(clamp(s.x, 0, L))
+    xsSet.add(Math.max(0, sx - eps)); xsSet.add(sx); xsSet.add(Math.min(L, sx + eps))
+  }
+  for (const ld of loads) {
+    if (ld.type === 'point' || ld.type === 'moment') {
+      const px = roundX(clamp(ld.x, 0, L))
+      xsSet.add(Math.max(0, px - 1e-4)); xsSet.add(px); xsSet.add(Math.min(L, px + 1e-4))
+    } else { xsSet.add(roundX(clamp(ld.x1, 0, L))); xsSet.add(roundX(clamp(ld.x2, 0, L))) }
+  }
+  const xs = [...xsSet].filter((x) => x >= 0 && x <= L).sort((a, b) => a - b)
+
+  // V, M by statics from the (corrected) reactions.
+  const V = new Array(xs.length).fill(0)
+  const M = new Array(xs.length).fill(0)
+  for (let k = 0; k < xs.length; k++) {
+    const x = xs[k]
+    let v = 0, m = 0
+    for (const r of react) {
+      if (r.x <= x) v += r.Rv
+      if (r.x < x) m += r.Rv * (x - r.x) + r.Rm
+      else if (r.x <= x && Math.abs(r.x) < 1e-9) m += r.Rm
+    }
+    for (const ld of loads) {
+      if (ld.type === 'point') {
+        if (ld.x <= x) { v -= ld.P; m -= ld.P * (x - ld.x) }
+      } else if (ld.type === 'udl') {
+        if (ld.x1 < x) {
+          const seg = Math.min(x, ld.x2) - ld.x1
+          const W = ld.w * seg
+          v -= W; m -= W * (x - (ld.x1 + seg / 2))
+        }
+      } else if (ld.type === 'vdl') {
+        if (ld.x1 < x) {
+          const span = Math.max(ld.x2 - ld.x1, 1e-9)
+          const t = Math.min(x, ld.x2) - ld.x1
+          const W = ld.w1 * t + ((ld.w2 - ld.w1) * t * t) / (2 * span)
+          const num = (ld.w1 * t * t) / 2 + ((ld.w2 - ld.w1) * t * t * t) / (3 * span)
+          const xc = ld.x1 + (W > 1e-9 ? num / W : t / 2)
+          v -= W; m -= W * (x - xc)
+        }
+      } else if (ld.type === 'moment') {
+        if (ld.x <= x) m += ld.M
+      }
+    }
+    V[k] = v; M[k] = m
+  }
+
+  // Deflection via Hermite interpolation of the FEM solution.
+  const interpDelta = (x: number): number => {
+    x = clamp(x, 0, L)
+    for (let e = 0; e < n - 1; e++) {
+      const x1n = nodes[e], x2n = nodes[e + 1]
+      if (x1n - 1e-9 <= x && x <= x2n + 1e-9) {
+        const le = x2n - x1n
+        if (le < 1e-10) return d[2 * nm.get(x1n)!]
+        const N = hermite((x - x1n) / le, le)
+        const i1 = nm.get(x1n)!, i2 = nm.get(x2n)!
+        return N[0] * d[2 * i1] + N[1] * d[2 * i1 + 1] + N[2] * d[2 * i2] + N[3] * d[2 * i2 + 1]
+      }
+    }
+    return 0
+  }
+  const D = xs.map((x) => interpDelta(x) * 1000)
+
+  return {
+    xs, V, M, D, reactions: react,
+    Vmax: Math.max(...V.map(Math.abs)),
+    Mmax: Math.max(...M.map(Math.abs)),
+    Dmax: Math.max(...D.map(Math.abs)),
+  }
+}
+
+// ── Three-moment theorem (Clapeyron) cross-check ─────────────────────────
+function reactionsSS(L: number, loads: BeamLoad[]): { Ra: number; Rb: number } {
+  let sumW = 0, sumMx = 0, sumMc = 0
+  for (const ld of loads) {
+    if (ld.type === 'moment') sumMc += ld.M
+    else { const { W, xc } = loadResultant(ld); sumW += W; sumMx += W * xc }
+  }
+  const Rb = (sumMx - sumMc) / L
+  return { Ra: sumW - Rb, Rb }
+}
+
+function shearMomentAtSS(x: number, Ra: number, loads: BeamLoad[]): { V: number; M: number } {
+  let v = Ra, m = Ra * x
+  for (const ld of loads) {
+    if (ld.type === 'point') {
+      if (ld.x <= x) { v -= ld.P; m -= ld.P * (x - ld.x) }
+    } else if (ld.type === 'udl' || ld.type === 'vdl') {
+      if (ld.x1 < x) {
+        const seg = Math.min(x, ld.x2) - ld.x1
+        let W: number, xc: number
+        if (ld.type === 'udl') { W = ld.w * seg; xc = ld.x1 + seg / 2 }
+        else {
+          W = ld.w1 * seg + ((ld.w2 - ld.w1) * seg) / 2
+          const num = (ld.w1 * seg * seg) / 2 + ((ld.w2 - ld.w1) * seg * seg) / 3
+          xc = ld.x1 + (Math.abs(W) > 1e-12 ? num / W : seg / 2)
+        }
+        v -= W; m -= W * (x - xc)
+      }
+    } else if (ld.type === 'moment') { if (ld.x <= x) m += ld.M }
+  }
+  return { V: v, M: m }
+}
+
+function trapz(y: number[], x: number[]): number {
+  let s = 0
+  for (let i = 1; i < x.length; i++) s += 0.5 * (y[i] + y[i - 1]) * (x[i] - x[i - 1])
+  return s
+}
+
+export interface ThreeMomentResult { supportMoments: number[]; reactions: number[] }
+
+export function threeMoment(spans: number[], loadsPerSpan: BeamLoad[][]): ThreeMomentResult | null {
+  const n = spans.length
+  if (n === 1) {
+    const { Ra, Rb } = reactionsSS(spans[0], loadsPerSpan[0])
+    return { supportMoments: [0, 0], reactions: [Ra, Rb] }
+  }
+  const sixQm = (L: number, lds: BeamLoad[], fromRight: boolean): number => {
+    const { Ra } = reactionsSS(L, lds)
+    const N = 200
+    const xs: number[] = []
+    for (let i = 0; i <= N; i++) xs.push((i * L) / N)
+    const Mss = xs.map((x) => shearMomentAtSS(x, Ra, lds).M)
+    const integrand = Mss.map((m, i) => m * (fromRight ? L - xs[i] : xs[i]))
+    return (6 / L) * trapz(integrand, xs)
+  }
+  const sixL = spans.map((L, i) => sixQm(L, loadsPerSpan[i], false))
+  const sixR = spans.map((L, i) => sixQm(L, loadsPerSpan[i], true))
+  const size = n - 1
+  const A = Array.from({ length: size }, () => new Array(size).fill(0))
+  const b = new Array(size).fill(0)
+  for (let k = 0; k < size; k++) {
+    A[k][k] = 2 * (spans[k] + spans[k + 1])
+    if (k > 0) A[k][k - 1] = spans[k]
+    if (k < size - 1) A[k][k + 1] = spans[k + 1]
+    b[k] = -(sixL[k] + sixR[k + 1])
+  }
+  const Mint = solveLinear(A, b)
+  if (!Mint) return null
+  const supportMoments = [0, ...Mint, 0]
+  const reactions = new Array(n + 1).fill(0)
+  for (let i = 0; i < n; i++) {
+    const L = spans[i]
+    const Mi = supportMoments[i], Mj = supportMoments[i + 1]
+    const { Ra, Rb } = reactionsSS(L, loadsPerSpan[i])
+    reactions[i] += Ra + (Mj - Mi) / L
+    reactions[i + 1] += Rb + (Mi - Mj) / L
+  }
+  return { supportMoments, reactions }
+}
+
+// ── Orchestrator: run every NSCP combination, pick the governing one ─────
+export interface ComboRun { combo: Combo; result: FemResult | null; factored: BeamLoad[]; skipped: boolean }
+export interface TmtCheck { positions: number[]; supportMoments: number[]; reactions: number[] }
+export interface BeamAnalysisResult {
+  perCombo: ComboRun[]
+  govIdx: number
+  /** Three-moment cross-check on the governing combo (continuous pin/roller beams only). */
+  tmt: TmtCheck | null
+}
+
+export function analyzeBeam(supports: Support[], loads: BeamLoad[], L: number, E: number, I: number): BeamAnalysisResult | null {
+  const perCombo: ComboRun[] = []
+  let govIdx = -1, govM = -1
+  for (const combo of NSCP_COMBOS) {
+    const factored = applyCombo(loads, combo.f)
+    if (factored.length === 0) { perCombo.push({ combo, result: null, factored, skipped: true }); continue }
+    const r = solveFEM(supports, factored, L, E, I)
+    perCombo.push({ combo, result: r, factored, skipped: false })
+    if (r && r.Mmax > govM) { govM = r.Mmax; govIdx = perCombo.length - 1 }
+  }
+  if (govIdx < 0) return null
+
+  // TMT applies to continuous beams on ≥3 distinct pin/roller supports only.
+  let tmt: TmtCheck | null = null
+  const simple = supports
+    .filter((s) => s.type === 'pin' || s.type === 'roller')
+    .map((s) => clamp(s.x, 0, L))
+    .sort((a, b) => a - b)
+  const distinct: number[] = []
+  for (const x of simple) if (!distinct.length || Math.abs(distinct[distinct.length - 1] - x) > 1e-6) distinct.push(x)
+  const hasOther = supports.some((s) => s.type === 'fixed' || s.type === 'spring')
+  if (distinct.length >= 3 && !hasOther) {
+    const gov = perCombo[govIdx]
+    const spans: number[] = []
+    const loadsPer: BeamLoad[][] = []
+    for (let i = 0; i < distinct.length - 1; i++) {
+      const xL = distinct[i], xR = distinct[i + 1]
+      spans.push(xR - xL)
+      const spanLoads: BeamLoad[] = []
+      for (const ld of gov.factored) {
+        if (ld.type === 'point' || ld.type === 'moment') {
+          if (ld.x >= xL - 1e-6 && ld.x <= xR + 1e-6) spanLoads.push({ ...ld, x: ld.x - xL })
+        } else {
+          const a = Math.max(ld.x1, xL), b = Math.min(ld.x2, xR)
+          if (b > a + 1e-9) {
+            if (ld.type === 'udl') spanLoads.push({ ...ld, x1: a - xL, x2: b - xL })
+            else {
+              const span = Math.max(ld.x2 - ld.x1, 1e-9)
+              const wAt = (xq: number) => ld.w1 + ((ld.w2 - ld.w1) * (xq - ld.x1)) / span
+              spanLoads.push({ ...ld, w1: wAt(a), w2: wAt(b), x1: a - xL, x2: b - xL })
+            }
+          }
+        }
+      }
+      loadsPer.push(spanLoads)
+    }
+    const res = threeMoment(spans, loadsPer)
+    if (res) tmt = { positions: distinct, supportMoments: res.supportMoments, reactions: res.reactions }
+  }
+
+  return { perCombo, govIdx, tmt }
+}

--- a/webapp/src/pages/BeamAnalysis.tsx
+++ b/webapp/src/pages/BeamAnalysis.tsx
@@ -1,0 +1,254 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import {
+  analyzeBeam, type Support, type SupportType, type BeamLoad, type LoadCategory,
+} from '../engine/beamAnalysis'
+import { BeamElevation } from '../components/BeamElevation'
+import { Diagram } from '../components/Diagram'
+import { ReportControls } from '../components/ReportControls'
+import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
+import { f1, f2 } from '../lib/format'
+import 'katex/dist/katex.min.css'
+
+const CATS: [LoadCategory, string][] = [
+  ['D', 'D — dead'], ['L', 'L — live'], ['Lr', 'Lr — roof live'],
+  ['S', 'S — snow'], ['R', 'R — rain'], ['W', 'W — wind'], ['E', 'E — seismic'],
+]
+
+let uid = 1
+interface SupRow extends Support { id: number }
+type LoadRow = BeamLoad & { id: number }
+
+const DEF_SUPPORTS: SupRow[] = [
+  { id: uid++, type: 'pin', x: 0 },
+  { id: uid++, type: 'roller', x: 6 },
+]
+const DEF_LOADS: LoadRow[] = [
+  { id: uid++, type: 'udl', x1: 0, x2: 6, w: 8, cat: 'D' },
+  { id: uid++, type: 'udl', x1: 0, x2: 6, w: 5, cat: 'L' },
+]
+
+function ItemShell({ title, onRemove, children }: {
+  title: string; onRemove: () => void; children: React.ReactNode
+}) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-xs font-bold uppercase tracking-wide text-slate-500">{title}</span>
+        <button type="button" onClick={onRemove} className="text-xs text-red-500 hover:underline">remove</button>
+      </div>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">{children}</div>
+    </div>
+  )
+}
+
+export default function BeamAnalysis() {
+  const [L, setL] = useState(6)
+  const [E, setE] = useState(25000)
+  const [I, setI] = useState(3.125e9)
+  const [supports, setSupports] = useState<SupRow[]>(DEF_SUPPORTS)
+  const [loads, setLoads] = useState<LoadRow[]>(DEF_LOADS)
+  const [selIdx, setSelIdx] = useState<number | null>(null)
+
+  const setSup = (id: number, patch: Partial<SupRow>) =>
+    setSupports((ss) => ss.map((s) => (s.id === id ? { ...s, ...patch } : s)))
+  const setLoad = (id: number, patch: Partial<LoadRow>) =>
+    setLoads((ls) => ls.map((l) => (l.id === id ? { ...l, ...patch } as LoadRow : l)))
+
+  const addSupport = (type: SupportType) =>
+    setSupports((ss) => [...ss, { id: uid++, type, x: L / 2, ...(type === 'spring' ? { k: 5000 } : {}) }])
+  const addLoad = (type: BeamLoad['type']) => {
+    const base = { id: uid++, cat: 'D' as LoadCategory }
+    if (type === 'point') setLoads((ls) => [...ls, { ...base, type, x: L / 2, P: 50 }])
+    else if (type === 'udl') setLoads((ls) => [...ls, { ...base, type, x1: 0, x2: L, w: 10 }])
+    else if (type === 'vdl') setLoads((ls) => [...ls, { ...base, type, x1: 0, x2: L, w1: 0, w2: 10 }])
+    else setLoads((ls) => [...ls, { ...base, type, x: L / 2, M: 20 }])
+  }
+
+  const stable = supports.length >= 2 || supports.some((s) => s.type === 'fixed')
+  const valid = L > 0 && E > 0 && I > 0 && stable && loads.length > 0
+
+  const res = useMemo(() => {
+    if (!valid) return null
+    try { return analyzeBeam(supports, loads, L, E, I) } catch { return null }
+  }, [supports, loads, L, E, I, valid])
+
+  const shownIdx = selIdx !== null && res && res.perCombo[selIdx]?.result ? selIdx : res?.govIdx ?? 0
+  const shown = res ? res.perCombo[shownIdx] : null
+  const r = shown?.result ?? null
+  const allowDefl = (L * 1000) / 360
+  const vlines = supports.map((s) => ({ x: s.x, label: s.type === 'spring' ? 'k' : s.type[0].toUpperCase() }))
+
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
+      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Beam Analysis</h1>
+      <p className="no-print mt-1 text-slate-600">
+        Euler–Bernoulli FEM (Hermite elements, Gauss-5) with modular supports — pin / roller / fixed / spring at any
+        position — and categorised loads run through all 7 NSCP 2015 load combinations. Includes a three-moment
+        (Clapeyron) cross-check for continuous beams.
+      </p>
+      <ReportControls title="Beam Analysis Report" />
+
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
+        <div className="space-y-5">
+          <Card title="Beam">
+            <Num label="Span L" unit="m" value={L} onChange={setL} />
+            <Num label="Modulus E" unit="MPa" value={E} onChange={setE} />
+            <Num label="Inertia I" unit="mm⁴" value={I} onChange={setI} />
+          </Card>
+
+          <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">Supports</legend>
+            <div className="no-print mb-3 flex flex-wrap gap-2">
+              {(['pin', 'roller', 'fixed', 'spring'] as SupportType[]).map((t) => (
+                <button key={t} type="button" onClick={() => addSupport(t)}
+                  className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">
+                  + {t[0].toUpperCase() + t.slice(1)}
+                </button>
+              ))}
+            </div>
+            <div className="space-y-3">
+              {supports.length === 0 && <p className="text-sm text-slate-400">No supports — add at least 2 (or a single Fixed).</p>}
+              {supports.map((s) => (
+                <ItemShell key={s.id} title={s.type} onRemove={() => setSupports((ss) => ss.filter((q) => q.id !== s.id))}>
+                  <Num label="x" unit="m" value={s.x} onChange={(v) => setSup(s.id, { x: v })} />
+                  {s.type === 'spring' && (
+                    <Num label="k" unit="kN/m" value={s.k ?? 5000} onChange={(v) => setSup(s.id, { k: v })} />
+                  )}
+                </ItemShell>
+              ))}
+            </div>
+          </fieldset>
+
+          <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">Loads</legend>
+            <div className="no-print mb-3 flex flex-wrap gap-2">
+              {([['point', '+ Point'], ['udl', '+ UDL'], ['vdl', '+ VDL'], ['moment', '+ Moment']] as const).map(([t, lbl]) => (
+                <button key={t} type="button" onClick={() => addLoad(t)}
+                  className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">
+                  {lbl}
+                </button>
+              ))}
+            </div>
+            <div className="space-y-3">
+              {loads.length === 0 && <p className="text-sm text-slate-400">No loads yet.</p>}
+              {loads.map((ld) => (
+                <ItemShell key={ld.id} title={ld.type.toUpperCase()} onRemove={() => setLoads((ls) => ls.filter((q) => q.id !== ld.id))}>
+                  {ld.type === 'point' && <>
+                    <Num label="x" unit="m" value={ld.x} onChange={(v) => setLoad(ld.id, { x: v })} />
+                    <Num label="P" unit="kN" value={ld.P} onChange={(v) => setLoad(ld.id, { P: v })} />
+                  </>}
+                  {ld.type === 'udl' && <>
+                    <Num label="x₁" unit="m" value={ld.x1} onChange={(v) => setLoad(ld.id, { x1: v })} />
+                    <Num label="x₂" unit="m" value={ld.x2} onChange={(v) => setLoad(ld.id, { x2: v })} />
+                    <Num label="w" unit="kN/m" value={ld.w} onChange={(v) => setLoad(ld.id, { w: v })} />
+                  </>}
+                  {ld.type === 'vdl' && <>
+                    <Num label="x₁" unit="m" value={ld.x1} onChange={(v) => setLoad(ld.id, { x1: v })} />
+                    <Num label="x₂" unit="m" value={ld.x2} onChange={(v) => setLoad(ld.id, { x2: v })} />
+                    <Num label="w₁" unit="kN/m" value={ld.w1} onChange={(v) => setLoad(ld.id, { w1: v })} />
+                    <Num label="w₂" unit="kN/m" value={ld.w2} onChange={(v) => setLoad(ld.id, { w2: v })} />
+                  </>}
+                  {ld.type === 'moment' && <>
+                    <Num label="x" unit="m" value={ld.x} onChange={(v) => setLoad(ld.id, { x: v })} />
+                    <Num label="M" unit="kN·m" value={ld.M} onChange={(v) => setLoad(ld.id, { M: v })} />
+                  </>}
+                  <Pick label="Category" value={ld.cat} onChange={(v) => setLoad(ld.id, { cat: v as LoadCategory })} options={CATS} />
+                </ItemShell>
+              ))}
+            </div>
+          </fieldset>
+        </div>
+
+        <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
+          <ResultCard title="Model">
+            <BeamElevation L={L} supports={supports} loads={loads} />
+            {!stable && <p className="mt-1 text-sm text-red-600">⚠ Unstable — add at least 2 supports (or one Fixed).</p>}
+          </ResultCard>
+
+          {res && (
+            <ResultCard title="NSCP 2015 load combinations">
+              <div className="overflow-x-auto">
+                <table className="w-full border-collapse text-xs">
+                  <thead>
+                    <tr className="text-left uppercase tracking-wide text-slate-500">
+                      <th className="py-1 pr-2 font-semibold">Combination</th>
+                      <th className="py-1 pr-2 text-right font-semibold">Vmax</th>
+                      <th className="py-1 pr-2 text-right font-semibold">Mmax</th>
+                      <th className="py-1 text-right font-semibold">δmax</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {res.perCombo.map((pc, i) => (
+                      <tr key={pc.combo.name}
+                        onClick={() => pc.result && setSelIdx(i)}
+                        className={`border-t border-slate-100 ${pc.result ? 'cursor-pointer hover:bg-blue-50' : 'text-slate-300'} ${
+                          i === res.govIdx ? 'bg-amber-50 font-semibold' : ''} ${i === shownIdx ? 'outline outline-1 outline-[#0056b3]' : ''}`}>
+                        <td className="py-1 pr-2">{pc.combo.name}{i === res.govIdx ? ' ★' : ''}</td>
+                        <td className="py-1 pr-2 text-right">{pc.result ? f1(pc.result.Vmax) : pc.skipped ? '—' : 'sing.'}</td>
+                        <td className="py-1 pr-2 text-right">{pc.result ? f1(pc.result.Mmax) : '—'}</td>
+                        <td className="py-1 text-right">{pc.result ? f2(pc.result.Dmax) : '—'}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <p className="mt-1 text-[11px] text-slate-400">★ governing (largest |M|). Click a row to view its reactions & diagrams.</p>
+            </ResultCard>
+          )}
+
+          {r && shown && (
+            <ResultCard title={`Reactions — ${shown.combo.name}`}>
+              {r.reactions.map((rc, i) => (
+                <Row key={i} label={`x = ${f2(rc.x)} m (${rc.type})`}
+                  value={`${f2(rc.Rv)} kN`}
+                  sub={Math.abs(rc.Rm) > 0.01 ? `M = ${f2(rc.Rm)} kN·m` : undefined} />
+              ))}
+              <Row alert={r.Dmax > allowDefl} label="Deflection vs L/360"
+                value={r.Dmax <= allowDefl ? '✓ OK' : '✗ exceeds'}
+                sub={`${f2(r.Dmax)} ≤ ${f2(allowDefl)} mm`} />
+              <div className="no-print mt-3">
+                <Link to={`/beam-design?mu=${r.Mmax.toFixed(1)}&vu=${r.Vmax.toFixed(1)}`}
+                  className="inline-block rounded-lg bg-gradient-to-br from-[#0056b3] to-[#003f86] px-4 py-2 text-sm font-semibold text-white shadow-md transition hover:shadow-lg">
+                  Use Mu & Vu in Beam Design →
+                </Link>
+              </div>
+            </ResultCard>
+          )}
+        </div>
+      </div>
+
+      {r && shown && (
+        <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
+          <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <Diagram xs={r.xs} ys={r.V} title={`SHEAR — ${shown.combo.name}`} unit="kN" color="#1f77b4" vlines={vlines} decimals={1} />
+          </div>
+          <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <Diagram xs={r.xs} ys={r.M} title="MOMENT" unit="kN·m" color="#d62728" vlines={vlines} decimals={1} />
+          </div>
+          <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <Diagram xs={r.xs} ys={r.D} title="DEFLECTION" unit="mm" color="#2ca02c" vlines={vlines} decimals={2} />
+          </div>
+        </div>
+      )}
+
+      {res?.tmt && (
+        <div className="mt-6 rounded-xl border border-slate-200 bg-white p-4 shadow-sm print-avoid-break">
+          <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">
+            Three-moment theorem check <span className="text-xs font-normal text-slate-400">Clapeyron — governing combo, interior support moments</span>
+          </h2>
+          {res.tmt.positions.map((x, i) => (
+            <Row key={i} label={`Support @ x = ${f2(x)} m`}
+              value={`M = ${f2(res.tmt!.supportMoments[i])} kN·m`}
+              sub={`R = ${f2(res.tmt!.reactions[i])} kN`} />
+          ))}
+          <p className="mt-1 text-xs text-slate-400">
+            M₍ᵢ₋₁₎Lᵢ + 2Mᵢ(Lᵢ+Lᵢ₊₁) + Mᵢ₊₁Lᵢ₊₁ = −6(Q/L)ᵢ − 6(Q/L)ᵢ₊₁ — end moments 0, interior solved from the
+            tri-diagonal system. Compare with the FEM reactions above as an independent hand-method check.
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import { designBeam, type BeamDesignInput } from '../engine/beamDesign'
 import { BeamSchematic } from '../components/BeamSchematic'
 import { ReportControls } from '../components/ReportControls'
@@ -25,7 +25,16 @@ const REGION: Record<string, string> = {
 }
 
 export default function BeamDesign() {
-  const [f, setF] = useState<FormState>(DEFAULTS)
+  // Accept demands handed over from Beam Analysis (?mu=…&vu=…).
+  const [params] = useSearchParams()
+  const fromAnalysis = useMemo(() => {
+    const mu = parseFloat(params.get('mu') ?? ''), vu = parseFloat(params.get('vu') ?? '')
+    return {
+      ...(Number.isFinite(mu) ? { Mu: mu } : {}),
+      ...(Number.isFinite(vu) ? { Vu: vu } : {}),
+    }
+  }, [params])
+  const [f, setF] = useState<FormState>({ ...DEFAULTS, ...fromAnalysis })
   const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) => setF((s) => ({ ...s, [k]: v }))
 
   const valid = useMemo(() => {


### PR DESCRIPTION
Ports the **legacy beam-analysis module** (the FEM one with modular loads & supports) from `beamDesign.html` to the React app.

## Engine — `beamAnalysis.ts` (faithful port)
- **Euler–Bernoulli FEM**: Hermite cubic elements, Gauss-5 consistent load vectors, 25-subdivision meshing between anchor nodes (ends, supports, load edges).
- **Modular supports**: pin / roller / fixed / **spring** (stiffness k added to the diagonal) at any position.
- **Modular loads**: point, UDL, **VDL** (trapezoidal), applied moment — each tagged with an NSCP category (D, L, Lr, S, R, W, E).
- **All 7 NSCP 2015 load combinations** run per analysis; governing = largest |M| (legacy rule). Reactions get the legacy two-outermost-support **equilibrium correction**; V/M come from statics on the corrected reactions; deflection by Hermite interpolation.
- **Three-moment (Clapeyron) cross-check** for continuous beams on ≥3 pin/rollers (suppressed when fixed/spring present), on the governing combo's factored loads — an independent hand-method verification of the FEM.

## UI — `/beam-analysis`
L/E/I inputs; add/remove **support cards** and **load cards**; live **elevation sketch** (pin/roller/fixed/spring symbols, arrow glyphs for point/UDL/VDL, moment arcs); **combos table** with the governing row starred and rows clickable to switch the displayed result; reactions grid; **L/360 deflection check** (red alert row on failure); SFD / BMD / deflection diagrams; TMT table; and **"Use Mu & Vu in Beam Design →"** — `BeamDesign` now accepts `?mu=&vu=`, recreating the legacy "Use values from: Beam Analysis" handoff.

## Verification — closed forms
9 engine tests (101 total): SS+UDL (`wL²/8`, `5wL⁴/384EI`), SS+midspan point (`PL/4`, `PL³/48EI`), cantilever (`PL`, `PL³/3EI`), spring equilibrium, triangular-load reactions (`wL/6`, `wL/3`), TMT interior moment `−wL²/8` **and** FEM↔TMT reaction agreement, and combo governance (1.2D+1.6L for D+L loading). Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)