### PR TITLE
Phase 4: 3D model space (react-three-fiber) + grid model generator

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -8,10 +8,13 @@
       "name": "webapp",
       "version": "0.0.0",
       "dependencies": {
+        "@react-three/drei": "^10.7.7",
+        "@react-three/fiber": "^9.6.1",
         "katex": "^0.17.0",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-router-dom": "^7.17.0",
+        "three": "^0.184.0",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -268,6 +271,15 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -315,6 +327,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
@@ -1002,6 +1020,113 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/@react-three/drei": {
+      "version": "10.7.7",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.7.tgz",
+      "integrity": "sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^3.1.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.8.3",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.4",
+        "tunnel-rat": "^0.1.2",
+        "use-sync-external-store": "^1.4.0",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^9.0.0",
+        "react": "^19",
+        "react-dom": "^19",
+        "three": ">=0.159"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
+      "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^2.0.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.27.0",
+        "suspend-react": "^0.1.3",
+        "use-sync-external-store": "^1.4.0",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=19 <19.3",
+        "react-dom": ">=19 <19.3",
+        "react-native": ">=0.78",
+        "three": ">=0.156"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1638,6 +1763,12 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1701,6 +1832,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
+      "license": "MIT"
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -1740,11 +1877,16 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1760,6 +1902,42 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.184.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.1.tgz",
+      "integrity": "sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.60.1",
@@ -2005,6 +2183,24 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -2209,6 +2405,26 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.34",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz",
@@ -2220,6 +2436,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -2268,6 +2493,43 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.2.tgz",
+      "integrity": "sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.126.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2364,11 +2626,28 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2383,7 +2662,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2411,6 +2689,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2420,6 +2707,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.368",
@@ -2756,6 +3049,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2867,6 +3166,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2891,6 +3196,32 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2900,6 +3231,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
@@ -2934,12 +3271,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
     },
     "node_modules/jiti": {
       "version": "2.7.0",
@@ -3043,6 +3397,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -3332,6 +3695,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3341,6 +3714,21 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "10.2.5",
@@ -3479,7 +3867,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3542,6 +3929,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3550,6 +3943,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
       }
     },
     "node_modules/punycode": {
@@ -3633,6 +4036,30 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.61.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
@@ -3704,7 +4131,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -3717,7 +4143,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3759,12 +4184,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
+    },
     "node_modules/std-env": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "4.3.0",
@@ -3786,6 +4246,45 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.8.3.tgz",
+      "integrity": "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -3831,6 +4330,36 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/troika-three-text": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
+      "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.4",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
+      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -3842,6 +4371,43 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/type-check": {
@@ -3942,6 +4508,24 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/vite": {
@@ -4110,11 +4694,21 @@
         }
       }
     },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -4234,6 +4828,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -11,10 +11,13 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.6.1",
     "katex": "^0.17.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-router-dom": "^7.17.0",
+    "three": "^0.184.0",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from 'react'
 import { Routes, Route, Link } from 'react-router-dom'
 import FoundationDesign from './pages/FoundationDesign'
 import PileCapDesign from './pages/PileCapDesign'
@@ -7,6 +8,8 @@ import BeamAnalysis from './pages/BeamAnalysis'
 import ColumnDesign from './pages/ColumnDesign'
 import FrameAnalysis from './pages/FrameAnalysis'
 import LoadPath from './pages/LoadPath'
+// three.js is heavy — the 3D model space loads in its own lazy chunk.
+const ModelSpace = lazy(() => import('./pages/ModelSpace'))
 import SlabEstimate from './pages/SlabEstimate'
 import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
