### PR TITLE
Optimize: refresh self-weight each iteration + migrate shared-section models

### DIFF
--- a/webapp/src/engine/modelBuilder.ts
+++ b/webapp/src/engine/modelBuilder.ts
@@ -160,6 +160,44 @@ export function buildGravityLoads(model: StructuralModel, sdl: number, ll: numbe
 }
 
 /**
+ * Recompute member SELF-WEIGHT (member-udl, category D) from each member's
+ * CURRENT section, leaving every other load untouched. No-op when the model
+ * carries no member self-weight (so user models without it are not altered).
+ */
+export function refreshSelfWeight(model: StructuralModel): StructuralModel {
+  const hasSW = model.loads.some((l) => l.kind === 'member-udl' && l.cat === 'D')
+  if (!hasSW) return model
+  const secMap = new Map(model.sections.map((s) => [s.id, s]))
+  const others = model.loads.filter((l) => !(l.kind === 'member-udl' && l.cat === 'D'))
+  const sw: StructuralModel['loads'] = model.members
+    .map((m) => {
+      const sec = secMap.get(m.section) ?? model.sections[0]
+      const w = sec ? (sec.b / 1000) * (sec.h / 1000) * GAMMA_C : 0
+      return { kind: 'member-udl' as const, member: m.id, w, cat: 'D' as const }
+    })
+    .filter((l) => l.w > 0)
+  return { ...model, loads: [...sw, ...others] }
+}
+
+/**
+ * Migration: ensure every member owns its OWN section (id = member id). Models
+ * generated before per-member sizing shared a single section, so optimisation
+ * moved them all together — splitting restores independent sizing. Idempotent.
+ */
+export function splitSharedSections(model: StructuralModel): StructuralModel {
+  if (model.members.every((m) => m.section === m.id)) return model
+  const secMap = new Map(model.sections.map((s) => [s.id, s]))
+  const fallback = model.sections[0]
+  const sections: RectSection[] = []
+  const members = model.members.map((m) => {
+    const base = secMap.get(m.section) ?? fallback
+    sections.push({ ...(base ?? { fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40, b: 300, h: 500 }), id: m.id, name: base ? `${base.b}×${base.h}` : '300×500' })
+    return { ...m, section: m.id }
+  })
+  return { ...model, sections, members }
+}
+
+/**
  * Strong-column / weak-beam geometry: at every node a supporting member must be
  * at least as WIDE (cross-section b) as the members it supports, so reinforcement
  * passes through. Enforces, at each node, girder.b ≥ beam.b and column.b ≥

--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { generateGridModel, buildGravityLoads, removeNode, enforceSectionHierarchy } from './modelBuilder'
+import { generateGridModel, buildGravityLoads, removeNode, enforceSectionHierarchy, refreshSelfWeight, splitSharedSections } from './modelBuilder'
 import { designStructure, optimizeStructure, designOK, type LateralCase } from './pipeline'
 import { computeSeismic } from './seismic'
 import type { RectSection, ModelLoad } from './model'
@@ -171,6 +171,39 @@ describe('optimizeStructure', () => {
     expect(col.b).toBe(300)
     expect(col.h).toBeLessThanOrEqual(500)
     expect(designOK(r.design)).toBe(true)
+  })
+})
+
+describe('self-weight refresh', () => {
+  it('recomputes member-udl D from the current section, keeping other loads', () => {
+    const m = makeModel()                       // area D/L only (no member SW yet)
+    expect(refreshSelfWeight(m)).toBe(m)        // no-op when there is no member SW
+    const withSW = { ...m, loads: buildGravityLoads(m, 1.5, 2.4) }
+    // grow every section and refresh — self-weight must scale with b·h
+    const big = { ...withSW, sections: withSW.sections.map((s) => ({ ...s, b: 600, h: 800 })) }
+    const r = refreshSelfWeight(big)
+    const sw = r.loads.filter((l) => l.kind === 'member-udl' && l.cat === 'D')
+    expect(sw.length).toBe(m.members.length)
+    for (const l of sw) expect((l as { w: number }).w).toBeCloseTo(0.6 * 0.8 * 24, 9)
+    // area + live loads survive untouched
+    expect(r.loads.filter((l) => l.kind === 'area').length)
+      .toBe(withSW.loads.filter((l) => l.kind === 'area').length)
+  })
+})
+
+describe('splitSharedSections (pre-per-member migration)', () => {
+  it('gives every member its own section cloned from the shared one', () => {
+    // emulate an old model: one section shared by all members
+    const m = makeModel()
+    const shared = { ...section, id: 'S1', name: '300×500' }
+    const old = { ...m, sections: [shared], members: m.members.map((x) => ({ ...x, section: 'S1' })) }
+    const split = splitSharedSections(old)
+    expect(split.sections.length).toBe(old.members.length)
+    expect(split.members.every((x) => x.section === x.id)).toBe(true)
+    // dimensions preserved from the shared section
+    expect(split.sections.every((s) => s.b === 300 && s.h === 500)).toBe(true)
+    // now optimisation can move members independently
+    expect(splitSharedSections(split)).toBe(split)   // idempotent
   })
 })
 

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -8,7 +8,7 @@
 // Every stage reuses the existing engines unchanged.
 // ─────────────────────────────────────────────────────────────────────────
 import type { StructuralModel, RectSection, ModelLoad } from './model'
-import { enforceSectionHierarchy } from './modelBuilder'
+import { enforceSectionHierarchy, refreshSelfWeight } from './modelBuilder'
 import { modelToFrame3D } from './modelBridge'
 import { solveFrame3D, applyF3Combo, type F3Result, type F3MemberResult, type F3Load } from './frame3d'
 import { nscpCombos } from './beamAnalysis'
@@ -381,14 +381,17 @@ export function optimizeStructure(
 ): OptimizeResult | null {
   if (model.members.length === 0) return null
   const memSecId = new Map(model.members.map((m) => [m.id, m.section]))
-  let work = enforceSectionHierarchy(model)          // start width-consistent
+  // sizes & self-weight kept consistent at every step
+  const settle = (m: StructuralModel) => refreshSelfWeight(enforceSectionHierarchy(m))
+  let work = settle(model)                            // start width-consistent
   const steps: OptimizeStep[] = []
 
   let design = designStructure(work, soil, plan, opts)
   if (!design) return null
   steps.push({ iter: 0, grown: 0, fails: countFails(design), ok: designOK(design) })
 
-  // GROW: bump every failing member's own section, then re-enforce the hierarchy
+  // GROW: bump every failing member's own section, re-enforce the hierarchy and
+  // refresh self-weight so the heavier members feed back into the demands.
   let iter = 0
   while (!designOK(design) && iter++ < maxIter) {
     const failSids = new Set<string>()
@@ -396,7 +399,7 @@ export function optimizeStructure(
     for (const c of design.columns) if (!c.ok) { const s = memSecId.get(c.id); if (s) failSids.add(s) }
     if (failSids.size === 0) break                   // only footings fail — not a section problem
     const sizes = new Map(work.sections.map((s) => [s.id, failSids.has(s.id) ? growOne(s) : s]))
-    work = enforceSectionHierarchy(withSizes(work, sizes))
+    work = settle(withSizes(work, sizes))
     const d = designStructure(work, soil, plan, opts)
     if (!d) break
     design = d
@@ -412,7 +415,7 @@ export function optimizeStructure(
       for (const s0 of work.sections) {
         if (s0.h - 25 < 300) continue
         const trialSec: RectSection = { ...s0, h: s0.h - 25, name: `${s0.b}×${s0.h - 25}` }
-        const trial = enforceSectionHierarchy(withSizes(work, new Map([[s0.id, trialSec]])))
+        const trial = settle(withSizes(work, new Map([[s0.id, trialSec]])))
         const d = designStructure(trial, soil, plan, opts)
         if (d && designOK(d)) { work = trial; design = d; improved = true }
       }

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import { Canvas } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 import * as THREE from 'three'
-import { generateGridModel, removeElements, removeNode, buildGravityLoads } from '../engine/modelBuilder'
+import { generateGridModel, removeElements, removeNode, buildGravityLoads, splitSharedSections } from '../engine/modelBuilder'
 import type { StructuralModel, Member, Plate, RectSection, ModelLoad, MemberRole } from '../engine/model'
 import { distributePanel } from '../engine/tributary'
 import { modelToFrame3D } from '../engine/modelBridge'
@@ -221,7 +221,8 @@ export default function ModelSpace() {
   const [model, setModel] = useState<StructuralModel | null>(() => {
     try {
       const raw = sessionStorage.getItem(AUTOSAVE_KEY)
-      return raw ? (JSON.parse(raw) as StructuralModel) : null
+      // migrate pre-per-member models so each member owns its section
+      return raw ? splitSharedSections(JSON.parse(raw) as StructuralModel) : null
     } catch { return null }
   })
   const [selected, setSelected] = useState<string | null>(null)
@@ -478,7 +479,7 @@ export default function ModelSpace() {
       const m = JSON.parse(await f.text()) as StructuralModel
       if (m.version !== 1 || !Array.isArray(m.nodes)) throw new Error('not a model file')
       setSelected(null)
-      save(m)
+      save(splitSharedSections(m))   // migrate shared-section models to per-member
     } catch { alert('Could not read that file as a structural model (.model.json).') }
   }
 


### PR DESCRIPTION
## Why "everything became 300×525"
That model was **autosaved before per-member sizing** (#154). Back then the whole frame shared **one** section, so optimisation grew it (300×500 → 550, fails) then trimmed it (→ 525) — and every member moved together because they all pointed at the same section. New models generated after #154 are already per-member; only the cached/legacy one was shared.

## Fixes
- **`splitSharedSections(model)`** — gives every member its own section (`id = member id`), cloned from whatever it referenced. Applied when loading the autosave and on JSON upload, so legacy models regain independent sizing **without regenerating**. Idempotent.
- **`refreshSelfWeight(model)`** — recomputes member self-weight (`member-udl`, cat D) from each member's **current** section, leaving every other load untouched (no-op when the model has no self-weight). The optimise loop now re-enforces the strong-column/weak-beam hierarchy **and** refreshes self-weight on every grow/shrink step, so heavier (or leaner) members feed back into the demands each iteration — as requested.

## Tests (+2, 180 total)
- `refreshSelfWeight` scales with b·h and preserves area/live loads
- `splitSharedSections` produces one section per member and is idempotent

Verified in-browser: a migrated 1-section / 26-member model optimises to **independent** sizes (columns 300×400/425/450, beams 300×450/475) with self-weight matching the final sections — no more uniform 300×525. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)