### PR TITLE
Phase 7: NSCP 208 seismic loads, storey drift check + printable report

### DIFF
--- a/webapp/src/engine/seismic.test.ts
+++ b/webapp/src/engine/seismic.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { computeSeismic, storeyWeights, driftCheck } from './seismic'
+import { generateGridModel } from './modelBuilder'
+import { modelToFrame3D } from './modelBridge'
+import { solveFrame3D, applyF3Combo } from './frame3d'
+import type { RectSection } from './model'
+
+const section: RectSection = { id: 'S1', name: '300×500', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
+
+function makeModel() {
+  const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3, 3], section })
+  m.loads = m.plates.map((p) => ({ kind: 'area' as const, plate: p.id, q: 5, cat: 'D' as const }))
+  return m
+}
+// Zone 4 / soil SD-ish parameters
+const params = { Ca: 0.44, Cv: 0.64, I: 1.0, R: 8.5, dir: 'x' as const }
+
+describe('storey weights', () => {
+  it('slab dead + beams at level + half columns above/below', () => {
+    const m = makeModel()
+    const ws = storeyWeights(m)
+    expect(ws.map((s) => s.elevation)).toEqual([3, 6])
+    const aSec = 0.3 * 0.5
+    const beams = (2 * 6 + 2 * 5) * aSec * 24          // 22 m per level
+    const colHalf = 4 * 3 * aSec * 24 / 2              // 4 columns × 3 m, half
+    // level 1: slab + beams + half cols below + half cols above
+    expect(ws[0].w).toBeCloseTo(5 * 30 + beams + 2 * colHalf, 6)
+    // roof: slab + beams + half cols below only
+    expect(ws[1].w).toBeCloseTo(5 * 30 + beams + colHalf, 6)
+  })
+})
+
+describe('NSCP 208 static lateral force', () => {
+  const m = makeModel()
+  const r = computeSeismic(m, params)!
+
+  it('period and base shear with the 2.5CaIW/R cap', () => {
+    expect(r.hn).toBe(6)
+    expect(r.T).toBeCloseTo(0.0731 * Math.pow(6, 0.75), 9)
+    expect(r.Vraw).toBeCloseTo((0.64 * r.W) / (8.5 * r.T), 6)
+    expect(r.Vmax).toBeCloseTo((2.5 * 0.44 * r.W) / 8.5, 6)
+    // short building → raw exceeds the cap → V = Vmax
+    expect(r.Vraw).toBeGreaterThan(r.Vmax)
+    expect(r.V).toBeCloseTo(r.Vmax, 9)
+  })
+
+  it('Ft = 0 for T ≤ 0.7 s and ΣFx = V', () => {
+    expect(r.T).toBeLessThan(0.7)
+    expect(r.Ft).toBe(0)
+    const sum = r.storeys.reduce((s, q) => s + q.Fx, 0)
+    expect(sum).toBeCloseTo(r.V, 6)
+    // distribution ∝ w·h → roof share > lower level share only if w·h larger
+    const f1 = r.storeys[0], f2 = r.storeys[1]
+    expect(f2.Fx / f1.Fx).toBeCloseTo((f2.wx * 6) / (f1.wx * 3), 6)
+  })
+
+  it('node loads carry category E and split per level node count', () => {
+    expect(r.loads.every((l) => l.cat === 'E' && l.kind === 'node')).toBe(true)
+    const lvl1 = r.loads.filter((l) => l.kind === 'node' && m.nodes.find((n) => n.id === l.node)!.y === 3)
+    expect(lvl1).toHaveLength(4)
+    const sum1 = lvl1.reduce((s, l) => s + ((l as { Fx?: number }).Fx ?? 0), 0)
+    expect(sum1).toBeCloseTo(r.storeys[0].Fx, 6)
+  })
+
+  it('tall-building branch: Ft = 0.07TV when T > 0.7 s', () => {
+    const tall = generateGridModel({ baysX: [6], baysZ: [5], storeyH: Array(12).fill(3), section })
+    tall.loads = tall.plates.map((p) => ({ kind: 'area' as const, plate: p.id, q: 5, cat: 'D' as const }))
+    const rt = computeSeismic(tall, params)!
+    expect(rt.T).toBeGreaterThan(0.7)
+    expect(rt.Ft).toBeCloseTo(Math.min(0.07 * rt.T * rt.V, 0.25 * rt.V), 9)
+    expect(rt.storeys.reduce((s, q) => s + q.Fx, 0)).toBeCloseTo(rt.V, 4)
+  })
+})
+
+describe('drift check', () => {
+  it('ΔM = 0.7RΔs against the elastic frame solution', () => {
+    const m = makeModel()
+    const seis = computeSeismic(m, params)!
+    m.loads = [...m.loads, ...seis.loads]
+    const br = modelToFrame3D(m)
+    const eOnly = applyF3Combo(br.loads, { E: 1 })
+    const sol = solveFrame3D(br.nodes, br.members, br.supports, eOnly)!
+    const rows = driftCheck(m, br.nodes, sol.d, params.R, seis.T, 'x')
+    expect(rows).toHaveLength(2)
+    for (const row of rows) {
+      expect(row.ds).toBeGreaterThan(0)
+      expect(row.dM).toBeCloseTo(0.7 * params.R * row.ds, 9)
+      expect(row.limit).toBeCloseTo(0.025 * row.hs, 9)   // T < 0.7 s
+      expect(row.ok).toBe(row.dM <= row.limit + 1e-9)
+    }
+  })
+})

