### PR TITLE
Hogging schematic mirroring, support-card layout fix + 3D model-space roadmap

### DIFF
--- a/docs/ROADMAP-3D.md
+++ b/docs/ROADMAP-3D.md
@@ -1,0 +1,125 @@
+# Roadmap — 3D Model Space (frames + plates → analyze → design the load path)
+
+**Goal.** A 3D modelling environment where you draw frames (beams + columns) and plates
+(slabs + walls), apply loads, run the analysis step by step, and design every section
+following the load path — slab → beam → girder → column → footing — **reusing the
+engines and pages already built**, not rewriting them.
+
+---
+
+## What we already have (the reuse inventory)
+
+| Existing asset | Where | Role in the 3D app |
+|---|---|---|
+| Euler–Bernoulli FEM (Hermite, Gauss-5, springs, eq. correction) | `engine/beamAnalysis.ts` | Kernel to generalise: 2-DOF/node beam → 6-DOF/node 3D frame element |
+| NSCP 2015 load combinations + categorised loads | `engine/beamAnalysis.ts` | Reused as-is at the model level (combos run on the whole structure) |
+| Critical-section auto-detect (supports Case A/B, V=0 extrema) | `engine/beamSections.ts` | Reused per member after the frame analysis |
+| RC beam design (SRRB/DRRB, layers/Varignon, hooks) | `engine/beamDesign.ts` | Designs every beam/girder section from member force diagrams |
+| Three-moment cross-check | `engine/beamAnalysis.ts` | Verification panel for continuous beam lines extracted from the model |
+| Foundation engines (square/rect/eccentric, methods, columns) | `engine/isolatedFooting.ts` etc. | Column base reactions → footing design (P + M → eccentric path) |
+| Combined footing (rigid + Winkler FEM) | `engine/combinedFooting.ts`, `flexibleCombinedFooting.ts` | Close column pairs at the base |
+| Pile cap (biaxial reactions) | `engine/pileCap.ts` | Alternative foundation for large reactions |
+| Quantity engines | `engine/quantities.ts` | Bill of materials straight from the designed model |
+| Worked-solution framework | `lib/solution.ts`, `WorkedSolution` | The "analyze step by step" narrative, per load-path stage |
+| Diagram / schematic components, dims | `components/` | Member-level results inside the 3D app's inspector |
+| Handoff pattern (sessionStorage + query param) | BeamAnalysis → BeamDesign | Model → existing design pages, member by member |
+| Excel batch import | `lib/foundationExcel.ts` | Pattern for importing/exporting model tables |
+
+**Missing engines (the only genuinely new calculation work):**
+1. **Column design** — axial + uniaxial/biaxial moment (P–M interaction, ties/spirals,
+   slenderness). Needed before any frame can be "designed down".
+2. **Frame element** — extend the beam FEM: 2D frame (axial + bending, 3 DOF/node),
+   then 3D (12-DOF element with torsion + biaxial bending; St-Venant J for torsion).
+3. **Plate behaviour** — *not* full shell FEM at first. Slabs via NSCP coefficient /
+   tributary-area method (one-way & two-way) that converts area loads into line loads
+   on the supporting beams — this is exactly the "load path" step. Walls as in-plane
+   panels (pier model) later.
+4. **Two-way slab design** — flexure per strip reuses `flexuralSteel`; new wrapper only.
+
+---
+
+## Phase plan (each phase = 1–3 PR-sized milestones, app stays shippable throughout)
+
+### Phase 1 — Structural model schema + column design engine
+- `engine/model.ts`: typed schema — `Node {id, x,y,z}`, `Member {id, i, j, role:
+  beam|girder|column, section, material}`, `Plate {id, corners, role: slab|wall,
+  thickness}`, `Load {target, category, kind}`, `SectionLib`, `Storey`.
+  Pure data, JSON-serialisable (save/load, undo, Excel round-trip later).
+- `engine/columnDesign.ts`: tied/spiral RC column — axial capacity, P–M interaction
+  (strain-compatibility fiber sweep reusing `beta1`/`rhoMin` style helpers), moment
+  magnification for slenderness. Worked solution + page `/column-design`
+  (same pattern as BeamDesign — this also fills the legacy `columnDesign.html` gap).
+
+### Phase 2 — 2D frame analysis (the kernel generalisation)
+- `engine/frame2d.ts`: 6-DOF (3/node) frame element = current Hermite bending matrix
+  ⊕ axial bar term, rotated by member orientation; assembly/BC/solve code lifts almost
+  verbatim from `beamAnalysis.ts` (extract the shared linear-algebra + assembly into
+  `engine/fem.ts` first).
+- Validate against the existing beam solver (a horizontal frame member with the same
+  supports must reproduce `solveFEM` exactly — regression tests) and portal-frame
+  closed forms.
+- Page `/frame` (2D): node/member editor on an SVG canvas, supports, member loads,
+  combos table, per-member V/M/N diagrams via the existing `Diagram`.
+
+### Phase 3 — Load path: plates → members (tributary engine)
+- `engine/tributary.ts`: slab panels distribute area loads to edge beams — one-way
+  (ℓ₂/ℓ₁ ≥ 2) as UDL on the long edges, two-way as trapezoid/triangle line loads
+  (exactly the `vdl` loads the beam FEM already accepts — zero new load machinery).
+- Wall self-weight → line loads on supporting members; storey dead/live presets.
+- "Load path" report: a `WorkedSolution` narrative — panel → kN/m on each beam,
+  with the NSCP categories preserved so combos still work downstream.
+
+### Phase 4 — 3D model space (UI)
+- `react-three-fiber` + `drei` (the only new dependency of consequence) for the
+  viewport: grid + storey levels, snap-to-node drawing of members, extruded plates,
+  load glyphs, selection + inspector panel.
+- The inspector reuses existing components wholesale: member → `Diagram` (N/V/M),
+  section → `BeamSchematic`, footing → `FootingSchematic`.
+- Analysis in a web worker (the dense solver is already pure — it moves as-is).
+- Model persistence: JSON file download/upload + sessionStorage autosave.
+
+### Phase 5 — 3D frame analysis
+- `engine/frame3d.ts`: 12-DOF space-frame element (biaxial Hermite + axial + torsion),
+  member-local → global transformation. Same assembly core from `fem.ts`.
+- Rigid (or beam-strip) diaphragm option per storey so slabs tie the frame.
+- Verification: 2D results must be reproduced by planar 3D models; textbook grids.
+
+### Phase 6 — Design the load path (the payoff)
+- Pipeline runner: for the governing combo —
+  1. slabs (strip design via `flexuralSteel`),
+  2. every beam/girder: `detectCriticalSections` → `designBeam` (multi-section),
+  3. every column: end forces → `columnDesign` (P–M),
+  4. column bases: reactions → footing selector — isolated (`P`, `P+M` eccentric),
+     **combined** when two columns are close (engine already decides geometry), or
+     **pile cap** when q_allow is exceeded;
+  5. quantities roll-up via `quantities.ts` → bill of materials.
+- Each stage emits its existing worked solution; the runner stitches them into one
+  "structure report" (print/PDF already works via `ReportControls`).
+- Per-member handoff buttons to the existing standalone pages (the proven
+  sessionStorage pattern) so anything can be inspected/overridden manually.
+
+### Phase 7 — Polish & parity
+- Wall pier design, slab deflection checks, drift checks, seismic static lateral
+  load generator (NSCP 208), model Excel import/export, retire remaining legacy pages.
+
+---
+
+## Architecture rules (so the reuse actually holds)
+
+1. **Engines stay pure & typed** — no React imports; every new engine ships with
+   closed-form tests like `beamAnalysis.test.ts`.
+2. **One FEM core** — extract `fem.ts` (solveLinear, assembly helpers, Gauss) in
+   Phase 2; beam, frame2d, frame3d, and the Winkler footing all consume it.
+3. **Loads keep NSCP categories end-to-end** — combos are applied once, at the model
+   level; everything downstream consumes factored member forces.
+4. **Design pages remain standalone** — the 3D app *drives* them through the data
+   schema + handoffs; they keep working independently (the incremental-coexistence
+   strategy that worked for the legacy migration, applied again).
+5. **Every stage explains itself** — `SolutionStep[]` is the lingua franca; the 3D
+   runner only concatenates narratives the engines already produce.
+
+## Suggested order of attack
+
+Phase 1 (column engine is needed regardless) → Phase 2 (kernel generalisation while
+the FEM code is fresh) → Phase 3 (tributary; quick win, makes even the 2D frame
+useful for real buildings) → Phase 4/5 (the 3D space) → Phase 6 (pipeline) → Phase 7.

