### PR TITLE
Phase 1: column design engine (axial/P–M/slender) + structural model schema

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -4,6 +4,7 @@ import PileCapDesign from './pages/PileCapDesign'
 import CombinedFootingDesign from './pages/CombinedFootingDesign'
 import BeamDesign from './pages/BeamDesign'
 import BeamAnalysis from './pages/BeamAnalysis'
+import ColumnDesign from './pages/ColumnDesign'
 import SlabEstimate from './pages/SlabEstimate'
 import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
@@ -37,6 +38,7 @@ function Home() {
         <Tile to="/combined">Combined Footing</Tile>
         <Tile to="/beam-design">Beam Design</Tile>
         <Tile to="/beam-analysis">Beam Analysis (FEM)</Tile>
+        <Tile to="/column-design">Column Design</Tile>
       </div>
 
       <h2 className="mt-8 text-lg font-semibold text-slate-800">Material estimation (quantity take-off)</h2>
@@ -60,6 +62,7 @@ export default function App() {
       <Route path="/combined" element={<CombinedFootingDesign />} />
       <Route path="/beam-design" element={<BeamDesign />} />
       <Route path="/beam-analysis" element={<BeamAnalysis />} />
+      <Route path="/column-design" element={<ColumnDesign />} />
       <Route path="/estimate/slab" element={<SlabEstimate />} />
       <Route path="/estimate/beam" element={<BeamEstimate />} />
       <Route path="/estimate/column" element={<ColumnEstimate />} />

--- a/webapp/src/components/ColumnSchematic.tsx
+++ b/webapp/src/components/ColumnSchematic.tsx
@@ -1,0 +1,78 @@
+import type { JSX } from 'react'
+import { DimBelow, DimSide } from './dims'
+
+const STROKE = '#37526e'
+const FILL = '#eef3f8'
+const BAR = '#37526e'
+
+export interface ColumnSchematicProps {
+  shape: 'tied' | 'spiral'
+  b?: number; h?: number      // mm, tied
+  D?: number                  // mm, spiral
+  cover: number; barDia: number; tieDia: number
+  bars: number
+  tieSpacing?: number         // label only
+}
+
+/** Column cross-section to scale: rectangular tied (bars on two faces, tie at
+ *  real thickness) or circular spiral (ring of bars + spiral wire). */
+export function ColumnSchematic({ shape, b = 0, h = 0, D = 0, cover, barDia, tieDia, bars, tieSpacing }: ColumnSchematicProps): JSX.Element {
+  const W = 320, H = 280
+  const padT = 28, availW = 170, availH = 190
+  const tied = shape === 'tied'
+  const bb = tied ? b : D, hh0 = tied ? h : D
+  const s = Math.min(availW / bb, availH / hh0)
+  const bw = bb * s, hgt = hh0 * s
+  const x0 = 70 + (availW - bw) / 2, y0 = padT
+  const stW = Math.max(1, tieDia * s)
+  const br = Math.max(3, (barDia / 2) * s)
+
+  const inset = (cover + tieDia / 2) * s
+
+  let body: JSX.Element
+  if (tied) {
+    const x1 = x0 + (cover + tieDia + barDia / 2) * s
+    const x2 = x0 + bw - (cover + tieDia + barDia / 2) * s
+    const yT = y0 + (cover + tieDia + barDia / 2) * s
+    const yB = y0 + hgt - (cover + tieDia + barDia / 2) * s
+    const nFace = Math.max(2, Math.ceil(bars / 2))
+    const rowX = Array.from({ length: nFace }, (_, i) => (nFace === 1 ? (x1 + x2) / 2 : x1 + ((x2 - x1) * i) / (nFace - 1)))
+    body = (
+      <g>
+        <rect x={x0} y={y0} width={bw} height={hgt} rx={2} fill={FILL} stroke={STROKE} strokeWidth={1.6} />
+        <rect x={x0 + inset} y={y0 + inset} width={bw - 2 * inset} height={hgt - 2 * inset}
+          rx={Math.max(2, 2.5 * tieDia * s)} fill="none" stroke={BAR} strokeWidth={stW} opacity={0.8} />
+        {rowX.map((bx, i) => <circle key={`t${i}`} cx={bx} cy={yT} r={br} fill={BAR} />)}
+        {rowX.slice(0, Math.max(2, Math.floor(bars / 2))).map((bx, i) => <circle key={`b${i}`} cx={bx} cy={yB} r={br} fill={BAR} />)}
+      </g>
+    )
+  } else {
+    const cx = x0 + bw / 2, cy = y0 + hgt / 2
+    const R = bw / 2
+    const ringR = R - (cover + tieDia + barDia / 2) * s
+    body = (
+      <g>
+        <circle cx={cx} cy={cy} r={R} fill={FILL} stroke={STROKE} strokeWidth={1.6} />
+        <circle cx={cx} cy={cy} r={R - inset} fill="none" stroke={BAR} strokeWidth={stW} opacity={0.8} strokeDasharray="10 4" />
+        {Array.from({ length: Math.max(6, bars) }, (_, i) => {
+          const ang = (2 * Math.PI * i) / Math.max(6, bars) - Math.PI / 2
+          return <circle key={i} cx={cx + ringR * Math.cos(ang)} cy={cy + ringR * Math.sin(ang)} r={br} fill={BAR} />
+        })}
+      </g>
+    )
+  }
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet"
+      style={{ width: '100%', height: 'auto', fontFamily: 'Arial, sans-serif' }}>
+      <text x={70} y={14} fontSize={11} fontWeight={700} fill="#0056b3">SECTION</text>
+      {body}
+      <text x={x0 + bw / 2} y={y0 + hgt + 12} fontSize={8.5} fill={BAR} textAnchor="middle">
+        {bars} ⌀{barDia} mm · {tied ? `ties ⌀${tieDia}` : `spiral ⌀${tieDia}`}{tieSpacing ? ` @ ${Math.round(tieSpacing)} mm` : ''}
+      </text>
+      <DimBelow xA={x0} xB={x0 + bw} featY={y0 + hgt + 14} dY={y0 + hgt + 30}
+        label={tied ? `b = ${Math.round(b)} mm` : `D = ${Math.round(D)} mm`} />
+      {tied && <DimSide yA={y0} yB={y0 + hgt} featX={x0} dX={x0 - 16} label={`h = ${Math.round(h)} mm`} side="left" />}
+    </svg>
+  )
+}

--- a/webapp/src/components/InteractionDiagram.tsx
+++ b/webapp/src/components/InteractionDiagram.tsx
@@ -1,0 +1,86 @@
+import type { JSX } from 'react'
+import type { InteractionResult } from '../engine/columnDesign'
+
+const NOM = '#94a3b8'
+const DES = '#0056b3'
+const DEMAND = '#dc2626'
+const BAL = '#7c3aed'
+
+/** P–M interaction diagram: nominal curve (grey), design curve φPn–φMn with
+ *  the 0.80Po cap (blue), the balanced point, and the factored demand. */
+export function InteractionDiagram({ r, Pu, Mu }: {
+  r: InteractionResult; Pu?: number; Mu?: number
+}): JSX.Element {
+  const W = 460, H = 300
+  const padL = 54, padR = 16, padT = 24, padB = 34
+  const pts = r.curve
+
+  const Mmax = Math.max(...pts.map((p) => p.Mn), Mu ?? 0) * 1.06
+  const Pmax = Math.max(r.Po, Pu ?? 0) * 1.06
+  const Pmin = Math.min(0, ...pts.map((p) => p.Pn)) * 1.1
+  const sx = (m: number) => padL + ((W - padL - padR) * m) / Math.max(Mmax, 1e-9)
+  const sy = (p: number) => padT + ((H - padT - padB) * (Pmax - p)) / Math.max(Pmax - Pmin, 1e-9)
+
+  const nomLine = pts.map((p) => `${sx(p.Mn).toFixed(1)},${sy(p.Pn).toFixed(1)}`).join(' ')
+  // Design curve: φPn capped at φ·0.80Po.
+  const cap = 0.65 * r.PnMax
+  const desPts = pts.map((p) => ({ m: p.phi * p.Mn, P: Math.min(p.phi * p.Pn, cap) }))
+  const desLine = desPts.map((p) => `${sx(p.m).toFixed(1)},${sy(p.P).toFixed(1)}`).join(' ')
+
+  const ticksP = 4, ticksM = 4
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet"
+      style={{ width: '100%', height: 'auto', fontFamily: 'Arial, sans-serif' }}>
+      <text x={padL} y={14} fontSize={11} fontWeight={700} fill="#0056b3">P–M INTERACTION</text>
+
+      {/* axes + ticks */}
+      <line x1={padL} y1={sy(0)} x2={W - padR} y2={sy(0)} stroke="#475569" strokeWidth={1} />
+      <line x1={padL} y1={padT} x2={padL} y2={H - padB} stroke="#475569" strokeWidth={1} />
+      {Array.from({ length: ticksP + 1 }, (_, i) => {
+        const P = Pmin + ((Pmax - Pmin) * i) / ticksP
+        return (
+          <g key={`p${i}`}>
+            <line x1={padL - 3} y1={sy(P)} x2={padL} y2={sy(P)} stroke="#475569" />
+            <text x={padL - 6} y={sy(P) + 3} fontSize={8} fill="#64748b" textAnchor="end">{Math.round(P)}</text>
+          </g>
+        )
+      })}
+      {Array.from({ length: ticksM + 1 }, (_, i) => {
+        const M = (Mmax * i) / ticksM
+        return (
+          <g key={`m${i}`}>
+            <line x1={sx(M)} y1={H - padB} x2={sx(M)} y2={H - padB + 3} stroke="#475569" />
+            <text x={sx(M)} y={H - padB + 13} fontSize={8} fill="#64748b" textAnchor="middle">{Math.round(M)}</text>
+          </g>
+        )
+      })}
+      <text x={W - padR} y={H - padB + 13} fontSize={8.5} fill="#64748b" textAnchor="end">M (kN·m)</text>
+      <text x={padL + 4} y={padT + 8} fontSize={8.5} fill="#64748b">P (kN)</text>
+
+      {/* curves */}
+      <polyline points={nomLine} fill="none" stroke={NOM} strokeWidth={1.3} strokeDasharray="5 3" />
+      <polyline points={desLine} fill="none" stroke={DES} strokeWidth={1.8} />
+
+      {/* balanced point */}
+      <circle cx={sx(r.balanced.Mb)} cy={sy(r.balanced.Pb)} r={3.5} fill="none" stroke={BAL} strokeWidth={1.5} />
+      <text x={sx(r.balanced.Mb) + 6} y={sy(r.balanced.Pb) - 4} fontSize={8} fill={BAL}>balanced</text>
+
+      {/* demand */}
+      {Pu !== undefined && Mu !== undefined && (
+        <g>
+          <line x1={sx(0)} y1={sy(0)} x2={sx(Mu)} y2={sy(Pu)} stroke={DEMAND} strokeWidth={0.7} strokeDasharray="4 3" />
+          <circle cx={sx(Mu)} cy={sy(Pu)} r={3.5} fill={DEMAND} />
+          <text x={sx(Mu) + 6} y={sy(Pu) + 3} fontSize={8} fill={DEMAND}>(Mu, Pu)</text>
+        </g>
+      )}
+
+      {/* legend */}
+      <g fontSize={8} fill="#64748b">
+        <line x1={W - 150} y1={padT + 2} x2={W - 130} y2={padT + 2} stroke={NOM} strokeDasharray="5 3" strokeWidth={1.3} />
+        <text x={W - 126} y={padT + 5}>nominal Pn–Mn</text>
+        <line x1={W - 150} y1={padT + 14} x2={W - 130} y2={padT + 14} stroke={DES} strokeWidth={1.8} />
+        <text x={W - 126} y={padT + 17}>design φPn–φMn (capped)</text>
+      </g>
+    </svg>
+  )
+}

