### PR TITLE
Priced Bill of Materials + to-scale designed footings (overlap detection) in 3D

### DIFF
--- a/webapp/src/engine/footingLayout.test.ts
+++ b/webapp/src/engine/footingLayout.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { footingLayout, type FootingIn, type CombinedIn } from './footingLayout'
+
+const xz = new Map([
+  ['n0', { x: 0, z: 0 }],
+  ['n1', { x: 3, z: 0 }],   // 3 m away in x
+  ['n2', { x: 0, z: 8 }],   // far in z
+])
+
+describe('footing footprint layout & overlap', () => {
+  it('isolated footings are to-scale squares centred on their node', () => {
+    const f: FootingIn[] = [{ node: 'n0', B: 1.8, Dc: 400 }]
+    const { items } = footingLayout(f, [], xz)
+    expect(items).toHaveLength(1)
+    const it = items[0]
+    expect(it.bx).toBe(1.8); expect(it.bz).toBe(1.8)
+    expect(it.dc).toBeCloseTo(0.4, 9)               // 400 mm → 0.4 m
+    expect(it.cx).toBe(0); expect(it.cz).toBe(0)
+    expect(it.label).toContain('1.80×1.80')
+  })
+
+  it('flags overlapping footprints and clears non-overlapping ones', () => {
+    // n0 & n1 are 3 m apart: B = 3.2 → halves 1.6+1.6 = 3.2 > 3 → overlap
+    const big = footingLayout([{ node: 'n0', B: 3.2, Dc: 400 }, { node: 'n1', B: 3.2, Dc: 400 }], [], xz)
+    expect(big.overlaps.has('ft-n0')).toBe(true)
+    expect(big.overlaps.has('ft-n1')).toBe(true)
+    // B = 2.0 → halves 1.0+1.0 = 2.0 < 3 → no overlap
+    const ok = footingLayout([{ node: 'n0', B: 2.0, Dc: 400 }, { node: 'n1', B: 2.0, Dc: 400 }], [], xz)
+    expect(ok.overlaps.size).toBe(0)
+    // far node never overlaps
+    const far = footingLayout([{ node: 'n0', B: 3.2, Dc: 400 }, { node: 'n2', B: 3.2, Dc: 400 }], [], xz)
+    expect(far.overlaps.size).toBe(0)
+  })
+
+  it('combined footing is oriented along the column axis with the right AABB', () => {
+    const cf: CombinedIn[] = [{ nodes: ['n0', 'n1'], Bx: 4.5, By: 1.5, Dc: 500, trapezoid: false }]
+    const { items } = footingLayout([], cf, xz)
+    const it = items[0]
+    expect(it.angle).toBeCloseTo(0, 9)              // n0→n1 along +x
+    expect(it.cx).toBeCloseTo(1.5, 9); expect(it.cz).toBeCloseTo(0, 9)   // midpoint
+    expect(it.hx).toBeCloseTo(2.25, 9); expect(it.hz).toBeCloseTo(0.75, 9)
+    expect(it.label).toContain('CRF')
+  })
+})