--- a/webapp/src/components/BeamSchematic.tsx
+++ b/webapp/src/components/BeamSchematic.tsx
@@ -22,6 +22,9 @@ export interface BeamSchematicProps {
   /** When false the section can't fit the steel: bars are clipped at the NA and
    *  an explicit warning is drawn. */
   flexOK?: boolean
+  /** Hogging (−Mu): the whole arrangement mirrors — tension steel at the TOP,
+   *  compression at the bottom, d measured from the bottom (compression) face. */
+  hogging?: boolean
 }
 
 /** Thin + mark with a dashed extension line out to a dimension line. */
@@ -42,7 +45,7 @@ function CentroidMark({ cx, cy, toX }: { cx: number; cy: number; toX: number }) 
  *  d / d′ dimension lines. */
 export function BeamSchematic({
   b, h, cover, barDia, stirrupDia, bars, d, dPrime, layers, comprLayers,
-  comprBars = 0, comprBarDia, naDepth = 0, flexOK = true,
+  comprBars = 0, comprBarDia, naDepth = 0, flexOK = true, hogging = false,
 }: BeamSchematicProps): JSX.Element {
   const W = 330, H = 322
   const padL = 56, padT = 30, availW = 150, availH = 210
@@ -79,7 +82,6 @@ export function BeamSchematic({
   const n = lay.reduce((a, q) => a + q, 0)
   const x1 = x0 + (cover + stirrupDia + barDia / 2) * s
   const x2 = x0 + bw - (cover + stirrupDia + barDia / 2) * s
-  const yBottom = y0 + hh - (cover + stirrupDia + barDia / 2) * s
   const pitch = (barDia + 25) * s
 
   const rowX = (q: number) => Array.from({ length: q }, (_, i) => (q === 1 ? (x1 + x2) / 2 : x1 + ((x2 - x1) * i) / (q - 1)))
@@ -88,14 +90,29 @@ export function BeamSchematic({
   const brC = Math.max(3, (dbC / 2) * s)
   const cLay = comprLayers && comprLayers.length > 0 ? comprLayers : (comprBars > 0 ? [comprBars] : [])
   const nC = cLay.reduce((a, q) => a + q, 0)
-  const yTop = y0 + (cover + stirrupDia + dbC / 2) * s
   const pitchC = (dbC + 25) * s
 
-  // When the layout diverges, clip the drawing at the neutral axis: tension
-  // layers stay below it, compression layers above it.
-  const yNA = naDepth > 0 ? y0 + naDepth * s : sy0 + r
-  const maxTen = flexOK ? lay.length : Math.max(1, Math.floor((yBottom - yNA - br) / pitch) + 1)
-  const maxCom = flexOK ? cLay.length : Math.max(nC > 0 ? 1 : 0, Math.floor((yNA - brC - yTop) / pitchC) + 1)
+  // Hogging mirrors everything: tension anchors at the TOP and stacks down,
+  // compression anchors at the bottom and stacks up; depths measure from the
+  // compression face (bottom).
+  const sgn = hogging ? -1 : 1
+  const yTen = hogging
+    ? y0 + (cover + stirrupDia + barDia / 2) * s
+    : y0 + hh - (cover + stirrupDia + barDia / 2) * s
+  const yCom = hogging
+    ? y0 + hh - (cover + stirrupDia + dbC / 2) * s
+    : y0 + (cover + stirrupDia + dbC / 2) * s
+  const tenY = (li: number) => yTen + sgn * li * pitch          // toward mid-depth
+  const comY = (li: number) => yCom - sgn * li * pitchC
+
+  // When the layout diverges, clip the drawing at the neutral axis (measured
+  // from the compression face): tension layers stay on their side, compression
+  // layers on theirs.
+  const yNA = naDepth > 0
+    ? (hogging ? y0 + hh - naDepth * s : y0 + naDepth * s)
+    : (hogging ? sy0 + sh - r : sy0 + r)
+  const maxTen = flexOK ? lay.length : Math.max(1, Math.floor((Math.abs(yTen - yNA) - br) / pitch) + 1)
+  const maxCom = flexOK ? cLay.length : Math.max(nC > 0 ? 1 : 0, Math.floor((Math.abs(yNA - yCom) - brC) / pitchC) + 1)
   const layDrawn = lay.slice(0, maxTen)
   const cLayDrawn = cLay.slice(0, maxCom)
 
@@ -103,8 +120,8 @@ export function BeamSchematic({
   const dxInner = x0 + bw + 14
   const dxOuter = x0 + bw + (hasDP ? 38 : 16)
   const cxMid = x0 + bw / 2
-  const cyD = y0 + dPx
-  const cyDP = hasDP ? y0 + (dPrime as number) * s : 0
+  const cyD = hogging ? y0 + hh - dPx : y0 + dPx
+  const cyDP = hasDP ? (hogging ? y0 + hh - (dPrime as number) * s : y0 + (dPrime as number) * s) : 0
 
   const tenLabel = lay.length > 3
     ? `${n} ⌀${barDia} mm — ${lay.length} layers`
@@ -124,17 +141,17 @@ export function BeamSchematic({
       <path d={hook1} fill="none" stroke={BAR} strokeWidth={stW} strokeLinecap="round" opacity={0.8} />
       <path d={hook2} fill="none" stroke={BAR} strokeWidth={stW} strokeLinecap="round" opacity={0.8} />
 
-      {/* compression bars (hollow), layered downward */}
+      {/* compression bars (hollow), stacking away from their face */}
       {cLayDrawn.map((q, li) =>
         rowX(q).map((bx, i) => (
-          <circle key={`c${li}-${i}`} cx={bx} cy={yTop + li * pitchC} r={brC} fill="#fff" stroke={BAR} strokeWidth={1.6} />
+          <circle key={`c${li}-${i}`} cx={bx} cy={comY(li)} r={brC} fill="#fff" stroke={BAR} strokeWidth={1.6} />
         )),
       )}
 
-      {/* tension bars (solid), layered upward */}
+      {/* tension bars (solid), stacking toward mid-depth */}
       {layDrawn.map((q, li) =>
         rowX(q).map((bx, i) => (
-          <circle key={`t${li}-${i}`} cx={bx} cy={yBottom - li * pitch} r={br} fill={BAR} />
+          <circle key={`t${li}-${i}`} cx={bx} cy={tenY(li)} r={br} fill={BAR} />
         )),
       )}
 
@@ -154,21 +171,26 @@ export function BeamSchematic({
       {hasDP && <CentroidMark cx={cxMid} cy={cyDP} toX={dxInner} />}
       <CentroidMark cx={cxMid} cy={cyD} toX={dxOuter} />
 
-      {/* labels: compression on top, tension at the bottom */}
+      {/* labels: each group labelled at its own face */}
       {nC > 0 && (
-        <text x={x0 + bw / 2} y={y0 - 6} fontSize={8.5} fill={BAR} textAnchor="middle">
-          {nC} ⌀{dbC} mm{cLay.length > 1 ? (cLay.length > 3 ? ` — ${cLay.length} layers` : ` (${cLay.join('+')})`) : ''} top
+        <text x={x0 + bw / 2} y={hogging ? y0 + hh + 12 : y0 - 6} fontSize={8.5} fill={BAR} textAnchor="middle">
+          {nC} ⌀{dbC} mm{cLay.length > 1 ? (cLay.length > 3 ? ` — ${cLay.length} layers` : ` (${cLay.join('+')})`) : ''}{hogging ? ' bottom' : ' top'}
         </text>
       )}
-      <text x={x0 + bw / 2} y={y0 + hh + 12} fontSize={8.5} fill={BAR} textAnchor="middle">{tenLabel}</text>
+      <text x={x0 + bw / 2} y={hogging ? y0 - 6 : y0 + hh + 12} fontSize={8.5} fill={BAR} textAnchor="middle">
+        {tenLabel}{hogging ? ' top' : ''}
+      </text>
 
-      {/* dimensions: b below, h left, d (and d′ for DRRB) right */}
+      {/* dimensions: b below, h left, d (and d′ for DRRB) right — measured
+          from the compression face (top for sagging, bottom for hogging) */}
       <DimBelow xA={x0} xB={x0 + bw} featY={y0 + hh + 14} dY={y0 + hh + 30} label={`b = ${Math.round(b)} mm`} />
       <DimSide yA={y0} yB={y0 + hh} featX={x0} dX={x0 - 16} label={`h = ${Math.round(h)} mm`} side="left" />
       {hasDP && (
-        <DimSide yA={y0} yB={cyDP} featX={x0 + bw} dX={dxInner} label={`d' = ${Math.round(dPrime as number)} mm`} side="right" />
+        <DimSide yA={hogging ? cyDP : y0} yB={hogging ? y0 + hh : cyDP} featX={x0 + bw} dX={dxInner}
+          label={`d' = ${Math.round(dPrime as number)} mm`} side="right" />
       )}
-      <DimSide yA={y0} yB={cyD} featX={x0 + bw} dX={dxOuter} label={`d = ${Math.round(d)} mm`} side="right" />
+      <DimSide yA={hogging ? cyD : y0} yB={hogging ? y0 + hh : cyD} featX={x0 + bw} dX={dxOuter}
+        label={`d = ${Math.round(d)} mm`} side="right" />
     </svg>
   )
 }

--- a/webapp/src/pages/BeamAnalysis.tsx
+++ b/webapp/src/pages/BeamAnalysis.tsx
@@ -39,7 +39,9 @@ function ItemShell({ title, onRemove, children }: {
         <span className="text-xs font-bold uppercase tracking-wide text-slate-500">{title}</span>
         <button type="button" onClick={onRemove} className="text-xs text-red-500 hover:underline">remove</button>
       </div>
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">{children}</div>
+      {/* fields take only the width they need — no wide blank area on
+          one-field cards like pin/roller */}
+      <div className="flex flex-wrap gap-3 [&>label]:w-36">{children}</div>
     </div>
   )
 }

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -232,12 +232,9 @@ export default function BeamDesign() {
                 bars={r.bars} d={r.d} dPrime={r.comprLayers.length > 0 ? r.dPrime : undefined}
                 layers={r.layers} comprLayers={r.comprLayers}
                 comprBars={r.comprBars} comprBarDia={f.comprBarDia}
-                naDepth={r.cNA} flexOK={r.flexOK} />
+                naDepth={r.cNA} flexOK={r.flexOK} hogging={hogging} />
             ) : (
               <p className="py-8 text-center text-sm text-slate-400">Enter a valid section (d must be positive).</p>
-            )}
-            {hogging && r && (
-              <p className="mt-1 text-xs text-slate-500">Hogging section — drawn bars apply mirrored: tension steel at the TOP.</p>
             )}
           </div>
 


### PR DESCRIPTION
## Fixes
- **Hogging sections now draw correctly.** `BeamSchematic` gains a `hogging` prop: tension bars anchor at the **top** and stack downward, compression bars sit at the bottom stacking up, the `d`/`d′` dimension lines and centroid + marks measure from the bottom (compression) face, the NA clip mirrors, and the face labels swap. The "drawn bars apply mirrored" caption is removed — the drawing simply matches the Results orientation now.
- **Support/load cards**: fields take only the width they need (flex-wrap, fixed-width fields) — no more wide blank area on one-field cards like pin/roller.

## Roadmap — 3D model space (`docs/ROADMAP-3D.md`)
The long-term plan for frames + plates → analyze → design the load path, organised around **reusing every existing engine and page**:
1. **Phase 1** — typed structural model schema + the missing **column P–M engine** (also closes the legacy `columnDesign.html` gap).
2. **Phase 2** — extract a shared `fem.ts` core from `beamAnalysis` and generalise to a **2D frame element** (regression-tested against the beam solver).
3. **Phase 3** — **tributary engine**: slab/wall area loads → one-way/two-way line loads on beams (emitted as the `udl`/`vdl` loads the FEM already accepts) — the load-path step, with a WorkedSolution narrative.
4. **Phase 4/5** — **react-three-fiber model space** (members, plates, loads, inspector reusing Diagram/Schematics; solver in a web worker) and the **12-DOF 3D frame element**.
5. **Phase 6** — the pipeline runner: slabs → `detectCriticalSections` + `designBeam` per member → column P–M → reactions into the existing footing/combined/pile-cap engines → `quantities.ts` bill of materials, stitching the per-stage worked solutions into one printable structure report.
6. **Phase 7** — walls, drift/deflection checks, NSCP 208 lateral loads, legacy retirement.

Architecture rules included (pure engines, one FEM core, NSCP categories end-to-end, design pages stay standalone via the proven handoff pattern).

## Verification
Build green; 104 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)