--- a/webapp/src/engine/columnDesign.test.ts
+++ b/webapp/src/engine/columnDesign.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import {
+  designAxialColumn, interaction, capacityAtEccentricity, breslerReciprocal,
+  momentMagnificationNonsway,
+} from './columnDesign'
+
+describe('axial — tied (review Concrete 7, Problem 2)', () => {
+  // 400 sq tied, D=1400 kN, L=790 kN → Pu = 1.2D + 1.6L = 2944 kN; 28 mm bars.
+  const Pu = 1.2 * 1400 + 1.6 * 790
+  const r = designAxialColumn({
+    shape: 'tied', b: 400, h: 400, cover: 40, barDia: 28, tieDia: 10,
+    fc: 28, fy: 415, Pu,
+  })
+
+  it('factored load and required bars (8 ⌀28)', () => {
+    expect(Pu).toBeCloseTo(2944, 6)
+    expect(r.bars).toBe(8)
+    expect(r.axialOK).toBe(true)
+    expect(r.rhoOK).toBe(true)
+  })
+
+  it('10 mm tie spacing = min(16db, 48dt, least) = 400 mm', () => {
+    expect(r.tieSpacing).toBe(400)
+    expect(r.tieGovern).toBe('least dimension')
+  })
+})
+
+describe('axial — spiral (review Concrete 7, Problem 3 / key 2,423.70 kN)', () => {
+  const r = designAxialColumn({
+    shape: 'spiral', D: 400, cover: 40, barDia: 25, tieDia: 10,
+    fc: 21, fy: 415, Pu: 1000, numBars: 8,
+  })
+
+  it('Po and design strength φPn = 0.75·0.85·Po', () => {
+    expect(r.phiPnMax).toBeCloseTo(2424.2, 0)   // key rounds π to 2423.70
+    expect(r.phi).toBe(0.75)
+    expect(r.alpha).toBe(0.85)
+  })
+
+  it('spiral ratio ≥ max[0.45(Ag/Ach−1), 0.12]·f′c/fyt and clear pitch 25–75', () => {
+    const Ag = (Math.PI / 4) * 400 ** 2
+    const Ach = (Math.PI / 4) * 320 ** 2
+    const expected = Math.max(0.45 * (Ag / Ach - 1), 0.12) * (21 / 415)
+    expect(r.rhoS).toBeCloseTo(expected, 9)
+    const clear = r.spiralPitch - 10
+    expect(clear).toBeGreaterThanOrEqual(25 - 1e-9)
+    expect(clear).toBeLessThanOrEqual(75 + 1e-9)
+  })
+})
+
+describe('interaction — balanced condition (review Concrete 8, Problem 4 keys)', () => {
+  // 300×400, f'c = 21, fy = 415, 6 ⌀28 (3 per 300 mm face), cover to centroid 60.
+  // Keys: Pb = 881.87 kN, Mb = 314.86 kN·m, eb = 357.03 mm.
+  const inp = {
+    b: 300, h: 400, cover: 40, barDia: 28, tieDia: 6,  // 40+6+14 = 60 to centroid
+    fc: 21, fy: 415, numBars: 6,
+  }
+
+  it('Pb, Mb, eb match the answer key', () => {
+    const r = interaction(inp)
+    expect(r.dPrime).toBeCloseTo(60, 9)
+    expect(r.balanced.Pb).toBeCloseTo(881.87, 0)
+    expect(r.balanced.Mb).toBeCloseTo(314.86, 0)
+    expect(r.balanced.eb * 1000).toBeCloseTo(357.03, 0)
+  })
+
+  it('the curve passes through Po at large c and φ transitions 0.65 → 0.90', () => {
+    const r = interaction(inp)
+    const top = r.curve[r.curve.length - 1]
+    expect(top.Pn).toBeCloseTo(r.Po, 0)
+    expect(top.phi).toBe(0.65)
+    const bottom = r.curve[0]
+    expect(bottom.phi).toBeCloseTo(0.90, 9)
+  })
+
+  it('capacityAtEccentricity recovers the balanced point at e = eb', () => {
+    const r = interaction(inp)
+    const p = capacityAtEccentricity(inp, r.balanced.eb)
+    expect(p.Pn).toBeCloseTo(r.balanced.Pb, 0)
+    expect(p.Mn).toBeCloseTo(r.balanced.Mb, 0)
+  })
+})
+
+describe('Bresler reciprocal', () => {
+  it('1/Pn = 1/Pnx + 1/Pny − 1/Po', () => {
+    expect(breslerReciprocal(2000, 1500, 4000)).toBeCloseTo(1 / (1 / 2000 + 1 / 1500 - 1 / 4000), 9)
+    // uniaxial degenerate: Pny = Po → Pn = Pnx
+    expect(breslerReciprocal(2000, 4000, 4000)).toBeCloseTo(2000, 6)
+  })
+})
+
+describe('slenderness — nonsway moment magnification (RC-06 conventions)', () => {
+  it('limit 34 + 12(M1/M2) ≤ 40; single curvature (−) lowers it', () => {
+    const single = momentMagnificationNonsway({
+      Pu: 500, M1: -100, M2: 100, k: 1, Lu: 3, h: 300, EI: 910000 / 1000,
+    })
+    expect(single.limit).toBeCloseTo(22, 9)      // 34 − 12
+    expect(single.Cm).toBeCloseTo(1.0, 9)        // 0.6 + 0.4
+    const dbl = momentMagnificationNonsway({
+      Pu: 500, M1: 100, M2: 100, k: 1, Lu: 3, h: 300, EI: 910000 / 1000,
+    })
+    expect(dbl.limit).toBeCloseTo(40, 9)         // 34 + 12 capped at 40 → 46 → 40
+    expect(dbl.Cm).toBeCloseTo(0.2, 9)
+  })
+
+  it('Euler load, δ ≥ 1 and M2,min = Pu(15 + 0.03h)', () => {
+    const r = momentMagnificationNonsway({
+      Pu: 1000, M1: -80, M2: 100, k: 0.8, Lu: 4, h: 400, EI: 50000,
+    })
+    expect(r.Pc).toBeCloseTo((Math.PI ** 2 * 50000) / (0.8 * 4) ** 2, 3)
+    expect(r.delta).toBeGreaterThanOrEqual(1)
+    expect(r.M2min).toBeCloseTo((1000 * (15 + 12)) / 1000, 6)   // 27 kN·m
+    expect(r.Mc).toBeCloseTo(r.delta * 100, 6)
+  })
+})

