### PR TITLE
Shear walls join the lateral system (equivalent diagonal struts)

### DIFF
--- a/webapp/src/engine/modelBridge.ts
+++ b/webapp/src/engine/modelBridge.ts
@@ -31,6 +31,53 @@ function sectionProps(s: RectSection) {
   }
 }
 
+/**
+ * Shear walls → equivalent diagonal struts that carry the panel's lateral
+ * (in-plane) stiffness. A wall tagged `shearWall` on a beam (i,j) braces the
+ * storey BELOW it: the panel is bounded by the beam nodes and the nodes
+ * directly beneath them. Its combined shear + cantilever-flexure stiffness
+ *   K = [ 1/(G·t·Lw/H) + 1/(3E·I_w/H³) ]⁻¹
+ * is reproduced by an X of two pin-like struts (large A, ~0 I) whose axial
+ * stiffness, projected horizontally (2·(EA/Ld)·cos²θ), equals K. Derived in the
+ * bridge so the walls stay walls and the design pipeline ignores the struts.
+ */
+function wallStruts(model: StructuralModel, nm: Map<string, F3Node>): F3Member[] {
+  const walls = (model.walls ?? []).filter((w) => w.shearWall)
+  if (walls.length === 0) return []
+  const fcOf = new Map(model.sections.map((s) => [s.id, s.fc]))
+  const belowOf = (id: string): F3Node | null => {
+    const n = nm.get(id); if (!n) return null
+    let best: F3Node | null = null
+    for (const q of nm.values()) {
+      if (q.id === id || q.y >= n.y - 1e-4) continue
+      if (Math.abs(q.x - n.x) < 1e-4 && Math.abs(q.z - n.z) < 1e-4 && (!best || q.y > best.y)) best = q
+    }
+    return best
+  }
+  const out: F3Member[] = []
+  for (const w of walls) {
+    const m = model.members.find((mm) => mm.id === w.member); if (!m) continue
+    const a = nm.get(m.i), b = nm.get(m.j); if (!a || !b) continue
+    const aD = belowOf(m.i), bD = belowOf(m.j); if (!aD || !bD) continue
+    const Lw = Math.hypot(b.x - a.x, b.z - a.z) * 1000      // mm, horizontal panel length
+    const H = (a.y - aD.y) * 1000                            // mm, panel height
+    if (!(Lw > 0 && H > 0)) continue
+    const fc = fcOf.get(m.section) ?? 28
+    const E = 4700 * Math.sqrt(Math.max(fc, 1)), G = E / 2.4
+    const Kshear = (G * w.thickness * Lw) / H                // N/mm
+    const Kflex = (3 * E * (w.thickness * Lw ** 3 / 12)) / H ** 3
+    const K = 1 / (1 / Kshear + 1 / Kflex)                   // N/mm ≡ kN/m
+    const Ldm = Math.hypot(Lw, H) / 1000                     // m
+    const cos = Lw / Math.hypot(Lw, H)
+    const Ad = (K * 1000 * Ldm) / (2 * E * cos * cos)        // mm² (matches solver EA=E·A/1000 over L)
+    const tiny = Math.max(1, Ad * 1e-6)
+    const strut = (id: string, i: string, j: string): F3Member =>
+      ({ id, i, j, E, G, A: Ad, Iy: tiny, Iz: tiny, J: tiny })
+    out.push(strut(`wallstrut_${w.id}_1`, aD.id, m.j), strut(`wallstrut_${w.id}_2`, bD.id, m.i))
+  }
+  return out
+}
+
 /** Map a BeamLoad (x from edge start) onto a member that may run either way. */
 function edgeLoadToMember(ld: BeamLoad, memberId: string, sameDir: boolean, L: number): F3Load | null {
   if (ld.type === 'udl') {
@@ -54,6 +101,8 @@ export function modelToFrame3D(model: StructuralModel): BridgeResult {
   const members: F3Member[] = model.members.map((m) => ({
     id: m.id, i: m.i, j: m.j, ...(secById.get(m.section) ?? fallback),
   }))
+  // shear walls → equivalent diagonal struts (lateral stiffness only)
+  members.push(...wallStruts(model, nm))
   const memberByPair = new Map<string, { id: string; i: string; j: string }>()
   for (const m of model.members) {
     memberByPair.set(`${m.i}|${m.j}`, m)

--- a/webapp/src/engine/shearWall.test.ts
+++ b/webapp/src/engine/shearWall.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { generateGridModel } from './modelBuilder'
+import { modelToFrame3D } from './modelBridge'
+import { solveFrame3D } from './frame3d'
+import type { F3Load } from './frame3d'
+import type { RectSection, StructuralModel } from './model'
+
+const section: RectSection = { id: 'S1', name: '300×500', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
+
+function topDriftX(m: StructuralModel): { dx: number; struts: number } {
+  const br = modelToFrame3D(m)
+  const loads: F3Load[] = [{ kind: 'node', node: 'n0.0.1', Fx: 100, cat: 'E' }]
+  const sol = solveFrame3D(br.nodes, br.members, br.supports, loads)!
+  const idx = br.nodes.findIndex((n) => n.id === 'n0.0.1')
+  return { dx: Math.abs(sol.d[6 * idx]), struts: br.members.filter((x) => x.id.startsWith('wallstrut')).length }
+}
+
+describe('shear wall lateral stiffness (equivalent diagonal struts)', () => {
+  const base = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })
+
+  it('a bare frame has no struts', () => {
+    const r = topDriftX(base)
+    expect(r.struts).toBe(0)
+    expect(r.dx).toBeGreaterThan(0)
+  })
+
+  it('tagging a shear wall on a beam injects an X of struts and stiffens the frame', () => {
+    const bare = topDriftX(base)
+    const withWall: StructuralModel = {
+      ...base,
+      walls: [{ id: 'w0', member: 'bx0.0.1', height: 3, thickness: 200, shearWall: true }],
+    }
+    const r = topDriftX(withWall)
+    expect(r.struts).toBe(2)                       // bottom-left→top-right + bottom-right→top-left
+    expect(r.dx).toBeLessThan(bare.dx * 0.5)       // markedly stiffer in-plane
+  })
+
+  it('a non-shear (gravity-only) wall adds no lateral stiffness', () => {
+    const bare = topDriftX(base)
+    const gravWall: StructuralModel = {
+      ...base,
+      walls: [{ id: 'w0', member: 'bx0.0.1', height: 3, thickness: 200, shearWall: false }],
+    }
+    const r = topDriftX(gravWall)
+    expect(r.struts).toBe(0)
+    expect(r.dx).toBeCloseTo(bare.dx, 9)
+  })
+})

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -106,6 +106,33 @@ function Support3D({ p }: { p: THREE.Vector3 }) {
   )
 }
 
+/** Wall panel between the beam nodes (tA,tB) and the nodes below (bA,bB).
+ *  Shear walls show the equivalent X-strut; gravity walls are a plain panel. */
+function Wall3D({ tA, tB, bA, bB, shear }: { tA: THREE.Vector3; tB: THREE.Vector3; bA: THREE.Vector3; bB: THREE.Vector3; shear: boolean }) {
+  const { fill, x1, x2 } = useMemo(() => {
+    const pos = [bA, bB, tB, bA, tB, tA].flatMap((p) => [p.x, p.y, p.z])
+    const fill = new THREE.BufferGeometry()
+    fill.setAttribute('position', new THREE.Float32BufferAttribute(pos, 3))
+    return {
+      fill,
+      x1: new THREE.BufferGeometry().setFromPoints([bA, tB]),
+      x2: new THREE.BufferGeometry().setFromPoints([bB, tA]),
+    }
+  }, [tA, tB, bA, bB])
+  const color = shear ? '#7c3aed' : '#94a3b8'
+  return (
+    <group>
+      <mesh geometry={fill}>
+        <meshBasicMaterial color={color} transparent opacity={shear ? 0.22 : 0.14} side={THREE.DoubleSide} depthWrite={false} />
+      </mesh>
+      {shear && <>
+        <primitive object={new THREE.Line(x1, new THREE.LineBasicMaterial({ color }))} />
+        <primitive object={new THREE.Line(x2, new THREE.LineBasicMaterial({ color }))} />
+      </>}
+    </group>
+  )
+}
+
 // ── Load glyphs ─────────────────────────────────────────────────────────────
 const UP = new THREE.Vector3(0, 1, 0)
 /** A single force arrow with its head at `tip`, drawn back along −`dir`. */
@@ -714,6 +741,22 @@ export default function ModelSpace() {
                   const p = nodePos.get(s.node)
                   return p ? <Support3D key={s.node} p={p} /> : null
                 })}
