### PR TITLE
Multi-section beam design + critical-section auto-detect

### DIFF
--- a/webapp/src/engine/beamSections.test.ts
+++ b/webapp/src/engine/beamSections.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { solveFEM, type Support, type BeamLoad } from './beamAnalysis'
+import { detectCriticalSections } from './beamSections'
+
+const E = 25000, I = 3.125e9
+
+describe('critical-section auto-detect', () => {
+  it('SS + UDL: two supports (Vu = |R| = wL/2) + midspan V=0 (Mu = wL²/8)', () => {
+    const L = 6, w = 10
+    const r = solveFEM(
+      [{ type: 'pin', x: 0 }, { type: 'roller', x: L }] as Support[],
+      [{ type: 'udl', x1: 0, x2: L, w, cat: 'D' }] as BeamLoad[], L, E, I)!
+    const secs = detectCriticalSections(r)
+    expect(secs).toHaveLength(3)
+    expect(secs[0].Vu).toBeCloseTo((w * L) / 2, 2)            // Case A: |R|
+    expect(secs[2].Vu).toBeCloseTo((w * L) / 2, 2)
+    // the global Max +M claims the midspan slot before the V=0 pass (legacy order)
+    const mid = secs[1]
+    expect(mid.label).toMatch(/Max \+M|Midspan/)
+    expect(mid.x).toBeCloseTo(L / 2, 2)
+    expect(mid.Mu).toBeCloseTo((w * L * L) / 8, 1)
+  })
+
+  it('2-span continuous: interior support claims Max −M (dedup) with the face shear', () => {
+    const L = 6, w = 10
+    const r = solveFEM(
+      [{ type: 'pin', x: 0 }, { type: 'roller', x: 3 }, { type: 'roller', x: 6 }] as Support[],
+      [{ type: 'udl', x1: 0, x2: L, w, cat: 'D' }] as BeamLoad[], L, E, I)!
+    const secs = detectCriticalSections(r)
+    const interior = secs.find((s) => s.label.startsWith('Interior'))!
+    // hogging at the interior support: M = −w·l²/8 with l = 3
+    expect(interior.Mu).toBeCloseTo((-w * 9) / 8, 1)
+    // no separate "Max −M" card — deduped into the support
+    expect(secs.some((s) => s.label.startsWith('Max −M'))).toBe(false)
+    // interior face shear = larger in-span side = 5wl/8 = 18.75
+    expect(interior.Vu).toBeCloseTo((5 * w * 3) / 8, 1)
+    // one moment extremum per span — one carries the global Max +M label,
+    // the mirror-span crossing keeps the per-span label (legacy dedup order)
+    expect(secs.filter((s) => /Max \+M|extremum/.test(s.label))).toHaveLength(2)
+  })
+
+  it('overhang: end support uses Case B (face shear from both sides)', () => {
+    // Supports at 0 and 4, beam runs to 6 → 2 m right overhang with UDL.
+    const r = solveFEM(
+      [{ type: 'pin', x: 0 }, { type: 'roller', x: 4 }] as Support[],
+      [{ type: 'udl', x1: 0, x2: 6, w: 10, cat: 'D' }] as BeamLoad[], 6, E, I)!
+    const secs = detectCriticalSections(r)
+    const right = secs.find((s) => s.label.startsWith('Right support'))!
+    expect(right.label).toContain('overhang')
+    // R0 = 15, R1 = 45. Just left of the support: 15 − 40 = −25; just right:
+    // +20 (the overhang). Case B takes the larger face → 25.
+    expect(right.Vu).toBeCloseTo(25, 1)
+    // hogging over the support: −w·a²/2 = −20 kN·m
+    expect(right.Mu).toBeCloseTo(-20, 1)
+  })
+})