--- a/webapp/src/engine/columnDesign.ts
+++ b/webapp/src/engine/columnDesign.ts
@@ -1,0 +1,261 @@
+// ─────────────────────────────────────────────────────────────────────────
+// RC column design — NSCP 2015 / ACI 318-14, following the review sheets:
+//  · Axial (short): Po = 0.85f'c(Ag − Ast) + fy·Ast (§422.4.2.2);
+//    Pn,max = 0.80Po tied / 0.85Po spiral; φ = 0.65 / 0.75.
+//    Steel 1–8% of Ag (§410.6.1.1); ≥4 bars tied rect, ≥6 spiral (§410.7.3.1).
+//    Ties §425.7.2 (Ø ≥ 10 mm up to ⌀32 bars else 12; s ≤ min(16db, 48dt, least
+//    dimension)). Spirals §425.7.3 (Ø ≥ 10; clear pitch 25–75 mm;
+//    ρs ≥ max[0.45(Ag/Ach − 1), 0.12]·f'c/fyt).
+//  · Eccentric (short, tied rectangular): strain-compatibility interaction —
+//    ε_cu = 0.003, fs = clamp(600(c−d)/c, ±fy), displaced concrete deducted
+//    for bars inside the stress block, moments about the plastic centroid.
+//    Balanced condition cb = 600dt/(600+fy). φ from ε_t (0.65/0.75 → 0.90).
+//  · Slender (braced/nonsway): neglect when kLu/r ≤ 34 + 12(M1/M2) ≤ 40
+//    (M1/M2 negative in single curvature — sheet convention);
+//    Cm = 0.6 − 0.4(M1/M2); Pc = π²EI/(kLu)²; δ = Cm/(1 − Pu/0.75Pc) ≥ 1;
+//    Mc = δ·max(M2, M2,min = Pu(15 + 0.03h)).
+//  · Bresler reciprocal for biaxial: 1/Pn = 1/Pnx + 1/Pny − 1/Po.
+// Units: mm, MPa, kN, kN·m.
+// ─────────────────────────────────────────────────────────────────────────
+import { beta1 } from './loads'
+
+export type ColumnShape = 'tied' | 'spiral'
+
+// ── Axial (short, concentric) ────────────────────────────────────────────
+export interface AxialColumnInput {
+  shape: ColumnShape
+  b?: number; h?: number       // tied rectangular, mm
+  D?: number                   // spiral circular, mm
+  cover: number                // clear cover, mm
+  barDia: number
+  tieDia: number               // tie or spiral wire Ø
+  fc: number; fy: number
+  fyt?: number                 // tie/spiral yield (default fy)
+  Pu: number                   // factored axial demand, kN
+  /** Provide to ANALYZE a chosen bar count; omit to DESIGN the steel. */
+  numBars?: number
+}
+
+export interface AxialColumnResult {
+  shape: ColumnShape
+  Ag: number                   // mm²
+  alpha: number                // 0.80 tied / 0.85 spiral
+  phi: number                  // 0.65 / 0.75
+  AstReq: number               // mm² required (0 when ρmin governs the bars)
+  rhoReq: number
+  bars: number
+  Ast: number                  // provided, mm²
+  rho: number
+  rhoOK: boolean               // 0.01 ≤ ρ ≤ 0.08
+  minBars: number
+  Po: number                   // kN
+  PnMax: number                // kN
+  phiPnMax: number             // kN
+  axialOK: boolean             // φPn,max ≥ Pu
+  // Tie detailing (tied)
+  tieDiaMin: number
+  tieSpacing: number           // governing s, mm
+  tieGovern: string
+  // Spiral detailing (spiral)
+  Ach: number
+  rhoS: number                 // required volumetric ratio
+  spiralPitch: number          // clear-pitch-capped pitch, mm
+  pitchClearOK: boolean        // 25 ≤ clear ≤ 75
+}
+
+const ES = 600 // 0.003·Es with Es = 200 GPa → fs = 600(c−d)/c
+
+export function designAxialColumn(i: AxialColumnInput): AxialColumnResult {
+  const fyt = i.fyt ?? i.fy
+  const tied = i.shape === 'tied'
+  const Ag = tied ? (i.b ?? 0) * (i.h ?? 0) : (Math.PI / 4) * (i.D ?? 0) ** 2
+  const alpha = tied ? 0.80 : 0.85
+  const phi = tied ? 0.65 : 0.75
+  const Ab = (Math.PI / 4) * i.barDia ** 2
+  const minBars = tied ? 4 : 6
+
+  // Required steel from Pu = φ·α·[0.85f'c(Ag − Ast) + fy·Ast]
+  const num = (i.Pu * 1000) / (phi * alpha) - 0.85 * i.fc * Ag
+  const AstReq = Math.max(0.01 * Ag, num / (i.fy - 0.85 * i.fc))
+  const rhoReq = AstReq / Ag
+
+  const bars = i.numBars ?? Math.max(minBars, Math.ceil(AstReq / Ab))
+  const Ast = bars * Ab
+  const rho = Ast / Ag
+  const rhoOK = rho >= 0.01 - 1e-9 && rho <= 0.08 + 1e-9
+
+  const Po = (0.85 * i.fc * (Ag - Ast) + i.fy * Ast) / 1000
+  const PnMax = alpha * Po
+  const phiPnMax = phi * PnMax
+
+  // §425.7.2 ties
+  const tieDiaMin = i.barDia <= 32 ? 10 : 12
+  const least = tied ? Math.min(i.b ?? 0, i.h ?? 0) : (i.D ?? 0)
+  const sCands: [number, string][] = [
+    [16 * i.barDia, '16d_b'],
+    [48 * i.tieDia, '48d_tie'],
+    [least, 'least dimension'],
+  ]
+  const [tieSpacing, tieGovern] = sCands.reduce((a, c) => (c[0] < a[0] ? c : a))
+
+  // §425.7.3 spiral
+  const Dch = (i.D ?? 0) - 2 * i.cover
+  const Ach = (Math.PI / 4) * Dch ** 2
+  const rhoS = tied ? 0 : Math.max(0.45 * (Ag / Ach - 1), 0.12) * (i.fc / fyt)
+  const Asp = (Math.PI / 4) * i.tieDia ** 2
+  let spiralPitch = 0, pitchClearOK = true
+  if (!tied && rhoS > 0) {
+    // ρs = 4Asp / (s·Dch) → s = 4Asp / (ρs·Dch); clear pitch 25–75 mm.
+    const sReq = (4 * Asp) / (rhoS * Dch)
+    const clear = sReq - i.tieDia
+    spiralPitch = Math.min(Math.max(clear, 25), 75) + i.tieDia
+    pitchClearOK = clear >= 25 - 1e-9
+  }
+
+  return {
+    shape: i.shape, Ag, alpha, phi, AstReq, rhoReq,
+    bars, Ast, rho, rhoOK, minBars,
+    Po, PnMax, phiPnMax, axialOK: phiPnMax >= i.Pu - 1e-9,
+    tieDiaMin, tieSpacing, tieGovern,
+    Ach, rhoS, spiralPitch, pitchClearOK,
+  }
+}
+
+// ── Strain-compatibility interaction (tied rectangular, two-face bars) ──
+export interface InteractionInput {
+  b: number; h: number          // mm; bending about the axis ⟂ h
+  cover: number; barDia: number; tieDia: number
+  fc: number; fy: number
+  numBars: number               // split evenly between the two faces ⟂ to h
+}
+
+export interface PMPoint { c: number; Pn: number; Mn: number; phi: number; et: number }
+export interface InteractionResult {
+  dPrime: number; dt: number
+  AsFace: number                // mm² per face
+  Po: number; PnMax: number; phiC: number
+  balanced: { c: number; Pb: number; Mb: number; eb: number }
+  curve: PMPoint[]              // c sweep, Pn descending
+}
+
+function pmAt(i: InteractionInput, dPrime: number, dt: number, AsFace: number, c: number): PMPoint {
+  const b1 = beta1(i.fc)
+  const a = Math.min(b1 * c, i.h)
+  const Cc = (0.85 * i.fc * a * i.b) / 1000
+  const layerF = (d: number): number => {
+    const fs = Math.max(-i.fy, Math.min(i.fy, (ES * (c - d)) / c))
+    const displaced = d <= a ? 0.85 * i.fc : 0
+    return (AsFace * (fs - displaced)) / 1000
+  }
+  const F1 = layerF(dPrime)
+  const F2 = layerF(dt)
+  const Pn = Cc + F1 + F2
+  const Mn = (Cc * (i.h / 2 - a / 2) + F1 * (i.h / 2 - dPrime) + F2 * (i.h / 2 - dt)) / 1000
+  const et = (0.003 * (dt - c)) / c
+  const ety = i.fy / 200000
+  const phi = et >= 0.005 ? 0.90 : et <= ety ? 0.65 : 0.65 + (0.25 * (et - ety)) / (0.005 - ety)
+  return { c, Pn, Mn, phi, et }
+}
+
+export function interaction(i: InteractionInput): InteractionResult {
+  const dPrime = i.cover + i.tieDia + i.barDia / 2
+  const dt = i.h - dPrime
+  const Ab = (Math.PI / 4) * i.barDia ** 2
+  const AsFace = (i.numBars / 2) * Ab
+  const Ast = i.numBars * Ab
+  const Ag = i.b * i.h
+  const Po = (0.85 * i.fc * (Ag - Ast) + i.fy * Ast) / 1000
+  const PnMax = 0.80 * Po
+
+  const cb = (600 / (600 + i.fy)) * dt
+  const bal = pmAt(i, dPrime, dt, AsFace, cb)
+
+  const curve: PMPoint[] = []
+  // Sweep from near-pure-bending (small c) to pure compression. The top end
+  // needs c ≥ 600·dt/(600 − fy) for the far-face steel to reach fy so the
+  // curve actually closes at Po — 8h covers practical fy.
+  const cMin = dPrime * 0.25
+  const cMaxV = i.h * 8
+  const N = 80
+  for (let k = 0; k <= N; k++) {
+    const c = cMin * Math.pow(cMaxV / cMin, k / N)   // log sweep
+    curve.push(pmAt(i, dPrime, dt, AsFace, c))
+  }
+
+  return {
+    dPrime, dt, AsFace, Po, PnMax, phiC: 0.65,
+    balanced: { c: cb, Pb: bal.Pn, Mb: bal.Mn, eb: bal.Pn > 1e-9 ? bal.Mn / bal.Pn : 0 },
+    curve,
+  }
+}
+
+/** Capacity along the demand ray e = Mu/Pu — bisection on c (e decreases with c). */
+export function capacityAtEccentricity(i: InteractionInput, e: number): PMPoint {
+  const dPrime = i.cover + i.tieDia + i.barDia / 2
+  const dt = i.h - dPrime
+  const AsFace = ((i.numBars / 2) * Math.PI * i.barDia ** 2) / 4
+  let lo = dPrime * 0.1, hi = i.h * 20
+  for (let k = 0; k < 80; k++) {
+    const mid = (lo + hi) / 2
+    const p = pmAt(i, dPrime, dt, AsFace, mid)
+    const eAt = p.Pn > 1e-9 ? p.Mn / p.Pn : Infinity
+    if (eAt > e) lo = mid
+    else hi = mid
+  }
+  return pmAt(i, dPrime, dt, AsFace, (lo + hi) / 2)
+}
+
+/** Bresler reciprocal load for biaxial bending: 1/Pn = 1/Pnx + 1/Pny − 1/Po. */
+export function breslerReciprocal(Pnx: number, Pny: number, Po: number): number {
+  return 1 / (1 / Pnx + 1 / Pny - 1 / Po)
+}
+
+// ── Slenderness — braced (nonsway) moment magnification ─────────────────
+export interface SlendernessInput {
+  Pu: number                   // kN
+  M1: number; M2: number       // kN·m, |M2| ≥ |M1|; sign of M1/M2 < 0 = single curvature
+  k: number                    // effective length factor
+  Lu: number                   // unsupported length, m
+  h: number                    // section dimension in the bending plane, mm
+  shape?: ColumnShape          // r = 0.3h rect (default) / 0.25D circular
+  /** Flexural rigidity EI, kN·m². Omit to use 0.4EcIg/(1+βd). */
+  EI?: number
+  fc?: number; b?: number      // needed when EI is derived
+  betaD?: number               // default 0.6
+}
+
+export interface SlendernessResult {
+  r: number                    // mm
+  kLuOverR: number
+  limit: number                // 34 + 12(M1/M2) ≤ 40
+  slender: boolean             // effects must be considered
+  Cm: number
+  EI: number                   // kN·m²
+  Pc: number                   // kN
+  delta: number
+  M2min: number                // kN·m
+  Mc: number                   // kN·m
+}
+
+export function momentMagnificationNonsway(i: SlendernessInput): SlendernessResult {
+  const r = (i.shape === 'spiral' ? 0.25 : 0.30) * i.h
+  const kLuOverR = (i.k * i.Lu * 1000) / r
+  // Sheet convention (RC-06): M1/M2 is NEGATIVE for single curvature.
+  // limit = 34 + 12(M1/M2) ≤ 40;  Cm = 0.6 − 0.4(M1/M2).
+  const ratio = i.M2 !== 0 ? i.M1 / i.M2 : 0
+  const lim = Math.min(34 + 12 * ratio, 40)
+  const slender = kLuOverR > lim
+  const Cm = 0.6 - 0.4 * ratio
+
+  let EI = i.EI ?? 0
+  if (!EI) {
+    const Ec = 4700 * Math.sqrt(i.fc ?? 28) * 1000          // kPa
+    const Ig = ((i.b ?? i.h) * Math.pow(i.h, 3)) / 12 * 1e-12  // m⁴
+    EI = (0.4 * Ec * Ig) / (1 + (i.betaD ?? 0.6))
+  }
+  const Pc = (Math.PI ** 2 * EI) / Math.pow(i.k * i.Lu, 2)
+  const delta = Math.max(1, Cm / (1 - i.Pu / (0.75 * Pc)))
+  const M2min = (i.Pu * (15 + 0.03 * i.h)) / 1000
+  const Mc = delta * Math.max(Math.abs(i.M2), M2min)
+  return { r, kLuOverR, limit: lim, slender, Cm, EI, Pc, delta, M2min, Mc }
+}

