### PR TITLE
Geometry tab: slabs/plates list + walls as beam line loads

### DIFF
--- a/webapp/src/engine/model.ts
+++ b/webapp/src/engine/model.ts
@@ -32,6 +32,17 @@ export interface Plate {
   thickness: number             // mm
 }
 
+/** A wall sitting on a member: its self-weight is applied to that member as a
+ *  line load (D). `shearWall` tags it as a reinforced shear wall (lateral
+ *  system) for downstream design; gravity-only otherwise. */
+export interface Wall {
+  id: string
+  member: string                // supporting member id
+  height: number                // m
+  thickness: number             // mm
+  shearWall: boolean
+}
+
 export type SupportFixity = 'pin' | 'fixed' | 'roller' | 'spring'
 export interface NodeSupport { node: string; fixity: SupportFixity; k?: number }
 
@@ -50,11 +61,12 @@ export interface StructuralModel {
   sections: RectSection[]
   members: Member[]
   plates: Plate[]
+  walls?: Wall[]
   supports: NodeSupport[]
   loads: ModelLoad[]
   storeys: Storey[]
 }
 
 export function emptyModel(name = 'Untitled'): StructuralModel {
-  return { version: 1, name, nodes: [], sections: [], members: [], plates: [], supports: [], loads: [], storeys: [] }
+  return { version: 1, name, nodes: [], sections: [], members: [], plates: [], walls: [], supports: [], loads: [], storeys: [] }
 }

--- a/webapp/src/engine/modelBuilder.test.ts
+++ b/webapp/src/engine/modelBuilder.test.ts
@@ -1,8 +1,23 @@
 import { describe, it, expect } from 'vitest'
