### PR TITLE
Take-off/BOM-BOQ, per-slab NSCP-204 SDL, live material apply, smallest-bar selection

### DIFF
--- a/webapp/src/engine/deadLoads.ts
+++ b/webapp/src/engine/deadLoads.ts
@@ -1,0 +1,79 @@
+// ─────────────────────────────────────────────────────────────────────────
+// NSCP 2015 dead-load reference data for composing a slab superimposed dead
+// load (SDL).
+//   · Table 204-1 — Minimum Design Dead Loads: COMPONENT weights given directly
+//     in kPa (finishes, ceilings, partitions, roofing, MEP allowances).
+//   · Table 204-2 — Minimum Densities for Design Loads from Materials: material
+//     UNIT WEIGHTS in kN/m³, multiplied by a user thickness to give kPa.
+// A slab's SDL = Σ(chosen 204-1 components) + Σ(204-2 material × thickness).
+// Values are representative entries from the code tables for everyday building
+// take-off; extend the lists as needed.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Table 204-1 component — a finished assembly with a fixed area load (kPa). */
+export interface DeadComponent { id: string; label: string; kPa: number; group: string }
+
+/** Table 204-2 material — a unit weight (kN/m³) applied over a thickness. */
+export interface DeadMaterial { id: string; label: string; gamma: number }
+
+/** NSCP 2015 Table 204-1 — Minimum Design Dead Loads (component, kPa). */
+export const TABLE_204_1: DeadComponent[] = [
+  // Floor finishes
+  { id: 'fin-ceramic', label: 'Ceramic / quarry tile (20 mm) on 25 mm mortar', kPa: 1.10, group: 'Floor finish' },
+  { id: 'fin-ceramic-thin', label: 'Ceramic / quarry tile (20 mm) on 12 mm mortar', kPa: 0.77, group: 'Floor finish' },
+  { id: 'fin-marble', label: 'Marble and mortar on stone-concrete fill', kPa: 1.58, group: 'Floor finish' },
+  { id: 'fin-cement', label: 'Cement finish (25 mm) on stone-concrete fill', kPa: 1.53, group: 'Floor finish' },
+  { id: 'fin-hardwood', label: 'Hardwood flooring (22 mm)', kPa: 0.19, group: 'Floor finish' },
+  { id: 'fin-vinyl', label: 'Vinyl / asphalt tile (on concrete)', kPa: 0.07, group: 'Floor finish' },
+  // Ceilings
+  { id: 'ceil-plaster-tile', label: 'Plaster on tile or concrete', kPa: 0.24, group: 'Ceiling' },
+  { id: 'ceil-susp-plaster', label: 'Suspended metal lath & gypsum plaster', kPa: 0.48, group: 'Ceiling' },
+  { id: 'ceil-acoustic', label: 'Acoustical fiber board (suspended)', kPa: 0.05, group: 'Ceiling' },
+  { id: 'ceil-gypsum', label: 'Gypsum board (one 13 mm layer)', kPa: 0.10, group: 'Ceiling' },
+  // Partitions
+  { id: 'part-gypsum', label: 'Wood/steel studs, 13 mm gypsum board both sides', kPa: 0.38, group: 'Partition' },
+  { id: 'part-movable', label: 'Movable steel partitions (allowance)', kPa: 0.19, group: 'Partition' },
+  { id: 'part-allow', label: 'Partition allowance (§204.3.2 min)', kPa: 1.00, group: 'Partition' },
+  // Waterproofing / roofing
+  { id: 'roof-5ply', label: 'Five-ply felt-and-gravel roofing', kPa: 0.26, group: 'Roofing / waterproofing' },
+  { id: 'roof-membrane', label: 'Bituminous, smooth-surface membrane', kPa: 0.07, group: 'Roofing / waterproofing' },
+  // MEP allowance
+  { id: 'mep-duct', label: 'Mechanical duct allowance', kPa: 0.20, group: 'MEP' },
+]
+
+/** NSCP 2015 Table 204-2 — Minimum Densities for Design Loads from Materials (kN/m³). */
+export const TABLE_204_2: DeadMaterial[] = [
+  { id: 'mat-rc', label: 'Concrete, reinforced (stone)', gamma: 23.6 },
+  { id: 'mat-pc', label: 'Concrete, plain (stone)', gamma: 22.6 },
+  { id: 'mat-cinder', label: 'Concrete, cinder', gamma: 17.0 },
+  { id: 'mat-mortar', label: 'Cement mortar', gamma: 21.2 },
+  { id: 'mat-chb', label: 'Masonry, concrete hollow block (grouted)', gamma: 21.2 },
+  { id: 'mat-brick', label: 'Masonry, brick', gamma: 18.8 },
+  { id: 'mat-earth', label: 'Earth (dry, packed)', gamma: 15.7 },
+  { id: 'mat-sand', label: 'Sand / gravel (dry, packed)', gamma: 15.7 },
+  { id: 'mat-water', label: 'Water', gamma: 9.81 },
+  { id: 'mat-steel', label: 'Steel', gamma: 77.3 },
+  { id: 'mat-wood', label: 'Wood (softwood, typical)', gamma: 6.3 },
+]
+
+/** A picked SDL line: either a 204-1 component (kPa direct) or a 204-2 material
+ *  over a thickness (kPa = γ·t). Stored on the plate so each slab owns its SDL. */
+export interface SdlItem {
+  id: string                 // table entry id
+  kind: '204-1' | '204-2'
+  label: string
+  kPa?: number               // 204-1 component
+  gamma?: number             // 204-2 material density, kN/m³
+  thicknessMm?: number       // 204-2 applied thickness, mm
+}
+
+/** Area load (kPa) contributed by one SDL line. */
+export function sdlItemKPa(item: SdlItem): number {
+  if (item.kind === '204-1') return item.kPa ?? 0
+  return ((item.gamma ?? 0) * (item.thicknessMm ?? 0)) / 1000   // γ[kN/m³]·t[m]
+}
+
+/** Total SDL (kPa) from a list of lines. */
+export function sdlTotal(items: SdlItem[] | undefined): number {
+  return (items ?? []).reduce((s, it) => s + sdlItemKPa(it), 0)
+}

--- a/webapp/src/engine/model.ts
+++ b/webapp/src/engine/model.ts
@@ -5,6 +5,7 @@
 // Units: coordinates m; sections mm; loads kN, kN/m, kPa.
 // ─────────────────────────────────────────────────────────────────────────
 import type { LoadCategory } from './beamAnalysis'
