### PR TITLE
Worked solution for combined footings (CRF/CTF)

### DIFF
--- a/webapp/src/lib/combinedFootingSolution.test.ts
+++ b/webapp/src/lib/combinedFootingSolution.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { designCombinedFooting, type CombinedFootingInput } from '../engine/combinedFooting'
+import { buildCombinedFootingSolution } from './combinedFootingSolution'
+
+const base: CombinedFootingInput = {
+  col1Width: 400, col2Width: 400, spacing: 5,
+  dl1: 600, ll1: 300, dl2: 900, ll2: 450,
+  leftRestrict: false, rightRestrict: false, leftOverhang: 0, rightOverhang: 0,
+  fc: 21, fy: 415, qAllow: 200, gammaSoil: 18, gammaConc: 24, surcharge: 0,
+  H: 1.5, barDia: 20, cover: 75,
+}
+
+describe('combined footing worked solution', () => {
+  it('CRF: produces provision-cited steps that match the engine result', () => {
+    const r = designCombinedFooting(base)
+    const steps = buildCombinedFootingSolution(base, r)
+    const titles = steps.map((s) => s.title)
+    expect(titles[0]).toMatch(/loads/i)
+    expect(titles.some((t) => /rectangular combined footing/i.test(t))).toBe(true)
+    expect(titles.some((t) => /punching/i.test(t))).toBe(true)
+    expect(titles.some((t) => /Longitudinal flexure/i.test(t))).toBe(true)
+    expect(titles.some((t) => /Transverse/i.test(t))).toBe(true)
+    // the rendered numbers reference the engine's governing results
+    const flat = steps.flatMap((s) => s.lines).map((l) => ('tex' in l ? l.tex : l.text)).join(' ')
+    expect(flat).toContain(r.Bx.toFixed(2))
+    expect(flat).toContain(String(Math.round(r.Dc)))
+    expect(flat).toContain(r.Pu.toFixed(1))
+  })
+
+  it('CTF: trapezoid branch when both ends restricted', () => {
+    const r = designCombinedFooting({ ...base, leftRestrict: true, rightRestrict: true, leftOverhang: 300, rightOverhang: 300 })
+    expect(r.shape[0]).toBe('T')
+    const steps = buildCombinedFootingSolution({ ...base, leftRestrict: true, rightRestrict: true, leftOverhang: 300, rightOverhang: 300 }, r)
+    expect(steps.some((s) => /trapezoidal combined footing/i.test(s.title))).toBe(true)
+    const flat = steps.flatMap((s) => s.lines).map((l) => ('tex' in l ? l.tex : l.text)).join(' ')
+    expect(flat).toContain(r.By1.toFixed(2))
+    expect(flat).toContain(r.By2.toFixed(2))
+  })
+})

