### PR TITLE
Phase 6: design pipeline — slabs → beams → columns → footings

### DIFF
--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { generateGridModel } from './modelBuilder'
+import { designStructure } from './pipeline'
+import type { RectSection } from './model'
+
+const section: RectSection = { id: 'S1', name: '300×500', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
+const soil = { qAllow: 200, gammaSoil: 18, gammaConc: 24, H: 1.5 }
+
+function makeModel() {
+  const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })
+  m.loads = m.plates.flatMap((p) => [
+    { kind: 'area' as const, plate: p.id, q: 4.8, cat: 'D' as const },
+    { kind: 'area' as const, plate: p.id, q: 2.4, cat: 'L' as const },
+  ])
+  return m
+}
+
+describe('design pipeline — single-bay single-storey grid', () => {
+  const r = designStructure(makeModel(), soil)!
+
+  it('covers every element down the load path', () => {
+    expect(r.govName).toContain('1.2D + 1.6L')
+    expect(r.beams).toHaveLength(4)          // 2 beams + 2 girders
+    expect(r.columns).toHaveLength(4)
+    expect(r.footings).toHaveLength(4)
+    expect(r.orphanEdges).toBe(0)
+  })
+
+  it('beams: every section designs cleanly with positive demands', () => {
+    for (const b of r.beams) {
+      expect(b.sections.length).toBeGreaterThanOrEqual(1)
+      expect(b.ok).toBe(true)
+      // the interior section of a loaded edge beam sags (+M)
+      const interior = b.sections.find((s) => s.label.startsWith('Interior'))
+      if (interior) expect(interior.Mu).toBeGreaterThan(0)
+      for (const s of b.sections) expect(s.design.bars).toBeGreaterThanOrEqual(2)
+    }
+  })
+
+  it('columns: Pu shares the floor load and the design closes', () => {
+    const wu = 1.2 * 4.8 + 1.6 * 2.4                  // 9.6 kPa
+    const total = wu * 6 * 5                          // 288 kN
+    const sumPu = r.columns.reduce((s, c) => s + c.Pu, 0)
+    // column axial sums to ≈ the floor load (members carry a bit of frame shear)
+    expect(sumPu).toBeGreaterThan(total * 0.9)
+    expect(sumPu).toBeLessThan(total * 1.1)
+    for (const c of r.columns) {
+      expect(c.ok).toBe(true)
+      expect(c.bars).toBeGreaterThanOrEqual(4)
+      expect(c.util).toBeLessThanOrEqual(1)
+    }
+  })
+
+  it('footings: service P < Pu, plan sized, checks pass', () => {
+    for (const f of r.footings) {
+      expect(f.P).toBeLessThan(f.Pu)
+      expect(f.design.B).toBeGreaterThan(0.5)
+      expect(f.ok).toBe(true)
+    }
+    // factored reactions reproduce the floor load
+    const sumPu = r.footings.reduce((s, f) => s + f.Pu, 0)
+    expect(sumPu).toBeCloseTo(9.6 * 30, 1)
+  })
+
+  it('concrete totals: members + slab', () => {
+    // 4 columns ×3 m + (2×6 + 2×5) m of beams = 12 + 22 = 34 m of 0.15 m² section
+    expect(r.totals.concreteMembers).toBeCloseTo(34 * 0.3 * 0.5, 6)
+    expect(r.totals.concreteSlabs).toBeCloseTo(6 * 5 * 0.15, 6)
+  })
+})

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -1,0 +1,179 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Structure design pipeline — Phase 6 of the 3D roadmap. For the governing
+// NSCP combination, design DOWN the load path:
+//   slabs (already distributed by the bridge) → every beam/girder
+//   (critical sections → SRRB/DRRB via designBeam) → every column
+//   (axial + P–M via columnDesign) → every base support (service +
+//   factored reactions → isolated footing) → concrete totals.
+// Every stage reuses the existing engines unchanged.
+// ─────────────────────────────────────────────────────────────────────────
+import type { StructuralModel, RectSection } from './model'
+import { modelToFrame3D } from './modelBridge'
+import { analyzeFrame3D, solveFrame3D, applyF3Combo, type F3Result, type F3MemberResult } from './frame3d'
+import { designBeam, type BeamDesignResult } from './beamDesign'
+import { designAxialColumn, capacityAtEccentricity, interaction } from './columnDesign'
+import { designSquareFooting, type SquareFootingResult } from './isolatedFooting'
+
+export interface SoilOptions {
+  qAllow: number; gammaSoil: number; gammaConc: number; H: number
+}
+
+export interface BeamSectionDesign {
+  label: string; Mu: number; Vu: number; hogging: boolean
+  design: BeamDesignResult
+}
+export interface BeamScheduleRow {
+  id: string; role: string; L: number
+  sections: BeamSectionDesign[]
+  ok: boolean
+}
+export interface ColumnScheduleRow {
+  id: string; L: number
+  Pu: number; Mu: number; e: number
+  bars: number; phiPn: number; util: number
+  tieSpacing: number
+  ok: boolean
+}
+export interface FootingScheduleRow {
+  node: string; P: number; Pu: number
+  design: SquareFootingResult
+  ok: boolean
+}
+export interface StructureDesign {
+  govName: string
+  beams: BeamScheduleRow[]
+  columns: ColumnScheduleRow[]
+  footings: FootingScheduleRow[]
+  totals: { concreteMembers: number; concreteSlabs: number; concrete: number }
+  orphanEdges: number
+}
+
+const beamOK = (d: BeamDesignResult) =>
+  d.flexOK && d.comprEffective && d.comprNAOK && d.region !== 'inadequate'
+
+/** Critical sections of a frame member: both ends + the interior |M| peak
+ *  between V-zero crossings (signed Mz; negative = hogging → top steel). */
+function memberSections(mr: F3MemberResult): { label: string; x: number; Mu: number; Vu: number }[] {
+  const out: { label: string; x: number; Mu: number; Vu: number }[] = []
+  const n = mr.xs.length - 1
+  out.push({ label: 'End i', x: 0, Mu: mr.Mz[0], Vu: Math.abs(mr.Vy[0]) })
+  out.push({ label: 'End j', x: mr.L, Mu: mr.Mz[n], Vu: Math.abs(mr.Vy[n]) })
+  // interior extremum: largest |Mz| strictly inside
+  let best = -1, bestM = 0
+  for (let k = 1; k < n; k++) {
+    if (Math.abs(mr.Mz[k]) > Math.abs(bestM)) { bestM = mr.Mz[k]; best = k }
+  }
+  if (best > 0 && mr.xs[best] > 0.02 * mr.L && mr.xs[best] < 0.98 * mr.L) {
+    out.push({ label: `Interior (x = ${mr.xs[best].toFixed(2)} m)`, x: mr.xs[best], Mu: bestM, Vu: Math.abs(mr.Vy[best]) })
+  }
+  return out
+}
+
+export function designStructure(model: StructuralModel, soil: SoilOptions): StructureDesign | null {
+  const sec: RectSection | undefined = model.sections[0]
+  if (!sec) return null
+
+  const br = modelToFrame3D(model)
+  const analysis = analyzeFrame3D(br.nodes, br.members, br.supports, br.loads)
+  if (!analysis) return null
+  const gov = analysis.perCombo[analysis.govIdx]
+  const govRes = gov.result
+  if (!govRes) return null
+
+  // Service (unfactored gravity) solve for the footing bearing check.
+  const serviceLoads = applyF3Combo(br.loads, { D: 1, L: 1, Lr: 1, S: 1, R: 1 })
+  const serviceRes: F3Result | null = serviceLoads.length
+    ? solveFrame3D(br.nodes, br.members, br.supports, serviceLoads)
+    : null
+
+  const roleOf = new Map(model.members.map((m) => [m.id, m.role]))
+
+  // ── Beams & girders ──
+  const beams: BeamScheduleRow[] = []
+  for (const mr of govRes.members) {
+    const role = roleOf.get(mr.id)
+    if (role !== 'beam' && role !== 'girder') continue
+    const sections: BeamSectionDesign[] = memberSections(mr)
+      .filter((s) => Math.abs(s.Mu) > 1e-6 || s.Vu > 1e-6)
+      .map((s) => ({
+        label: s.label, Mu: s.Mu, Vu: s.Vu, hogging: s.Mu < 0,
+        design: designBeam({
+          b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia,
+          comprBarDia: 16, stirrupDia: sec.tieDia,
+          fc: sec.fc, fy: sec.fy, Mu: Math.abs(s.Mu), Vu: s.Vu,
+        }),
+      }))
+    beams.push({ id: mr.id, role, L: mr.L, sections, ok: sections.every((s) => beamOK(s.design)) })
+  }
+
+  // ── Columns ──
+  const columns: ColumnScheduleRow[] = []
+  for (const mr of govRes.members) {
+    if (roleOf.get(mr.id) !== 'column') continue
+    const Pu = Math.max(0, -Math.min(...mr.N))           // compression (N < 0)
+    const Mu = mr.Mmax
+    const ax = designAxialColumn({
+      shape: 'tied', b: sec.b, h: sec.h, cover: sec.cover,
+      barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, Pu,
+    })
+    let phiPn = ax.phiPnMax
+    const e = Pu > 1e-9 ? Mu / Pu : 0
+    if (e > 1e-4) {
+      const cap = capacityAtEccentricity(
+        { b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, numBars: ax.bars },
+        e,
+      )
+      // axial cap still applies near pure compression
+      const inter = interaction({ b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, numBars: ax.bars })
+      phiPn = Math.min(cap.phi * cap.Pn, 0.65 * inter.PnMax)
+    }
+    const util = phiPn > 1e-9 ? Pu / phiPn : Infinity
+    columns.push({
+      id: mr.id, L: mr.L, Pu, Mu, e, bars: ax.bars, phiPn, util,
+      tieSpacing: ax.tieSpacing, ok: util <= 1 + 1e-9 && ax.rhoOK,
+    })
+  }
+
+  // ── Footings (base supports) ──
+  const footings: FootingScheduleRow[] = []
+  for (let i = 0; i < govRes.reactions.length; i++) {
+    const ru = govRes.reactions[i]
+    const rs = serviceRes?.reactions[i]
+    const Pu = Math.max(0, ru.F[1])
+    const P = Math.max(0, rs?.F[1] ?? Pu / 1.4)
+    if (Pu < 1e-6) continue
+    const d = designSquareFooting({
+      serviceLoad: P, ultimateLoad: Pu, columnWidth: Math.min(sec.b, sec.h),
+      fc: sec.fc, fy: sec.fy, qAllow: soil.qAllow,
+      gammaSoil: soil.gammaSoil, gammaConc: soil.gammaConc, H: soil.H,
+      barDia: sec.barDia, cover: 75,
+    })
+    footings.push({ node: ru.node, P, Pu, design: d, ok: d.qNet > 0 && d.punchOK && d.beamOK })
+  }
+
+  // ── Concrete totals ──
+  const nm = new Map(model.nodes.map((n) => [n.id, n]))
+  let concreteMembers = 0
+  for (const m of model.members) {
+    const a = nm.get(m.i), b2 = nm.get(m.j)
+    if (!a || !b2) continue
+    const L = Math.hypot(b2.x - a.x, b2.y - a.y, b2.z - a.z)
+    concreteMembers += (sec.b / 1000) * (sec.h / 1000) * L
+  }
+  let concreteSlabs = 0
+  for (const p of model.plates) {
+    const c = p.corners.map((id) => nm.get(id))
+    if (c.some((q) => !q)) continue
+    const [c0, c1, , c3] = c as { x: number; y: number; z: number }[]
+    const lx = Math.hypot(c1.x - c0.x, c1.y - c0.y, c1.z - c0.z)
+    const lz = Math.hypot(c3.x - c0.x, c3.y - c0.y, c3.z - c0.z)
+    concreteSlabs += lx * lz * (p.thickness / 1000)
+  }
+
+  return {
+    govName: gov.combo.name,
+    beams, columns, footings,
+    totals: { concreteMembers, concreteSlabs, concrete: concreteMembers + concreteSlabs },
+    orphanEdges: br.orphanEdges.length,
+  }
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -8,6 +8,7 @@ import type { StructuralModel, Member, Plate, RectSection } from '../engine/mode
 import { distributePanel } from '../engine/tributary'
 import { modelToFrame3D } from '../engine/modelBridge'
 import { analyzeFrame3D, type F3Analysis } from '../engine/frame3d'
+import { designStructure, type StructureDesign } from '../engine/pipeline'
 import { Diagram } from '../components/Diagram'
 import { Num, Card, ResultCard, Row } from '../components/qty'
 import { f1, f2 } from '../lib/format'
@@ -84,6 +85,8 @@ export default function ModelSpace() {
   const [storeyH, setStoreyH] = useState('3.5, 3')
   const [b, setB] = useState(300); const [h, setH] = useState(500); const [fc, setFc] = useState(28)
   const [qD, setQD] = useState(4.8); const [qL, setQL] = useState(2.4)
+  // Soil (for the footing stage of the design pipeline)
+  const [qa, setQa] = useState(200); const [Hf, setHf] = useState(1.5)
 
   const [model, setModel] = useState<StructuralModel | null>(() => {
     try {
@@ -93,12 +96,14 @@ export default function ModelSpace() {
   })
   const [selected, setSelected] = useState<string | null>(null)
   const [analysis, setAnalysis] = useState<F3Analysis | null>(null)
+  const [design, setDesign] = useState<StructureDesign | null>(null)
   const [orphans, setOrphans] = useState(0)
   const fileRef = useRef<HTMLInputElement>(null)
 
   const save = (m: StructuralModel | null) => {
     setModel(m)
     setAnalysis(null)             // geometry changed — results are stale
+    setDesign(null)
     try {
       if (m) sessionStorage.setItem(AUTOSAVE_KEY, JSON.stringify(m))
       else sessionStorage.removeItem(AUTOSAVE_KEY)
@@ -110,6 +115,11 @@ export default function ModelSpace() {
     const br = modelToFrame3D(model)
     setOrphans(br.orphanEdges.length)
     setAnalysis(analyzeFrame3D(br.nodes, br.members, br.supports, br.loads))
+  }
+
+  const runPipeline = () => {
+    if (!model) return
+    setDesign(designStructure(model, { qAllow: qa, gammaSoil: 18, gammaConc: 24, H: Hf }))
   }
 
   const gov = analysis ? analysis.perCombo[analysis.govIdx] : null
@@ -210,6 +220,8 @@ export default function ModelSpace() {
             <Num label="f′c" unit="MPa" value={fc} onChange={setFc} />
             <Num label="q dead" unit="kPa" value={qD} onChange={setQD} />
             <Num label="q live" unit="kPa" value={qL} onChange={setQL} />
+            <Num label="Soil qa" unit="kPa" value={qa} onChange={setQa} />
+            <Num label="Footing depth H" unit="m" value={Hf} onChange={setHf} />
           </Card>
 
           <div className="no-print flex flex-wrap gap-2">
@@ -220,6 +232,10 @@ export default function ModelSpace() {
             <button type="button" onClick={analyze} disabled={!model}
               className="rounded-lg bg-gradient-to-br from-[#0e7490] to-[#155e75] px-4 py-2 text-sm font-semibold text-white shadow-md transition hover:shadow-lg disabled:opacity-40">
               ▶ Analyze (3D FEM)
+            </button>
+            <button type="button" onClick={runPipeline} disabled={!model}
+              className="rounded-lg bg-gradient-to-br from-[#15803d] to-[#166534] px-4 py-2 text-sm font-semibold text-white shadow-md transition hover:shadow-lg disabled:opacity-40">
+              🏗 Design structure
             </button>
             <button type="button" onClick={download} disabled={!model}
               className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50 disabled:opacity-40">
@@ -333,6 +349,111 @@ export default function ModelSpace() {
           )}
         </div>
       </div>
+
+      {design && (
+        <div className="mt-6 space-y-6">
+          <h2 className="text-xl font-extrabold tracking-tight text-[#0056b3]">
+            Structure design — {design.govName} governs
+            <span className="ml-3 text-sm font-normal text-slate-500">
+              concrete ≈ {f1(design.totals.concrete)} m³ ({f1(design.totals.concreteMembers)} members + {f1(design.totals.concreteSlabs)} slabs)
+            </span>
+          </h2>
+
+          <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Beam & girder schedule</h3>
+            <table className="w-full border-collapse text-xs">
+              <thead>
+                <tr className="text-left uppercase tracking-wide text-slate-500">
+                  <th className="py-1 pr-2 font-semibold">Member</th>
+                  <th className="py-1 pr-2 font-semibold">Section</th>
+                  <th className="py-1 pr-2 text-right font-semibold">Mu (kN·m)</th>
+                  <th className="py-1 pr-2 text-right font-semibold">Vu (kN)</th>
+                  <th className="py-1 pr-2 font-semibold">Mode</th>
+                  <th className="py-1 pr-2 font-semibold">Tension</th>
+                  <th className="py-1 font-semibold">Stirrups</th>
+                </tr>
+              </thead>
+              <tbody>
+                {design.beams.flatMap((bm) => bm.sections.map((s, k) => {
+                  const d = s.design
+                  const bad = !(d.flexOK && d.comprEffective && d.comprNAOK && d.region !== 'inadequate')
+                  return (
+                    <tr key={`${bm.id}-${k}`} className={`border-t border-slate-100 ${bad ? 'bg-red-50 text-red-700' : ''}`}>
+                      <td className="py-1 pr-2 font-medium">{k === 0 ? `${bm.id} (${bm.role}, ${f1(bm.L)} m)` : ''}</td>
+                      <td className="py-1 pr-2">{s.label}{s.hogging ? ' (hog)' : ''}</td>
+                      <td className="py-1 pr-2 text-right">{f1(Math.abs(s.Mu))}</td>
+                      <td className="py-1 pr-2 text-right">{f1(s.Vu)}</td>
+                      <td className="py-1 pr-2">{d.mode}</td>
+                      <td className="py-1 pr-2">{d.bars}⌀{model?.sections[0]?.barDia}{d.layers.length > 1 ? ` (${d.layers.join('+')})` : ''}{s.hogging ? ' top' : ''}</td>
+                      <td className="py-1">{d.sAdopt > 0 ? `@${Math.round(d.sAdopt)}` : d.region === 'none' ? 'none' : '⚠'}</td>
+                    </tr>
+                  )
+                }))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Column schedule</h3>
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="text-left uppercase tracking-wide text-slate-500">
+                    <th className="py-1 pr-2 font-semibold">Column</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Pu (kN)</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Mu</th>
+                    <th className="py-1 pr-2 font-semibold">Bars</th>
+                    <th className="py-1 text-right font-semibold">Util</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {design.columns.map((c) => (
+                    <tr key={c.id} className={`border-t border-slate-100 ${c.ok ? '' : 'bg-red-50 text-red-700'}`}>
+                      <td className="py-1 pr-2 font-medium">{c.id}</td>
+                      <td className="py-1 pr-2 text-right">{f1(c.Pu)}</td>
+                      <td className="py-1 pr-2 text-right">{f1(c.Mu)}</td>
+                      <td className="py-1 pr-2">{c.bars}⌀{model?.sections[0]?.barDia} · ties @{Math.round(c.tieSpacing)}</td>
+                      <td className="py-1 text-right">{(c.util * 100).toFixed(0)}%</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Footing schedule</h3>
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="text-left uppercase tracking-wide text-slate-500">
+                    <th className="py-1 pr-2 font-semibold">Node</th>
+                    <th className="py-1 pr-2 text-right font-semibold">P / Pu (kN)</th>
+                    <th className="py-1 pr-2 font-semibold">Plan</th>
+                    <th className="py-1 pr-2 font-semibold">Dc</th>
+                    <th className="py-1 font-semibold">Steel</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {design.footings.map((f) => (
+                    <tr key={f.node} className={`border-t border-slate-100 ${f.ok ? '' : 'bg-red-50 text-red-700'}`}>
+                      <td className="py-1 pr-2 font-medium">{f.node}</td>
+                      <td className="py-1 pr-2 text-right">{f1(f.P)} / {f1(f.Pu)}</td>
+                      <td className="py-1 pr-2">B = {f2(f.design.B)} m</td>
+                      <td className="py-1 pr-2">{Math.round(f.design.Dc)} mm</td>
+                      <td className="py-1">{f.design.bars}⌀{model?.sections[0]?.barDia} @ {Math.round(f.design.barSpacing)} e.w.</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <p className="text-xs text-slate-400">
+            Pipeline: slab area loads → tributary line loads → 3D frame FEM (governing NSCP combo) → beam/girder
+            critical sections (SRRB/DRRB) → column P–M → base reactions → isolated footings. Open any standalone
+            page for the full worked solution of a given element.
+          </p>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Sixth milestone of the 3D roadmap: **design down the load path**, every stage reusing the engines already built.

> If #143 (Phase 5) is still open this PR is stacked on it — merge #143 first and GitHub retargets this one to `main`.

## `engine/pipeline.ts` — `designStructure(model, soil)`
For the governing NSCP combination:
1. **Bridge + 3D FEM** (`modelToFrame3D` → `analyzeFrame3D`), plus a **service-gravity solve** (D, L, Lr, S, R at 1.0) for the footing bearing check.
2. **Beams & girders** — critical sections per member (both ends + the interior |Mz| peak, **signed**: negative = hogging → top steel) → `designBeam` per section (SRRB/DRRB, layered bars, stirrups).
3. **Columns** — `Pu` = max compression from N(x), `Mu` = member Mmax → `designAxialColumn` (bars + §425.7.2 ties) then `capacityAtEccentricity` along e = Mu/Pu, capped by the 0.80Po ceiling → **utilisation**.
4. **Footings** — service P + factored Pu per base support → `designSquareFooting`.
5. **Concrete totals** (members + slabs).

## Model space
Soil inputs (qa, H) + **🏗 Design structure**: renders the **beam & girder schedule** (per-section Mu/Vu, mode, bars+layers, stirrups, hogging tagged), the **column schedule** (Pu/Mu, bars, ties, utilisation %) and the **footing schedule** (P/Pu, B, Dc, steel) — red rows on any failed check. Schedules invalidate when the model changes.

## Verification (5 tests, 145 total — all passed first run)
On a 1-bay × 1-storey grid with D+L slab loads: full element coverage under 1.2D+1.6L governance; every beam section designs cleanly with **sagging interior moments**; **column ΣPu ≈ the floor load** (within frame-shear tolerance) with util ≤ 1; footing **service < factored** and ΣPu reproducing `q_u·A` exactly; concrete totals matching hand geometry (34 m of members × 0.15 m² + 30 m² × 0.15 m slab).

The roadmap's core promise — model → analyze → design every section following the load path — now runs end to end. Remaining (Phase 7): walls/drift/deflection checks, NSCP 208 lateral load generator, per-element worked-solution report stitching, legacy retirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)