### PR TITLE
Phase 2: shared FEM core + 2D frame analysis

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -5,6 +5,7 @@ import CombinedFootingDesign from './pages/CombinedFootingDesign'
 import BeamDesign from './pages/BeamDesign'
 import BeamAnalysis from './pages/BeamAnalysis'
 import ColumnDesign from './pages/ColumnDesign'
+import FrameAnalysis from './pages/FrameAnalysis'
 import SlabEstimate from './pages/SlabEstimate'
 import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
@@ -39,6 +40,7 @@ function Home() {
         <Tile to="/beam-design">Beam Design</Tile>
         <Tile to="/beam-analysis">Beam Analysis (FEM)</Tile>
         <Tile to="/column-design">Column Design</Tile>
+        <Tile to="/frame">Frame Analysis (2D)</Tile>
       </div>
 
       <h2 className="mt-8 text-lg font-semibold text-slate-800">Material estimation (quantity take-off)</h2>
@@ -63,6 +65,7 @@ export default function App() {
       <Route path="/beam-design" element={<BeamDesign />} />
       <Route path="/beam-analysis" element={<BeamAnalysis />} />
       <Route path="/column-design" element={<ColumnDesign />} />
+      <Route path="/frame" element={<FrameAnalysis />} />
       <Route path="/estimate/slab" element={<SlabEstimate />} />
       <Route path="/estimate/beam" element={<BeamEstimate />} />
       <Route path="/estimate/column" element={<ColumnEstimate />} />

--- a/webapp/src/components/FrameSketch.tsx
+++ b/webapp/src/components/FrameSketch.tsx
@@ -1,0 +1,124 @@
+import type { JSX } from 'react'
+import type { FNode, FMember, FSupport, FLoad } from '../engine/frame2d'
+
+const MEM = '#37526e'
+const SUP = '#0056b3'
+const LOAD = '#dc2626'
+const SEL = '#f59e0b'
+
+/** 2D frame elevation: members, node ids, support symbols and load glyphs. */
+export function FrameSketch({ nodes, members, supports, loads, selected }: {
+  nodes: FNode[]; members: FMember[]; supports: FSupport[]; loads: FLoad[]; selected?: string
+}): JSX.Element {
+  const W = 560, H = 320
+  const pad = 46
+  const xs = nodes.map((n) => n.x), ys = nodes.map((n) => n.y)
+  const minX = Math.min(0, ...xs), maxX = Math.max(1, ...xs)
+  const minY = Math.min(0, ...ys), maxY = Math.max(1, ...ys)
+  const s = Math.min((W - 2 * pad) / Math.max(maxX - minX, 1e-9), (H - 2 * pad) / Math.max(maxY - minY, 1e-9))
+  const sx = (x: number) => pad + (x - minX) * s
+  const sy = (y: number) => H - pad - (y - minY) * s
+  const nm = new Map(nodes.map((n) => [n.id, n]))
+
+  const mid = (m: FMember) => {
+    const a = nm.get(m.i), b = nm.get(m.j)
+    if (!a || !b) return null
+    return { x1: sx(a.x), y1: sy(a.y), x2: sx(b.x), y2: sy(b.y) }
+  }
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet"
+      style={{ width: '100%', height: 'auto', fontFamily: 'Arial, sans-serif' }}>
+      {/* members */}
+      {members.map((m) => {
+        const g = mid(m)
+        if (!g) return null
+        const cx = (g.x1 + g.x2) / 2, cy = (g.y1 + g.y2) / 2
+        const sel = m.id === selected
+        return (
+          <g key={m.id}>
+            <line x1={g.x1} y1={g.y1} x2={g.x2} y2={g.y2}
+              stroke={sel ? SEL : MEM} strokeWidth={sel ? 5 : 3.5} strokeLinecap="round" />
+            <text x={cx + 6} y={cy - 6} fontSize={9} fill={sel ? SEL : MEM} fontWeight={700}>{m.id}</text>
+          </g>
+        )
+      })}
+
+      {/* member loads */}
+      {loads.map((ld, k) => {
+        if (ld.kind === 'node') {
+          const n = nm.get(ld.node)
+          if (!n) return null
+          const x = sx(n.x), y = sy(n.y)
+          return (
+            <g key={k} stroke={LOAD} strokeWidth={1.3} fill="none">
+              {ld.Fy !== 0 && <g><line x1={x} y1={y - 34} x2={x} y2={y - 6} /><path d={`M ${x - 3} ${y - 12} L ${x} ${y - 6} L ${x + 3} ${y - 12}`} /></g>}
+              {ld.Fx !== 0 && <g><line x1={x - 34 * Math.sign(ld.Fx)} y1={y} x2={x - 6 * Math.sign(ld.Fx)} y2={y} /><path d={`M ${x - 12 * Math.sign(ld.Fx)} ${y - 3} L ${x - 6 * Math.sign(ld.Fx)} ${y} L ${x - 12 * Math.sign(ld.Fx)} ${y + 3}`} /></g>}
+              <text x={x + 6} y={y - 22} fontSize={8} fill={LOAD} stroke="none">
+                {[ld.Fx ? `Fx=${ld.Fx}` : '', ld.Fy ? `Fy=${ld.Fy}` : '', ld.Mz ? `M=${ld.Mz}` : ''].filter(Boolean).join(' ')} ({ld.cat})
+              </text>
+            </g>
+          )
+        }
+        const m = members.find((q) => q.id === ld.member)
+        const g = m ? mid(m) : null
+        if (!g) return null
+        if (ld.kind === 'member-udl') {
+          const nA = 6
+          return (
+            <g key={k} stroke={LOAD} strokeWidth={1.1}>
+              {Array.from({ length: nA + 1 }, (_, i) => {
+                const t = i / nA
+                const x = g.x1 + (g.x2 - g.x1) * t, y = g.y1 + (g.y2 - g.y1) * t
+                return <g key={i}><line x1={x} y1={y - 22} x2={x} y2={y - 4} /><path d={`M ${x - 2.5} ${y - 9} L ${x} ${y - 4} L ${x + 2.5} ${y - 9}`} fill="none" /></g>
+              })}
+              <text x={(g.x1 + g.x2) / 2} y={(g.y1 + g.y2) / 2 - 26} fontSize={8} fill={LOAD} stroke="none" textAnchor="middle">
+                w={ld.w} kN/m ({ld.cat})
+              </text>
+            </g>
+          )
+        }
+        const m2 = nm.get(m!.i)!, m3 = nm.get(m!.j)!
+        const L = Math.hypot(m3.x - m2.x, m3.y - m2.y)
+        const t = Math.max(0, Math.min(1, ld.a / Math.max(L, 1e-9)))
+        const x = g.x1 + (g.x2 - g.x1) * t, y = g.y1 + (g.y2 - g.y1) * t
+        return (
+          <g key={k} stroke={LOAD} strokeWidth={1.3} fill="none">
+            <line x1={x} y1={y - 30} x2={x} y2={y - 4} />
+            <path d={`M ${x - 3} ${y - 10} L ${x} ${y - 4} L ${x + 3} ${y - 10}`} />
+            <text x={x + 4} y={y - 20} fontSize={8} fill={LOAD} stroke="none">P={ld.P} ({ld.cat})</text>
+          </g>
+        )
+      })}
+
+      {/* supports */}
+      {supports.map((sp, k) => {
+        const n = nm.get(sp.node)
+        if (!n) return null
+        const x = sx(n.x), y = sy(n.y)
+        if (sp.type === 'fixed') {
+          return (
+            <g key={k} stroke={SUP} strokeWidth={1.5}>
+              <line x1={x - 12} y1={y + 2} x2={x + 12} y2={y + 2} />
+              {[-10, -4, 2, 8].map((dx) => <line key={dx} x1={x + dx} y1={y + 2} x2={x + dx - 5} y2={y + 9} strokeWidth={1} />)}
+            </g>
+          )
+        }
+        return (
+          <g key={k} stroke={SUP} strokeWidth={1.4} fill="#fff">
+            <path d={`M ${x} ${y + 1} L ${x - 8} ${y + 14} L ${x + 8} ${y + 14} Z`} />
+            {sp.type === 'roller' && [-5, 0, 5].map((dx) => <circle key={dx} cx={x + dx} cy={y + 18} r={2.4} />)}
+          </g>
+        )
+      })}
+
+      {/* nodes */}
+      {nodes.map((n) => (
+        <g key={n.id}>
+          <circle cx={sx(n.x)} cy={sy(n.y)} r={3.4} fill="#fff" stroke={MEM} strokeWidth={1.6} />
+          <text x={sx(n.x) - 6} y={sy(n.y) - 7} fontSize={9} fill={MEM} textAnchor="end">{n.id}</text>
+        </g>
+      ))}
+    </svg>
+  )
+}

--- a/webapp/src/engine/beamAnalysis.ts
+++ b/webapp/src/engine/beamAnalysis.ts
@@ -36,31 +36,10 @@ export const NSCP_COMBOS: Combo[] = [
   { name: '0.9D + 1.0E', f: { D: 0.9, E: 1.0 } },
 ]
 
+import { solveLinear } from './fem'
+
 const roundX = (x: number, dec = 8) => Math.round(x * 10 ** dec) / 10 ** dec
 const clamp = (x: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, x))