--- a/webapp/src/lib/combinedFootingSolution.ts
+++ b/webapp/src/lib/combinedFootingSolution.ts
@@ -1,0 +1,127 @@
+// Detailed worked solution for the combined footing (rigid/conventional
+// method) — provision-cited steps mirroring engine/combinedFooting.ts:
+// loads → net bearing → plan geometry (CRF rectangle / CTF trapezoid sized so
+// the soil resultant is concentric) → equivalent uniformly-varying line load
+// with closed-form V(x), M(x) → thickness from punching + one-way shear →
+// longitudinal and transverse flexure.
+import type { CombinedFootingInput, CombinedFootingResult } from '../engine/combinedFooting'
+import { type SolutionStep, type SolutionLine, sn0, sn1, sn2, sn3 } from './solution'
+
+const txt = (text: string): SolutionLine => ({ text })
+const eq = (tex: string): SolutionLine => ({ tex })
+const roundUp = (v: number, step: number) => Math.ceil(v / step) * step
+
+export function buildCombinedFootingSolution(i: CombinedFootingInput, r: CombinedFootingResult): SolutionStep[] {
+  const steps: SolutionStep[] = []
+  const crf = r.shape[0] === 'R'
+  const Pa1 = i.dl1 + i.ll1, Pa2 = i.dl2 + i.ll2
+
+  // 1 — Loads
+  steps.push({
+    title: 'Service & factored column loads',
+    lines: [
+      txt('Each column carries its own service load P = D + L (for soil bearing) and factored load Pu = max(1.4D, 1.2D + 1.6L) for strength design (NSCP 2015 §203.3.1 / ACI 318-14 §5.3).'),
+      eq(String.raw`P_{a1}=${sn0(i.dl1)}+${sn0(i.ll1)}=${sn1(Pa1)},\quad P_{a2}=${sn0(i.dl2)}+${sn0(i.ll2)}=${sn1(Pa2)}\ \text{kN}`),
+      eq(String.raw`\sum P_a=\mathbf{${sn1(r.Pa)}}\ \text{kN}`),
+      eq(String.raw`P_{u1}=\max(1.4\cdot${sn0(i.dl1)},\,1.2\cdot${sn0(i.dl1)}+1.6\cdot${sn0(i.ll1)})=\mathbf{${sn1(r.Pu1)}}\ \text{kN}`),
+      eq(String.raw`P_{u2}=\max(1.4\cdot${sn0(i.dl2)},\,1.2\cdot${sn0(i.dl2)}+1.6\cdot${sn0(i.ll2)})=\mathbf{${sn1(r.Pu2)}},\quad \sum P_u=\mathbf{${sn1(r.Pu)}}\ \text{kN}`),
+    ],
+  })
+
+  // 2 — Net bearing
+  steps.push({
+    title: 'Net allowable soil pressure',
+    lines: [
+      txt('Subtract the overburden (soil above the footing) and the footing self-weight from the allowable bearing, with a trial thickness Dc = 0.25 m.'),
+      eq(String.raw`q_{net}=q_a-\gamma_s(H-D_c)-\gamma_c D_c-q_{sur}`),
+      eq(String.raw`q_{net}=${sn0(i.qAllow)}-${sn0(i.gammaSoil)}(${sn2(i.H)}-0.25)-${sn0(i.gammaConc)}(0.25)-${sn0(i.surcharge)}=\mathbf{${sn1(r.qNet)}}\ \text{kPa}`),
+    ],
+  })
+
+  // 3 — Plan geometry
+  if (crf) {
+    const eRes = (Pa2 * i.spacing) / r.Pa
+    steps.push({
+      title: 'Plan dimensions — rectangular combined footing (CRF)',
+      lines: [
+        txt('For uniform soil pressure the footing length is positioned so the centroid of its area lines up with the resultant of the service loads. The resultant sits a distance e from column 1:'),
+        eq(String.raw`e=\dfrac{P_{a2}\,s}{\sum P_a}=\dfrac{${sn1(Pa2)}\cdot${sn2(i.spacing)}}{${sn1(r.Pa)}}=${sn3(eRes)}\ \text{m}`),
+        txt('The length Bx is taken so the soil resultant is concentric and both columns are covered; the width then carries the uniform pressure:'),
+        eq(String.raw`B_x=\mathbf{${sn2(r.Bx)}}\ \text{m},\quad B_y=\dfrac{\sum P_a}{q_{net}\,B_x}=\dfrac{${sn1(r.Pa)}}{${sn1(r.qNet)}\cdot${sn2(r.Bx)}}=\mathbf{${sn2(r.By)}}\ \text{m}`),
+        eq(String.raw`x_1=${sn2(r.x1)}\ \text{m},\quad x_2=${sn2(r.x2)}\ \text{m (column positions from the left edge)}`),
+      ],
+      note: r.widened ? 'Width increased so each column sits on the slab plus a 75 mm projection on every side.' : undefined,
+    })
+  } else {
+    const A = r.Pa / r.qNet
+    const xbar = (Pa1 * r.x1 + Pa2 * r.x2) / r.Pa
+    steps.push({
+      title: 'Plan dimensions — trapezoidal combined footing (CTF)',
+      lines: [
+        txt('When both ends are restricted the length is fixed by the geometry, so a trapezoid (widths By1 at the left, By2 at the right) is used to keep the area centroid under the load resultant.'),
+        eq(String.raw`B_x=s+\tfrac{c_1}{2}+\tfrac{c_2}{2}+\text{overhangs}=\mathbf{${sn2(r.Bx)}}\ \text{m}`),
+        eq(String.raw`A=\dfrac{\sum P_a}{q_{net}}=\dfrac{${sn1(r.Pa)}}{${sn1(r.qNet)}}=${sn2(A)}\ \text{m}^2,\quad \bar x=\dfrac{P_{a1}x_1+P_{a2}x_2}{\sum P_a}=${sn2(xbar)}\ \text{m}`),
+        eq(String.raw`B_{y1}=\mathbf{${sn2(r.By1)}}\ \text{m},\quad B_{y2}=\mathbf{${sn2(r.By2)}}\ \text{m}`),
+      ],
+      note: r.widened ? 'Width increased so each column sits on the slab plus a 75 mm projection on every side.' : undefined,
+    })
+  }
+
+  // 4 — Equivalent line load + shear/moment
+  const wsum = (2 * r.Pu) / r.Bx
+  const w1p2 = (6 * (r.Pu1 * r.x1 + r.Pu2 * r.x2)) / (r.Bx * r.Bx)
+  steps.push({
+    title: 'Factored soil reaction as a line load, then V(x) and M(x)',
+    lines: [
+      txt('Treating the footing as a rigid beam on soil, the factored upward pressure is an equivalent uniformly-varying line load wu1 → wu2 (kN/m) that reproduces the total reaction and its resultant location:'),
+      eq(String.raw`\sum w=\dfrac{2\sum P_u}{B_x}=\dfrac{2\cdot${sn1(r.Pu)}}{${sn2(r.Bx)}}=${sn1(wsum)},\quad w_1{+}2w_2=\dfrac{6(P_{u1}x_1+P_{u2}x_2)}{B_x^{2}}=${sn1(w1p2)}`),
+      eq(String.raw`w_{u1}=\mathbf{${sn1(r.wu1)}}\ \text{kN/m},\quad w_{u2}=\mathbf{${sn1(r.wu2)}}\ \text{kN/m}`),
+      txt('Integrating the line load minus the two column loads gives the shear and moment. Shear crosses zero (peak moment) at:'),
+      eq(String.raw`x_{V=0}=${sn2(r.xPeak)}\ \text{m}\;\Rightarrow\; M_{max}=\mathbf{${sn1(r.mPeak)}}\ \text{kN·m}`),
+    ],
+  })
+
+  // 5 — Thickness
+  const DcPunch = roundUp(r.dPunch + i.cover + i.barDia, 25)
+  const DcBeam = roundUp(r.dBeam + i.cover + i.barDia, 25)
+  const Afoot = crf ? r.Bx * r.By : ((r.By1 + r.By2) * r.Bx) / 2
+  const qu = r.Pu / Afoot
+  steps.push({
+    title: 'Slab thickness — two-way (punching) and one-way (beam) shear',
+    lines: [
+      txt('The depth is governed by the larger of punching shear around the critical column (perimeter at d/2, NSCP §422.6 / ACI §22.6) and one-way shear at d from the column face (NSCP §422.5, Vc = (1/6)√f′c·b·d), both with φ = 0.75.'),
+      eq(String.raw`q_u=\dfrac{\sum P_u}{A_{foot}}=\dfrac{${sn1(r.Pu)}}{${sn2(Afoot)}}=${sn1(qu)}\ \text{kPa}`),
+      eq(String.raw`d_{punch}=${sn0(r.dPunch)}\ \text{mm}\;\Rightarrow\;D_{c,punch}=${sn0(DcPunch)}\ \text{mm}`),
+      eq(String.raw`d_{beam}=${sn0(r.dBeam)}\ \text{mm}\;\Rightarrow\;D_{c,beam}=${sn0(DcBeam)}\ \text{mm}`),
+      eq(String.raw`D_c=\max(D_{c,punch},D_{c,beam})=\mathbf{${sn0(r.Dc)}}\ \text{mm}`),
+    ],
+  })
+
+  // 6 — Longitudinal flexure
+  const dFlex = r.Dc - i.cover - i.barDia / 2
+  steps.push({
+    title: 'Longitudinal flexure (top & bottom steel)',
+    lines: [
+      txt(`The footing spans longitudinally between columns. Tension steel is designed (φ = 0.90, NSCP §410) at the maximum interior moment (top bars) and at each column face, using d = Dc − cover − db/2 = ${sn0(dFlex)} mm.`),
+      ...r.longSections.flatMap((s) => [
+        eq(String.raw`\text{${s.label}: } M_u=${sn1(s.Mu)}\ \text{kN·m},\; b=${sn0(s.b)}\ \text{mm}\;\Rightarrow\; A_s=${sn0(s.As)}\ \text{mm}^2`),
+        eq(String.raw`\quad\to\;${s.bars}\,\varnothing${sn0(i.barDia)}\ \text{@}\ ${sn0(s.spacing)}\ \text{mm}\ (\text{${s.top ? 'top' : 'bottom'}})`),
+      ]),
+    ],
+  })
+
+  // 7 — Transverse flexure
+  const dT = r.Dc - i.cover - 1.5 * i.barDia
+  steps.push({
+    title: 'Transverse flexure under each column (per metre strip)',
+    lines: [
+      txt(`Across the width, each column load spreads through a transverse strip cantilevering from the column face, arm = (By − c)/2, with d = Dc − cover − 1.5db = ${sn0(dT)} mm.`),
+      ...r.transverse.flatMap((t) => [
+        eq(String.raw`\text{${t.label}: } \text{arm}=${sn2(t.arm)}\ \text{m},\; M_u=${sn1(t.MuPerM)}\ \text{kN·m/m}\;\Rightarrow\; A_s=${sn0(t.AsPerM)}\ \text{mm}^2/\text{m}`),
+        eq(String.raw`\quad\to\;\varnothing${sn0(i.barDia)}\ \text{@}\ ${sn0(t.spacing)}\ \text{mm}`),
+      ]),
+    ],
+  })
+
+  return steps
+}