--- a/webapp/src/engine/model.ts
+++ b/webapp/src/engine/model.ts
@@ -1,0 +1,60 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Structural model schema — Phase 1 of the 3D model space (docs/ROADMAP-3D.md).
+// Pure, JSON-serialisable data: the 3D editor, the frame solvers, the
+// tributary engine and the design pipeline all consume this one shape.
+// Units: coordinates m; sections mm; loads kN, kN/m, kPa.
+// ─────────────────────────────────────────────────────────────────────────
+import type { LoadCategory } from './beamAnalysis'
+
+export interface Node { id: string; x: number; y: number; z: number }
+
+export interface RectSection {
+  id: string
+  name: string
+  b: number; h: number          // mm
+  fc: number; fy: number
+  barDia: number; tieDia: number; cover: number
+}
+
+export type MemberRole = 'beam' | 'girder' | 'column' | 'brace'
+export interface Member {
+  id: string
+  i: string; j: string          // node ids
+  role: MemberRole
+  section: string               // RectSection id
+}
+
+export type PlateRole = 'slab' | 'wall'
+export interface Plate {
+  id: string
+  corners: [string, string, string, string]  // node ids, CCW
+  role: PlateRole
+  thickness: number             // mm
+}
+
+export type SupportFixity = 'pin' | 'fixed' | 'roller' | 'spring'
+export interface NodeSupport { node: string; fixity: SupportFixity; k?: number }
+
+export type ModelLoad =
+  | { kind: 'node'; node: string; Fx?: number; Fy?: number; Fz?: number; cat: LoadCategory }
+  | { kind: 'member-point'; member: string; t: number /* 0–1 along i→j */; P: number; cat: LoadCategory }
+  | { kind: 'member-udl'; member: string; w: number; cat: LoadCategory }
+  | { kind: 'area'; plate: string; q: number /* kPa */; cat: LoadCategory }
+
+export interface Storey { id: string; name: string; elevation: number /* m */ }
+
+export interface StructuralModel {
+  version: 1
+  name: string
+  nodes: Node[]
+  sections: RectSection[]
+  members: Member[]
+  plates: Plate[]
+  supports: NodeSupport[]
+  loads: ModelLoad[]
+  storeys: Storey[]
+}
+
+export function emptyModel(name = 'Untitled'): StructuralModel {
+  return { version: 1, name, nodes: [], sections: [], members: [], plates: [], supports: [], loads: [], storeys: [] }
+}