+                {(model.walls ?? []).map((w) => {
+                  const m = model.members.find((mm) => mm.id === w.member)
+                  const tA = m && nodePos.get(m.i), tB = m && nodePos.get(m.j)
+                  if (!tA || !tB) return null
+                  const below = (p: THREE.Vector3) => {
+                    let best: THREE.Vector3 | null = null
+                    for (const n of model.nodes) {
+                      const q = nodePos.get(n.id)!
+                      if (Math.abs(q.x - p.x) < 1e-4 && Math.abs(q.z - p.z) < 1e-4 && q.y < p.y - 1e-4 && (!best || q.y > best.y)) best = q
+                    }
+                    return best
+                  }
+                  const bA = below(tA), bB = below(tB)
+                  if (!bA || !bB) return null
+                  return <Wall3D key={w.id} tA={tA} tB={tB} bA={bA} bB={bB} shear={w.shearWall} />
+                })}
                 {showLoads && <Loads3D model={model} nodePos={nodePos} />}
                 <OrbitControls makeDefault target={[6, 3, 2.5]} />
               </Canvas>
@@ -986,7 +1029,7 @@ export default function ModelSpace() {
                     <button type="button" onClick={addWall} disabled={!wallMember}
                       className="rounded-md border border-slate-300 px-2 py-1 font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50 disabled:opacity-40">+ Add wall</button>
                   </div>
-                  <p className="mt-1 text-[11px] text-slate-400">A wall adds its self-weight (t·h·γc) as a line load on the chosen beam. “Shear wall” is tagged for the lateral system (stiffness handled in a later step).</p>
+                  <p className="mt-1 text-[11px] text-slate-400">A wall adds its self-weight (t·h·γc) as a line load on the chosen beam. A “shear wall” also braces the storey below it — modelled as an equivalent X of diagonal struts (shear + flexure stiffness) so it carries seismic/wind in the analysis.</p>
                 </div>
               )}
             </div>


