### PR TITLE
Directional lateral load cases (+X/−X/+Z/−Z) with per-member envelope

### DIFF
--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import { generateGridModel, buildGravityLoads, removeNode } from './modelBuilder'
-import { designStructure, optimizeStructure, designOK } from './pipeline'
-import type { RectSection } from './model'
+import { designStructure, optimizeStructure, designOK, type LateralCase } from './pipeline'
+import { computeSeismic } from './seismic'
+import type { RectSection, ModelLoad } from './model'
 
 const section: RectSection = { id: 'S1', name: '300×500', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
 const soil = { qAllow: 200, gammaSoil: 18, gammaConc: 24, H: 1.5 }
@@ -100,6 +101,36 @@ describe('combined footing plan', () => {
     expect(c.dl2).toBeGreaterThan(c.ll2)
     expect(c.design.Bx).toBeGreaterThan(c.spacing)  // footing spans both columns
     expect(c.ok).toBe(true)
+  })
+})
+
+describe('directional lateral load cases (STAAD-style envelope)', () => {
+  // four seismic directions, scaled large so lateral governs the columns
+  const dirCases = (): LateralCase[] => {
+    const m = makeModel()
+    const base = computeSeismic(m, { Ca: 0.44, Cv: 0.64, I: 1, R: 8.5, dir: 'x' })!.loads
+    const mag = (l: ModelLoad) => Math.abs((l as { Fx?: number }).Fx ?? 0) * 40
+    const mk = (name: string, axis: 'Fx' | 'Fz', sign: number): LateralCase => ({
+      name, kind: 'E',
+      loads: base.map((l) => ({ kind: 'node', node: (l as { node: string }).node, [axis]: sign * mag(l), cat: 'E' })),
+    })
+    return [mk('E+X', 'Fx', 1), mk('E-X', 'Fx', -1), mk('E+Z', 'Fz', 1), mk('E-Z', 'Fz', -1)]
+  }
+
+  it('expands the two E-combos over four directions (13 runs) and envelopes per member', () => {
+    const r = designStructure(makeModel(), soil, {}, { lateral: dirCases() })!
+    // 7 combos: 2 with E → ×4 = 8; 3 with W (no W cases) → 3; 2 gravity → 2  = 13
+    expect(r.cases).toHaveLength(13)
+    expect(r.cases.some((c) => c.includes('E+X'))).toBe(true)
+    expect(r.cases.some((c) => c.includes('E-Z'))).toBe(true)
+    // a column is governed by a seismic direction, recorded on the row
+    expect(r.columns.some((c) => /E[+-][XZ]/.test(c.gov ?? ''))).toBe(true)
+  })
+
+  it('gravity-only model still runs exactly the 7 NSCP combinations', () => {
+    const r = designStructure(makeModel(), soil)!
+    expect(r.cases).toHaveLength(7)
+    expect(r.beams.every((b) => (b.gov ?? '').length > 0)).toBe(true)
   })
 })
 

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -7,9 +7,10 @@
 //   factored reactions → isolated footing) → concrete totals.
 // Every stage reuses the existing engines unchanged.
 // ─────────────────────────────────────────────────────────────────────────
-import type { StructuralModel, RectSection } from './model'
+import type { StructuralModel, RectSection, ModelLoad } from './model'
 import { modelToFrame3D } from './modelBridge'
-import { analyzeFrame3D, solveFrame3D, applyF3Combo, type F3Result, type F3MemberResult } from './frame3d'
+import { solveFrame3D, applyF3Combo, type F3Result, type F3MemberResult, type F3Load } from './frame3d'
+import { nscpCombos } from './beamAnalysis'
 import { designBeam, type BeamDesignResult } from './beamDesign'
 import { designAxialColumn, capacityAtEccentricity, interaction } from './columnDesign'
 import { designSquareFooting, type SquareFootingResult } from './isolatedFooting'
@@ -19,12 +20,20 @@ export interface SoilOptions {
   qAllow: number; gammaSoil: number; gammaConc: number; H: number
 }
 