+import type { SdlItem } from './deadLoads'
 
 export interface Node { id: string; x: number; y: number; z: number }
 
@@ -30,6 +31,9 @@ export interface Plate {
   corners: [string, string, string, string]  // node ids, CCW
   role: PlateRole
   thickness: number             // mm
+  /** Per-slab superimposed dead load composed from NSCP Table 204-1/204-2.
+   *  When present, overrides the global SDL for this panel's area dead load. */
+  sdlItems?: SdlItem[]
 }
 
 /** A wall sitting on a member: its self-weight is applied to that member as a

--- a/webapp/src/engine/modelBuilder.ts
+++ b/webapp/src/engine/modelBuilder.ts
@@ -7,6 +7,7 @@
 // the three.js viewport.
 // ─────────────────────────────────────────────────────────────────────────
 import type { StructuralModel, RectSection, Node, Member, Plate, NodeSupport, MemberRole } from './model'
+import { sdlTotal } from './deadLoads'
 
 export interface GridSpec {
   baysX: number[]      // bay widths along x, m
@@ -162,8 +163,10 @@ export function buildGravityLoads(model: StructuralModel, sdl: number, ll: numbe
     .filter((p) => p.role !== 'wall')
     .flatMap((p) => {
       const qSW = (p.thickness / 1000) * gammaC
+      // per-slab NSCP-204 SDL when composed, else the global SDL argument
+      const slabSdl = p.sdlItems && p.sdlItems.length > 0 ? sdlTotal(p.sdlItems) : sdl
       return [
-        { kind: 'area' as const, plate: p.id, q: qSW + sdl, cat: 'D' as const },
+        { kind: 'area' as const, plate: p.id, q: qSW + slabSdl, cat: 'D' as const },
         ...(ll > 0 ? [{ kind: 'area' as const, plate: p.id, q: ll, cat: 'L' as const }] : []),
       ]
     })

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -446,6 +446,17 @@ export function designStructure(
 export const BAR_LADDER_BEAM = [16, 20, 25, 28, 32]
 export const BAR_LADDER_COLUMN = [20, 25, 28, 32]
 
+/** §425.2.1 — do `bars` of Ø `db` fit one face of the column at the minimum
+ *  clear spacing max(1.5db, 40 mm)? Bars split evenly over the two faces ⟂ to h
+ *  (the interaction model's layout), spread across width b. */
+function columnBarsFit(sec: RectSection, db: number, bars: number): boolean {
+  const perFace = Math.ceil(bars / 2)
+  if (perFace <= 1) return true
+  const clearWidth = sec.b - 2 * (sec.cover + sec.tieDia) - perFace * db
+  const sClear = clearWidth / (perFace - 1)
+  return sClear >= Math.max(1.5 * db, 40) - 1e-6
+}
+
 /**
  * Pick the most economical bar diameter for every beam/girder and column from a
  * candidate ladder: the smallest-steel size that still passes, falling back to
@@ -462,37 +473,30 @@ export function selectBarDiameters(
   const secById = new Map(model.sections.map((s) => [s.id, s]))
   const memSecId = new Map(model.members.map((m) => [m.id, m.section]))
   const chosen = new Map<string, number>()
+  // candidate sizes, SMALLEST first — we adopt the first one that passes.
   const ladder = (cands: number[], current: number) => [...new Set([current, ...cands])].sort((a, b) => a - b)
 
-  // beams/girders: minimise total tension steel across the member's sections,
-  // among bar sizes where every section is adequate.
+  // beams/girders: smallest bar Ø whose every section passes capacity AND the
+  // §407.7.1 clear-spacing / layer-fit check (both folded into beamOK).
   for (const row of design.beams) {
     const sec = secById.get(memSecId.get(row.id) ?? ''); if (!sec) continue
-    let best: { db: number; As: number } | null = null
     for (const db of ladder(BAR_LADDER_BEAM, sec.barDia)) {
-      let allOK = true, totalAs = 0
-      for (const s of row.sections) {
-        const d = designBeam({
-          b: sec.b, h: sec.h, cover: sec.cover, barDia: db, comprBarDia: 16,
-          stirrupDia: sec.tieDia, fc: sec.fc, fy: sec.fy, Mu: Math.abs(s.Mu), Vu: s.Vu,
-        })
-        if (!beamOK(d)) { allOK = false; break }
-        totalAs += d.As
-      }
-      if (allOK && (!best || totalAs < best.As - 1e-6)) best = { db, As: totalAs }
+      const allOK = row.sections.every((s) => beamOK(designBeam({
+        b: sec.b, h: sec.h, cover: sec.cover, barDia: db, comprBarDia: 16,
+        stirrupDia: sec.tieDia, fc: sec.fc, fy: sec.fy, Mu: Math.abs(s.Mu), Vu: s.Vu,
+      })))
+      if (allOK) { if (db !== sec.barDia) chosen.set(sec.id, db); break }
     }
-    if (best && best.db !== sec.barDia) chosen.set(sec.id, best.db)
   }
 
-  // columns: minimise provided steel Ast among bar sizes that pass P–M + ρ.
+  // columns: smallest bar Ø that passes P–M + ρ AND fits the §425.2.1 minimum
+  // clear bar spacing across the section face (≥ max(1.5db, 40 mm)).
   for (const row of design.columns) {
     const sec = secById.get(memSecId.get(row.id) ?? ''); if (!sec) continue
-    let best: { db: number; ast: number } | null = null
     for (const db of ladder(BAR_LADDER_COLUMN, sec.barDia)) {
       const r = designColumnFromPM({ ...sec, barDia: db }, row.Pu, row.Mu)
-      if (r.ok && (!best || r.Ast < best.ast - 1e-6)) best = { db, ast: r.Ast }
+      if (r.ok && columnBarsFit(sec, db, r.bars)) { if (db !== sec.barDia) chosen.set(sec.id, db); break }
     }
-    if (best && best.db !== sec.barDia) chosen.set(sec.id, best.db)
   }
 
   if (chosen.size === 0) return model

--- a/webapp/src/engine/takeoff.test.ts
+++ b/webapp/src/engine/takeoff.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { generateGridModel, buildGravityLoads } from './modelBuilder'
+import { designStructure } from './pipeline'
+import { estimateTakeoff } from './takeoff'
+import { sdlItemKPa, sdlTotal, type SdlItem } from './deadLoads'
+import type { RectSection } from './model'
+
+const section: RectSection = { id: 'S1', name: '300×500', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
+const soil = { qAllow: 200, gammaSoil: 18, gammaConc: 24, H: 1.5 }
+
+function makeModel() {
+  const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })
+  m.loads = buildGravityLoads(m, 4.8, 2.4)
+  return m
+}
+
+describe('NSCP-204 SDL composition', () => {
+  it('204-1 components contribute their kPa directly; 204-2 = γ·t', () => {
+    const tile: SdlItem = { id: 'fin-ceramic', kind: '204-1', label: 'tile', kPa: 1.1 }
+    const screed: SdlItem = { id: 'mat-mortar', kind: '204-2', label: 'mortar', gamma: 21.2, thicknessMm: 50 }
+    expect(sdlItemKPa(tile)).toBeCloseTo(1.1, 9)
+    expect(sdlItemKPa(screed)).toBeCloseTo(21.2 * 0.05, 9)        // 1.06 kPa
+    expect(sdlTotal([tile, screed])).toBeCloseTo(1.1 + 1.06, 9)
+  })
+
+  it('per-slab SDL overrides the global SDL in the area dead load', () => {
+    const m = generateGridModel({ baysX: [6, 6], baysZ: [5], storeyH: [3], section })   // 2 panels
+    m.plates[0].sdlItems = [{ id: 'x', kind: '204-1', label: 'heavy', kPa: 5 }]
+    const loads = buildGravityLoads(m, 4.8, 2.4)
+    const qOf = (plate: string) =>
+      (loads.find((l) => l.kind === 'area' && l.cat === 'D' && (l as { plate: string }).plate === plate) as { q: number }).q
+    // slab self-weight = 0.15·24 = 3.6; panel 0 → +5 SDL, others → +4.8 global
+    expect(qOf(m.plates[0].id)).toBeCloseTo(3.6 + 5, 6)
+    expect(qOf(m.plates[1]?.id ?? m.plates[0].id)).toBeCloseTo(3.6 + 4.8, 6)
+  })
+})
+
+describe('structure take-off / BOM-BOQ', () => {
+  const m = makeModel()
+  const design = designStructure(m, soil)!
+  const t = estimateTakeoff(m, design, { concreteClass: 'A' })
+
+  it('total concrete matches the design totals and yields cement/sand/gravel', () => {
+    expect(t.totalConcreteM3).toBeGreaterThan(0)
+    // members + slabs (footings add a little more) ≥ design member+slab concrete
+    expect(t.totalConcreteM3).toBeGreaterThanOrEqual(design.totals.concrete - 1e-6)
+    expect(t.concrete.cement).toBe(Math.ceil(t.totalConcreteM3 * 9))      // class A = 9 bags/m³
+    expect(t.concrete.gravel).toBeCloseTo(t.totalConcreteM3 * 1.0, 6)
+  })
+
+  it('produces a non-empty cut list and steel grouped by bar Ø', () => {
+    expect(t.cutList.length).toBeGreaterThan(0)
+    expect(t.totalSteelKg).toBeGreaterThan(0)
+    const sumByDia = t.steelByDia.reduce((s, d) => s + d.weightKg, 0)
+    expect(sumByDia).toBeCloseTo(t.totalSteelKg, 6)
+    expect(t.steelByDia).toEqual([...t.steelByDia].sort((a, b) => a.dia - b.dia))
+    expect(t.steelByDia.every((d) => d.pieces6m >= 1)).toBe(true)
+  })
+
+  it('BOQ lists concrete + formwork per element kind and flags slab steel as approx', () => {
+    expect(t.boq.some((r) => /Beam — concrete/.test(r.item) && r.unit === 'm³')).toBe(true)
+    expect(t.boq.some((r) => /formwork/.test(r.item) && r.unit === 'm²')).toBe(true)
+    expect(t.slabSteelApprox).toBe(true)
+    // every element-quantity is finite & non-negative
+    for (const e of t.byElement) {
+      expect(e.concreteM3).toBeGreaterThanOrEqual(0)
+      expect(Number.isFinite(e.steelKg)).toBe(true)
+    }
+  })
+})

--- a/webapp/src/engine/takeoff.ts
+++ b/webapp/src/engine/takeoff.ts
@@ -1,0 +1,211 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Quantity take-off / BOM-BOQ for a designed 3D structure. Consumes the model
+// geometry + the StructureDesign schedules and produces, per element:
+//   · concrete volume (m³) and formwork (m²)
+//   · a reinforcement CUT LIST (per-piece cut length, count, weight) built with
+//     standard detailing allowances, and
+//   · aggregates: steel by bar Ø, total concrete materials (cement/sand/gravel
+//     by NSCP mix class) → a Bill of Materials, plus a Bill of Quantities table.
+// Reuses the material-estimation solvers in quantities.ts (concreteMaterials).
+//
+// Detailing assumptions (documented, editable): straight-bar end allowance =
+// Ld = 40·db (tension lap/anchorage); stirrup/tie hook allowance = 2·max(6·dt,
+// 75 mm); footing bars straight (cover only); slab steel from a bottom+top mat
+// at the positive-moment spacing (APPROXIMATE — flagged in the result).
+// Units: lengths m, Ø mm, steel kg (ρ = 7850 kg/m³).
+// ─────────────────────────────────────────────────────────────────────────
+import type { StructuralModel, RectSection } from './model'
+import type { StructureDesign } from './pipeline'
+import { concreteMaterials, type ConcreteClass, type ConcreteMaterials } from './quantities'
+
+const STEEL_DENSITY = 7850            // kg/m³
+const BAR_LENGTH = 6                  // m, commercial length
+const barAreaM2 = (dia: number) => (Math.PI / 4) * (dia / 1000) ** 2
+const kgPerM = (dia: number) => barAreaM2(dia) * STEEL_DENSITY
+const Ld = (dia: number) => (40 * dia) / 1000                       // tension lap/anchorage, m
+/** Closed stirrup/tie cut length for a b×h section, m. */
+const tiePerimeter = (b: number, h: number, cover: number, tieDia: number) =>
+  (2 * ((b - 2 * cover) + (h - 2 * cover))) / 1000 + (2 * Math.max(6 * tieDia, 75)) / 1000
+
+export interface CutItem {
+  element: string          // e.g. 'Beam bx0.0.1'
+  mark: string             // 'Bottom main', 'Stirrup', 'Vertical', 'Tie', 'Bottom (each way)'
+  dia: number              // mm
+  count: number
+  cutLengthM: number       // per piece
+  totalM: number
+  weightKg: number
+}
+export interface ElementQty {
+  kind: 'Beam' | 'Girder' | 'Column' | 'Footing' | 'Combined footing' | 'Slab' | 'Wall'
+  id: string
+  concreteM3: number
+  formworkM2: number
+  steelKg: number
+}
+export interface SteelByDia { dia: number; lengthM: number; weightKg: number; pieces6m: number }
+export interface BoqRow { item: string; unit: string; qty: number }
+
+export interface TakeoffResult {
+  byElement: ElementQty[]
+  cutList: CutItem[]
+  steelByDia: SteelByDia[]
+  concrete: ConcreteMaterials             // totals for the whole structure
+  formworkM2: number
+  totalSteelKg: number
+  totalConcreteM3: number
+  boq: BoqRow[]
+  slabSteelApprox: boolean                // true when any slab steel was estimated
+}
+
+export interface TakeoffOptions { concreteClass?: ConcreteClass; customFactor?: number }
+
+export function estimateTakeoff(
+  model: StructuralModel, design: StructureDesign, opts: TakeoffOptions = {},
+): TakeoffResult {
+  const klass = opts.concreteClass ?? 'A'
+  const secById = new Map(model.sections.map((s) => [s.id, s]))
+  const memSecId = new Map(model.members.map((m) => [m.id, m.section]))
+  const fallback: RectSection = model.sections[0] ?? { id: '', name: '', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
+  const secOf = (memberId: string) => secById.get(memSecId.get(memberId) ?? '') ?? fallback
+  const colAtNode = (node: string) => model.members.find((m) => m.role === 'column' && (m.i === node || m.j === node))
+
+  const byElement: ElementQty[] = []
+  const cutList: CutItem[] = []
+  const add = (element: string, mark: string, dia: number, count: number, cut: number): number => {
+    if (count <= 0 || cut <= 0 || dia <= 0) return 0
+    const totalM = count * cut
+    const weightKg = totalM * kgPerM(dia)
+    cutList.push({ element, mark, dia, count, cutLengthM: cut, totalM, weightKg })
+    return weightKg
+  }
+
+  // ── Beams & girders ──
+  for (const b of design.beams) {
+    const sec = secOf(b.id)
+    const L = b.L
+    const db = sec.barDia
+    const tag = `${b.role === 'girder' ? 'Girder' : 'Beam'} ${b.id}`
+    const concreteM3 = (sec.b / 1000) * (sec.h / 1000) * L
+    const formworkM2 = (sec.b / 1000 + 2 * (sec.h / 1000)) * L          // soffit + 2 sides (top with slab)
+    const sag = b.sections.filter((s) => !s.hogging)
+    const hog = b.sections.filter((s) => s.hogging)
+    const nBottom = Math.max(0, ...sag.map((s) => s.design.bars))
+    const nTop = Math.max(0, ...hog.map((s) => s.design.bars))
+    let steelKg = 0
+    steelKg += add(tag, 'Bottom main', db, nBottom, L + 2 * Ld(db))
+    steelKg += add(tag, 'Top main', db, nTop, L + 2 * Ld(db))
+    // stirrups: governing (closest) adopted spacing across the member
+    const spac = b.sections.map((s) => s.design.sAdopt).filter((s) => s > 0)
+    if (spac.length) {
+      const s = Math.min(...spac) / 1000
+      const count = Math.ceil(L / s) + 1
+      steelKg += add(tag, 'Stirrup', sec.tieDia, count, tiePerimeter(sec.b, sec.h, sec.cover, sec.tieDia))
+    }
+    byElement.push({ kind: b.role === 'girder' ? 'Girder' : 'Beam', id: b.id, concreteM3, formworkM2, steelKg })
+  }
+
+  // ── Columns ──
+  for (const c of design.columns) {
+    const sec = secOf(c.id)
+    const H = c.L
+    const tag = `Column ${c.id}`
+    const concreteM3 = (sec.b / 1000) * (sec.h / 1000) * H
+    const formworkM2 = (2 * (sec.b / 1000 + sec.h / 1000)) * H
+    let steelKg = 0
+    steelKg += add(tag, 'Vertical', sec.barDia, c.bars, H + Ld(sec.barDia))     // + splice lap at floor
+    if (c.tieSpacing > 0) {
+      const count = Math.ceil(H / (c.tieSpacing / 1000)) + 1
+      steelKg += add(tag, 'Tie', sec.tieDia, count, tiePerimeter(sec.b, sec.h, sec.cover, sec.tieDia))
+    }
+    byElement.push({ kind: 'Column', id: c.id, concreteM3, formworkM2, steelKg })
+  }
+
+  // ── Isolated footings ──
+  for (const f of design.footings) {
+    const cs = (() => { const col = colAtNode(f.node); return col ? secOf(col.id) : fallback })()
+    const B = f.design.B, Dc = f.design.Dc / 1000
+    const tag = `Footing ${f.node}`
+    const concreteM3 = B * B * Dc
+    const formworkM2 = 4 * B * Dc
+    // bars each way, straight, cover 75 mm
+    const steelKg = add(tag, 'Bottom (each way)', cs.barDia, 2 * f.design.bars, Math.max(0.1, B - 0.15))
+    byElement.push({ kind: 'Footing', id: f.node, concreteM3, formworkM2, steelKg })
+  }
+
+  // ── Combined footings (concrete + formwork; reinforcement in the schedule) ──
+  for (const cf of design.combined) {
+    const d = cf.design
+    const Dc = d.Dc / 1000
+    byElement.push({
+      kind: 'Combined footing', id: cf.nodes.join('+'),
+      concreteM3: d.Bx * d.By * Dc, formworkM2: 2 * (d.Bx + d.By) * Dc, steelKg: 0,
+    })
+  }
+
+  // ── Slabs (steel APPROXIMATE: bottom + top mats at the +M spacing) ──
+  let slabSteelApprox = false
+  for (const sl of design.slabs) {
+    const dd = sl.design
+    const lx = sl.lx, ly = sl.ly
+    const concreteM3 = lx * ly * (dd.h / 1000)
+    const formworkM2 = lx * ly                                   // soffit
+    const posSpacing = (dir: typeof dd.x) => {
+      const pos = dir.locations.find((l) => l.name === '+M') ?? dir.locations[dir.locations.length - 1]
+      return Math.max(50, pos.column.spacing)                    // mm
+    }
+    const sX = posSpacing(dd.x), sY = posSpacing(dd.y)
+    // bars in X run the lx span, distributed along ly at spacing sY (and vice-versa)
+    const nX = Math.ceil((ly * 1000) / sY) + 1
+    const nY = Math.ceil((lx * 1000) / sX) + 1
+    const tag = `Slab ${sl.plate}`
+    let steelKg = 0
+    // bottom mat (full) + top mat over continuity (~half) → 1.5× the bottom mat
+    steelKg += add(tag, 'Bottom mat — X', 12, nX, lx)
+    steelKg += add(tag, 'Bottom mat — Y', 12, nY, ly)
+    steelKg += add(tag, 'Top mat — X (approx)', 12, Math.ceil(nX / 2), lx)
+    steelKg += add(tag, 'Top mat — Y (approx)', 12, Math.ceil(nY / 2), ly)
+    slabSteelApprox = true
+    byElement.push({ kind: 'Slab', id: sl.plate, concreteM3, formworkM2, steelKg })
+  }
+
+  // ── Walls (concrete + formwork from the panel; reinforcement via design ρ) ──
+  for (const w of design.walls) {
+    const t = w.thickness / 1000
+    const concreteM3 = w.lw * w.hw * t
+    const formworkM2 = 2 * w.lw * w.hw
+    byElement.push({ kind: 'Wall', id: w.id, concreteM3, formworkM2, steelKg: 0 })
+  }
+
+  // ── Aggregates ──
+  const totalConcreteM3 = byElement.reduce((s, e) => s + e.concreteM3, 0)
+  const formworkM2 = byElement.reduce((s, e) => s + e.formworkM2, 0)
+  const totalSteelKg = cutList.reduce((s, c) => s + c.weightKg, 0)
+  const concrete = concreteMaterials(totalConcreteM3, klass, opts.customFactor)
+
+  const diaMap = new Map<number, { lengthM: number; weightKg: number }>()
+  for (const c of cutList) {
+    const e = diaMap.get(c.dia) ?? { lengthM: 0, weightKg: 0 }
+    e.lengthM += c.totalM; e.weightKg += c.weightKg
+    diaMap.set(c.dia, e)
+  }
+  const steelByDia: SteelByDia[] = [...diaMap.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([dia, v]) => ({ dia, lengthM: v.lengthM, weightKg: v.weightKg, pieces6m: Math.ceil(v.lengthM / BAR_LENGTH) }))
+
+  // BOQ — work items with quantities (concrete/formwork/steel per element kind)
+  const kinds = [...new Set(byElement.map((e) => e.kind))]
+  const boq: BoqRow[] = []
+  for (const k of kinds) {
+    const es = byElement.filter((e) => e.kind === k)
+    boq.push({ item: `${k} — concrete`, unit: 'm³', qty: es.reduce((s, e) => s + e.concreteM3, 0) })
+    boq.push({ item: `${k} — formwork`, unit: 'm²', qty: es.reduce((s, e) => s + e.formworkM2, 0) })
+    const sk = es.reduce((s, e) => s + e.steelKg, 0)
+    if (sk > 0) boq.push({ item: `${k} — reinforcing steel`, unit: 'kg', qty: sk })
+  }
+
+  return {
+    byElement, cutList, steelByDia, concrete, formworkM2,
+    totalSteelKg, totalConcreteM3, boq, slabSteelApprox,
+  }
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -9,6 +9,9 @@ import { distributePanel } from '../engine/tributary'
 import { modelToFrame3D } from '../engine/modelBridge'
 import { analyzeFrame3D, type F3Analysis } from '../engine/frame3d'
 import { designStructure, optimizeStructure, selectBarDiameters, type StructureDesign, type FootingPlan, type OptimizeResult, type LateralCase } from '../engine/pipeline'
+import { estimateTakeoff } from '../engine/takeoff'
+import { TABLE_204_1, TABLE_204_2, sdlItemKPa, sdlTotal, type SdlItem } from '../engine/deadLoads'
+import type { ConcreteClass } from '../engine/quantities'
 import { computeSeismic, driftCheck, type SeismicResult, type DriftRow } from '../engine/seismic'
 import { computeWind, type WindResult } from '../engine/wind'
 import { solveFrame3D, applyF3Combo } from '../engine/frame3d'
@@ -419,6 +422,10 @@ export default function ModelSpace() {
   const [expanded, setExpanded] = useState<string | null>(null)   // open schedule-row solution
   const [report, setReport] = useState<'' | 'schedules' | 'drawings' | 'solutions' | 'full' | 'sol-only' | 'draw-only'>('')  // consolidated report template
   const [modelImg, setModelImg] = useState<string | null>(null)   // 3D snapshot for the printed report
+  const [concreteClass, setConcreteClass] = useState<ConcreteClass>('A')   // mix class for the take-off
+  const [sdlDraft, setSdlDraft] = useState<SdlItem[]>([])          // NSCP-204 SDL composition being built
+  const [sdlMatId, setSdlMatId] = useState(TABLE_204_2[0].id)      // 204-2 material add-row
+  const [sdlMatT, setSdlMatT] = useState(50)                       // 204-2 thickness, mm
   const [tab, setTab] = useState<Tab>('geometry')                 // right-panel tab
   const [orphans, setOrphans] = useState(0)
   // footing plan: base node → '' (isolated) or partner node id (combined)
@@ -516,22 +523,52 @@ export default function ModelSpace() {
     return plan
   }
 
+  /** Apply the current Properties material (f′c, fy, ⌀, ties, cover) to every
+   *  section and refresh the gravity loads with the current SDL/LL and γc — so
+   *  Design/Optimize reflect Properties edits without regenerating the grid. */
+  const applyMaterial = (m: StructuralModel): StructuralModel => {
+    const sections = m.sections.map((s) => ({ ...s, fc, fy, barDia, tieDia, cover }))
+    const withMat = { ...m, sections }
+    return { ...withMat, loads: buildGravityLoads(withMat, qD, qL, gammaC) }
+  }
+
+  // ── NSCP-204 SDL composer ──
+  const toggleSdl204_1 = (c: typeof TABLE_204_1[number]) =>
+    setSdlDraft((d) => d.some((x) => x.id === c.id)
+      ? d.filter((x) => x.id !== c.id)
+      : [...d, { id: c.id, kind: '204-1', label: c.label, kPa: c.kPa }])
+  const addSdl204_2 = () => {
+    const mtl = TABLE_204_2.find((x) => x.id === sdlMatId); if (!mtl || !(sdlMatT > 0)) return
+    setSdlDraft((d) => [...d, { id: `${mtl.id}@${sdlMatT}`, kind: '204-2', label: `${mtl.label} (${sdlMatT} mm)`, gamma: mtl.gamma, thicknessMm: sdlMatT }])
+  }
+  const removeSdlItem = (idx: number) => setSdlDraft((d) => d.filter((_, i) => i !== idx))
+  /** Write the composed SDL to all slabs (or just the selected plate). */
+  const applySdl = (toAll: boolean) => {
+    if (!model) return
+    const items = sdlDraft.length ? sdlDraft : undefined
+    const plates = model.plates.map((p) =>
+      p.role !== 'wall' && (toAll || p.id === selected) ? { ...p, sdlItems: items } : p)
+    const m2 = { ...model, plates }
+    save({ ...m2, loads: buildGravityLoads(m2, qD, qL, gammaC) })
+  }
+
   const runPipeline = () => {
     if (!model) return
     setOpt(null)
     const plan = footingPlan()
+    const base = applyMaterial(model)
     // when bar-trying is on, pick the economical bar Ø per member first, then
     // design and persist those sections so schedules/drawings stay consistent.
-    const m = tryBars ? selectBarDiameters(model, soil, plan, anaOpts) : model
+    const m = tryBars ? selectBarDiameters(base, soil, plan, anaOpts) : base
     const d = designStructure(m, soil, plan, anaOpts)
-    if (m !== model) save(m)
+    save(m)
     setDesign(d)
     requestAnimationFrame(captureModel)   // refresh the printable 3D snapshot
   }
 
   const optimize = () => {
     if (!model) return
-    const r = optimizeStructure(model, soil, footingPlan(), 30, anaOpts, tryBars)
+    const r = optimizeStructure(applyMaterial(model), soil, footingPlan(), 30, anaOpts, tryBars)
     if (!r) return
     // adopt the optimised per-member sections
     save(r.model)
@@ -643,6 +680,12 @@ export default function ModelSpace() {
     // self-weight + SDL (D) and LL (L) regenerated; E loads survive untouched
     save({ ...model, loads: buildGravityLoads(model, qD, qL, gammaC) })
   }
+
+  // material take-off / BOM-BOQ for the current design + mix class
+  const takeoff = useMemo(
+    () => (design && model ? estimateTakeoff(model, design, { concreteClass }) : null),
+    [design, model, concreteClass],
+  )
 
   const gov = analysis ? analysis.perCombo[analysis.govIdx] : null
   const govRes = gov?.result ?? null
@@ -1169,9 +1212,98 @@ export default function ModelSpace() {
           {tab === 'loading' && (
             <div className="space-y-4">
               <Card title="Slab loads">
-                <Num label="SDL (superimposed)" unit="kPa" value={qD} onChange={setQD} />
+                <Num label="Default SDL" unit="kPa" value={qD} onChange={setQD} />
                 <Num label="Live load" unit="kPa" value={qL} onChange={setQL} />
+                <p className="col-span-full text-[11px] text-slate-400">
+                  “Default SDL” applies to any slab without a composed NSCP-204 SDL below. Live load is shared.
+                </p>
               </Card>
+
+              {/* NSCP 204 superimposed-dead-load composer (per slab) */}
+              <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                <h3 className="mb-1 text-[1.02rem] font-bold text-[#0056b3]">Superimposed dead load — NSCP 204</h3>
+                <p className="mb-2 text-[11px] text-slate-500">
+                  Build the SDL from finishes/ceilings/partitions (Table 204-1, kPa) and material layers
+                  (Table 204-2, γ × thickness). Then apply it to every slab, or to the slab selected in the 3D view.
+                </p>
+                <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+                  {/* Table 204-1 components */}
+                  <div>
+                    <p className="mb-1 text-[11px] font-semibold text-slate-600">Table 204-1 — components (kPa)</p>
+                    <div className="max-h-44 space-y-0.5 overflow-auto pr-1">
+                      {TABLE_204_1.map((c) => (
+                        <label key={c.id} className="flex items-center gap-2 text-[11px]">
+                          <input type="checkbox" checked={sdlDraft.some((x) => x.id === c.id)} onChange={() => toggleSdl204_1(c)} />
+                          <span className="flex-1">{c.label}</span>
+                          <span className="text-slate-400">{c.kPa.toFixed(2)}</span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                  {/* Table 204-2 material layers + the running composition */}
+                  <div>
+                    <p className="mb-1 text-[11px] font-semibold text-slate-600">Table 204-2 — material layer (γ × t)</p>
+                    <div className="flex flex-wrap items-end gap-2">
+                      <select value={sdlMatId} onChange={(e) => setSdlMatId(e.target.value)}
+                        className="flex-1 rounded-md border border-slate-300 px-2 py-1 text-xs">
+                        {TABLE_204_2.map((mtl) => <option key={mtl.id} value={mtl.id}>{mtl.label} ({mtl.gamma})</option>)}
+                      </select>
+                      <input type="number" value={sdlMatT} onChange={(e) => setSdlMatT(parseFloat(e.target.value))}
+                        className="w-20 rounded-md border border-slate-300 px-2 py-1 text-xs" /> <span className="text-[11px] text-slate-400">mm</span>
+                      <button type="button" onClick={addSdl204_2}
+                        className="rounded-md border border-slate-300 px-2 py-1 text-xs font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">+ Add</button>
+                    </div>
+                    <div className="mt-2 space-y-0.5">
+                      {sdlDraft.length === 0 && <p className="text-[11px] text-slate-400">No components selected.</p>}
+                      {sdlDraft.map((it, i) => (
+                        <div key={i} className="flex items-center gap-2 text-[11px]">
+                          <span className="flex-1">{it.label}</span>
+                          <span className="text-slate-500">{sdlItemKPa(it).toFixed(2)} kPa</span>
+                          <button type="button" onClick={() => removeSdlItem(i)} className="rounded px-1 text-red-500 hover:bg-red-50">✕</button>
+                        </div>
+                      ))}
+                      <div className="mt-1 border-t border-slate-100 pt-1 text-[11px] font-semibold">
+                        Composed SDL = <span className="text-[#0056b3]">{sdlTotal(sdlDraft).toFixed(2)} kPa</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div className="mt-2 flex flex-wrap items-center gap-2">
+                  <button type="button" onClick={() => applySdl(true)} disabled={!model}
+                    className="rounded-md bg-[#0056b3] px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-40">Apply to all slabs</button>
+                  <button type="button" onClick={() => applySdl(false)} disabled={!selPlate || selPlate.role === 'wall'}
+                    className="rounded-md border border-[#0056b3] px-3 py-1.5 text-xs font-semibold text-[#0056b3] disabled:opacity-40"
+                    title="Select a slab panel in the 3D view first">
+                    Apply to selected slab{selPlate && selPlate.role !== 'wall' ? ` (${selPlate.id})` : ''}
+                  </button>
+                  <span className="text-[11px] text-slate-400">Empty composition clears a slab back to the default SDL.</span>
+                </div>
+                {model && model.plates.filter((p) => p.role !== 'wall').length > 0 && (
+                  <div className="mt-3 max-h-40 overflow-auto">
+                    <table className="w-full border-collapse text-[11px]">
+                      <thead>
+                        <tr className="text-left uppercase tracking-wide text-slate-500">
+                          <th className="py-1 pr-2 font-semibold">Slab</th>
+                          <th className="py-1 pr-2 text-right font-semibold">SDL (kPa)</th>
+                          <th className="py-1 font-semibold">Source</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {model.plates.filter((p) => p.role !== 'wall').map((p) => {
+                          const composed = p.sdlItems && p.sdlItems.length > 0
+                          return (
+                            <tr key={p.id} className={`border-t border-slate-100 ${selected === p.id ? 'bg-blue-50/60' : ''}`}>
+                              <td className="py-0.5 pr-2 font-medium">{p.id}</td>
+                              <td className="py-0.5 pr-2 text-right">{(composed ? sdlTotal(p.sdlItems) : qD).toFixed(2)}</td>
+                              <td className="py-0.5 text-slate-500">{composed ? `NSCP-204 (${p.sdlItems!.length} item${p.sdlItems!.length === 1 ? '' : 's'})` : 'default'}</td>
+                            </tr>
+                          )
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </div>
 
               {model && (
                 <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
@@ -1446,21 +1578,22 @@ export default function ModelSpace() {
         const wantSol = report === '' || report === 'full' || report === 'solutions' || report === 'sol-only'
         const wantDraw = report === '' || report === 'full' || report === 'drawings' || report === 'draw-only'
         const tablesHidden = report === 'sol-only' || report === 'draw-only'   // *-only: no schedule tables
-        const mat = model?.sections[0]
         const distinct = (role: MemberRole) => {
           const ids = new Set((model?.members ?? []).filter((m) => m.role === role).map((m) => m.section))
           return [...new Set((model?.sections ?? []).filter((s) => ids.has(s.id)).map((s) => s.name))].join(', ') || '—'
         }
         const slabT = [...new Set((model?.plates ?? []).filter((p) => p.role !== 'wall').map((p) => p.thickness))].join(', ')
         const barsUsed = [...new Set((model?.sections ?? []).map((s) => s.barDia))].sort((a, b) => a - b)
+        const slabSdls = [...new Set((model?.plates ?? []).filter((p) => p.role !== 'wall')
+          .map((p) => (p.sdlItems && p.sdlItems.length ? sdlTotal(p.sdlItems) : qD)))].sort((a, b) => a - b)
         const props: [string, string][] = [
           ['Column grid', `bays X ${baysX} m · bays Z ${baysZ} m · storeys ${storeyH} m`],
-          ['Material', mat ? `f′c ${mat.fc} MPa · fy ${mat.fy} MPa · main ⌀${barsUsed.join('/⌀') || mat.barDia} · ties ⌀${mat.tieDia} · cover ${mat.cover} mm` : '—'],
+          ['Material', `f′c ${fc} MPa · fy ${fy} MPa · main ⌀${barsUsed.join('/⌀') || barDia} · ties ⌀${tieDia} · cover ${cover} mm`],
           ['Columns', distinct('column')],
           ['Girders', distinct('girder')],
           ['Beams', distinct('beam')],
-          ['Slabs', `t = ${slabT || '—'} mm`],
-          ['Loads', `SDL ${qD} kPa · LL ${qL} kPa · γc ${gammaC} kN/m³`],
+          ['Slabs', `t = ${slabT || '—'} mm · SDL ${slabSdls.map((v) => v.toFixed(2)).join(' / ')} kPa`],
+          ['Loads', `default SDL ${qD} kPa · LL ${qL} kPa · γc ${gammaC} kN/m³`],
           ['Soil / footing', `qa ${qa} kPa · γsoil ${gammaSoil} kN/m³ · depth H ${Hf} m`],
           ['Seismic (NSCP 208)', `Ca ${Ca} · Cv ${Cv} · R ${Rw} · I ${Ie} · Z ${Zf} · Nv ${Nv}`],
           ['Wind (NSCP 207B)', `V ${Vw} m/s · exposure ${expo} · Kzt ${Kzt}`],
@@ -1927,6 +2060,138 @@ export default function ModelSpace() {
         </div>
         )
       })()}
+
+      {/* ── Material take-off — BOM / BOQ (full width) ── */}
+      {design && takeoff && (
+        <div className="mt-6 space-y-4 break-before-page">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h2 className="text-xl font-extrabold tracking-tight text-[#0056b3]">
+              Material take-off — Bill of Quantities &amp; Materials
+            </h2>
+            <label className="no-print flex items-center gap-2 text-sm">
+              <span className="font-medium text-slate-600">Concrete class</span>
+              <select value={concreteClass} onChange={(e) => setConcreteClass(e.target.value as ConcreteClass)}
+                className="rounded-md border border-slate-300 px-2 py-1 text-sm">
+                <option value="AA">AA (12 bags/m³)</option>
+                <option value="A">A (9)</option>
+                <option value="B">B (7.5)</option>
+                <option value="C">C (6)</option>
+              </select>
+            </label>
+          </div>
+
+          {/* BOM summary */}
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+            {[
+              ['Concrete', `${f2(takeoff.totalConcreteM3)} m³`],
+              ['Cement', `${takeoff.concrete.cement} bags`],
+              ['Sand', `${f2(takeoff.concrete.sand)} m³`],
+              ['Gravel', `${f2(takeoff.concrete.gravel)} m³`],
+              ['Formwork', `${f1(takeoff.formworkM2)} m²`],
+              ['Reinf. steel', `${f1(takeoff.totalSteelKg)} kg`],
+            ].map(([k, v]) => (
+              <div key={k} className="rounded-lg border border-slate-200 bg-white p-2 text-center shadow-sm">
+                <div className="text-[11px] uppercase tracking-wide text-slate-500">{k}</div>
+                <div className="text-sm font-bold text-[#0056b3]">{v}</div>
+              </div>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            {/* BOQ */}
+            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Bill of Quantities (by element)</h3>
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="text-left uppercase tracking-wide text-slate-500">
+                    <th className="py-1 pr-2 font-semibold">Item</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Qty</th>
+                    <th className="py-1 font-semibold">Unit</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {takeoff.boq.map((r) => (
+                    <tr key={r.item} className="border-t border-slate-100">
+                      <td className="py-0.5 pr-2">{r.item}</td>
+                      <td className="py-0.5 pr-2 text-right">{f2(r.qty)}</td>
+                      <td className="py-0.5 text-slate-500">{r.unit}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {/* Steel by diameter (BOM) */}
+            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Reinforcement by bar Ø</h3>
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="text-left uppercase tracking-wide text-slate-500">
+                    <th className="py-1 pr-2 font-semibold">Bar</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Length (m)</th>
+                    <th className="py-1 pr-2 text-right font-semibold">6 m pcs</th>
+                    <th className="py-1 text-right font-semibold">Weight (kg)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {takeoff.steelByDia.map((d) => (
+                    <tr key={d.dia} className="border-t border-slate-100">
+                      <td className="py-0.5 pr-2 font-medium">⌀{d.dia}</td>
+                      <td className="py-0.5 pr-2 text-right">{f1(d.lengthM)}</td>
+                      <td className="py-0.5 pr-2 text-right">{d.pieces6m}</td>
+                      <td className="py-0.5 text-right">{f1(d.weightKg)}</td>
+                    </tr>
+                  ))}
+                  <tr className="border-t border-slate-200 font-semibold">
+                    <td className="py-1 pr-2">Total</td>
+                    <td />
+                    <td />
+                    <td className="py-1 text-right">{f1(takeoff.totalSteelKg)}</td>
+                  </tr>
+                </tbody>
+              </table>
+              <p className="mt-1 text-[11px] text-slate-400">
+                Class {concreteClass}: {takeoff.concrete.factor} cement bags/m³ · sand 0.5, gravel 1.0 m³/m³ (NSCP mix).
+              </p>
+            </div>
+          </div>
+
+          {/* Detailed cut list */}
+          <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Reinforcement cut list</h3>
+            <table className="w-full border-collapse text-xs">
+              <thead>
+                <tr className="text-left uppercase tracking-wide text-slate-500">
+                  <th className="py-1 pr-2 font-semibold">Element</th>
+                  <th className="py-1 pr-2 font-semibold">Mark</th>
+                  <th className="py-1 pr-2 text-right font-semibold">Bar</th>
+                  <th className="py-1 pr-2 text-right font-semibold">No.</th>
+                  <th className="py-1 pr-2 text-right font-semibold">Cut (m)</th>
+                  <th className="py-1 pr-2 text-right font-semibold">Total (m)</th>
+                  <th className="py-1 text-right font-semibold">kg</th>
+                </tr>
+              </thead>
+              <tbody>
+                {takeoff.cutList.map((c, i) => (
+                  <tr key={i} className="border-t border-slate-100">
+                    <td className="py-0.5 pr-2">{c.element}</td>
+                    <td className="py-0.5 pr-2">{c.mark}</td>
+                    <td className="py-0.5 pr-2 text-right">⌀{c.dia}</td>
+                    <td className="py-0.5 pr-2 text-right">{c.count}</td>
+                    <td className="py-0.5 pr-2 text-right">{f2(c.cutLengthM)}</td>
+                    <td className="py-0.5 pr-2 text-right">{f1(c.totalM)}</td>
+                    <td className="py-0.5 text-right">{f1(c.weightKg)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <p className="mt-1 text-[11px] text-slate-400">
+              Cut lengths include a 40·d_b lap/anchorage allowance on straight bars and a 2·max(6·d_t, 75 mm) hook
+              allowance on stirrups/ties. {takeoff.slabSteelApprox ? 'Slab steel is an estimated bottom + top mat at the positive-moment spacing (approximate).' : ''}
+            </p>
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Addresses all four points from the latest feedback.

## 1. Inputs card was stale until "Generate" — fixed
**Design** and **Optimize** now apply the current Properties material (f′c, fy, main ⌀, ties, cover) plus γc / SDL / LL to the model *before* designing (`applyMaterial`), so changing those values takes effect without regenerating the grid. The report's "Material" and "Loads" rows now read live state.

## 2. Optimize favoured larger bars — fixed
`selectBarDiameters` now adopts the **smallest** ladder size that passes **all** checks, instead of minimising steel area:
- Beams: capacity **and** §407.7 clear-spacing/layer fit (both via `beamOK`).
- Columns: P–M + ρ **and** a new §425.2.1 `columnBarsFit` clear-spacing check (≥ max(1.5·db, 40 mm)).

Verified: a uniform ⌀32 start drops to ⌀16/⌀20 on Design.

## 3. Quantity take-off engine + BOM/BOQ report (new)
`engine/takeoff.ts` consumes the model + `StructureDesign` and produces, per element:
- concrete volume + formwork area, and
- a reinforcement **cut list** with standard detailing allowances (40·db lap/anchorage on straight bars; 2·max(6·dt, 75 mm) hooks on stirrups/ties),

then aggregates into:
- **steel by bar Ø** (length, 6 m pieces, weight),
- **concrete materials** — cement/sand/gravel by NSCP mix class (reuses `quantities.ts`),
- a **Bill of Quantities** (concrete/formwork/steel per element kind) and a **Bill of Materials** summary.

Rendered as a printable section under the design report with a concrete-class picker. Slab steel is an estimated bottom + top mat at the +M spacing (flagged approximate); the rest (beams/columns/footings) is detailed.

## 4. Per-slab SDL from NSCP Tables 204-1 / 204-2 (new)
`engine/deadLoads.ts` carries curated Table 204-1 components (kPa) and Table 204-2 material densities (γ × thickness). `Plate` gains optional `sdlItems`; `buildGravityLoads` uses the per-slab composition when present, else the global default SDL. The Loading tab gets a composer: tick components, add material layers, then **Apply to all slabs** or **Apply to selected slab** (the panel selected in 3D), with a per-slab SDL table.

## Verification
- `tsc -b` clean; `vitest run` → **234 passed** (new `takeoff.test.ts`: SDL composition + per-slab override; take-off concrete matches design totals, steel grouped by Ø, BOQ rows; bar tests updated).
- Browser: composed SDL 1.54 kPa applied to slabs → area dead 5.14 kPa (3.6 SW + 1.54); set f′c 35 + ⌀32 then Design (no regenerate) → model f′c 35, bars ⌀16/⌀20, inputs row "f′c 35 MPa"; take-off rendered BOM (321 cement bags @ class A, 3567 kg steel), BOQ (15 rows), reinforcement-by-Ø, and an 84-row cut list. No console errors.

> Per the question answers: SDL is **per-slab**, and the take-off includes both **MVP aggregates and a detailed cut list**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)