### PR TITLE
Wind loads — NSCP §207B directional procedure (MWFRS)

### DIFF
--- a/webapp/src/engine/wind.test.ts
+++ b/webapp/src/engine/wind.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { computeWind, windKz, cpLeeward } from './wind'
+import { generateGridModel } from './modelBuilder'
+import { modelToFrame3D } from './modelBridge'
+import { solveFrame3D, applyF3Combo } from './frame3d'
+import type { RectSection } from './model'
+
+const section: RectSection = { id: 'S1', name: '300×500', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
+
+describe('NSCP 207B.3 — velocity-pressure exposure coefficient Kz', () => {
+  it('matches the printed Table 207B.3-1 values (Note-1 formula)', () => {
+    // Exposure C: table gives 0.85 (≤4.5 m), 0.98 (9 m), 1.09 (15 m)
+    expect(windKz(4.5, 'C')).toBeCloseTo(0.85, 2)
+    expect(windKz(9, 'C')).toBeCloseTo(0.98, 2)
+    expect(windKz(15, 'C')).toBeCloseTo(1.09, 2)
+    // Exposure B at ≤4.5 m → 0.57; Exposure D at 9 m → 1.16
+    expect(windKz(4.5, 'B')).toBeCloseTo(0.57, 2)
+    expect(windKz(9, 'D')).toBeCloseTo(1.16, 2)
+  })
+  it('floors below 4.5 m and caps at the gradient height', () => {
+    expect(windKz(2, 'C')).toBe(windKz(4.5, 'C'))
+    expect(windKz(1000, 'C')).toBeCloseTo(2.01, 6)     // z ≥ zg → Kz = 2.01
+  })
+})
+
+describe('NSCP Figure 207B.4-1 — leeward wall Cp(L/B)', () => {
+  it('−0.5 (≤1), −0.3 (=2), −0.2 (≥4), linear between', () => {
+    expect(cpLeeward(0.5)).toBe(-0.5)
+    expect(cpLeeward(1)).toBe(-0.5)
+    expect(cpLeeward(2)).toBeCloseTo(-0.3, 9)
+    expect(cpLeeward(3)).toBeCloseTo(-0.25, 9)
+    expect(cpLeeward(4)).toBeCloseTo(-0.2, 9)
+    expect(cpLeeward(8)).toBe(-0.2)
+  })
+})
+
+describe('NSCP 207B.4 — MWFRS directional wind on a frame', () => {
+  const makeModel = () => generateGridModel({ baysX: [6, 6], baysZ: [5], storeyH: [3.5, 3], section })
+  const params = { V: 50, exposure: 'C' as const, dir: 'x' as const }
+
+  it('qz, pressures and per-level forces follow 207B.3-1 / 207B.4-1', () => {
+    const m = makeModel()
+    const r = computeWind(m, params)!
+    expect(r.h).toBeCloseTo(6.5, 9)
+    expect(r.B).toBeCloseTo(5, 9)          // across-wind (z extent)
+    expect(r.L).toBeCloseTo(12, 9)         // along-wind (x extent)
+    expect(r.LB).toBeCloseTo(12 / 5, 9)
+    // qh = 0.613·Kz(h)·Kd·V² /1000, Kzt = 1
+    const qhExp = (0.613 * windKz(6.5, 'C') * 0.85 * 50 ** 2) / 1000
+    expect(r.qh).toBeCloseTo(qhExp, 9)
+    // windward pressure at a level = qz·G·0.8
+    const lvl = r.levels[0]
+    expect(lvl.pWind).toBeCloseTo(lvl.qz * 0.85 * 0.8, 9)
+    expect(lvl.pLee).toBeCloseTo(r.qh * 0.85 * Math.abs(r.CpLee), 9)
+    // two elevated levels; tributary heights cover mid-storey-1 upward
+    expect(r.levels).toHaveLength(2)
+    expect(r.levels[0].tribH).toBeCloseTo(1.75 + 1.5, 9)
+    expect(r.levels[1].tribH).toBeCloseTo(1.5, 9)
+  })
+
+  it('emits category-W node loads that sum to the base shear', () => {
+    const r = computeWind(makeModel(), params)!
+    expect(r.loads.every((l) => l.cat === 'W' && l.kind === 'node')).toBe(true)
+    const sumLoads = r.loads.reduce((s, l) => s + ((l as { Fx?: number }).Fx ?? 0), 0)
+    expect(sumLoads).toBeCloseTo(r.baseShear, 6)
+    expect(r.baseShear).toBeGreaterThan(0)
+  })
+
+  it('base shear scales with V² and the frame equilibrates the wind loads', () => {
+    const m = makeModel()
+    const r1 = computeWind(m, { ...params, V: 40 })!
+    const r2 = computeWind(m, { ...params, V: 80 })!
+    expect(r2.baseShear / r1.baseShear).toBeCloseTo(4, 6)   // (80/40)² = 4
+
+    // apply the W loads and confirm ΣFx reaction balances the base shear
+    m.loads = r2.loads
+    const br = modelToFrame3D(m)
+    const wOnly = applyF3Combo(br.loads, { W: 1 })
+    const sol = solveFrame3D(br.nodes, br.members, br.supports, wOnly)!
+    const sumRx = sol.reactions.reduce((s, q) => s + q.F[0], 0)
+    expect(sumRx).toBeCloseTo(-r2.baseShear, 4)
+    // no spurious vertical/transverse reactions from a pure along-wind (X) load
+    expect(sol.reactions.reduce((s, q) => s + q.F[2], 0)).toBeCloseTo(0, 4)
+  })
+
+  it('Z-direction wind swaps the along/across dimensions', () => {
+    const r = computeWind(makeModel(), { ...params, dir: 'z' })!
+    expect(r.B).toBeCloseTo(12, 9)   // across-wind now the x extent
+    expect(r.L).toBeCloseTo(5, 9)
+    expect(r.loads.every((l) => (l as { Fz?: number }).Fz !== undefined)).toBe(true)
+  })
+})

--- a/webapp/src/engine/wind.ts
+++ b/webapp/src/engine/wind.ts
@@ -1,0 +1,118 @@
+// ─────────────────────────────────────────────────────────────────────────
+// NSCP 2015 §207B Directional Procedure — MWFRS wind loads for enclosed
+// rigid buildings of all heights.
+//   Velocity pressure   qz = 0.613·Kz·Kzt·Kd·V²   (N/m², V in m/s)   (207B.3-1)
+//   Kz = 2.01·(z/zg)^(2/α), z floored at 4.5 m, capped at zg          (Table 207B.3-1, Note 1)
+//   Design pressure     p = q·G·Cp − qi·(GCpi)     (N/m²)            (207B.4-1)
+//     q  = qz (windward, varies with height); qh (leeward/side, at roof h)
+//     Cp = +0.8 windward, leeward −0.5/−0.3/−0.2 by L/B (Figure 207B.4-1)
+//     G  = 0.85 (rigid, §207A.9);  Kd = 0.85 (Table 207A.6-1)
+// For the lateral (along-wind) MWFRS the internal pressure GCpi acts equally
+// on windward and leeward faces and cancels in the horizontal sum, so the net
+// storey force uses only the external windward + leeward wall pressures. The
+// forces are emitted as NODE loads (category 'W') split across each level's
+// nodes — the existing NSCP combinations (1.2D+1.0W+…, 0.9D+1.0W) pick them up.
+// (Roof uplift, side-wall and components-&-cladding pressures are out of scope.)
+// ─────────────────────────────────────────────────────────────────────────
+import type { StructuralModel, ModelLoad } from './model'
+
+export interface WindParams {
+  V: number                  // basic wind speed, m/s (§207A.5)
+  exposure: 'B' | 'C' | 'D'
+  Kzt?: number               // topographic factor (default 1.0, §207A.8)
+  Kd?: number                // directionality factor (default 0.85, Table 207A.6-1)
+  G?: number                 // gust-effect factor (default 0.85 rigid, §207A.9)
+  dir: 'x' | 'z'
+}
+
+export interface WindLevel {
+  elevation: number; Kz: number; qz: number   // qz in kN/m²
+  pWind: number; pLee: number                  // kN/m² (= q·G·Cp, leeward as magnitude)
+  tribH: number; Fx: number                    // kN net horizontal force at the level
+  nodes: number
+}
+
+export interface WindResult {
+  V: number; h: number; B: number; L: number; LB: number
+  Kd: number; G: number; qh: number; CpLee: number
+  levels: WindLevel[]
+  baseShear: number
+  loads: ModelLoad[]         // node loads, cat 'W'
+}
+
+/** Exposure constants (Table 207A.9-1): power-law exponent α, gradient height zg (m). */
+const EXPO: Record<string, { a: number; zg: number }> = {
+  B: { a: 7.0, zg: 365.76 },
+  C: { a: 9.5, zg: 274.32 },
+  D: { a: 11.5, zg: 213.36 },
+}
+
+/** Velocity-pressure exposure coefficient Kz (Table 207B.3-1, Note 1):
+ *  Kz = 2.01·(z/zg)^(2/α), with z floored at 4.5 m and capped at zg. */
+export function windKz(z: number, exposure: 'B' | 'C' | 'D'): number {
+  const { a, zg } = EXPO[exposure]
+  const zz = Math.min(Math.max(z, 4.5), zg)
+  return 2.01 * (zz / zg) ** (2 / a)
+}
+
+/** Leeward-wall external pressure coefficient Cp (Figure 207B.4-1), a function
+ *  of the along-wind/across-wind ratio L/B: −0.5 (≤1), −0.3 (=2), −0.2 (≥4). */
+export function cpLeeward(LB: number): number {
+  if (LB <= 1) return -0.5
+  if (LB <= 2) return -0.5 + (LB - 1) * 0.2          // −0.5 → −0.3
+  if (LB < 4) return -0.3 + (LB - 2) * 0.05          // −0.3 → −0.2
+  return -0.2
+}
+
+const CP_WIND = 0.8   // windward wall, Figure 207B.4-1
+
+export function computeWind(model: StructuralModel, p: WindParams): WindResult | null {
+  if (model.nodes.length === 0) return null
+  const xs = model.nodes.map((n) => n.x)
+  const ys = model.nodes.map((n) => n.y)
+  const zs = model.nodes.map((n) => n.z)
+  const h = Math.max(...ys)
+  if (!(h > 0)) return null
+  const xr = Math.max(...xs) - Math.min(...xs)
+  const zr = Math.max(...zs) - Math.min(...zs)
+  const B = p.dir === 'x' ? zr : xr                  // across-wind width
+  const L = p.dir === 'x' ? xr : zr                  // along-wind depth
+  if (!(B > 0)) return null
+  const LB = L > 0 ? L / B : 1
+
+  const Kd = p.Kd ?? 0.85, Kzt = p.Kzt ?? 1.0, G = p.G ?? 0.85
+  const q = (z: number) => (0.613 * windKz(z, p.exposure) * Kzt * Kd * p.V ** 2) / 1000 // kN/m²
+  const qh = q(h)
+  const CpLee = cpLeeward(LB)
+  const pLee = qh * G * Math.abs(CpLee)              // leeward suction → adds to along-wind force
+
+  // Diaphragm levels (elevated storeys) with the ground at 0.
+  const elev = [...new Set(model.storeys.map((s) => s.elevation))].sort((a, b) => a - b)
+  const levelsAll = [0, ...elev]
+  const nodesAt = (e: number) => model.nodes.filter((n) => Math.abs(n.y - e) < 1e-6)
+
+  const levels: WindLevel[] = []
+  const loads: ModelLoad[] = []
+  let baseShear = 0
+  for (let k = 1; k < levelsAll.length; k++) {
+    const e = levelsAll[k]
+    const below = levelsAll[k - 1]
+    const above = k + 1 < levelsAll.length ? levelsAll[k + 1] : null
+    const tribH = (e - below) / 2 + (above !== null ? (above - e) / 2 : 0)
+    const qz = q(e)
+    const pWind = qz * G * CP_WIND
+    const F = (pWind + pLee) * B * tribH             // kN, net windward + leeward
+    const nodes = nodesAt(e)
+    levels.push({ elevation: e, Kz: windKz(e, p.exposure), qz, pWind, pLee, tribH, Fx: F, nodes: nodes.length })
+    baseShear += F
+    if (nodes.length > 0 && F > 1e-9) {
+      const per = F / nodes.length
+      for (const n of nodes) {
+        loads.push(p.dir === 'x'
+          ? { kind: 'node', node: n.id, Fx: per, cat: 'W' }
+          : { kind: 'node', node: n.id, Fz: per, cat: 'W' })
+      }
+    }
+  }
+  return { V: p.V, h, B, L, LB, Kd, G, qh, CpLee, levels, baseShear, loads }
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -10,6 +10,7 @@ import { modelToFrame3D } from '../engine/modelBridge'
 import { analyzeFrame3D, type F3Analysis } from '../engine/frame3d'
 import { designStructure, optimizeStructure, type StructureDesign, type FootingPlan, type OptimizeResult } from '../engine/pipeline'
 import { computeSeismic, driftCheck, type SeismicResult, type DriftRow } from '../engine/seismic'
+import { computeWind, type WindResult } from '../engine/wind'
 import { solveFrame3D, applyF3Combo } from '../engine/frame3d'
 import { ReportControls } from '../components/ReportControls'
 import { Diagram } from '../components/Diagram'
@@ -97,6 +98,10 @@ export default function ModelSpace() {
   const [eDir, setEDir] = useState<'x' | 'z'>('x')
   const [seis, setSeis] = useState<SeismicResult | null>(null)
   const [drift, setDrift] = useState<DriftRow[] | null>(null)
+  // Wind (NSCP 207B directional procedure, MWFRS)
+  const [Vw, setVw] = useState(50); const [expo, setExpo] = useState<'B' | 'C' | 'D'>('C')
+  const [Kzt, setKzt] = useState(1.0); const [wDir, setWDir] = useState<'x' | 'z'>('x')
+  const [wind, setWind] = useState<WindResult | null>(null)
   // Analysis options: f₁ live-load factor (§203.3.1) and P-Δ second order
   const [assembly, setAssembly] = useState(false)
   const [pDelta, setPDelta] = useState(false)
@@ -155,6 +160,15 @@ export default function ModelSpace() {
     setSeis(r)
     // replace any previous E node loads with the new set
     save({ ...model, loads: [...model.loads.filter((l) => !(l.cat === 'E' && l.kind === 'node')), ...r.loads] })
+  }
+
+  const generateW = () => {
+    if (!model) return
+    const r = computeWind(model, { V: Vw, exposure: expo, Kzt, dir: wDir })
+    if (!r) return
+    setWind(r)
+    // replace any previous W node loads with the new set
+    save({ ...model, loads: [...model.loads.filter((l) => !(l.cat === 'W' && l.kind === 'node')), ...r.loads] })
   }
 
   const soil = { qAllow: qa, gammaSoil: 18, gammaConc: 24, H: Hf }
@@ -255,6 +269,7 @@ export default function ModelSpace() {
     m.loads = buildGravityLoads(m, qD, qL)
     setSelected(null)
     setSeis(null)
+    setWind(null)
     setPlanSel({})
     save(m)
   }
@@ -369,6 +384,40 @@ export default function ModelSpace() {
                     : seis.V === seis.Vmin ? ' (0.11CaIW floor governs)' : ''}
                   {seis.Ft > 0 ? ` · Ft = ${f1(seis.Ft)} kN` : ''} — applied as cat-E node loads ({eDir.toUpperCase()}).
                   {Zf >= 0.4 ? ` Zone-4 floor = ${f1(seis.Vsrc)} kN.` : ' (Zone-4 floor off: Z < 0.4)'}
+                </p>
+              )}
+            </div>
+          </Card>
+
+          <Card title="Wind — NSCP 207B MWFRS (directional)">
+            <Num label="V (basic speed)" unit="m/s" value={Vw} onChange={setVw} />
+            <Num label="Kzt (topographic)" value={Kzt} onChange={setKzt} />
+            <label className="flex flex-col text-sm">
+              <span className="mb-1 font-medium text-slate-600">Exposure</span>
+              <select value={expo} onChange={(e) => setExpo(e.target.value as 'B' | 'C' | 'D')}
+                className="rounded-md border border-slate-300 px-2.5 py-1.5">
+                <option value="B">B (suburban)</option>
+                <option value="C">C (open)</option>
+                <option value="D">D (flat/coastal)</option>
+              </select>
+            </label>
+            <label className="flex flex-col text-sm">
+              <span className="mb-1 font-medium text-slate-600">Direction</span>
+              <select value={wDir} onChange={(e) => setWDir(e.target.value as 'x' | 'z')}
+                className="rounded-md border border-slate-300 px-2.5 py-1.5">
+                <option value="x">X</option><option value="z">Z</option>
+              </select>
+            </label>
+            <div className="col-span-full">
+              <button type="button" onClick={generateW} disabled={!model}
+                className="no-print rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50 disabled:opacity-40">
+                🌬 Generate W loads
+              </button>
+              {wind && (
+                <p className="mt-1 text-xs text-slate-500">
+                  qh = {f2(wind.qh)} kPa · B×L = {f1(wind.B)}×{f1(wind.L)} m (L/B {f2(wind.LB)}) ·
+                  Cp,lee {f2(wind.CpLee)} · base shear V = {f1(wind.baseShear)} kN — applied as cat-W
+                  node loads ({wDir.toUpperCase()}). Windward Cp = 0.8, G = {wind.G}, Kd = {wind.Kd}.
                 </p>
               )}
             </div>


### PR DESCRIPTION
Adds wind loading via the **NSCP 2015 §207B Directional Procedure** for the main wind-force-resisting system of enclosed rigid buildings — the same pattern as the seismic feature (compute → apply as category-`W` node loads → existing combinations carry them).

All core equations were verified directly against the code PDF:

| Provision | Implemented |
|---|---|
| Velocity pressure (207B.3-1) | `qz = 0.613·Kz·Kzt·Kd·V²` (N/m², V in m/s) |
| Kz (Table 207B.3-1, Note 1) | `Kz = 2.01·(z/zg)^(2/α)`, floored at 4.5 m, capped at zg |
| Exposure α, zg (Table 207A.9-1) | B 7.0 / 365.76 m · C 9.5 / 274.32 m · D 11.5 / 213.36 m |
| Design pressure (207B.4-1) | `p = q·G·Cp − qi·(GCpi)` |
| Cp (Figure 207B.4-1) | windward +0.8 (on qz), leeward −0.5/−0.3/−0.2 by L/B (on qh) |
| G, Kd | 0.85 rigid (§207A.9), 0.85 (Table 207A.6-1) |

I checked the printed Kz table (e.g. Exposure C: 0.85 / 0.98 / 1.09 at ≤4.5 / 9 / 15 m) against the Note-1 formula — they agree to two decimals.

**Net MWFRS lateral load.** For the along-wind frame, the internal pressure `GCpi` acts equally on windward and leeward faces and cancels in the horizontal sum, so each storey's net force = (windward `qz·G·0.8` + leeward `qh·G·|Cp|`) × across-wind width × tributary height, lumped to the diaphragm level and split across its nodes as category-`W` loads. The lower half of the ground storey goes to the foundation. (Roof uplift, side-wall and components-&-cladding pressures are intentionally out of scope — this is the lateral MWFRS case.)

**UI.** New "Wind — NSCP 207B MWFRS" card: basic speed `V`, exposure B/C/D, `Kzt`, direction; a Generate W loads button; and a `qh / L-B / Cp,lee / base shear` readout.

**Tests (+7, 172 total):** Kz vs the printed Table 207B.3-1 (plus 4.5 m floor and zg cap); leeward Cp(L/B); qz / pressure / tributary heights per 207B.3-1 & 207B.4-1; W node loads summing to the base shear; base shear ∝ V² with the frame equilibrating `ΣFx = −V` and no spurious transverse reactions; Z-direction swapping the along/across dimensions. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)