--- a/webapp/src/engine/footingLayout.ts
+++ b/webapp/src/engine/footingLayout.ts
@@ -1,0 +1,59 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Footing footprint layout for the 3D view. Turns the designed footings
+// (isolated squares + combined CRF/CTF) into to-scale plan rectangles centred
+// on their base nodes, and flags overlapping footprints (axis-aligned bounding-
+// box test). Pure + framework-free so it can be unit-tested; the 3D scene maps
+// each Footprint to a translucent box below grade.
+// Units: metres.
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface FootingIn { node: string; B: number; Dc: number }            // isolated square (mm Dc)
+export interface CombinedIn { nodes: [string, string]; Bx: number; By: number; Dc: number; trapezoid: boolean }
+
+export interface Footprint {
+  key: string
+  cx: number; cz: number          // plan centre, m
+  bx: number; bz: number          // plan dimensions, m (local, before rotation)
+  dc: number                      // depth, m
+  angle: number                   // plan rotation about +Y, rad (0 for isolated)
+  hx: number; hz: number          // world AABB half-extents, m (for overlap test)
+  label: string
+}
+
+const aabbHalf = (bx: number, bz: number, angle: number) => ({
+  hx: (Math.abs(bx * Math.cos(angle)) + Math.abs(bz * Math.sin(angle))) / 2,
+  hz: (Math.abs(bx * Math.sin(angle)) + Math.abs(bz * Math.cos(angle))) / 2,
+})
+
+/** Build to-scale footprints + the set of overlapping keys. */
+export function footingLayout(
+  footings: FootingIn[], combined: CombinedIn[], nodeXZ: Map<string, { x: number; z: number }>,
+): { items: Footprint[]; overlaps: Set<string> } {
+  const items: Footprint[] = []
+  for (const f of footings) {
+    const p = nodeXZ.get(f.node); if (!p) continue
+    items.push({
+      key: `ft-${f.node}`, cx: p.x, cz: p.z, bx: f.B, bz: f.B, dc: f.Dc / 1000, angle: 0,
+      hx: f.B / 2, hz: f.B / 2, label: `${f.node}  ${f.B.toFixed(2)}×${f.B.toFixed(2)}`,
+    })
+  }
+  for (const cf of combined) {
+    const a = nodeXZ.get(cf.nodes[0]), b = nodeXZ.get(cf.nodes[1]); if (!a || !b) continue
+    const angle = Math.atan2(b.z - a.z, b.x - a.x)
+    const { hx, hz } = aabbHalf(cf.Bx, cf.By, angle)
+    items.push({
+      key: `cf-${cf.nodes.join('-')}`, cx: (a.x + b.x) / 2, cz: (a.z + b.z) / 2,
+      bx: cf.Bx, bz: cf.By, dc: cf.Dc / 1000, angle, hx, hz,
+      label: `${cf.trapezoid ? 'CTF' : 'CRF'} ${cf.Bx.toFixed(2)}×${cf.By.toFixed(2)}`,
+    })
+  }
+  const overlaps = new Set<string>()
+  for (let i = 0; i < items.length; i++)
+    for (let j = i + 1; j < items.length; j++) {
+      const A = items[i], C = items[j]
+      if (Math.abs(A.cx - C.cx) < A.hx + C.hx - 1e-6 && Math.abs(A.cz - C.cz) < A.hz + C.hz - 1e-6) {
+        overlaps.add(A.key); overlaps.add(C.key)
+      }
+    }
+  return { items, overlaps }
+}

--- a/webapp/src/engine/takeoff.test.ts
+++ b/webapp/src/engine/takeoff.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { generateGridModel, buildGravityLoads } from './modelBuilder'
 import { designStructure } from './pipeline'
-import { estimateTakeoff } from './takeoff'
+import { estimateTakeoff, costBill, type PriceList } from './takeoff'
 import { sdlItemKPa, sdlTotal, type SdlItem } from './deadLoads'
 import type { RectSection } from './model'
 