--- a/webapp/src/lib/columnSolution.ts
+++ b/webapp/src/lib/columnSolution.ts
@@ -1,0 +1,140 @@
+// Detailed worked solution for the column design — provision-cited steps in
+// the foundation/beam style, mirroring engine/columnDesign.ts.
+import {
+  type AxialColumnInput, type AxialColumnResult,
+  type InteractionInput, type InteractionResult, type PMPoint,
+  type SlendernessInput, type SlendernessResult,
+} from '../engine/columnDesign'
+import { beta1 } from '../engine/loads'
+import { type SolutionStep, type SolutionLine, sn0, sn1, sn2, sn3, sn4 } from './solution'
+
+const txt = (text: string): SolutionLine => ({ text })
+const eq = (tex: string): SolutionLine => ({ tex })
+
+export function axialColumnSolution(i: AxialColumnInput, r: AxialColumnResult): SolutionStep[] {
+  const tied = i.shape === 'tied'
+  const steps: SolutionStep[] = []
+
+  steps.push({
+    title: 'Gross section & demand',
+    lines: [
+      txt(tied
+        ? 'Short tied rectangular column under concentric factored load.'
+        : 'Short spiral circular column under concentric factored load.'),
+      eq(tied
+        ? String.raw`A_g = b\,h = ${sn0(i.b ?? 0)}\times ${sn0(i.h ?? 0)} = ${sn0(r.Ag)}\ \text{mm}^2,\qquad P_u = ${sn1(i.Pu)}\ \text{kN}`
+        : String.raw`A_g = \tfrac{\pi}{4}D^2 = \tfrac{\pi}{4}(${sn0(i.D ?? 0)})^2 = ${sn0(r.Ag)}\ \text{mm}^2,\qquad P_u = ${sn1(i.Pu)}\ \text{kN}`),
+    ],
+  })
+
+  steps.push({
+    title: 'Required longitudinal steel',
+    lines: [
+      txt(`Axial design strength (§422.4.2): φPn,max = φ·α·[0.85f′c(Ag − Ast) + fy·Ast], with α = ${r.alpha.toFixed(2)} and φ = ${r.phi.toFixed(2)} for a ${tied ? 'tied' : 'spiral'} column (§421.2). Solve for Ast at φPn,max = Pu, floored at ρ = 1% (§410.6.1.1).`),
+      eq(String.raw`A_{st,req} = \dfrac{P_u/(\phi\alpha) - 0.85 f'_c A_g}{f_y - 0.85 f'_c} = ${sn0(r.AstReq)}\ \text{mm}^2\ (\rho = ${sn4(r.rhoReq)})`),
+    ],
+    note: r.rhoReq <= 0.01 + 1e-9 ? 'ρmin = 1% governs.' : undefined,
+  })
+
+  steps.push({
+    title: 'Bar selection & limits',
+    lines: [
+      txt(`Steel must satisfy 0.01Ag ≤ Ast ≤ 0.08Ag (§410.6.1.1) with at least ${r.minBars} bars for a ${tied ? 'rectangular tied' : 'spiral'} column (§410.7.3.1).`),
+      eq(String.raw`n = \lceil A_{st,req}/A_b \rceil = ${r.bars}\ \text{⌀}${i.barDia}\ \Rightarrow A_{st} = ${sn0(r.Ast)}\ \text{mm}^2\ (\rho = ${sn4(r.rho)})\ ${r.rhoOK ? '\\checkmark' : '\\times'}`),
+    ],
+  })
+
+  steps.push({
+    title: 'Design axial strength check',
+    lines: [
+      eq(String.raw`P_o = 0.85 f'_c (A_g - A_{st}) + f_y A_{st} = ${sn1(r.Po)}\ \text{kN}`),
+      eq(String.raw`\phi P_{n,max} = ${r.phi.toFixed(2)}\times ${r.alpha.toFixed(2)}\times P_o = ${sn1(r.phiPnMax)}\ \text{kN} \;${r.axialOK ? '\\ge' : '<'}\; P_u = ${sn1(i.Pu)}\ \text{kN}\ ${r.axialOK ? '\\checkmark' : '\\times'}`),
+    ],
+  })
+
+  if (tied) {
+    steps.push({
+      title: 'Tie detailing (§425.7.2)',
+      lines: [
+        txt(`Ties at least ⌀${r.tieDiaMin} mm for ⌀${i.barDia} longitudinal bars; spacing the least of 16d_b, 48d_tie, and the least column dimension.`),
+        eq(String.raw`s \le \min(16\times ${i.barDia},\ 48\times ${i.tieDia},\ ${sn0(Math.min(i.b ?? 0, i.h ?? 0))}) = ${sn0(r.tieSpacing)}\ \text{mm}\ (\text{${r.tieGovern}})`),
+      ],
+      note: `Provide ⌀${Math.max(i.tieDia, r.tieDiaMin)} mm ties @ ${sn0(r.tieSpacing)} mm.`,
+    })
+  } else {
+    steps.push({
+      title: 'Spiral detailing (§425.7.3)',
+      lines: [
+        txt('The volumetric ratio must satisfy ρs ≥ max[0.45(Ag/Ach − 1), 0.12]·f′c/fyt (§425.7.3.3); the clear pitch must lie between 25 and 75 mm (§425.7.3.1).'),
+        eq(String.raw`\rho_s = ${sn4(r.rhoS)},\qquad s = \dfrac{4 A_{sp}}{\rho_s D_{ch}} \Rightarrow ${sn0(r.spiralPitch)}\ \text{mm pitch}\ ${r.pitchClearOK ? '\\checkmark' : '\\times'}`),
+      ],
+      note: `Provide a ⌀${i.tieDia} mm spiral @ ${sn0(r.spiralPitch)} mm pitch.`,
+    })
+  }
+
+  return steps
+}
+
+export function eccentricColumnSolution(
+  i: InteractionInput, r: InteractionResult, Pu: number, Mu: number, cap: PMPoint,
+): SolutionStep[] {
+  const e = Pu > 1e-9 ? Mu / Pu : 0
+  const compr = e <= r.balanced.eb
+  const util = cap.phi * cap.Pn > 1e-9 ? Pu / (cap.phi * cap.Pn) : Infinity
+  const b1 = beta1(i.fc)
+  const aB = Math.min(b1 * r.balanced.c, i.h)
+
+  return [
+    {
+      title: 'Eccentricity of the load',
+      lines: [
+        txt('The displaced concrete is not neglected; moments are taken about the plastic centroid (the geometric centre of this symmetric section).'),
+        eq(String.raw`e = \dfrac{M_u}{P_u} = \dfrac{${sn1(Mu)}}{${sn1(Pu)}} = ${sn0(e * 1000)}\ \text{mm}`),
+      ],
+    },
+    {
+      title: 'Balanced strain condition',
+      lines: [
+        txt('Concrete crushes (εc = 0.003) exactly as the extreme tension steel yields (εs = fy/Es) — locating the neutral axis at cb = 600·dt/(600 + fy).'),
+        eq(String.raw`c_b = \dfrac{600\,d_t}{600+f_y} = \dfrac{600(${sn0(r.dt)})}{${sn0(600 + i.fy)}} = ${sn1(r.balanced.c)}\ \text{mm},\quad a_b = \beta_1 c_b = ${sn1(aB)}\ \text{mm}`),
+        eq(String.raw`P_b = ${sn1(r.balanced.Pb)}\ \text{kN},\qquad M_b = ${sn1(r.balanced.Mb)}\ \text{kN·m},\qquad e_b = ${sn0(r.balanced.eb * 1000)}\ \text{mm}`),
+      ],
+      note: compr
+        ? `e ≤ eb — compression-controlled side of the interaction diagram.`
+        : `e > eb — tension-controlled side of the interaction diagram.`,
+    },
+    {
+      title: 'Capacity along the demand ray (strain compatibility)',
+      lines: [
+        txt('Sweep the neutral axis until Mn/Pn equals the demand eccentricity: fs = 600(c − d)/c clamped at ±fy on each face, displaced concrete deducted for bars inside the stress block, φ from εt (§421.2: 0.65 compression- to 0.90 tension-controlled).'),
+        eq(String.raw`c = ${sn1(cap.c)}\ \text{mm},\quad \varepsilon_t = ${sn4(cap.et)},\quad \phi = ${sn3(cap.phi)}`),
+        eq(String.raw`P_n = ${sn1(cap.Pn)}\ \text{kN},\quad M_n = ${sn1(cap.Mn)}\ \text{kN·m}`),
+        eq(String.raw`\phi P_n = ${sn1(cap.phi * cap.Pn)}\ \text{kN} \;${util <= 1 ? '\\ge' : '<'}\; P_u = ${sn1(Pu)}\ \text{kN}\quad(\text{utilisation } ${sn2(util)})\ ${util <= 1 ? '\\checkmark' : '\\times'}`),
+      ],
+      note: util <= 1 ? 'Section is adequate at this eccentricity.' : 'Section is NOT adequate — add steel or enlarge the section.',
+    },
+  ]
+}
+
+export function slendernessSolution(i: SlendernessInput, r: SlendernessResult): SolutionStep[] {
+  return [
+    {
+      title: 'Slenderness classification (nonsway)',
+      lines: [
+        txt('For compression members braced against sidesway, slenderness may be neglected when kLu/r ≤ 34 + 12(M1/M2) ≤ 40, with M1/M2 negative in single curvature (RC-06 / §406.2.5). r = 0.3h for rectangular sections.'),
+        eq(String.raw`\dfrac{k L_u}{r} = \dfrac{${sn2(i.k)}\times ${sn2(i.Lu)}\times 1000}{${sn1(r.r)}} = ${sn1(r.kLuOverR)} \;${r.slender ? '>' : '\\le'}\; ${sn1(r.limit)}`),
+      ],
+      note: r.slender ? 'Slender — magnify the moment.' : 'Short — slenderness effects may be neglected (δ shown for reference).',
+    },
+    {
+      title: 'Moment magnification (§406.6.4)',
+      lines: [
+        eq(String.raw`C_m = 0.6 - 0.4\,\tfrac{M_1}{M_2} = ${sn3(r.Cm)}`),
+        eq(String.raw`P_c = \dfrac{\pi^2 EI}{(k L_u)^2} = \dfrac{\pi^2 (${sn0(r.EI)})}{(${sn2(i.k * i.Lu)})^2} = ${sn1(r.Pc)}\ \text{kN}`),
+        eq(String.raw`\delta = \dfrac{C_m}{1 - \tfrac{P_u}{0.75 P_c}} = ${sn3(r.delta)} \ge 1.0`),
+        eq(String.raw`M_{2,min} = P_u(15 + 0.03h) = ${sn2(r.M2min)}\ \text{kN·m},\qquad M_c = \delta\,M_2 = \mathbf{${sn2(r.Mc)}}\ \text{kN·m}`),
+      ],
+      note: 'Mc replaces Mu in the eccentric design above.',
+    },
+  ]
+}

