### PR TITLE
Editable γc & γsoil + bar-diameter selection in design/optimize

### DIFF
--- a/webapp/src/engine/barSelectionAndGamma.test.ts
+++ b/webapp/src/engine/barSelectionAndGamma.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { generateGridModel, buildGravityLoads, refreshSelfWeight } from './modelBuilder'
+import { storeyWeights } from './seismic'
+import { designStructure, selectBarDiameters } from './pipeline'
+import type { RectSection, ModelLoad } from './model'
+
+const section: RectSection = { id: 'S1', name: '300×500', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
+const soil = { qAllow: 200, gammaSoil: 18, gammaConc: 24, H: 1.5 }
+
+function makeModel() {
+  const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })
+  m.loads = buildGravityLoads(m, 4.8, 2.4)   // default γc = 24
+  return m
+}
+
+describe('concrete unit weight γc threads through self-weight & seismic mass', () => {
+  const bare = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })   // no slab loads
+
+  it('buildGravityLoads scales member self-weight and slab dead by γc', () => {
+    const sw = (loads: ModelLoad[]) =>
+      (loads.find((x) => x.kind === 'member-udl' && x.cat === 'D') as { w: number }).w
+    const areaD = (loads: ModelLoad[]) =>
+      (loads.find((x) => x.kind === 'area' && x.cat === 'D') as { q: number }).q
+    const l24 = buildGravityLoads(bare, 4.8, 2.4, 24)
+    const l30 = buildGravityLoads(bare, 4.8, 2.4, 30)
+    expect(sw(l30) / sw(l24)).toBeCloseTo(30 / 24, 9)            // member SW ∝ γc
+    expect(areaD(l24)).toBeCloseTo(0.15 * 24 + 4.8, 9)          // slab SW (t=150) + SDL
+    expect(areaD(l30)).toBeCloseTo(0.15 * 30 + 4.8, 9)
+  })
+
+  it('refreshSelfWeight honours γc', () => {
+    const base = { ...bare, loads: buildGravityLoads(bare, 4.8, 2.4, 24) }
+    const w = (refreshSelfWeight(base, 30).loads.find((x) => x.kind === 'member-udl' && x.cat === 'D') as { w: number }).w
+    expect(w).toBeCloseTo(0.3 * 0.5 * 30, 6)                     // 300×500 member at γc = 30
+  })
+
+  it('seismic storey weight scales member self-weight with γc', () => {
+    const sum = (g: number) => storeyWeights(bare, g).reduce((s, x) => s + x.w, 0)
+    expect(sum(30) / sum(24)).toBeCloseTo(30 / 24, 9)            // only member SW (no slab loads)
+  })
+})
+
+describe('selectBarDiameters — bar choice is a pure detailing pass', () => {
+  const m = makeModel()
+  // start every section oversized at ⌀32 so an economical size exists
+  const big = { ...m, sections: m.sections.map((s) => ({ ...s, barDia: 32 })) }
+  const base = designStructure(big, soil)!
+  const picked = selectBarDiameters(big, soil, {}, {}, base)
+  const after = designStructure(picked, soil)!
+
+  it('changes only barDia, never the concrete b×h', () => {
+    picked.sections.forEach((s, i) => {
+      expect(s.b).toBe(big.sections[i].b)
+      expect(s.h).toBe(big.sections[i].h)
+    })
+  })
+
+  it('does not alter the frame demands (bar Ø is stiffness-neutral)', () => {
+    const dem = (d: typeof base) => d.beams.map((b) => b.sections.map((s) => +s.Mu.toFixed(6)))
+    expect(dem(after)).toEqual(dem(base))
+  })
+
+  it('adopts a more economical bar where one passes, and never breaks a passing member', () => {
+    expect(picked.sections.some((s) => s.barDia < 32)).toBe(true)
+    const okBefore = new Map(base.columns.map((c) => [c.id, c.ok]))
+    for (const c of after.columns) if (okBefore.get(c.id)) expect(c.ok).toBe(true)
+    const okBeamBefore = new Map(base.beams.map((b) => [b.id, b.ok]))
+    for (const b of after.beams) if (okBeamBefore.get(b.id)) expect(b.ok).toBe(true)
+  })
+
+  it('keeps chosen diameters within the standard ladder', () => {
+    const allowed = new Set([16, 20, 25, 28, 32])
+    for (const s of picked.sections) expect(allowed.has(s.barDia)).toBe(true)
+  })
+})