--- a/webapp/src/engine/beamSections.ts
+++ b/webapp/src/engine/beamSections.ts
@@ -1,0 +1,114 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Critical-section detection for multi-section RC design — faithful port of
+// the legacy rcDetectCriticalSections():
+//   1. Supports FIRST (so they claim their x-slot with the correct shear):
+//      Case A — end support without overhang → Vu = |R| exactly;
+//      Case B — end support with overhang, or interior → the larger of
+//      |V_before| and |V_after| across the support face.
+//   2. Global max +M and max −M (deduped against the supports).
+//   3. Per-span V = 0 crossings — the TRUE moment extrema (dM/dx = V),
+//      located by linear interpolation between samples.
+// Sections are de-duplicated by x within 25 mm and sorted left → right.
+// ─────────────────────────────────────────────────────────────────────────
+import type { FemResult } from './beamAnalysis'
+
+export interface CriticalSection {
+  label: string
+  x: number
+  Mu: number   // signed: negative = hogging (top tension)
+  Vu: number   // magnitude
+}
+
+function interpAt(x: number, xs: number[], ys: number[]): number {
+  if (x <= xs[0]) return ys[0]
+  for (let i = 1; i < xs.length; i++) {
+    if (xs[i] >= x) {
+      const t = (x - xs[i - 1]) / Math.max(xs[i] - xs[i - 1], 1e-12)
+      return ys[i - 1] + t * (ys[i] - ys[i - 1])
+    }
+  }
+  return ys[ys.length - 1]
+}
+
+export function detectCriticalSections(r: FemResult): CriticalSection[] {
+  const { xs, V, M } = r
+  const supps = [...r.reactions].sort((a, b) => a.x - b.x)
+
+  const idxAt = (x: number, dir = 0): number => {
+    let best = 0, bd = Infinity
+    for (let i = 0; i < xs.length; i++) {
+      const d = Math.abs(xs[i] - x)
+      if (d < bd) { bd = d; best = i }
+    }
+    if (dir < 0 && xs[best] > x && best > 0) best -= 1
+    if (dir > 0 && xs[best] < x && best < xs.length - 1) best += 1
+    return best
+  }
+
+  const sections: CriticalSection[] = []
+  const tryAdd = (x: number, Mu: number, Vu: number, label: string) => {
+    if (sections.some((s) => Math.abs(s.x - x) < 0.025)) return
+    sections.push({ label, x, Mu: Math.round(Mu * 1000) / 1000, Vu: Math.round(Vu * 1000) / 1000 })
+  }
+
+  // 1. Supports first (overhang-aware Case A / Case B shear).
+  const xLeftEdge = xs[0]
+  const xRightEdge = xs[xs.length - 1]
+  const overhangTol = 1e-3
+  supps.forEach((s, i) => {
+    const idx = idxAt(s.x)
+    const Rv = Number(s.Rv) || 0
+    const isLeftEnd = i === 0
+    const isRightEnd = i === supps.length - 1
+    const hasLeftOverhang = isLeftEnd && s.x - xLeftEdge > overhangTol
+    const hasRightOverhang = isRightEnd && xRightEdge - s.x > overhangTol
+
+    let Vu: number
+    if ((isLeftEnd && !hasLeftOverhang) || (isRightEnd && !hasRightOverhang)) {
+      Vu = Math.abs(Rv)                       // Case A — face shear = reaction
+    } else {
+      const Vat = V[idx] || 0                 // Case B — larger of the two faces
+      Vu = Math.max(Math.abs(Vat - Rv), Math.abs(Vat))
+    }
+    const Mu = M[idx] || 0
+    const label = isLeftEnd
+      ? `Left support (x = ${s.x.toFixed(2)} m${hasLeftOverhang ? ', w/ overhang' : ''})`
+      : isRightEnd
+        ? `Right support (x = ${s.x.toFixed(2)} m${hasRightOverhang ? ', w/ overhang' : ''})`
+        : `Interior support ${i} (x = ${s.x.toFixed(2)} m)`
+    tryAdd(s.x, Mu, Vu, label)
+  })
+
+  // 2. Global max / min moment.
+  let iMax = 0, iMin = 0
+  for (let i = 1; i < M.length; i++) {
+    if (M[i] > M[iMax]) iMax = i
+    if (M[i] < M[iMin]) iMin = i
+  }
+  const peak = Math.max(Math.abs(M[iMax]), Math.abs(M[iMin]), 1e-9)
+  const eps = peak * 0.005 + 1e-6
+  if (M[iMax] > eps) tryAdd(xs[iMax], M[iMax], Math.abs(V[iMax]), `Max +M (x = ${xs[iMax].toFixed(2)} m)`)
+  if (M[iMin] < -eps) tryAdd(xs[iMin], M[iMin], Math.abs(V[iMin]), `Max −M (x = ${xs[iMin].toFixed(2)} m)`)
+
+  // 3. Per-span V = 0 crossings — true moment extrema.
+  for (let i = 0; i < supps.length - 1; i++) {
+    const xL = supps[i].x, xR = supps[i + 1].x
+    const iL = idxAt(xL, +1)
+    const iR = idxAt(xR, -1)
+    let zeroCount = 0
+    for (let k = iL; k < iR; k++) {
+      if (V[k] * V[k + 1] < 0) {
+        const x0 = xs[k] - (V[k] * (xs[k + 1] - xs[k])) / (V[k + 1] - V[k])
+        if (x0 - xL < 0.05 || xR - x0 < 0.05) continue
+        zeroCount += 1
+        const lbl = supps.length === 2
+          ? `Midspan @ V=0 (x = ${x0.toFixed(2)} m)`
+          : `Span ${i + 1} extremum ${zeroCount} (x = ${x0.toFixed(2)} m)`
+        tryAdd(x0, interpAt(x0, xs, M), Math.abs(interpAt(x0, xs, V)), lbl)
+      }
+    }
+  }
+
+  sections.sort((a, b) => a.x - b.x)
+  return sections
+}

