### PR TITLE
feat: slab deflection (Branson Ie) + shear-wall in-plane reinforcement

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -67,7 +67,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1083,7 +1082,6 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
       "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -1872,7 +1870,6 @@
       "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1888,7 +1885,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1923,7 +1919,6 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.1.tgz",
       "integrity": "sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -1984,7 +1979,6 @@
       "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.1",
         "@typescript-eslint/types": "8.60.1",
@@ -2341,7 +2335,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2480,7 +2473,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2813,7 +2805,6 @@
       "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3892,7 +3883,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3970,7 +3960,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3980,7 +3969,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4251,8 +4239,7 @@
       "version": "0.184.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
       "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -4429,7 +4416,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4534,7 +4520,6 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4812,7 +4797,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -17,6 +17,7 @@ import { designAxialColumn, capacityAtEccentricity, interaction } from './column
 import { designSquareFooting, type SquareFootingResult } from './isolatedFooting'
 import { designCombinedFooting, type CombinedFootingResult } from './combinedFooting'
 import { designSlabDDM, type SlabDesignResult } from './slabDDM'
+import { designShearWall, type ShearWallResult } from './shearWallDesign'
 
 export interface SoilOptions {
   qAllow: number; gammaSoil: number; gammaConc: number; H: number
@@ -77,6 +78,15 @@ export interface SlabScheduleRow {
   design: SlabDesignResult
   ok: boolean
 }
+export interface WallScheduleRow {
+  id: string
+  member: string
+  lw: number; hw: number; thickness: number
+  Vu: number
+  design: ShearWallResult
+  ok: boolean
+  gov?: string
+}
 /** Per-support footing choice: isolated (default) or combined with another node. */
 export type FootingPlan = Record<string, { type: 'isolated' } | { type: 'combined'; with: string }>
 
@@ -86,6 +96,7 @@ export interface StructureDesign {
   beams: BeamScheduleRow[]
   columns: ColumnScheduleRow[]
   slabs: SlabScheduleRow[]
+  walls: WallScheduleRow[]
   footings: FootingScheduleRow[]
   combined: CombinedScheduleRow[]
   totals: { concreteMembers: number; concreteSlabs: number; concrete: number }
@@ -379,10 +390,38 @@ export function designStructure(
     slabs.push({ plate: p.id, lx, ly: lz, design, ok: design.applicable })
   }
 
+  // ── Shear walls — in-plane reinforcement ──
+  // The bridge models each shear wall as an X of two diagonal struts
+  // (wallstrut_<id>_1/2). The panel's in-plane shear is the horizontal
+  // projection of the two strut axial forces, enveloped across all runs.
+  const walls: WallScheduleRow[] = []
+  for (const w of (model.walls ?? []).filter((x) => x.shearWall)) {
+    const m = model.members.find((mm) => mm.id === w.member); if (!m) continue
+    const a = nm.get(m.i), b2 = nm.get(m.j); if (!a || !b2) continue
+    const lw = Math.hypot(b2.x - a.x, b2.z - a.z)         // horizontal length, m
+    const hw = w.height
+    if (!(lw > 0 && hw > 0)) continue
+    const cos = lw / Math.hypot(lw, hw)
+    const strutAxial = (run: FrameRun, id: string) => {
+      const mr = run.result.members.find((x) => x.id === id)
+      return mr ? Math.max(...mr.N.map(Math.abs)) : 0
+    }
+    let Vu = 0, gov = ''
+    for (const run of runs) {
+      const v = (strutAxial(run, `wallstrut_${w.id}_1`) + strutAxial(run, `wallstrut_${w.id}_2`)) * cos
+      if (v > Vu) { Vu = v; gov = run.name }
+    }
+    const sec = secOf(m.id)
+    const design = designShearWall({
+      lw, hw, thickness: w.thickness, fc: sec.fc, fy: sec.fy, Vu, barDia: 12,
+    })
+    walls.push({ id: w.id, member: w.member, lw, hw, thickness: w.thickness, Vu, design, ok: design.shearOK, gov })
+  }
+
   return {
     govName: runs[govIdx].name,
     cases: runs.map((r) => r.name),
-    beams, columns, slabs, footings, combined,
+    beams, columns, slabs, walls, footings, combined,
     totals: { concreteMembers, concreteSlabs, concrete: concreteMembers + concreteSlabs },
     orphanEdges: br.orphanEdges.length,
   }

--- a/webapp/src/engine/shearWallDesign.test.ts
+++ b/webapp/src/engine/shearWallDesign.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { designShearWall } from './shearWallDesign'
+
+const BASE = {
+  lw: 4, hw: 3, thickness: 200, fc: 28, fy: 415, Vu: 600, barDia: 12,
+}
+
+describe('designShearWall — in-plane shear', () => {
+  it('produces a usable design', () => {
+    const r = designShearWall(BASE)
+    expect(r.Acv).toBeCloseTo(4000 * 200, 6)
+    expect(r.aspect).toBeCloseTo(0.75, 6)
+    expect(r.phiVn).toBeGreaterThan(0)
+    expect(r.horiz.spacing).toBeGreaterThan(0)
+    expect(r.vert.spacing).toBeGreaterThan(0)
+  })
+
+  it('squat wall (hw/lw ≤ 1.5) uses αc = 0.25', () => {
+    const r = designShearWall({ ...BASE, lw: 4, hw: 3 })  // 0.75 ≤ 1.5
+    expect(r.alphaC).toBeCloseTo(0.25, 6)
+  })
+
+  it('slender wall (hw/lw ≥ 2) uses αc = 0.17', () => {
+    const r = designShearWall({ ...BASE, lw: 3, hw: 9 })  // 3.0 ≥ 2
+    expect(r.alphaC).toBeCloseTo(0.17, 6)
+  })
+
+  it('αc interpolates linearly between 1.5 and 2.0', () => {
+    const r = designShearWall({ ...BASE, lw: 4, hw: 7 })  // 1.75
+    expect(r.alphaC).toBeCloseTo(0.21, 6)
+  })
+
+  it('adopted ratios never fall below the 0.0025 minimum', () => {
+    const r = designShearWall({ ...BASE, Vu: 1 })          // tiny demand
+    expect(r.horiz.rho).toBeGreaterThanOrEqual(0.0025)
+    expect(r.vert.rho).toBeGreaterThanOrEqual(0.0025)
+    expect(r.horiz.usedMin).toBe(true)
+  })
+
+  it('higher shear demands more horizontal steel (smaller spacing)', () => {
+    const lo = designShearWall({ ...BASE, Vu: 800 })
+    const hi = designShearWall({ ...BASE, Vu: 1600 })
+    expect(hi.horiz.rho).toBeGreaterThan(lo.horiz.rho)
+    expect(hi.horiz.spacing).toBeLessThanOrEqual(lo.horiz.spacing)
+  })
+
+  it('φVn ≥ Vu when the design passes', () => {
+    const r = designShearWall(BASE)
+    if (r.shearOK) expect(r.phiVn).toBeGreaterThanOrEqual(BASE.Vu - 1e-6)
+  })
+
+  it('excess shear is flagged by the web-crushing cap', () => {
+    const r = designShearWall({ ...BASE, Vu: 50000 })
+    expect(r.capOK).toBe(false)
+    expect(r.shearOK).toBe(false)
+    expect(r.notes.some((n) => n.includes('cap'))).toBe(true)
+  })
+
+  it('thick walls (t ≥ 250) require two curtains', () => {
+    const r = designShearWall({ ...BASE, thickness: 300, Vu: 10 })
+    expect(r.twoCurtains).toBe(true)
+  })
+
+  it('low shear, thin wall permits a single curtain', () => {
+    const r = designShearWall({ ...BASE, thickness: 150, Vu: 10 })
+    expect(r.twoCurtains).toBe(false)
+  })
+
+  it('spacing never exceeds min(lw/5, 3t, 450)', () => {
+    const r = designShearWall(BASE)
+    const sMax = Math.min(4000 / 5, 3 * 200, 450)
+    expect(r.sMax).toBeCloseTo(sMax, 6)
+    expect(r.horiz.spacing).toBeLessThanOrEqual(sMax + 1e-6)
+    expect(r.vert.spacing).toBeLessThanOrEqual(sMax + 1e-6)
+  })
+
+  it('squat wall ties vertical ratio to the horizontal ratio', () => {
+    const r = designShearWall({ ...BASE, lw: 4, hw: 3, Vu: 1500 })  // aspect 0.75 ≤ 2
+    expect(r.vert.rho).toBeGreaterThanOrEqual(r.horiz.rho - 1e-9)
+  })
+
+  it('high axial + moment triggers boundary elements', () => {
+    const r = designShearWall({ ...BASE, Pu: 8000, Mu: 6000 })
+    expect(r.boundaryElement).toBe(true)
+    expect(r.notes.some((n) => n.includes('boundary'))).toBe(true)
+  })
+
+  it('no axial/moment → no boundary element', () => {
+    const r = designShearWall(BASE)
+    expect(r.boundaryElement).toBe(false)
+  })
+})

--- a/webapp/src/engine/shearWallDesign.ts
+++ b/webapp/src/engine/shearWallDesign.ts
@@ -1,0 +1,117 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Shear-wall reinforcement — in-plane (web) shear design.
+// NSCP 2015 §418.10 / ACI 318-14 §11 & §18.10 (structural walls).
+//   Acv = ℓw·t                                              (gross web area)
+//   Vn  = Acv·(αc·λ·√f′c + ρt·fy)                           (§418.10.4.1)
+//   φVn ≥ Vu,  φ = 0.75;   Vn ≤ 0.83·Acv·√f′c (cap, §418.10.4.4)
+//   αc = 0.25 (hw/ℓw ≤ 1.5) … 0.17 (hw/ℓw ≥ 2.0), linear between
+//   minimum ρt, ρℓ = 0.0025;  two curtains if Vu > 0.17·Acv·λ√f′c or t ≥ 250
+//   spacing s ≤ min(ℓw/5, 3t, 450)                          (§411.7.2/3)
+// Units: ℓw, hw in m; t, db, spacing in mm; fc, fy in MPa; forces in kN.
+// ─────────────────────────────────────────────────────────────────────────
+
+const PHI_SHEAR = 0.75
+const RHO_MIN = 0.0025          // §411.6 distributed web steel minimum
+
+export interface ShearWallInput {
+  lw: number          // horizontal wall length, m
+  hw: number          // wall (storey) height, m
+  thickness: number   // web thickness t, mm
+  fc: number
+  fy: number
+  Vu: number          // factored in-plane shear, kN
+  Pu?: number         // factored axial (compression +), kN — boundary-element trigger
+  Mu?: number         // factored in-plane moment, kN·m — boundary-element trigger
+  barDia?: number     // distributed-bar diameter, mm (default 12)
+  lambda?: number     // lightweight factor (default 1)
+}
+
+export interface WallCurtainSteel {
+  rhoReq: number      // demand reinforcement ratio (before the minimum)
+  rho: number         // adopted ratio (≥ ρ_min)
+  spacing: number     // bar spacing, mm
+  usedMin: boolean
+}
+
+export interface ShearWallResult {
+  Acv: number         // gross web area, mm²
+  aspect: number      // hw/ℓw
+  alphaC: number
+  Vc: number          // concrete contribution φ-less, kN
+  Vn: number          // nominal shear with adopted ρt, kN
+  phiVn: number       // design shear, kN
+  VnCap: number       // 0.83·Acv·√fc, kN
+  shearOK: boolean    // φVn ≥ Vu and within the cap
+  capOK: boolean      // Vu ≤ φ·VnCap (web crushing limit)
+  twoCurtains: boolean
+  horiz: WallCurtainSteel   // ρt — horizontal (transverse) bars resist shear
+  vert: WallCurtainSteel    // ρℓ — vertical (longitudinal) distributed bars
+  sMax: number        // governing maximum spacing, mm
+  boundaryElement: boolean  // §418.10.6 special boundary element indicated
+  notes: string[]
+}
+
+export function designShearWall(i: ShearWallInput): ShearWallResult {
+  const lambda = i.lambda ?? 1
+  const db = i.barDia ?? 12
+  const Ab = (Math.PI / 4) * db * db
+  const lwmm = i.lw * 1000
+  const t = i.thickness
+  const Acv = lwmm * t                                    // mm²
+  const aspect = i.lw > 0 ? i.hw / i.lw : 0
+  const rootFc = Math.sqrt(Math.max(i.fc, 1))
+
+  // αc by aspect ratio (linear 0.25 → 0.17 over hw/ℓw 1.5 → 2.0)
+  const alphaC = aspect <= 1.5 ? 0.25 : aspect >= 2.0 ? 0.17 : 0.25 + (0.17 - 0.25) * (aspect - 1.5) / 0.5
+
+  const Vc = (alphaC * lambda * rootFc * Acv) / 1000     // kN (concrete term)
+  const VnCap = (0.83 * rootFc * Acv) / 1000             // kN — web crushing cap
+  const capOK = i.Vu <= PHI_SHEAR * VnCap
+
+  // required horizontal ratio ρt from φ·Acv·(αc·λ√fc + ρt·fy) ≥ Vu
+  const rhoTreq = Math.max(0, (i.Vu * 1000 / (PHI_SHEAR * Acv) - alphaC * lambda * rootFc) / i.fy)
+  const rhoT = Math.max(rhoTreq, RHO_MIN)
+
+  // vertical ratio: §418.10.4.3 — for hw/ℓw ≤ 2.0, ρℓ ≥ ρt; else ≥ ρ_min
+  const rhoLreq = aspect <= 2.0 ? Math.max(rhoT, RHO_MIN) : RHO_MIN
+  const rhoL = Math.max(rhoLreq, RHO_MIN)
+
+  // two curtains of reinforcement (§418.10.2.2)
+  const twoCurtains = i.Vu > 0.17 * lambda * rootFc * Acv / 1000 || t >= 250
+  const curtains = twoCurtains ? 2 : 1
+  const AvLayer = curtains * Ab                            // steel area per spacing in the wall thickness
+
+  // maximum spacing (§411.7.2.1 / §411.7.3.1)
+  const sMax = Math.min(lwmm / 5, 3 * t, 450)
+
+  // spacing from ratio: ρ = Av/(t·s) → s = Av/(ρ·t), capped at sMax
+  const spacingFrom = (rho: number): number =>
+    Math.min(sMax, AvLayer / (rho * t))
+
+  const Vn = Math.min((alphaC * lambda * rootFc + rhoT * i.fy) * Acv / 1000, VnCap)
+  const phiVn = PHI_SHEAR * Vn
+  const shearOK = phiVn >= i.Vu && capOK
+
+  // §418.10.6.2 stress-based boundary-element trigger:
+  // extreme-fibre compressive stress under Pu + Mu > 0.2 f′c.
+  const Ag = Acv
+  const Ig = (t * lwmm ** 3) / 12                          // mm⁴ (about the wall's strong axis)
+  const sigma = (i.Pu ?? 0) * 1000 / Ag
+    + (i.Mu ?? 0) * 1e6 * (lwmm / 2) / Math.max(Ig, 1)     // MPa
+  const boundaryElement = sigma > 0.2 * i.fc
+
+  const notes: string[] = []
+  if (!capOK) notes.push(`Web shear stress exceeds the §418.10.4.4 cap φ·0.83·Acv·√f′c = ${(PHI_SHEAR * VnCap).toFixed(0)} kN — thicken the wall or add a pier.`)
+  if (twoCurtains) notes.push('Two curtains of reinforcement required (Vu > 0.17·Acv·λ√f′c or t ≥ 250 mm, §418.10.2.2).')
+  else notes.push('Single curtain permitted (low shear, t < 250 mm).')
+  if (aspect <= 2.0) notes.push('Squat wall (hw/ℓw ≤ 2): vertical ratio ρℓ ≥ ρt (§418.10.4.3).')
+  if (boundaryElement) notes.push('Extreme-fibre stress > 0.2 f′c → special boundary elements indicated (§418.10.6.2); detail confined boundary zones.')
+  notes.push('Distributed web steel governs in-plane shear; flexural boundary reinforcement is designed separately.')
+
+  return {
+    Acv, aspect, alphaC, Vc, Vn, phiVn, VnCap, shearOK, capOK, twoCurtains,
+    horiz: { rhoReq: rhoTreq, rho: rhoT, spacing: spacingFrom(rhoT), usedMin: rhoTreq <= RHO_MIN + 1e-12 },
+    vert: { rhoReq: rhoLreq, rho: rhoL, spacing: spacingFrom(rhoL), usedMin: rhoLreq <= RHO_MIN + 1e-12 },
+    sMax, boundaryElement, notes,
+  }
+}

--- a/webapp/src/engine/slabDDM.ts
+++ b/webapp/src/engine/slabDDM.ts
@@ -10,6 +10,7 @@
 // Units: spans m; loads kPa; h/cover/db mm; moments kN·m; steel mm².
 // ─────────────────────────────────────────────────────────────────────────
 import { flexuralSteel } from './flexure'
+import { slabPanelDeflection, type SlabDeflectionResult } from './slabDeflection'
 
 export interface SlabInput {
   lx: number; ly: number          // centre-to-centre spans, m (lx ≤ ly used as short/long)
@@ -41,6 +42,7 @@ export interface SlabDirResult {
   dir: 'x' | 'y'
   l1: number; l2: number; ln: number
   Mo: number
+  d: number                       // effective depth used for this direction, mm
   csWidth: number; msWidth: number   // m
   locations: SlabLocation[]
 }
@@ -52,6 +54,7 @@ export interface SlabDesignResult {
   notes: string[]
   x: SlabDirResult
   y: SlabDirResult
+  deflection: SlabDeflectionResult
 }
 
 const interp = (r: number, a: number, b: number, c: number): number =>
@@ -120,12 +123,34 @@ export function designSlabDDM(i: SlabInput): SlabDesignResult {
         middle: steel((1 - csFrac) * M, msWidth * 1000),
       }
     })
-    return { dir: which, l1, l2, ln, Mo, csWidth, msWidth, locations }
+    return { dir: which, l1, l2, ln, Mo, d, csWidth, msWidth, locations }
   }
