### PR TITLE
Model space: expand schedule rows to step-by-step worked solutions

### DIFF
--- a/webapp/src/lib/modelSpaceSolutions.ts
+++ b/webapp/src/lib/modelSpaceSolutions.ts
@@ -1,0 +1,56 @@
+// Adapters that rebuild the detailed worked solutions for the model-space
+// schedules from the design rows, reusing the same builders the standalone
+// calculator pages use (beam / column / isolated footing).
+import type { RectSection } from '../engine/model'
+import type { BeamSectionDesign, ColumnScheduleRow, FootingScheduleRow, SoilOptions } from '../engine/pipeline'
+import { designAxialColumn, interaction, capacityAtEccentricity } from '../engine/columnDesign'
+import { buildBeamSolution } from './beamSolution'
+import { axialColumnSolution, eccentricColumnSolution } from './columnSolution'
+import { buildFoundationSolution, type SolutionCtx } from './foundationSolution'
+import type { SolutionStep } from './solution'
+
+/** Worked solution for one beam/girder critical section. */
+export function beamSectionSolution(sec: RectSection, s: BeamSectionDesign): SolutionStep[] {
+  return buildBeamSolution({
+    b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia,
+    comprBarDia: 16, stirrupDia: sec.tieDia, fc: sec.fc, fy: sec.fy,
+    Mu: Math.abs(s.Mu), Vu: s.Vu,
+  }, s.design)
+}
+
+/** Worked solution for a column row — mirrors the pipeline's column design
+ *  (axial bar selection, then the P–M check when e > 0). */
+export function columnRowSolution(sec: RectSection, row: ColumnScheduleRow): SolutionStep[] {
+  const base = {
+    shape: 'tied' as const, b: sec.b, h: sec.h, cover: sec.cover,
+    barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, Pu: row.Pu,
+  }
+  const ax = designAxialColumn(base)
+  const steps: SolutionStep[] = []
+  if (row.e > 1e-4 && row.Pu > 0) {
+    const ic = { b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, numBars: ax.bars }
+    steps.push(...eccentricColumnSolution(ic, interaction(ic), row.Pu, row.Mu, capacityAtEccentricity(ic, row.e)))
+  }
+  steps.push(...axialColumnSolution(base, ax))
+  return steps
+}
+
+/** Worked solution for an isolated (square) footing row. */
+export function footingRowSolution(sec: RectSection, soil: SoilOptions, row: FootingScheduleRow): SolutionStep[] {
+  const r = row.design
+  const ctx: SolutionCtx = {
+    type: 'square', loading: 'concentric', analysis: r.analysis, method: r.method,
+    serviceLoad: row.P, ultimateLoad: row.Pu, loads: null,
+    serviceMoment: 0, ultimateMoment: 0,
+    columnWidth: Math.min(sec.b, sec.h), columnWidthY: Math.min(sec.b, sec.h), column: null,
+    fc: sec.fc, fy: sec.fy,
+    qAllow: soil.qAllow, gammaSoil: soil.gammaSoil, gammaConc: soil.gammaConc, H: soil.H,
+    barDia: sec.barDia, cover: 75, surcharge: 0, position: 'interior',
+    Bx: r.B, By: r.B, Dc: r.Dc, qNet: r.qNet, qu: r.qu,
+    dPunch: r.dPunch, dBeamLong: r.dBeam, dBeamShort: r.dBeam, dProvided: r.dProvided,
+    punchOK: r.punchOK, beamOK: r.beamOK,
+    long: { As: r.steelArea, bars: r.bars, spacing: r.barSpacing, usedMin: r.usedMinSteel, rho: r.rho },
+    short: null, ecc: null,
+  }
+  return buildFoundationSolution(ctx)
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -13,6 +13,8 @@ import { computeSeismic, driftCheck, type SeismicResult, type DriftRow } from '.
 import { computeWind, type WindResult } from '../engine/wind'
 import { solveFrame3D, applyF3Combo } from '../engine/frame3d'
 import { ReportControls } from '../components/ReportControls'
+import { WorkedSolution } from '../components/WorkedSolution'
+import { beamSectionSolution, columnRowSolution, footingRowSolution } from '../lib/modelSpaceSolutions'
 import { Diagram } from '../components/Diagram'
 import { Num, Card, ResultCard, Row } from '../components/qty'
 import { f1, f2 } from '../lib/format'
@@ -218,6 +220,7 @@ export default function ModelSpace() {
   const [analysis, setAnalysis] = useState<F3Analysis | null>(null)
   const [design, setDesign] = useState<StructureDesign | null>(null)
   const [opt, setOpt] = useState<OptimizeResult | null>(null)
+  const [expanded, setExpanded] = useState<string | null>(null)   // open schedule-row solution
   const [orphans, setOrphans] = useState(0)
   // footing plan: base node → '' (isolated) or partner node id (combined)
   const [planSel, setPlanSel] = useState<Record<string, string>>({})
@@ -231,6 +234,7 @@ export default function ModelSpace() {
     setAnalysis(null)             // geometry changed — results are stale
     setDesign(null)
     setOpt(null)
+    setExpanded(null)
     setDrift(null)
     try {
       if (m) sessionStorage.setItem(AUTOSAVE_KEY, JSON.stringify(m))
@@ -972,6 +976,7 @@ export default function ModelSpace() {
           <p className="-mt-3 text-xs text-slate-500">
             Envelope of <b>{design.cases.length}</b> load case{design.cases.length === 1 ? '' : 's'} (NSCP combinations × lateral directions).
             Each element is designed for its own governing case, shown in the “Case” column.
+            <span className="no-print"> Click any row to expand its step-by-step solution.</span>
           </p>
 
           <div className="print-avoid-break overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
@@ -990,12 +995,15 @@ export default function ModelSpace() {
                 </tr>
               </thead>
               <tbody>
-                {design.beams.flatMap((bm) => bm.sections.map((s, k) => {
+                {design.beams.flatMap((bm) => bm.sections.flatMap((s, k) => {
                   const d = s.design
                   const bad = !(d.flexOK && d.comprEffective && d.comprNAOK && d.region !== 'inadequate')
-                  return (
-                    <tr key={`${bm.id}-${k}`} className={`border-t border-slate-100 ${bad ? 'bg-red-50 text-red-700' : ''}`}>
-                      <td className="py-1 pr-2 font-medium">{k === 0 ? `${bm.id} (${bm.role}, ${f1(bm.L)} m)` : ''}</td>
+                  const key = `beam:${bm.id}:${k}`
+                  const open = expanded === key
+                  return [
+                    <tr key={key} onClick={() => setExpanded(open ? null : key)}
+                      className={`cursor-pointer border-t border-slate-100 hover:bg-blue-50/40 ${bad ? 'bg-red-50 text-red-700' : ''}`}>
+                      <td className="py-1 pr-2 font-medium">{k === 0 ? `${open ? '▾' : '▸'} ${bm.id} (${bm.role}, ${f1(bm.L)} m)` : ''}</td>
                       <td className="py-1 pr-2">{s.label}{s.hogging ? ' (hog)' : ''}</td>
                       <td className="py-1 pr-2 text-right">{f1(Math.abs(s.Mu))}</td>
                       <td className="py-1 pr-2 text-right">{f1(s.Vu)}</td>
@@ -1003,8 +1011,15 @@ export default function ModelSpace() {
                       <td className="py-1 pr-2">{d.bars}⌀{model?.sections[0]?.barDia}{d.layers.length > 1 ? ` (${d.layers.join('+')})` : ''}{s.hogging ? ' top' : ''}</td>
                       <td className="py-1 pr-2">{d.sAdopt > 0 ? `@${Math.round(d.sAdopt)}` : d.region === 'none' ? 'none' : '⚠'}</td>
                       <td className="py-1 text-slate-400">{k === 0 ? bm.gov : ''}</td>
-                    </tr>
-                  )
+                    </tr>,
+                    open && model && (
+                      <tr key={`${key}:sol`}>
+                        <td colSpan={8} className="bg-slate-50/60 px-2 pb-2">
+                          <WorkedSolution steps={beamSectionSolution(model.sections[0], s)} title={`${bm.id} · ${s.label} — worked solution`} />
+                        </td>
+                      </tr>
+                    ),
+                  ]
                 }))}
               </tbody>
             </table>
@@ -1025,16 +1040,27 @@ export default function ModelSpace() {
                   </tr>
                 </thead>
                 <tbody>
-                  {design.columns.map((c) => (
-                    <tr key={c.id} className={`border-t border-slate-100 ${c.ok ? '' : 'bg-red-50 text-red-700'}`}>
-                      <td className="py-1 pr-2 font-medium">{c.id}</td>
-                      <td className="py-1 pr-2 text-right">{f1(c.Pu)}</td>
-                      <td className="py-1 pr-2 text-right">{f1(c.Mu)}</td>
-                      <td className="py-1 pr-2">{c.bars}⌀{model?.sections[0]?.barDia} · ties @{Math.round(c.tieSpacing)}</td>
-                      <td className="py-1 pr-2 text-right">{(c.util * 100).toFixed(0)}%</td>
-                      <td className="py-1 text-slate-400">{c.gov}</td>
-                    </tr>
-                  ))}
+                  {design.columns.flatMap((c) => {
+                    const key = `col:${c.id}`, open = expanded === key
+                    return [
+                      <tr key={key} onClick={() => setExpanded(open ? null : key)}
+                        className={`cursor-pointer border-t border-slate-100 hover:bg-blue-50/40 ${c.ok ? '' : 'bg-red-50 text-red-700'}`}>
+                        <td className="py-1 pr-2 font-medium">{open ? '▾' : '▸'} {c.id}</td>
+                        <td className="py-1 pr-2 text-right">{f1(c.Pu)}</td>
+                        <td className="py-1 pr-2 text-right">{f1(c.Mu)}</td>
+                        <td className="py-1 pr-2">{c.bars}⌀{model?.sections[0]?.barDia} · ties @{Math.round(c.tieSpacing)}</td>
+                        <td className="py-1 pr-2 text-right">{(c.util * 100).toFixed(0)}%</td>
+                        <td className="py-1 text-slate-400">{c.gov}</td>
+                      </tr>,
+                      open && model && (
+                        <tr key={`${key}:sol`}>
+                          <td colSpan={6} className="bg-slate-50/60 px-2 pb-2">
+                            <WorkedSolution steps={columnRowSolution(model.sections[0], c)} title={`${c.id} — worked solution`} />
+                          </td>
+                        </tr>
+                      ),
+                    ]
+                  })}
                 </tbody>
               </table>
             </div>
@@ -1053,16 +1079,27 @@ export default function ModelSpace() {
                   </tr>
                 </thead>
                 <tbody>
-                  {design.footings.map((f) => (
-                    <tr key={f.node} className={`border-t border-slate-100 ${f.ok ? '' : 'bg-red-50 text-red-700'}`}>
-                      <td className="py-1 pr-2 font-medium">{f.node}</td>
-                      <td className="py-1 pr-2 text-right">{f1(f.P)} / {f1(f.Pu)}</td>
-                      <td className="py-1 pr-2">B = {f2(f.design.B)} m</td>
-                      <td className="py-1 pr-2">{Math.round(f.design.Dc)} mm</td>
-                      <td className="py-1 pr-2">{f.design.bars}⌀{model?.sections[0]?.barDia} @ {Math.round(f.design.barSpacing)} e.w.</td>
-                      <td className="py-1 text-slate-400">{f.gov}</td>
-                    </tr>
-                  ))}
+                  {design.footings.flatMap((f) => {
+                    const key = `ftg:${f.node}`, open = expanded === key
+                    return [
+                      <tr key={key} onClick={() => setExpanded(open ? null : key)}
+                        className={`cursor-pointer border-t border-slate-100 hover:bg-blue-50/40 ${f.ok ? '' : 'bg-red-50 text-red-700'}`}>
+                        <td className="py-1 pr-2 font-medium">{open ? '▾' : '▸'} {f.node}</td>
+                        <td className="py-1 pr-2 text-right">{f1(f.P)} / {f1(f.Pu)}</td>
+                        <td className="py-1 pr-2">B = {f2(f.design.B)} m</td>
+                        <td className="py-1 pr-2">{Math.round(f.design.Dc)} mm</td>
+                        <td className="py-1 pr-2">{f.design.bars}⌀{model?.sections[0]?.barDia} @ {Math.round(f.design.barSpacing)} e.w.</td>
+                        <td className="py-1 text-slate-400">{f.gov}</td>
+                      </tr>,
+                      open && model && (
+                        <tr key={`${key}:sol`}>
+                          <td colSpan={6} className="bg-slate-50/60 px-2 pb-2">
+                            <WorkedSolution steps={footingRowSolution(model.sections[0], soil, f)} title={`Footing ${f.node} — worked solution`} />
+                          </td>
+                        </tr>
+                      ),
+                    ]
+                  })}
                 </tbody>
               </table>
             </div>


### PR DESCRIPTION
Part 2 of 2. Clicking any **beam/girder, column, or isolated-footing** row in the design schedules now expands an accordion with the full **KaTeX worked solution** — reusing the exact builders the standalone calculator pages use, so the model-space report matches the per-element pages.

## How
- `lib/modelSpaceSolutions.ts` — small adapters that rebuild each solution from the schedule row:
  - **beam** → `buildBeamSolution` (input reconstructed from the section + shared RC section)
  - **column** → re-runs `designAxialColumn` + the P–M check and assembles `axialColumnSolution` (+ `eccentricColumnSolution` when e > 0), mirroring the pipeline's column logic
  - **footing** → maps the stored `SquareFootingResult` into `SolutionCtx` → `buildFoundationSolution`
- `ModelSpace` — schedule rows are clickable (▸/▾) and render `<WorkedSolution>` in a full-width row; only one open at a time; cleared when the model changes.

## Verified in-browser
Generated a model, ran the design, expanded rows:
- beam `bx0.0.1 · End i` → **8 steps**, 17 KaTeX equations
- column `c0.0.0` → **8 steps**, 12 equations
- footing `n0.0.0` → **10 steps**, 23 equations

No console/overlay errors. 174 tests pass, build clean. (No new engine tests — this is UI reusing already-tested solution builders.)

Note: combined-footing rows don't expand yet (no single-footing solution builder covers the CRF/CTF case); that can be a follow-up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)