--- a/webapp/src/pages/ColumnDesign.tsx
+++ b/webapp/src/pages/ColumnDesign.tsx
@@ -1,0 +1,207 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import {
+  designAxialColumn, interaction, capacityAtEccentricity, momentMagnificationNonsway,
+  type ColumnShape,
+} from '../engine/columnDesign'
+import { factoredLoad } from '../engine/loads'
+import { ColumnSchematic } from '../components/ColumnSchematic'
+import { InteractionDiagram } from '../components/InteractionDiagram'
+import { ReportControls } from '../components/ReportControls'
+import { WorkedSolution } from '../components/WorkedSolution'
+import { axialColumnSolution, eccentricColumnSolution, slendernessSolution } from '../lib/columnSolution'
+import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
+import { Math as KTex } from '../lib/math'
+import { f0, f1, f2 } from '../lib/format'
+import type { SolutionStep } from '../lib/solution'
+import 'katex/dist/katex.min.css'
+
+type Mode = 'axial' | 'eccentric'
+type LoadInput = 'direct' | 'individual'
+type BarMode = 'design' | 'analyze'
+
+export default function ColumnDesign() {
+  const [mode, setMode] = useState<Mode>('axial')
+  const [shape, setShape] = useState<ColumnShape>('tied')
+  const [b, setB] = useState(400); const [h, setH] = useState(400); const [D, setD] = useState(400)
+  const [cover, setCover] = useState(40)
+  const [barDia, setBarDia] = useState(28); const [tieDia, setTieDia] = useState(10)
+  const [fc, setFc] = useState(28); const [fy, setFy] = useState(415); const [fyt, setFyt] = useState(415)
+  const [loadInput, setLoadInput] = useState<LoadInput>('individual')
+  const [dead, setDead] = useState(1400); const [live, setLive] = useState(790)
+  const [PuDirect, setPuDirect] = useState(2944)
+  const [Mu, setMu] = useState(200)
+  const [barMode, setBarMode] = useState<BarMode>('design')
+  const [numBars, setNumBars] = useState(8)
+  // Slenderness (nonsway)
+  const [slenderOn, setSlenderOn] = useState(false)
+  const [kEff, setKEff] = useState(1.0); const [Lu, setLu] = useState(3.0)
+  const [M1, setM1] = useState(-150); const [M2, setM2] = useState(200)
+  const [EIin, setEIin] = useState(0)   // kN·m², 0 → derive 0.4EcIg/(1+βd)
+
+  const eccentric = mode === 'eccentric'
+  const tied = shape === 'tied' || eccentric    // eccentric pilot is tied-rect only
+  const Pu = loadInput === 'individual' ? factoredLoad({ dead, live }) : PuDirect
+
+  const axial = useMemo(() => {
+    if (!(fc > 0 && fy > 0 && Pu > 0)) return null
+    try {
+      return designAxialColumn({
+        shape: tied ? 'tied' : 'spiral', b, h, D, cover, barDia, tieDia, fc, fy, fyt, Pu,
+        numBars: barMode === 'analyze' || eccentric ? numBars : undefined,
+      })
+    } catch { return null }
+  }, [tied, b, h, D, cover, barDia, tieDia, fc, fy, fyt, Pu, barMode, numBars, eccentric])
+
+  const slender = useMemo(() => {
+    if (!eccentric || !slenderOn) return null
+    return momentMagnificationNonsway({
+      Pu, M1, M2, k: kEff, Lu, h, shape: 'tied',
+      EI: EIin > 0 ? EIin : undefined, fc, b, betaD: 0.6,
+    })
+  }, [eccentric, slenderOn, Pu, M1, M2, kEff, Lu, h, EIin, fc, b])
+
+  const MuEff = slender ? slender.Mc : Mu
+  const inter = useMemo(() => {
+    if (!eccentric || !(b > 0 && h > 0)) return null
+    try { return interaction({ b, h, cover, barDia, tieDia, fc, fy, numBars }) } catch { return null }
+  }, [eccentric, b, h, cover, barDia, tieDia, fc, fy, numBars])
+  const cap = useMemo(() => {
+    if (!inter || !(Pu > 0) || !(MuEff > 0)) return null
+    return capacityAtEccentricity({ b, h, cover, barDia, tieDia, fc, fy, numBars }, MuEff / Pu)
+  }, [inter, Pu, MuEff, b, h, cover, barDia, tieDia, fc, fy, numBars])
+
+  const solution = useMemo(() => {
+    const steps: SolutionStep[] = []
+    if (slender) steps.push(...slendernessSolution({ Pu, M1, M2, k: kEff, Lu, h, EI: EIin > 0 ? EIin : undefined, fc, b }, slender))
+    if (eccentric && inter && cap) steps.push(...eccentricColumnSolution({ b, h, cover, barDia, tieDia, fc, fy, numBars }, inter, Pu, MuEff, cap))
+    if (axial) steps.push(...axialColumnSolution({
+      shape: tied ? 'tied' : 'spiral', b, h, D, cover, barDia, tieDia, fc, fy, fyt, Pu,
+      numBars: barMode === 'analyze' || eccentric ? numBars : undefined,
+    }, axial))
+    return steps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [slender, eccentric, inter, cap, axial, Pu, MuEff])
+
+  const util = cap && cap.phi * cap.Pn > 1e-9 ? Pu / (cap.phi * cap.Pn) : null
+
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
+      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Column Design</h1>
+      <p className="no-print mt-1 text-slate-600">
+        RC column — short axial (tied / spiral with §425.7 detailing), eccentric via strain-compatibility
+        P–M interaction (balanced condition, φ transition), and nonsway moment magnification for slender
+        columns. NSCP 2015 / ACI 318-14.
+      </p>
+      <ReportControls title="Column Design Report" />
+
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
+        <div className="space-y-5">
+          <Card title="Column">
+            <Pick label="Loading" value={mode} onChange={(v) => setMode(v as Mode)}
+              options={[['axial', 'Concentric (axial)'], ['eccentric', 'Eccentric (P + M)']]} />
+            <Pick label="Shape" value={eccentric ? 'tied' : shape} onChange={(v) => setShape(v as ColumnShape)}
+              options={eccentric ? [['tied', 'Tied rectangular']] : [['tied', 'Tied rectangular'], ['spiral', 'Spiral circular']]} />
+            {tied ? <>
+              <Num label="Width b" unit="mm" value={b} onChange={setB} />
+              <Num label="Depth h (bending dir.)" unit="mm" value={h} onChange={setH} />
+            </> : (
+              <Num label="Diameter D" unit="mm" value={D} onChange={setD} />
+            )}
+            <Num label="Clear cover" unit="mm" value={cover} onChange={setCover} />
+            <Num label={<>Bar <KTex tex="d_b" /></>} unit="mm" value={barDia} onChange={setBarDia} />
+            <Num label={tied ? <>Tie <KTex tex="d_t" /></> : <>Spiral <KTex tex="d_s" /></>} unit="mm" value={tieDia} onChange={setTieDia} />
+            <Pick label="Bars" value={eccentric ? 'analyze' : barMode} onChange={(v) => setBarMode(v as BarMode)}
+              options={eccentric ? [['analyze', 'Given count']] : [['design', 'Design automatically'], ['analyze', 'Given count']]} />
+            {(barMode === 'analyze' || eccentric) && (
+              <Num label="No. of bars" value={numBars} onChange={setNumBars} />
+            )}
+          </Card>
+
+          <Card title="Materials">
+            <Num label={<KTex tex="f'_c" />} unit="MPa" value={fc} onChange={setFc} />
+            <Num label={<KTex tex="f_y" />} unit="MPa" value={fy} onChange={setFy} />
+            <Num label={<KTex tex="f_{yt}" />} unit="MPa" value={fyt} onChange={setFyt} />
+          </Card>
+
+          <Card title="Loads">
+            <Pick label="Load entry" value={loadInput} onChange={(v) => setLoadInput(v as LoadInput)}
+              options={[['individual', 'Individual (D & L)'], ['direct', 'Factored Pu']]} />
+            {loadInput === 'individual' ? <>
+              <Num label={<>Dead <KTex tex="D" /></>} unit="kN" value={dead} onChange={setDead} />
+              <Num label={<>Live <KTex tex="L" /></>} unit="kN" value={live} onChange={setLive} />
+              <p className="col-span-full text-xs text-slate-400">Pu = max(1.4D, 1.2D+1.6L) = {f0(Pu)} kN</p>
+            </> : (
+              <Num label={<KTex tex="P_u" />} unit="kN" value={PuDirect} onChange={setPuDirect} />
+            )}
+            {eccentric && <Num label={<KTex tex="M_u" />} unit="kN·m" value={Mu} onChange={setMu} />}
+          </Card>
+
+          {eccentric && (
+            <Card title="Slenderness (nonsway)">
+              <Pick label="Consider slenderness" value={slenderOn ? 'yes' : 'no'} onChange={(v) => setSlenderOn(v === 'yes')}
+                options={[['no', 'No — short column'], ['yes', 'Yes — magnify moment']]} />
+              {slenderOn && <>
+                <Num label="k" value={kEff} onChange={setKEff} />
+                <Num label={<KTex tex="L_u" />} unit="m" value={Lu} onChange={setLu} />
+                <Num label={<KTex tex="M_1" />} unit="kN·m" value={M1} onChange={setM1} />
+                <Num label={<KTex tex="M_2" />} unit="kN·m" value={M2} onChange={setM2} />
+                <Num label="EI (0 = 0.4EcIg/1.6)" unit="kN·m²" value={EIin} onChange={setEIin} />
+                <p className="col-span-full text-xs text-slate-400">
+                  Sheet convention: M1/M2 negative for single curvature.
+                </p>
+              </>}
+            </Card>
+          )}
+        </div>
+
+        <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
+          <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Section</h2>
+            <ColumnSchematic shape={tied ? 'tied' : 'spiral'} b={b} h={h} D={D} cover={cover}
+              barDia={barDia} tieDia={tieDia} bars={axial?.bars ?? numBars}
+              tieSpacing={axial ? (tied ? axial.tieSpacing : axial.spiralPitch) : undefined} />
+          </div>
+
+          {axial && (
+            <ResultCard title="Results">
+              {eccentric && slender && (
+                <Row label="Magnified Mc" value={`${f2(slender.Mc)} kN·m`}
+                  sub={`δ=${slender.delta.toFixed(3)} · ${slender.slender ? 'slender' : 'short'}`} />
+              )}
+              {eccentric && util !== null && cap && (
+                <Row alert={util > 1} label="Utilisation" value={`${(util * 100).toFixed(0)} %`}
+                  sub={`φPn=${f1(cap.phi * cap.Pn)} kN @ e=${f0((MuEff / Pu) * 1000)} mm`} />
+              )}
+              <Row label="Bars" value={`${axial.bars} ⌀${barDia} mm`}
+                sub={`ρ=${(axial.rho * 100).toFixed(2)}% ${axial.rhoOK ? '✓' : '✗ (1–8%)'}`} />
+              <Row alert={!axial.axialOK && !eccentric} label={<KTex tex="\phi P_{n,max}" />}
+                value={`${f1(axial.phiPnMax)} kN`}
+                sub={`Po=${f1(axial.Po)} · ${axial.alpha.toFixed(2)}Po cap`} />
+              {tied ? (
+                <Row label="Ties" value={`⌀${Math.max(tieDia, axial.tieDiaMin)} @ ${f0(axial.tieSpacing)} mm`}
+                  sub={axial.tieGovern} />
+              ) : (
+                <Row alert={!axial.pitchClearOK} label="Spiral" value={`⌀${tieDia} @ ${f0(axial.spiralPitch)} mm pitch`}
+                  sub={`ρs=${axial.rhoS.toFixed(4)}`} />
+              )}
+              {eccentric && inter && (
+                <Row label="Balanced point" value={`Pb=${f1(inter.balanced.Pb)} kN`}
+                  sub={`Mb=${f1(inter.balanced.Mb)} · eb=${f0(inter.balanced.eb * 1000)} mm`} />
+              )}
+            </ResultCard>
+          )}
+
+          {eccentric && inter && (
+            <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <InteractionDiagram r={inter} Pu={Pu} Mu={MuEff} />
+            </div>
+          )}
+        </div>
+      </div>
+
+      {solution.length > 0 && <WorkedSolution steps={solution} />}
+    </div>
+  )
+}


