### PR TITLE
Seismic Zone-4 base shear floor (208-11), f₁ live-load switch, P-Δ second order

### DIFF
--- a/webapp/src/engine/beamAnalysis.test.ts
+++ b/webapp/src/engine/beamAnalysis.test.ts
@@ -1,5 +1,18 @@
 import { describe, it, expect } from 'vitest'
-import { solveFEM, analyzeBeam, threeMoment, type Support, type BeamLoad } from './beamAnalysis'
+import { solveFEM, analyzeBeam, threeMoment, nscpCombos, NSCP_COMBOS, type Support, type BeamLoad } from './beamAnalysis'
+
+describe('NSCP §203.3.1 — f₁ live-load factor', () => {
+  it('f₁ scales L in eqs 203-3/4/5 only; default export is the 1.0 set', () => {
+    const c1 = nscpCombos(1.0), c05 = nscpCombos(0.5)
+    expect(c1).toHaveLength(7)
+    expect(c05[1].f.L).toBe(1.6)                         // 203-2 always 1.6L
+    expect(c1[2].f.L).toBe(1.0); expect(c05[2].f.L).toBe(0.5)   // 203-3
+    expect(c1[3].f.L).toBe(1.0); expect(c05[3].f.L).toBe(0.5)   // 203-4
+    expect(c1[5].f.L).toBe(1.0); expect(c05[5].f.L).toBe(0.5)   // 203-5 (seismic)
+    expect(c05[4].f.L).toBeUndefined()                  // 203-6 (0.9D+1.0W) has no L
+    expect(NSCP_COMBOS[2].f.L).toBe(1.0)                // conservative default
+  })
+})
 
 const E = 25000      // MPa
 const I = 3.125e9    // mm⁴ (≈ 250×500 gross)

--- a/webapp/src/engine/beamAnalysis.ts
+++ b/webapp/src/engine/beamAnalysis.ts
@@ -26,15 +26,28 @@ export interface FemResult {
 }
 
 export interface Combo { name: string; f: Partial<Record<LoadCategory, number>> }
-export const NSCP_COMBOS: Combo[] = [
-  { name: '1.4D', f: { D: 1.4 } },
-  { name: '1.2D + 1.6L + 0.5(Lr|S|R)', f: { D: 1.2, L: 1.6, Lr: 0.5, S: 0.5, R: 0.5 } },
-  { name: '1.2D + 1.6(Lr|S|R) + (L|0.5W)', f: { D: 1.2, Lr: 1.6, S: 1.6, R: 1.6, L: 1.0, W: 0.5 } },
-  { name: '1.2D + 1.0W + L + 0.5(Lr|S|R)', f: { D: 1.2, W: 1.0, L: 1.0, Lr: 0.5, S: 0.5, R: 0.5 } },
-  { name: '0.9D + 1.0W', f: { D: 0.9, W: 1.0 } },
-  { name: '1.2D + 1.0E + L + 0.2S', f: { D: 1.2, E: 1.0, L: 1.0, S: 0.2 } },
-  { name: '0.9D + 1.0E', f: { D: 0.9, E: 1.0 } },
-]
+
+/**
+ * NSCP 2015 §203.3.1 strength-design (LRFD) combinations, eqs (203-1)…(203-7).
+ * The live-load factor f₁ (eqs 203-3, 203-4, 203-5) is **1.0** for floors of
+ * public assembly, live loads > 4.8 kPa, and garages; **0.5** otherwise.
+ * (S is carried for ASCE-7 parity but is zero in the Philippines — no snow.)
+ */
+export function nscpCombos(f1 = 1.0): Combo[] {
+  const lf = f1 === 1 ? '1.0L' : `${f1}L`
+  return [
+    { name: '1.4D', f: { D: 1.4 } },                                                          // 203-1
+    { name: '1.2D + 1.6L + 0.5(Lr|S|R)', f: { D: 1.2, L: 1.6, Lr: 0.5, S: 0.5, R: 0.5 } },     // 203-2
+    { name: `1.2D + 1.6(Lr|S|R) + (${lf}|0.5W)`, f: { D: 1.2, Lr: 1.6, S: 1.6, R: 1.6, L: f1, W: 0.5 } }, // 203-3
+    { name: `1.2D + 1.0W + ${lf} + 0.5(Lr|S|R)`, f: { D: 1.2, W: 1.0, L: f1, Lr: 0.5, S: 0.5, R: 0.5 } }, // 203-4
+    { name: '0.9D + 1.0W', f: { D: 0.9, W: 1.0 } },                                            // 203-6
+    { name: `1.2D + 1.0E + ${lf} + 0.2S`, f: { D: 1.2, E: 1.0, L: f1, S: 0.2 } },              // 203-5
+    { name: '0.9D + 1.0E', f: { D: 0.9, E: 1.0 } },                                            // 203-7
+  ]
+}
+
+/** Default combination set (f₁ = 1.0 — conservative for ordinary occupancies). */
+export const NSCP_COMBOS: Combo[] = nscpCombos(1.0)
 
 import { solveLinear } from './fem'
 