+/** A directional lateral load case (one of +X/−X/+Z/−Z for E or W): a set of
+ *  category-E or category-W node loads applied as one primary case. */
+export interface LateralCase { name: string; kind: 'E' | 'W'; loads: ModelLoad[] }
+
 /** Analysis options threaded into the frame solve. */
 export interface AnalyzeOptions {
   /** NSCP §203.3.1 live-load factor f₁ (1.0 / 0.5). */
   f1?: number
   /** Run the second-order P-Δ iteration. */
   pDelta?: boolean
+  /** Directional lateral cases (E/W in ±X/±Z). When given, every combination
+   *  with an E (or W) factor is run once per E (or W) case and the design is
+   *  enveloped per member — STAAD-style. */
+  lateral?: LateralCase[]
 }
 
 export interface BeamSectionDesign {
@@ -35,6 +44,7 @@ export interface BeamScheduleRow {
   id: string; role: string; L: number
   sections: BeamSectionDesign[]
   ok: boolean
+  gov?: string   // governing load case (envelope)
 }
 export interface ColumnScheduleRow {
   id: string; L: number
@@ -42,11 +52,13 @@ export interface ColumnScheduleRow {
   bars: number; phiPn: number; util: number
   tieSpacing: number
   ok: boolean
+  gov?: string
 }
 export interface FootingScheduleRow {
   node: string; P: number; Pu: number
   design: SquareFootingResult
   ok: boolean
+  gov?: string
 }
 export interface CombinedScheduleRow {
   nodes: [string, string]
@@ -60,6 +72,7 @@ export type FootingPlan = Record<string, { type: 'isolated' } | { type: 'combine
 
 export interface StructureDesign {
   govName: string
+  cases: string[]   // every load case (combo × direction) run for the envelope
   beams: BeamScheduleRow[]
   columns: ColumnScheduleRow[]
   footings: FootingScheduleRow[]
@@ -94,82 +107,153 @@ function memberSections(mr: F3MemberResult): { label: string; x: number; Mu: num
   return out
 }
 
+/** Design one beam/girder member from a single run's member result. */
+function designBeamRow(mr: F3MemberResult, role: string, sec: RectSection): BeamScheduleRow {
+  const sections: BeamSectionDesign[] = memberSections(mr)
+    .filter((s) => Math.abs(s.Mu) > 1e-6 || s.Vu > 1e-6)
+    .map((s) => ({
+      label: s.label, Mu: s.Mu, Vu: s.Vu, hogging: s.Mu < 0,
+      design: designBeam({
+        b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia,
+        comprBarDia: 16, stirrupDia: sec.tieDia,
+        fc: sec.fc, fy: sec.fy, Mu: Math.abs(s.Mu), Vu: s.Vu,
+      }),
+    }))
+  return { id: mr.id, role, L: mr.L, sections, ok: sections.every((s) => beamOK(s.design)) }
+}
+
+/** Design one column from a single run's member result. */
+function designColumnRow(mr: F3MemberResult, sec: RectSection): ColumnScheduleRow {
+  const Pu = Math.max(0, -Math.min(...mr.N))           // compression (N < 0)
+  const Mu = mr.Mmax
+  const ax = designAxialColumn({
+    shape: 'tied', b: sec.b, h: sec.h, cover: sec.cover,
+    barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, Pu,
+  })
+  let phiPn = ax.phiPnMax
+  const e = Pu > 1e-9 ? Mu / Pu : 0
+  if (e > 1e-4) {
+    const cap = capacityAtEccentricity(
+      { b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, numBars: ax.bars },
+      e,
+    )
+    const inter = interaction({ b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, numBars: ax.bars })
+    phiPn = Math.min(cap.phi * cap.Pn, 0.65 * inter.PnMax)
+  }
+  const util = phiPn > 1e-9 ? Pu / phiPn : Infinity
+  return {
+    id: mr.id, L: mr.L, Pu, Mu, e, bars: ax.bars, phiPn, util,
+    tieSpacing: ax.tieSpacing, ok: util <= 1 + 1e-9 && ax.rhoOK,
+  }
+}
+
+const beamSeverity = (r: BeamScheduleRow) =>
+  (r.ok ? 0 : 1e9) + Math.max(0, ...r.sections.map((s) => Math.abs(s.Mu)))
+
+interface FrameRun { name: string; result: F3Result }
+
+/** Build the load cases to envelope: every NSCP combination, expanded once per
+ *  directional lateral case (E/W) when the combination carries that factor. */
+function buildRuns(model: StructuralModel, opts: AnalyzeOptions) {
+  // gravity (everything except lateral E/W) is bridged once — includes the
+  // slab tributary line loads and member self-weight; lateral cases are pure
+  // node loads applied on top per direction.
+  const gravityModel = { ...model, loads: model.loads.filter((l) => l.cat !== 'E' && l.cat !== 'W') }
+  const br = modelToFrame3D(gravityModel)
+
+  let lateral = opts.lateral ?? []
+  if (lateral.length === 0) {
+    const eL = model.loads.filter((l) => l.kind === 'node' && l.cat === 'E')
+    const wL = model.loads.filter((l) => l.kind === 'node' && l.cat === 'W')
+    if (eL.length) lateral = [...lateral, { name: 'E', kind: 'E', loads: eL }]
+    if (wL.length) lateral = [...lateral, { name: 'W', kind: 'W', loads: wL }]
+  }
+  const toF3 = (l: ModelLoad): F3Load =>
+    ({ kind: 'node', node: (l as { node: string }).node, Fx: (l as { Fx?: number }).Fx, Fy: (l as { Fy?: number }).Fy, Fz: (l as { Fz?: number }).Fz, cat: l.cat })
+  const eCases = lateral.filter((c) => c.kind === 'E')
+  const wCases = lateral.filter((c) => c.kind === 'W')
+
+  const runs: FrameRun[] = []
+  for (const combo of nscpCombos(opts.f1 ?? 1.0)) {
+    const hasE = (combo.f.E ?? 0) !== 0
+    const hasW = (combo.f.W ?? 0) !== 0
+    const variants: { tag: string; lat: F3Load[] }[] =
+      hasE && eCases.length ? eCases.map((c) => ({ tag: c.name, lat: c.loads.map(toF3) }))
+        : hasW && wCases.length ? wCases.map((c) => ({ tag: c.name, lat: c.loads.map(toF3) }))
+          : [{ tag: '', lat: [] }]
+    for (const v of variants) {
+      const factored = applyF3Combo([...br.loads, ...v.lat], combo.f)
+      if (!factored.length) continue
+      const result = solveFrame3D(br.nodes, br.members, br.supports, factored, opts)
+      if (result) runs.push({ name: combo.name + (v.tag ? ` · ${v.tag}` : ''), result })
+    }
+  }
+  return { br, runs }
+}
+
 export function designStructure(
   model: StructuralModel, soil: SoilOptions, plan: FootingPlan = {}, opts: AnalyzeOptions = {},
 ): StructureDesign | null {
   const sec: RectSection | undefined = model.sections[0]
   if (!sec) return null
 
-  const br = modelToFrame3D(model)
-  const analysis = analyzeFrame3D(br.nodes, br.members, br.supports, br.loads, opts)
-  if (!analysis) return null
-  const gov = analysis.perCombo[analysis.govIdx]
-  const govRes = gov.result
-  if (!govRes) return null
+  const { br, runs } = buildRuns(model, opts)
+  if (runs.length === 0) return null
+  // headline governing run = largest overall bending response
+  let govIdx = 0
+  runs.forEach((r, i) => { if (r.result.Mmax > runs[govIdx].result.Mmax) govIdx = i })
 
-  // Service (unfactored gravity) solve for the footing bearing check, plus
-  // D-only / L-only solves so combined footings get their dl/ll split.
+  // Service (unfactored gravity) + D-only / L-only solves for the footing
+  // bearing check and the combined-footing dl/ll split (direction-independent).
   const serviceLoads = applyF3Combo(br.loads, { D: 1, L: 1, Lr: 1, S: 1, R: 1 })
   const serviceRes: F3Result | null = serviceLoads.length
-    ? solveFrame3D(br.nodes, br.members, br.supports, serviceLoads, opts)
-    : null
+    ? solveFrame3D(br.nodes, br.members, br.supports, serviceLoads, opts) : null
   const dLoads = applyF3Combo(br.loads, { D: 1 })
   const lLoads = applyF3Combo(br.loads, { L: 1 })
   const dRes = dLoads.length ? solveFrame3D(br.nodes, br.members, br.supports, dLoads, opts) : null
   const lRes = lLoads.length ? solveFrame3D(br.nodes, br.members, br.supports, lLoads, opts) : null
+  const serviceAt = (node: string) => {
+    const i = serviceRes?.reactions.findIndex((r) => r.node === node) ?? -1
+    return i >= 0 ? Math.max(0, serviceRes!.reactions[i].F[1]) : 0
+  }
+  const reactAt = (res: F3Result | null, node: string) => {
+    const i = res?.reactions.findIndex((r) => r.node === node) ?? -1
+    return i >= 0 ? Math.max(0, res!.reactions[i].F[1]) : 0
+  }
   const dAt = new Map<string, number>()
   const lAt = new Map<string, number>()
-  govRes.reactions.forEach((r, i) => {
-    dAt.set(r.node, Math.max(0, dRes?.reactions[i]?.F[1] ?? 0))
-    lAt.set(r.node, Math.max(0, lRes?.reactions[i]?.F[1] ?? 0))
-  })
-
-  const roleOf = new Map(model.members.map((m) => [m.id, m.role]))
-
-  // ── Beams & girders ──
-  const beams: BeamScheduleRow[] = []
-  for (const mr of govRes.members) {
-    const role = roleOf.get(mr.id)
-    if (role !== 'beam' && role !== 'girder') continue
-    const sections: BeamSectionDesign[] = memberSections(mr)
-      .filter((s) => Math.abs(s.Mu) > 1e-6 || s.Vu > 1e-6)
-      .map((s) => ({
-        label: s.label, Mu: s.Mu, Vu: s.Vu, hogging: s.Mu < 0,
-        design: designBeam({
-          b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia,
-          comprBarDia: 16, stirrupDia: sec.tieDia,
-          fc: sec.fc, fy: sec.fy, Mu: Math.abs(s.Mu), Vu: s.Vu,
-        }),
-      }))
-    beams.push({ id: mr.id, role, L: mr.L, sections, ok: sections.every((s) => beamOK(s.design)) })
+  for (const r of runs[govIdx].result.reactions) {
+    dAt.set(r.node, reactAt(dRes, r.node))
+    lAt.set(r.node, reactAt(lRes, r.node))
   }
 
-  // ── Columns ──
+  const roleOf = new Map(model.members.map((m) => [m.id, m.role]))
+  const memberOf = (run: FrameRun, id: string) => run.result.members.find((m) => m.id === id)
+
+  // ── Beams & girders — per-member worst case across all runs ──
+  const beams: BeamScheduleRow[] = []
   const columns: ColumnScheduleRow[] = []
-  for (const mr of govRes.members) {
-    if (roleOf.get(mr.id) !== 'column') continue
-    const Pu = Math.max(0, -Math.min(...mr.N))           // compression (N < 0)
-    const Mu = mr.Mmax
-    const ax = designAxialColumn({
-      shape: 'tied', b: sec.b, h: sec.h, cover: sec.cover,
-      barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, Pu,
-    })
-    let phiPn = ax.phiPnMax
-    const e = Pu > 1e-9 ? Mu / Pu : 0
-    if (e > 1e-4) {
-      const cap = capacityAtEccentricity(
-        { b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, numBars: ax.bars },
-        e,
-      )
-      // axial cap still applies near pure compression
-      const inter = interaction({ b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, numBars: ax.bars })
-      phiPn = Math.min(cap.phi * cap.Pn, 0.65 * inter.PnMax)
+  for (const m of model.members) {
+    const role = roleOf.get(m.id)
+    if (role === 'beam' || role === 'girder') {
+      let best: BeamScheduleRow | null = null, bestSev = -1, gov = ''
+      for (const run of runs) {
+        const mr = memberOf(run, m.id); if (!mr) continue
+        const row = designBeamRow(mr, role, sec)
+        if (row.sections.length === 0) continue
+        const sev = beamSeverity(row)
+        if (sev > bestSev) { bestSev = sev; best = row; gov = run.name }
+      }
+      if (best) beams.push({ ...best, gov })
+    } else if (role === 'column') {
+      let best: ColumnScheduleRow | null = null, bestUtil = -1, gov = ''
+      for (const run of runs) {
+        const mr = memberOf(run, m.id); if (!mr) continue
+        const row = designColumnRow(mr, sec)
+        if (row.util > bestUtil) { bestUtil = row.util; best = row; gov = run.name }
+      }
+      if (best) columns.push({ ...best, gov })
     }
-    const util = phiPn > 1e-9 ? Pu / phiPn : Infinity
-    columns.push({
-      id: mr.id, L: mr.L, Pu, Mu, e, bars: ax.bars, phiPn, util,
-      tieSpacing: ax.tieSpacing, ok: util <= 1 + 1e-9 && ax.rhoOK,
-    })
   }
 
   // ── Footings (base supports) — isolated by default, combined per plan ──
@@ -204,20 +288,24 @@ export function designStructure(
   }
 
   const footings: FootingScheduleRow[] = []
-  for (let i = 0; i < govRes.reactions.length; i++) {
-    const ru = govRes.reactions[i]
+  for (const ru of runs[govIdx].result.reactions) {
     if (paired.has(ru.node)) continue
-    const rs = serviceRes?.reactions[i]
-    const Pu = Math.max(0, ru.F[1])
-    const P = Math.max(0, rs?.F[1] ?? Pu / 1.4)
+    // envelope the factored axial reaction across all runs (a lateral combo may
+    // load a base more than gravity); service load from the gravity solve.
+    let Pu = 0, gov = ''
+    for (const run of runs) {
+      const p = reactAt(run.result, ru.node)
+      if (p > Pu) { Pu = p; gov = run.name }
+    }
     if (Pu < 1e-6) continue
+    const P = Math.max(serviceAt(ru.node), Pu / 1.4)
     const d = designSquareFooting({
       serviceLoad: P, ultimateLoad: Pu, columnWidth: Math.min(sec.b, sec.h),
       fc: sec.fc, fy: sec.fy, qAllow: soil.qAllow,
       gammaSoil: soil.gammaSoil, gammaConc: soil.gammaConc, H: soil.H,
       barDia: sec.barDia, cover: 75,
     })
-    footings.push({ node: ru.node, P, Pu, design: d, ok: d.qNet > 0 && d.punchOK && d.beamOK })
+    footings.push({ node: ru.node, P, Pu, design: d, ok: d.qNet > 0 && d.punchOK && d.beamOK, gov })
   }
 
   // ── Concrete totals ──
@@ -240,7 +328,8 @@ export function designStructure(
   }
 
   return {
-    govName: gov.combo.name,
+    govName: runs[govIdx].name,
+    cases: runs.map((r) => r.name),
     beams, columns, footings, combined,
     totals: { concreteMembers, concreteSlabs, concrete: concreteMembers + concreteSlabs },
     orphanEdges: br.orphanEdges.length,

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -8,7 +8,7 @@ import type { StructuralModel, Member, Plate, RectSection, ModelLoad, MemberRole
 import { distributePanel } from '../engine/tributary'
 import { modelToFrame3D } from '../engine/modelBridge'
 import { analyzeFrame3D, type F3Analysis } from '../engine/frame3d'
-import { designStructure, optimizeStructure, type StructureDesign, type FootingPlan, type OptimizeResult } from '../engine/pipeline'
+import { designStructure, optimizeStructure, type StructureDesign, type FootingPlan, type OptimizeResult, type LateralCase } from '../engine/pipeline'
 import { computeSeismic, driftCheck, type SeismicResult, type DriftRow } from '../engine/seismic'
 import { computeWind, type WindResult } from '../engine/wind'
 import { solveFrame3D, applyF3Combo } from '../engine/frame3d'
@@ -162,6 +162,24 @@ function Loads3D({ model, nodePos }: { model: StructuralModel; nodePos: Map<stri
   return <group>{glyphs}</group>
 }
 
+const LAT_DIRS = ['+X', '-X', '+Z', '-Z']
+/** Multi-select of lateral directions to envelope (+X/−X/+Z/−Z). */
+function DirPicker({ value, onChange }: { value: string[]; onChange: (v: string[]) => void }) {
+  const toggle = (d: string) => onChange(value.includes(d) ? value.filter((x) => x !== d) : [...value, d])
+  return (
+    <div className="col-span-full flex flex-col text-sm">
+      <span className="mb-1 font-medium text-slate-600">Directions to envelope</span>
+      <div className="flex gap-1.5">
+        {LAT_DIRS.map((d) => (
+          <label key={d} className={`inline-flex cursor-pointer items-center gap-1 rounded border px-2 py-0.5 text-xs ${value.includes(d) ? 'border-[#0056b3] bg-blue-50 text-[#0056b3]' : 'border-slate-200 text-slate-500'}`}>
+            <input type="checkbox" className="sr-only" checked={value.includes(d)} onChange={() => toggle(d)} />{d}
+          </label>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 // ── Page ──────────────────────────────────────────────────────────────────
 export default function ModelSpace() {
   const [baysX, setBaysX] = useState('6, 6')
@@ -175,13 +193,16 @@ export default function ModelSpace() {
   const [Ca, setCa] = useState(0.44); const [Cv, setCv] = useState(0.64)
   const [Rw, setRw] = useState(8.5); const [Ie, setIe] = useState(1.0)
   const [Zf, setZf] = useState(0.4); const [Nv, setNv] = useState(1.0)   // Zone factor + near-source (208-11)
-  const [eDir, setEDir] = useState<'x' | 'z'>('x')
+  const [eDirs, setEDirs] = useState<string[]>(['+X', '-X', '+Z', '-Z'])  // directional E cases to envelope
   const [seis, setSeis] = useState<SeismicResult | null>(null)
   const [drift, setDrift] = useState<DriftRow[] | null>(null)
   // Wind (NSCP 207B directional procedure, MWFRS)
   const [Vw, setVw] = useState(50); const [expo, setExpo] = useState<'B' | 'C' | 'D'>('C')
-  const [Kzt, setKzt] = useState(1.0); const [wDir, setWDir] = useState<'x' | 'z'>('x')
+  const [Kzt, setKzt] = useState(1.0)
+  const [wDirs, setWDirs] = useState<string[]>(['+X', '-X', '+Z', '-Z'])  // directional W cases
   const [wind, setWind] = useState<WindResult | null>(null)
+  const [eCases, setECases] = useState<LateralCase[]>([])
+  const [wCases, setWCases] = useState<LateralCase[]>([])
   // Analysis options: f₁ live-load factor (§203.3.1) and P-Δ second order
   const [assembly, setAssembly] = useState(false)
   const [pDelta, setPDelta] = useState(false)
@@ -219,37 +240,65 @@ export default function ModelSpace() {
 
   // §203.3.1: f₁ = 1.0 for assembly/garage or live load > 4.8 kPa, else 0.5.
   const fLive = assembly || qL > 4.8 ? 1.0 : 0.5
-  const anaOpts = { f1: fLive, pDelta }
+  const lateral = [...eCases, ...wCases]
+  const anaOpts = { f1: fLive, pDelta, lateral }
 
   const analyze = () => {
     if (!model) return
     const br = modelToFrame3D(model)
     setOrphans(br.orphanEdges.length)
     setAnalysis(analyzeFrame3D(br.nodes, br.members, br.supports, br.loads, anaOpts))
-    // Storey drift from the E-only elastic solution (NSCP 208.5.10).
+    // Storey drift from the E-only elastic solution (NSCP 208.5.10), along the
+    // primary committed direction.
     if (seis) {
       const eOnly = applyF3Combo(br.loads, { E: 1 })
       const sol = eOnly.length ? solveFrame3D(br.nodes, br.members, br.supports, eOnly, { pDelta }) : null
-      setDrift(sol ? driftCheck(model, br.nodes, sol.d, Rw, seis.T, eDir) : null)
+      const driftAxis = (eDirs[0] ?? '+X').includes('X') ? 'x' : 'z'
+      setDrift(sol ? driftCheck(model, br.nodes, sol.d, Rw, seis.T, driftAxis) : null)
     } else setDrift(null)
+  }
+
+  // Re-sign / re-axis a base node-load set into a directional case.
+  const dirCase = (base: ModelLoad[], kind: 'E' | 'W', d: string): LateralCase => {
+    const axis = d.includes('X') ? 'Fx' : 'Fz'
+    const sign = d.startsWith('-') ? -1 : 1
+    return {
+      name: `${kind}${d}`, kind,
+      loads: base.map((l) => {
+        const mag = Math.abs((l as { Fx?: number }).Fx ?? 0) || Math.abs((l as { Fz?: number }).Fz ?? 0)
+        return { kind: 'node', node: (l as { node: string }).node, [axis]: sign * mag, cat: kind }
+      }),
+    }
   }
 
   const generateE = () => {
     if (!model) return
-    const r = computeSeismic(model, { Ca, Cv, I: Ie, R: Rw, Z: Zf, Nv, dir: eDir })
+    // base magnitude is direction-independent (storey force per node), so one
+    // solve gives every ±X/±Z case.
+    const r = computeSeismic(model, { Ca, Cv, I: Ie, R: Rw, Z: Zf, Nv, dir: 'x' })
     if (!r) return
     setSeis(r)
-    // replace any previous E node loads with the new set
-    save({ ...model, loads: [...model.loads.filter((l) => !(l.cat === 'E' && l.kind === 'node')), ...r.loads] })
+    setECases(eDirs.map((d) => dirCase(r.loads, 'E', d)))
+    // commit the primary direction for the load-diagram overlay + drift check
+    const primary = dirCase(r.loads, 'E', eDirs[0] ?? '+X')
+    save({ ...model, loads: [...model.loads.filter((l) => !(l.cat === 'E' && l.kind === 'node')), ...primary.loads] })
   }
 
   const generateW = () => {
     if (!model) return
-    const r = computeWind(model, { V: Vw, exposure: expo, Kzt, dir: wDir })
-    if (!r) return
-    setWind(r)
-    // replace any previous W node loads with the new set
-    save({ ...model, loads: [...model.loads.filter((l) => !(l.cat === 'W' && l.kind === 'node')), ...r.loads] })
+    // wind magnitude IS axis-dependent (B, L differ), so solve each axis used.
+    const needX = wDirs.some((d) => d.includes('X')), needZ = wDirs.some((d) => d.includes('Z'))
+    const rx = needX ? computeWind(model, { V: Vw, exposure: expo, Kzt, dir: 'x' }) : null
+    const rz = needZ ? computeWind(model, { V: Vw, exposure: expo, Kzt, dir: 'z' }) : null
+    const primaryRes = rx ?? rz
+    if (!primaryRes) return
+    setWind(primaryRes)
+    setWCases(wDirs.map((d) => {
+      const base = (d.includes('X') ? rx : rz)?.loads ?? []
+      return dirCase(base, 'W', d)
+    }))
+    const primary = dirCase(primaryRes.loads, 'W', wDirs[0] ?? '+X')
+    save({ ...model, loads: [...model.loads.filter((l) => !(l.cat === 'W' && l.kind === 'node')), ...primary.loads] })
   }
 
   const soil = { qAllow: qa, gammaSoil: 18, gammaConc: 24, H: Hf }
@@ -351,6 +400,8 @@ export default function ModelSpace() {
     setSelected(null)
     setSeis(null)
     setWind(null)
+    setECases([])
+    setWCases([])
     setPlanSel({})
     save(m)
   }
@@ -445,17 +496,11 @@ export default function ModelSpace() {
             <Num label="I" value={Ie} onChange={setIe} />
             <Num label="Z (zone)" value={Zf} onChange={setZf} />
             <Num label="Nv (near-source)" value={Nv} onChange={setNv} />
-            <label className="flex flex-col text-sm">
-              <span className="mb-1 font-medium text-slate-600">Direction</span>
-              <select value={eDir} onChange={(e) => setEDir(e.target.value as 'x' | 'z')}
-                className="rounded-md border border-slate-300 px-2.5 py-1.5">
-                <option value="x">X</option><option value="z">Z</option>
-              </select>
-            </label>
+            <DirPicker value={eDirs} onChange={setEDirs} />
             <div className="col-span-full">
-              <button type="button" onClick={generateE} disabled={!model}
+              <button type="button" onClick={generateE} disabled={!model || eDirs.length === 0}
                 className="no-print rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50 disabled:opacity-40">
-                ⚡ Generate E loads
+                ⚡ Generate E cases
               </button>
               {seis && (
                 <p className="mt-1 text-xs text-slate-500">
@@ -463,7 +508,7 @@ export default function ModelSpace() {
                   {seis.V === seis.Vmax ? ' (2.5CaIW/R cap governs)'
                     : seis.Vsrc > 0 && seis.V === seis.Vsrc ? ' (Zone-4 0.8ZNvIW/R floor governs)'
                     : seis.V === seis.Vmin ? ' (0.11CaIW floor governs)' : ''}
-                  {seis.Ft > 0 ? ` · Ft = ${f1(seis.Ft)} kN` : ''} — applied as cat-E node loads ({eDir.toUpperCase()}).
+                  {seis.Ft > 0 ? ` · Ft = ${f1(seis.Ft)} kN` : ''} — {eCases.length} cat-E case{eCases.length === 1 ? '' : 's'} ({eDirs.join(', ') || 'none'}).
                   {Zf >= 0.4 ? ` Zone-4 floor = ${f1(seis.Vsrc)} kN.` : ' (Zone-4 floor off: Z < 0.4)'}
                 </p>
               )}
@@ -482,23 +527,17 @@ export default function ModelSpace() {
                 <option value="D">D (flat/coastal)</option>
               </select>
             </label>
-            <label className="flex flex-col text-sm">
-              <span className="mb-1 font-medium text-slate-600">Direction</span>
-              <select value={wDir} onChange={(e) => setWDir(e.target.value as 'x' | 'z')}
-                className="rounded-md border border-slate-300 px-2.5 py-1.5">
-                <option value="x">X</option><option value="z">Z</option>
-              </select>
-            </label>
+            <DirPicker value={wDirs} onChange={setWDirs} />
             <div className="col-span-full">
-              <button type="button" onClick={generateW} disabled={!model}
+              <button type="button" onClick={generateW} disabled={!model || wDirs.length === 0}
                 className="no-print rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50 disabled:opacity-40">
-                🌬 Generate W loads
+                🌬 Generate W cases
               </button>
               {wind && (
                 <p className="mt-1 text-xs text-slate-500">
                   qh = {f2(wind.qh)} kPa · B×L = {f1(wind.B)}×{f1(wind.L)} m (L/B {f2(wind.LB)}) ·
-                  Cp,lee {f2(wind.CpLee)} · base shear V = {f1(wind.baseShear)} kN — applied as cat-W
-                  node loads ({wDir.toUpperCase()}). Windward Cp = 0.8, G = {wind.G}, Kd = {wind.Kd}.
+                  Cp,lee {f2(wind.CpLee)} · base shear V = {f1(wind.baseShear)} kN — {wCases.length} cat-W
+                  case{wCases.length === 1 ? '' : 's'} ({wDirs.join(', ') || 'none'}). Windward Cp = 0.8, G = {wind.G}, Kd = {wind.Kd}.
                 </p>
               )}
             </div>
@@ -587,7 +626,7 @@ export default function ModelSpace() {
           )}
 
           {drift && seis && (
-            <ResultCard title={`Storey drift — ${eDir.toUpperCase()} (ΔM = 0.7·R·Δs)`}>
+            <ResultCard title={`Storey drift — ${(eDirs[0] ?? '+X').replace(/[+-]/, '')} (ΔM = 0.7·R·Δs)`}>
               {drift.map((row) => (
                 <Row key={row.elevation} alert={!row.ok}
                   label={`Level ${f1(row.elevation)} m`}
@@ -930,6 +969,10 @@ export default function ModelSpace() {
               concrete ≈ {f1(design.totals.concrete)} m³ ({f1(design.totals.concreteMembers)} members + {f1(design.totals.concreteSlabs)} slabs)
             </span>
           </h2>
+          <p className="-mt-3 text-xs text-slate-500">
+            Envelope of <b>{design.cases.length}</b> load case{design.cases.length === 1 ? '' : 's'} (NSCP combinations × lateral directions).
+            Each element is designed for its own governing case, shown in the “Case” column.
+          </p>
 
           <div className="print-avoid-break overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Beam & girder schedule</h3>
@@ -942,7 +985,8 @@ export default function ModelSpace() {
                   <th className="py-1 pr-2 text-right font-semibold">Vu (kN)</th>
                   <th className="py-1 pr-2 font-semibold">Mode</th>
                   <th className="py-1 pr-2 font-semibold">Tension</th>
-                  <th className="py-1 font-semibold">Stirrups</th>
+                  <th className="py-1 pr-2 font-semibold">Stirrups</th>
+                  <th className="py-1 font-semibold">Case</th>
                 </tr>
               </thead>
               <tbody>
@@ -957,7 +1001,8 @@ export default function ModelSpace() {
                       <td className="py-1 pr-2 text-right">{f1(s.Vu)}</td>
                       <td className="py-1 pr-2">{d.mode}</td>
                       <td className="py-1 pr-2">{d.bars}⌀{model?.sections[0]?.barDia}{d.layers.length > 1 ? ` (${d.layers.join('+')})` : ''}{s.hogging ? ' top' : ''}</td>
-                      <td className="py-1">{d.sAdopt > 0 ? `@${Math.round(d.sAdopt)}` : d.region === 'none' ? 'none' : '⚠'}</td>
+                      <td className="py-1 pr-2">{d.sAdopt > 0 ? `@${Math.round(d.sAdopt)}` : d.region === 'none' ? 'none' : '⚠'}</td>
+                      <td className="py-1 text-slate-400">{k === 0 ? bm.gov : ''}</td>
                     </tr>
                   )
                 }))}
@@ -975,7 +1020,8 @@ export default function ModelSpace() {
                     <th className="py-1 pr-2 text-right font-semibold">Pu (kN)</th>
                     <th className="py-1 pr-2 text-right font-semibold">Mu</th>
                     <th className="py-1 pr-2 font-semibold">Bars</th>
-                    <th className="py-1 text-right font-semibold">Util</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Util</th>
+                    <th className="py-1 font-semibold">Case</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -985,7 +1031,8 @@ export default function ModelSpace() {
                       <td className="py-1 pr-2 text-right">{f1(c.Pu)}</td>
                       <td className="py-1 pr-2 text-right">{f1(c.Mu)}</td>
                       <td className="py-1 pr-2">{c.bars}⌀{model?.sections[0]?.barDia} · ties @{Math.round(c.tieSpacing)}</td>
-                      <td className="py-1 text-right">{(c.util * 100).toFixed(0)}%</td>
+                      <td className="py-1 pr-2 text-right">{(c.util * 100).toFixed(0)}%</td>
+                      <td className="py-1 text-slate-400">{c.gov}</td>
                     </tr>
                   ))}
                 </tbody>
@@ -1001,7 +1048,8 @@ export default function ModelSpace() {
                     <th className="py-1 pr-2 text-right font-semibold">P / Pu (kN)</th>
                     <th className="py-1 pr-2 font-semibold">Plan</th>
                     <th className="py-1 pr-2 font-semibold">Dc</th>
-                    <th className="py-1 font-semibold">Steel</th>
+                    <th className="py-1 pr-2 font-semibold">Steel</th>
+                    <th className="py-1 font-semibold">Case</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -1011,7 +1059,8 @@ export default function ModelSpace() {
                       <td className="py-1 pr-2 text-right">{f1(f.P)} / {f1(f.Pu)}</td>
                       <td className="py-1 pr-2">B = {f2(f.design.B)} m</td>
                       <td className="py-1 pr-2">{Math.round(f.design.Dc)} mm</td>
-                      <td className="py-1">{f.design.bars}⌀{model?.sections[0]?.barDia} @ {Math.round(f.design.barSpacing)} e.w.</td>
+                      <td className="py-1 pr-2">{f.design.bars}⌀{model?.sections[0]?.barDia} @ {Math.round(f.design.barSpacing)} e.w.</td>
+                      <td className="py-1 text-slate-400">{f.gov}</td>
                     </tr>
                   ))}
                 </tbody>


### PR DESCRIPTION
STAAD-style directional load cases: earthquake and wind are run as separate primary cases in +X/−X/+Z/−Z, and the design is **enveloped per member** (each element designed for its own governing case).

## Engine (`pipeline.ts`)
- `LateralCase` type + `AnalyzeOptions.lateral`.
- `buildRuns()` expands every NSCP combination once per E (or W) directional case it carries; combinations without that factor run once.
- `designStructure` now designs **each** beam / column / footing for its own worst case across all runs — max flexural demand for beams, max utilisation for columns, max factored axial reaction for footings (a lateral combo can load a base harder than gravity) — and records the governing case on each row (`gov`). The full case list is returned in `cases`.
- Backward compatible: a gravity-only model still runs exactly the 7 NSCP combinations, and the existing 12 pipeline tests pass unchanged.

## UI (`ModelSpace`)
- Per-direction pickers (+X/−X/+Z/−Z) for both E and W.
- **Generate E/W cases** build the directional sets — seismic magnitude is axis-independent (one solve covers all four), wind solves each axis actually used (B/L differ). The committed primary direction still drives the load-diagram overlay and the drift check.
- Design output shows the enveloped **case count** and a **"Case"** column on each schedule (beam, column, footing).

## Tests (+2, 174 total)
- The two E-combinations expand to **13 runs** over four directions and the envelope assigns directional governing cases per member.
- Gravity-only still runs exactly 7 cases.

Verified in-browser (DOM): header shows `1.2D + 1.0E + 0.5L + 0.2S · E-X governs`, `Envelope of 13 load cases`, and all four directions appear as governing cases across members. Build clean.

Part 1 of 2 (the accordion detailed-solutions in the schedules will follow in a separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)