### PR TITLE
Slab design — two-way Direct Design Method (NSCP §408.10) + schedule

### DIFF
--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -16,6 +16,7 @@ import { designBeam, type BeamDesignResult } from './beamDesign'
 import { designAxialColumn, capacityAtEccentricity, interaction } from './columnDesign'
 import { designSquareFooting, type SquareFootingResult } from './isolatedFooting'
 import { designCombinedFooting, type CombinedFootingResult } from './combinedFooting'
+import { designSlabDDM, type SlabDesignResult } from './slabDDM'
 
 export interface SoilOptions {
   qAllow: number; gammaSoil: number; gammaConc: number; H: number
@@ -70,6 +71,12 @@ export interface CombinedScheduleRow {
   design: CombinedFootingResult
   ok: boolean
 }
+export interface SlabScheduleRow {
+  plate: string
+  lx: number; ly: number
+  design: SlabDesignResult
+  ok: boolean
+}
 /** Per-support footing choice: isolated (default) or combined with another node. */
 export type FootingPlan = Record<string, { type: 'isolated' } | { type: 'combined'; with: string }>
 
@@ -78,6 +85,7 @@ export interface StructureDesign {
   cases: string[]   // every load case (combo × direction) run for the envelope
   beams: BeamScheduleRow[]
   columns: ColumnScheduleRow[]
+  slabs: SlabScheduleRow[]
   footings: FootingScheduleRow[]
   combined: CombinedScheduleRow[]
   totals: { concreteMembers: number; concreteSlabs: number; concrete: number }
@@ -346,10 +354,35 @@ export function designStructure(
     concreteSlabs += lx * lz * (p.thickness / 1000)
   }
 
+  // ── Slabs — two-way Direct Design Method ──
+  const xMin = Math.min(...model.nodes.map((n) => n.x)), xMax = Math.max(...model.nodes.map((n) => n.x))
+  const zMin = Math.min(...model.nodes.map((n) => n.z)), zMax = Math.max(...model.nodes.map((n) => n.z))
+  const slabs: SlabScheduleRow[] = []
+  for (const p of model.plates) {
+    if (p.role === 'wall') continue
+    const c = p.corners.map((id) => nm.get(id)); if (c.some((q) => !q)) continue
+    const cc = c as { x: number; y: number; z: number }[]
+    const lx = Math.hypot(cc[1].x - cc[0].x, cc[1].z - cc[0].z)
+    const lz = Math.hypot(cc[3].x - cc[0].x, cc[3].z - cc[0].z)
+    if (!(lx > 0 && lz > 0)) continue
+    const areaD = model.loads.filter((l) => l.kind === 'area' && l.plate === p.id && l.cat === 'D').reduce((s, l) => s + (l as { q: number }).q, 0)
+    const areaL = model.loads.filter((l) => l.kind === 'area' && l.plate === p.id && l.cat === 'L').reduce((s, l) => s + (l as { q: number }).q, 0)
+    if (areaD + areaL < 1e-9) continue
+    const cs = footSec(p.corners[0])
+    const extX = cc.some((q) => Math.abs(q.x - xMin) < 1e-4) || cc.some((q) => Math.abs(q.x - xMax) < 1e-4)
+    const extZ = cc.some((q) => Math.abs(q.z - zMin) < 1e-4) || cc.some((q) => Math.abs(q.z - zMax) < 1e-4)
+    const design = designSlabDDM({
+      lx, ly: lz, colWidth: Math.min(cs.b, cs.h), D: areaD, L: areaL,
+      fc: cs.fc, fy: cs.fy, h: p.thickness, cover: 20, barDia: 12,
+      exterior: { x: extX, y: extZ }, withBeams: true,
+    })
+    slabs.push({ plate: p.id, lx, ly: lz, design, ok: design.applicable })
+  }
+
   return {
     govName: runs[govIdx].name,
     cases: runs.map((r) => r.name),
-    beams, columns, footings, combined,
+    beams, columns, slabs, footings, combined,
     totals: { concreteMembers, concreteSlabs, concrete: concreteMembers + concreteSlabs },
     orphanEdges: br.orphanEdges.length,
   }

--- a/webapp/src/engine/slabDDM.test.ts
+++ b/webapp/src/engine/slabDDM.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { designSlabDDM } from './slabDDM'
+
+const base = { lx: 6, ly: 6, colWidth: 400, D: 5.0, L: 2.0, fc: 28, fy: 415, cover: 20, barDia: 12 }
+
+describe('slab DDM — static moment & distribution', () => {
+  it('Mo = wu·ℓ2·ℓn²/8 and the interior split is 0.65 / 0.35', () => {
+    const r = designSlabDDM({ ...base })            // interior panel (no exterior edges)
+    const wu = 1.2 * 5 + 1.6 * 2                     // 10.0 kPa
+    const ln = 6 - 0.4                               // 5.6 m
+    const Mo = (wu * 6 * ln * ln) / 8
+    expect(r.wu).toBeCloseTo(wu, 9)
+    expect(r.x.ln).toBeCloseTo(ln, 9)
+    expect(r.x.Mo).toBeCloseTo(Mo, 6)
+    const neg = r.x.locations.find((l) => l.name === 'Support −M')!
+    const pos = r.x.locations.find((l) => l.name === '+M')!
+    expect(neg.coeff).toBeCloseTo(0.65, 9)
+    expect(pos.coeff).toBeCloseTo(0.35, 9)
+    // column + middle moment sum back to the location total
+    expect(neg.column.M + neg.middle.M).toBeCloseTo(0.65 * Mo, 6)
+  })
+
+  it('end span uses 0.16 / 0.57 / 0.70 with beams on all edges', () => {
+    const r = designSlabDDM({ ...base, exterior: { x: true, y: false } })
+    const coeffs = r.x.locations.map((l) => l.coeff)
+    expect(coeffs).toEqual([0.16, 0.57, 0.70])
+    // exterior negative goes entirely to the column strip (no edge beam, βt = 0)
+    const ext = r.x.locations[0]
+    expect(ext.csFrac).toBe(1.0)
+    expect(ext.middle.M).toBeCloseTo(0, 9)
+  })
+
+  it('square panel is symmetric in x and y', () => {
+    const r = designSlabDDM({ ...base })
+    expect(r.x.Mo).toBeCloseTo(r.y.Mo, 6)
+  })
+})
+
+describe('slab DDM — steel & checks', () => {
+  it('every section meets temp/shrinkage minimum and the 2h/450 spacing cap', () => {
+    const r = designSlabDDM({ ...base, h: 180 })
+    const asMin = 0.0018 * 1000 * 180                       // per metre width
+    for (const loc of [...r.x.locations, ...r.y.locations]) {
+      for (const strip of [loc.column, loc.middle]) {
+        if (strip.b < 1) continue
+        expect(strip.As / strip.b).toBeGreaterThanOrEqual(asMin / 1000 - 1e-6) // ≥ ρ_min·b
+        expect(strip.spacing).toBeLessThanOrEqual(Math.min(2 * 180, 450) + 1)
+        expect(strip.bars).toBeGreaterThanOrEqual(2)
+      }
+    }
+  })
+
+  it('minimum thickness from §408.3.1.2 and a sensible default h', () => {
+    const r = designSlabDDM({ ...base })
+    const lnLong = 6 - 0.4, beta = 1
+    const hmin = (lnLong * 1000 * (0.8 + 415 / 1400)) / (36 + 9 * beta)
+    expect(r.hmin).toBeCloseTo(Math.max(90, hmin), 3)
+    expect(r.h).toBeGreaterThanOrEqual(r.hmin)
+  })
+
+  it('flags DDM-applicability violations', () => {
+    const oneWay = designSlabDDM({ ...base, ly: 14 })       // 14/6 > 2
+    expect(oneWay.twoWay).toBe(false)
+    expect(oneWay.applicable).toBe(false)
+    const heavyLL = designSlabDDM({ ...base, D: 2, L: 6 })  // L > 2D
+    expect(heavyLL.applicable).toBe(false)
+    expect(heavyLL.notes.some((n) => /Live load/.test(n))).toBe(true)
+  })
+})

--- a/webapp/src/engine/slabDDM.ts
+++ b/webapp/src/engine/slabDDM.ts
@@ -1,0 +1,131 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Two-way slab — Direct Design Method (NSCP 2015 §408.10 / ACI 318-14 §8.10).
+//   Total static moment  Mo = wu·ℓ2·ℓn²/8           (§408.10.3)
+//   split into negative / positive (interior or end span, §408.10.4) then into
+//   column-strip / middle-strip shares (§408.10.5/6), each reinforced for
+//   flexure with the §408.6.1.1 temperature/shrinkage minimum and §408.7.2.2
+//   maximum spacing. Beam stiffness αf is conservatively neglected for the
+//   SLAB steel (the bounding beams are designed separately by the frame
+//   pipeline), so the slab carries the full column-strip share.
+// Units: spans m; loads kPa; h/cover/db mm; moments kN·m; steel mm².
+// ─────────────────────────────────────────────────────────────────────────
+import { flexuralSteel } from './flexure'
+
+export interface SlabInput {
+  lx: number; ly: number          // centre-to-centre spans, m (lx ≤ ly used as short/long)
+  colWidth: number                // support width along the span, mm (clear-span deduction)
+  D: number; L: number            // service area loads, kPa
+  fc: number; fy: number
+  h?: number                      // slab thickness, mm (defaults to the §408.3.1.2 minimum)
+  cover?: number; barDia?: number
+  /** Is the panel's span an END span (one discontinuous edge) in each dir? */
+  exterior?: { x: boolean; y: boolean }
+  /** Beams on all edges (grid panels) → end-span coefficients per case (b). */
+  withBeams?: boolean
+}
+
+export interface SlabSectionSteel {
+  M: number                       // kN·m on the strip
+  b: number                       // strip width, mm
+  As: number; bars: number; spacing: number; usedMin: boolean
+}
+export interface SlabLocation {
+  name: 'Ext −M' | '+M' | 'Int −M' | 'Support −M'
+  coeff: number                   // fraction of Mo
+  M: number                       // kN·m (total across ℓ2)
+  csFrac: number                  // column-strip share
+  column: SlabSectionSteel
+  middle: SlabSectionSteel
+}
+export interface SlabDirResult {
+  dir: 'x' | 'y'
+  l1: number; l2: number; ln: number
+  Mo: number
+  csWidth: number; msWidth: number   // m
+  locations: SlabLocation[]
+}
+export interface SlabDesignResult {
+  h: number; hmin: number; wu: number
+  ratio: number                   // long/short
+  twoWay: boolean
+  applicable: boolean
+  notes: string[]
+  x: SlabDirResult
+  y: SlabDirResult
+}
+
+const interp = (r: number, a: number, b: number, c: number): number =>
+  r <= 0.5 ? a : r >= 2 ? c : r <= 1 ? a + (b - a) * (r - 0.5) / 0.5 : b + (c - b) * (r - 1) / 1
+
+// Column-strip share of each moment (slab WITHOUT beams, βt = 0), by ℓ2/ℓ1.
+const csInteriorNeg = (r: number) => interp(r, 0.90, 0.75, 0.45)
+const csPositive = (r: number) => interp(r, 0.60, 0.60, 0.45)
+const csExteriorNeg = () => 1.0       // no edge beam → column strip takes all
+
+export function designSlabDDM(i: SlabInput): SlabDesignResult {
+  const cover = i.cover ?? 20, db = i.barDia ?? 12, Ab = (Math.PI / 4) * db * db
+  const short = Math.min(i.lx, i.ly), long = Math.max(i.lx, i.ly)
+  const ratio = long / short
+  const twoWay = ratio < 2
+  const wu = 1.2 * i.D + 1.6 * i.L
+
+  // minimum thickness (two-way with beams, αfm ≥ 2 governing form, §408.3.1.2)
+  const lnLong = long - i.colWidth / 1000
+  const lnShort = short - i.colWidth / 1000
+  const beta = lnLong / Math.max(lnShort, 1e-9)
+  const hmin = Math.max(90, (lnLong * 1000 * (0.8 + i.fy / 1400)) / (36 + 9 * beta))
+  const h = i.h ?? Math.ceil(hmin / 5) * 5
+
+  const notes: string[] = []
+  if (!twoWay) notes.push('Long/short > 2 → behaves one-way; DDM (two-way) not applicable.')
+  if (i.L > 2 * i.D) notes.push('Live load > 2× dead — outside DDM limit §408.10.2.6 (unfactored L/D ≤ 2).')
+  if (i.h !== undefined && i.h < hmin) notes.push(`Thickness ${i.h} mm < minimum ${Math.round(hmin)} mm (§408.3.1.2).`)
+  notes.push('DDM assumes ≥ 3 spans each way, roughly equal spans and ≤ 10% column offset.')
+  notes.push('Beam stiffness αf neglected for slab steel (conservative; beams designed separately).')
+
+  const dir = (which: 'x' | 'y'): SlabDirResult => {
+    const l1 = which === 'x' ? i.lx : i.ly
+    const l2 = which === 'x' ? i.ly : i.lx
+    const ln = Math.max(0.65 * l1, l1 - i.colWidth / 1000)
+    const Mo = (wu * l2 * ln * ln) / 8
+    const r = l2 / l1
+    const csWidth = 2 * Math.min(0.25 * l1, 0.25 * l2)   // m
+    const msWidth = Math.max(0, l2 - csWidth)
+    // effective depth — short dir uses the outer layer, long dir the inner
+    const d = which === (i.lx <= i.ly ? 'x' : 'y') ? h - cover - db / 2 : h - cover - 1.5 * db
+
+    const isEnd = i.exterior?.[which] ?? false
+    const withBeams = i.withBeams ?? true
+    // (coeff of Mo, location name, column-strip fraction)
+    const spec: [number, SlabLocation['name'], number][] = isEnd
+      ? withBeams
+        ? [[0.16, 'Ext −M', csExteriorNeg()], [0.57, '+M', csPositive(r)], [0.70, 'Int −M', csInteriorNeg(r)]]
+        : [[0.26, 'Ext −M', csExteriorNeg()], [0.52, '+M', csPositive(r)], [0.70, 'Int −M', csInteriorNeg(r)]]
+      : [[0.65, 'Support −M', csInteriorNeg(r)], [0.35, '+M', csPositive(r)]]
+
+    const steel = (M: number, b: number): SlabSectionSteel => {
+      const flex = flexuralSteel({ Mu: Math.abs(M), b, d, fc: i.fc, fy: i.fy })
+      const asMin = (i.fy >= 420 ? 0.0018 : 0.002) * b * h    // §408.6.1.1 temp/shrinkage
+      const As = Math.max(flex.As, asMin)
+      const smax = Math.min(2 * h, 450)                        // §408.7.2.2
+      const n = Math.max(2, Math.ceil(As / Ab), Math.ceil(b / smax))
+      return { M: Math.abs(M), b, As, bars: n, spacing: (b - db) / (n - 1), usedMin: As <= asMin + 1e-9 }
+    }
+
+    const locations: SlabLocation[] = spec.map(([coeff, name, csFrac]) => {
+      const M = coeff * Mo
+      return {
+        name, coeff, M, csFrac,
+        column: steel(csFrac * M, csWidth * 1000),
+        middle: steel((1 - csFrac) * M, msWidth * 1000),
+      }
+    })
+    return { dir: which, l1, l2, ln, Mo, csWidth, msWidth, locations }
+  }
+
+  return {
+    h, hmin, wu, ratio, twoWay,
+    applicable: twoWay && i.L <= 2 * i.D,
+    notes, x: dir('x'), y: dir('y'),
+  }
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -1510,6 +1510,86 @@ export default function ModelSpace() {
             </table>
           </div>
 
+          {/* Slab schedule (full width) — two-way DDM */}
+          {design.slabs.length > 0 && (
+            <div className="print-avoid-break overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Slab schedule (two-way DDM)</h3>
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="text-left uppercase tracking-wide text-slate-500">
+                    <th className="py-1 pr-2 font-semibold">Panel</th>
+                    <th className="py-1 pr-2 font-semibold">lx × ly (m)</th>
+                    <th className="py-1 pr-2 font-semibold">h (mm)</th>
+                    <th className="py-1 pr-2 font-semibold">Behaviour</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Mo,x / Mo,y (kN·m)</th>
+                    <th className="py-1 font-semibold">DDM</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {design.slabs.flatMap((sl) => {
+                    const key = `slab:${sl.plate}`, open = expanded === key
+                    const dd = sl.design
+                    return [
+                      <tr key={key} onClick={() => setExpanded(open ? null : key)}
+                        className={`cursor-pointer border-t border-slate-100 hover:bg-blue-50/40 ${dd.applicable ? '' : 'bg-amber-50 text-amber-800'}`}>
+                        <td className="py-1 pr-2 font-medium">{open ? '▾' : '▸'} {sl.plate}</td>
+                        <td className="py-1 pr-2">{f1(sl.lx)} × {f1(sl.ly)}</td>
+                        <td className="py-1 pr-2">{Math.round(dd.h)}{dd.h < dd.hmin ? ` (< ${Math.round(dd.hmin)} min)` : ''}</td>
+                        <td className="py-1 pr-2">{dd.twoWay ? 'two-way' : 'one-way'}</td>
+                        <td className="py-1 pr-2 text-right">{f1(dd.x.Mo)} / {f1(dd.y.Mo)}</td>
+                        <td className="py-1">{dd.applicable ? '✓' : '⚠ check'}</td>
+                      </tr>,
+                      open && (
+                        <tr key={`${key}:sol`}>
+                          <td colSpan={6} className="bg-slate-50/60 px-3 pb-3">
+                            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                              {[dd.x, dd.y].map((dr) => (
+                                <div key={dr.dir}>
+                                  <p className="mb-1 mt-2 text-[12px] font-bold text-[#0056b3]">
+                                    {dr.dir.toUpperCase()}-direction — ℓ1 = {f1(dr.l1)} m, ℓn = {f1(dr.ln)} m, Mo = {f1(dr.Mo)} kN·m
+                                  </p>
+                                  <table className="w-full border-collapse text-[11px]">
+                                    <thead>
+                                      <tr className="text-left text-slate-500">
+                                        <th className="py-0.5 pr-2">Location</th>
+                                        <th className="py-0.5 pr-2 text-right">M (kN·m)</th>
+                                        <th className="py-0.5 pr-2">Column strip</th>
+                                        <th className="py-0.5">Middle strip</th>
+                                      </tr>
+                                    </thead>
+                                    <tbody>
+                                      {dr.locations.map((loc, li) => (
+                                        <tr key={li} className="border-t border-slate-100">
+                                          <td className="py-0.5 pr-2">{loc.name} <span className="text-slate-400">({loc.coeff.toFixed(2)})</span></td>
+                                          <td className="py-0.5 pr-2 text-right">{f1(loc.M)}</td>
+                                          <td className="py-0.5 pr-2">⌀12 @ {Math.round(loc.column.spacing)}{loc.column.usedMin ? ' (min)' : ''}</td>
+                                          <td className="py-0.5">{loc.middle.b > 1 ? `⌀12 @ ${Math.round(loc.middle.spacing)}${loc.middle.usedMin ? ' (min)' : ''}` : '—'}</td>
+                                        </tr>
+                                      ))}
+                                    </tbody>
+                                  </table>
+                                </div>
+                              ))}
+                            </div>
+                            {dd.notes.length > 0 && (
+                              <ul className="mt-2 list-disc pl-5 text-[11px] text-slate-500">
+                                {dd.notes.map((n, ni) => <li key={ni}>{n}</li>)}
+                              </ul>
+                            )}
+                          </td>
+                        </tr>
+                      ),
+                    ]
+                  })}
+                </tbody>
+              </table>
+              <p className="mt-1 text-[11px] text-slate-400">
+                NSCP §408.10 Direct Design Method: Mo = wu·ℓ2·ℓn²/8 split into negative/positive then column/middle
+                strips (αf neglected → conservative slab steel). Column-strip width = 2·min(0.25ℓ1, 0.25ℓ2).
+              </p>
+            </div>
+          )}
+
           {/* Footing schedule (full width) */}
           <div className="print-avoid-break overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Footing schedule</h3>


### PR DESCRIPTION
Final big item of the model-space roadmap: a **two-way slab Direct Design Method** engine, wired into the pipeline with a slab schedule.

## Engine (`slabDDM.ts`)
For each panel and each direction:
- **Static moment** `Mo = wu·ℓ2·ℓn²/8` (§408.10.3), clear span `ℓn = ℓ1 − colWidth ≥ 0.65ℓ1`.
- **Negative/positive split** (§408.10.4): interior 0.65 / 0.35; end span 0.16 / 0.57 / 0.70 with beams (0.26 / 0.52 / 0.70 without).
- **Column / middle strip** shares (§408.10.5/6) interpolated by ℓ2/ℓ1; column-strip width = 2·min(0.25ℓ1, 0.25ℓ2). Beam stiffness αf is conservatively neglected for the *slab* steel (bounding beams are designed separately), so the slab carries the full column-strip share.
- **Steel** via `flexuralSteel` with the §408.6.1.1 temperature/shrinkage minimum (0.0018/0.002·b·h) and §408.7.2.2 max spacing (2h ≤ 450).
- **Min thickness** (§408.3.1.2) and **DDM applicability** checks (two-way ratio ≤ 2, LL ≤ 2DL, ≥3 spans note).

## Pipeline + UI
- Each slab panel is designed from its spans, area loads and exterior edges into `design.slabs` (clear span uses the corner column width).
- New full-width **"Slab schedule (two-way DDM)"** with a per-panel accordion: X/Y direction Mo, the negative/positive coefficients, and column/middle-strip ⌀12 spacing, plus the code notes.

## Tests (+6, 191 total)
Mo formula; interior & end-span distribution; column+middle moment closure; temp/shrinkage minimum + spacing cap; min-thickness; applicability flags (one-way slab, LL > 2DL). Build clean; verified in-browser (schedule renders, accordion shows both directions).

This completes the planned series (drawings → hints → plates/walls → shear-wall stiffness → slab DDM). Designing the slab's deflection and the shear-wall's own reinforcement remain as optional future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)