--- a/webapp/src/engine/frame3d.test.ts
+++ b/webapp/src/engine/frame3d.test.ts
@@ -130,3 +130,50 @@ describe('frame3d — full model bridge (grid + slab loads)', () => {
     expect(sumRy).toBeCloseTo(wu * area, 1)
   })
 })
+
+describe('frame3d — P-Δ second order (vertical cantilever, L = 4)', () => {
+  const L = 4
+  const colNodes = [{ id: 'base', x: 0, y: 0, z: 0 }, { id: 'top', x: 0, y: L, z: 0 }] as F3Node[]
+  const colMem = [{ id: 'c', i: 'base', j: 'top', ...sec }] as F3Member[]
+  const sup = [{ node: 'base', fixity: 'fixed' }] as F3Support[]
+  const H = 10
+  const lat: F3Load[] = [{ kind: 'node', node: 'top', Fx: H, cat: 'D' }]
+
+  // first-order lateral drift (exact for a tip point load — cubic Hermite)
+  const lin = solveFrame3D(colNodes, colMem, sup, lat)!
+  const d1 = Math.abs(lin.d[6 + 0])
+  // effective Euler buckling load of the cantilever from the linear stiffness
+  const EIeff = (H * L ** 3) / (3 * d1)
+  const Pe = (Math.PI ** 2 * EIeff) / (4 * L ** 2)
+
+  it('compression amplifies drift ≈ 1/(1−P/Pe) and converges', () => {
+    const P = 0.25 * Pe
+    const r = solveFrame3D(colNodes, colMem, sup,
+      [...lat, { kind: 'node', node: 'top', Fy: -P, cat: 'D' }], { pDelta: true })!
+    const d2 = Math.abs(r.d[6 + 0])
+    expect(d2).toBeGreaterThan(d1)
+    // one-element consistent Pcr is within ~1% of π²EI/4L², so the amplifier matches
+    expect(d2 / d1).toBeCloseTo(1 / (1 - 0.25), 1)
+  })
+
+  it('tension stiffens the column (drift below first order)', () => {
+    const P = 0.25 * Pe
+    const r = solveFrame3D(colNodes, colMem, sup,
+      [...lat, { kind: 'node', node: 'top', Fy: +P, cat: 'D' }], { pDelta: true })!
+    expect(Math.abs(r.d[6 + 0])).toBeLessThan(d1)
+  })
+
+  it('negligible axial → P-Δ collapses to the first-order result', () => {
+    const r = solveFrame3D(colNodes, colMem, sup,
+      [...lat, { kind: 'node', node: 'top', Fy: -1e-3 * Pe, cat: 'D' }], { pDelta: true })!
+    expect(Math.abs(r.d[6 + 0]) / d1).toBeCloseTo(1, 2)   // within 0.5% of linear
+  })
+
+  it('base moment is amplified in step with the drift', () => {
+    const P = 0.25 * Pe
+    const r = solveFrame3D(colNodes, colMem, sup,
+      [...lat, { kind: 'node', node: 'top', Fy: -P, cat: 'D' }], { pDelta: true })!
+    // second-order base moment = H·L + P·Δ > first-order H·L
+    expect(Math.abs(r.members[0].My[0])).toBeGreaterThan(H * L)
+  })
+})