+
+  const x = dir('x'), y = dir('y')
+
+  // ── Deflection (Branson Ie + crossing-strip method) ──
+  // Positive-moment section drives mid-panel deflection; scale the factored
+  // design moment back to the SERVICE level for the cracking check.
+  const wService = i.D + i.L
+  const scale = wu > 1e-9 ? wService / wu : 0
+  const posOf = (dr: typeof x) => dr.locations.find((l) => l.name === '+M') ?? dr.locations[dr.locations.length - 1]
+  const dirParam = (dr: typeof x) => {
+    const pos = posOf(dr)
+    return {
+      ln: dr.ln, csW: dr.csWidth, msW: dr.msWidth, h, d: dr.d,
+      AsCol: pos.column.As, AsMid: pos.middle.As,
+      MaCol: pos.column.M * scale, MaMid: pos.middle.M * scale,
+      exterior: dr.dir === 'x' ? (i.exterior?.x ?? false) : (i.exterior?.y ?? false),
+    }
+  }
+  const deflection = slabPanelDeflection({
+    x: dirParam(x), y: dirParam(y), wD: i.D, wL: i.L, fc: i.fc,
+  })
+  if (!deflection.totalOK) notes.push(`Long-term + live deflection ${deflection.total.toFixed(1)} mm > ℓn/240 = ${deflection.limitTotal.toFixed(1)} mm — increase thickness.`)
 
   return {
     h, hmin, wu, ratio, twoWay,
     applicable: twoWay && i.L <= 2 * i.D,
-    notes, x: dir('x'), y: dir('y'),
+    notes, x, y, deflection,
   }
 }