@@ -43,6 +46,7 @@ function Home() {
         <Tile to="/column-design">Column Design</Tile>
         <Tile to="/frame">Frame Analysis (2D)</Tile>
         <Tile to="/load-path">Slab Load Path</Tile>
+        <Tile to="/model">3D Model Space</Tile>
       </div>
 
       <h2 className="mt-8 text-lg font-semibold text-slate-800">Material estimation (quantity take-off)</h2>
@@ -69,6 +73,11 @@ export default function App() {
       <Route path="/column-design" element={<ColumnDesign />} />
       <Route path="/frame" element={<FrameAnalysis />} />
       <Route path="/load-path" element={<LoadPath />} />
+      <Route path="/model" element={
+        <Suspense fallback={<p className="p-8 text-center text-sm text-slate-400">Loading 3D model space…</p>}>
+          <ModelSpace />
+        </Suspense>
+      } />
       <Route path="/estimate/slab" element={<SlabEstimate />} />
       <Route path="/estimate/beam" element={<BeamEstimate />} />
       <Route path="/estimate/column" element={<ColumnEstimate />} />

--- a/webapp/src/engine/modelBuilder.test.ts
+++ b/webapp/src/engine/modelBuilder.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { generateGridModel, removeElements, nodeId } from './modelBuilder'
+import type { RectSection } from './model'
+
+const sec: RectSection = { id: 'S1', name: '300×500', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
+
+describe('grid model generator', () => {
+  // 2 bays × 1 bay × 2 storeys → 3×2 grid points, 3 levels
+  const m = generateGridModel({ baysX: [6, 6], baysZ: [5], storeyH: [3.5, 3], section: sec })
+
+  it('node / member / plate / support counts', () => {
+    expect(m.nodes).toHaveLength(3 * 2 * 3)                  // 18
+    expect(m.members.filter((x) => x.role === 'column')).toHaveLength(6 * 2)   // grid pts × storeys
+    expect(m.members.filter((x) => x.role === 'beam')).toHaveLength(2 * 2 * 2) // baysX × nz × levels
+    expect(m.members.filter((x) => x.role === 'girder')).toHaveLength(3 * 1 * 2)
+    expect(m.plates).toHaveLength(2 * 1 * 2)
+    expect(m.supports).toHaveLength(6)
+    expect(m.supports.every((s) => s.fixity === 'fixed')).toBe(true)
+    expect(m.storeys.map((s) => s.elevation)).toEqual([3.5, 6.5])
+  })
+
+  it('connectivity: every member endpoint and plate corner is a real node', () => {
+    const ids = new Set(m.nodes.map((n) => n.id))
+    expect(m.members.every((x) => ids.has(x.i) && ids.has(x.j))).toBe(true)
+    expect(m.plates.every((p) => p.corners.every((c) => ids.has(c)))).toBe(true)
+  })
+
+  it('geometry: columns are vertical, beams along x, girders along z', () => {
+    const byId = new Map(m.nodes.map((n) => [n.id, n]))
+    for (const mb of m.members) {
+      const a = byId.get(mb.i)!, b2 = byId.get(mb.j)!
+      if (mb.role === 'column') { expect(a.x).toBe(b2.x); expect(a.z).toBe(b2.z); expect(b2.y).toBeGreaterThan(a.y) }
+      if (mb.role === 'beam') { expect(a.y).toBe(b2.y); expect(a.z).toBe(b2.z); expect(b2.x).toBeGreaterThan(a.x) }
+      if (mb.role === 'girder') { expect(a.y).toBe(b2.y); expect(a.x).toBe(b2.x); expect(b2.z).toBeGreaterThan(a.z) }
+    }
+  })
+
+  it('JSON round-trips', () => {
+    const back = JSON.parse(JSON.stringify(m))
+    expect(back).toEqual(m)
+  })
+})
+
+describe('removeElements', () => {
+  it('drops members/plates and their attached loads, keeps the rest', () => {
+    const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section: sec })
+    const slab = m.plates[0].id
+    const beam = m.members.find((x) => x.role === 'beam')!.id
+    const withLoads = {
+      ...m,
+      loads: [
+        { kind: 'area' as const, plate: slab, q: 4.8, cat: 'D' as const },
+        { kind: 'member-udl' as const, member: beam, w: 10, cat: 'D' as const },
+        { kind: 'node' as const, node: nodeId(0, 0, 1), Fx: 20, cat: 'W' as const },
+      ],
+    }
+    const out = removeElements(withLoads, new Set([slab, beam]))
+    expect(out.plates.find((p) => p.id === slab)).toBeUndefined()
+    expect(out.members.find((x) => x.id === beam)).toBeUndefined()
+    expect(out.loads).toHaveLength(1)
+    expect(out.loads[0].kind).toBe('node')
+    // untouched collections preserved
+    expect(out.nodes).toEqual(m.nodes)
+    expect(out.supports).toEqual(m.supports)
+  })
+})

--- a/webapp/src/engine/modelBuilder.ts
+++ b/webapp/src/engine/modelBuilder.ts
@@ -1,0 +1,94 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Building-grid model generator — Phase 4 of the 3D roadmap. Produces a
+// StructuralModel (engine/model.ts) for a regular frame: column grid from
+// the bay lists, storeys from the height list, beams (X) + girders (Z) at
+// every level, a slab per bay per level, fixed supports at the base.
+// Coordinates: x = plan east, z = plan north, y = elevation (up) — matching
+// the three.js viewport.
+// ─────────────────────────────────────────────────────────────────────────
+import type { StructuralModel, RectSection, Node, Member, Plate, NodeSupport } from './model'
+
+export interface GridSpec {
+  baysX: number[]      // bay widths along x, m
+  baysZ: number[]      // bay widths along z, m
+  storeyH: number[]    // storey heights bottom-up, m
+  section: RectSection
+}
+
+const acc = (bays: number[]): number[] => {
+  const out = [0]
+  for (const b of bays) out.push(out[out.length - 1] + b)
+  return out
+}
+
+export const nodeId = (i: number, j: number, k: number) => `n${i}.${j}.${k}`
+
+export function generateGridModel(spec: GridSpec, name = 'Grid frame'): StructuralModel {
+  const xs = acc(spec.baysX)
+  const zs = acc(spec.baysZ)
+  const ys = acc(spec.storeyH)
+  const nx = xs.length, nz = zs.length, ny = ys.length
+
+  const nodes: Node[] = []
+  for (let k = 0; k < ny; k++)
+    for (let j = 0; j < nz; j++)
+      for (let i = 0; i < nx; i++)
+        nodes.push({ id: nodeId(i, j, k), x: xs[i], y: ys[k], z: zs[j] })
+
+  const members: Member[] = []
+  // columns between consecutive levels at every grid point
+  for (let k = 0; k < ny - 1; k++)
+    for (let j = 0; j < nz; j++)
+      for (let i = 0; i < nx; i++)
+        members.push({ id: `c${i}.${j}.${k}`, i: nodeId(i, j, k), j: nodeId(i, j, k + 1), role: 'column', section: spec.section.id })
+  // beams along X and girders along Z at every elevated level
+  for (let k = 1; k < ny; k++) {
+    for (let j = 0; j < nz; j++)
+      for (let i = 0; i < nx - 1; i++)
+        members.push({ id: `bx${i}.${j}.${k}`, i: nodeId(i, j, k), j: nodeId(i + 1, j, k), role: 'beam', section: spec.section.id })
+    for (let j = 0; j < nz - 1; j++)
+      for (let i = 0; i < nx; i++)
+        members.push({ id: `bz${i}.${j}.${k}`, i: nodeId(i, j, k), j: nodeId(i, j + 1, k), role: 'girder', section: spec.section.id })
+  }
+
+  const plates: Plate[] = []
+  for (let k = 1; k < ny; k++)
+    for (let j = 0; j < nz - 1; j++)
+      for (let i = 0; i < nx - 1; i++)
+        plates.push({
+          id: `s${i}.${j}.${k}`,
+          corners: [nodeId(i, j, k), nodeId(i + 1, j, k), nodeId(i + 1, j + 1, k), nodeId(i, j + 1, k)],
+          role: 'slab',
+          thickness: 150,
+        })
+
+  const supports: NodeSupport[] = []
+  for (let j = 0; j < nz; j++)
+    for (let i = 0; i < nx; i++)
+      supports.push({ node: nodeId(i, j, 0), fixity: 'fixed' })
+
+  return {
+    version: 1,
+    name,
+    nodes,
+    sections: [spec.section],
+    members,
+    plates,
+    supports,
+    loads: [],
+    storeys: ys.slice(1).map((y, k) => ({ id: `st${k + 1}`, name: `Level ${k + 1}`, elevation: y })),
+  }
+}
+
+/** Drop a set of member/plate ids from the model (immutably). */
+export function removeElements(model: StructuralModel, ids: Set<string>): StructuralModel {
+  return {
+    ...model,
+    members: model.members.filter((m) => !ids.has(m.id)),
+    plates: model.plates.filter((p) => !ids.has(p.id)),
+    loads: model.loads.filter((l) =>
+      l.kind === 'node' ? true
+        : l.kind === 'area' ? !ids.has(l.plate)
+          : !ids.has(l.member)),
+  }
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -1,0 +1,278 @@
+import { useMemo, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Canvas } from '@react-three/fiber'
+import { OrbitControls } from '@react-three/drei'
+import * as THREE from 'three'
+import { generateGridModel, removeElements } from '../engine/modelBuilder'
+import type { StructuralModel, Member, Plate, RectSection } from '../engine/model'
+import { distributePanel } from '../engine/tributary'
+import { Num, Card, ResultCard, Row } from '../components/qty'
+import { f1, f2 } from '../lib/format'
+
+const AUTOSAVE_KEY = 'model-space-autosave'
+
+const ROLE_COLOR: Record<string, string> = {
+  column: '#475569', beam: '#0056b3', girder: '#0e7490',
+}
+const SEL = '#f59e0b'
+
+const parseList = (s: string): number[] =>
+  s.split(/[, ]+/).map(parseFloat).filter((v) => Number.isFinite(v) && v > 0)
+
+// ── 3D primitives ─────────────────────────────────────────────────────────
+function Member3D({ a, b, role, selected, onPick }: {
+  a: THREE.Vector3; b: THREE.Vector3; role: string; selected: boolean; onPick: () => void
+}) {
+  const { mid, quat, len } = useMemo(() => {
+    const dir = new THREE.Vector3().subVectors(b, a)
+    const len = dir.length()
+    const quat = new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(1, 0, 0), dir.clone().normalize())
+    return { mid: new THREE.Vector3().addVectors(a, b).multiplyScalar(0.5), quat, len }
+  }, [a, b])
+  const t = role === 'column' ? 0.3 : 0.22
+  return (
+    <mesh position={mid} quaternion={quat}
+      onClick={(e) => { e.stopPropagation(); onPick() }}>
+      <boxGeometry args={[len, t, t]} />
+      <meshStandardMaterial color={selected ? SEL : ROLE_COLOR[role] ?? '#64748b'} />
+    </mesh>
+  )
+}
+
+function Slab3D({ corners, selected, onPick }: {
+  corners: THREE.Vector3[]; selected: boolean; onPick: () => void
+}) {
+  const { mid, sx, sz } = useMemo(() => {
+    const mid = corners.reduce((s, c) => s.add(c.clone()), new THREE.Vector3()).multiplyScalar(0.25)
+    const sx = Math.abs(corners[1].x - corners[0].x) || Math.abs(corners[2].x - corners[0].x)
+    const sz = Math.abs(corners[3].z - corners[0].z) || Math.abs(corners[2].z - corners[0].z)
+    return { mid, sx, sz }
+  }, [corners])
+  return (
+    <mesh position={[mid.x, mid.y + 0.05, mid.z]}
+      onClick={(e) => { e.stopPropagation(); onPick() }}>
+      <boxGeometry args={[sx * 0.96, 0.1, sz * 0.96]} />
+      <meshStandardMaterial color={selected ? SEL : '#7ba6d4'} transparent opacity={selected ? 0.85 : 0.45} />
+    </mesh>
+  )
+}
+
+function Support3D({ p }: { p: THREE.Vector3 }) {
+  return (
+    <mesh position={[p.x, p.y - 0.22, p.z]}>
+      <coneGeometry args={[0.28, 0.45, 4]} />
+      <meshStandardMaterial color="#0056b3" />
+    </mesh>
+  )
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────
+export default function ModelSpace() {
+  const [baysX, setBaysX] = useState('6, 6')
+  const [baysZ, setBaysZ] = useState('5')
+  const [storeyH, setStoreyH] = useState('3.5, 3')
+  const [b, setB] = useState(300); const [h, setH] = useState(500); const [fc, setFc] = useState(28)
+  const [qD, setQD] = useState(4.8); const [qL, setQL] = useState(2.4)
+
+  const [model, setModel] = useState<StructuralModel | null>(() => {
+    try {
+      const raw = sessionStorage.getItem(AUTOSAVE_KEY)
+      return raw ? (JSON.parse(raw) as StructuralModel) : null
+    } catch { return null }
+  })
+  const [selected, setSelected] = useState<string | null>(null)
+  const fileRef = useRef<HTMLInputElement>(null)
+
+  const save = (m: StructuralModel | null) => {
+    setModel(m)
+    try {
+      if (m) sessionStorage.setItem(AUTOSAVE_KEY, JSON.stringify(m))
+      else sessionStorage.removeItem(AUTOSAVE_KEY)
+    } catch { /* quota — ignore */ }
+  }
+
+  const generate = () => {
+    const section: RectSection = { id: 'S1', name: `${b}×${h}`, b, h, fc, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
+    const m = generateGridModel({ baysX: parseList(baysX), baysZ: parseList(baysZ), storeyH: parseList(storeyH), section })
+    // area loads on every slab, categories preserved for the combos downstream
+    m.loads = m.plates.flatMap((p) => [
+      ...(qD > 0 ? [{ kind: 'area' as const, plate: p.id, q: qD, cat: 'D' as const }] : []),
+      ...(qL > 0 ? [{ kind: 'area' as const, plate: p.id, q: qL, cat: 'L' as const }] : []),
+    ])
+    setSelected(null)
+    save(m)
+  }
+
+  const nodePos = useMemo(() => {
+    const map = new Map<string, THREE.Vector3>()
+    model?.nodes.forEach((n) => map.set(n.id, new THREE.Vector3(n.x, n.y, n.z)))
+    return map
+  }, [model])
+
+  const selMember: Member | undefined = model?.members.find((m) => m.id === selected)
+  const selPlate: Plate | undefined = model?.plates.find((p) => p.id === selected)
+
+  const plateInfo = useMemo(() => {
+    if (!selPlate || !model) return null
+    const c = selPlate.corners.map((id) => nodePos.get(id)!)
+    const lx = Math.abs(c[1].x - c[0].x) || Math.abs(c[2].x - c[0].x)
+    const lz = Math.abs(c[3].z - c[0].z) || Math.abs(c[2].z - c[0].z)
+    const areaLoads = model.loads
+      .filter((l) => l.kind === 'area' && l.plate === selPlate.id)
+      .map((l) => ({ q: (l as { q: number }).q, cat: l.cat }))
+    const trib = areaLoads.length ? distributePanel(lx, lz, areaLoads) : null
+    return { lx, lz, areaLoads, trib }
+  }, [selPlate, model, nodePos])
+
+  const memberLen = selMember
+    ? nodePos.get(selMember.i)!.distanceTo(nodePos.get(selMember.j)!)
+    : 0
+
+  const download = () => {
+    if (!model) return
+    const blob = new Blob([JSON.stringify(model, null, 2)], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url; a.download = `${model.name.replace(/\s+/g, '-')}.model.json`; a.click()
+    URL.revokeObjectURL(url)
+  }
+  const upload = async (f: File) => {
+    try {
+      const m = JSON.parse(await f.text()) as StructuralModel
+      if (m.version !== 1 || !Array.isArray(m.nodes)) throw new Error('not a model file')
+      setSelected(null)
+      save(m)
+    } catch { alert('Could not read that file as a structural model (.model.json).') }
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
+      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">3D Model Space</h1>
+      <p className="no-print mt-1 text-slate-600">
+        Generate a building frame on a column grid — beams, girders, columns and slab panels with categorised
+        area loads — orbit it in 3D, click any element to inspect or delete it, and save/load the model as JSON.
+        Phase 4 of the roadmap; the 3D solver (Phase 5) and the design pipeline (Phase 6) consume this model.
+      </p>
+
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1fr_2fr]">
+        <div className="space-y-5">
+          <Card title="Column grid">
+            <label className="flex flex-col text-sm">
+              <span className="mb-1 font-medium text-slate-600">Bays X (m, comma-sep)</span>
+              <input value={baysX} onChange={(e) => setBaysX(e.target.value)}
+                className="rounded-md border border-slate-300 px-2.5 py-1.5" />
+            </label>
+            <label className="flex flex-col text-sm">
+              <span className="mb-1 font-medium text-slate-600">Bays Z (m)</span>
+              <input value={baysZ} onChange={(e) => setBaysZ(e.target.value)}
+                className="rounded-md border border-slate-300 px-2.5 py-1.5" />
+            </label>
+            <label className="flex flex-col text-sm">
+              <span className="mb-1 font-medium text-slate-600">Storey heights (m)</span>
+              <input value={storeyH} onChange={(e) => setStoreyH(e.target.value)}
+                className="rounded-md border border-slate-300 px-2.5 py-1.5" />
+            </label>
+          </Card>
+
+          <Card title="Section & slab loads">
+            <Num label="b" unit="mm" value={b} onChange={setB} />
+            <Num label="h" unit="mm" value={h} onChange={setH} />
+            <Num label="f′c" unit="MPa" value={fc} onChange={setFc} />
+            <Num label="q dead" unit="kPa" value={qD} onChange={setQD} />
+            <Num label="q live" unit="kPa" value={qL} onChange={setQL} />
+          </Card>
+
+          <div className="no-print flex flex-wrap gap-2">
+            <button type="button" onClick={generate}
+              className="rounded-lg bg-gradient-to-br from-[#0056b3] to-[#003f86] px-4 py-2 text-sm font-semibold text-white shadow-md transition hover:shadow-lg">
+              ⚙ Generate model
+            </button>
+            <button type="button" onClick={download} disabled={!model}
+              className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50 disabled:opacity-40">
+              ⤓ Save JSON
+            </button>
+            <button type="button" onClick={() => fileRef.current?.click()}
+              className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">
+              ⤒ Load JSON
+            </button>
+            <input ref={fileRef} type="file" accept=".json" className="sr-only"
+              onChange={(e) => { const f = e.target.files?.[0]; if (f) void upload(f) }} />
+          </div>
+
+          {model && (
+            <ResultCard title="Model">
+              <Row label="Nodes / members" value={`${model.nodes.length} / ${model.members.length}`}
+                sub={`${model.members.filter((m) => m.role === 'column').length} col · ${model.members.filter((m) => m.role !== 'column').length} bm`} />
+              <Row label="Slabs / loads" value={`${model.plates.length} / ${model.loads.length}`} />
+              <Row label="Storeys" value={`${model.storeys.length}`}
+                sub={model.storeys.map((s) => `${s.elevation} m`).join(' · ')} />
+            </ResultCard>
+          )}
+
+          {selMember && model && (
+            <ResultCard title={`Member — ${selMember.id}`}>
+              <Row label="Role" value={selMember.role} />
+              <Row label="Length" value={`${f2(memberLen)} m`} />
+              <Row label="Section" value={model.sections[0]?.name ?? selMember.section} />
+              <button type="button" onClick={() => { save(removeElements(model, new Set([selMember.id]))); setSelected(null) }}
+                className="no-print mt-2 rounded-lg border border-red-300 px-3 py-1.5 text-sm font-semibold text-red-600 hover:bg-red-50">
+                Delete member
+              </button>
+            </ResultCard>
+          )}
+
+          {selPlate && plateInfo && model && (
+            <ResultCard title={`Slab — ${selPlate.id}`}>
+              <Row label="Panel" value={`${f2(plateInfo.lx)} × ${f2(plateInfo.lz)} m`}
+                sub={`t = ${selPlate.thickness} mm`} />
+              {plateInfo.areaLoads.map((l, i) => (
+                <Row key={i} label={`q (${l.cat})`} value={`${f2(l.q)} kPa`} />
+              ))}
+              {plateInfo.trib && (
+                <Row label="Tributary" value={plateInfo.trib.behaviour}
+                  sub={`peak ${f1(plateInfo.trib.edges[0].peak)} kN/m on long edges`} />
+              )}
+              <button type="button" onClick={() => { save(removeElements(model, new Set([selPlate.id]))); setSelected(null) }}
+                className="no-print mt-2 rounded-lg border border-red-300 px-3 py-1.5 text-sm font-semibold text-red-600 hover:bg-red-50">
+                Delete slab
+              </button>
+            </ResultCard>
+          )}
+        </div>
+
+        <div className="h-[560px] overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+          {model ? (
+            <Canvas camera={{ position: [14, 11, 14], fov: 45 }} onPointerMissed={() => setSelected(null)}>
+              <color attach="background" args={['#f8fafc']} />
+              <ambientLight intensity={0.85} />
+              <directionalLight position={[12, 18, 8]} intensity={0.9} />
+              <gridHelper args={[40, 40, '#cbd5e1', '#e2e8f0']} />
+              {model.members.map((m) => {
+                const a = nodePos.get(m.i), bb = nodePos.get(m.j)
+                if (!a || !bb) return null
+                return <Member3D key={m.id} a={a} b={bb} role={m.role}
+                  selected={m.id === selected} onPick={() => setSelected(m.id)} />
+              })}
+              {model.plates.map((p) => {
+                const cs = p.corners.map((c) => nodePos.get(c))
+                if (cs.some((c) => !c)) return null
+                return <Slab3D key={p.id} corners={cs as THREE.Vector3[]}
+                  selected={p.id === selected} onPick={() => setSelected(p.id)} />
+              })}
+              {model.supports.map((s) => {
+                const p = nodePos.get(s.node)
+                return p ? <Support3D key={s.node} p={p} /> : null
+              })}
+              <OrbitControls makeDefault target={[6, 3, 2.5]} />
+            </Canvas>
+          ) : (
+            <div className="flex h-full items-center justify-center text-sm text-slate-400">
+              Set the grid and hit “Generate model”.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Fourth milestone of the 3D roadmap: the model space itself.

## `engine/modelBuilder.ts` — pure grid generator
`generateGridModel({baysX, baysZ, storeyH, section})` produces a **`StructuralModel`** (the Phase 1 schema): column grid from the bay lists, columns between levels, **beams (X) + girders (Z)** at every floor, a **slab panel per bay per floor**, fixed supports at the base, storeys from the height list. `removeElements()` deletes members/plates immutably and prunes their attached loads.

**5 tests**: element counts, connectivity (every endpoint/corner is a real node), geometric orientation (columns vertical, beams along x, girders along z), JSON round-trip, and load pruning on deletion — **131 total passing**.

## `/model` — the 3D viewport
- **react-three-fiber** scene: orbit controls, ground grid, members as role-coloured boxes (columns slate, beams blue, girders teal), slabs as translucent panels, support cones at the base.
- **Click to inspect**: a member shows role/length/section; a slab shows panel dims, its categorised area loads, and a **live Phase-3 tributary readout** (behaviour + peak edge load). **Delete** from the inspector.
- **Per-category slab area loads** (D/L kPa) written into the model — ready for the combos downstream.
- **Persistence**: Save/Load `.model.json` + sessionStorage autosave.

## Bundle discipline
New deps (`three` 0.184, `@react-three/fiber` 9.6, `@react-three/drei` 10.7) are confined to a **React.lazy route** — the 3D stack ships as its own `ModelSpace-*.js` chunk (~915 kB, ~248 kB gzip) loaded only when `/model` is opened; the main bundle is unaffected.

Next per the roadmap: **Phase 5 — the 12-DOF 3D frame element** on the shared `fem.ts` core, solving this model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)