--- a/webapp/src/lib/modelSpaceSolutions.ts
+++ b/webapp/src/lib/modelSpaceSolutions.ts
@@ -2,11 +2,13 @@
 // schedules from the design rows, reusing the same builders the standalone
 // calculator pages use (beam / column / isolated footing).
 import type { RectSection } from '../engine/model'
-import type { BeamSectionDesign, ColumnScheduleRow, FootingScheduleRow, SoilOptions } from '../engine/pipeline'
+import type { BeamSectionDesign, ColumnScheduleRow, FootingScheduleRow, CombinedScheduleRow, SoilOptions } from '../engine/pipeline'
+import type { CombinedFootingInput } from '../engine/combinedFooting'
 import { designAxialColumn, interaction, capacityAtEccentricity } from '../engine/columnDesign'
 import { buildBeamSolution } from './beamSolution'
 import { axialColumnSolution, eccentricColumnSolution } from './columnSolution'
 import { buildFoundationSolution, type SolutionCtx } from './foundationSolution'
+import { buildCombinedFootingSolution } from './combinedFootingSolution'
 import type { SolutionStep } from './solution'
 
 /** Worked solution for one beam/girder critical section. */
@@ -53,4 +55,17 @@ export function footingRowSolution(sec: RectSection, soil: SoilOptions, row: Foo
     short: null, ecc: null,
   }
   return buildFoundationSolution(ctx)