@@ -71,6 +71,17 @@ describe('structure take-off / BOM-BOQ', () => {
     expect(t.formwork.lumberM).toBeGreaterThan(0)
     expect(t.tieWire.intersections).toBeGreaterThan(0)
     expect(t.tieWire.rolls).toBeGreaterThanOrEqual(1)
+  })
+
+  it('costBill prices the aggregates into line amounts + a grand total', () => {
+    const prices: PriceList = { cementBag: 260, sandM3: 1500, gravelM3: 1600, steelKg: 65, tieWireRoll: 2500, plywoodSheet: 700, lumberM: 25 }
+    const bill = costBill(t, prices)
+    const cement = bill.rows.find((r) => r.item === 'Cement')!
+    expect(cement.amount).toBeCloseTo(t.concrete.cement * 260, 6)
+    const steel = bill.rows.find((r) => r.item === 'Reinforcing steel')!
+    expect(steel.amount).toBeCloseTo(t.totalSteelPurchasedKg * 65, 6)
+    expect(bill.total).toBeCloseTo(bill.rows.reduce((s, r) => s + r.amount, 0), 6)
+    expect(bill.total).toBeGreaterThan(0)
   })
 
   it('combined footings contribute reinforcement (longitudinal + transverse)', () => {

--- a/webapp/src/engine/takeoff.ts
+++ b/webapp/src/engine/takeoff.ts
@@ -80,6 +80,30 @@ export interface TakeoffResult {
   slabSteelDDM: boolean                   // slab steel from the DDM strip layout
 }
 
+// ── Pricing — turn the take-off into a costed Bill of Materials ──
+export interface PriceList {
+  cementBag: number; sandM3: number; gravelM3: number; steelKg: number
+  tieWireRoll: number; plywoodSheet: number; lumberM: number
+}
+export interface BillRow { item: string; qty: number; unit: string; unitPrice: number; amount: number }
+export interface CostedBill { rows: BillRow[]; total: number }
+
+/** Price the take-off aggregates against a unit-price list → line amounts + total. */
+export function costBill(t: TakeoffResult, p: PriceList): CostedBill {
+  const row = (item: string, qty: number, unit: string, unitPrice: number): BillRow =>
+    ({ item, qty, unit, unitPrice, amount: qty * unitPrice })
+  const rows: BillRow[] = [
+    row('Cement', t.concrete.cement, 'bag', p.cementBag),
+    row('Sand', t.concrete.sand, 'm³', p.sandM3),
+    row('Gravel', t.concrete.gravel, 'm³', p.gravelM3),
+    row('Reinforcing steel', t.totalSteelPurchasedKg, 'kg', p.steelKg),
+    row('Tie wire (#16 G.I.)', t.tieWire.rolls, 'roll', p.tieWireRoll),
+    row('Formwork — plywood', t.formwork.plywoodSheets, 'sheet', p.plywoodSheet),
+    row('Formwork — lumber', t.formwork.lumberM, 'lin·m', p.lumberM),
+  ]
+  return { rows, total: rows.reduce((s, r) => s + r.amount, 0) }
+}
+
 export interface TakeoffOptions {
   concreteClass?: ConcreteClass; customFactor?: number
   lapLengthM?: number                     // splice lap deducted from each 6 m bar (default 0.30)

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useState, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { Canvas } from '@react-three/fiber'
-import { OrbitControls } from '@react-three/drei'
+import { OrbitControls, Text } from '@react-three/drei'
 import * as THREE from 'three'
 import { generateGridModel, removeElements, removeNode, buildGravityLoads, splitSharedSections } from '../engine/modelBuilder'
 import type { StructuralModel, Member, Plate, RectSection, ModelLoad, MemberRole } from '../engine/model'
@@ -9,7 +9,8 @@ import { distributePanel } from '../engine/tributary'
 import { modelToFrame3D } from '../engine/modelBridge'
 import { analyzeFrame3D, type F3Analysis } from '../engine/frame3d'
 import { designStructure, optimizeStructure, selectBarDiameters, type StructureDesign, type FootingPlan, type OptimizeResult, type LateralCase } from '../engine/pipeline'
-import { estimateTakeoff } from '../engine/takeoff'
+import { estimateTakeoff, costBill, type PriceList } from '../engine/takeoff'
+import { footingLayout } from '../engine/footingLayout'
 import { TABLE_204_1, TABLE_204_2, sdlItemKPa, sdlTotal, type SdlItem } from '../engine/deadLoads'
 import { TABLE_205_1, TABLE_206 } from '../engine/liveLoads'
 import type { ConcreteClass } from '../engine/quantities'
@@ -107,6 +108,29 @@ function Support3D({ p }: { p: THREE.Vector3 }) {
       <coneGeometry args={[0.28, 0.45, 4]} />
       <meshStandardMaterial color="#0056b3" />
     </mesh>
+  )
+}
+
+/** A designed footing drawn to ACTUAL plan size below grade, so overlapping
+ *  footprints are visible. bx/bz = plan dimensions (m), dc = depth (m), angle =
+ *  plan rotation about Y (combined footings follow the column axis). Overlapping
+ *  footings are tinted red. */
+function Footing3D({ cx, cz, bx, bz, dc, angle = 0, overlap = false, label }: {
+  cx: number; cz: number; bx: number; bz: number; dc: number; angle?: number; overlap?: boolean; label?: string
+}) {
+  return (
+    <group position={[cx, -dc / 2, cz]} rotation={[0, -angle, 0]}>
+      <mesh>
+        <boxGeometry args={[bx, dc, bz]} />
+        <meshStandardMaterial color={overlap ? '#dc2626' : '#b45309'} transparent opacity={overlap ? 0.6 : 0.45} />
+      </mesh>
+      {label && (
+        <Text position={[0, dc / 2 + 0.04, 0]} rotation={[-Math.PI / 2, 0, 0]} fontSize={0.32}
+          color={overlap ? '#991b1b' : '#7c2d12'} anchorX="center" anchorY="middle" outlineWidth={0.012} outlineColor="#ffffff">
+          {label}
+        </Text>
+      )}
+    </group>
   )
 }
 
@@ -408,6 +432,7 @@ export default function ModelSpace() {
   const [pDelta, setPDelta] = useState(false)
   const [tryBars, setTryBars] = useState(true)        // let design/optimize pick bar Ø from a ladder
   const [showLoads, setShowLoads] = useState(true)   // load-diagram overlay
+  const [showFootings, setShowFootings] = useState(true)   // designed footing footprints
 
   const [model, setModel] = useState<StructuralModel | null>(() => {
     try {
@@ -424,6 +449,9 @@ export default function ModelSpace() {
   const [report, setReport] = useState<'' | 'schedules' | 'drawings' | 'solutions' | 'full' | 'sol-only' | 'draw-only'>('')  // consolidated report template
   const [modelImg, setModelImg] = useState<string | null>(null)   // 3D snapshot for the printed report
   const [concreteClass, setConcreteClass] = useState<ConcreteClass>('A')   // mix class for the take-off
+  const [prices, setPrices] = useState<PriceList>({   // unit prices for the costed bill (PHP)
+    cementBag: 260, sandM3: 1500, gravelM3: 1600, steelKg: 65, tieWireRoll: 2500, plywoodSheet: 700, lumberM: 25,
+  })
   const [sdlDraft, setSdlDraft] = useState<SdlItem[]>([])          // NSCP-204 SDL composition being built
   const [sdlMatId, setSdlMatId] = useState(TABLE_204_2[0].id)      // 204-2 material add-row
   const [sdlMatT, setSdlMatT] = useState(50)                       // 204-2 thickness, mm
@@ -709,6 +737,8 @@ export default function ModelSpace() {
     () => (design && model ? estimateTakeoff(model, design, { concreteClass }) : null),
     [design, model, concreteClass],
   )
+  const bill = useMemo(() => (takeoff ? costBill(takeoff, prices) : null), [takeoff, prices])
+  const peso = (v: number) => `₱${v.toLocaleString('en-PH', { maximumFractionDigits: 0 })}`
 
   const gov = analysis ? analysis.perCombo[analysis.govIdx] : null
   const govRes = gov?.result ?? null
@@ -834,6 +864,17 @@ export default function ModelSpace() {
                   const p = nodePos.get(s.node)
                   return p ? <Support3D key={s.node} p={p} /> : null
                 })}
+                {showFootings && design && (() => {
+                  const xz = new Map([...nodePos].map(([id, p]) => [id, { x: p.x, z: p.z }]))
+                  const { items, overlaps } = footingLayout(
+                    design.footings.map((f) => ({ node: f.node, B: f.design.B, Dc: f.design.Dc })),
+                    design.combined.map((cf) => ({ nodes: cf.nodes, Bx: cf.design.Bx, By: cf.design.By, Dc: cf.design.Dc, trapezoid: cf.design.shape.startsWith('Trap') })),
+                    xz,
+                  )
+                  return <group>{items.map((f) => (
+                    <Footing3D key={f.key} cx={f.cx} cz={f.cz} bx={f.bx} bz={f.bz} dc={f.dc} angle={f.angle} overlap={overlaps.has(f.key)} label={f.label} />
+                  ))}</group>
+                })()}
                 {(model.walls ?? []).map((w) => {
                   const m = model.members.find((mm) => mm.id === w.member)
                   const tA = m && nodePos.get(m.i), tB = m && nodePos.get(m.j)
@@ -859,6 +900,14 @@ export default function ModelSpace() {
               </div>
             )}
           </div>
+          {design && (
+            <label className="no-print mt-2 flex items-center gap-2 text-xs text-slate-600">
+              <input type="checkbox" checked={showFootings} onChange={(e) => setShowFootings(e.target.checked)} />
+              Show designed footings to scale
+              <span className="ml-1 inline-flex items-center gap-1"><span className="inline-block h-2 w-3 rounded-sm" style={{ background: '#b45309' }} />ok</span>
+              <span className="inline-flex items-center gap-1"><span className="inline-block h-2 w-3 rounded-sm" style={{ background: '#dc2626' }} />overlap</span>
+            </label>
+          )}
           <label className="no-print mt-2 flex items-center gap-2 text-xs text-slate-600">
             <input type="checkbox" checked={showLoads} onChange={(e) => setShowLoads(e.target.checked)} />
             Show load diagrams on the model
@@ -2173,6 +2222,55 @@ export default function ModelSpace() {
               </div>
             ))}
           </div>
+
+          {/* Priced Bill of Materials — unit prices make it an actual Bill */}
+          {bill && (
+            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+                <h3 className="text-[1.02rem] font-bold text-[#0056b3]">Bill of Materials (priced)</h3>
+                <span className="text-sm font-bold text-[#0056b3]">Grand total: {peso(bill.total)}</span>
+              </div>
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="text-left uppercase tracking-wide text-slate-500">
+                    <th className="py-1 pr-2 font-semibold">Material</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Qty</th>
+                    <th className="py-1 pr-2 font-semibold">Unit</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Unit price (₱)</th>
+                    <th className="py-1 text-right font-semibold">Amount (₱)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {bill.rows.map((r, i) => {
+                    const keys: (keyof PriceList)[] = ['cementBag', 'sandM3', 'gravelM3', 'steelKg', 'tieWireRoll', 'plywoodSheet', 'lumberM']
+                    const key = keys[i]
+                    return (
+                      <tr key={r.item} className="border-t border-slate-100">
+                        <td className="py-0.5 pr-2">{r.item}</td>
+                        <td className="py-0.5 pr-2 text-right">{f2(r.qty)}</td>
+                        <td className="py-0.5 pr-2 text-slate-500">{r.unit}</td>
+                        <td className="py-0.5 pr-2 text-right">
+                          <input type="number" value={prices[key]}
+                            onChange={(e) => setPrices((p) => ({ ...p, [key]: parseFloat(e.target.value) || 0 }))}
+                            className="no-print w-24 rounded border border-slate-200 px-1 py-0.5 text-right" />
+                          <span className="print-only">{prices[key].toLocaleString('en-PH')}</span>
+                        </td>
+                        <td className="py-0.5 text-right font-medium">{peso(r.amount)}</td>
+                      </tr>
+                    )
+                  })}
+                  <tr className="border-t border-slate-200 font-bold text-[#0056b3]">
+                    <td className="py-1 pr-2" colSpan={4}>Grand total</td>
+                    <td className="py-1 text-right">{peso(bill.total)}</td>
+                  </tr>
+                </tbody>
+              </table>
+              <p className="mt-1 text-[11px] text-slate-400">
+                Edit the unit prices to your local rates (PHP). Steel priced on the purchased (6 m-bar) weight incl. lap/waste;
+                concrete via cement/sand/gravel. Labour, hauling and contingencies not included.
+              </p>
+            </div>
+          )}
 
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
             {/* BOQ */}


### PR DESCRIPTION
## 1. A Bill needs prices → costed Bill of Materials
- `takeoff.ts` `costBill(takeoff, priceList)` → per-material line amounts + grand total: cement/sand/gravel, reinforcing steel (priced on the **purchased** 6 m-bar weight incl. lap/waste), tie-wire rolls, plywood sheets, lumber lin-m.
- Report adds an **editable unit-price list (PHP)** and a **"Bill of Materials (priced)"** table — qty · unit · unit price · amount · **grand total**. Prices are live-editable (verified: cement ₱260→₱1000 moved the total ₱505,823 → ₱748,543).

## 2. Designed footings on the 3D model (overlap detection)
- New **`footingLayout.ts`** (pure, unit-tested): converts the designed footings into to-scale plan footprints centred on their base nodes — **isolated squares** (B×B) and **combined CRF/CTF** oriented along the column axis (Bx×By) — and flags **overlapping** footprints with an axis-aligned bounding-box test.
- **`Footing3D`** draws each footprint as a translucent box **below grade at actual size**, tinted **amber (ok)** / **red (overlap)**, with a dimension label (drei `Text`).
- A **"Show designed footings to scale"** toggle appears once the structure is designed, so the model immediately reveals clashing/overlapping foundations.

## Verification
- `tsc -b` clean; `vitest run` → **241 passed**. New `footingLayout.test.ts`: to-scale squares, overlap flagged when B-halves exceed node spacing (3.2 m ftgs @ 3 m → overlap; 2.0 m → clear), combined orientation + AABB; plus `costBill` pricing.
- Browser: design → footing toggle present, priced bill renders with live-editable prices and grand total; no console errors. (The WebGL viewport can't be pixel-captured by the screenshot tool, so the footprint geometry/overlap is covered by the unit tests + the pure layout module.)

> Notes: default prices are placeholder PHP rates — edit to local. Steel priced on purchased weight; labour/hauling/contingency not included. Footing overlap uses an axis-aligned bounding box (slightly conservative for rotated combined footings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)