--- a/webapp/src/engine/modelBuilder.ts
+++ b/webapp/src/engine/modelBuilder.ts
@@ -134,33 +134,34 @@ export function removeNode(model: StructuralModel, nodeId: string): StructuralMo
   }
 }
 
-const GAMMA_C = 24 // kN/m³
+const GAMMA_C = 24 // kN/m³, default concrete unit weight
 
 /**
  * Build the gravity load set: member SELF-WEIGHT (D, kN/m from the section),
  * WALL self-weight on its supporting member (D, kN/m = t·h·γc), slab
  * SELF-WEIGHT + superimposed dead load (D, kPa), and live load (L, kPa).
  * Loads of other categories (e.g. seismic E) are preserved from the model.
+ * `gammaC` is the concrete unit weight (kN/m³, default 24).
  */
-export function buildGravityLoads(model: StructuralModel, sdl: number, ll: number): StructuralModel['loads'] {
+export function buildGravityLoads(model: StructuralModel, sdl: number, ll: number, gammaC = GAMMA_C): StructuralModel['loads'] {
   const secMap = new Map(model.sections.map((s) => [s.id, s]))
   const kept = model.loads.filter((l) => l.cat !== 'D' && l.cat !== 'L')
   // member self-weight from each member's OWN section
   const memberSW: StructuralModel['loads'] = model.members
     .map((m) => {
       const sec = secMap.get(m.section) ?? model.sections[0]
-      const w = sec ? (sec.b / 1000) * (sec.h / 1000) * GAMMA_C : 0
+      const w = sec ? (sec.b / 1000) * (sec.h / 1000) * gammaC : 0
       return { kind: 'member-udl' as const, member: m.id, w, cat: 'D' as const }
     })
     .filter((l) => l.w > 0)
   // wall self-weight as a line load on its supporting member
   const wallSW: StructuralModel['loads'] = (model.walls ?? [])
-    .map((wl) => ({ kind: 'member-udl' as const, member: wl.member, w: (wl.thickness / 1000) * wl.height * GAMMA_C, cat: 'D' as const }))
+    .map((wl) => ({ kind: 'member-udl' as const, member: wl.member, w: (wl.thickness / 1000) * wl.height * gammaC, cat: 'D' as const }))
     .filter((l) => l.w > 0)
   const plateLoads: StructuralModel['loads'] = model.plates
     .filter((p) => p.role !== 'wall')
     .flatMap((p) => {
-      const qSW = (p.thickness / 1000) * GAMMA_C
+      const qSW = (p.thickness / 1000) * gammaC
       return [
         { kind: 'area' as const, plate: p.id, q: qSW + sdl, cat: 'D' as const },
         ...(ll > 0 ? [{ kind: 'area' as const, plate: p.id, q: ll, cat: 'L' as const }] : []),
@@ -174,7 +175,7 @@ export function buildGravityLoads(model: StructuralModel, sdl: number, ll: numbe
  * CURRENT section, leaving every other load untouched. No-op when the model
  * carries no member self-weight (so user models without it are not altered).
  */
-export function refreshSelfWeight(model: StructuralModel): StructuralModel {
+export function refreshSelfWeight(model: StructuralModel, gammaC = GAMMA_C): StructuralModel {
   const hasSW = model.loads.some((l) => l.kind === 'member-udl' && l.cat === 'D')
   if (!hasSW) return model
   const secMap = new Map(model.sections.map((s) => [s.id, s]))
@@ -182,7 +183,7 @@ export function refreshSelfWeight(model: StructuralModel): StructuralModel {
   const sw: StructuralModel['loads'] = model.members
     .map((m) => {
       const sec = secMap.get(m.section) ?? model.sections[0]
-      const w = sec ? (sec.b / 1000) * (sec.h / 1000) * GAMMA_C : 0
+      const w = sec ? (sec.b / 1000) * (sec.h / 1000) * gammaC : 0
       return { kind: 'member-udl' as const, member: m.id, w, cat: 'D' as const }
     })
     .filter((l) => l.w > 0)

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -149,10 +149,9 @@ function designBeamRow(mr: F3MemberResult, role: string, sec: RectSection): Beam
   }
 }
 
-/** Design one column from a single run's member result. */
-function designColumnRow(mr: F3MemberResult, sec: RectSection): ColumnScheduleRow {
-  const Pu = Math.max(0, -Math.min(...mr.N))           // compression (N < 0)
-  const Mu = mr.Mmax
+/** Column capacity for a given section and a known factored P/M demand (no frame
+ *  solve — bar diameter does not change demands, so this is reused for bar trials). */
+function designColumnFromPM(sec: RectSection, Pu: number, Mu: number) {
   const ax = designAxialColumn({
     shape: 'tied', b: sec.b, h: sec.h, cover: sec.cover,
     barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, Pu,
@@ -168,9 +167,17 @@ function designColumnRow(mr: F3MemberResult, sec: RectSection): ColumnScheduleRo
     phiPn = Math.min(cap.phi * cap.Pn, 0.65 * inter.PnMax)
   }
   const util = phiPn > 1e-9 ? Pu / phiPn : Infinity
+  return { e, bars: ax.bars, Ast: ax.Ast, phiPn, util, tieSpacing: ax.tieSpacing, ok: util <= 1 + 1e-9 && ax.rhoOK }
+}
+
+/** Design one column from a single run's member result. */
+function designColumnRow(mr: F3MemberResult, sec: RectSection): ColumnScheduleRow {
+  const Pu = Math.max(0, -Math.min(...mr.N))           // compression (N < 0)
+  const Mu = mr.Mmax
+  const r = designColumnFromPM(sec, Pu, Mu)
   return {
-    id: mr.id, L: mr.L, Pu, Mu, e, bars: ax.bars, phiPn, util,
-    tieSpacing: ax.tieSpacing, ok: util <= 1 + 1e-9 && ax.rhoOK,
+    id: mr.id, L: mr.L, Pu, Mu, e: r.e, bars: r.bars, phiPn: r.phiPn, util: r.util,
+    tieSpacing: r.tieSpacing, ok: r.ok,
   }
 }
 
@@ -430,6 +437,71 @@ export function designStructure(
   }
 }
 
+// ── Bar-diameter selection ────────────────────────────────────────────────
+// Standard NSCP bar sizes the design/optimise engines may try. Bar diameter
+// changes neither stiffness nor self-weight (both gross-concrete), so it never
+// alters the frame demands — selection is a pure per-member detailing pass that
+// rewrites each member's section.barDia, keeping every schedule/drawing/solution
+// (which all read sec.barDia) consistent for free.
+export const BAR_LADDER_BEAM = [16, 20, 25, 28, 32]
+export const BAR_LADDER_COLUMN = [20, 25, 28, 32]
+
+/**
+ * Pick the most economical bar diameter for every beam/girder and column from a
+ * candidate ladder: the smallest-steel size that still passes, falling back to
+ * the section's current bar when none of the candidates work (so the section can
+ * grow instead). Returns a new model with the chosen per-member section.barDia.
+ * Pass `base` (an already-computed design of `model`) to skip the internal solve.
+ */
+export function selectBarDiameters(
+  model: StructuralModel, soil: SoilOptions, plan: FootingPlan = {}, opts: AnalyzeOptions = {},
+  base?: StructureDesign | null,
+): StructuralModel {
+  const design = base ?? designStructure(model, soil, plan, opts)
+  if (!design) return model
+  const secById = new Map(model.sections.map((s) => [s.id, s]))
+  const memSecId = new Map(model.members.map((m) => [m.id, m.section]))
+  const chosen = new Map<string, number>()
+  const ladder = (cands: number[], current: number) => [...new Set([current, ...cands])].sort((a, b) => a - b)
+
+  // beams/girders: minimise total tension steel across the member's sections,
+  // among bar sizes where every section is adequate.
+  for (const row of design.beams) {
+    const sec = secById.get(memSecId.get(row.id) ?? ''); if (!sec) continue
+    let best: { db: number; As: number } | null = null
+    for (const db of ladder(BAR_LADDER_BEAM, sec.barDia)) {
+      let allOK = true, totalAs = 0
+      for (const s of row.sections) {
+        const d = designBeam({
+          b: sec.b, h: sec.h, cover: sec.cover, barDia: db, comprBarDia: 16,
+          stirrupDia: sec.tieDia, fc: sec.fc, fy: sec.fy, Mu: Math.abs(s.Mu), Vu: s.Vu,
+        })
+        if (!beamOK(d)) { allOK = false; break }
+        totalAs += d.As
+      }
+      if (allOK && (!best || totalAs < best.As - 1e-6)) best = { db, As: totalAs }
+    }
+    if (best && best.db !== sec.barDia) chosen.set(sec.id, best.db)
+  }
+
+  // columns: minimise provided steel Ast among bar sizes that pass P–M + ρ.
+  for (const row of design.columns) {
+    const sec = secById.get(memSecId.get(row.id) ?? ''); if (!sec) continue
+    let best: { db: number; ast: number } | null = null
+    for (const db of ladder(BAR_LADDER_COLUMN, sec.barDia)) {
+      const r = designColumnFromPM({ ...sec, barDia: db }, row.Pu, row.Mu)
+      if (r.ok && (!best || r.Ast < best.ast - 1e-6)) best = { db, ast: r.Ast }
+    }
+    if (best && best.db !== sec.barDia) chosen.set(sec.id, best.db)
+  }
+
+  if (chosen.size === 0) return model
+  return {
+    ...model,
+    sections: model.sections.map((s) => (chosen.has(s.id) ? { ...s, barDia: chosen.get(s.id)! } : s)),
+  }
+}
+
 // ── Optimisation loop ─────────────────────────────────────────────────────
 export interface OptimizeStep { iter: number; grown: number; fails: number; ok: boolean }
 export interface OptimizeResult {
@@ -459,17 +531,26 @@ const growOne = (s: RectSection): RectSection =>
  */
 export function optimizeStructure(
   model: StructuralModel, soil: SoilOptions, plan: FootingPlan = {}, maxIter = 30,
-  opts: AnalyzeOptions = {},
+  opts: AnalyzeOptions = {}, tryBars = false,
 ): OptimizeResult | null {
   if (model.members.length === 0) return null
   const memSecId = new Map(model.members.map((m) => [m.id, m.section]))
-  // sizes & self-weight kept consistent at every step
-  const settle = (m: StructuralModel) => refreshSelfWeight(enforceSectionHierarchy(m))
+  // sizes & self-weight kept consistent at every step (self-weight uses the
+  // footing concrete unit weight so a custom γc feeds the gravity demands).
+  const settle = (m: StructuralModel) => refreshSelfWeight(enforceSectionHierarchy(m), soil.gammaConc)
+  // re-detail the bars (cheapest design variable) before measuring fails, so a
+  // member that only needs a bigger bar is not grown unnecessarily.
+  const detail = (m: StructuralModel, d: StructureDesign): { m: StructuralModel; d: StructureDesign } => {
+    if (!tryBars) return { m, d }
+    const m2 = selectBarDiameters(m, soil, plan, opts, d)
+    return m2 === m ? { m, d } : { m: m2, d: designStructure(m2, soil, plan, opts) ?? d }
+  }
   let work = settle(model)                            // start width-consistent
   const steps: OptimizeStep[] = []
 
   let design = designStructure(work, soil, plan, opts)
   if (!design) return null
+  ;({ m: work, d: design } = detail(work, design))
   steps.push({ iter: 0, grown: 0, fails: countFails(design), ok: designOK(design) })
 
   // GROW: bump every failing member's own section, re-enforce the hierarchy and
@@ -484,7 +565,7 @@ export function optimizeStructure(
     work = settle(withSizes(work, sizes))
     const d = designStructure(work, soil, plan, opts)
     if (!d) break
-    design = d
+    ;({ m: work, d: design } = detail(work, d))
     steps.push({ iter, grown: failSids.size, fails: countFails(design), ok: designOK(design) })
   }
   const converged = designOK(design)
@@ -501,6 +582,11 @@ export function optimizeStructure(
         const d = designStructure(trial, soil, plan, opts)
         if (d && designOK(d)) { work = trial; design = d; improved = true }
       }
+    }
+    // final bar re-detail at the trimmed sizes for the most economical layout
+    if (tryBars) {
+      const m2 = selectBarDiameters(work, soil, plan, opts, design)
+      if (m2 !== work) { const d = designStructure(m2, soil, plan, opts); if (d) { work = m2; design = d } }
     }
     steps.push({ iter: iter + 1, grown: 0, fails: 0, ok: true })
   }

--- a/webapp/src/engine/seismic.ts
+++ b/webapp/src/engine/seismic.ts
@@ -20,6 +20,7 @@ export interface SeismicParams {
   Z?: number                // seismic zone factor (0.4 = Zone 4); enables eq 208-11
   Nv?: number               // near-source velocity factor (default 1.0)
   Ct?: number               // default 0.0731 (RC moment frame, metres)
+  gammaC?: number           // concrete unit weight for member self-weight (default 24)
   dir: 'x' | 'z'
 }
 
@@ -35,10 +36,10 @@ export interface SeismicResult {
   loads: ModelLoad[]        // node loads, cat 'E'
 }
 
-const GAMMA_C = 24 // kN/m³
+const GAMMA_C = 24 // kN/m³, default concrete unit weight
 
 /** Seismic weight per elevated level: slab dead loads + member self-weight. */
-export function storeyWeights(model: StructuralModel): { elevation: number; w: number }[] {
+export function storeyWeights(model: StructuralModel, gammaC = GAMMA_C): { elevation: number; w: number }[] {
   const nm = new Map(model.nodes.map((n) => [n.id, n]))
   const secMap = new Map(model.sections.map((s) => [s.id, s]))
   const aSecOf = (mSection: string) => {
@@ -67,7 +68,7 @@ export function storeyWeights(model: StructuralModel): { elevation: number; w: n
     const a = nm.get(m.i), b = nm.get(m.j)
     if (!a || !b) continue
     const L = Math.hypot(b.x - a.x, b.y - a.y, b.z - a.z)
-    const wSelf = aSecOf(m.section) * L * GAMMA_C
+    const wSelf = aSecOf(m.section) * L * gammaC
     if (m.role === 'column') {
       const top = Math.max(a.y, b.y), bot = Math.min(a.y, b.y)
       const topLvl = levels.includes(top) ? top : closest(top)
@@ -83,7 +84,7 @@ export function storeyWeights(model: StructuralModel): { elevation: number; w: n
 }
 
 export function computeSeismic(model: StructuralModel, p: SeismicParams): SeismicResult | null {
-  const storeyW = storeyWeights(model)
+  const storeyW = storeyWeights(model, p.gammaC ?? GAMMA_C)
   if (storeyW.length === 0) return null
   const hn = Math.max(...storeyW.map((s) => s.elevation))
   const W = storeyW.reduce((s, q) => s + q.w, 0)

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -8,7 +8,7 @@ import type { StructuralModel, Member, Plate, RectSection, ModelLoad, MemberRole
 import { distributePanel } from '../engine/tributary'
 import { modelToFrame3D } from '../engine/modelBridge'
 import { analyzeFrame3D, type F3Analysis } from '../engine/frame3d'
-import { designStructure, optimizeStructure, type StructureDesign, type FootingPlan, type OptimizeResult, type LateralCase } from '../engine/pipeline'
+import { designStructure, optimizeStructure, selectBarDiameters, type StructureDesign, type FootingPlan, type OptimizeResult, type LateralCase } from '../engine/pipeline'
 import { computeSeismic, driftCheck, type SeismicResult, type DriftRow } from '../engine/seismic'
 import { computeWind, type WindResult } from '../engine/wind'
 import { solveFrame3D, applyF3Combo } from '../engine/frame3d'
@@ -380,9 +380,11 @@ export default function ModelSpace() {
   const [fc, setFc] = useState(28); const [fy, setFy] = useState(415)
   const [barDia, setBarDia] = useState(20); const [tieDia, setTieDia] = useState(10)
   const [cover, setCover] = useState(40); const [slabThk, setSlabThk] = useState(150)
+  const [gammaC, setGammaC] = useState(24)            // concrete unit weight, kN/m³
   const [qD, setQD] = useState(4.8); const [qL, setQL] = useState(2.4)
   // Soil (for the footing stage of the design pipeline)
   const [qa, setQa] = useState(200); const [Hf, setHf] = useState(1.5)
+  const [gammaSoil, setGammaSoil] = useState(18)      // soil unit weight (overburden), kN/m³
   // Seismic (NSCP 208 static lateral force)
   const [Ca, setCa] = useState(0.44); const [Cv, setCv] = useState(0.64)
   const [Rw, setRw] = useState(8.5); const [Ie, setIe] = useState(1.0)
@@ -400,6 +402,7 @@ export default function ModelSpace() {
   // Analysis options: f₁ live-load factor (§203.3.1) and P-Δ second order
   const [assembly, setAssembly] = useState(false)
   const [pDelta, setPDelta] = useState(false)
+  const [tryBars, setTryBars] = useState(true)        // let design/optimize pick bar Ø from a ladder
   const [showLoads, setShowLoads] = useState(true)   // load-diagram overlay
 
   const [model, setModel] = useState<StructuralModel | null>(() => {
@@ -478,7 +481,7 @@ export default function ModelSpace() {
     if (!model) return
     // base magnitude is direction-independent (storey force per node), so one
     // solve gives every ±X/±Z case.
-    const r = computeSeismic(model, { Ca, Cv, I: Ie, R: Rw, Z: Zf, Nv, dir: 'x' })
+    const r = computeSeismic(model, { Ca, Cv, I: Ie, R: Rw, Z: Zf, Nv, gammaC, dir: 'x' })
     if (!r) return
     setSeis(r)
     setECases(eDirs.map((d) => dirCase(r.loads, 'E', d)))
@@ -504,7 +507,7 @@ export default function ModelSpace() {
     save({ ...model, loads: [...model.loads.filter((l) => !(l.cat === 'W' && l.kind === 'node')), ...primary.loads] })
   }
 
-  const soil = { qAllow: qa, gammaSoil: 18, gammaConc: 24, H: Hf }
+  const soil = { qAllow: qa, gammaSoil, gammaConc: gammaC, H: Hf }
   const footingPlan = (): FootingPlan => {
     const plan: FootingPlan = {}
     for (const [node, partner] of Object.entries(planSel)) {
@@ -516,13 +519,19 @@ export default function ModelSpace() {
   const runPipeline = () => {
     if (!model) return
     setOpt(null)
-    setDesign(designStructure(model, soil, footingPlan(), anaOpts))
+    const plan = footingPlan()
+    // when bar-trying is on, pick the economical bar Ø per member first, then
+    // design and persist those sections so schedules/drawings stay consistent.
+    const m = tryBars ? selectBarDiameters(model, soil, plan, anaOpts) : model
+    const d = designStructure(m, soil, plan, anaOpts)
+    if (m !== model) save(m)
+    setDesign(d)
     requestAnimationFrame(captureModel)   // refresh the printable 3D snapshot
   }
 
   const optimize = () => {
     if (!model) return
-    const r = optimizeStructure(model, soil, footingPlan(), 30, anaOpts)
+    const r = optimizeStructure(model, soil, footingPlan(), 30, anaOpts, tryBars)
     if (!r) return
     // adopt the optimised per-member sections
     save(r.model)
@@ -596,7 +605,7 @@ export default function ModelSpace() {
   const updPlateThickness = (id: string, t: number) => {
     if (!model || !Number.isFinite(t)) return
     const m2 = { ...model, plates: model.plates.map((p) => (p.id === id ? { ...p, thickness: t } : p)) }
-    save({ ...m2, loads: buildGravityLoads(m2, qD, qL) })
+    save({ ...m2, loads: buildGravityLoads(m2, qD, qL, gammaC) })
   }
   const addWall = () => {
     if (!model || !wallMember) return
@@ -605,12 +614,12 @@ export default function ModelSpace() {
     while ((model.walls ?? []).some((w) => w.id === `w${k}`)) k++
     const walls = [...(model.walls ?? []), { id: `w${k}`, member: wallMember, height: wallH, thickness: wallT, shearWall: wallShear }]
     const m2 = { ...model, walls }
-    save({ ...m2, loads: buildGravityLoads(m2, qD, qL) })
+    save({ ...m2, loads: buildGravityLoads(m2, qD, qL, gammaC) })
   }
   const removeWall = (id: string) => {
     if (!model) return
     const m2 = { ...model, walls: (model.walls ?? []).filter((w) => w.id !== id) }
-    save({ ...m2, loads: buildGravityLoads(m2, qD, qL) })
+    save({ ...m2, loads: buildGravityLoads(m2, qD, qL, gammaC) })
   }
   const updLoad = (idx: number, v: number) => {
     if (!model || !Number.isFinite(v)) return
@@ -632,7 +641,7 @@ export default function ModelSpace() {
   const rebuildGravity = () => {
     if (!model) return
     // self-weight + SDL (D) and LL (L) regenerated; E loads survive untouched
-    save({ ...model, loads: buildGravityLoads(model, qD, qL) })
+    save({ ...model, loads: buildGravityLoads(model, qD, qL, gammaC) })
   }
 
   const gov = analysis ? analysis.perCombo[analysis.govIdx] : null
@@ -652,7 +661,7 @@ export default function ModelSpace() {
       slabThickness: slabThk,
     })
     // gravity loads: member self-weight (D), slab self-weight + SDL (D), LL (L)
-    m.loads = buildGravityLoads(m, qD, qL)
+    m.loads = buildGravityLoads(m, qD, qL, gammaC)
     setSelected(null)
     setSeis(null)
     setWind(null)
@@ -1097,11 +1106,14 @@ export default function ModelSpace() {
                 <Pick label="Tie / stirrup ⌀ (mm)" value={String(tieDia)} onChange={(v) => setTieDia(+v)}
                   options={[['10', '⌀10'], ['12', '⌀12'], ['16', '⌀16']]} />
                 <Num label="Clear cover" unit="mm" value={cover} onChange={setCover} step="5" />
+                <Num label="Concrete unit wt γc" unit="kN/m³" value={gammaC} onChange={setGammaC} step="0.5" />
               </Card>
               <p className="text-[11px] text-slate-400">
                 Per-member b×h are editable in the Geometry → Beams &amp; columns table; slab thickness per panel
-                in Geometry → Slabs. These are the defaults applied when you generate a new grid — regenerate (or
-                edit per element) to apply changes. Concrete unit weight γc = 24 kN/m³.
+                in Geometry → Slabs. f′c, fy, ⌀, cover and slab thickness are applied when you generate a new grid;
+                γc feeds self-weight (members + slabs) and seismic mass — change it, then “Rebuild D + L” (Loading)
+                or regenerate. Bar Ø here is the starting size — the design/optimise engines may pick another when
+                “try alternative bar sizes” is on (Analysis).
               </p>
             </div>
           )}
@@ -1112,8 +1124,11 @@ export default function ModelSpace() {
               <Card title="Soil (footing design)">
                 <Num label="Soil qa" unit="kPa" value={qa} onChange={setQa} />
                 <Num label="Footing depth H" unit="m" value={Hf} onChange={setHf} />
+                <Num label="Soil unit wt γsoil" unit="kN/m³" value={gammaSoil} onChange={setGammaSoil} step="0.5" />
                 <p className="col-span-full text-[11px] text-slate-400">
                   Base supports are toggled per node in the Geometry → Nodes table (“Sup” column).
+                  qa is the allowable bearing; γsoil is the overburden weight deducted for the net bearing
+                  (q_net = qa − γsoil·Ds − γc·Dc). Applied on the next Design / Optimize.
                 </p>
               </Card>
               {model && model.supports.length > 0 && (
@@ -1286,6 +1301,10 @@ export default function ModelSpace() {
                   <input type="checkbox" checked={pDelta} onChange={(e) => setPDelta(e.target.checked)} />
                   <span>P-Δ second-order analysis</span>
                 </label>
+                <label className="col-span-full flex items-center gap-2 text-sm">
+                  <input type="checkbox" checked={tryBars} onChange={(e) => setTryBars(e.target.checked)} />
+                  <span>Try alternative bar sizes (Design / Optimize pick ⌀16–⌀32 beams, ⌀20–⌀32 columns)</span>
+                </label>
                 <p className="col-span-full text-[11px] text-slate-500">
                   §203.3.1 live-load factor f₁ = <b>{fLive.toFixed(1)}</b>
                   {fLive === 1 ? (assembly ? ' (assembly/garage)' : ' (Lo > 4.8 kPa)') : ' (ordinary occupancy)'}.
@@ -1433,15 +1452,16 @@ export default function ModelSpace() {
           return [...new Set((model?.sections ?? []).filter((s) => ids.has(s.id)).map((s) => s.name))].join(', ') || '—'
         }
         const slabT = [...new Set((model?.plates ?? []).filter((p) => p.role !== 'wall').map((p) => p.thickness))].join(', ')
+        const barsUsed = [...new Set((model?.sections ?? []).map((s) => s.barDia))].sort((a, b) => a - b)
         const props: [string, string][] = [
           ['Column grid', `bays X ${baysX} m · bays Z ${baysZ} m · storeys ${storeyH} m`],
-          ['Material', mat ? `f′c ${mat.fc} MPa · fy ${mat.fy} MPa · ⌀${mat.barDia} bars · ⌀${mat.tieDia} ties · cover ${mat.cover} mm` : '—'],
+          ['Material', mat ? `f′c ${mat.fc} MPa · fy ${mat.fy} MPa · main ⌀${barsUsed.join('/⌀') || mat.barDia} · ties ⌀${mat.tieDia} · cover ${mat.cover} mm` : '—'],
           ['Columns', distinct('column')],
           ['Girders', distinct('girder')],
           ['Beams', distinct('beam')],
           ['Slabs', `t = ${slabT || '—'} mm`],
-          ['Loads', `SDL ${qD} kPa · LL ${qL} kPa · γc 24 kN/m³`],
-          ['Soil / footing', `qa ${qa} kPa · depth H ${Hf} m`],
+          ['Loads', `SDL ${qD} kPa · LL ${qL} kPa · γc ${gammaC} kN/m³`],
+          ['Soil / footing', `qa ${qa} kPa · γsoil ${gammaSoil} kN/m³ · depth H ${Hf} m`],
           ['Seismic (NSCP 208)', `Ca ${Ca} · Cv ${Cv} · R ${Rw} · I ${Ie} · Z ${Zf} · Nv ${Nv}`],
           ['Wind (NSCP 207B)', `V ${Vw} m/s · exposure ${expo} · Kzt ${Kzt}`],
           ['Model', `${model?.nodes.length ?? 0} nodes · ${model?.members.length ?? 0} members · ${model?.plates.length ?? 0} slabs · ${(model?.walls ?? []).length} walls · ${model?.supports.length ?? 0} supports`],


### PR DESCRIPTION
## What & why
Three things that were previously fixed are now user-controllable:

### 1. Concrete unit weight γc (editable)
Hardcoded at 24 kN/m³ across the self-weight and seismic engine. Now a parameter:
- `buildGravityLoads`, `refreshSelfWeight` (modelBuilder) and `storeyWeights` / `computeSeismic` (seismic) take a `γc` argument (default 24), so member + slab self-weight **and** seismic mass follow the user value.
- UI: **γc** field in the Properties → "Concrete & reinforcement" card.

### 2. Soil unit weight γsoil (editable)
The footing engine already accepted `gammaSoil`/`gammaConc` via the `soil` object — ModelSpace just hardcoded `18`/`24`. Now it passes the user's γc/γsoil (feeds net bearing `q_net = qa − γsoil·Ds − γc·Dc`).
- UI: **γsoil** field in the Supports → "Soil" card.

### 3. Design & optimize try other bar diameters
- **Key insight:** bar Ø changes neither stiffness nor self-weight, so it never alters the frame demands. Bar selection is therefore a pure per-member detailing pass.
- New `selectBarDiameters()` picks the most economical size from a standard ladder (beams ⌀16–32, columns ⌀20–32) that still passes, falling back to the section's bar when none work, and rewrites `section.barDia`. Because every schedule/drawing/worked-solution reads `sec.barDia`, they stay consistent with **zero render changes**.
- `optimizeStructure` gains a `tryBars` flag: it re-details bars **before** measuring fails (so a member that only needs a bigger bar isn't grown unnecessarily) and again at the trimmed sizes. The **Design** button selects bars up front and persists them.
- `designColumnRow` refactored to reuse a P/M-only `designColumnFromPM` helper.
- UI: **"Try alternative bar sizes"** toggle (Analysis), default **on**.

The report's "Project & design inputs" reflects γc, γsoil, and the actual distinct bar sizes used.

> Note: tests call `designStructure`/`optimizeStructure` without the new flags, so existing behavior (and all prior assertions) are unchanged.

## Verification
- `tsc -b` clean; `vitest run` → **229 passed** (incl. new `barSelectionAndGamma.test.ts`: γc scaling of self-weight & seismic; bar selection is stiffness-neutral, economical, ladder-bounded, and never breaks a passing member).
- Browser: set γc 30 → slab dead 9.3 kPa (=0.15·30+4.8) and column SW 4.8 kN/m (=0.16·30); set a uniform ⌀32 start, ran **Design** with the toggle on → bars dropped to per-member economical sizes (beams ⌀16, columns ⌀20/⌀28, girders ⌀16/⌀32); beam schedule rendered "3⌀16"; inputs row showed `γc 30`, `γsoil 18`, `main ⌀16/⌀20/⌀28/⌀32`. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)