--- a/webapp/src/engine/slabDeflection.test.ts
+++ b/webapp/src/engine/slabDeflection.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import { Ec, crackedInertia, effectiveInertia, stripDeflection, slabPanelDeflection } from './slabDeflection'
+
+describe('Ec', () => {
+  it('Ec = 4700√fc (MPa)', () => {
+    expect(Ec(28)).toBeCloseTo(4700 * Math.sqrt(28), 6)
+  })
+})
+
+describe('crackedInertia', () => {
+  it('is smaller than the gross inertia for a normal slab strip', () => {
+    const b = 1000, h = 200, d = 165, As = 800, fc = 28
+    const Icr = crackedInertia({ b, d, As, fc })
+    const Ig = (b * h ** 3) / 12
+    expect(Icr).toBeGreaterThan(0)
+    expect(Icr).toBeLessThan(Ig)
+  })
+
+  it('more steel → larger cracked inertia', () => {
+    const lo = crackedInertia({ b: 1000, d: 165, As: 600, fc: 28 })
+    const hi = crackedInertia({ b: 1000, d: 165, As: 1200, fc: 28 })
+    expect(hi).toBeGreaterThan(lo)
+  })
+})
+
+describe('effectiveInertia (Branson)', () => {
+  it('returns Ig when uncracked (Ma ≤ Mcr)', () => {
+    const r = effectiveInertia({ Ma: 1, b: 1000, h: 200, d: 165, As: 800, fc: 28 })
+    expect(r.Ie).toBeCloseTo(r.Ig, 6)
+  })
+
+  it('Icr ≤ Ie ≤ Ig once cracked', () => {
+    const r = effectiveInertia({ Ma: 60, b: 1000, h: 200, d: 165, As: 800, fc: 28 })
+    expect(r.Ie).toBeGreaterThanOrEqual(r.Icr - 1e-3)
+    expect(r.Ie).toBeLessThanOrEqual(r.Ig + 1e-3)
+  })
+
+  it('Ie decreases as the service moment grows', () => {
+    const a = effectiveInertia({ Ma: 30, b: 1000, h: 200, d: 165, As: 800, fc: 28 })
+    const b = effectiveInertia({ Ma: 90, b: 1000, h: 200, d: 165, As: 800, fc: 28 })
+    expect(b.Ie).toBeLessThanOrEqual(a.Ie)
+  })
+})
+
+describe('stripDeflection', () => {
+  const base = {
+    ln: 6, bStrip: 3000, h: 200, d: 165, As: 1500,
+    wD: 15, wL: 8, Ma: 40, fc: 28, exterior: false,
+  }
+  it('immediate D+L = immediate D + immediate L', () => {
+    const r = stripDeflection(base)
+    expect(r.immDL).toBeCloseTo(r.immD + r.immL, 6)
+  })
+  it('end span deflects more than an interior span', () => {
+    const interior = stripDeflection({ ...base, exterior: false })
+    const end = stripDeflection({ ...base, exterior: true })
+    expect(end.immDL).toBeGreaterThan(interior.immDL)
+  })
+  it('longer span deflects much more (≈ ℓ⁴)', () => {
+    const s6 = stripDeflection({ ...base, ln: 6 })
+    const s8 = stripDeflection({ ...base, ln: 8 })
+    expect(s8.immDL).toBeGreaterThan(s6.immDL * 2)
+  })
+})
+
+describe('slabPanelDeflection', () => {
+  const sq = {
+    ln: 6, csW: 3, msW: 3, h: 200, d: 165,
+    AsCol: 1500, AsMid: 1000, MaCol: 45, MaMid: 30, exterior: false,
+  }
+  const params = { x: { ...sq }, y: { ...sq }, wD: 5, wL: 3, fc: 28 }
+
+  it('computes a positive mid-panel deflection', () => {
+    const r = slabPanelDeflection(params)
+    expect(r.immediate).toBeGreaterThan(0)
+    expect(r.total).toBeGreaterThan(0)
+  })
+
+  it('long-term uses λΔ = 2.0 (ρ′ = 0)', () => {
+    const r = slabPanelDeflection(params)
+    expect(r.lambdaDelta).toBeCloseTo(2.0, 6)
+  })
+
+  it('total = λΔ·immD + immediate live', () => {
+    const r = slabPanelDeflection(params)
+    expect(r.total).toBeGreaterThan(r.longTerm)        // includes the live part
+    expect(r.total).toBeGreaterThanOrEqual(r.immLive)
+  })
+
+  it('limits are ℓn/360 (live) and ℓn/240 (total)', () => {
+    const r = slabPanelDeflection(params)
+    expect(r.limitLive).toBeCloseTo((6 * 1000) / 360, 6)
+    expect(r.limitTotal).toBeCloseTo((6 * 1000) / 240, 6)
+  })
+
+  it('a stiff (thick) panel passes both checks', () => {
+    const thick = {
+      x: { ...sq, h: 300, d: 260 }, y: { ...sq, h: 300, d: 260 },
+      wD: 5, wL: 3, fc: 28,
+    }
+    const r = slabPanelDeflection(thick)
+    expect(r.liveOK).toBe(true)
+    expect(r.totalOK).toBe(true)
+  })
+
+  it('a slender, heavily loaded long-span panel fails the total limit', () => {
+    const weak = {
+      x: { ln: 9, csW: 3, msW: 3, h: 150, d: 120, AsCol: 800, AsMid: 600, MaCol: 70, MaMid: 45, exterior: true },
+      y: { ln: 9, csW: 3, msW: 3, h: 150, d: 120, AsCol: 800, AsMid: 600, MaCol: 70, MaMid: 45, exterior: true },
+      wD: 8, wL: 6, fc: 28,
+    }
+    const r = slabPanelDeflection(weak)
+    expect(r.totalOK).toBe(false)
+  })
+})