-
-// ── Linear algebra ────────────────────────────────────────────────────────
-function solveLinear(A: number[][], b: number[]): number[] | null {
-  const n = b.length
-  const M = A.map((row, i) => [...row, b[i]])
-  for (let k = 0; k < n; k++) {
-    let piv = k
-    for (let i = k + 1; i < n; i++) if (Math.abs(M[i][k]) > Math.abs(M[piv][k])) piv = i
-    if (piv !== k) [M[k], M[piv]] = [M[piv], M[k]]
-    if (Math.abs(M[k][k]) < 1e-14) return null
-    for (let i = k + 1; i < n; i++) {
-      const f = M[i][k] / M[k][k]
-      for (let j = k; j <= n; j++) M[i][j] -= f * M[k][j]
-    }
-  }
-  const x = new Array(n).fill(0)
-  for (let i = n - 1; i >= 0; i--) {
-    let s = M[i][n]
-    for (let j = i + 1; j < n; j++) s -= M[i][j] * x[j]
-    x[i] = s / M[i][i]
-  }
-  return x
-}
 
 // ── Load helpers ──────────────────────────────────────────────────────────
 export function loadResultant(ld: BeamLoad): { W: number; xc: number } {

--- a/webapp/src/engine/fem.ts
+++ b/webapp/src/engine/fem.ts
@@ -1,0 +1,58 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Shared FEM core — Phase 2 of the 3D roadmap. One linear-algebra +
+// quadrature toolbox consumed by the beam solver (beamAnalysis), the 2D
+// frame solver (frame2d), the Winkler footing, and the future 3D frame.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Dense Gaussian elimination with partial pivoting; null when singular. */
+export function solveLinear(A: number[][], b: number[]): number[] | null {
+  const n = b.length
+  const M = A.map((row, i) => [...row, b[i]])
+  for (let k = 0; k < n; k++) {
+    let piv = k
+    for (let i = k + 1; i < n; i++) if (Math.abs(M[i][k]) > Math.abs(M[piv][k])) piv = i
+    if (piv !== k) [M[k], M[piv]] = [M[piv], M[k]]
+    if (Math.abs(M[k][k]) < 1e-14) return null
+    for (let i = k + 1; i < n; i++) {
+      const f = M[i][k] / M[k][k]
+      for (let j = k; j <= n; j++) M[i][j] -= f * M[k][j]
+    }
+  }
+  const x = new Array(n).fill(0)
+  for (let i = n - 1; i >= 0; i--) {
+    let s = M[i][n]
+    for (let j = i + 1; j < n; j++) s -= M[i][j] * x[j]
+    x[i] = s / M[i][i]
+  }
+  return x
+}
+
+export function matVec(K: number[][], d: number[]): number[] {
+  const n = K.length
+  const r = new Array(n).fill(0)
+  for (let i = 0; i < n; i++) for (let j = 0; j < n; j++) r[i] += K[i][j] * d[j]
+  return r
+}
+
+/** Hermite cubic shape functions for a beam element of length le at ξ ∈ [0,1]. */
+export function hermite(xi: number, le: number): [number, number, number, number] {
+  return [
+    1 - 3 * xi * xi + 2 * xi * xi * xi,
+    le * xi * (1 - xi) * (1 - xi),
+    3 * xi * xi - 2 * xi * xi * xi,
+    le * xi * xi * (xi - 1),
+  ]
+}
+
+/** 5-point Gauss quadrature of a vector-valued integrand over [a, b]. */
+export function gauss5Vec(f: (x: number) => number[], a: number, b: number, size = 4): number[] {
+  const gp = [-0.90618, -0.53847, 0, 0.53847, 0.90618]
+  const gw = [0.23693, 0.47863, 0.56889, 0.47863, 0.23693]
+  const mid = (a + b) / 2, half = (b - a) / 2
+  const acc = new Array(size).fill(0)
+  for (let i = 0; i < 5; i++) {
+    const fi = f(mid + half * gp[i])
+    for (let j = 0; j < size; j++) acc[j] += gw[i] * fi[j]
+  }
+  return acc.map((v) => half * v)
+}

--- a/webapp/src/engine/frame2d.test.ts
+++ b/webapp/src/engine/frame2d.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+import { solveFrame2D, analyzeFrame2D, type FNode, type FMember, type FSupport, type FLoad } from './frame2d'
+import { solveFEM } from './beamAnalysis'
+
+const E = 25000      // MPa
+const A = 250 * 500  // mm²
+const I = 3.125e9    // mm⁴ → EI = 78,125 kN·m²
+const EI = E * I * 1e-9
+const EA = (E * A) / 1000
+
+const sec = { E, A, I }
+
+describe('frame2d — regression vs the beam solver', () => {
+  it('horizontal member, SS + UDL: reactions wL/2, member Mmax = wL²/8', () => {
+    const L = 6, w = 10
+    const nodes: FNode[] = [{ id: 'a', x: 0, y: 0 }, { id: 'b', x: L, y: 0 }]
+    const members: FMember[] = [{ id: 'm', i: 'a', j: 'b', ...sec }]
+    const supports: FSupport[] = [{ node: 'a', type: 'pin' }, { node: 'b', type: 'roller' }]
+    const loads: FLoad[] = [{ kind: 'member-udl', member: 'm', w, cat: 'D' }]
+    const r = solveFrame2D(nodes, members, supports, loads)!
+    expect(r.reactions[0].Ry).toBeCloseTo((w * L) / 2, 6)
+    expect(r.reactions[1].Ry).toBeCloseTo((w * L) / 2, 6)
+    expect(r.members[0].Mmax).toBeCloseTo((w * L * L) / 8, 3)
+
+    const beam = solveFEM(
+      [{ type: 'pin', x: 0 }, { type: 'roller', x: L }],
+      [{ type: 'udl', x1: 0, x2: L, w, cat: 'D' }], L, E, I)!
+    expect(r.members[0].Mmax).toBeCloseTo(beam.Mmax, 2)
+  })
+
+  it('midspan point load: Mmax = PL/4, matches solveFEM', () => {
+    const L = 6, P = 50
+    const r = solveFrame2D(
+      [{ id: 'a', x: 0, y: 0 }, { id: 'b', x: L, y: 0 }],
+      [{ id: 'm', i: 'a', j: 'b', ...sec }],
+      [{ node: 'a', type: 'pin' }, { node: 'b', type: 'roller' }],
+      [{ kind: 'member-point', member: 'm', a: L / 2, P, cat: 'D' }])!
+    expect(r.members[0].Mmax).toBeCloseTo((P * L) / 4, 3)
+    const beam = solveFEM(
+      [{ type: 'pin', x: 0 }, { type: 'roller', x: L }],
+      [{ type: 'point', x: L / 2, P, cat: 'D' }], L, E, I)!
+    expect(r.members[0].Mmax).toBeCloseTo(beam.Mmax, 2)
+  })
+})
+
+describe('frame2d — orientation (vertical members)', () => {
+  it('cantilever column + horizontal tip load: δ = PL³/3EI, Mbase = PL', () => {
+    const H = 3, P = 20
+    const r = solveFrame2D(
+      [{ id: 'base', x: 0, y: 0 }, { id: 'top', x: 0, y: H }],
+      [{ id: 'c', i: 'base', j: 'top', ...sec }],
+      [{ node: 'base', type: 'fixed' }],
+      [{ kind: 'node', node: 'top', Fx: P, Fy: 0, Mz: 0, cat: 'D' }])!
+    // top node is index 1 → dof 3 (x-translation)
+    expect(r.d[3]).toBeCloseTo((P * H ** 3) / (3 * EI), 9)
+    expect(Math.abs(r.reactions[0].Rm)).toBeCloseTo(P * H, 6)
+    expect(r.reactions[0].Rx).toBeCloseTo(-P, 6)
+    expect(r.members[0].Mmax).toBeCloseTo(P * H, 3)
+  })
+
+  it('axial column: δ = PL/EA, N = −P (compression)', () => {
+    const H = 3, P = 100
+    const r = solveFrame2D(
+      [{ id: 'base', x: 0, y: 0 }, { id: 'top', x: 0, y: H }],
+      [{ id: 'c', i: 'base', j: 'top', ...sec }],
+      [{ node: 'base', type: 'fixed' }],
+      [{ kind: 'node', node: 'top', Fx: 0, Fy: -P, Mz: 0, cat: 'D' }])!
+    expect(r.d[4]).toBeCloseTo((-P * H) / EA, 9)
+    expect(r.members[0].N[0]).toBeCloseTo(-P, 6)
+    expect(r.reactions[0].Ry).toBeCloseTo(P, 6)
+  })
+})
+
+describe('frame2d — portal frame', () => {
+  it('pinned-base portal with beam UDL: equilibrium + symmetry', () => {
+    const L = 6, H = 3, w = 12
+    const nodes: FNode[] = [
+      { id: 'A', x: 0, y: 0 }, { id: 'B', x: 0, y: H },
+      { id: 'C', x: L, y: H }, { id: 'D', x: L, y: 0 },
+    ]
+    const members: FMember[] = [
+      { id: 'col1', i: 'A', j: 'B', ...sec },
+      { id: 'beam', i: 'B', j: 'C', ...sec },
+      { id: 'col2', i: 'D', j: 'C', ...sec },
+    ]
+    const supports: FSupport[] = [{ node: 'A', type: 'pin' }, { node: 'D', type: 'pin' }]
+    const loads: FLoad[] = [{ kind: 'member-udl', member: 'beam', w, cat: 'D' }]
+    const r = solveFrame2D(nodes, members, supports, loads)!
+    const RyA = r.reactions[0].Ry, RyD = r.reactions[1].Ry
+    expect(RyA + RyD).toBeCloseTo(w * L, 4)
+    expect(RyA).toBeCloseTo(RyD, 4)                       // symmetry
+    expect(r.reactions[0].Rx).toBeCloseTo(-r.reactions[1].Rx, 4)  // thrust pair
+    expect(Math.abs(r.reactions[0].Rx)).toBeGreaterThan(0.1)      // frame action exists
+    // beam end (corner) moment equals the column top moment (joint equilibrium)
+    const beam = r.members.find((m) => m.id === 'beam')!
+    const col = r.members.find((m) => m.id === 'col1')!
+    expect(Math.abs(beam.M[0])).toBeCloseTo(Math.abs(col.M[col.M.length - 1]), 3)
+  })
+})
+
+describe('frame2d — NSCP combinations', () => {
+  it('runs all 7; 1.2D + 1.6L governs for D+L loading', () => {
+    const nodes: FNode[] = [{ id: 'a', x: 0, y: 0 }, { id: 'b', x: 6, y: 0 }]
+    const members: FMember[] = [{ id: 'm', i: 'a', j: 'b', ...sec }]
+    const supports: FSupport[] = [{ node: 'a', type: 'pin' }, { node: 'b', type: 'roller' }]
+    const loads: FLoad[] = [
+      { kind: 'member-udl', member: 'm', w: 8, cat: 'D' },
+      { kind: 'member-udl', member: 'm', w: 5, cat: 'L' },
+    ]
+    const res = analyzeFrame2D(nodes, members, supports, loads)!
+    expect(res.perCombo).toHaveLength(7)
+    expect(res.perCombo[res.govIdx].combo.name).toContain('1.2D + 1.6L')
+    const wu = 1.2 * 8 + 1.6 * 5
+    expect(res.perCombo[res.govIdx].result!.Mmax).toBeCloseTo((wu * 36) / 8, 2)
+  })
+})

--- a/webapp/src/engine/frame2d.ts
+++ b/webapp/src/engine/frame2d.ts
@@ -1,0 +1,265 @@
+// ─────────────────────────────────────────────────────────────────────────
+// 2D frame analysis — Phase 2 of the 3D roadmap. 6-DOF (3/node) frame
+// element: the beam solver's Hermite bending stiffness ⊕ the axial bar term,
+// rotated into global coordinates. Supports pin / roller / fixed nodes;
+// loads are nodal (Fx, Fy, Mz) or member gravity loads (global −Y UDL and
+// point loads, converted to consistent local fixed-end vectors). Loads carry
+// NSCP categories and the analysis runs every NSCP 2015 combination, like
+// the beam module.
+// Units: coordinates m; E MPa; A mm²; I mm⁴; forces kN, kN·m.
+// Sign conventions on diagrams: N > 0 tension; V & M follow the beam pages.
+// ─────────────────────────────────────────────────────────────────────────
+import { solveLinear, matVec } from './fem'
+import { NSCP_COMBOS, type Combo, type LoadCategory } from './beamAnalysis'
+
+export interface FNode { id: string; x: number; y: number }
+export interface FMember {
+  id: string; i: string; j: string
+  E: number   // MPa
+  A: number   // mm²
+  I: number   // mm⁴
+}
+export type FSupportType = 'pin' | 'roller' | 'fixed'
+export interface FSupport { node: string; type: FSupportType }
+
+export type FLoad =
+  | { kind: 'node'; node: string; Fx: number; Fy: number; Mz: number; cat: LoadCategory }
+  | { kind: 'member-udl'; member: string; w: number; cat: LoadCategory }      // kN/m, global −Y (gravity +)
+  | { kind: 'member-point'; member: string; a: number; P: number; cat: LoadCategory } // kN at a (m) from node i, global −Y
+
+export interface MemberResult {
+  id: string
+  L: number
+  /** Local end forces ON the member [Fxi, Fyi, Mi, Fxj, Fyj, Mj], kN / kN·m. */
+  f: number[]
+  xs: number[]; N: number[]; V: number[]; M: number[]
+  Nmax: number; Vmax: number; Mmax: number
+}
+export interface FrameReaction { node: string; type: FSupportType; Rx: number; Ry: number; Rm: number }
+export interface FrameResult {
+  d: number[]                       // global DOF displacements (m, rad)
+  reactions: FrameReaction[]
+  members: MemberResult[]
+  Mmax: number; Vmax: number; Nmax: number
+}
+
+function scaleFLoad(ld: FLoad, f: number): FLoad {
+  if (ld.kind === 'node') return { ...ld, Fx: ld.Fx * f, Fy: ld.Fy * f, Mz: ld.Mz * f }
+  if (ld.kind === 'member-udl') return { ...ld, w: ld.w * f }
+  return { ...ld, P: ld.P * f }
+}
+
+export function applyFrameCombo(loads: FLoad[], factors: Partial<Record<LoadCategory, number>>): FLoad[] {
+  return loads
+    .map((ld) => scaleFLoad(ld, factors[ld.cat] ?? 0))
+    .filter((ld) => {
+      if (ld.kind === 'node') return Math.abs(ld.Fx) + Math.abs(ld.Fy) + Math.abs(ld.Mz) > 1e-9
+      if (ld.kind === 'member-udl') return Math.abs(ld.w) > 1e-9
+      return Math.abs(ld.P) > 1e-9
+    })
+}
+
+/** Local 6×6 stiffness for EA (kN), EI (kN·m²), length L (m). */
+function kLocal(EA: number, EI: number, L: number): number[][] {
+  const a = EA / L
+  const b = (12 * EI) / L ** 3, c = (6 * EI) / L ** 2, e = (4 * EI) / L, g = (2 * EI) / L
+  return [
+    [a, 0, 0, -a, 0, 0],
+    [0, b, c, 0, -b, c],
+    [0, c, e, 0, -c, g],
+    [-a, 0, 0, a, 0, 0],
+    [0, -b, -c, 0, b, -c],
+    [0, c, g, 0, -c, e],
+  ]
+}
+
+/** Transformation: local = T · global for the 6 member DOFs. */
+function tMatrix(cx: number, cy: number): number[][] {
+  return [
+    [cx, cy, 0, 0, 0, 0],
+    [-cy, cx, 0, 0, 0, 0],
+    [0, 0, 1, 0, 0, 0],
+    [0, 0, 0, cx, cy, 0],
+    [0, 0, 0, -cy, cx, 0],
+    [0, 0, 0, 0, 0, 1],
+  ]
+}
+
+const mul = (A: number[][], B: number[][]): number[][] =>
+  A.map((row) => B[0].map((_, j) => row.reduce((s, v, k) => s + v * B[k][j], 0)))
+const transpose = (A: number[][]): number[][] => A[0].map((_, j) => A.map((row) => row[j]))
+
+interface Prep {
+  L: number; cx: number; cy: number
+  kl: number[][]; T: number[][]; kg: number[][]
+  dofs: number[]
+  /** local consistent load vector from member loads (forces ON nodes) */
+  feq: number[]
+  /** local load intensities for diagram sampling */
+  q: number      // transverse local UDL (+y′)
+  p: number      // axial local UDL (+x′)
+  pts: { a: number; Pt: number; Pa: number }[]   // local point loads at a
+}
+
+function prepMember(m: FMember, nodes: Map<string, FNode>, idx: Map<string, number>, loads: FLoad[]): Prep {
+  const ni = nodes.get(m.i)!, nj = nodes.get(m.j)!
+  const dx = nj.x - ni.x, dy = nj.y - ni.y
+  const L = Math.hypot(dx, dy)
+  const cx = dx / L, cy = dy / L
+  const EA = (m.E * m.A) / 1000          // kN
+  const EI = m.E * m.I * 1e-9            // kN·m²
+  const kl = kLocal(EA, EI, L)
+  const T = tMatrix(cx, cy)
+  const kg = mul(mul(transpose(T), kl), T)
+  const ii = idx.get(m.i)!, jj = idx.get(m.j)!
+  const dofs = [3 * ii, 3 * ii + 1, 3 * ii + 2, 3 * jj, 3 * jj + 1, 3 * jj + 2]
+
+  // Member loads → local intensities/points. Gravity (global −Y) decomposes
+  // into local transverse q = −w·cx and axial p = −w·cy (per metre of member).
+  let q = 0, p = 0
+  const pts: { a: number; Pt: number; Pa: number }[] = []
+  const feq = new Array(6).fill(0)
+  for (const ld of loads) {
+    if (ld.kind === 'member-udl' && ld.member === m.id) {
+      const qi = -ld.w * cx, pi = -ld.w * cy
+      q += qi; p += pi
+      // consistent: axial pL/2 each end; transverse qL/2, ±qL²/12
+      feq[0] += (pi * L) / 2; feq[3] += (pi * L) / 2
+      feq[1] += (qi * L) / 2; feq[4] += (qi * L) / 2
+      feq[2] += (qi * L * L) / 12; feq[5] -= (qi * L * L) / 12
+    } else if (ld.kind === 'member-point' && ld.member === m.id) {
+      const a = Math.max(0, Math.min(L, ld.a))
+      const Pt = -ld.P * cx, Pa = -ld.P * cy
+      pts.push({ a, Pt, Pa })
+      const xi = a / L
+      // Hermite consistent transverse + linear axial
+      const N = [1 - 3 * xi ** 2 + 2 * xi ** 3, L * xi * (1 - xi) ** 2, 3 * xi ** 2 - 2 * xi ** 3, L * xi * xi * (xi - 1)]
+      feq[0] += Pa * (1 - xi); feq[3] += Pa * xi
+      feq[1] += Pt * N[0]; feq[2] += Pt * N[1]
+      feq[4] += Pt * N[2]; feq[5] += Pt * N[3]
+    }
+  }
+  return { L, cx, cy, kl, T, kg, dofs, feq, q, p, pts }
+}
+
+export function solveFrame2D(
+  nodes: FNode[], members: FMember[], supports: FSupport[], loads: FLoad[],
+): FrameResult | null {
+  const nm = new Map(nodes.map((n) => [n.id, n]))
+  const idx = new Map(nodes.map((n, i) => [n.id, i]))
+  const ndof = 3 * nodes.length
+
+  const preps = members.map((m) => prepMember(m, nm, idx, loads))
+
+  const K: number[][] = Array.from({ length: ndof }, () => new Array(ndof).fill(0))
+  const F = new Array(ndof).fill(0)
+  preps.forEach((pr) => {
+    const fg = matVec(transpose(pr.T), pr.feq)
+    for (let a = 0; a < 6; a++) {
+      F[pr.dofs[a]] += fg[a]
+      for (let b = 0; b < 6; b++) K[pr.dofs[a]][pr.dofs[b]] += pr.kg[a][b]
+    }
+  })
+  for (const ld of loads) {
+    if (ld.kind !== 'node') continue
+    const i = idx.get(ld.node)
+    if (i === undefined) continue
+    F[3 * i] += ld.Fx; F[3 * i + 1] += ld.Fy; F[3 * i + 2] += ld.Mz
+  }
+
+  const constrained = new Set<number>()
+  for (const s of supports) {
+    const i = idx.get(s.node)
+    if (i === undefined) continue
+    if (s.type === 'roller') constrained.add(3 * i + 1)
+    else {
+      constrained.add(3 * i); constrained.add(3 * i + 1)
+      if (s.type === 'fixed') constrained.add(3 * i + 2)
+    }
+  }
+  const free: number[] = []
+  for (let d = 0; d < ndof; d++) if (!constrained.has(d)) free.push(d)
+  const d = new Array(ndof).fill(0)
+  if (free.length > 0) {
+    const Kff = free.map((i) => free.map((j) => K[i][j]))
+    const dF = solveLinear(Kff, free.map((i) => F[i]))
+    if (dF === null) return null
+    free.forEach((dof, k) => (d[dof] = dF[k]))
+  }
+
+  // Reactions = K·d − F at the supported nodes.
+  const R = matVec(K, d).map((v, i) => v - F[i])
+  const reactions: FrameReaction[] = supports
+    .filter((s) => idx.has(s.node))
+    .map((s) => {
+      const i = idx.get(s.node)!
+      return {
+        node: s.node, type: s.type,
+        Rx: s.type === 'roller' ? 0 : R[3 * i],
+        Ry: R[3 * i + 1],
+        Rm: s.type === 'fixed' ? R[3 * i + 2] : 0,
+      }
+    })
+
+  // Member end forces + sampled diagrams.
+  const results: MemberResult[] = members.map((m, mi) => {
+    const pr = preps[mi]
+    const de = pr.dofs.map((dof) => d[dof])
+    const dl = matVec(pr.T, de)
+    const f = matVec(pr.kl, dl).map((v, k) => v - pr.feq[k])
+
+    const xsSet = new Set<number>()
+    const NS = 40
+    for (let k = 0; k <= NS; k++) xsSet.add((pr.L * k) / NS)
+    pr.pts.forEach((pt) => { xsSet.add(Math.max(0, pt.a - 1e-6)); xsSet.add(pt.a); xsSet.add(Math.min(pr.L, pt.a + 1e-6)) })
+    const xs = [...xsSet].sort((a, b) => a - b)
+
+    // Segment statics from end i: f = forces ON the member at its ends (local).
+    const N: number[] = [], V: number[] = [], M: number[] = []
+    for (const x of xs) {
+      let n = -(f[0] + pr.p * x)
+      let v = f[1] + pr.q * x
+      let mm = -f[2] + f[1] * x + (pr.q * x * x) / 2
+      for (const pt of pr.pts) {
+        if (pt.a <= x) {
+          n -= pt.Pa
+          v += pt.Pt
+          mm += pt.Pt * (x - pt.a)
+        }
+      }
+      N.push(n); V.push(v); M.push(mm)
+    }
+    return {
+      id: m.id, L: pr.L, f, xs, N, V, M,
+      Nmax: Math.max(...N.map(Math.abs)),
+      Vmax: Math.max(...V.map(Math.abs)),
+      Mmax: Math.max(...M.map(Math.abs)),
+    }
+  })
+
+  return {
+    d, reactions, members: results,
+    Mmax: Math.max(...results.map((r) => r.Mmax), 0),
+    Vmax: Math.max(...results.map((r) => r.Vmax), 0),
+    Nmax: Math.max(...results.map((r) => r.Nmax), 0),
+  }
+}
+
+// ── NSCP combination orchestration (mirrors analyzeBeam) ─────────────────
+export interface FrameComboRun { combo: Combo; result: FrameResult | null; factored: FLoad[]; skipped: boolean }
+export interface FrameAnalysis { perCombo: FrameComboRun[]; govIdx: number }
+
+export function analyzeFrame2D(
+  nodes: FNode[], members: FMember[], supports: FSupport[], loads: FLoad[],
+): FrameAnalysis | null {
+  const perCombo: FrameComboRun[] = []
+  let govIdx = -1, govM = -1
+  for (const combo of NSCP_COMBOS) {
+    const factored = applyFrameCombo(loads, combo.f)
+    if (factored.length === 0) { perCombo.push({ combo, result: null, factored, skipped: true }); continue }
+    const r = solveFrame2D(nodes, members, supports, factored)
+    perCombo.push({ combo, result: r, factored, skipped: false })
+    if (r && r.Mmax > govM) { govM = r.Mmax; govIdx = perCombo.length - 1 }
+  }
+  return govIdx < 0 ? null : { perCombo, govIdx }
+}

--- a/webapp/src/pages/FrameAnalysis.tsx
+++ b/webapp/src/pages/FrameAnalysis.tsx
@@ -1,0 +1,273 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import {
+  analyzeFrame2D, type FNode, type FMember, type FSupport, type FSupportType, type FLoad,
+} from '../engine/frame2d'
+import type { LoadCategory } from '../engine/beamAnalysis'
+import { FrameSketch } from '../components/FrameSketch'
+import { Diagram } from '../components/Diagram'
+import { ReportControls } from '../components/ReportControls'
+import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
+import { f1, f2 } from '../lib/format'
+import 'katex/dist/katex.min.css'
+
+const CATS: [LoadCategory, string][] = [
+  ['D', 'D — dead'], ['L', 'L — live'], ['Lr', 'Lr — roof live'],
+  ['S', 'S — snow'], ['R', 'R — rain'], ['W', 'W — wind'], ['E', 'E — seismic'],
+]
+
+let uid = 1
+interface NodeRow extends FNode { uid: number }
+interface MemberRow { uid: number; id: string; i: string; j: string }
+interface SupportRow extends FSupport { uid: number }
+type LoadRow = FLoad & { uid: number }
+
+// Default: a pinned-base portal frame.
+const DEF_NODES: NodeRow[] = [
+  { uid: uid++, id: 'A', x: 0, y: 0 }, { uid: uid++, id: 'B', x: 0, y: 3 },
+  { uid: uid++, id: 'C', x: 6, y: 3 }, { uid: uid++, id: 'D', x: 6, y: 0 },
+]
+const DEF_MEMBERS: MemberRow[] = [
+  { uid: uid++, id: 'col1', i: 'A', j: 'B' },
+  { uid: uid++, id: 'beam', i: 'B', j: 'C' },
+  { uid: uid++, id: 'col2', i: 'D', j: 'C' },
+]
+const DEF_SUPPORTS: SupportRow[] = [
+  { uid: uid++, node: 'A', type: 'pin' }, { uid: uid++, node: 'D', type: 'pin' },
+]
+const DEF_LOADS: LoadRow[] = [
+  { uid: uid++, kind: 'member-udl', member: 'beam', w: 12, cat: 'D' },
+  { uid: uid++, kind: 'member-udl', member: 'beam', w: 8, cat: 'L' },
+  { uid: uid++, kind: 'node', node: 'B', Fx: 20, Fy: 0, Mz: 0, cat: 'W' },
+]
+
+function Shell({ title, onRemove, children }: { title: string; onRemove: () => void; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-xs font-bold uppercase tracking-wide text-slate-500">{title}</span>
+        <button type="button" onClick={onRemove} className="text-xs text-red-500 hover:underline">remove</button>
+      </div>
+      <div className="flex flex-wrap gap-3 [&>label]:w-32">{children}</div>
+    </div>
+  )
+}
+
+export default function FrameAnalysis() {
+  // Section (applied to every member): rectangular b×h + f'c → E, A, I.
+  const [b, setB] = useState(300); const [h, setH] = useState(500); const [fc, setFc] = useState(28)
+  const [nodes, setNodes] = useState<NodeRow[]>(DEF_NODES)
+  const [members, setMembers] = useState<MemberRow[]>(DEF_MEMBERS)
+  const [supports, setSupports] = useState<SupportRow[]>(DEF_SUPPORTS)
+  const [loads, setLoads] = useState<LoadRow[]>(DEF_LOADS)
+  const [selCombo, setSelCombo] = useState<number | null>(null)
+  const [selMember, setSelMember] = useState<string>('beam')
+
+  const E = 4700 * Math.sqrt(Math.max(fc, 1))
+  const fMembers: FMember[] = useMemo(
+    () => members.map((m) => ({ id: m.id, i: m.i, j: m.j, E, A: b * h, I: (b * h ** 3) / 12 })),
+    [members, E, b, h],
+  )
+
+  const valid = nodes.length >= 2 && members.length >= 1 && supports.length >= 1
+  const res = useMemo(() => {
+    if (!valid) return null
+    try { return analyzeFrame2D(nodes, fMembers, supports, loads) } catch { return null }
+  }, [nodes, fMembers, supports, loads, valid])
+
+  const shownIdx = selCombo !== null && res && res.perCombo[selCombo]?.result ? selCombo : res?.govIdx ?? 0
+  const shown = res ? res.perCombo[shownIdx] : null
+  const r = shown?.result ?? null
+  const mem = r?.members.find((m) => m.id === selMember) ?? r?.members[0] ?? null
+
+  const nodeIds = nodes.map((n) => n.id)
+  const memberIds = members.map((m) => m.id)
+  const upd = <T extends { uid: number }>(set: React.Dispatch<React.SetStateAction<T[]>>) =>
+    (uidV: number, patch: Partial<T>) => set((xs) => xs.map((x) => (x.uid === uidV ? { ...x, ...patch } : x)))
+  const updNode = upd(setNodes), updSup = upd(setSupports), updLoad = upd(setLoads)
+  const updMember = upd(setMembers)
+
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
+      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Frame Analysis (2D)</h1>
+      <p className="no-print mt-1 text-slate-600">
+        2D frame FEM — 6-DOF members (axial + Hermite bending) built on the shared core, with pinned / roller /
+        fixed nodes, nodal & member gravity loads, and all 7 NSCP 2015 load combinations. Phase 2 of the 3D
+        model-space roadmap.
+      </p>
+      <ReportControls title="Frame Analysis Report" />
+
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
+        <div className="space-y-5">
+          <Card title="Member section (all members)">
+            <Num label="b" unit="mm" value={b} onChange={setB} />
+            <Num label="h" unit="mm" value={h} onChange={setH} />
+            <Num label="f′c" unit="MPa" value={fc} onChange={setFc} />
+            <p className="col-span-full text-xs text-slate-400">
+              E = 4700√f′c = {f1(E)} MPa · A = {b * h} mm² · I = {(b * h ** 3 / 12 / 1e9).toFixed(3)}×10⁹ mm⁴
+            </p>
+          </Card>
+
+          <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">Nodes</legend>
+            <button type="button" onClick={() => setNodes((ns) => [...ns, { uid: uid++, id: `N${ns.length + 1}`, x: 0, y: 0 }])}
+              className="no-print mb-3 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">+ Node</button>
+            <div className="space-y-3">
+              {nodes.map((n) => (
+                <Shell key={n.uid} title={n.id} onRemove={() => setNodes((ns) => ns.filter((q) => q.uid !== n.uid))}>
+                  <label className="flex w-32 flex-col text-sm">
+                    <span className="mb-1 font-medium text-slate-600">id</span>
+                    <input value={n.id} onChange={(e) => updNode(n.uid, { id: e.target.value })}
+                      className="rounded-md border border-slate-300 px-2.5 py-1.5" />
+                  </label>
+                  <Num label="x" unit="m" value={n.x} onChange={(v) => updNode(n.uid, { x: v })} />
+                  <Num label="y" unit="m" value={n.y} onChange={(v) => updNode(n.uid, { y: v })} />
+                </Shell>
+              ))}
+            </div>
+          </fieldset>
+
+          <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">Members</legend>
+            <button type="button" onClick={() => setMembers((ms) => [...ms, { uid: uid++, id: `m${ms.length + 1}`, i: nodeIds[0] ?? '', j: nodeIds[1] ?? '' }])}
+              className="no-print mb-3 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">+ Member</button>
+            <div className="space-y-3">
+              {members.map((m) => (
+                <Shell key={m.uid} title={m.id} onRemove={() => setMembers((ms) => ms.filter((q) => q.uid !== m.uid))}>
+                  <label className="flex w-32 flex-col text-sm">
+                    <span className="mb-1 font-medium text-slate-600">id</span>
+                    <input value={m.id} onChange={(e) => updMember(m.uid, { id: e.target.value })}
+                      className="rounded-md border border-slate-300 px-2.5 py-1.5" />
+                  </label>
+                  <Pick label="node i" value={m.i} onChange={(v) => updMember(m.uid, { i: v })} options={nodeIds.map((q) => [q, q])} />
+                  <Pick label="node j" value={m.j} onChange={(v) => updMember(m.uid, { j: v })} options={nodeIds.map((q) => [q, q])} />
+                </Shell>
+              ))}
+            </div>
+          </fieldset>
+
+          <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">Supports</legend>
+            <button type="button" onClick={() => setSupports((ss) => [...ss, { uid: uid++, node: nodeIds[0] ?? '', type: 'pin' }])}
+              className="no-print mb-3 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">+ Support</button>
+            <div className="space-y-3">
+              {supports.map((s) => (
+                <Shell key={s.uid} title={s.type} onRemove={() => setSupports((ss) => ss.filter((q) => q.uid !== s.uid))}>
+                  <Pick label="node" value={s.node} onChange={(v) => updSup(s.uid, { node: v })} options={nodeIds.map((q) => [q, q])} />
+                  <Pick label="type" value={s.type} onChange={(v) => updSup(s.uid, { type: v as FSupportType })}
+                    options={[['pin', 'Pin'], ['roller', 'Roller'], ['fixed', 'Fixed']]} />
+                </Shell>
+              ))}
+            </div>
+          </fieldset>
+
+          <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">Loads</legend>
+            <div className="no-print mb-3 flex flex-wrap gap-2">
+              <button type="button" onClick={() => setLoads((ls) => [...ls, { uid: uid++, kind: 'node', node: nodeIds[0] ?? '', Fx: 0, Fy: -50, Mz: 0, cat: 'D' }])}
+                className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">+ Node load</button>
+              <button type="button" onClick={() => setLoads((ls) => [...ls, { uid: uid++, kind: 'member-udl', member: memberIds[0] ?? '', w: 10, cat: 'D' }])}
+                className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">+ Member UDL</button>
+              <button type="button" onClick={() => setLoads((ls) => [...ls, { uid: uid++, kind: 'member-point', member: memberIds[0] ?? '', a: 1, P: 50, cat: 'D' }])}
+                className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">+ Member point</button>
+            </div>
+            <div className="space-y-3">
+              {loads.map((ld) => (
+                <Shell key={ld.uid} title={ld.kind} onRemove={() => setLoads((ls) => ls.filter((q) => q.uid !== ld.uid))}>
+                  {ld.kind === 'node' && <>
+                    <Pick label="node" value={ld.node} onChange={(v) => updLoad(ld.uid, { node: v } as Partial<LoadRow>)} options={nodeIds.map((q) => [q, q])} />
+                    <Num label="Fx" unit="kN" value={ld.Fx} onChange={(v) => updLoad(ld.uid, { Fx: v } as Partial<LoadRow>)} />
+                    <Num label="Fy" unit="kN" value={ld.Fy} onChange={(v) => updLoad(ld.uid, { Fy: v } as Partial<LoadRow>)} />
+                    <Num label="Mz" unit="kN·m" value={ld.Mz} onChange={(v) => updLoad(ld.uid, { Mz: v } as Partial<LoadRow>)} />
+                  </>}
+                  {ld.kind === 'member-udl' && <>
+                    <Pick label="member" value={ld.member} onChange={(v) => updLoad(ld.uid, { member: v } as Partial<LoadRow>)} options={memberIds.map((q) => [q, q])} />
+                    <Num label="w (gravity ↓)" unit="kN/m" value={ld.w} onChange={(v) => updLoad(ld.uid, { w: v } as Partial<LoadRow>)} />
+                  </>}
+                  {ld.kind === 'member-point' && <>
+                    <Pick label="member" value={ld.member} onChange={(v) => updLoad(ld.uid, { member: v } as Partial<LoadRow>)} options={memberIds.map((q) => [q, q])} />
+                    <Num label="a from i" unit="m" value={ld.a} onChange={(v) => updLoad(ld.uid, { a: v } as Partial<LoadRow>)} />
+                    <Num label="P (gravity ↓)" unit="kN" value={ld.P} onChange={(v) => updLoad(ld.uid, { P: v } as Partial<LoadRow>)} />
+                  </>}
+                  <Pick label="category" value={ld.cat} onChange={(v) => updLoad(ld.uid, { cat: v as LoadCategory } as Partial<LoadRow>)} options={CATS} />
+                </Shell>
+              ))}
+            </div>
+          </fieldset>
+        </div>
+
+        <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
+          <ResultCard title="Model">
+            <FrameSketch nodes={nodes} members={members.map((m) => ({ ...m, E: 0, A: 0, I: 0 }))}
+              supports={supports} loads={loads} selected={selMember} />
+            {!res && valid && <p className="mt-1 text-sm text-red-600">⚠ Unstable or singular — check supports/connectivity.</p>}
+          </ResultCard>
+
+          {res && (
+            <ResultCard title="NSCP 2015 load combinations">
+              <div className="overflow-x-auto">
+                <table className="w-full border-collapse text-xs">
+                  <thead>
+                    <tr className="text-left uppercase tracking-wide text-slate-500">
+                      <th className="py-1 pr-2 font-semibold">Combination</th>
+                      <th className="py-1 pr-2 text-right font-semibold">Nmax</th>
+                      <th className="py-1 pr-2 text-right font-semibold">Vmax</th>
+                      <th className="py-1 text-right font-semibold">Mmax</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {res.perCombo.map((pc, i) => (
+                      <tr key={pc.combo.name} onClick={() => pc.result && setSelCombo(i)}
+                        className={`border-t border-slate-100 ${pc.result ? 'cursor-pointer hover:bg-blue-50' : 'text-slate-300'} ${
+                          i === res.govIdx ? 'bg-amber-50 font-semibold' : ''} ${i === shownIdx ? 'outline outline-1 outline-[#0056b3]' : ''}`}>
+                        <td className="py-1 pr-2">{pc.combo.name}{i === res.govIdx ? ' ★' : ''}</td>
+                        <td className="py-1 pr-2 text-right">{pc.result ? f1(pc.result.Nmax) : '—'}</td>
+                        <td className="py-1 pr-2 text-right">{pc.result ? f1(pc.result.Vmax) : '—'}</td>
+                        <td className="py-1 text-right">{pc.result ? f1(pc.result.Mmax) : '—'}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </ResultCard>
+          )}
+
+          {r && shown && (
+            <ResultCard title={`Reactions — ${shown.combo.name}`}>
+              {r.reactions.map((rc, i) => (
+                <Row key={i} label={`${rc.node} (${rc.type})`}
+                  value={`Ry ${f2(rc.Ry)} kN`}
+                  sub={`Rx ${f2(rc.Rx)}${Math.abs(rc.Rm) > 0.01 ? ` · M ${f2(rc.Rm)}` : ''}`} />
+              ))}
+            </ResultCard>
+          )}
+        </div>
+      </div>
+
+      {r && mem && (
+        <div className="mt-6">
+          <div className="mb-2 flex flex-wrap items-center gap-3">
+            <h2 className="text-[1.02rem] font-bold text-[#0056b3]">Member diagrams</h2>
+            <select value={selMember} onChange={(e) => setSelMember(e.target.value)}
+              className="rounded-md border border-slate-300 px-2.5 py-1.5 text-sm">
+              {r.members.map((m) => <option key={m.id} value={m.id}>{m.id}</option>)}
+            </select>
+            <span className="text-xs text-slate-400">local x from node i · N &gt; 0 tension</span>
+          </div>
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+            <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <Diagram xs={mem.xs} ys={mem.N} title={`AXIAL — ${mem.id}`} unit="kN" color="#7c3aed" decimals={1} />
+            </div>
+            <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <Diagram xs={mem.xs} ys={mem.V} title="SHEAR" unit="kN" color="#1f77b4" decimals={1} />
+            </div>
+            <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <Diagram xs={mem.xs} ys={mem.M} title="MOMENT" unit="kN·m" color="#d62728" decimals={1} />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Second milestone of the 3D roadmap (docs/ROADMAP-3D.md): the kernel generalisation.

## `engine/fem.ts` — one FEM core
`solveLinear`, `matVec`, `hermite`, `gauss5Vec` extracted from `beamAnalysis`, which now imports them — **zero behaviour change** (all 9 beam closed-form tests pass untouched). The 2D frame, the future 3D frame, and the Winkler footing can all consume this one toolbox.

## `engine/frame2d.ts` — the 2D frame element
- **6-DOF (3/node) member**: the beam solver's Hermite bending stiffness ⊕ the axial bar term, rotated into global coordinates by the member orientation.
- **Supports**: pin / roller / fixed nodes. **Loads**: nodal (Fx, Fy, Mz) and member **gravity** loads (global −Y UDL & point) — decomposed into local transverse + axial components for inclined members and applied as consistent fixed-end vectors.
- **Member end-force recovery** (`f = k_l·T·d − f_eq`) and sampled **N/V/M diagrams** by segment statics (N > 0 tension).
- `analyzeFrame2D` runs **all 7 NSCP 2015 combinations** (reusing `NSCP_COMBOS` and the categorised-load pattern); governing = max |M|.

## `/frame` page
Node / member / support / load card editors; one rectangular section (b×h, f′c → E = 4700√f′c) for all members; frame **elevation sketch** (support symbols, load glyphs, selected-member highlight); combos table (governing ★, click-to-view); reactions; **per-member N/V/M diagrams** via the existing `Diagram`.

## Verification — closed forms & regression (all passed first run)
- SS-beam-as-frame **reproduces `solveFEM`**: UDL (`wL²/8`) and midspan point (`PL/4`) match the beam module to 2 decimals.
- Vertical cantilever, horizontal tip load: `δ = PL³/3EI`, `M_base = PL` (validates the rotation matrix).
- Axial column: `δ = PL/EA`, `N = −P` compression.
- Pinned-base portal with beam UDL: vertical equilibrium, symmetric reactions, equal-and-opposite thrust, and **corner moment continuity** (beam end M = column top M).
- 1.2D + 1.6L governs for D+L loading.

**120 tests total**; build green. Next per the roadmap: Phase 3 — the tributary (load-path) engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)