--- a/webapp/src/engine/frame3d.ts
+++ b/webapp/src/engine/frame3d.ts
@@ -10,7 +10,10 @@
 // Units: coordinates m; E,G MPa; A mm²; I,J mm⁴; forces kN, kN·m.
 // ─────────────────────────────────────────────────────────────────────────
 import { solveLinear, matVec, hermite, gauss5Vec } from './fem'
-import { NSCP_COMBOS, type Combo, type LoadCategory } from './beamAnalysis'
+import { nscpCombos, type Combo, type LoadCategory } from './beamAnalysis'
+
+/** Second-order (P-Δ) options for the frame solve. */
+export interface PDeltaOpts { pDelta?: boolean; maxIter?: number; tol?: number }
 
 export interface F3Node { id: string; x: number; y: number; z: number }
 export interface F3Member {
@@ -86,6 +89,27 @@ function kLocal(EA: number, GJ: number, EIy: number, EIz: number, L: number): nu
   set(4, 4, cy); set(4, 8, by); set(4, 10, dy)
   set(8, 8, ay); set(8, 10, by)
   set(10, 10, cy)
+  return k
+}
+
+/** Local 12×12 geometric (initial-stress) stiffness for member axial force N
+ *  (tension positive): adds stiffness in tension, removes it in compression —
+ *  the basis of the P-Δ second-order iteration. Axial and torsion DOFs carry
+ *  none; the two bending planes mirror kLocal's sign convention. */
+function kgLocal(N: number, L: number): number[][] {
+  const k = Array.from({ length: 12 }, () => new Array(12).fill(0))
+  const set = (r: number, c: number, v: number) => { k[r][c] = v; k[c][r] = v }
+  const a = (6 * N) / (5 * L), b = N / 10, c = (2 * N * L) / 15, e = -(N * L) / 30
+  // x′-y′ plane (uy, θz at 1,5,7,11)
+  set(1, 1, a); set(1, 5, b); set(1, 7, -a); set(1, 11, b)
+  set(5, 5, c); set(5, 7, -b); set(5, 11, e)
+  set(7, 7, a); set(7, 11, -b)
+  set(11, 11, c)
+  // x′-z′ plane (uz, θy at 2,4,8,10) — mirrored coupling signs
+  set(2, 2, a); set(2, 4, -b); set(2, 8, -a); set(2, 10, -b)
+  set(4, 4, c); set(4, 8, b); set(4, 10, e)
+  set(8, 8, a); set(8, 10, b)
+  set(10, 10, c)
   return k
 }
 