--- a/webapp/src/engine/seismic.ts
+++ b/webapp/src/engine/seismic.ts
@@ -1,0 +1,155 @@
+// ─────────────────────────────────────────────────────────────────────────
+// NSCP 2015 §208 (UBC-97) static lateral force procedure + storey drift —
+// Phase 7 of the 3D roadmap.
+//   T = Ct·hn^(3/4)                  (Ct = 0.0731 for RC moment frames, m)
+//   V = Cv·I·W / (R·T)               2.5·Ca·I·W/R ≥ V ≥ 0.11·Ca·I·W
+//   Ft = 0.07·T·V ≤ 0.25·V  (T > 0.7 s, else 0)
+//   Fx = (V − Ft)·wx·hx / Σ(w·h)     (+Ft at the roof)
+// Seismic weight W: slab dead area loads + member self-weight (beams at the
+// level, half of the columns above & below). The generated forces are NODE
+// loads with category 'E', split across the level's nodes, so the existing
+// NSCP combinations (1.2D+1.0E+L+0.2S, 0.9D+1.0E) pick them up unchanged.
+// Drift: Δs from the elastic results, ΔM = 0.7·R·Δs ≤ 0.025·hs (T < 0.7 s)
+// or 0.020·hs otherwise.
+// ─────────────────────────────────────────────────────────────────────────
+import type { StructuralModel, ModelLoad } from './model'
+
+export interface SeismicParams {
+  Ca: number; Cv: number
+  I: number; R: number
+  Ct?: number               // default 0.0731 (RC moment frame, metres)
+  dir: 'x' | 'z'
+}
+
+export interface StoreyForce {
+  elevation: number; hx: number; wx: number; Fx: number; nodes: number
+}
+
+export interface SeismicResult {
+  hn: number; T: number; W: number
+  Vraw: number; Vmax: number; Vmin: number; V: number
+  Ft: number
+  storeys: StoreyForce[]
+  loads: ModelLoad[]        // node loads, cat 'E'
+}
+
+const GAMMA_C = 24 // kN/m³
+
+/** Seismic weight per elevated level: slab dead loads + member self-weight. */
+export function storeyWeights(model: StructuralModel): { elevation: number; w: number }[] {
+  const nm = new Map(model.nodes.map((n) => [n.id, n]))
+  const sec = model.sections[0]
+  const aSec = sec ? (sec.b / 1000) * (sec.h / 1000) : 0
+  const levels = [...new Set(model.storeys.map((s) => s.elevation))].sort((a, b) => a - b)
+  const w = new Map<number, number>(levels.map((e) => [e, 0]))
+  const closest = (y: number) => levels.reduce((best, e) => (Math.abs(e - y) < Math.abs(best - y) ? e : best), levels[0])
+
+  // slabs: dead area loads × panel area
+  for (const p of model.plates) {
+    const c = p.corners.map((id) => nm.get(id))
+    if (c.some((q) => !q)) continue
+    const [c0, c1, , c3] = c as { x: number; y: number; z: number }[]
+    const lx = Math.hypot(c1.x - c0.x, c1.y - c0.y, c1.z - c0.z)
+    const lz = Math.hypot(c3.x - c0.x, c3.y - c0.y, c3.z - c0.z)
+    const lvl = closest(c0.y)
+    const qD = model.loads
+      .filter((l) => l.kind === 'area' && l.plate === p.id && l.cat === 'D')
+      .reduce((s, l) => s + (l as { q: number }).q, 0)
+    w.set(lvl, (w.get(lvl) ?? 0) + qD * lx * lz)
+  }
+  // members: beams/girders at their level; columns half up, half down
+  for (const m of model.members) {
+    const a = nm.get(m.i), b = nm.get(m.j)
+    if (!a || !b) continue
+    const L = Math.hypot(b.x - a.x, b.y - a.y, b.z - a.z)
+    const wSelf = aSec * L * GAMMA_C
+    if (m.role === 'column') {
+      const top = Math.max(a.y, b.y), bot = Math.min(a.y, b.y)
+      const topLvl = levels.includes(top) ? top : closest(top)
+      w.set(topLvl, (w.get(topLvl) ?? 0) + wSelf / 2)
+      if (levels.includes(bot)) w.set(bot, (w.get(bot) ?? 0) + wSelf / 2)
+      // lower half of ground-storey columns goes to the foundation, not W
+    } else {
+      const lvl = closest(a.y)
+      w.set(lvl, (w.get(lvl) ?? 0) + wSelf)
+    }
+  }
+  return levels.map((e) => ({ elevation: e, w: w.get(e) ?? 0 }))
+}
+
+export function computeSeismic(model: StructuralModel, p: SeismicParams): SeismicResult | null {
+  const storeyW = storeyWeights(model)
+  if (storeyW.length === 0) return null
+  const hn = Math.max(...storeyW.map((s) => s.elevation))
+  const W = storeyW.reduce((s, q) => s + q.w, 0)
+  if (!(hn > 0) || !(W > 0)) return null
+
+  const Ct = p.Ct ?? 0.0731
+  const T = Ct * Math.pow(hn, 0.75)
+  const Vraw = (p.Cv * p.I * W) / (p.R * T)
+  const Vmax = (2.5 * p.Ca * p.I * W) / p.R
+  const Vmin = 0.11 * p.Ca * p.I * W
+  const V = Math.max(Vmin, Math.min(Vraw, Vmax))
+  const Ft = T > 0.7 ? Math.min(0.07 * T * V, 0.25 * V) : 0
+
+  const sumWH = storeyW.reduce((s, q) => s + q.w * q.elevation, 0)
+  const top = hn
+  const nodesAt = (e: number) => model.nodes.filter((n) => Math.abs(n.y - e) < 1e-6)
+
+  const storeys: StoreyForce[] = storeyW.map((s) => {
+    const Fx = sumWH > 0 ? ((V - Ft) * s.w * s.elevation) / sumWH + (Math.abs(s.elevation - top) < 1e-9 ? Ft : 0) : 0
+    return { elevation: s.elevation, hx: s.elevation, wx: s.w, Fx, nodes: nodesAt(s.elevation).length }
+  })
+
+  const loads: ModelLoad[] = []
+  for (const s of storeys) {
+    const nodes = nodesAt(s.elevation)
+    if (nodes.length === 0 || Math.abs(s.Fx) < 1e-9) continue
+    const per = s.Fx / nodes.length
+    for (const n of nodes) {
+      loads.push(p.dir === 'x'
+        ? { kind: 'node', node: n.id, Fx: per, cat: 'E' }
+        : { kind: 'node', node: n.id, Fz: per, cat: 'E' })
+    }
+  }
+
+  return { hn, T, W, Vraw, Vmax, Vmin, V, Ft, storeys, loads }
+}
+
+// ── Storey drift (NSCP 208.5.10) ─────────────────────────────────────────
+export interface DriftRow {
+  elevation: number; hs: number
+  ds: number     // elastic storey drift Δs, mm
+  dM: number     // inelastic ΔM = 0.7·R·Δs, mm
+  limit: number  // 0.025·hs (T < 0.7 s) or 0.020·hs, mm
+  ok: boolean
+}
+
+/**
+ * Drift from a frame3d solution: `d` are the global DOFs in the order of
+ * `nodeOrder` (6/node); displacement component 0 = x, 2 = z.
+ */
+export function driftCheck(
+  model: StructuralModel, nodeOrder: { id: string; y: number }[], d: number[],
+  R: number, T: number, dir: 'x' | 'z',
+): DriftRow[] {
+  const comp = dir === 'x' ? 0 : 2
+  const levels = [0, ...[...new Set(model.storeys.map((s) => s.elevation))].sort((a, b) => a - b)]
+  const maxU = new Map<number, number>(levels.map((e) => [e, 0]))
+  nodeOrder.forEach((n, i) => {
+    const lvl = levels.find((e) => Math.abs(e - n.y) < 1e-6)
+    if (lvl === undefined) return
+    const u = Math.abs(d[6 * i + comp]) * 1000   // mm
+    if (u > (maxU.get(lvl) ?? 0)) maxU.set(lvl, u)
+  })
+  const ratio = T < 0.7 ? 0.025 : 0.020
+  const rows: DriftRow[] = []
+  for (let k = 1; k < levels.length; k++) {
+    const hs = (levels[k] - levels[k - 1]) * 1000
+    const ds = (maxU.get(levels[k]) ?? 0) - (maxU.get(levels[k - 1]) ?? 0)
+    const dM = 0.7 * R * ds
+    const limit = ratio * hs
+    rows.push({ elevation: levels[k], hs, ds, dM, limit, ok: dM <= limit + 1e-9 })
+  }
+  return rows
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -9,6 +9,9 @@ import { distributePanel } from '../engine/tributary'
 import { modelToFrame3D } from '../engine/modelBridge'
 import { analyzeFrame3D, type F3Analysis } from '../engine/frame3d'
 import { designStructure, type StructureDesign } from '../engine/pipeline'
+import { computeSeismic, driftCheck, type SeismicResult, type DriftRow } from '../engine/seismic'
+import { solveFrame3D, applyF3Combo } from '../engine/frame3d'
+import { ReportControls } from '../components/ReportControls'
 import { Diagram } from '../components/Diagram'
 import { Num, Card, ResultCard, Row } from '../components/qty'
 import { f1, f2 } from '../lib/format'
@@ -87,6 +90,12 @@ export default function ModelSpace() {
   const [qD, setQD] = useState(4.8); const [qL, setQL] = useState(2.4)
   // Soil (for the footing stage of the design pipeline)
   const [qa, setQa] = useState(200); const [Hf, setHf] = useState(1.5)
+  // Seismic (NSCP 208 static lateral force)
+  const [Ca, setCa] = useState(0.44); const [Cv, setCv] = useState(0.64)
+  const [Rw, setRw] = useState(8.5); const [Ie, setIe] = useState(1.0)
+  const [eDir, setEDir] = useState<'x' | 'z'>('x')
+  const [seis, setSeis] = useState<SeismicResult | null>(null)
+  const [drift, setDrift] = useState<DriftRow[] | null>(null)
 
   const [model, setModel] = useState<StructuralModel | null>(() => {
     try {
@@ -104,6 +113,7 @@ export default function ModelSpace() {
     setModel(m)
     setAnalysis(null)             // geometry changed — results are stale
     setDesign(null)
+    setDrift(null)
     try {
       if (m) sessionStorage.setItem(AUTOSAVE_KEY, JSON.stringify(m))
       else sessionStorage.removeItem(AUTOSAVE_KEY)
@@ -115,6 +125,21 @@ export default function ModelSpace() {
     const br = modelToFrame3D(model)
     setOrphans(br.orphanEdges.length)
     setAnalysis(analyzeFrame3D(br.nodes, br.members, br.supports, br.loads))
+    // Storey drift from the E-only elastic solution (NSCP 208.5.10).
+    if (seis) {
+      const eOnly = applyF3Combo(br.loads, { E: 1 })
+      const sol = eOnly.length ? solveFrame3D(br.nodes, br.members, br.supports, eOnly) : null
+      setDrift(sol ? driftCheck(model, br.nodes, sol.d, Rw, seis.T, eDir) : null)
+    } else setDrift(null)
+  }
+
+  const generateE = () => {
+    if (!model) return
+    const r = computeSeismic(model, { Ca, Cv, I: Ie, R: Rw, dir: eDir })
+    if (!r) return
+    setSeis(r)
+    // replace any previous E node loads with the new set
+    save({ ...model, loads: [...model.loads.filter((l) => !(l.cat === 'E' && l.kind === 'node')), ...r.loads] })
   }
 
   const runPipeline = () => {
@@ -139,6 +164,7 @@ export default function ModelSpace() {
       ...(qL > 0 ? [{ kind: 'area' as const, plate: p.id, q: qL, cat: 'L' as const }] : []),
     ])
     setSelected(null)
+    setSeis(null)
     save(m)
   }
 
@@ -190,9 +216,10 @@ export default function ModelSpace() {
       <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">3D Model Space</h1>
       <p className="no-print mt-1 text-slate-600">
         Generate a building frame on a column grid — beams, girders, columns and slab panels with categorised
-        area loads — orbit it in 3D, click any element to inspect or delete it, and save/load the model as JSON.
-        Phase 4 of the roadmap; the 3D solver (Phase 5) and the design pipeline (Phase 6) consume this model.
+        area loads — orbit it in 3D, analyze it (3D FEM, NSCP combos, seismic E loads + drift), design every
+        element down the load path, and print the schedules as a report.
       </p>
+      <ReportControls title="Structure Design Report" />
 
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1fr_2fr]">
         <div className="space-y-5">
@@ -222,6 +249,33 @@ export default function ModelSpace() {
             <Num label="q live" unit="kPa" value={qL} onChange={setQL} />
             <Num label="Soil qa" unit="kPa" value={qa} onChange={setQa} />
             <Num label="Footing depth H" unit="m" value={Hf} onChange={setHf} />
+          </Card>
+
+          <Card title="Seismic — NSCP 208 static force">
+            <Num label="Ca" value={Ca} onChange={setCa} />
+            <Num label="Cv" value={Cv} onChange={setCv} />
+            <Num label="R" value={Rw} onChange={setRw} />
+            <Num label="I" value={Ie} onChange={setIe} />
+            <label className="flex flex-col text-sm">
+              <span className="mb-1 font-medium text-slate-600">Direction</span>
+              <select value={eDir} onChange={(e) => setEDir(e.target.value as 'x' | 'z')}
+                className="rounded-md border border-slate-300 px-2.5 py-1.5">
+                <option value="x">X</option><option value="z">Z</option>
+              </select>
+            </label>
+            <div className="col-span-full">
+              <button type="button" onClick={generateE} disabled={!model}
+                className="no-print rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50 disabled:opacity-40">
+                ⚡ Generate E loads
+              </button>
+              {seis && (
+                <p className="mt-1 text-xs text-slate-500">
+                  T = {seis.T.toFixed(3)} s · W = {f1(seis.W)} kN · V = {f1(seis.V)} kN
+                  {seis.V === seis.Vmax ? ' (2.5CaIW/R cap governs)' : seis.V === seis.Vmin ? ' (0.11CaIW floor governs)' : ''}
+                  {seis.Ft > 0 ? ` · Ft = ${f1(seis.Ft)} kN` : ''} — applied as cat-E node loads ({eDir.toUpperCase()}).
+                </p>
+              )}
+            </div>
           </Card>
 
           <div className="no-print flex flex-wrap gap-2">
@@ -271,6 +325,20 @@ export default function ModelSpace() {
             </ResultCard>
           )}
 
+          {drift && seis && (
+            <ResultCard title={`Storey drift — ${eDir.toUpperCase()} (ΔM = 0.7·R·Δs)`}>
+              {drift.map((row) => (
+                <Row key={row.elevation} alert={!row.ok}
+                  label={`Level ${f1(row.elevation)} m`}
+                  value={`ΔM = ${row.dM.toFixed(1)} mm ${row.ok ? '✓' : '✗'}`}
+                  sub={`Δs ${row.ds.toFixed(2)} · limit ${row.limit.toFixed(0)} mm`} />
+              ))}
+              <p className="mt-1 text-[11px] text-slate-400">
+                Limit {seis.T < 0.7 ? '0.025' : '0.020'}·hs (T {seis.T < 0.7 ? '<' : '≥'} 0.7 s) — NSCP 208.5.10.
+              </p>
+            </ResultCard>
+          )}
+
           {selMember && model && (
             <ResultCard title={`Member — ${selMember.id}`}>
               <Row label="Role" value={selMember.role} />
@@ -315,7 +383,7 @@ export default function ModelSpace() {
           )}
         </div>
 
-        <div className="h-[560px] overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+        <div className="no-print h-[560px] overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
           {model ? (
             <Canvas camera={{ position: [14, 11, 14], fov: 45 }} onPointerMissed={() => setSelected(null)}>
               <color attach="background" args={['#f8fafc']} />
@@ -359,7 +427,7 @@ export default function ModelSpace() {
             </span>
           </h2>
 
-          <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="print-avoid-break overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Beam & girder schedule</h3>
             <table className="w-full border-collapse text-xs">
               <thead>
@@ -394,7 +462,7 @@ export default function ModelSpace() {
           </div>
 
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="print-avoid-break overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
               <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Column schedule</h3>
               <table className="w-full border-collapse text-xs">
                 <thead>
@@ -420,7 +488,7 @@ export default function ModelSpace() {
               </table>
             </div>
 
-            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="print-avoid-break overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
               <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Footing schedule</h3>
               <table className="w-full border-collapse text-xs">
                 <thead>


### PR DESCRIPTION
Final roadmap phase: the lateral story.

## `engine/seismic.ts` — NSCP 2015 §208 static force procedure
- `T = Ct·hn^¾` (Ct = 0.0731, RC moment frames); `V = Cv·I·W/(R·T)` bounded by **2.5·Ca·I·W/R** above and **0.11·Ca·I·W** below; `Ft = min(0.07TV, 0.25V)` when T > 0.7 s; vertical distribution `Fx = (V−Ft)·wx·hx/Σwh` (+Ft at the roof).
- **Seismic weight from the model itself**: slab dead area loads + beam/girder self-weight at each level + half the columns above & below.
- Forces are emitted as **category-E node loads** split across each level's nodes — so the existing NSCP combinations (`1.2D+1.0E+L+0.2S`, `0.9D+1.0E`) pick them up with **zero new machinery**, the same architecture rule as the tributary engine.
- `driftCheck()`: storey Δs from the **E-only elastic** solution, ΔM = 0.7·R·Δs vs 0.025·hs (T < 0.7 s) / 0.020·hs — NSCP 208.5.10.

## Model space
- **Seismic card** (Ca, Cv, R, I, direction X/Z) + **⚡ Generate E loads** — replaces prior E loads, reports T/W/V (flagging which bound governs) and Ft.
- **Analyze** now also runs the E-only solve and renders the **per-storey drift table** (red rows on failure).
- **ReportControls** added; the 3D viewport is excluded from print, so Print/Save-PDF produces the structure report: combos, reactions, drift, and the beam/column/footing schedules.

## Verification (6 tests, 151 total — all first-run passes)
Storey-weight hand check; V hitting the 2.5CaIW/R cap on a short building; Ft = 0 with ΣFx = V and the w·h-proportional split; per-level node-load partition; the **tall-building Ft branch** (12 storeys, T > 0.7 s); and drift ΔM = 0.7RΔs verified against the elastic frame solution end-to-end (model → seismic loads → bridge → FEM → drift).

With this, the roadmap is complete: **model → gravity + seismic loads → 3D FEM with NSCP combos → drift check → design every element down the load path → printable report**, with every stage testable and reused from the standalone tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)