+}
+
+/** Worked solution for a combined-footing pair row (rigid method). */
+export function combinedRowSolution(sec: RectSection, soil: SoilOptions, row: CombinedScheduleRow): SolutionStep[] {
+  const cw = Math.min(sec.b, sec.h)
+  const input: CombinedFootingInput = {
+    col1Width: cw, col2Width: cw, spacing: row.spacing,
+    dl1: row.dl1, ll1: row.ll1, dl2: row.dl2, ll2: row.ll2,
+    leftRestrict: false, rightRestrict: false, leftOverhang: 0, rightOverhang: 0,
+    fc: sec.fc, fy: sec.fy, qAllow: soil.qAllow, gammaSoil: soil.gammaSoil, gammaConc: soil.gammaConc,
+    surcharge: 0, H: soil.H, barDia: sec.barDia, cover: 75,
+  }
+  return buildCombinedFootingSolution(input, row.design)
 }

--- a/webapp/src/pages/CombinedFootingDesign.tsx
+++ b/webapp/src/pages/CombinedFootingDesign.tsx
@@ -5,6 +5,8 @@ import { designFlexibleCombinedFooting } from '../engine/flexibleCombinedFooting
 import { CombinedFootingSchematic } from '../components/CombinedFootingSchematic'
 import { Diagram } from '../components/Diagram'
 import { ReportControls } from '../components/ReportControls'