--- a/webapp/src/engine/slabDeflection.ts
+++ b/webapp/src/engine/slabDeflection.ts
@@ -1,0 +1,142 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Two-way slab deflection — Branson effective inertia + crossing-strip method.
+// NSCP 2015 §424.2 / ACI 318-14 §24.2.
+//   fr   = 0.62·λ·√f′c                                       (§419.2.3.1)
+//   Mcr  = fr·Ig / yt,  Ig = b·h³/12,  yt = h/2
+//   Ie   = (Mcr/Ma)³·Ig + [1−(Mcr/Ma)³]·Icr ≤ Ig            (§424.2.3.5)
+//   λΔ   = ξ / (1 + 50ρ′),  ξ = 2.0 (≥ 5 yr)                (§424.2.4.1.1)
+// Mid-panel deflection uses the crossing-strip model (ACI R24.2): the column
+// strip in one direction plus the orthogonal middle strip. The governing
+// (larger) crossing combination is reported.
+// Units: spans m; h/d/db mm; moments kN·m; loads kPa; deflections mm.
+// ─────────────────────────────────────────────────────────────────────────
+
+const ES = 200000               // MPa, steel modulus
+const XI_LONGTERM = 2.0         // sustained-load time factor (≥ 5 years)
+
+export const Ec = (fc: number): number => 4700 * Math.sqrt(Math.max(fc, 1))   // MPa
+
+/** Cracked transformed moment of inertia of a singly-reinforced strip, mm⁴. */
+export function crackedInertia(params: { b: number; d: number; As: number; fc: number }): number {
+  const { b, d, As, fc } = params
+  if (As <= 0 || b <= 0 || d <= 0) return (b * d ** 3) / 12
+  const n = ES / Ec(fc)
+  const rhoN = (n * As) / (b * d)
+  const k = Math.sqrt(2 * rhoN + rhoN * rhoN) - rhoN     // neutral-axis depth ratio
+  const kd = k * d
+  return (b * kd ** 3) / 3 + n * As * (d - kd) ** 2
+}
+
+/** Branson effective moment of inertia, mm⁴ (Ig when uncracked Ma ≤ Mcr). */
+export function effectiveInertia(params: {
+  Ma: number; b: number; h: number; d: number; As: number; fc: number; lambda?: number
+}): { Ie: number; Ig: number; Icr: number; Mcr: number } {
+  const { Ma, b, h, d, As, fc } = params
+  const lambda = params.lambda ?? 1
+  const Ig = (b * h ** 3) / 12
+  const fr = 0.62 * lambda * Math.sqrt(Math.max(fc, 1))   // MPa
+  const Mcr = (fr * Ig) / (h / 2) / 1e6                   // N·mm → kN·m
+  const Icr = crackedInertia({ b, d, As, fc })
+  if (Ma <= Mcr || Ma <= 0) return { Ie: Ig, Ig, Icr, Mcr }
+  const r = (Mcr / Ma) ** 3
+  const Ie = Math.min(Ig, r * Ig + (1 - r) * Icr)
+  return { Ie, Ig, Icr, Mcr }
+}
+
+/** Deflection coefficient k in δ = k·w·ℓ⁴/(384·E·I): interior (fixed–fixed) 1,
+ *  end span (one discontinuous edge) 2.6, fully simple 5.0. */
+const spanCoeff = (exterior: boolean): number => (exterior ? 2.6 : 1.0)
+
+export interface StripDeflection {
+  Ie: number; Icr: number; Ig: number; Mcr: number
+  immD: number; immL: number; immDL: number      // immediate, mm (dead / live / D+L)
+  cracked: boolean
+}
+
+/** Immediate deflection of one column strip acting as a continuous wide beam. */
+export function stripDeflection(params: {
+  ln: number          // clear span, m
+  bStrip: number      // strip width, mm
+  h: number; d: number; As: number
+  wD: number; wL: number   // service line loads on the strip, kN/m
+  Ma: number          // service positive moment on the strip, kN·m
+  fc: number; exterior: boolean; lambda?: number
+}): StripDeflection {
+  const { ln, h, d, As, wD, wL, Ma, fc, exterior } = params
+  const { Ie, Icr, Ig, Mcr } = effectiveInertia({ Ma, b: params.bStrip, h, d, As, fc, lambda: params.lambda })
+  const E = Ec(fc) * 1000                                  // kPa (kN/m²)
+  const Iem4 = Ie / 1e12                                   // mm⁴ → m⁴
+  const k = spanCoeff(exterior)
+  const defl = (w: number) => (k * w * ln ** 4) / (384 * E * Iem4) * 1000   // m → mm
+  const immD = defl(wD)
+  const immDL = defl(wD + wL)
+  return { Ie, Icr, Ig, Mcr, immD, immL: immDL - immD, immDL, cracked: Ma > Mcr }
+}
+
+export interface SlabDeflectionResult {
+  immediate: number       // mid-panel immediate D+L, mm
+  immLive: number         // immediate live only, mm
+  longTerm: number        // long-term (sustained dead × λΔ), mm
+  total: number           // long-term sustained + immediate live, mm
+  lambdaDelta: number
+  ln: number              // governing clear span used for the limits, m
+  limitLive: number       // ℓn/360, mm
+  limitTotal: number      // ℓn/240, mm
+  liveOK: boolean
+  totalOK: boolean
+  cracked: boolean        // any contributing strip cracked under service load
+}
+
+/**
+ * Mid-panel deflection by the crossing-strip method: δ = δ(column strip, dir A)
+ * + δ(middle strip, dir B). Both crossing combinations are evaluated and the
+ * larger governs. Live deflection → ℓn/360; long-term + live → ℓn/240.
+ */
+export function slabPanelDeflection(params: {
+  x: { ln: number; csW: number; msW: number; h: number; d: number; AsCol: number; AsMid: number; MaCol: number; MaMid: number; exterior: boolean }
+  y: { ln: number; csW: number; msW: number; h: number; d: number; AsCol: number; AsMid: number; MaCol: number; MaMid: number; exterior: boolean }
+  wD: number; wL: number      // service AREA loads, kPa
+  fc: number; lambda?: number
+}): SlabDeflectionResult {
+  const { wD, wL, fc } = params
+  const lambda = params.lambda ?? 1
+
+  // Per-direction column-strip & middle-strip deflections (load on the strip =
+  // area load × strip width).
+  const strip = (s: typeof params.x, which: 'col' | 'mid') => {
+    const bStrip = (which === 'col' ? s.csW : s.msW) * 1000
+    const As = which === 'col' ? s.AsCol : s.AsMid
+    const Ma = which === 'col' ? s.MaCol : s.MaMid
+    const wWidth = which === 'col' ? s.csW : s.msW
+    return stripDeflection({
+      ln: s.ln, bStrip, h: s.h, d: s.d, As,
+      wD: wD * wWidth, wL: wL * wWidth, Ma, fc, exterior: s.exterior, lambda,
+    })
+  }
+
+  const xc = strip(params.x, 'col'), xm = strip(params.x, 'mid')
+  const yc = strip(params.y, 'col'), ym = strip(params.y, 'mid')
+
+  // Crossing combinations: column strip in one dir + middle strip in the other.
+  const combo = (a: StripDeflection, b: StripDeflection) => ({
+    immDL: a.immDL + b.immDL, immD: a.immD + b.immD, immL: a.immL + b.immL,
+    cracked: a.cracked || b.cracked,
+  })
+  const cAB = combo(xc, ym)   // column strip x + middle strip y
+  const cBA = combo(yc, xm)   // column strip y + middle strip x
+  const gov = cAB.immDL >= cBA.immDL ? cAB : cBA
+  const govDir = cAB.immDL >= cBA.immDL ? params.x : params.y
+
+  const lambdaDelta = XI_LONGTERM / (1 + 50 * 0)          // ρ′ = 0 in a slab
+  const longTerm = lambdaDelta * gov.immD
+  const total = longTerm + gov.immL
+  const ln = govDir.ln
+  const limitLive = (ln * 1000) / 360
+  const limitTotal = (ln * 1000) / 240
+
+  return {
+    immediate: gov.immDL, immLive: gov.immL, longTerm, total, lambdaDelta, ln,
+    limitLive, limitTotal,
+    liveOK: gov.immL <= limitLive, totalOK: total <= limitTotal, cracked: gov.cracked,
+  }
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -1537,7 +1537,7 @@ export default function ModelSpace() {
                         <td className="py-1 pr-2">{Math.round(dd.h)}{dd.h < dd.hmin ? ` (< ${Math.round(dd.hmin)} min)` : ''}</td>
                         <td className="py-1 pr-2">{dd.twoWay ? 'two-way' : 'one-way'}</td>
                         <td className="py-1 pr-2 text-right">{f1(dd.x.Mo)} / {f1(dd.y.Mo)}</td>
-                        <td className="py-1">{dd.applicable ? '✓' : '⚠ check'}</td>
+                        <td className="py-1">{dd.applicable ? (dd.deflection.totalOK ? '✓' : '⚠ defl') : '⚠ check'}</td>
                       </tr>,
                       open && (
                         <tr key={`${key}:sol`}>
@@ -1571,6 +1571,33 @@ export default function ModelSpace() {
                                 </div>
                               ))}
                             </div>
+                            {/* Deflection (Branson Ie + crossing-strip) */}
+                            <div className="mt-3 rounded-lg border border-slate-200 bg-white p-2">
+                              <p className="mb-1 text-[12px] font-bold text-[#0056b3]">Deflection (NSCP §424.2)</p>
+                              <table className="w-full border-collapse text-[11px]">
+                                <tbody>
+                                  <tr className="border-t border-slate-100">
+                                    <td className="py-0.5 pr-2 text-slate-500">Immediate (D+L)</td>
+                                    <td className="py-0.5 pr-2 text-right">{dd.deflection.immediate.toFixed(1)} mm</td>
+                                    <td className="py-0.5 pr-2 text-slate-500">{dd.deflection.cracked ? 'section cracked (Ie < Ig)' : 'uncracked (Ie = Ig)'}</td>
+                                  </tr>
+                                  <tr className="border-t border-slate-100">
+                                    <td className="py-0.5 pr-2 text-slate-500">Immediate live</td>
+                                    <td className="py-0.5 pr-2 text-right">{dd.deflection.immLive.toFixed(1)} mm</td>
+                                    <td className={`py-0.5 pr-2 ${dd.deflection.liveOK ? 'text-emerald-600' : 'text-rose-600'}`}>
+                                      ≤ ℓn/360 = {dd.deflection.limitLive.toFixed(1)} mm {dd.deflection.liveOK ? '✓' : '✗'}
+                                    </td>
+                                  </tr>
+                                  <tr className="border-t border-slate-100">
+                                    <td className="py-0.5 pr-2 text-slate-500">Long-term + live (λΔ = {dd.deflection.lambdaDelta.toFixed(1)})</td>
+                                    <td className="py-0.5 pr-2 text-right">{dd.deflection.total.toFixed(1)} mm</td>
+                                    <td className={`py-0.5 pr-2 ${dd.deflection.totalOK ? 'text-emerald-600' : 'text-rose-600'}`}>
+                                      ≤ ℓn/240 = {dd.deflection.limitTotal.toFixed(1)} mm {dd.deflection.totalOK ? '✓' : '✗'}
+                                    </td>
+                                  </tr>
+                                </tbody>
+                              </table>
+                            </div>
                             {dd.notes.length > 0 && (
                               <ul className="mt-2 list-disc pl-5 text-[11px] text-slate-500">
                                 {dd.notes.map((n, ni) => <li key={ni}>{n}</li>)}
@@ -1586,6 +1613,73 @@ export default function ModelSpace() {
               <p className="mt-1 text-[11px] text-slate-400">
                 NSCP §408.10 Direct Design Method: Mo = wu·ℓ2·ℓn²/8 split into negative/positive then column/middle
                 strips (αf neglected → conservative slab steel). Column-strip width = 2·min(0.25ℓ1, 0.25ℓ2).
+                Deflection per §424.2 (Branson Ie + crossing-strip; λΔ = 2.0).
+              </p>
+            </div>
+          )}
+
+          {/* Shear-wall schedule (full width) — in-plane reinforcement */}
+          {design.walls.length > 0 && (
+            <div className="print-avoid-break overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Shear-wall schedule (in-plane)</h3>
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="text-left uppercase tracking-wide text-slate-500">
+                    <th className="py-1 pr-2 font-semibold">Wall</th>
+                    <th className="py-1 pr-2 font-semibold">ℓw × hw (m)</th>
+                    <th className="py-1 pr-2 font-semibold">t (mm)</th>
+                    <th className="py-1 pr-2 font-semibold">hw/ℓw</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Vu / φVn (kN)</th>
+                    <th className="py-1 pr-2 font-semibold">Horiz ρt</th>
+                    <th className="py-1 pr-2 font-semibold">Vert ρℓ</th>
+                    <th className="py-1 font-semibold">OK</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {design.walls.flatMap((wl) => {
+                    const key = `wall:${wl.id}`, open = expanded === key
+                    const wd = wl.design
+                    const curt = wd.twoCurtains ? '2 curtains' : '1 curtain'
+                    return [
+                      <tr key={key} onClick={() => setExpanded(open ? null : key)}
+                        className={`cursor-pointer border-t border-slate-100 hover:bg-blue-50/40 ${wl.ok ? '' : 'bg-rose-50 text-rose-700'}`}>
+                        <td className="py-1 pr-2 font-medium">{open ? '▾' : '▸'} {wl.id} <span className="text-slate-400">({wl.member})</span></td>
+                        <td className="py-1 pr-2">{f1(wl.lw)} × {f1(wl.hw)}</td>
+                        <td className="py-1 pr-2">{Math.round(wl.thickness)}</td>
+                        <td className="py-1 pr-2">{wd.aspect.toFixed(2)}</td>
+                        <td className="py-1 pr-2 text-right">{f1(wl.Vu)} / {f1(wd.phiVn)}</td>
+                        <td className="py-1 pr-2">⌀12 @ {Math.round(wd.horiz.spacing)}{wd.horiz.usedMin ? ' (min)' : ''}</td>
+                        <td className="py-1 pr-2">⌀12 @ {Math.round(wd.vert.spacing)}{wd.vert.usedMin ? ' (min)' : ''}</td>
+                        <td className="py-1">{wl.ok ? '✓' : '✗'}</td>
+                      </tr>,
+                      open && (
+                        <tr key={`${key}:sol`}>
+                          <td colSpan={8} className="bg-slate-50/60 px-3 pb-3">
+                            <div className="mt-2 grid grid-cols-2 gap-x-6 gap-y-1 text-[11px] sm:grid-cols-3">
+                              <div><span className="text-slate-500">Acv</span> = {Math.round(wd.Acv)} mm²</div>
+                              <div><span className="text-slate-500">αc</span> = {wd.alphaC.toFixed(2)}</div>
+                              <div><span className="text-slate-500">Curtains</span>: {curt}</div>
+                              <div><span className="text-slate-500">Vn cap (0.83·Acv√fc)</span> = {f1(wd.VnCap)} kN</div>
+                              <div><span className="text-slate-500">ρt req</span> = {wd.horiz.rhoReq.toFixed(4)}</div>
+                              <div><span className="text-slate-500">s,max</span> = {Math.round(wd.sMax)} mm</div>
+                              <div><span className="text-slate-500">Boundary elements</span>: {wd.boundaryElement ? 'required' : 'not indicated'}</div>
+                              <div><span className="text-slate-500">Governing case</span>: {wl.gov || '—'}</div>
+                            </div>
+                            {wd.notes.length > 0 && (
+                              <ul className="mt-2 list-disc pl-5 text-[11px] text-slate-500">
+                                {wd.notes.map((n, ni) => <li key={ni}>{n}</li>)}
+                              </ul>
+                            )}
+                          </td>
+                        </tr>
+                      ),
+                    ]
+                  })}
+                </tbody>
+              </table>
+              <p className="mt-1 text-[11px] text-slate-400">
+                NSCP §418.10: Vn = Acv(αc·λ√f′c + ρt·fy), φ = 0.75, capped at 0.83·Acv·√f′c. In-plane shear from the
+                enveloped strut forces; distributed web steel ρt, ρℓ ≥ 0.0025. Flexural boundary reinforcement designed separately.
               </p>
             </div>
           )}


### PR DESCRIPTION
## Summary

- **Slab deflection engine** (`slabDeflection.ts`): Branson effective inertia (`Ie`), cracked transformed-section inertia (`Icr`), crossing-strip mid-panel method for two-way slabs, long-term multiplier `λΔ = 2.0` (ρ′ = 0), checks against ℓn/360 (live) and ℓn/240 (total+live) per NSCP §424.2 / ACI 318-14 §24.2
- **Shear-wall reinforcement engine** (`shearWallDesign.ts`): In-plane shear design per NSCP §418.10 / ACI §11 & §18.10 — `Vn = Acv(αc·λ√f′c + ρt·fy)`, αc interpolated 0.25→0.17 for hw/ℓw 1.5→2.0, minimum ρ = 0.0025, two-curtain rule, spacing cap `min(ℓw/5, 3t, 450)`, boundary-element trigger
- **Integration** (`slabDDM.ts`, `pipeline.ts`): DDM now returns `deflection: SlabDeflectionResult`; pipeline computes shear-wall Vu from equivalent diagonal-strut axial forces (cos θ projection) and populates `walls: WallScheduleRow[]`
- **UI** (`ModelSpace.tsx`): Slab schedule shows deflection status (✓ / ⚠ defl) with expandable detail table; new shear-wall schedule table with accordion detail (Acv, αc, curtains, ρt, spacing, boundary elements)
- **Tests**: 29 new tests (15 slab-deflection + 14 shear-wall), total suite now 220 tests — all passing, TypeScript clean, production build clean

## Test plan

- [ ] `cd webapp && ./node_modules/.bin/vitest run` — all 220 tests pass
- [ ] `npm run build` — no TypeScript errors, clean production bundle
- [ ] Load a model with shear walls in the UI — wall schedule renders with Vu/φVn, ρt, ρℓ, OK status
- [ ] Slab panel with thin slab shows `⚠ defl` in schedule and deflection detail in accordion
- [ ] Thick slab panel shows `✓` with passing limits

https://claude.ai/code/session_01RU7XQEuScseJCc63Ekbz3d

---
_Generated by [Claude Code](https://claude.ai/code/session_01RU7XQEuScseJCc63Ekbz3d)_