### PR TITLE
Phase 5: 12-DOF 3D frame element + model-space analysis

### DIFF
--- a/webapp/src/engine/fem.ts
+++ b/webapp/src/engine/fem.ts
@@ -46,8 +46,8 @@ export function hermite(xi: number, le: number): [number, number, number, number
 
 /** 5-point Gauss quadrature of a vector-valued integrand over [a, b]. */
 export function gauss5Vec(f: (x: number) => number[], a: number, b: number, size = 4): number[] {
-  const gp = [-0.90618, -0.53847, 0, 0.53847, 0.90618]
-  const gw = [0.23693, 0.47863, 0.56889, 0.47863, 0.23693]
+  const gp = [-0.906179845938664, -0.5384693101056831, 0, 0.5384693101056831, 0.906179845938664]
+  const gw = [0.23692688505618908, 0.47862867049936647, 0.5688888888888889, 0.47862867049936647, 0.23692688505618908]
   const mid = (a + b) / 2, half = (b - a) / 2
   const acc = new Array(size).fill(0)
   for (let i = 0; i < 5; i++) {

--- a/webapp/src/engine/frame3d.test.ts
+++ b/webapp/src/engine/frame3d.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest'
+import { solveFrame3D, analyzeFrame3D, rectJ, type F3Node, type F3Member, type F3Support, type F3Load } from './frame3d'
+import { solveFrame2D } from './frame2d'
+import { generateGridModel } from './modelBuilder'
+import { modelToFrame3D } from './modelBridge'
+import type { RectSection } from './model'
+
+const E = 25000, G = E / 2.4
+const b = 300, h = 500
+const A = b * h, Iz = (b * h ** 3) / 12, Iy = (h * b ** 3) / 12, J = rectJ(b, h)
+const sec = { E, G, A, Iy, Iz, J }
+const EIz = E * Iz * 1e-9, EIy = E * Iy * 1e-9, GJ = G * J * 1e-9, EA = (E * A) / 1000
+
+const cant = (loads: F3Load[]) => solveFrame3D(
+  [{ id: 'a', x: 0, y: 0, z: 0 }, { id: 'b', x: 3, y: 0, z: 0 }] as F3Node[],
+  [{ id: 'm', i: 'a', j: 'b', ...sec }] as F3Member[],
+  [{ node: 'a', fixity: 'fixed' }] as F3Support[],
+  loads)!
+
+describe('frame3d — closed forms (cantilever along x, L = 3)', () => {
+  const L = 3
+  it('tip gravity point (−Y): δy = PL³/3EIz, Mz,base = PL', () => {
+    const P = 20
+    const r = cant([{ kind: 'member-point', member: 'm', a: L, P, cat: 'D' }])
+    expect(r.d[6 + 1]).toBeCloseTo((-P * L ** 3) / (3 * EIz), 9)
+    expect(Math.abs(r.members[0].Mz[0])).toBeCloseTo(P * L, 3)
+    expect(r.reactions[0].F[1]).toBeCloseTo(P, 6)
+  })
+
+  it('tip lateral nodal load (−Z): δz = PL³/3EIy, My,base = PL (second plane)', () => {
+    const P = 15
+    const r = cant([{ kind: 'node', node: 'b', Fz: -P, cat: 'D' }])
+    expect(r.d[6 + 2]).toBeCloseTo((-P * L ** 3) / (3 * EIy), 9)
+    expect(Math.abs(r.members[0].My[0])).toBeCloseTo(P * L, 3)
+  })
+
+  it('gravity UDL: Mz,base = wL²/2, δtip = wL⁴/8EIz', () => {
+    const w = 10
+    const r = cant([{ kind: 'member-udl', member: 'm', w, cat: 'D' }])
+    expect(Math.abs(r.members[0].Mz[0])).toBeCloseTo((w * L * L) / 2, 2)
+    expect(r.d[6 + 1]).toBeCloseTo((-w * L ** 4) / (8 * EIz), 6)
+    expect(r.reactions[0].F[1]).toBeCloseTo(w * L, 4)
+  })
+
+  it('tip torque Mx: θx = TL/GJ, T constant', () => {
+    const T = 12
+    const r = cant([{ kind: 'node', node: 'b', Mx: T, cat: 'D' }])
+    expect(r.d[6 + 3]).toBeCloseTo((T * L) / GJ, 9)
+    expect(Math.abs(r.members[0].T[0])).toBeCloseTo(T, 6)
+  })
+
+  it('axial nodal load (+X): δx = PL/EA', () => {
+    const P = 100
+    const r = cant([{ kind: 'node', node: 'b', Fx: P, cat: 'D' }])
+    expect(r.d[6 + 0]).toBeCloseTo((P * L) / EA, 12)
+    expect(r.members[0].N[0]).toBeCloseTo(P, 4)
+  })
+})
+
+describe('frame3d — square-section J', () => {
+  it('rectJ(square) ≈ 0.1406·b⁴', () => {
+    expect(rectJ(300, 300) / 300 ** 4).toBeCloseTo(0.1406, 3)
+  })
+})
+
+describe('frame3d — planar portal matches frame2d', () => {
+  it('fixed-base portal with beam UDL: same reactions and beam Mmax', () => {
+    const L = 6, H = 3, w = 12
+    const n3: F3Node[] = [
+      { id: 'A', x: 0, y: 0, z: 0 }, { id: 'B', x: 0, y: H, z: 0 },
+      { id: 'C', x: L, y: H, z: 0 }, { id: 'D', x: L, y: 0, z: 0 },
+    ]
+    // A vertical column's in-plane (global X) sway bends it about its LOCAL
+    // y′ axis (= Iy). Give the 3D members Iy = Iz so the planar comparison
+    // matches the 2D model, which used a single I for every member.
+    const secPlanar = { ...sec, Iy: Iz }
+    const m3: F3Member[] = [
+      { id: 'col1', i: 'A', j: 'B', ...secPlanar },
+      { id: 'beam', i: 'B', j: 'C', ...secPlanar },
+      { id: 'col2', i: 'D', j: 'C', ...secPlanar },
+    ]
+    const r3 = solveFrame3D(n3, m3,
+      [{ node: 'A', fixity: 'fixed' }, { node: 'D', fixity: 'fixed' }],
+      [{ kind: 'member-udl', member: 'beam', w, cat: 'D' }])!
+
+    const r2 = solveFrame2D(
+      [{ id: 'A', x: 0, y: 0 }, { id: 'B', x: 0, y: H }, { id: 'C', x: L, y: H }, { id: 'D', x: L, y: 0 }],
+      [{ id: 'col1', i: 'A', j: 'B', E, A, I: Iz }, { id: 'beam', i: 'B', j: 'C', E, A, I: Iz }, { id: 'col2', i: 'D', j: 'C', E, A, I: Iz }],
+      [{ node: 'A', type: 'fixed' }, { node: 'D', type: 'fixed' }],
+      [{ kind: 'member-udl', member: 'beam', w, cat: 'D' }])!
+
+    expect(r3.reactions[0].F[1]).toBeCloseTo(r2.reactions[0].Ry, 4)
+    expect(r3.reactions[0].F[0]).toBeCloseTo(r2.reactions[0].Rx, 4)
+    const beam3 = r3.members.find((m) => m.id === 'beam')!
+    const beam2 = r2.members.find((m) => m.id === 'beam')!
+    expect(beam3.Mmax).toBeCloseTo(beam2.Mmax, 3)
+  })
+})
+
+describe('frame3d — full model bridge (grid + slab loads)', () => {
+  const section: RectSection = { id: 'S1', name: '300×500', b, h, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
+
+  it('slab area load reaches the supports: ΣRy = factored q·A under 1.4D', () => {
+    const model = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })
+    model.loads = model.plates.map((p) => ({ kind: 'area', plate: p.id, q: 5, cat: 'D' }))
+    const br = modelToFrame3D(model)
+    expect(br.orphanEdges).toHaveLength(0)
+    const res = analyzeFrame3D(br.nodes, br.members, br.supports, br.loads)!
+    const gov = res.perCombo[res.govIdx]
+    expect(gov.combo.name).toBe('1.4D')
+    const sumRy = gov.result!.reactions.reduce((s, q) => s + q.F[1], 0)
+    expect(sumRy).toBeCloseTo(1.4 * 5 * 6 * 5, 2)     // 210 kN
+    // lateral equilibrium too
+    expect(gov.result!.reactions.reduce((s, q) => s + q.F[0], 0)).toBeCloseTo(0, 4)
+    expect(gov.result!.reactions.reduce((s, q) => s + q.F[2], 0)).toBeCloseTo(0, 4)
+  })
+
+  it('two-storey grid solves and distributes both categories', () => {
+    const model = generateGridModel({ baysX: [6, 6], baysZ: [5], storeyH: [3.5, 3], section })
+    model.loads = model.plates.flatMap((p) => [
+      { kind: 'area' as const, plate: p.id, q: 4.8, cat: 'D' as const },
+      { kind: 'area' as const, plate: p.id, q: 2.4, cat: 'L' as const },
+    ])
+    const br = modelToFrame3D(model)
+    const res = analyzeFrame3D(br.nodes, br.members, br.supports, br.loads)!
+    expect(res.perCombo[res.govIdx].combo.name).toContain('1.2D + 1.6L')
+    const wu = 1.2 * 4.8 + 1.6 * 2.4                  // 9.6 kPa
+    const area = 12 * 5 * 2                            // two floors
+    const sumRy = res.perCombo[res.govIdx].result!.reactions.reduce((s, q) => s + q.F[1], 0)
+    expect(sumRy).toBeCloseTo(wu * area, 1)
+  })
+})

--- a/webapp/src/engine/frame3d.ts
+++ b/webapp/src/engine/frame3d.ts
@@ -1,0 +1,338 @@
+// ─────────────────────────────────────────────────────────────────────────
+// 3D space-frame analysis — Phase 5 of the 3D roadmap. 12-DOF members
+// (axial + St-Venant torsion + biaxial Hermite bending) on the shared
+// fem.ts core. DOF order per node: [ux, uy, uz, θx, θy, θz]; y is UP
+// (matching the model space). Local axes: x′ along the member; y′ as close
+// to global up as possible (global Z for verticals); z′ = x′ × y′.
+// Loads: nodal (F/M all axes) and member gravity loads (global −Y): UDL,
+// trapezoid (vdl) and point — converted to consistent local fixed-end
+// vectors (Gauss + Hermite for the distributed ones).
+// Units: coordinates m; E,G MPa; A mm²; I,J mm⁴; forces kN, kN·m.
+// ─────────────────────────────────────────────────────────────────────────
+import { solveLinear, matVec, hermite, gauss5Vec } from './fem'
+import { NSCP_COMBOS, type Combo, type LoadCategory } from './beamAnalysis'
+
+export interface F3Node { id: string; x: number; y: number; z: number }
+export interface F3Member {
+  id: string; i: string; j: string
+  E: number; G: number      // MPa
+  A: number                 // mm²
+  Iy: number; Iz: number    // mm⁴ (Iz: bending under gravity for horizontal members)
+  J: number                 // mm⁴
+}
+export type F3Fixity = 'pin' | 'fixed'
+export interface F3Support { node: string; fixity: F3Fixity }
+
+export type F3Load =
+  | { kind: 'node'; node: string; Fx?: number; Fy?: number; Fz?: number; Mx?: number; My?: number; Mz?: number; cat: LoadCategory }
+  | { kind: 'member-udl'; member: string; w: number; cat: LoadCategory }                       // kN/m, global −Y
+  | { kind: 'member-vdl'; member: string; x1: number; x2: number; w1: number; w2: number; cat: LoadCategory } // global −Y
+  | { kind: 'member-point'; member: string; a: number; P: number; cat: LoadCategory }          // kN, global −Y at a from i
+
+export interface F3MemberResult {
+  id: string; L: number
+  f: number[]                 // local end forces ON the member (12)
+  xs: number[]
+  N: number[]; Vy: number[]; Vz: number[]; T: number[]; My: number[]; Mz: number[]
+  Nmax: number; Vmax: number; Mmax: number; Tmax: number
+}
+export interface F3Reaction { node: string; fixity: F3Fixity; F: [number, number, number]; M: [number, number, number] }
+export interface F3Result {
+  d: number[]
+  reactions: F3Reaction[]
+  members: F3MemberResult[]
+  Mmax: number; Vmax: number; Nmax: number
+}
+
+/** St-Venant torsional constant for a solid rectangle b×h (mm). */
+export function rectJ(b: number, h: number): number {
+  const a = Math.max(b, h) / 2, c = Math.min(b, h) / 2
+  return a * c ** 3 * (16 / 3 - 3.36 * (c / a) * (1 - c ** 4 / (12 * a ** 4)))
+}
+
+function scaleF3(ld: F3Load, f: number): F3Load {
+  if (ld.kind === 'node') return { ...ld, Fx: (ld.Fx ?? 0) * f, Fy: (ld.Fy ?? 0) * f, Fz: (ld.Fz ?? 0) * f, Mx: (ld.Mx ?? 0) * f, My: (ld.My ?? 0) * f, Mz: (ld.Mz ?? 0) * f }
+  if (ld.kind === 'member-udl') return { ...ld, w: ld.w * f }
+  if (ld.kind === 'member-vdl') return { ...ld, w1: ld.w1 * f, w2: ld.w2 * f }
+  return { ...ld, P: ld.P * f }
+}
+
+export function applyF3Combo(loads: F3Load[], factors: Partial<Record<LoadCategory, number>>): F3Load[] {
+  return loads
+    .map((ld) => scaleF3(ld, factors[ld.cat] ?? 0))
+    .filter((ld) => {
+      if (ld.kind === 'node') return [ld.Fx, ld.Fy, ld.Fz, ld.Mx, ld.My, ld.Mz].some((v) => Math.abs(v ?? 0) > 1e-9)
+      if (ld.kind === 'member-udl') return Math.abs(ld.w) > 1e-9
+      if (ld.kind === 'member-vdl') return Math.abs(ld.w1) + Math.abs(ld.w2) > 1e-9
+      return Math.abs(ld.P) > 1e-9
+    })
+}
+
+/** Local 12×12 stiffness. */
+function kLocal(EA: number, GJ: number, EIy: number, EIz: number, L: number): number[][] {
+  const k = Array.from({ length: 12 }, () => new Array(12).fill(0))
+  const set = (r: number, c: number, v: number) => { k[r][c] = v; k[c][r] = v }
+  set(0, 0, EA / L); set(0, 6, -EA / L); set(6, 6, EA / L)
+  set(3, 3, GJ / L); set(3, 9, -GJ / L); set(9, 9, GJ / L)
+  // bending about z′ (uy, θz)
+  const az = (12 * EIz) / L ** 3, bz = (6 * EIz) / L ** 2, cz = (4 * EIz) / L, dz = (2 * EIz) / L
+  set(1, 1, az); set(1, 5, bz); set(1, 7, -az); set(1, 11, bz)
+  set(5, 5, cz); set(5, 7, -bz); set(5, 11, dz)
+  set(7, 7, az); set(7, 11, -bz)
+  set(11, 11, cz)
+  // bending about y′ (uz, θy) — mirrored signs
+  const ay = (12 * EIy) / L ** 3, by = (6 * EIy) / L ** 2, cy = (4 * EIy) / L, dy = (2 * EIy) / L
+  set(2, 2, ay); set(2, 4, -by); set(2, 8, -ay); set(2, 10, -by)
+  set(4, 4, cy); set(4, 8, by); set(4, 10, dy)
+  set(8, 8, ay); set(8, 10, by)
+  set(10, 10, cy)
+  return k
+}
+
+type V3 = [number, number, number]
+const sub = (a: V3, b: V3): V3 => [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+const cross = (a: V3, b: V3): V3 => [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]]
+const dot = (a: V3, b: V3): number => a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+const norm = (a: V3): V3 => { const l = Math.hypot(...a); return [a[0] / l, a[1] / l, a[2] / l] }
+
+/** Rotation matrix rows = local axes (x′, y′, z′) in global components. */
+function localAxes(dir: V3): [V3, V3, V3] {
+  const xp = norm(dir)
+  const up: V3 = Math.abs(dot(xp, [0, 1, 0])) > 0.999 ? [0, 0, 1] : [0, 1, 0]
+  const proj = dot(up, xp)
+  const yp = norm([up[0] - proj * xp[0], up[1] - proj * xp[1], up[2] - proj * xp[2]])
+  const zp = cross(xp, yp)
+  return [xp, yp, zp]
+}
+
+function tMatrix(R: [V3, V3, V3]): number[][] {
+  const T = Array.from({ length: 12 }, () => new Array(12).fill(0))
+  for (let blk = 0; blk < 4; blk++)
+    for (let r = 0; r < 3; r++)
+      for (let c = 0; c < 3; c++) T[3 * blk + r][3 * blk + c] = R[r][c]
+  return T
+}
+
+const mul = (A: number[][], B: number[][]): number[][] =>
+  A.map((row) => B[0].map((_, j) => row.reduce((s, v, k) => s + v * B[k][j], 0)))
+const transpose = (A: number[][]): number[][] => A[0].map((_, j) => A.map((row) => row[j]))
+
+interface Prep {
+  L: number; R: [V3, V3, V3]
+  kl: number[][]; T: number[][]; kg: number[][]
+  dofs: number[]
+  feq: number[]
+  // local gravity components for diagram sampling
+  qy: (x: number) => number; qz: (x: number) => number; p: (x: number) => number
+  pts: { a: number; Py: number; Pz: number; Pa: number }[]
+}
+
+function prepMember(m: F3Member, nm: Map<string, F3Node>, idx: Map<string, number>, loads: F3Load[]): Prep {
+  const ni = nm.get(m.i)!, nj = nm.get(m.j)!
+  const dir: V3 = sub([nj.x, nj.y, nj.z], [ni.x, ni.y, ni.z])
+  const L = Math.hypot(...dir)
+  const R = localAxes(dir)
+  const EA = (m.E * m.A) / 1000
+  const GJ = m.G * m.J * 1e-9
+  const EIy = m.E * m.Iy * 1e-9
+  const EIz = m.E * m.Iz * 1e-9
+  const kl = kLocal(EA, GJ, EIy, EIz, L)
+  const T = tMatrix(R)
+  const kg = mul(mul(transpose(T), kl), T)
+  const ii = idx.get(m.i)!, jj = idx.get(m.j)!
+  const dofs = [...Array.from({ length: 6 }, (_, k) => 6 * ii + k), ...Array.from({ length: 6 }, (_, k) => 6 * jj + k)]
+
+  // gravity unit vector in local coords: g_local = R · (0, −1, 0)
+  const gl: V3 = [R[0][1] * -1, R[1][1] * -1, R[2][1] * -1]
+
+  const feq = new Array(12).fill(0)
+  const dists: { x1: number; x2: number; w1: number; w2: number }[] = []
+  const pts: Prep['pts'] = []
+
+  for (const ld of loads) {
+    if (ld.kind === 'member-udl' && ld.member === m.id) dists.push({ x1: 0, x2: L, w1: ld.w, w2: ld.w })
+    else if (ld.kind === 'member-vdl' && ld.member === m.id) dists.push({ x1: Math.max(0, ld.x1), x2: Math.min(L, ld.x2), w1: ld.w1, w2: ld.w2 })
+    else if (ld.kind === 'member-point' && ld.member === m.id) {
+      const a = Math.max(0, Math.min(L, ld.a))
+      pts.push({ a, Py: ld.P * gl[1], Pz: ld.P * gl[2], Pa: ld.P * gl[0] })
+      const xi = a / L
+      const N = hermite(xi, L)
+      feq[0] += ld.P * gl[0] * (1 - xi); feq[6] += ld.P * gl[0] * xi
+      feq[1] += ld.P * gl[1] * N[0]; feq[5] += ld.P * gl[1] * N[1]
+      feq[7] += ld.P * gl[1] * N[2]; feq[11] += ld.P * gl[1] * N[3]
+      feq[2] += ld.P * gl[2] * N[0]; feq[4] -= ld.P * gl[2] * N[1]
+      feq[8] += ld.P * gl[2] * N[2]; feq[10] -= ld.P * gl[2] * N[3]
+    }
+  }
+  // distributed gravity: consistent vectors by Gauss over each segment
+  for (const dd of dists) {
+    if (dd.x2 <= dd.x1) continue
+    const wAt = (x: number) => dd.w1 + ((dd.w2 - dd.w1) * (x - dd.x1)) / Math.max(dd.x2 - dd.x1, 1e-12)
+    const fe = gauss5Vec((x) => {
+      const w = wAt(x)
+      const xi = x / L
+      const N = hermite(xi, L)
+      return [
+        w * gl[0] * (1 - xi), w * gl[0] * xi,                       // axial i, j
+        w * gl[1] * N[0], w * gl[1] * N[1], w * gl[1] * N[2], w * gl[1] * N[3],  // y-plane
+        w * gl[2] * N[0], -w * gl[2] * N[1], w * gl[2] * N[2], -w * gl[2] * N[3], // z-plane (θy sign)
+      ]
+    }, dd.x1, dd.x2, 10)
+    feq[0] += fe[0]; feq[6] += fe[1]
+    feq[1] += fe[2]; feq[5] += fe[3]; feq[7] += fe[4]; feq[11] += fe[5]
+    feq[2] += fe[6]; feq[4] += fe[7]; feq[8] += fe[8]; feq[10] += fe[9]
+  }
+
+  const intensity = (x: number, comp: number) => {
+    let s = 0
+    for (const dd of dists) if (dd.x1 <= x && x <= dd.x2) {
+      const w = dd.w1 + ((dd.w2 - dd.w1) * (x - dd.x1)) / Math.max(dd.x2 - dd.x1, 1e-12)
+      s += w * gl[comp]
+    }
+    return s
+  }
+  return {
+    L, R, kl, T, kg, dofs, feq,
+    p: (x) => intensity(x, 0), qy: (x) => intensity(x, 1), qz: (x) => intensity(x, 2),
+    pts,
+  }
+}
+
+export function solveFrame3D(
+  nodes: F3Node[], members: F3Member[], supports: F3Support[], loads: F3Load[],
+): F3Result | null {
+  const nm = new Map(nodes.map((n) => [n.id, n]))
+  const idx = new Map(nodes.map((n, i) => [n.id, i]))
+  const ndof = 6 * nodes.length
+
+  const preps = members.map((m) => prepMember(m, nm, idx, loads))
+  const K: number[][] = Array.from({ length: ndof }, () => new Array(ndof).fill(0))
+  const F = new Array(ndof).fill(0)
+  preps.forEach((pr) => {
+    const fg = matVec(transpose(pr.T), pr.feq)
+    for (let a = 0; a < 12; a++) {
+      F[pr.dofs[a]] += fg[a]
+      for (let b = 0; b < 12; b++) K[pr.dofs[a]][pr.dofs[b]] += pr.kg[a][b]
+    }
+  })
+  for (const ld of loads) {
+    if (ld.kind !== 'node') continue
+    const i = idx.get(ld.node)
+    if (i === undefined) continue
+    const v = [ld.Fx ?? 0, ld.Fy ?? 0, ld.Fz ?? 0, ld.Mx ?? 0, ld.My ?? 0, ld.Mz ?? 0]
+    for (let k = 0; k < 6; k++) F[6 * i + k] += v[k]
+  }
+
+  const constrained = new Set<number>()
+  for (const s of supports) {
+    const i = idx.get(s.node)
+    if (i === undefined) continue
+    for (let k = 0; k < (s.fixity === 'fixed' ? 6 : 3); k++) constrained.add(6 * i + k)
+  }
+  const free: number[] = []
+  for (let d0 = 0; d0 < ndof; d0++) if (!constrained.has(d0)) free.push(d0)
+  const d = new Array(ndof).fill(0)
+  if (free.length > 0) {
+    const Kff = free.map((i) => free.map((j) => K[i][j]))
+    const dF = solveLinear(Kff, free.map((i) => F[i]))
+    if (dF === null) return null
+    free.forEach((dof, k) => (d[dof] = dF[k]))
+  }
+
+  const R = matVec(K, d).map((v, i) => v - F[i])
+  const reactions: F3Reaction[] = supports
+    .filter((s) => idx.has(s.node))
+    .map((s) => {
+      const i = idx.get(s.node)!
+      return {
+        node: s.node, fixity: s.fixity,
+        F: [R[6 * i], R[6 * i + 1], R[6 * i + 2]],
+        M: s.fixity === 'fixed' ? [R[6 * i + 3], R[6 * i + 4], R[6 * i + 5]] : [0, 0, 0],
+      }
+    })
+
+  const results: F3MemberResult[] = members.map((m, mi) => {
+    const pr = preps[mi]
+    const de = pr.dofs.map((dof) => d[dof])
+    const dl = matVec(pr.T, de)
+    const f = matVec(pr.kl, dl).map((v, k) => v - pr.feq[k])
+
+    const NS = 24
+    const xsSet = new Set<number>()
+    for (let k = 0; k <= NS; k++) xsSet.add((pr.L * k) / NS)
+    pr.pts.forEach((pt) => { xsSet.add(Math.max(0, pt.a - 1e-6)); xsSet.add(pt.a); xsSet.add(Math.min(pr.L, pt.a + 1e-6)) })
+    const xs = [...xsSet].sort((a, b) => a - b)
+
+    const NN: number[] = [], Vy: number[] = [], Vz: number[] = [], TT: number[] = [], My: number[] = [], Mz: number[] = []
+    const STEPS = 60
+    const integ = (fn: (x: number) => number, x: number) => {
+      // simple trapezoid over [0, x] — intensities are piecewise linear
+      let s = 0
+      const n = Math.max(2, Math.ceil((x / Math.max(pr.L, 1e-9)) * STEPS))
+      for (let k = 1; k <= n; k++) {
+        const x0 = (x * (k - 1)) / n, x1 = (x * k) / n
+        s += 0.5 * (fn(x0) + fn(x1)) * (x1 - x0)
+      }
+      return s
+    }
+    const integM = (fn: (x: number) => number, x: number) => {
+      let s = 0
+      const n = Math.max(2, Math.ceil((x / Math.max(pr.L, 1e-9)) * STEPS))
+      for (let k = 1; k <= n; k++) {
+        const x0 = (x * (k - 1)) / n, x1 = (x * k) / n
+        const mid = (x0 + x1) / 2
+        s += fn(mid) * (x - mid) * (x1 - x0)
+      }
+      return s
+    }
+    for (const x of xs) {
+      let n = -(f[0] + integ(pr.p, x))
+      let vy = f[1] + integ(pr.qy, x)
+      let vz = f[2] + integ(pr.qz, x)
+      let mz = -f[5] + f[1] * x + integM(pr.qy, x)
+      let my = f[4] - f[2] * x - integM(pr.qz, x)
+      for (const pt of pr.pts) {
+        if (pt.a <= x) {
+          n -= pt.Pa
+          vy += pt.Py; vz += pt.Pz
+          mz += pt.Py * (x - pt.a)
+          my -= pt.Pz * (x - pt.a)
+        }
+      }
+      NN.push(n); Vy.push(vy); Vz.push(vz); TT.push(-f[3]); My.push(my); Mz.push(mz)
+    }
+    return {
+      id: m.id, L: pr.L, f, xs, N: NN, Vy, Vz, T: TT, My, Mz,
+      Nmax: Math.max(...NN.map(Math.abs)),
+      Vmax: Math.max(...Vy.map(Math.abs), ...Vz.map(Math.abs)),
+      Mmax: Math.max(...My.map(Math.abs), ...Mz.map(Math.abs)),
+      Tmax: Math.max(...TT.map(Math.abs)),
+    }
+  })
+
+  return {
+    d, reactions, members: results,
+    Mmax: Math.max(...results.map((r) => r.Mmax), 0),
+    Vmax: Math.max(...results.map((r) => r.Vmax), 0),
+    Nmax: Math.max(...results.map((r) => r.Nmax), 0),
+  }
+}
+
+// ── NSCP combination orchestration ────────────────────────────────────────
+export interface F3ComboRun { combo: Combo; result: F3Result | null; factored: F3Load[]; skipped: boolean }
+export interface F3Analysis { perCombo: F3ComboRun[]; govIdx: number }
+
+export function analyzeFrame3D(
+  nodes: F3Node[], members: F3Member[], supports: F3Support[], loads: F3Load[],
+): F3Analysis | null {
+  const perCombo: F3ComboRun[] = []
+  let govIdx = -1, govM = -1
+  for (const combo of NSCP_COMBOS) {
+    const factored = applyF3Combo(loads, combo.f)
+    if (factored.length === 0) { perCombo.push({ combo, result: null, factored, skipped: true }); continue }
+    const r = solveFrame3D(nodes, members, supports, factored)
+    perCombo.push({ combo, result: r, factored, skipped: false })
+    if (r && r.Mmax > govM) { govM = r.Mmax; govIdx = perCombo.length - 1 }
+  }
+  return govIdx < 0 ? null : { perCombo, govIdx }
+}

--- a/webapp/src/engine/modelBridge.ts
+++ b/webapp/src/engine/modelBridge.ts
@@ -1,0 +1,126 @@
+// ─────────────────────────────────────────────────────────────────────────
+// StructuralModel → frame3d bridge. Sections become E/G/A/Iy/Iz/J; supports
+// map to fixed/pin; slab AREA loads run through the Phase-3 tributary engine
+// and land on the matching edge members as vdl/udl gravity loads (categories
+// preserved) — the load path, automated.
+// ─────────────────────────────────────────────────────────────────────────
+import type { StructuralModel, RectSection } from './model'
+import type { F3Node, F3Member, F3Support, F3Load } from './frame3d'
+import { rectJ } from './frame3d'
+import { distributePanel, type AreaLoad } from './tributary'
+import type { BeamLoad } from './beamAnalysis'
+
+export interface BridgeResult {
+  nodes: F3Node[]
+  members: F3Member[]
+  supports: F3Support[]
+  loads: F3Load[]
+  /** Edges whose loads could not be attached (no matching member). */
+  orphanEdges: string[]
+}
+
+function sectionProps(s: RectSection) {
+  const E = 4700 * Math.sqrt(Math.max(s.fc, 1))
+  return {
+    E,
+    G: E / 2.4,                 // ν = 0.2
+    A: s.b * s.h,
+    Iz: (s.b * s.h ** 3) / 12,  // gravity bending (depth h vertical)
+    Iy: (s.h * s.b ** 3) / 12,
+    J: rectJ(s.b, s.h),
+  }
+}
+
+/** Map a BeamLoad (x from edge start) onto a member that may run either way. */
+function edgeLoadToMember(ld: BeamLoad, memberId: string, sameDir: boolean, L: number): F3Load | null {
+  if (ld.type === 'udl') {
+    const [x1, x2] = sameDir ? [ld.x1, ld.x2] : [L - ld.x2, L - ld.x1]
+    return { kind: 'member-vdl', member: memberId, x1, x2, w1: ld.w, w2: ld.w, cat: ld.cat }
+  }
+  if (ld.type === 'vdl') {
+    if (sameDir) return { kind: 'member-vdl', member: memberId, x1: ld.x1, x2: ld.x2, w1: ld.w1, w2: ld.w2, cat: ld.cat }
+    return { kind: 'member-vdl', member: memberId, x1: L - ld.x2, x2: L - ld.x1, w1: ld.w2, w2: ld.w1, cat: ld.cat }
+  }
+  if (ld.type === 'point') return { kind: 'member-point', member: memberId, a: sameDir ? ld.x : L - ld.x, P: ld.P, cat: ld.cat }
+  return null
+}
+
+export function modelToFrame3D(model: StructuralModel): BridgeResult {
+  const nodes: F3Node[] = model.nodes.map((n) => ({ id: n.id, x: n.x, y: n.y, z: n.z }))
+  const nm = new Map(nodes.map((n) => [n.id, n]))
+  const secById = new Map(model.sections.map((s) => [s.id, sectionProps(s)]))
+  const fallback = sectionProps(model.sections[0] ?? { id: '', name: '', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 })
+
+  const members: F3Member[] = model.members.map((m) => ({
+    id: m.id, i: m.i, j: m.j, ...(secById.get(m.section) ?? fallback),
+  }))
+  const memberByPair = new Map<string, { id: string; i: string; j: string }>()
+  for (const m of model.members) {
+    memberByPair.set(`${m.i}|${m.j}`, m)
+    memberByPair.set(`${m.j}|${m.i}`, m)
+  }
+
+  const supports: F3Support[] = model.supports.map((s) => ({
+    node: s.node,
+    fixity: s.fixity === 'fixed' ? 'fixed' : 'pin',   // roller/spring → pin in 3D for now
+  }))
+
+  const loads: F3Load[] = []
+  const orphanEdges: string[] = []
+
+  // direct loads
+  for (const ld of model.loads) {
+    if (ld.kind === 'node') loads.push({ kind: 'node', node: ld.node, Fx: ld.Fx, Fy: ld.Fy, Fz: ld.Fz, cat: ld.cat })
+    else if (ld.kind === 'member-udl') loads.push({ kind: 'member-udl', member: ld.member, w: ld.w, cat: ld.cat })
+    else if (ld.kind === 'member-point') {
+      const m = model.members.find((q) => q.id === ld.member)
+      if (!m) continue
+      const a = nm.get(m.i)!, b = nm.get(m.j)!
+      const L = Math.hypot(b.x - a.x, b.y - a.y, b.z - a.z)
+      loads.push({ kind: 'member-point', member: ld.member, a: ld.t * L, P: ld.P, cat: ld.cat })
+    }
+  }
+
+  // slab area loads → tributary → edge members
+  for (const plate of model.plates) {
+    const areaLoads: AreaLoad[] = model.loads
+      .filter((l) => l.kind === 'area' && l.plate === plate.id)
+      .map((l) => ({ q: (l as { q: number }).q, cat: l.cat }))
+    if (areaLoads.length === 0) continue
+
+    const c = plate.corners.map((id) => nm.get(id))
+    if (c.some((q) => !q)) continue
+    const [c0, c1, c2, c3] = c as F3Node[]
+    const lxSpan = Math.hypot(c1.x - c0.x, c1.y - c0.y, c1.z - c0.z)   // edge c0→c1 (and c3→c2)
+    const lzSpan = Math.hypot(c3.x - c0.x, c3.y - c0.y, c3.z - c0.z)   // edge c0→c3 (and c1→c2)
+    const trib = distributePanel(lxSpan, lzSpan, areaLoads)
+
+    // pair the panel's long/short tributary edges with the actual corner edges
+    const xEdges: [F3Node, F3Node][] = [[c0, c1], [c3, c2]]
+    const zEdges: [F3Node, F3Node][] = [[c0, c3], [c1, c2]]
+    const longEdges = lxSpan >= lzSpan ? xEdges : zEdges
+    const shortEdges = lxSpan >= lzSpan ? zEdges : xEdges
+    const assign: [EdgePair: [F3Node, F3Node], kind: 'long' | 'short'][] = [
+      [longEdges[0], 'long'], [longEdges[1], 'long'],
+      [shortEdges[0], 'short'], [shortEdges[1], 'short'],
+    ]
+
+    let li = 0, si = 0
+    for (const [[a, b], kind] of assign) {
+      const trEdge = kind === 'long'
+        ? trib.edges.filter((e) => e.kind === 'long')[li++]
+        : trib.edges.filter((e) => e.kind === 'short')[si++]
+      if (!trEdge || trEdge.loads.length === 0) continue
+      const m = memberByPair.get(`${a.id}|${b.id}`)
+      if (!m) { orphanEdges.push(`${plate.id}:${a.id}-${b.id}`); continue }
+      const sameDir = m.i === a.id
+      const L = trEdge.length
+      for (const ld of trEdge.loads) {
+        const f3 = edgeLoadToMember(ld, m.id, sameDir, L)
+        if (f3) loads.push(f3)
+      }
+    }
+  }
+
+  return { nodes, members, supports, loads, orphanEdges }
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -6,6 +6,9 @@ import * as THREE from 'three'
 import { generateGridModel, removeElements } from '../engine/modelBuilder'
 import type { StructuralModel, Member, Plate, RectSection } from '../engine/model'
 import { distributePanel } from '../engine/tributary'
+import { modelToFrame3D } from '../engine/modelBridge'
+import { analyzeFrame3D, type F3Analysis } from '../engine/frame3d'
+import { Diagram } from '../components/Diagram'
 import { Num, Card, ResultCard, Row } from '../components/qty'
 import { f1, f2 } from '../lib/format'
 
@@ -20,8 +23,11 @@ const parseList = (s: string): number[] =>
   s.split(/[, ]+/).map(parseFloat).filter((v) => Number.isFinite(v) && v > 0)
 
 // ── 3D primitives ─────────────────────────────────────────────────────────
-function Member3D({ a, b, role, selected, onPick }: {
-  a: THREE.Vector3; b: THREE.Vector3; role: string; selected: boolean; onPick: () => void
+function Member3D({ a, b, role, selected, tint = 0, onPick }: {
+  a: THREE.Vector3; b: THREE.Vector3; role: string; selected: boolean
+  /** 0–1 utilisation tint (|M| relative to the model max) after analysis. */
+  tint?: number
+  onPick: () => void
 }) {
   const { mid, quat, len } = useMemo(() => {
     const dir = new THREE.Vector3().subVectors(b, a)
@@ -30,11 +36,16 @@ function Member3D({ a, b, role, selected, onPick }: {
     return { mid: new THREE.Vector3().addVectors(a, b).multiplyScalar(0.5), quat, len }
   }, [a, b])
   const t = role === 'column' ? 0.3 : 0.22
+  const color = useMemo(() => {
+    if (selected) return SEL
+    const base = new THREE.Color(ROLE_COLOR[role] ?? '#64748b')
+    return tint > 0 ? `#${base.lerp(new THREE.Color('#dc2626'), tint).getHexString()}` : `#${base.getHexString()}`
+  }, [selected, role, tint])
   return (
     <mesh position={mid} quaternion={quat}
       onClick={(e) => { e.stopPropagation(); onPick() }}>
       <boxGeometry args={[len, t, t]} />
-      <meshStandardMaterial color={selected ? SEL : ROLE_COLOR[role] ?? '#64748b'} />
+      <meshStandardMaterial color={color} />
     </mesh>
   )
 }
@@ -81,15 +92,33 @@ export default function ModelSpace() {
     } catch { return null }
   })
   const [selected, setSelected] = useState<string | null>(null)
+  const [analysis, setAnalysis] = useState<F3Analysis | null>(null)
+  const [orphans, setOrphans] = useState(0)
   const fileRef = useRef<HTMLInputElement>(null)
 
   const save = (m: StructuralModel | null) => {
     setModel(m)
+    setAnalysis(null)             // geometry changed — results are stale
     try {
       if (m) sessionStorage.setItem(AUTOSAVE_KEY, JSON.stringify(m))
       else sessionStorage.removeItem(AUTOSAVE_KEY)
     } catch { /* quota — ignore */ }
   }
+
+  const analyze = () => {
+    if (!model) return
+    const br = modelToFrame3D(model)
+    setOrphans(br.orphanEdges.length)
+    setAnalysis(analyzeFrame3D(br.nodes, br.members, br.supports, br.loads))
+  }
+
+  const gov = analysis ? analysis.perCombo[analysis.govIdx] : null
+  const govRes = gov?.result ?? null
+  const memForce = useMemo(() => {
+    const map = new Map<string, { Mmax: number; Vmax: number; Nmax: number }>()
+    govRes?.members.forEach((m) => map.set(m.id, { Mmax: m.Mmax, Vmax: m.Vmax, Nmax: m.Nmax }))
+    return map
+  }, [govRes])
 
   const generate = () => {
     const section: RectSection = { id: 'S1', name: `${b}×${h}`, b, h, fc, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
@@ -188,6 +217,10 @@ export default function ModelSpace() {
               className="rounded-lg bg-gradient-to-br from-[#0056b3] to-[#003f86] px-4 py-2 text-sm font-semibold text-white shadow-md transition hover:shadow-lg">
               ⚙ Generate model
             </button>
+            <button type="button" onClick={analyze} disabled={!model}
+              className="rounded-lg bg-gradient-to-br from-[#0e7490] to-[#155e75] px-4 py-2 text-sm font-semibold text-white shadow-md transition hover:shadow-lg disabled:opacity-40">
+              ▶ Analyze (3D FEM)
+            </button>
             <button type="button" onClick={download} disabled={!model}
               className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50 disabled:opacity-40">
               ⤓ Save JSON
@@ -210,11 +243,36 @@ export default function ModelSpace() {
             </ResultCard>
           )}
 
+          {gov && govRes && (
+            <ResultCard title={`Analysis — ${gov.combo.name} governs`}>
+              <Row label="ΣRy (gravity)" value={`${f1(govRes.reactions.reduce((s, q) => s + q.F[1], 0))} kN`} />
+              <Row label="Extremes" value={`M ${f1(govRes.Mmax)} kN·m`}
+                sub={`V ${f1(govRes.Vmax)} · N ${f1(govRes.Nmax)} kN`} />
+              {orphans > 0 && <Row alert label="⚠ Orphan edges" value={`${orphans}`} sub="slab edges with no member" />}
+              <p className="mt-1 text-[11px] text-slate-400">
+                Members tinted red by |M| relative to the model max. Click one for its diagrams.
+              </p>
+            </ResultCard>
+          )}
+
           {selMember && model && (
             <ResultCard title={`Member — ${selMember.id}`}>
               <Row label="Role" value={selMember.role} />
               <Row label="Length" value={`${f2(memberLen)} m`} />
               <Row label="Section" value={model.sections[0]?.name ?? selMember.section} />
+              {(() => {
+                const mr = govRes?.members.find((m) => m.id === selMember.id)
+                if (!mr) return null
+                return (
+                  <div className="mt-2 space-y-2">
+                    <Row label="Forces (governing)" value={`M ${f1(mr.Mmax)} kN·m`}
+                      sub={`V ${f1(mr.Vmax)} · N ${f1(mr.Nmax)} kN`} />
+                    <Diagram xs={mr.xs} ys={mr.Mz} title="Mz" unit="kN·m" color="#d62728" decimals={1} />
+                    <Diagram xs={mr.xs} ys={mr.Vy} title="Vy" unit="kN" color="#1f77b4" decimals={1} />
+                    <Diagram xs={mr.xs} ys={mr.N} title="N (+tension)" unit="kN" color="#7c3aed" decimals={1} />
+                  </div>
+                )
+              })()}
               <button type="button" onClick={() => { save(removeElements(model, new Set([selMember.id]))); setSelected(null) }}
                 className="no-print mt-2 rounded-lg border border-red-300 px-3 py-1.5 text-sm font-semibold text-red-600 hover:bg-red-50">
                 Delete member
@@ -251,7 +309,9 @@ export default function ModelSpace() {
               {model.members.map((m) => {
                 const a = nodePos.get(m.i), bb = nodePos.get(m.j)
                 if (!a || !bb) return null
-                return <Member3D key={m.id} a={a} b={bb} role={m.role}
+                const tint = govRes && govRes.Mmax > 1e-9
+                  ? (memForce.get(m.id)?.Mmax ?? 0) / govRes.Mmax : 0
+                return <Member3D key={m.id} a={a} b={bb} role={m.role} tint={tint * 0.85}
                   selected={m.id === selected} onPick={() => setSelected(m.id)} />
               })}
               {model.plates.map((p) => {


### PR DESCRIPTION
Fifth milestone of the 3D roadmap: the model space becomes a solver.

## `engine/frame3d.ts` — the space-frame element
- **12-DOF member** on the shared `fem.ts` core: axial + **St-Venant torsion** + **biaxial Hermite bending**; local axes x′ along the member, y′ toward global up (global Z for verticals); full 12×12 transformation.
- **Loads**: nodal forces/moments on all six axes; member **gravity** loads (global −Y) as UDL / trapezoid (`vdl`) / point — consistent fixed-end vectors by Gauss + Hermite in **both bending planes** (θy sign convention handled).
- Member end-force recovery + sampled **N/Vy/Vz/T/My/Mz** diagrams; `analyzeFrame3D` runs all 7 NSCP combinations; `rectJ(b,h)` for the rectangular torsional constant.

## `engine/modelBridge.ts` — StructuralModel → solver
Sections become E/G/A/Iy/Iz/J; supports map fixed/pin; **slab area loads run through the Phase-3 tributary engine and attach to the matching edge members** as vdl/udl gravity loads (orientation-aware mirroring, categories preserved) — the load path, fully automated.

## Model space integration
**▶ Analyze (3D FEM)**: governing-combo card (ΣRy, extremes, orphan-edge warning), members **tinted red by |M|** relative to the model max, and per-member **Mz/Vy/N diagrams** in the inspector.

## Fix uncovered along the way
`fem.ts` now uses full-precision Gauss–Legendre constants — the legacy's 5-decimal truncation produced ~5×10⁻⁶ relative error, invisible at beam tolerances but caught by the frame tests.

## Verification (9 tests, 140 total)
Cantilever closed forms in **both** bending planes (`PL³/3EIz`, `PL³/3EIy`, `wL⁴/8EI`, `wL²/2`), torsion `TL/GJ`, axial `PL/EA`, `rectJ` square = 0.1406b⁴, a planar portal **reproducing frame2d** (with the documented Iy=Iz note — a vertical column's in-plane sway engages its local-y axis), and the full **grid + slab bridge**: ΣRy = factored q·A under 1.4D and 1.2D+1.6L with lateral equilibrium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)