+import { WorkedSolution } from '../components/WorkedSolution'
+import { buildCombinedFootingSolution } from '../lib/combinedFootingSolution'
 import { Math } from '../lib/math'
 import { f0, f2, f3 } from '../lib/format'
 import 'katex/dist/katex.min.css'
@@ -150,6 +152,11 @@ export default function CombinedFootingDesign() {
       return null
     }
   }, [form, valid])
+
+  const solutionSteps = useMemo(
+    () => (result ? buildCombinedFootingSolution({ ...form }, result) : null),
+    [form, result],
+  )
 
   const flexible = form.method === 'flexible'
   // Diagrams & longitudinal steel come from the active method; geometry/plan/transverse from rigid.
@@ -341,6 +348,10 @@ export default function CombinedFootingDesign() {
           </p>
         )}
       </div>
+
+      {solutionSteps && (
+        <WorkedSolution steps={solutionSteps} title="Combined footing — worked solution (rigid method)" />
+      )}
     </div>
   )
 }

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -14,7 +14,7 @@ import { computeWind, type WindResult } from '../engine/wind'
 import { solveFrame3D, applyF3Combo } from '../engine/frame3d'
 import { ReportControls } from '../components/ReportControls'
 import { WorkedSolution } from '../components/WorkedSolution'
-import { beamSectionSolution, columnRowSolution, footingRowSolution } from '../lib/modelSpaceSolutions'
+import { beamSectionSolution, columnRowSolution, footingRowSolution, combinedRowSolution } from '../lib/modelSpaceSolutions'
 import { Diagram } from '../components/Diagram'
 import { Num, Card, ResultCard, Row } from '../components/qty'
 import { f1, f2 } from '../lib/format'
