### PR TITLE
Phase 3: tributary (load-path) engine + Slab Load Path page

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -6,6 +6,7 @@ import BeamDesign from './pages/BeamDesign'
 import BeamAnalysis from './pages/BeamAnalysis'
 import ColumnDesign from './pages/ColumnDesign'
 import FrameAnalysis from './pages/FrameAnalysis'
+import LoadPath from './pages/LoadPath'
 import SlabEstimate from './pages/SlabEstimate'
 import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
@@ -41,6 +42,7 @@ function Home() {
         <Tile to="/beam-analysis">Beam Analysis (FEM)</Tile>
         <Tile to="/column-design">Column Design</Tile>
         <Tile to="/frame">Frame Analysis (2D)</Tile>
+        <Tile to="/load-path">Slab Load Path</Tile>
       </div>
 
       <h2 className="mt-8 text-lg font-semibold text-slate-800">Material estimation (quantity take-off)</h2>
@@ -66,6 +68,7 @@ export default function App() {
       <Route path="/beam-analysis" element={<BeamAnalysis />} />
       <Route path="/column-design" element={<ColumnDesign />} />
       <Route path="/frame" element={<FrameAnalysis />} />
+      <Route path="/load-path" element={<LoadPath />} />
       <Route path="/estimate/slab" element={<SlabEstimate />} />
       <Route path="/estimate/beam" element={<BeamEstimate />} />
       <Route path="/estimate/column" element={<ColumnEstimate />} />

--- a/webapp/src/components/PanelSketch.tsx
+++ b/webapp/src/components/PanelSketch.tsx
@@ -1,0 +1,60 @@
+import type { JSX } from 'react'
+import type { TributaryResult } from '../engine/tributary'
+import { DimBelow, DimSide } from './dims'
+
+const STROKE = '#37526e'
+const FILL = '#eef3f8'
+const TRIB = '#16a34a'
+const EDGE = '#0056b3'
+
+/** Plan of the slab panel with its tributary areas: 45° lines (two-way) or
+ *  the one-way strip direction, and the edge labels. */
+export function PanelSketch({ r }: { r: TributaryResult }): JSX.Element {
+  const W = 420, H = 280
+  const padL = 56, padT = 30, availW = 280, availH = 180
+  const s = Math.min(availW / r.ly, availH / r.lx)
+  const w = r.ly * s, h = r.lx * s
+  const x0 = padL + (availW - w) / 2, y0 = padT
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet"
+      style={{ width: '100%', height: 'auto', fontFamily: 'Arial, sans-serif' }}>
+      <text x={padL} y={14} fontSize={11} fontWeight={700} fill="#0056b3">PANEL PLAN — {r.behaviour}</text>
+
+      <rect x={x0} y={y0} width={w} height={h} fill={FILL} stroke={STROKE} strokeWidth={1.6} />
+
+      {r.behaviour === 'two-way' ? (
+        <g stroke={TRIB} strokeWidth={1} strokeDasharray="5 3">
+          <line x1={x0} y1={y0} x2={x0 + h / 2} y2={y0 + h / 2} />
+          <line x1={x0} y1={y0 + h} x2={x0 + h / 2} y2={y0 + h / 2} />
+          <line x1={x0 + w} y1={y0} x2={x0 + w - h / 2} y2={y0 + h / 2} />
+          <line x1={x0 + w} y1={y0 + h} x2={x0 + w - h / 2} y2={y0 + h / 2} />
+          <line x1={x0 + h / 2} y1={y0 + h / 2} x2={x0 + w - h / 2} y2={y0 + h / 2} />
+        </g>
+      ) : (
+        <g stroke={TRIB} strokeWidth={1} strokeDasharray="5 3">
+          <line x1={x0} y1={y0 + h / 2} x2={x0 + w} y2={y0 + h / 2} />
+          {Array.from({ length: 5 }, (_, i) => {
+            const x = x0 + (w * (i + 1)) / 6
+            return (
+              <g key={i}>
+                <line x1={x} y1={y0 + 6} x2={x} y2={y0 + h - 6} strokeDasharray="2 3" strokeWidth={0.8} />
+                <path d={`M ${x - 3} ${y0 + 10} L ${x} ${y0 + 5} L ${x + 3} ${y0 + 10}`} fill="none" strokeDasharray="" />
+                <path d={`M ${x - 3} ${y0 + h - 10} L ${x} ${y0 + h - 5} L ${x + 3} ${y0 + h - 10}`} fill="none" strokeDasharray="" />
+              </g>
+            )
+          })}
+        </g>
+      )}
+
+      {/* edge labels */}
+      <text x={x0 + w / 2} y={y0 - 5} fontSize={9} fill={EDGE} textAnchor="middle" fontWeight={700}>L1 (long)</text>
+      <text x={x0 + w / 2} y={y0 + h + 11} fontSize={9} fill={EDGE} textAnchor="middle" fontWeight={700}>L2 (long)</text>
+      <text x={x0 - 6} y={y0 + h / 2} fontSize={9} fill={EDGE} textAnchor="end" fontWeight={700}>S1</text>
+      <text x={x0 + w + 6} y={y0 + h / 2} fontSize={9} fill={EDGE} fontWeight={700}>S2</text>
+
+      <DimBelow xA={x0} xB={x0 + w} featY={y0 + h + 14} dY={y0 + h + 30} label={`ℓy = ${r.ly.toFixed(2)} m`} />
+      <DimSide yA={y0} yB={y0 + h} featX={x0} dX={x0 - 22} label={`ℓx = ${r.lx.toFixed(2)} m`} side="left" />
+    </svg>
+  )
+}

--- a/webapp/src/engine/tributary.test.ts
+++ b/webapp/src/engine/tributary.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { distributePanel, wallLineLoad } from './tributary'
+import { solveFEM } from './beamAnalysis'
+
+describe('tributary — classification & closure', () => {
+  it('one-way when long/short ≥ 2: long edges carry q·lx/2 UDL, short edges nothing', () => {
+    const r = distributePanel(3, 7, [{ q: 10, cat: 'D' }])    // ratio 2.33
+    expect(r.behaviour).toBe('one-way')
+    const long = r.edges.filter((e) => e.kind === 'long')
+    const short = r.edges.filter((e) => e.kind === 'short')
+    expect(long[0].peak).toBeCloseTo((10 * 3) / 2, 9)          // 15 kN/m
+    expect(long[0].loads[0].type).toBe('udl')
+    expect(short[0].loads).toHaveLength(0)
+    // closure: 2 × 15 × 7 = 210 = q·lx·ly
+    expect(r.totalDistributed).toBeCloseTo(r.totalApplied, 9)
+  })
+
+  it('two-way: triangles on short edges, trapezoids on long; closure holds', () => {
+    const r = distributePanel(4, 6, [{ q: 12, cat: 'L' }])     // ratio 1.5
+    expect(r.behaviour).toBe('two-way')
+    const long = r.edges.find((e) => e.kind === 'long')!
+    const short = r.edges.find((e) => e.kind === 'short')!
+    const peak = (12 * 4) / 2                                  // 24 kN/m
+    expect(long.peak).toBeCloseTo(peak, 9)
+    // trapezoid total: peak·(ly − lx/2) = 24·4 = 96; triangle: peak·lx/2 = 48
+    expect(long.total).toBeCloseTo(peak * (6 - 4 / 2), 6)
+    expect(short.total).toBeCloseTo((peak * 4) / 2, 6)
+    expect(r.totalDistributed).toBeCloseTo(12 * 4 * 6, 6)
+  })
+
+  it('square panel: four identical triangles', () => {
+    const r = distributePanel(5, 5, [{ q: 8, cat: 'D' }])
+    expect(r.behaviour).toBe('two-way')
+    const totals = r.edges.map((e) => e.total)
+    totals.forEach((t) => expect(t).toBeCloseTo(totals[0], 9))
+    expect(r.totalDistributed).toBeCloseTo(8 * 25, 6)
+  })
+
+  it('categories are preserved per emitted load', () => {
+    const r = distributePanel(4, 6, [{ q: 5, cat: 'D' }, { q: 3, cat: 'L' }])
+    const long = r.edges.find((e) => e.kind === 'long')!
+    expect(long.loads.some((l) => l.cat === 'D')).toBe(true)
+    expect(long.loads.some((l) => l.cat === 'L')).toBe(true)
+    expect(r.totalDistributed).toBeCloseTo(8 * 24, 6)
+  })
+})
+
+describe('tributary — the emitted loads run straight through the beam FEM', () => {
+  it('a long-edge trapezoid analyses without conversion and balances its reactions', () => {
+    const r = distributePanel(4, 6, [{ q: 12, cat: 'D' }])
+    const long = r.edges.find((e) => e.kind === 'long')!
+    const fem = solveFEM(
+      [{ type: 'pin', x: 0 }, { type: 'roller', x: long.length }],
+      long.loads, long.length, 25000, 3.125e9)!
+    const sumR = fem.reactions.reduce((s, q) => s + q.Rv, 0)
+    expect(sumR).toBeCloseTo(long.total, 3)
+    // symmetric trapezoid → equal reactions
+    expect(fem.reactions[0].Rv).toBeCloseTo(fem.reactions[1].Rv, 3)
+  })
+})
+
+describe('wall line load', () => {
+  it('150 mm × 3.0 m wall at 24 kN/m³ → 10.8 kN/m', () => {
+    expect(wallLineLoad(150, 3)).toBeCloseTo(10.8, 9)
+  })
+})

--- a/webapp/src/engine/tributary.ts
+++ b/webapp/src/engine/tributary.ts
@@ -1,0 +1,103 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Tributary (load-path) engine — Phase 3 of the 3D roadmap. A slab panel's
+// area loads are distributed to its edge beams:
+//   · one-way  (long/short ≥ 2): the two LONG edges each carry a uniform
+//     line load w = q·lx/2 over their length; the short edges carry none.
+//   · two-way (45° tributary lines): the short edges carry a TRIANGLE
+//     (0 → q·lx/2 → 0), the long edges a TRAPEZOID (45° ramps over lx/2 at
+//     each end, flat q·lx/2 in between).
+// The edge loads are emitted as the SAME BeamLoad shapes (udl / vdl, with
+// their NSCP category preserved) that the beam & frame solvers consume —
+// the load path needs no new load machinery downstream.
+// Units: spans m; q kPa (kN/m²); line loads kN/m.
+// ─────────────────────────────────────────────────────────────────────────
+import type { BeamLoad, LoadCategory } from './beamAnalysis'
+import { loadResultant } from './beamAnalysis'
+
+export interface AreaLoad { q: number; cat: LoadCategory }
+
+export type PanelBehaviour = 'one-way' | 'two-way'
+export type EdgeKind = 'long' | 'short'
+
+export interface EdgeLoads {
+  edge: 'L1' | 'L2' | 'S1' | 'S2'   // two long, two short edges
+  kind: EdgeKind
+  length: number                    // m
+  /** Peak line-load intensity per category source, kN/m (Σq·lx/2 across cats). */
+  peak: number
+  loads: BeamLoad[]                 // udl / vdl along the edge, x from one end
+  /** Total carried by this edge (all categories), kN. */
+  total: number
+}
+
+export interface TributaryResult {
+  lx: number                        // short span, m
+  ly: number                        // long span, m
+  ratio: number                     // ly / lx ≥ 1
+  behaviour: PanelBehaviour
+  edges: EdgeLoads[]
+  /** Σ over edges — must equal q·lx·ly per category (closure). */
+  totalApplied: number
+  totalDistributed: number
+}
+
+function sumW(loads: BeamLoad[]): number {
+  return loads.reduce((s, ld) => s + loadResultant(ld).W, 0)
+}
+
+/**
+ * Distribute the panel's area loads to its four edges.
+ * `a` × `b` are the panel plan dimensions (m) in any order.
+ */
+export function distributePanel(a: number, b: number, areaLoads: AreaLoad[]): TributaryResult {
+  const lx = Math.min(a, b)
+  const ly = Math.max(a, b)
+  const ratio = ly / Math.max(lx, 1e-9)
+  const behaviour: PanelBehaviour = ratio >= 2 ? 'one-way' : 'two-way'
+
+  const qTot = areaLoads.reduce((s, l) => s + l.q, 0)
+  const peak = (qTot * lx) / 2
+
+  const mkLong = (edge: 'L1' | 'L2'): EdgeLoads => {
+    const loads: BeamLoad[] = []
+    for (const al of areaLoads) {
+      const p = (al.q * lx) / 2
+      if (Math.abs(p) < 1e-12) continue
+      if (behaviour === 'one-way') {
+        loads.push({ type: 'udl', x1: 0, x2: ly, w: p, cat: al.cat })
+      } else {
+        // trapezoid: 45° ramps over lx/2 at each end, flat in between
+        loads.push({ type: 'vdl', x1: 0, x2: lx / 2, w1: 0, w2: p, cat: al.cat })
+        if (ly - lx > 1e-9) loads.push({ type: 'udl', x1: lx / 2, x2: ly - lx / 2, w: p, cat: al.cat })
+        loads.push({ type: 'vdl', x1: ly - lx / 2, x2: ly, w1: p, w2: 0, cat: al.cat })
+      }
+    }
+    return { edge, kind: 'long', length: ly, peak, loads, total: sumW(loads) }
+  }
+
+  const mkShort = (edge: 'S1' | 'S2'): EdgeLoads => {
+    const loads: BeamLoad[] = []
+    if (behaviour === 'two-way') {
+      for (const al of areaLoads) {
+        const p = (al.q * lx) / 2
+        if (Math.abs(p) < 1e-12) continue
+        // triangle: 0 at the corners, peak at midspan
+        loads.push({ type: 'vdl', x1: 0, x2: lx / 2, w1: 0, w2: p, cat: al.cat })
+        loads.push({ type: 'vdl', x1: lx / 2, x2: lx, w1: p, w2: 0, cat: al.cat })
+      }
+    }
+    return { edge, kind: 'short', length: lx, peak: behaviour === 'two-way' ? peak : 0, loads, total: sumW(loads) }
+  }
+
+  const edges = [mkLong('L1'), mkLong('L2'), mkShort('S1'), mkShort('S2')]
+  return {
+    lx, ly, ratio, behaviour, edges,
+    totalApplied: qTot * lx * ly,
+    totalDistributed: edges.reduce((s, e) => s + e.total, 0),
+  }
+}
+
+/** Wall self-weight as a line load on its supporting member, kN/m. */
+export function wallLineLoad(thicknessMm: number, heightM: number, gammaConc = 24): number {
+  return (thicknessMm / 1000) * heightM * gammaConc
+}

--- a/webapp/src/lib/tributarySolution.ts
+++ b/webapp/src/lib/tributarySolution.ts
@@ -1,0 +1,61 @@
+// Worked "load path" narrative for the tributary engine — explains how the
+// panel's area load becomes line loads on its edge beams.
+import type { AreaLoad, TributaryResult } from '../engine/tributary'
+import { type SolutionStep, type SolutionLine, sn1, sn2 } from './solution'
+
+const txt = (text: string): SolutionLine => ({ text })
+const eq = (tex: string): SolutionLine => ({ tex })
+
+export function tributarySolution(areaLoads: AreaLoad[], r: TributaryResult): SolutionStep[] {
+  const qTot = areaLoads.reduce((s, l) => s + l.q, 0)
+  const peak = (qTot * r.lx) / 2
+  const steps: SolutionStep[] = []
+
+  steps.push({
+    title: 'Panel classification',
+    lines: [
+      txt('A slab panel spans to its stiffer (shorter) direction first. When the aspect ratio reaches 2 the long direction carries almost nothing — the panel behaves one-way; below 2 both directions work — two-way.'),
+      eq(String.raw`m = \dfrac{\ell_y}{\ell_x} = \dfrac{${sn2(r.ly)}}{${sn2(r.lx)}} = ${sn2(r.ratio)} \;${r.ratio >= 2 ? '\\ge' : '<'}\; 2 \Rightarrow \textbf{${r.behaviour}}`),
+    ],
+  })
+
+  steps.push({
+    title: 'Area load on the panel',
+    lines: [
+      ...areaLoads.map((l) => eq(String.raw`q_{${l.cat}} = ${sn2(l.q)}\ \text{kPa}`)),
+      eq(String.raw`W = q\,\ell_x \ell_y = ${sn2(qTot)}\times ${sn2(r.lx)}\times ${sn2(r.ly)} = ${sn1(r.totalApplied)}\ \text{kN}`),
+    ],
+    note: 'Each category stays separate so the NSCP combinations can be applied downstream.',
+  })
+
+  if (r.behaviour === 'one-way') {
+    steps.push({
+      title: 'One-way distribution',
+      lines: [
+        txt('The slab strips span the short direction ℓx, so each LONG edge carries half the strip — a uniform line load over its whole length. The short edges receive only nominal load (taken as zero).'),
+        eq(String.raw`w = \dfrac{q\,\ell_x}{2} = \dfrac{${sn2(qTot)}\times ${sn2(r.lx)}}{2} = \mathbf{${sn2(peak)}}\ \text{kN/m on each long edge}`),
+      ],
+    })
+  } else {
+    steps.push({
+      title: 'Two-way distribution (45° tributary lines)',
+      lines: [
+        txt('Tributary lines run at 45° from the corners, meeting along the mid-line: each SHORT edge collects a triangular area (peak at midspan), each LONG edge a trapezoidal one (45° ramps over ℓx/2, flat in between).'),
+        eq(String.raw`w_{peak} = \dfrac{q\,\ell_x}{2} = ${sn2(peak)}\ \text{kN/m}`),
+        eq(String.raw`\text{short edge: triangle } 0 \to ${sn2(peak)} \to 0\ \text{over}\ ${sn2(r.lx)}\ \text{m}`),
+        eq(String.raw`\text{long edge: ramp}\ \tfrac{\ell_x}{2} = ${sn2(r.lx / 2)}\ \text{m}, \text{ flat } ${sn2(peak)}\ \text{kN/m over } ${sn2(r.ly - r.lx)}\ \text{m, ramp down}`),
+      ],
+      note: 'Emitted as the exact UDL/VDL loads the beam & frame solvers accept — no equivalent-uniform approximation.',
+    })
+  }
+
+  steps.push({
+    title: 'Closure check',
+    lines: [
+      txt('Everything the slab carries must land on its edges — the distributed edge totals must reproduce the applied panel load.'),
+      eq(String.raw`\sum_{edges} W_e = ${sn1(r.totalDistributed)}\ \text{kN} \;=\; W = ${sn1(r.totalApplied)}\ \text{kN}\ \checkmark`),
+    ],
+  })
+
+  return steps
+}

--- a/webapp/src/pages/BeamAnalysis.tsx
+++ b/webapp/src/pages/BeamAnalysis.tsx
@@ -1,10 +1,11 @@
 import { useMemo, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import {
   analyzeBeam, type Support, type SupportType, type BeamLoad, type LoadCategory,
 } from '../engine/beamAnalysis'
 import { detectCriticalSections } from '../engine/beamSections'
 import { SECTIONS_HANDOFF_KEY } from './BeamDesign'
+import { BEAM_LOADS_HANDOFF_KEY } from './LoadPath'
 import { BeamElevation } from '../components/BeamElevation'
 import { Diagram } from '../components/Diagram'
 import { ReportControls } from '../components/ReportControls'
@@ -47,11 +48,30 @@ function ItemShell({ title, onRemove, children }: {
 }
 
 export default function BeamAnalysis() {
-  const [L, setL] = useState(6)
+  // Handoff from the Load Path page (?handoff=loads): span + edge line loads
+  // arrive via sessionStorage; default supports = pin/roller at the ends.
+  const [params] = useSearchParams()
+  const handoff = useMemo(() => {
+    if (params.get('handoff') !== 'loads') return null
+    try {
+      const raw = sessionStorage.getItem(BEAM_LOADS_HANDOFF_KEY)
+      if (!raw) return null
+      const { L, loads } = JSON.parse(raw) as { L: number; loads: BeamLoad[] }
+      if (!(L > 0) || !loads?.length) return null
+      return {
+        L,
+        supports: [{ id: uid++, type: 'pin', x: 0 }, { id: uid++, type: 'roller', x: L }] as SupRow[],
+        loads: loads.map((ld) => ({ ...ld, id: uid++ })) as LoadRow[],
+      }
+    } catch { return null }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const [L, setL] = useState(handoff?.L ?? 6)
   const [E, setE] = useState(25000)
   const [I, setI] = useState(3.125e9)
-  const [supports, setSupports] = useState<SupRow[]>(DEF_SUPPORTS)
-  const [loads, setLoads] = useState<LoadRow[]>(DEF_LOADS)
+  const [supports, setSupports] = useState<SupRow[]>(handoff?.supports ?? DEF_SUPPORTS)
+  const [loads, setLoads] = useState<LoadRow[]>(handoff?.loads ?? DEF_LOADS)
   const [selIdx, setSelIdx] = useState<number | null>(null)
   const navigate = useNavigate()
 

--- a/webapp/src/pages/LoadPath.tsx
+++ b/webapp/src/pages/LoadPath.tsx
@@ -1,0 +1,145 @@
+import { useMemo, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { distributePanel, wallLineLoad, type AreaLoad } from '../engine/tributary'
+import type { LoadCategory } from '../engine/beamAnalysis'
+import { PanelSketch } from '../components/PanelSketch'
+import { ReportControls } from '../components/ReportControls'
+import { WorkedSolution } from '../components/WorkedSolution'
+import { tributarySolution } from '../lib/tributarySolution'
+import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
+import { f1, f2 } from '../lib/format'
+import 'katex/dist/katex.min.css'
+
+export const BEAM_LOADS_HANDOFF_KEY = 'beam-analysis-loads-handoff'
+
+const CATS: [LoadCategory, string][] = [
+  ['D', 'D — dead'], ['L', 'L — live'], ['Lr', 'Lr — roof live'],
+  ['S', 'S — snow'], ['R', 'R — rain'], ['W', 'W — wind'], ['E', 'E — seismic'],
+]
+
+let uid = 1
+interface AreaRow extends AreaLoad { id: number }
+
+export default function LoadPath() {
+  const navigate = useNavigate()
+  const [a, setA] = useState(4)
+  const [b, setB] = useState(6)
+  const [areaLoads, setAreaLoads] = useState<AreaRow[]>([
+    { id: uid++, q: 4.8, cat: 'D' },     // e.g. 200 mm slab self-weight
+    { id: uid++, q: 2.4, cat: 'L' },
+  ])
+  // Optional wall riding on an edge beam
+  const [wallOn, setWallOn] = useState(false)
+  const [wallT, setWallT] = useState(150)
+  const [wallH, setWallH] = useState(3)
+
+  const valid = a > 0 && b > 0 && areaLoads.length > 0
+  const r = useMemo(() => (valid ? distributePanel(a, b, areaLoads) : null), [a, b, areaLoads, valid])
+  const solution = useMemo(() => (r ? tributarySolution(areaLoads, r) : null), [areaLoads, r])
+  const wWall = wallOn ? wallLineLoad(wallT, wallH) : 0
+
+  const sendToBeam = (edgeIdx: number) => {
+    if (!r) return
+    const e = r.edges[edgeIdx]
+    const loads = [...e.loads]
+    if (wallOn && wWall > 0) loads.push({ type: 'udl', x1: 0, x2: e.length, w: wWall, cat: 'D' })
+    sessionStorage.setItem(BEAM_LOADS_HANDOFF_KEY, JSON.stringify({ L: e.length, loads }))
+    navigate('/beam-analysis?handoff=loads')
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
+      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Slab Load Path (Tributary)</h1>
+      <p className="no-print mt-1 text-slate-600">
+        Distribute a slab panel's area loads to its edge beams — one-way (UDL on the long edges) or two-way
+        (45° tributary triangles & trapezoids) — with categories preserved for the NSCP combinations. Send any
+        edge straight into Beam Analysis. Phase 3 of the 3D model-space roadmap.
+      </p>
+      <ReportControls title="Slab Load Path Report" />
+
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
+        <div className="space-y-5">
+          <Card title="Panel">
+            <Num label="Side a" unit="m" value={a} onChange={setA} />
+            <Num label="Side b" unit="m" value={b} onChange={setB} />
+            <p className="col-span-full text-xs text-slate-400">
+              ℓx = short span, ℓy = long span — assigned automatically.
+            </p>
+          </Card>
+
+          <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">Area loads</legend>
+            <button type="button" onClick={() => setAreaLoads((ls) => [...ls, { id: uid++, q: 2, cat: 'L' }])}
+              className="no-print mb-3 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">+ Area load</button>
+            <div className="space-y-3">
+              {areaLoads.map((l) => (
+                <div key={l.id} className="rounded-lg border border-slate-200 bg-slate-50 p-3">
+                  <div className="mb-2 flex items-center justify-between">
+                    <span className="text-xs font-bold uppercase tracking-wide text-slate-500">{l.cat} load</span>
+                    <button type="button" onClick={() => setAreaLoads((ls) => ls.filter((q) => q.id !== l.id))}
+                      className="text-xs text-red-500 hover:underline">remove</button>
+                  </div>
+                  <div className="flex flex-wrap gap-3 [&>label]:w-36">
+                    <Num label="q" unit="kPa" value={l.q}
+                      onChange={(v) => setAreaLoads((ls) => ls.map((q) => (q.id === l.id ? { ...q, q: v } : q)))} />
+                    <Pick label="category" value={l.cat}
+                      onChange={(v) => setAreaLoads((ls) => ls.map((q) => (q.id === l.id ? { ...q, cat: v as LoadCategory } : q)))}
+                      options={CATS} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </fieldset>
+
+          <Card title="Wall on the edge beam (optional)">
+            <Pick label="Include wall" value={wallOn ? 'yes' : 'no'} onChange={(v) => setWallOn(v === 'yes')}
+              options={[['no', 'No'], ['yes', 'Yes — add D line load']]} />
+            {wallOn && <>
+              <Num label="Thickness" unit="mm" value={wallT} onChange={setWallT} />
+              <Num label="Height" unit="m" value={wallH} onChange={setWallH} />
+              <p className="col-span-full text-xs text-slate-400">
+                w = t·h·24 = {f2(wWall)} kN/m (dead) — added to whichever edge you send to Beam Analysis.
+              </p>
+            </>}
+          </Card>
+        </div>
+
+        <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
+          {r && (
+            <ResultCard title="Tributary plan">
+              <PanelSketch r={r} />
+            </ResultCard>
+          )}
+
+          {r && (
+            <ResultCard title="Edge line loads">
+              {r.edges.map((e, i) => (
+                <Row key={e.edge}
+                  label={
+                    <span className="inline-flex items-center gap-2">
+                      {e.edge} ({e.kind}, {f2(e.length)} m)
+                      {e.loads.length > 0 && (
+                        <button type="button" onClick={() => sendToBeam(i)}
+                          className="no-print rounded border border-[#0056b3] px-1.5 py-0.5 text-[10px] font-semibold text-[#0056b3] hover:bg-blue-50">
+                          analyze →
+                        </button>
+                      )}
+                    </span>
+                  }
+                  value={e.loads.length === 0 ? '— none'
+                    : r.behaviour === 'one-way' ? `${f2(e.peak)} kN/m UDL`
+                      : e.kind === 'short' ? `△ 0→${f2(e.peak)}→0 kN/m`
+                        : `▱ peak ${f2(e.peak)} kN/m`}
+                  sub={`W = ${f1(e.total)} kN`} />
+              ))}
+              <Row label="Closure" value={`${f1(r.totalDistributed)} = ${f1(r.totalApplied)} kN ✓`} />
+            </ResultCard>
+          )}
+        </div>
+      </div>
+
+      {solution && <WorkedSolution steps={solution} title="Load path — step by step" />}
+    </div>
+  )
+}


### PR DESCRIPTION
Third milestone of the 3D roadmap (docs/ROADMAP-3D.md): the **load-path step** — slab area loads become line loads on the supporting beams.

## `engine/tributary.ts`
- `distributePanel(a, b, areaLoads)` classifies the panel — **one-way** when long/short ≥ 2, else **two-way** — and distributes to the four edges:
  - one-way: `w = q·lx/2` **UDL on each long edge**, nothing on the short edges;
  - two-way (45° tributary lines): **triangles** `0 → q·lx/2 → 0` on the short edges, **trapezoids** (lx/2 ramps + flat plateau) on the long edges.
- The edge loads are emitted as the **same `udl`/`vdl` `BeamLoad` shapes** the beam & frame solvers already consume, with the **NSCP category preserved per source load** — no equivalent-uniform approximation, no new load machinery downstream (exactly the architecture rule in the roadmap).
- `wallLineLoad(t, h)` for wall self-weight; closure totals (`Σ edges = q·lx·ly`) carried on the result.

## `/load-path` page
Panel dimensions, per-category area loads, optional wall card; **tributary plan sketch** (45° lines for two-way, strip arrows for one-way); per-edge load summary with the closure check; the worked **"Load path — step by step"** narrative; and a per-edge **"analyze →"** button that opens **Beam Analysis** with the span and the exact edge loads preloaded (sessionStorage + `?handoff=loads`) — the slab → beam pipeline working end to end, feeding the existing combos → critical-sections → multi-section-design chain.

## Verification
6 engine tests: one-way classification & closure; two-way trapezoid (`peak·(ly − lx/2)`) and triangle (`peak·lx/2`) totals; square-panel symmetry (4 identical triangles); category preservation; **an emitted trapezoid run straight through `solveFEM`** with reactions balancing the edge total; and the wall line load (150 mm × 3 m → 10.8 kN/m). **126 total passing**; build green.

Next per the roadmap: Phase 4 — the react-three-fiber 3D model space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)