### PR TITLE
Beam solution: fix tie KaTeX, fix all-hog interior, add V/M/load diagrams

### DIFF
--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -77,6 +77,25 @@ describe('design pipeline — single-bay single-storey grid', () => {
   })
 })
 
+describe('beam critical sections — interior is the sagging peak', () => {
+  it('a continuous multi-bay frame still sags at mid-span (not all hogging)', () => {
+    const m = generateGridModel({ baysX: [6, 6], baysZ: [5], storeyH: [3.5, 3], section })
+    m.loads = buildGravityLoads(m, 1.5, 2.4)
+    const r = designStructure(m, soil)!
+    const withInterior = r.beams.filter((b) => b.sections.some((s) => s.label.startsWith('Interior')))
+    expect(withInterior.length).toBeGreaterThan(0)
+    for (const b of withInterior) {
+      const interior = b.sections.find((s) => s.label.startsWith('Interior'))!
+      expect(interior.Mu).toBeGreaterThan(0)     // sagging (+M), bottom steel
+      expect(interior.hogging).toBe(false)
+      const ends = b.sections.filter((s) => s.label.startsWith('End'))
+      expect(ends.some((s) => s.hogging)).toBe(true)   // ends still hog
+    }
+    // governing-case diagrams are carried for the worked solution
+    expect(r.beams.every((b) => b.diag && b.diag.xs.length > 2)).toBe(true)
+  })
+})
+
 describe('combined footing plan', () => {
   const plan = { 'n0.0.0': { type: 'combined' as const, with: 'n1.0.0' } }
   const r = designStructure(makeModel(), soil, plan)!

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -38,7 +38,7 @@ export interface AnalyzeOptions {
 }
 
 export interface BeamSectionDesign {
-  label: string; Mu: number; Vu: number; hogging: boolean
+  label: string; x: number; Mu: number; Vu: number; hogging: boolean
   design: BeamDesignResult
 }
 export interface BeamScheduleRow {
@@ -46,6 +46,8 @@ export interface BeamScheduleRow {
   sections: BeamSectionDesign[]
   ok: boolean
   gov?: string   // governing load case (envelope)
+  /** Governing-case force diagrams along the member (for the worked solution). */
+  diag?: { xs: number[]; Vy: number[]; Mz: number[] }
 }
 export interface ColumnScheduleRow {
   id: string; L: number
@@ -90,17 +92,19 @@ export function designOK(d: StructureDesign): boolean {
 const beamOK = (d: BeamDesignResult) =>
   d.flexOK && d.comprEffective && d.comprNAOK && d.region !== 'inadequate'
 
-/** Critical sections of a frame member: both ends + the interior |M| peak
- *  between V-zero crossings (signed Mz; negative = hogging → top steel). */
+/** Critical sections of a frame member: the two ends (which carry the hogging
+ *  moments, top steel) plus the interior SAGGING peak — the most positive Mz
+ *  strictly inside (bottom steel). Using the signed peak rather than |Mz| keeps
+ *  the midspan section from latching onto a near-support hogging point. */
 function memberSections(mr: F3MemberResult): { label: string; x: number; Mu: number; Vu: number }[] {
   const out: { label: string; x: number; Mu: number; Vu: number }[] = []
   const n = mr.xs.length - 1
   out.push({ label: 'End i', x: 0, Mu: mr.Mz[0], Vu: Math.abs(mr.Vy[0]) })
   out.push({ label: 'End j', x: mr.L, Mu: mr.Mz[n], Vu: Math.abs(mr.Vy[n]) })
-  // interior extremum: largest |Mz| strictly inside
-  let best = -1, bestM = 0
+  // interior sagging peak: most positive Mz strictly inside the span
+  let best = -1, bestM = -Infinity
   for (let k = 1; k < n; k++) {
-    if (Math.abs(mr.Mz[k]) > Math.abs(bestM)) { bestM = mr.Mz[k]; best = k }
+    if (mr.Mz[k] > bestM) { bestM = mr.Mz[k]; best = k }
   }
   if (best > 0 && mr.xs[best] > 0.02 * mr.L && mr.xs[best] < 0.98 * mr.L) {
     out.push({ label: `Interior (x = ${mr.xs[best].toFixed(2)} m)`, x: mr.xs[best], Mu: bestM, Vu: Math.abs(mr.Vy[best]) })
@@ -113,14 +117,17 @@ function designBeamRow(mr: F3MemberResult, role: string, sec: RectSection): Beam
   const sections: BeamSectionDesign[] = memberSections(mr)
     .filter((s) => Math.abs(s.Mu) > 1e-6 || s.Vu > 1e-6)
     .map((s) => ({
-      label: s.label, Mu: s.Mu, Vu: s.Vu, hogging: s.Mu < 0,
+      label: s.label, x: s.x, Mu: s.Mu, Vu: s.Vu, hogging: s.Mu < 0,
       design: designBeam({
         b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia,
         comprBarDia: 16, stirrupDia: sec.tieDia,
         fc: sec.fc, fy: sec.fy, Mu: Math.abs(s.Mu), Vu: s.Vu,
       }),
     }))
-  return { id: mr.id, role, L: mr.L, sections, ok: sections.every((s) => beamOK(s.design)) }
+  return {
+    id: mr.id, role, L: mr.L, sections, ok: sections.every((s) => beamOK(s.design)),
+    diag: { xs: mr.xs, Vy: mr.Vy, Mz: mr.Mz },
+  }
 }
 
 /** Design one column from a single run's member result. */

--- a/webapp/src/lib/columnSolution.ts
+++ b/webapp/src/lib/columnSolution.ts
@@ -11,6 +11,11 @@ import { type SolutionStep, type SolutionLine, sn0, sn1, sn2, sn3, sn4 } from '.
 const txt = (text: string): SolutionLine => ({ text })
 const eq = (tex: string): SolutionLine => ({ tex })
 
+/** KaTeX-safe label for the governing tie-spacing term (underscores would
+ *  break inside \text, so render as proper math subscripts). */
+const tieGovernTex = (g: string): string =>
+  g === '16d_b' ? '16d_b' : g === '48d_tie' ? '48d_{tie}' : String.raw`\text{least dim.}`
+
 export function axialColumnSolution(i: AxialColumnInput, r: AxialColumnResult): SolutionStep[] {
   const tied = i.shape === 'tied'
   const steps: SolutionStep[] = []
@@ -56,8 +61,8 @@ export function axialColumnSolution(i: AxialColumnInput, r: AxialColumnResult): 
     steps.push({
       title: 'Tie detailing (§425.7.2)',
       lines: [
-        txt(`Ties at least ⌀${r.tieDiaMin} mm for ⌀${i.barDia} longitudinal bars; spacing the least of 16d_b, 48d_tie, and the least column dimension.`),
-        eq(String.raw`s \le \min(16\times ${i.barDia},\ 48\times ${i.tieDia},\ ${sn0(Math.min(i.b ?? 0, i.h ?? 0))}) = ${sn0(r.tieSpacing)}\ \text{mm}\ (\text{${r.tieGovern}})`),
+        txt(`Ties at least ⌀${r.tieDiaMin} mm for ⌀${i.barDia} longitudinal bars; spacing the least of 16·d_b, 48·d_tie, and the least column dimension.`),
+        eq(String.raw`s \le \min(16\times ${i.barDia},\ 48\times ${i.tieDia},\ ${sn0(Math.min(i.b ?? 0, i.h ?? 0))}) = ${sn0(r.tieSpacing)}\ \text{mm}\quad(${tieGovernTex(r.tieGovern)})`),
       ],
       note: `Provide ⌀${Math.max(i.tieDia, r.tieDiaMin)} mm ties @ ${sn0(r.tieSpacing)} mm.`,
     })

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -34,6 +34,15 @@ const LOAD_COLOR: Record<string, string> = {
 const parseList = (s: string): number[] =>
   s.split(/[, ]+/).map(parseFloat).filter((v) => Number.isFinite(v) && v > 0)
 
+/** Distributed load along a member derived from the shear, w ≈ −dV/dx
+ *  (central difference), for the loading diagram in the worked solution. */
+const loadFromShear = (xs: number[], Vy: number[]): number[] =>
+  xs.map((_, i) => {
+    if (i === 0 || i === xs.length - 1) return 0
+    const dx = xs[i + 1] - xs[i - 1]
+    return dx !== 0 ? -(Vy[i + 1] - Vy[i - 1]) / dx : 0
+  })
+
 // ── 3D primitives ─────────────────────────────────────────────────────────
 function Member3D({ a, b, role, selected, tint = 0, sec, onPick }: {
   a: THREE.Vector3; b: THREE.Vector3; role: string; selected: boolean
@@ -1078,6 +1087,16 @@ export default function ModelSpace() {
                     open && model && (
                       <tr key={`${key}:sol`}>
                         <td colSpan={8} className="bg-slate-50/60 px-2 pb-2">
+                          {bm.diag && (
+                            <div className="mt-2 grid grid-cols-1 gap-3 lg:grid-cols-3">
+                              <Diagram xs={bm.diag.xs} ys={loadFromShear(bm.diag.xs, bm.diag.Vy)} title="LOAD w (≈ −dV/dx)" unit="kN/m"
+                                color="#475569" vlines={[{ x: s.x, label: s.label.split(' ')[0] }]} />
+                              <Diagram xs={bm.diag.xs} ys={bm.diag.Vy} title="SHEAR Vy" unit="kN"
+                                color="#1f77b4" vlines={[{ x: s.x, label: s.label.split(' ')[0] }]} />
+                              <Diagram xs={bm.diag.xs} ys={bm.diag.Mz} title="MOMENT Mz (+sag)" unit="kN·m"
+                                color="#d62728" vlines={[{ x: s.x, label: s.label.split(' ')[0] }]} />
+                            </div>
+                          )}
                           <WorkedSolution steps={beamSectionSolution(sectionFor(bm.id) ?? model.sections[0], s)} title={`${bm.id} · ${s.label} — worked solution`} />
                         </td>
                       </tr>


### PR DESCRIPTION
Four fixes from the latest review of the model-space worked solutions.

### 1. Ties display error (KaTeX)
The §425.7.2 tie line rendered the governing term inside `\text{…}` — e.g. `\text{16d_b}` — and the underscore made KaTeX throw, so the whole equation showed as red source. Now rendered as proper math: `16d_b`, `48d_{tie}`, or `\text{least dim.}`.

### 2. Why every section of a member read "(hog)"
`memberSections` picked the interior critical section by the **largest |Mz|** strictly inside the span. In a stiff frame the end hogging dominates, so the "interior" point latched onto a value just inside the support — a **hogging** point — making End i / End j / Interior all read hog. It now takes the **most-positive Mz** (the true mid-span **sagging** peak); the two ends still carry the hogging. So a member now reads correctly: ends hog (top steel), mid-span sags (bottom steel).

### 3 & 4. Load / shear / moment diagrams in the solution, with the section marked
Each beam row now carries its governing-case force arrays (`diag: xs/Vy/Mz`) and each section's `x`. Expanding a beam/girder row renders three diagrams — **LOAD** (w ≈ −dV/dx), **SHEAR Vy**, **MOMENT Mz (+sag)** — above the step-by-step solution, each with a **dashed vertical line** at the critical-section location (reusing the existing `Diagram` `vlines`).

### Tests (+1, 181 total)
A continuous 2-bay × 2-storey frame now sags at mid-span (interior `Mu > 0`, `hogging: false`) while the ends hog, and the diagram arrays are carried.

Verified in-browser: **0 KaTeX errors**, **14/14** interior sections sag at mid-span, and the beam accordion shows the three diagrams with the section marker (screenshot: End-i section of bx0.0.1 with load/shear/moment and the dashed line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)