@@ -1119,23 +1119,33 @@ export default function ModelSpace() {
                     </tr>
                   </thead>
                   <tbody>
-                    {design.combined.map((c) => (
-                      <tr key={c.nodes.join('-')} className={`border-t border-slate-100 ${c.ok ? '' : 'bg-red-50 text-red-700'}`}>
-                        <td className="py-1 pr-2 font-medium">{c.nodes[0]} + {c.nodes[1]}</td>
-                        <td className="py-1 pr-2 text-right">{f2(c.spacing)} m</td>
-                        <td className="py-1 pr-2 text-right">
-                          {f1(c.dl1)}/{f1(c.ll1)} · {f1(c.dl2)}/{f1(c.ll2)}
-                        </td>
-                        <td className="py-1 pr-2">{c.design.shape}</td>
-                        <td className="py-1 pr-2">{f2(c.design.Bx)} × {f2(c.design.By)} m</td>
-                        <td className="py-1">{Math.round(c.design.Dc)} mm</td>
-                      </tr>
-                    ))}
+                    {design.combined.flatMap((c) => {
+                      const key = `comb:${c.nodes.join('-')}`, open = expanded === key
+                      return [
+                        <tr key={key} onClick={() => setExpanded(open ? null : key)}
+                          className={`cursor-pointer border-t border-slate-100 hover:bg-blue-50/40 ${c.ok ? '' : 'bg-red-50 text-red-700'}`}>
+                          <td className="py-1 pr-2 font-medium">{open ? '▾' : '▸'} {c.nodes[0]} + {c.nodes[1]}</td>
+                          <td className="py-1 pr-2 text-right">{f2(c.spacing)} m</td>
+                          <td className="py-1 pr-2 text-right">
+                            {f1(c.dl1)}/{f1(c.ll1)} · {f1(c.dl2)}/{f1(c.ll2)}
+                          </td>
+                          <td className="py-1 pr-2">{c.design.shape}</td>
+                          <td className="py-1 pr-2">{f2(c.design.Bx)} × {f2(c.design.By)} m</td>
+                          <td className="py-1">{Math.round(c.design.Dc)} mm</td>
+                        </tr>,
+                        open && model && (
+                          <tr key={`${key}:sol`}>
+                            <td colSpan={6} className="bg-slate-50/60 px-2 pb-2">
+                              <WorkedSolution steps={combinedRowSolution(model.sections[0], soil, c)} title={`Combined footing ${c.nodes.join(' + ')} — worked solution`} />
+                            </td>
+                          </tr>
+                        ),
+                      ]
+                    })}
                   </tbody>
                 </table>
                 <p className="mt-1 text-[11px] text-slate-400">
-                  Column loads split from D-only / L-only frame solves; open the Combined Footing page for the full
-                  worked solution of a pair.
+                  Column loads split from D-only / L-only frame solves. Click a row for the full worked solution.
                 </p>
               </div>
             )}


### PR DESCRIPTION
Adds the step-by-step worked solution for combined footings — the gap left in #152 — on **both** the standalone Combined Footing page and the 3D model-space schedule.

## Engine-faithful solution (`lib/combinedFootingSolution.ts`)
Mirrors `engine/combinedFooting.ts` (rigid/conventional method) with provision-cited steps:
1. Service & factored column loads — `Pu = max(1.4D, 1.2D+1.6L)` (§203.3.1)
2. Net allowable soil pressure — `q_net = q_a − γ_s(H−Dc) − γ_c·Dc − q_sur`
3. Plan geometry — **CRF** rectangle sized so the soil resultant is concentric (`e = Pa2·s/ΣPa`, `By = ΣPa/(q_net·Bx)`); **CTF** trapezoid widths `By1/By2` from the area + centroid match
4. Equivalent uniformly-varying line load `wu1→wu2` with closed-form `V(x)`, `M(x)` and the zero-shear peak moment
5. Thickness — two-way (punching, §422.6) and one-way (beam, §422.5) shear, `Dc = max`
6. Longitudinal flexure (top/bottom steel) at the interior peak and column faces (§410, φ=0.90)
7. Transverse flexure under each column strip (per metre)

## UI
- **Combined Footing page**: renders `<WorkedSolution>` (rigid method) under the results.
- **Model space**: combined-footing schedule rows are now expandable (▸/▾), reusing the builder via `combinedRowSolution` — completing the accordion coverage from #152.

## Tests (+2, 176 total)
CRF and CTF branches produce the correctly-titled steps and echo the engine's governing `Bx`/`Dc`/`Pu` and `By1`/`By2`.

Verified in-browser: page panel **7 steps / 43 KaTeX**; model-space accordion **7 steps / 26 KaTeX**, no console errors. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)