--- a/webapp/src/pages/BeamAnalysis.tsx
+++ b/webapp/src/pages/BeamAnalysis.tsx
@@ -1,8 +1,10 @@
 import { useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import {
   analyzeBeam, type Support, type SupportType, type BeamLoad, type LoadCategory,
 } from '../engine/beamAnalysis'
+import { detectCriticalSections } from '../engine/beamSections'
+import { SECTIONS_HANDOFF_KEY } from './BeamDesign'
 import { BeamElevation } from '../components/BeamElevation'
 import { Diagram } from '../components/Diagram'
 import { ReportControls } from '../components/ReportControls'
@@ -49,6 +51,7 @@ export default function BeamAnalysis() {
   const [supports, setSupports] = useState<SupRow[]>(DEF_SUPPORTS)
   const [loads, setLoads] = useState<LoadRow[]>(DEF_LOADS)
   const [selIdx, setSelIdx] = useState<number | null>(null)
+  const navigate = useNavigate()
 
   const setSup = (id: number, patch: Partial<SupRow>) =>
     setSupports((ss) => ss.map((s) => (s.id === id ? { ...s, ...patch } : s)))
@@ -208,11 +211,22 @@ export default function BeamAnalysis() {
               <Row alert={r.Dmax > allowDefl} label="Deflection vs L/360"
                 value={r.Dmax <= allowDefl ? '✓ OK' : '✗ exceeds'}
                 sub={`${f2(r.Dmax)} ≤ ${f2(allowDefl)} mm`} />
-              <div className="no-print mt-3">
+              <div className="no-print mt-3 flex flex-wrap gap-2">
                 <Link to={`/beam-design?mu=${r.Mmax.toFixed(1)}&vu=${r.Vmax.toFixed(1)}`}
-                  className="inline-block rounded-lg bg-gradient-to-br from-[#0056b3] to-[#003f86] px-4 py-2 text-sm font-semibold text-white shadow-md transition hover:shadow-lg">
-                  Use Mu & Vu in Beam Design →
+                  className="inline-block rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-[#0056b3] transition hover:border-[#0056b3] hover:bg-blue-50">
+                  Use Mmax & Vmax →
                 </Link>
+                <button type="button"
+                  onClick={() => {
+                    const gov = res!.perCombo[res!.govIdx].result!
+                    const secs = detectCriticalSections(gov)
+                    if (!secs.length) return
+                    sessionStorage.setItem(SECTIONS_HANDOFF_KEY, JSON.stringify(secs))
+                    navigate('/beam-design?sections=auto')
+                  }}
+                  className="inline-block rounded-lg bg-gradient-to-br from-[#0056b3] to-[#003f86] px-4 py-2 text-sm font-semibold text-white shadow-md transition hover:shadow-lg">
+                  ⚡ Auto-detect critical sections → design
+                </button>
               </div>
             </ResultCard>
           )}

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -1,12 +1,13 @@
 import { useMemo, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
-import { designBeam, type BeamDesignInput } from '../engine/beamDesign'
+import { designBeam, type BeamDesignInput, type BeamDesignResult } from '../engine/beamDesign'
+import type { CriticalSection } from '../engine/beamSections'
 import { BeamSchematic } from '../components/BeamSchematic'
 import { ReportControls } from '../components/ReportControls'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { buildBeamSolution } from '../lib/beamSolution'
-import { Num, Card, ResultCard, Row } from '../components/qty'
-import { Math } from '../lib/math'
+import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
+import { Math as KTex } from '../lib/math'
 import { f0, f1 } from '../lib/format'
 import 'katex/dist/katex.min.css'
 
@@ -24,42 +25,100 @@ const REGION: Record<string, string> = {
   inadequate: '⚠ Section inadequate',
 }
 
+/** Storage key for the Beam Analysis → multi-section handoff. */
+export const SECTIONS_HANDOFF_KEY = 'beam-critical-sections'
+
+let uid = 1
+interface SecRow extends CriticalSection { id: number }
+
+const DEF_SECTIONS: SecRow[] = [
+  { id: uid++, label: 'Midspan', x: 3, Mu: 180, Vu: 30 },
+  { id: uid++, label: 'Support', x: 0, Mu: -120, Vu: 150 },
+]
+
+function sectionOK(r: BeamDesignResult): boolean {
+  return r.flexOK && r.comprEffective && r.comprNAOK && r.region !== 'inadequate'
+}
+
 export default function BeamDesign() {
-  // Accept demands handed over from Beam Analysis (?mu=…&vu=…).
   const [params] = useSearchParams()
-  const fromAnalysis = useMemo(() => {
+
+  // Handoffs from Beam Analysis: ?mu&vu (single) or ?sections=auto (multi,
+  // via sessionStorage — the list is too rich for query params).
+  const handoff = useMemo(() => {
+    if (params.get('sections') === 'auto') {
+      try {
+        const raw = sessionStorage.getItem(SECTIONS_HANDOFF_KEY)
+        if (raw) {
+          const secs = (JSON.parse(raw) as CriticalSection[]).map((s) => ({ ...s, id: uid++ }))
+          if (secs.length) return { multi: true as const, sections: secs }
+        }
+      } catch { /* fall through to defaults */ }
+    }
     const mu = parseFloat(params.get('mu') ?? ''), vu = parseFloat(params.get('vu') ?? '')
     return {
-      ...(Number.isFinite(mu) ? { Mu: mu } : {}),
-      ...(Number.isFinite(vu) ? { Vu: vu } : {}),
+      multi: false as const,
+      single: {
+        ...(Number.isFinite(mu) ? { Mu: mu } : {}),
+        ...(Number.isFinite(vu) ? { Vu: vu } : {}),
+      },
     }
   }, [params])
-  const [f, setF] = useState<FormState>({ ...DEFAULTS, ...fromAnalysis })
-  const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) => setF((s) => ({ ...s, [k]: v }))
 
-  const valid = useMemo(() => {
-    const keys: (keyof FormState)[] = ['b', 'h', 'cover', 'barDia', 'stirrupDia', 'fc', 'fy', 'fyt', 'Mu', 'Vu', 'legs']
+  const [f, setF] = useState<FormState>({ ...DEFAULTS, ...(handoff.multi ? {} : handoff.single) })
+  const [multi, setMulti] = useState<boolean>(handoff.multi)
+  const [sections, setSections] = useState<SecRow[]>(handoff.multi ? handoff.sections : DEF_SECTIONS)
+  const [selId, setSelId] = useState<number | null>(handoff.multi ? handoff.sections[0].id : null)
+  const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) => setF((s) => ({ ...s, [k]: v }))
+  const setSec = (id: number, patch: Partial<SecRow>) =>
+    setSections((ss) => ss.map((s) => (s.id === id ? { ...s, ...patch } : s)))
+
+  const sectionGeomOK = useMemo(() => {
+    const keys: (keyof FormState)[] = ['b', 'h', 'cover', 'barDia', 'stirrupDia', 'fc', 'fy', 'fyt', 'legs']
     return keys.every((k) => Number.isFinite(f[k] as number)) && f.b > 0 && f.h > 0 && f.fc > 0 && f.fy > 0
       && f.h - f.cover - f.stirrupDia - f.barDia / 2 > 0
   }, [f])
 
-  const r = useMemo(() => (valid ? designBeam(f) : null), [f, valid])
-  const solution = useMemo(() => (r ? buildBeamSolution(f, r) : null), [f, r])
+  // Per-section designs (multi) — hogging sections design with |Mu|.
+  const designs = useMemo(() => {
+    if (!sectionGeomOK || !multi) return []
+    return sections.map((s) => {
+      if (!Number.isFinite(s.Mu) || !Number.isFinite(s.Vu)) return null
+      return designBeam({ ...f, Mu: Math.abs(s.Mu), Vu: Math.abs(s.Vu) })
+    })
+  }, [f, sections, multi, sectionGeomOK])
 
-  const stirrupText = r
-    ? r.region === 'designed' || r.region === 'minimum'
-      ? `⌀${f.stirrupDia} ${f.legs}-leg @ ${f0(r.sAdopt)} mm`
-      : r.region === 'none' ? '— none' : '⚠ enlarge'
-    : '—'
+  // The active demand: selected section (multi) or the single Mu/Vu fields.
+  const selIdx = multi ? Math.max(0, sections.findIndex((s) => s.id === selId)) : -1
+  const active = multi ? sections[selIdx] ?? sections[0] : null
+  const hogging = multi ? (active?.Mu ?? 0) < 0 : f.Mu < 0
+
+  const singleValid = sectionGeomOK && Number.isFinite(f.Mu) && Number.isFinite(f.Vu)
+  const r = multi
+    ? designs[selIdx] ?? null
+    : singleValid ? designBeam({ ...f, Mu: Math.abs(f.Mu) }) : null
+  const demand = multi
+    ? { Mu: Math.abs(active?.Mu ?? 0), Vu: Math.abs(active?.Vu ?? 0) }
+    : { Mu: Math.abs(f.Mu), Vu: f.Vu }
+  const solution = useMemo(
+    () => (r ? buildBeamSolution({ ...f, ...demand }, r) : null),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [r, f, demand.Mu, demand.Vu],
+  )
+
+  const stirrupText = (rr: BeamDesignResult) =>
+    rr.region === 'designed' || rr.region === 'minimum'
+      ? `⌀${f.stirrupDia} ${f.legs}-leg @ ${f0(rr.sAdopt)} mm`
+      : rr.region === 'none' ? '— none' : '⚠ enlarge'
 
   return (
     <div className="mx-auto max-w-6xl p-6">
       <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
       <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Beam Design</h1>
       <p className="no-print mt-1 text-slate-600">
-        Rectangular RC beam — SRRB/DRRB flexure (compression steel designed automatically beyond the
-        tension-controlled ceiling at ρ_max = (0.85f′c/fy·β₁)(3/8)(dt/d)), §407.7 bar layout with automatic
-        layering (Varignon d), and one-way shear. NSCP 2015 / ACI 318-14.
+        Rectangular RC beam — SRRB/DRRB flexure, §407.7 bar layout with automatic layering (Varignon d), one-way
+        shear & 135° hooks. Design one section, or a whole list of critical sections (negative Mu = hogging) on the
+        same cross-section — auto-detected from Beam Analysis or entered by hand. NSCP 2015 / ACI 318-14.
       </p>
       <ReportControls title="Beam Design Report" />
 
@@ -69,25 +128,105 @@ export default function BeamDesign() {
             <Num label="Width b" unit="mm" value={f.b} onChange={set('b')} />
             <Num label="Total depth h" unit="mm" value={f.h} onChange={set('h')} />
             <Num label="Clear cover" unit="mm" value={f.cover} onChange={set('cover')} />
-            <Num label={<>Bar <Math tex="d_b" /></>} unit="mm" value={f.barDia} onChange={set('barDia')} />
-            <Num label={<>Compr. bar <Math tex="d_b'" /></>} unit="mm" value={f.comprBarDia} onChange={set('comprBarDia')} />
-            <Num label={<>Stirrup <Math tex="d_s" /></>} unit="mm" value={f.stirrupDia} onChange={set('stirrupDia')} />
+            <Num label={<>Bar <KTex tex="d_b" /></>} unit="mm" value={f.barDia} onChange={set('barDia')} />
+            <Num label={<>Compr. bar <KTex tex="d_b'" /></>} unit="mm" value={f.comprBarDia} onChange={set('comprBarDia')} />
+            <Num label={<>Stirrup <KTex tex="d_s" /></>} unit="mm" value={f.stirrupDia} onChange={set('stirrupDia')} />
             <Num label="Stirrup legs" value={f.legs} onChange={set('legs')} />
           </Card>
           <Card title="Materials">
-            <Num label={<Math tex="f'_c" />} unit="MPa" value={f.fc} onChange={set('fc')} />
-            <Num label={<Math tex="f_y" />} unit="MPa" value={f.fy} onChange={set('fy')} />
-            <Num label={<Math tex="f_{yt}" />} unit="MPa" value={f.fyt} onChange={set('fyt')} />
+            <Num label={<KTex tex="f'_c" />} unit="MPa" value={f.fc} onChange={set('fc')} />
+            <Num label={<KTex tex="f_y" />} unit="MPa" value={f.fy} onChange={set('fy')} />
+            <Num label={<KTex tex="f_{yt}" />} unit="MPa" value={f.fyt} onChange={set('fyt')} />
           </Card>
+
           <Card title="Factored demands">
-            <Num label={<Math tex="M_u" />} unit="kN·m" value={f.Mu} onChange={set('Mu')} />
-            <Num label={<Math tex="V_u" />} unit="kN" value={f.Vu} onChange={set('Vu')} />
+            <Pick label="Mode" value={multi ? 'multi' : 'single'}
+              onChange={(v) => setMulti(v === 'multi')}
+              options={[['single', 'Single section'], ['multi', 'Multiple critical sections']]} />
+            {!multi && <>
+              <Num label={<KTex tex="M_u" />} unit="kN·m" value={f.Mu} onChange={set('Mu')} />
+              <Num label={<KTex tex="V_u" />} unit="kN" value={f.Vu} onChange={set('Vu')} />
+            </>}
+            {hogging && !multi && (
+              <p className="col-span-full text-xs text-slate-400">Negative Mu — hogging: designed with |Mu|; the tension steel goes at the TOP.</p>
+            )}
           </Card>
+
+          {multi && (
+            <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">Critical sections</legend>
+              <div className="no-print mb-3 flex flex-wrap items-center gap-2">
+                <button type="button"
+                  onClick={() => setSections((ss) => [...ss, { id: uid++, label: `Section ${ss.length + 1}`, x: 0, Mu: 50, Vu: 30 }])}
+                  className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">
+                  + Add section
+                </button>
+                <span className="text-xs text-slate-400">or auto-detect from <Link to="/beam-analysis" className="text-[#0056b3] hover:underline">Beam Analysis</Link>. Negative Mu = hogging (top steel).</span>
+              </div>
+              <div className="space-y-3">
+                {sections.map((s) => (
+                  <div key={s.id} className={`rounded-lg border p-3 ${s.id === active?.id ? 'border-[#0056b3] bg-blue-50/40' : 'border-slate-200 bg-slate-50'}`}>
+                    <div className="mb-2 flex items-center justify-between">
+                      <input value={s.label} onChange={(e) => setSec(s.id, { label: e.target.value })}
+                        className="w-1/2 rounded border border-transparent bg-transparent px-1 text-xs font-bold uppercase tracking-wide text-slate-600 focus:border-slate-300 focus:bg-white" />
+                      <span className="flex gap-3">
+                        <button type="button" onClick={() => setSelId(s.id)} className="text-xs text-[#0056b3] hover:underline">view</button>
+                        <button type="button" onClick={() => setSections((ss) => ss.filter((q) => q.id !== s.id))} className="text-xs text-red-500 hover:underline">remove</button>
+                      </span>
+                    </div>
+                    <div className="grid grid-cols-3 gap-3">
+                      <Num label="x" unit="m" value={s.x} onChange={(v) => setSec(s.id, { x: v })} />
+                      <Num label={<KTex tex="M_u" />} unit="kN·m" value={s.Mu} onChange={(v) => setSec(s.id, { Mu: v })} />
+                      <Num label={<KTex tex="V_u" />} unit="kN" value={s.Vu} onChange={(v) => setSec(s.id, { Vu: v })} />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </fieldset>
+          )}
         </div>
 
         <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
+          {multi && (
+            <ResultCard title="Section schedule">
+              <div className="overflow-x-auto">
+                <table className="w-full border-collapse text-xs">
+                  <thead>
+                    <tr className="text-left uppercase tracking-wide text-slate-500">
+                      <th className="py-1 pr-2 font-semibold">Section</th>
+                      <th className="py-1 pr-2 font-semibold">Mode</th>
+                      <th className="py-1 pr-2 font-semibold">Tension</th>
+                      <th className="py-1 pr-2 font-semibold">Compr.</th>
+                      <th className="py-1 font-semibold">Stirrups</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {sections.map((s, i) => {
+                      const d = designs[i]
+                      const bad = d ? !sectionOK(d) : true
+                      return (
+                        <tr key={s.id} onClick={() => setSelId(s.id)}
+                          className={`cursor-pointer border-t border-slate-100 hover:bg-blue-50 ${
+                            bad ? 'bg-red-50 text-red-700' : ''} ${s.id === active?.id ? 'outline outline-1 outline-[#0056b3]' : ''}`}>
+                          <td className="py-1 pr-2">{s.label}{s.Mu < 0 ? ' (hog)' : ''}</td>
+                          <td className="py-1 pr-2">{d ? d.mode : '—'}</td>
+                          <td className="py-1 pr-2">{d ? `${d.bars}⌀${f.barDia}${d.layers.length > 1 ? ` (${d.layers.join('+')})` : ''}` : '—'}</td>
+                          <td className="py-1 pr-2">{d && d.comprBars > 0 ? `${d.comprBars}⌀${f.comprBarDia}` : '—'}</td>
+                          <td className="py-1">{d ? (d.sAdopt > 0 ? `@${f0(d.sAdopt)}` : d.region === 'none' ? 'none' : '⚠') : '—'}</td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              </div>
+              <p className="mt-1 text-[11px] text-slate-400">Click a row to view its drawing, results and worked solution. Red rows have errors.</p>
+            </ResultCard>
+          )}
+
           <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-            <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Section preview</h2>
+            <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">
+              Section preview{multi && active ? ` — ${active.label}` : ''}
+            </h2>
             {r ? (
               <BeamSchematic b={f.b} h={f.h} cover={f.cover} barDia={f.barDia} stirrupDia={f.stirrupDia}
                 bars={r.bars} d={r.d} dPrime={r.comprLayers.length > 0 ? r.dPrime : undefined}
@@ -97,14 +236,18 @@ export default function BeamDesign() {
             ) : (
               <p className="py-8 text-center text-sm text-slate-400">Enter a valid section (d must be positive).</p>
             )}
+            {hogging && r && (
+              <p className="mt-1 text-xs text-slate-500">Hogging section — drawn bars apply mirrored: tension steel at the TOP.</p>
+            )}
           </div>
 
           {r && (
-            <ResultCard title="Results">
+            <ResultCard title={`Results${multi && active ? ` — ${active.label}` : ''}`}>
               {!r.flexOK && (
                 <Row alert label="⚠ Section" value={`${r.bars} bars cannot fit`}
                   sub="layout diverges — enlarge b or h" />
               )}
+              {hogging && <Row label="Orientation" value="hogging (−Mu)" sub="tension steel at the top" />}
               <Row label="Effective depth d" value={`${f1(r.d)} mm`}
                 sub={r.layers.length > 1 ? `dt=${f1(r.dt)} · ȳ=${f1(r.yBar)} mm` : undefined} />
               <Row label="Flexure mode" value={r.mode}
@@ -129,9 +272,9 @@ export default function BeamDesign() {
                 <Row alert={!r.comprNAOK} label="NA check" value={r.comprNAOK ? '✓ above NA' : '✗ crosses NA'}
                   sub={`deepest d'=${f0(r.dPrimeExtreme)} vs c=${f0(r.cNA)} mm`} />
               )}
-              <Row label={<Math tex="\phi V_c" />} value={`${f1(r.phiVc)} kN`} sub={`Vc=${f1(r.Vc)}`} />
+              <Row label={<KTex tex="\phi V_c" />} value={`${f1(r.phiVc)} kN`} sub={`Vc=${f1(r.Vc)}`} />
               <Row alert={r.region === 'inadequate'} label="Shear" value={REGION[r.region]} />
-              <Row label="Stirrups" value={stirrupText}
+              <Row label="Stirrups" value={stirrupText(r)}
                 sub={r.region === 'designed' ? `s_req=${f0(r.sReq)} · s_max=${f0(r.sMax)} mm` : undefined} />
               <Row label="Hooks (135°)" value={`ext ${f0(r.stirrupHookExt)} mm`}
                 sub={`bend Ø ${f0(r.stirrupBendDia)} mm (4ds)`} />
@@ -140,7 +283,10 @@ export default function BeamDesign() {
         </div>
       </div>
 
-      {solution && <WorkedSolution steps={solution} />}
+      {solution && (
+        <WorkedSolution steps={solution}
+          title={multi && active ? `Solution — ${active.label}` : 'Solution — step by step'} />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Ports the legacy **Critical Sections** feature — design a whole list of beam sections in one run, auto-detected from the FEM analysis.

## Detection engine — `beamSections.ts` (faithful port)
`detectCriticalSections(fem)` reproduces the legacy algorithm including its subtle ordering rules:
1. **Supports first**, so each claims its x-slot with the correct design shear — **Case A** (end support, no overhang): `Vu = |R|` exactly; **Case B** (overhang or interior): `max(|V_before|, |V_after|)` across the face.
2. **Global max +M / max −M** — deduped against the supports (so a hogging peak AT a support doesn't overwrite the support's |R| shear, the legacy bug-fix comment preserved).
3. **Per-span V = 0 crossings** — the true moment extrema (dM/dx = V), located by linear interpolation.
De-dup within 25 mm, sorted left → right.

## Beam Design — multi-section mode
- *Factored demands* gains **Single section / Multiple critical sections**. Multi shows an editable list (label, x, **signed Mu** — negative = hogging, designed with |Mu| and flagged "tension steel at the top", Vu).
- Every section is designed on the shared cross-section; a **Section schedule** table shows mode (SRRB/DRRB), tension bars + layers, compression bars, stirrup spacing — **red rows on any error** (can't fit / NA / ineffective A′s / shear).
- Clicking a row switches the **drawing, results card, and worked solution** to that section.

## Beam Analysis — the handoff
**"⚡ Auto-detect critical sections → design"** runs the detector on the **governing combo** and opens Beam Design in multi mode with the list pre-loaded (sessionStorage + `?sections=auto`). The single Mmax/Vmax handoff stays as a secondary button.

## Verification
3 engine tests against hand statics: SS+UDL (support Vu = wL/2, midspan wL²/8), 2-span continuous (interior support claims −wl²/8 hogging with face shear 5wl/8; the Max −M card correctly deduped), and the overhang Case B (Vu = 25 from the heavier face, Mu = −20). **104 total passing**; build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)