### PR DESCRIPTION
First milestone of the 3D roadmap, specified directly from the attached CE review sheets (Concrete 6–8 + 2015 NSCP extracts).

## `engine/columnDesign.ts`
- **Short axial — tied & spiral**: `Po = 0.85f′c(Ag−Ast) + fy·Ast` (§422.4.2.2), `Pn,max = 0.80Po / 0.85Po`, φ = 0.65/0.75; steel **designed from Pu** (or analyzed for a given count) with the 1–8 % limits (§410.6.1.1) and 4/6 minimum bars (§410.7.3.1); **tie detailing** per §425.7.2 (Ø rule, `s = min(16d_b, 48d_t, least dimension)`); **spiral detailing** per §425.7.3 (`ρs ≥ max[0.45(Ag/Ach−1), 0.12]·f′c/fyt`, pitch from `ρs = 4Asp/(s·Dch)`, 25–75 mm clear).
- **Eccentric (tied rectangular)** — strain-compatibility interaction exactly as the sheets solve it: `fs = 600(c−d)/c` clamped at ±fy, **displaced concrete deducted** for bars inside the stress block, moments about the **plastic centroid**; balanced condition `cb = 600dt/(600+fy)`; full P–M curve (log sweep closing at Po); φ transition 0.65→0.90 from εt; `capacityAtEccentricity` by bisection on the demand ray; **Bresler reciprocal** for biaxial.
- **Slender (nonsway)**: `kLu/r ≤ 34 + 12(M1/M2) ≤ 40` (M1/M2 negative in single curvature — the sheet/RC-06 convention), `Cm = 0.6 − 0.4(M1/M2)`, `Pc = π²EI/(kLu)²` (EI given or `0.4EcIg/(1+βd)`), `δ = Cm/(1 − Pu/0.75Pc) ≥ 1`, `M2,min = Pu(15+0.03h)`, `Mc = δM2`.