### PR DESCRIPTION
PR 4 of the model-space follow-ups. Walls tagged **shear wall** now carry lateral load, not just gravity.

## How
- `modelBridge.wallStruts()` derives an **equivalent X of diagonal struts** for each shear wall, bracing the storey **below** its beam (panel = beam nodes + the nodes directly beneath). The struts are sized so their horizontal axial stiffness reproduces the wall panel's combined **shear + cantilever-flexure** stiffness:
  - `K = [ 1/(G·t·Lw/H) + 1/(3E·I_w/H³) ]⁻¹`
  - two struts → `2·(E·A/Ld)·cos²θ = K` ⇒ solve `A`; struts get a near-zero `I` so they act as pin-jointed truss members (no spurious frame bending).
- Derived **in the bridge**, so the model keeps walls as walls and the design pipeline ignores the struts. Seismic, wind and storey-drift all see the added stiffness automatically.
- **3D:** `Wall3D` draws the wall panel — purple with its X-strut for shear walls, grey for gravity walls — in the braced storey.

## Tests (+3, 185 total)
- A bare frame has no struts.
- Tagging a shear wall injects exactly 2 struts and cuts the in-plane lateral drift by **> 50 %**.
- A gravity-only wall adds no struts and leaves drift unchanged.

Build clean. Verified in-browser: adding a shear wall on a beam applies its self-weight line load and renders the panel with no errors.

Note: this adds the wall's **stiffness participation** in the lateral system. Designing the wall itself (in-plane shear/boundary elements from the strut axial force) is a natural follow-up. Next planned PR: the **slab design engine (Direct Design Method, §408)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)