-import { generateGridModel, removeElements, nodeId } from './modelBuilder'
+import { generateGridModel, removeElements, nodeId, buildGravityLoads } from './modelBuilder'
 import type { RectSection } from './model'
 
 const sec: RectSection = { id: 'S1', name: '300×500', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
+
+describe('wall self-weight as a beam line load', () => {
+  it('adds a member-udl D of t·h·γc on the wall’s member', () => {
+    const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section: sec })
+    const beam = m.members.find((x) => x.role === 'beam')!
+    m.walls = [{ id: 'w0', member: beam.id, height: 3, thickness: 150, shearWall: false }]
+    const loads = buildGravityLoads(m, 0, 0)
+    const wall = loads.filter((l) => l.kind === 'member-udl' && l.member === beam.id && l.cat === 'D')
+    // beam self-weight (0.3·0.5·24 = 3.6) + wall (0.15·3·24 = 10.8)
+    const total = wall.reduce((s, l) => s + (l as { w: number }).w, 0)
+    expect(total).toBeCloseTo(0.3 * 0.5 * 24 + 0.15 * 3 * 24, 6)
+    expect(wall.some((l) => Math.abs((l as { w: number }).w - 10.8) < 1e-6)).toBe(true)  // the wall udl
+    expect(wall).toHaveLength(2)   // beam self-weight + wall
+  })
+})
 
 describe('grid model generator', () => {
   // 2 bays × 1 bay × 2 storeys → 3×2 grid points, 3 levels

--- a/webapp/src/engine/modelBuilder.ts
+++ b/webapp/src/engine/modelBuilder.ts
@@ -135,7 +135,8 @@ const GAMMA_C = 24 // kN/m³
 
 /**
  * Build the gravity load set: member SELF-WEIGHT (D, kN/m from the section),
- * slab SELF-WEIGHT + superimposed dead load (D, kPa), and live load (L, kPa).
+ * WALL self-weight on its supporting member (D, kN/m = t·h·γc), slab
+ * SELF-WEIGHT + superimposed dead load (D, kPa), and live load (L, kPa).
  * Loads of other categories (e.g. seismic E) are preserved from the model.
  */
 export function buildGravityLoads(model: StructuralModel, sdl: number, ll: number): StructuralModel['loads'] {
@@ -149,14 +150,20 @@ export function buildGravityLoads(model: StructuralModel, sdl: number, ll: numbe
       return { kind: 'member-udl' as const, member: m.id, w, cat: 'D' as const }
     })
     .filter((l) => l.w > 0)
-  const plateLoads: StructuralModel['loads'] = model.plates.flatMap((p) => {
-    const qSW = (p.thickness / 1000) * GAMMA_C
-    return [
-      { kind: 'area' as const, plate: p.id, q: qSW + sdl, cat: 'D' as const },
-      ...(ll > 0 ? [{ kind: 'area' as const, plate: p.id, q: ll, cat: 'L' as const }] : []),
-    ]
-  })
-  return [...memberSW, ...plateLoads, ...kept]
+  // wall self-weight as a line load on its supporting member
+  const wallSW: StructuralModel['loads'] = (model.walls ?? [])
+    .map((wl) => ({ kind: 'member-udl' as const, member: wl.member, w: (wl.thickness / 1000) * wl.height * GAMMA_C, cat: 'D' as const }))
+    .filter((l) => l.w > 0)
+  const plateLoads: StructuralModel['loads'] = model.plates
+    .filter((p) => p.role !== 'wall')
+    .flatMap((p) => {
+      const qSW = (p.thickness / 1000) * GAMMA_C
+      return [
+        { kind: 'area' as const, plate: p.id, q: qSW + sdl, cat: 'D' as const },
+        ...(ll > 0 ? [{ kind: 'area' as const, plate: p.id, q: ll, cat: 'L' as const }] : []),
+      ]
+    })
+  return [...memberSW, ...wallSW, ...plateLoads, ...kept]
 }
 
 /**

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -391,6 +391,9 @@ export default function ModelSpace() {
   // frame-editor add-member picks
   const [newI, setNewI] = useState(''); const [newJ, setNewJ] = useState('')
   const [newRole, setNewRole] = useState<MemberRole>('beam')
+  // wall-add form
+  const [wallMember, setWallMember] = useState(''); const [wallH, setWallH] = useState(3)
+  const [wallT, setWallT] = useState(150); const [wallShear, setWallShear] = useState(false)
   const fileRef = useRef<HTMLInputElement>(null)
 
   const save = (m: StructuralModel | null) => {
@@ -546,6 +549,24 @@ export default function ModelSpace() {
       sections: [...model.sections, { ...tmpl, id, name: `${tmpl.b}×${tmpl.h}` }],
       members: [...model.members, { id, i: newI, j: newJ, role: newRole, section: id }],
     })
+  }
+  const updPlateThickness = (id: string, t: number) => {
+    if (!model || !Number.isFinite(t)) return
+    const m2 = { ...model, plates: model.plates.map((p) => (p.id === id ? { ...p, thickness: t } : p)) }
+    save({ ...m2, loads: buildGravityLoads(m2, qD, qL) })
+  }
+  const addWall = () => {
+    if (!model || !wallMember) return
+    let k = model.walls?.length ?? 0
+    while ((model.walls ?? []).some((w) => w.id === `w${k}`)) k++
+    const walls = [...(model.walls ?? []), { id: `w${k}`, member: wallMember, height: wallH, thickness: wallT, shearWall: wallShear }]
+    const m2 = { ...model, walls }
+    save({ ...m2, loads: buildGravityLoads(m2, qD, qL) })
+  }
+  const removeWall = (id: string) => {
+    if (!model) return
+    const m2 = { ...model, walls: (model.walls ?? []).filter((w) => w.id !== id) }
+    save({ ...m2, loads: buildGravityLoads(m2, qD, qL) })
   }
   const updLoad = (idx: number, v: number) => {
     if (!model || !Number.isFinite(v)) return
@@ -876,6 +897,96 @@ export default function ModelSpace() {
                     <button type="button" onClick={addMember} disabled={!newI || !newJ || newI === newJ}
                       className="rounded-md border border-slate-300 px-2 py-1 font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50 disabled:opacity-40">+ Add member</button>
                   </div>
+                </div>
+              )}
+
+              {/* ── Plates (slabs) ── */}
+              {model && (
+                <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                  <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Slabs / plates</h3>
+                  {model.plates.filter((p) => p.role !== 'wall').length === 0 ? (
+                    <p className="text-xs text-slate-400">No slabs — generate a grid or add members forming closed panels.</p>
+                  ) : (
+                    <div className="max-h-60 overflow-auto">
+                      <table className="w-full border-collapse text-xs">
+                        <thead>
+                          <tr className="text-left uppercase tracking-wide text-slate-500">
+                            <th className="py-1 pr-2 font-semibold">Slab</th>
+                            <th className="py-1 pr-2 font-semibold">Corners</th>
+                            <th className="py-1 pr-1 font-semibold">t (mm)</th>
+                            <th className="py-1" />
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {model.plates.filter((p) => p.role !== 'wall').map((p) => (
+                            <tr key={p.id} className={`border-t border-slate-100 ${p.id === selected ? 'bg-amber-50' : ''}`}>
+                              <td className="py-0.5 pr-2 font-medium cursor-pointer" onClick={() => setSelected(p.id)}>{p.id}</td>
+                              <td className="py-0.5 pr-2 text-slate-500">{p.corners.join(', ')}</td>
+                              <td className="py-0.5 pr-1">
+                                <input type="number" step="10" value={p.thickness}
+                                  onChange={(e) => updPlateThickness(p.id, parseFloat(e.target.value))}
+                                  className="w-16 rounded border border-slate-200 px-1 py-0.5" />
+                              </td>
+                              <td className="py-0.5 text-right">
+                                <button type="button" onClick={() => { save(removeElements(model, new Set([p.id]))); if (selected === p.id) setSelected(null) }}
+                                  className="rounded px-1.5 text-red-500 hover:bg-red-50">✕</button>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+                  <p className="mt-1 text-[11px] text-slate-400">Thickness drives slab self-weight (t·γc) → tributary line loads on the edge beams.</p>
+                </div>
+              )}
+
+              {/* ── Walls ── */}
+              {model && (
+                <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                  <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Walls (on beams)</h3>
+                  {(model.walls ?? []).length > 0 && (
+                    <div className="mb-2 max-h-48 overflow-auto">
+                      <table className="w-full border-collapse text-xs">
+                        <thead>
+                          <tr className="text-left uppercase tracking-wide text-slate-500">
+                            <th className="py-1 pr-2 font-semibold">On</th>
+                            <th className="py-1 pr-1 font-semibold">h (m)</th>
+                            <th className="py-1 pr-1 font-semibold">t (mm)</th>
+                            <th className="py-1 pr-1 font-semibold">w (kN/m)</th>
+                            <th className="py-1 pr-1 font-semibold">Type</th>
+                            <th className="py-1" />
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {(model.walls ?? []).map((w) => (
+                            <tr key={w.id} className="border-t border-slate-100">
+                              <td className="py-0.5 pr-2 font-medium">{w.member}</td>
+                              <td className="py-0.5 pr-1">{f1(w.height)}</td>
+                              <td className="py-0.5 pr-1">{w.thickness}</td>
+                              <td className="py-0.5 pr-1">{f1((w.thickness / 1000) * w.height * 24)}</td>
+                              <td className="py-0.5 pr-1">{w.shearWall ? <span className="font-semibold text-purple-700">shear</span> : 'gravity'}</td>
+                              <td className="py-0.5 text-right">
+                                <button type="button" onClick={() => removeWall(w.id)} className="rounded px-1.5 text-red-500 hover:bg-red-50">✕</button>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+                  <div className="flex flex-wrap items-center gap-1 border-t border-slate-100 pt-2 text-xs">
+                    <select value={wallMember} onChange={(e) => setWallMember(e.target.value)} className="max-w-[6rem] rounded border border-slate-200 px-1 py-0.5">
+                      <option value="">on beam…</option>
+                      {model.members.filter((m) => m.role === 'beam' || m.role === 'girder').map((m) => <option key={m.id} value={m.id}>{m.id}</option>)}
+                    </select>
+                    <label className="inline-flex items-center gap-1">h <input type="number" step="0.5" value={wallH} onChange={(e) => setWallH(parseFloat(e.target.value) || 0)} className="w-12 rounded border border-slate-200 px-1 py-0.5" /></label>
+                    <label className="inline-flex items-center gap-1">t <input type="number" step="10" value={wallT} onChange={(e) => setWallT(parseFloat(e.target.value) || 0)} className="w-14 rounded border border-slate-200 px-1 py-0.5" /></label>
+                    <label className="inline-flex items-center gap-1"><input type="checkbox" checked={wallShear} onChange={(e) => setWallShear(e.target.checked)} /> shear wall</label>
+                    <button type="button" onClick={addWall} disabled={!wallMember}
+                      className="rounded-md border border-slate-300 px-2 py-1 font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50 disabled:opacity-40">+ Add wall</button>
+                  </div>
+                  <p className="mt-1 text-[11px] text-slate-400">A wall adds its self-weight (t·h·γc) as a line load on the chosen beam. “Shear wall” is tagged for the lateral system (stiffness handled in a later step).</p>
                 </div>
               )}
             </div>


### PR DESCRIPTION
PR 3 of the model-space follow-ups. Adds slab management and walls to the **Geometry** tab.

## Slabs / plates
A panel listing every slab with its corner nodes and an **editable thickness** (mm), plus remove. Changing thickness rebuilds the gravity loads so the slab self-weight (t·γc) → tributary line loads update immediately.

## Walls (on beams)
Add a **wall on a beam/girder** with a height (m), thickness (mm) and a **shear-wall / reinforced** flag. The wall applies its self-weight **t·h·γc as a line load (D)** on the chosen member — shown in the list as `w (kN/m)` and tagged gravity / shear. Remove supported.

- `model.ts`: new `Wall` type + optional `model.walls` (backward compatible — old files/loads unaffected).
- `buildGravityLoads`: emits the wall line loads and excludes any `role: 'wall'` plates from slab area loads.

The **shear-wall flag is stored for the lateral-force-resisting system**; adding actual shear-wall stiffness to the frame is the next PR (it's the larger FE change). Likewise the **slab Direct Design Method** engine follows after.

Test (+1, 182 total): a wall adds a 10.8 kN/m line load alongside the beam self-weight. Build clean. Verified in-browser: Slabs and Walls panels render, adding a wall on `bx0.0.1` creates the wall + its line load, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)