### PR TITLE
Fix: shear-wall Vu from the strut's actual geometry

### DIFF
--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -16,6 +16,38 @@ function makeModel() {
   return m
 }
 
+// big +X seismic case so the lateral system is exercised
+function seismicXcase(m: ReturnType<typeof makeModel>): LateralCase {
+  const base = computeSeismic(m, { Ca: 0.44, Cv: 0.64, I: 1, R: 8.5, dir: 'x' })!.loads
+  return {
+    name: 'E+X', kind: 'E',
+    loads: base.map((l) => ({ kind: 'node', node: (l as { node: string }).node, Fx: Math.abs((l as { Fx?: number }).Fx ?? 0) * 40, cat: 'E' })),
+  }
+}
+
+describe('shear-wall schedule (in-plane shear from struts)', () => {
+  it('designs a tagged shear wall and Vu stays within the applied story shear', () => {
+    const m = makeModel()
+    m.walls = [{ id: 'w0', member: 'bx0.0.1', height: 3, thickness: 200, shearWall: true }]
+    const eX = seismicXcase(m)
+    const r = designStructure(m, soil, {}, { lateral: [eX] })!
+    expect(r.walls).toHaveLength(1)
+    const w = r.walls[0]
+    const totalE = eX.loads.reduce((s, l) => s + Math.abs((l as { Fx?: number }).Fx ?? 0), 0)
+    expect(w.Vu).toBeGreaterThan(0)
+    expect(w.Vu).toBeLessThanOrEqual(totalE + 1e-6)   // a single wall can't exceed the story shear
+    expect(w.design.horiz.rho).toBeGreaterThanOrEqual(0.0025)
+    expect(typeof w.design.shearOK).toBe('boolean')
+  })
+
+  it('a non-shear wall produces no wall-design row', () => {
+    const m = makeModel()
+    m.walls = [{ id: 'w0', member: 'bx0.0.1', height: 3, thickness: 200, shearWall: false }]
+    const r = designStructure(m, soil)!
+    expect(r.walls).toHaveLength(0)
+  })
+})
+
 describe('design pipeline — single-bay single-storey grid', () => {
   const r = designStructure(makeModel(), soil)!
 

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -401,14 +401,17 @@ export function designStructure(
     const lw = Math.hypot(b2.x - a.x, b2.z - a.z)         // horizontal length, m
     const hw = w.height
     if (!(lw > 0 && hw > 0)) continue
-    const cos = lw / Math.hypot(lw, hw)
-    const strutAxial = (run: FrameRun, id: string) => {
+    // in-plane shear = horizontal projection of the strut axials, taken from
+    // each strut's ACTUAL geometry (cos = lw / strut length) so it stays
+    // consistent with the bridge whatever the wall's nominal height.
+    const strutShear = (run: FrameRun, id: string) => {
       const mr = run.result.members.find((x) => x.id === id)
-      return mr ? Math.max(...mr.N.map(Math.abs)) : 0
+      if (!mr || mr.L <= 0) return 0
+      return Math.max(...mr.N.map(Math.abs)) * (lw / mr.L)
     }
     let Vu = 0, gov = ''
     for (const run of runs) {
-      const v = (strutAxial(run, `wallstrut_${w.id}_1`) + strutAxial(run, `wallstrut_${w.id}_2`)) * cos
+      const v = strutShear(run, `wallstrut_${w.id}_1`) + strutShear(run, `wallstrut_${w.id}_2`)
       if (v > Vu) { Vu = v; gov = run.name }
     }
     const sec = secOf(m.id)


### PR DESCRIPTION
Follow-up review of #164 (slab deflection + shear-wall reinforcement). The engines are correct and match the intended NSCP approach; this fixes one accuracy inconsistency found while verifying.

## The issue
The pipeline extracted the wall's in-plane shear as
`Vu = (|N₁| + |N₂|)·cos`, with `cos = ℓw/√(ℓw² + w.height²)`. But the bridge
builds each equivalent strut across the **actual panel** (the node directly
below the beam), whose height is the storey spacing — not the wall's nominal
`height`. When those differ (e.g. the default 3 m wall on a 3.5 m storey) the
projection angle is wrong, so `Vu` came out a few percent high.

## The fix
Project each strut's axial with its **own** length: `cos = ℓw / strutLength`
(`mr.L`). This is exact and self-consistent with the bridge whatever the
wall's nominal height. The wall's own height is still used where it belongs —
the design aspect ratio `hw/ℓw` (→ αc) and the gravity line load.

## Tests (+2, 222 total)
- The wall schedule designs a tagged shear wall with `Vu` within the applied
  story shear and `ρt ≥ 0.0025`.
- A non-shear wall produces no wall-design row.

Verified the rest of #164 too: shear-wall `Vn = Acv(αc·λ√f′c + ρt·fy)`, φ=0.75,
0.83√f′c·Acv cap, curtains and boundary trigger are all correct; the slab
Branson `Ie`, cracked transformed `Icr`, λΔ and ℓn/360 & ℓn/240 limits check out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)