@@ -200,6 +224,7 @@ function prepMember(m: F3Member, nm: Map<string, F3Node>, idx: Map<string, numbe
 
 export function solveFrame3D(
   nodes: F3Node[], members: F3Member[], supports: F3Support[], loads: F3Load[],
+  opts?: PDeltaOpts,
 ): F3Result | null {
   const nm = new Map(nodes.map((n) => [n.id, n]))
   const idx = new Map(nodes.map((n, i) => [n.id, i]))
@@ -232,11 +257,39 @@ export function solveFrame3D(
   const free: number[] = []
   for (let d0 = 0; d0 < ndof; d0++) if (!constrained.has(d0)) free.push(d0)
   const d = new Array(ndof).fill(0)
-  if (free.length > 0) {
-    const Kff = free.map((i) => free.map((j) => K[i][j]))
-    const dF = solveLinear(Kff, free.map((i) => F[i]))
-    if (dF === null) return null
-    free.forEach((dof, k) => (d[dof] = dF[k]))
+  const solveFree = (Mat: number[][]): number[] | null => {
+    if (free.length === 0) return []
+    const Mff = free.map((i) => free.map((j) => Mat[i][j]))
+    return solveLinear(Mff, free.map((i) => F[i]))
+  }
+  // First-order (linear elastic) solve.
+  const d0 = solveFree(K)
+  if (d0 === null) return null
+  free.forEach((dof, k) => (d[dof] = d0[k]))
+
+  // Second-order: iterate K + Kg(N) where N is each member's current axial
+  // force (tension +), re-solving until the displacements settle. A singular
+  // tangent (det → 0) signals elastic instability — keep the last solution.
+  if (opts?.pDelta && free.length > 0) {
+    const maxIter = opts.maxIter ?? 20
+    const tol = opts.tol ?? 1e-5
+    for (let it = 0; it < maxIter; it++) {
+      const Kt = K.map((row) => row.slice())
+      for (const pr of preps) {
+        const de = pr.dofs.map((dof) => d[dof])
+        const dl = matVec(pr.T, de)
+        const f = matVec(pr.kl, dl).map((v, k) => v - pr.feq[k])
+        const N = (f[6] - f[0]) / 2                       // representative axial, tension +
+        const kgg = mul(mul(transpose(pr.T), kgLocal(N, pr.L)), pr.T)
+        for (let a = 0; a < 12; a++) for (let b = 0; b < 12; b++) Kt[pr.dofs[a]][pr.dofs[b]] += kgg[a][b]
+      }
+      const dn = solveFree(Kt)
+      if (dn === null) break                              // instability — retain last d
+      let num = 0, den = 0
+      free.forEach((dof, k) => { num += (dn[k] - d[dof]) ** 2; den += dn[k] ** 2 })
+      free.forEach((dof, k) => (d[dof] = dn[k]))
+      if (den === 0 || Math.sqrt(num / den) < tol) break
+    }
   }
 
   const R = matVec(K, d).map((v, i) => v - F[i])
@@ -322,15 +375,21 @@ export function solveFrame3D(
 export interface F3ComboRun { combo: Combo; result: F3Result | null; factored: F3Load[]; skipped: boolean }
 export interface F3Analysis { perCombo: F3ComboRun[]; govIdx: number }
 
+export interface F3AnalyzeOpts extends PDeltaOpts {
+  /** NSCP §203.3.1 live-load factor f₁ (1.0 assembly/garage/Lo>4.8 kPa, else 0.5). */
+  f1?: number
+}
+
 export function analyzeFrame3D(
   nodes: F3Node[], members: F3Member[], supports: F3Support[], loads: F3Load[],
+  opts?: F3AnalyzeOpts,
 ): F3Analysis | null {
   const perCombo: F3ComboRun[] = []
   let govIdx = -1, govM = -1
-  for (const combo of NSCP_COMBOS) {
+  for (const combo of nscpCombos(opts?.f1 ?? 1.0)) {
     const factored = applyF3Combo(loads, combo.f)
     if (factored.length === 0) { perCombo.push({ combo, result: null, factored, skipped: true }); continue }
-    const r = solveFrame3D(nodes, members, supports, factored)
+    const r = solveFrame3D(nodes, members, supports, factored, opts)
     perCombo.push({ combo, result: r, factored, skipped: false })
     if (r && r.Mmax > govM) { govM = r.Mmax; govIdx = perCombo.length - 1 }
   }

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -19,6 +19,14 @@ export interface SoilOptions {
   qAllow: number; gammaSoil: number; gammaConc: number; H: number
 }
 
+/** Analysis options threaded into the frame solve. */
+export interface AnalyzeOptions {
+  /** NSCP §203.3.1 live-load factor f₁ (1.0 / 0.5). */
+  f1?: number
+  /** Run the second-order P-Δ iteration. */
+  pDelta?: boolean
+}
+
 export interface BeamSectionDesign {
   label: string; Mu: number; Vu: number; hogging: boolean
   design: BeamDesignResult
@@ -86,12 +94,14 @@ function memberSections(mr: F3MemberResult): { label: string; x: number; Mu: num
   return out
 }
 
-export function designStructure(model: StructuralModel, soil: SoilOptions, plan: FootingPlan = {}): StructureDesign | null {
+export function designStructure(
+  model: StructuralModel, soil: SoilOptions, plan: FootingPlan = {}, opts: AnalyzeOptions = {},
+): StructureDesign | null {
   const sec: RectSection | undefined = model.sections[0]
   if (!sec) return null
 
   const br = modelToFrame3D(model)
-  const analysis = analyzeFrame3D(br.nodes, br.members, br.supports, br.loads)
+  const analysis = analyzeFrame3D(br.nodes, br.members, br.supports, br.loads, opts)
   if (!analysis) return null
   const gov = analysis.perCombo[analysis.govIdx]
   const govRes = gov.result
@@ -101,12 +111,12 @@ export function designStructure(model: StructuralModel, soil: SoilOptions, plan:
   // D-only / L-only solves so combined footings get their dl/ll split.
   const serviceLoads = applyF3Combo(br.loads, { D: 1, L: 1, Lr: 1, S: 1, R: 1 })
   const serviceRes: F3Result | null = serviceLoads.length
-    ? solveFrame3D(br.nodes, br.members, br.supports, serviceLoads)
+    ? solveFrame3D(br.nodes, br.members, br.supports, serviceLoads, opts)
     : null
   const dLoads = applyF3Combo(br.loads, { D: 1 })
   const lLoads = applyF3Combo(br.loads, { L: 1 })
-  const dRes = dLoads.length ? solveFrame3D(br.nodes, br.members, br.supports, dLoads) : null
-  const lRes = lLoads.length ? solveFrame3D(br.nodes, br.members, br.supports, lLoads) : null
+  const dRes = dLoads.length ? solveFrame3D(br.nodes, br.members, br.supports, dLoads, opts) : null
+  const lRes = lLoads.length ? solveFrame3D(br.nodes, br.members, br.supports, lLoads, opts) : null
   const dAt = new Map<string, number>()
   const lAt = new Map<string, number>()
   govRes.reactions.forEach((r, i) => {
@@ -262,12 +272,13 @@ const withSection = (model: StructuralModel, sec: RectSection): StructuralModel 
  */
 export function optimizeStructure(
   model: StructuralModel, soil: SoilOptions, plan: FootingPlan = {}, maxIter = 24,
+  opts: AnalyzeOptions = {},
 ): OptimizeResult | null {
   if (!model.sections[0]) return null
   let sec: RectSection = { ...model.sections[0] }
   const steps: OptimizeStep[] = []
 
-  let design = designStructure(withSection(model, sec), soil, plan)
+  let design = designStructure(withSection(model, sec), soil, plan, opts)
   if (!design) return null
   steps.push({ b: sec.b, h: sec.h, fails: countFails(design), ok: designOK(design) })
 
@@ -277,7 +288,7 @@ export function optimizeStructure(
     if (sec.h >= 3 * sec.b) sec = { ...sec, b: sec.b + 50, name: '' }
     else sec = { ...sec, h: sec.h + 50, name: '' }
     sec.name = `${sec.b}×${sec.h}`
-    const d = designStructure(withSection(model, sec), soil, plan)
+    const d = designStructure(withSection(model, sec), soil, plan, opts)
     if (!d) break
     design = d
     steps.push({ b: sec.b, h: sec.h, fails: countFails(design), ok: designOK(design) })
@@ -287,7 +298,7 @@ export function optimizeStructure(
   // shrink back while still passing (find the lean edge)
   while (converged && sec.h - 25 >= 300) {
     const trial: RectSection = { ...sec, h: sec.h - 25, name: `${sec.b}×${sec.h - 25}` }
-    const d = designStructure(withSection(model, trial), soil, plan)
+    const d = designStructure(withSection(model, trial), soil, plan, opts)
     if (!d || !designOK(d)) break
     sec = trial
     design = d

--- a/webapp/src/engine/seismic.test.ts
+++ b/webapp/src/engine/seismic.test.ts
@@ -72,6 +72,27 @@ describe('NSCP 208 static lateral force', () => {
   })
 })
 
+describe('NSCP 208-11 — Seismic Zone 4 base shear floor', () => {
+  it('0.8·Z·Nv·I·W/R governs a long-period building near a fault', () => {
+    const tall = generateGridModel({ baysX: [6], baysZ: [5], storeyH: Array(12).fill(3), section })
+    tall.loads = tall.plates.map((p) => ({ kind: 'area' as const, plate: p.id, q: 5, cat: 'D' as const }))
+    const base = computeSeismic(tall, params)!                       // no Z → floor disabled
+    const z4 = computeSeismic(tall, { ...params, Z: 0.4, Nv: 2.0 })! // near-source Zone 4
+    const expected = (0.8 * 0.4 * 2.0 * params.I * z4.W) / params.R
+    expect(z4.Vsrc).toBeCloseTo(expected, 6)
+    expect(z4.Vsrc).toBeGreaterThan(z4.Vmin)
+    expect(z4.Vsrc).toBeGreaterThan(z4.Vraw)                          // raw shear below the floor
+    expect(z4.V).toBeCloseTo(z4.Vsrc, 6)                              // 208-11 governs
+    expect(base.Vsrc).toBe(0)                                         // disabled without Z
+    expect(z4.V).toBeGreaterThan(base.V)                              // floor raised the design shear
+  })
+
+  it('floor is inactive outside Zone 4 (Z < 0.4)', () => {
+    const r = computeSeismic(makeModel(), { ...params, Z: 0.2, Nv: 1.5 })!
+    expect(r.Vsrc).toBe(0)
+  })
+})
+
 describe('drift check', () => {
   it('ΔM = 0.7RΔs against the elastic frame solution', () => {
     const m = makeModel()

--- a/webapp/src/engine/seismic.ts
+++ b/webapp/src/engine/seismic.ts
@@ -17,6 +17,8 @@ import type { StructuralModel, ModelLoad } from './model'
 export interface SeismicParams {
   Ca: number; Cv: number
   I: number; R: number
+  Z?: number                // seismic zone factor (0.4 = Zone 4); enables eq 208-11
+  Nv?: number               // near-source velocity factor (default 1.0)
   Ct?: number               // default 0.0731 (RC moment frame, metres)
   dir: 'x' | 'z'
 }
@@ -27,7 +29,7 @@ export interface StoreyForce {
 
 export interface SeismicResult {
   hn: number; T: number; W: number
-  Vraw: number; Vmax: number; Vmin: number; V: number
+  Vraw: number; Vmax: number; Vmin: number; Vsrc: number; V: number
   Ft: number
   storeys: StoreyForce[]
   loads: ModelLoad[]        // node loads, cat 'E'
@@ -87,9 +89,11 @@ export function computeSeismic(model: StructuralModel, p: SeismicParams): Seismi
   const Ct = p.Ct ?? 0.0731
   const T = Ct * Math.pow(hn, 0.75)
   const Vraw = (p.Cv * p.I * W) / (p.R * T)
-  const Vmax = (2.5 * p.Ca * p.I * W) / p.R
-  const Vmin = 0.11 * p.Ca * p.I * W
-  const V = Math.max(Vmin, Math.min(Vraw, Vmax))
+  const Vmax = (2.5 * p.Ca * p.I * W) / p.R          // 208-9 upper bound
+  const Vmin = 0.11 * p.Ca * p.I * W                  // 208-10 lower bound
+  // 208-11: in Seismic Zone 4 the base shear shall also be ≥ 0.8·Z·Nv·I·W/R.
+  const Vsrc = (p.Z ?? 0) >= 0.4 ? (0.8 * (p.Z ?? 0.4) * (p.Nv ?? 1.0) * p.I * W) / p.R : 0
+  const V = Math.max(Vmin, Vsrc, Math.min(Vraw, Vmax))
   const Ft = T > 0.7 ? Math.min(0.07 * T * V, 0.25 * V) : 0
 
   const sumWH = storeyW.reduce((s, q) => s + q.w * q.elevation, 0)
@@ -113,7 +117,7 @@ export function computeSeismic(model: StructuralModel, p: SeismicParams): Seismi
     }
   }
 
-  return { hn, T, W, Vraw, Vmax, Vmin, V, Ft, storeys, loads }
+  return { hn, T, W, Vraw, Vmax, Vmin, Vsrc, V, Ft, storeys, loads }
 }
 
 // ── Storey drift (NSCP 208.5.10) ─────────────────────────────────────────

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -93,9 +93,13 @@ export default function ModelSpace() {
   // Seismic (NSCP 208 static lateral force)
   const [Ca, setCa] = useState(0.44); const [Cv, setCv] = useState(0.64)
   const [Rw, setRw] = useState(8.5); const [Ie, setIe] = useState(1.0)
+  const [Zf, setZf] = useState(0.4); const [Nv, setNv] = useState(1.0)   // Zone factor + near-source (208-11)
   const [eDir, setEDir] = useState<'x' | 'z'>('x')
   const [seis, setSeis] = useState<SeismicResult | null>(null)
   const [drift, setDrift] = useState<DriftRow[] | null>(null)
+  // Analysis options: f₁ live-load factor (§203.3.1) and P-Δ second order
+  const [assembly, setAssembly] = useState(false)
+  const [pDelta, setPDelta] = useState(false)
 
   const [model, setModel] = useState<StructuralModel | null>(() => {
     try {
@@ -127,22 +131,26 @@ export default function ModelSpace() {
     } catch { /* quota — ignore */ }
   }
 
+  // §203.3.1: f₁ = 1.0 for assembly/garage or live load > 4.8 kPa, else 0.5.
+  const fLive = assembly || qL > 4.8 ? 1.0 : 0.5
+  const anaOpts = { f1: fLive, pDelta }
+
   const analyze = () => {
     if (!model) return
     const br = modelToFrame3D(model)
     setOrphans(br.orphanEdges.length)
-    setAnalysis(analyzeFrame3D(br.nodes, br.members, br.supports, br.loads))
+    setAnalysis(analyzeFrame3D(br.nodes, br.members, br.supports, br.loads, anaOpts))
     // Storey drift from the E-only elastic solution (NSCP 208.5.10).
     if (seis) {
       const eOnly = applyF3Combo(br.loads, { E: 1 })
-      const sol = eOnly.length ? solveFrame3D(br.nodes, br.members, br.supports, eOnly) : null
+      const sol = eOnly.length ? solveFrame3D(br.nodes, br.members, br.supports, eOnly, { pDelta }) : null
       setDrift(sol ? driftCheck(model, br.nodes, sol.d, Rw, seis.T, eDir) : null)
     } else setDrift(null)
   }
 
   const generateE = () => {
     if (!model) return
-    const r = computeSeismic(model, { Ca, Cv, I: Ie, R: Rw, dir: eDir })
+    const r = computeSeismic(model, { Ca, Cv, I: Ie, R: Rw, Z: Zf, Nv, dir: eDir })
     if (!r) return
     setSeis(r)
     // replace any previous E node loads with the new set
@@ -161,12 +169,12 @@ export default function ModelSpace() {
   const runPipeline = () => {
     if (!model) return
     setOpt(null)
-    setDesign(designStructure(model, soil, footingPlan()))
+    setDesign(designStructure(model, soil, footingPlan(), anaOpts))
   }
 
   const optimize = () => {
     if (!model) return
-    const r = optimizeStructure(model, soil, footingPlan())
+    const r = optimizeStructure(model, soil, footingPlan(), 24, anaOpts)
     if (!r) return
     // adopt the optimised section in the model + the grid inputs
     const m2 = { ...model, sections: [r.section] }
@@ -339,6 +347,8 @@ export default function ModelSpace() {
             <Num label="Cv" value={Cv} onChange={setCv} />
             <Num label="R" value={Rw} onChange={setRw} />
             <Num label="I" value={Ie} onChange={setIe} />
+            <Num label="Z (zone)" value={Zf} onChange={setZf} />
+            <Num label="Nv (near-source)" value={Nv} onChange={setNv} />
             <label className="flex flex-col text-sm">
               <span className="mb-1 font-medium text-slate-600">Direction</span>
               <select value={eDir} onChange={(e) => setEDir(e.target.value as 'x' | 'z')}
@@ -354,11 +364,30 @@ export default function ModelSpace() {
               {seis && (
                 <p className="mt-1 text-xs text-slate-500">
                   T = {seis.T.toFixed(3)} s · W = {f1(seis.W)} kN · V = {f1(seis.V)} kN
-                  {seis.V === seis.Vmax ? ' (2.5CaIW/R cap governs)' : seis.V === seis.Vmin ? ' (0.11CaIW floor governs)' : ''}
+                  {seis.V === seis.Vmax ? ' (2.5CaIW/R cap governs)'
+                    : seis.Vsrc > 0 && seis.V === seis.Vsrc ? ' (Zone-4 0.8ZNvIW/R floor governs)'
+                    : seis.V === seis.Vmin ? ' (0.11CaIW floor governs)' : ''}
                   {seis.Ft > 0 ? ` · Ft = ${f1(seis.Ft)} kN` : ''} — applied as cat-E node loads ({eDir.toUpperCase()}).
+                  {Zf >= 0.4 ? ` Zone-4 floor = ${f1(seis.Vsrc)} kN.` : ' (Zone-4 floor off: Z < 0.4)'}
                 </p>
               )}
             </div>
+          </Card>
+
+          <Card title="Analysis options">
+            <label className="col-span-full flex items-center gap-2 text-sm">
+              <input type="checkbox" checked={assembly} onChange={(e) => setAssembly(e.target.checked)} />
+              <span>Public assembly / garage (f₁ = 1.0)</span>
+            </label>
+            <label className="col-span-full flex items-center gap-2 text-sm">
+              <input type="checkbox" checked={pDelta} onChange={(e) => setPDelta(e.target.checked)} />
+              <span>P-Δ second-order analysis</span>
+            </label>
+            <p className="col-span-full text-[11px] text-slate-500">
+              §203.3.1 live-load factor f₁ = <b>{fLive.toFixed(1)}</b>
+              {fLive === 1 ? (assembly ? ' (assembly/garage)' : ' (Lo > 4.8 kPa)') : ' (ordinary occupancy)'}.
+              {pDelta ? ' Frame solved with the geometric-stiffness P-Δ iteration.' : ' First-order (linear) frame solve.'}
+            </p>
           </Card>
 
           <div className="no-print flex flex-wrap gap-2">


### PR DESCRIPTION
Implements the three gaps found in the NSCP-2015 accuracy audit (verified directly against the code PDF). Scope: the quick code-compliance fixes + P-Δ (the "recommended stop").

## 1. NSCP eq (208-11) — Seismic Zone 4 base shear floor
The audit confirmed the engine enforced only the 208-9 cap and 208-10 floor (`0.11CaIW`), but **not** the Zone-4 near-source minimum `V ≥ 0.8·Z·Nv·I·W/R`. Verified verbatim on NSCP p. 2-214.
- `computeSeismic` now takes optional `Z` and `Nv`; `V = max(Vmin, Vsrc, min(Vraw, Vmax))`.
- `SeismicResult.Vsrc` reports the floor (0 when `Z < 0.4`, i.e. outside Zone 4).

## 2. §203.3.1 live-load factor f₁
The combos hardcoded the live-load factor at 1.0; the code uses **f₁ = 0.5** for ordinary occupancies, 1.0 only for assembly / garage / Lo > 4.8 kPa (verified on p. 2-11). Using 1.0 everywhere was conservative but oversized members.
- `nscpCombos(f1)` builds the set with the correct f₁ in eqs 203-3/4/5; `NSCP_COMBOS` stays as the conservative `f1 = 1.0` default for existing callers.

## 3. P-Δ second-order analysis
The frame solver was first-order only. Added a geometric-stiffness P-Δ iteration.
- `kgLocal(N, L)` — 12-DOF geometric (initial-stress) stiffness, tension positive: stiffens in tension, softens in compression.
- `solveFrame3D(..., PDeltaOpts)` iterates `K + Kg(N)`, re-deriving each member's axial force from the current displacements until they settle (a singular tangent → elastic instability, last solution retained).
- `analyzeFrame3D` accepts `{ f1, pDelta }`; `designStructure` / `optimizeStructure` thread `AnalyzeOptions` through the governing, service and D/L-only solves.

## UI
- Seismic card: `Z` / `Nv` inputs and a Zone-4-floor readout (shows which bound governs).
- New **Analysis options** card: "Public assembly / garage (f₁ = 1.0)" and "P-Δ second-order" toggles, with a live f₁ readout; wired into Analyze, Design and Optimize.

## Tests (+7, 165 total)
- Zone-4 floor governs a long-period building near a fault; inert for `Z < 0.4`.
- f₁ scales L only in eqs 203-3/4/5; default export stays 1.0.
- P-Δ: compression amplifies drift ≈ `1/(1−P/Pe)` and converges; tension stiffens; negligible axial collapses to first order; base moment amplifies in step with the drift.

Build clean, full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)