## `engine/model.ts`
The JSON-serialisable structural model schema from the roadmap (nodes, sections, members, plates, supports, NSCP-categorised loads, storeys) — the shared data shape for the coming frame solvers, tributary engine, 3D editor and design pipeline.

## UI — `/column-design`
Axial / eccentric modes, D&L or direct Pu, design-or-given bars, optional slenderness card; cross-section schematic (tied & spiral); **P–M interaction diagram** (nominal + capped design curve, balanced point, demand ray); provision-cited worked solution for every step.

## Verification — pinned to the sheets' answer keys
- Tied design (Concrete 7 P2): Pu = 2944 kN → **8 ⌀28** with **400 mm** tie spacing (least dimension governs) ✓
- Spiral (P3/P9 key **2,423.70 kN**): φPn = 2424.2 ✓ (key rounds π)
- Balanced condition (Concrete 8 P4 keys): **Pb = 881.87 kN, Mb = 314.86 kN·m, eb = 357.03 mm** — all matched ✓
- Curve closes at Po; capacity-at-e roundtrips the balanced point; Bresler degenerate case; slenderness limits (22 / 40), Cm, Pc, M2,min.

**114 tests total passing**; build green. Eccentric interaction is tied-rectangular in this phase (the sheets' scope); circular-section interaction comes with the frame work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)