### PR TITLE
Run analyze/design/optimize in a Web Worker — fix UI freeze on large models

### DIFF
--- a/webapp/src/engine/solverWorker.ts
+++ b/webapp/src/engine/solverWorker.ts
@@ -1,0 +1,47 @@
+/// <reference lib="webworker" />
+// ─────────────────────────────────────────────────────────────────────────
+// Off-main-thread solver. The 3D FEM analysis, the design pipeline and the
+// optimisation loop are CPU-heavy and were freezing the UI on large models.
+// They are pure functions over JSON-serialisable data, so they run here in a
+// Web Worker and post results back; the page stays responsive (and can show a
+// "computing…" state). One request → one response, matched by `id`.
+// ─────────────────────────────────────────────────────────────────────────
+import type { StructuralModel } from './model'
+import { modelToFrame3D } from './modelBridge'
+import { analyzeFrame3D, solveFrame3D, applyF3Combo, type F3AnalyzeOpts } from './frame3d'
+import { driftCheck } from './seismic'
+import { designStructure, optimizeStructure, selectBarDiameters, type SoilOptions, type FootingPlan, type AnalyzeOptions } from './pipeline'
+
+type DriftReq = { hasSeis: boolean; T: number; R: number; axis: 'x' | 'z'; pDelta: boolean }
+export type SolverRequest =
+  | { id: number; kind: 'analyze'; model: StructuralModel; opts: F3AnalyzeOpts; drift: DriftReq }
+  | { id: number; kind: 'design'; model: StructuralModel; soil: SoilOptions; plan: FootingPlan; opts: AnalyzeOptions; tryBars: boolean }
+  | { id: number; kind: 'optimize'; model: StructuralModel; soil: SoilOptions; plan: FootingPlan; opts: AnalyzeOptions; tryBars: boolean; maxIter: number }
+
+const ctx = self as unknown as Worker
+
+ctx.onmessage = (e: MessageEvent<SolverRequest>) => {
+  const msg = e.data
+  try {
+    if (msg.kind === 'analyze') {
+      const br = modelToFrame3D(msg.model)
+      const analysis = analyzeFrame3D(br.nodes, br.members, br.supports, br.loads, msg.opts)
+      let drift = null
+      if (msg.drift.hasSeis) {
+        const eOnly = applyF3Combo(br.loads, { E: 1 })
+        const sol = eOnly.length ? solveFrame3D(br.nodes, br.members, br.supports, eOnly, { pDelta: msg.drift.pDelta }) : null
+        drift = sol ? driftCheck(msg.model, br.nodes, sol.d, msg.drift.R, msg.drift.T, msg.drift.axis) : null
+      }
+      ctx.postMessage({ id: msg.id, ok: true, result: { analysis, orphans: br.orphanEdges.length, drift } })
+    } else if (msg.kind === 'design') {
+      const m = msg.tryBars ? selectBarDiameters(msg.model, msg.soil, msg.plan, msg.opts) : msg.model
+      const design = designStructure(m, msg.soil, msg.plan, msg.opts)
+      ctx.postMessage({ id: msg.id, ok: true, result: { model: m, design } })
+    } else {
+      const result = optimizeStructure(msg.model, msg.soil, msg.plan, msg.maxIter, msg.opts, msg.tryBars)
+      ctx.postMessage({ id: msg.id, ok: true, result })
+    }
+  } catch (err) {
+    ctx.postMessage({ id: msg.id, ok: false, error: err instanceof Error ? err.message : String(err) })
+  }
+}

--- a/webapp/src/lib/useSolver.ts
+++ b/webapp/src/lib/useSolver.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { SolverRequest } from '../engine/solverWorker'
+
+type Kind = SolverRequest['kind']
+type PayloadByKind = { [K in Kind]: Omit<Extract<SolverRequest, { kind: K }>, 'id' | 'kind'> }
+
+/**
+ * Runs the heavy FEM/design/optimise work in a Web Worker so the page never
+ * freezes. `run(kind, payload)` returns a promise with the worker result; `busy`
+ * reflects the in-flight job kind ('' when idle) for spinners / disabled buttons.
+ */
+export function useSolver() {
+  const worker = useRef<Worker | null>(null)
+  const pending = useRef(new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>())
+  const nextId = useRef(1)
+  const [busy, setBusy] = useState<'' | Kind>('')
+
+  useEffect(() => {
+    const w = new Worker(new URL('../engine/solverWorker.ts', import.meta.url), { type: 'module' })
+    w.onmessage = (e: MessageEvent<{ id: number; ok: boolean; result?: unknown; error?: string }>) => {
+      const { id, ok, result, error } = e.data
+      const p = pending.current.get(id); if (!p) return
+      pending.current.delete(id)
+      if (pending.current.size === 0) setBusy('')
+      if (ok) p.resolve(result); else p.reject(new Error(error ?? 'solver failed'))
+    }
+    w.onerror = (e) => { for (const p of pending.current.values()) p.reject(new Error(e.message)); pending.current.clear(); setBusy('') }
+    worker.current = w
+    return () => { w.terminate(); pending.current.clear() }
+  }, [])
+
+  const run = useCallback(<K extends Kind>(kind: K, payload: PayloadByKind[K]): Promise<unknown> => {
+    const w = worker.current
+    if (!w) return Promise.reject(new Error('solver not ready'))
+    const id = nextId.current++
+    setBusy(kind)
+    return new Promise<unknown>((resolve, reject) => {
+      pending.current.set(id, { resolve, reject })
+      w.postMessage({ id, kind, ...payload })
+    })
+  }, [])
+
+  return { busy, run }
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -6,17 +6,16 @@ import * as THREE from 'three'
 import { generateGridModel, removeElements, removeNode, buildGravityLoads, splitSharedSections } from '../engine/modelBuilder'
 import type { StructuralModel, Member, Plate, RectSection, ModelLoad, MemberRole } from '../engine/model'
 import { distributePanel } from '../engine/tributary'
-import { modelToFrame3D } from '../engine/modelBridge'
-import { analyzeFrame3D, type F3Analysis } from '../engine/frame3d'
-import { designStructure, optimizeStructure, selectBarDiameters, type StructureDesign, type FootingPlan, type OptimizeResult, type LateralCase } from '../engine/pipeline'
+import { type F3Analysis } from '../engine/frame3d'
+import { type StructureDesign, type FootingPlan, type OptimizeResult, type LateralCase } from '../engine/pipeline'
 import { estimateTakeoff, costBill, type PriceList } from '../engine/takeoff'
 import { footingLayout } from '../engine/footingLayout'
+import { useSolver } from '../lib/useSolver'
 import { TABLE_204_1, TABLE_204_2, sdlItemKPa, sdlTotal, type SdlItem } from '../engine/deadLoads'
 import { TABLE_205_1, TABLE_206 } from '../engine/liveLoads'
 import type { ConcreteClass } from '../engine/quantities'
-import { computeSeismic, driftCheck, type SeismicResult, type DriftRow } from '../engine/seismic'
+import { computeSeismic, type SeismicResult, type DriftRow } from '../engine/seismic'
 import { computeWind, type WindResult } from '../engine/wind'
-import { solveFrame3D, applyF3Combo } from '../engine/frame3d'
 import { ReportControls } from '../components/ReportControls'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { beamSectionSolution, columnRowSolution, footingRowSolution, combinedRowSolution } from '../lib/modelSpaceSolutions'
@@ -467,6 +466,7 @@ export default function ModelSpace() {
   const [wallMember, setWallMember] = useState(''); const [wallH, setWallH] = useState(3)
   const [wallT, setWallT] = useState(150); const [wallShear, setWallShear] = useState(false)
   const fileRef = useRef<HTMLInputElement>(null)
+  const { busy, run } = useSolver()   // off-thread FEM/design/optimise
 
   const save = (m: StructuralModel | null) => {
     setModel(m)
@@ -487,18 +487,17 @@ export default function ModelSpace() {
   const anaOpts = { f1: fLive, pDelta, lateral }
 
   const analyze = () => {
-    if (!model) return
-    const br = modelToFrame3D(model)
-    setOrphans(br.orphanEdges.length)
-    setAnalysis(analyzeFrame3D(br.nodes, br.members, br.supports, br.loads, anaOpts))
-    // Storey drift from the E-only elastic solution (NSCP 208.5.10), along the
-    // primary committed direction.
-    if (seis) {
-      const eOnly = applyF3Combo(br.loads, { E: 1 })
-      const sol = eOnly.length ? solveFrame3D(br.nodes, br.members, br.supports, eOnly, { pDelta }) : null
-      const driftAxis = (eDirs[0] ?? '+X').includes('X') ? 'x' : 'z'
-      setDrift(sol ? driftCheck(model, br.nodes, sol.d, Rw, seis.T, driftAxis) : null)
-    } else setDrift(null)
+    if (!model || busy) return
+    const axis: 'x' | 'z' = (eDirs[0] ?? '+X').includes('X') ? 'x' : 'z'
+    // 3D FEM + storey drift run in the worker so the UI stays responsive.
+    run('analyze', {
+      model, opts: anaOpts, drift: { hasSeis: !!seis, T: seis?.T ?? 0, R: Rw, axis, pDelta },
+    }).then((r) => {
+      const res = r as { analysis: F3Analysis | null; orphans: number; drift: DriftRow[] | null }
+      setOrphans(res.orphans)
+      setAnalysis(res.analysis)
+      setDrift(res.drift)
+    }).catch((e) => console.error('analyze failed', e))
   }
 
   // Re-sign / re-axis a base node-load set into a directional case.
@@ -604,28 +603,32 @@ export default function ModelSpace() {
   }
 
   const runPipeline = () => {
-    if (!model) return
+    if (!model || busy) return
     setOpt(null)
-    const plan = footingPlan()
-    const base = applyMaterial(model)
-    // when bar-trying is on, pick the economical bar Ø per member first, then
-    // design and persist those sections so schedules/drawings stay consistent.
-    const m = tryBars ? selectBarDiameters(base, soil, plan, anaOpts) : base
-    const d = designStructure(m, soil, plan, anaOpts)
-    save(m)
-    setDesign(d)
-    requestAnimationFrame(captureModel)   // refresh the printable 3D snapshot
+    // material is applied on the main thread (cheap); the FEM + bar selection +
+    // designStructure run in the worker so the page never freezes.
+    run('design', {
+      model: applyMaterial(model), soil, plan: footingPlan(), opts: anaOpts, tryBars,
+    }).then((r) => {
+      const res = r as { model: StructuralModel; design: StructureDesign | null }
+      save(res.model)
+      setDesign(res.design)
+      requestAnimationFrame(captureModel)   // refresh the printable 3D snapshot
+    }).catch((e) => console.error('design failed', e))
   }
 
   const optimize = () => {
-    if (!model) return
-    const r = optimizeStructure(applyMaterial(model), soil, footingPlan(), 30, anaOpts, tryBars)
-    if (!r) return
-    // adopt the optimised per-member sections
-    save(r.model)
-    setOpt(r)
-    setDesign(r.design)
-    requestAnimationFrame(captureModel)   // refresh the printable 3D snapshot
+    if (!model || busy) return
+    run('optimize', {
+      model: applyMaterial(model), soil, plan: footingPlan(), opts: anaOpts, tryBars, maxIter: 30,
+    }).then((raw) => {
+      const r = raw as OptimizeResult | null
+      if (!r) return
+      save(r.model)        // adopt the optimised per-member sections
+      setOpt(r)
+      setDesign(r.design)
+      requestAnimationFrame(captureModel)
+    }).catch((e) => console.error('optimize failed', e))
   }
 
   /** Snapshot the live 3D canvas as a PNG for the printed report's first page. */
@@ -1569,7 +1572,9 @@ export default function ModelSpace() {
                   {pDelta ? ' Frame solved with the geometric-stiffness P-Δ iteration.' : ' First-order (linear) frame solve.'}
                 </p>
                 <div className="col-span-full">
-                  <button type="button" onClick={analyze} disabled={!model} className={btn('from-[#0e7490] to-[#155e75]')}>▶ Analyze (3D FEM)</button>
+                  <button type="button" onClick={analyze} disabled={!model || !!busy} className={btn('from-[#0e7490] to-[#155e75]')}>
+                    {busy === 'analyze' ? '⏳ Analyzing…' : '▶ Analyze (3D FEM)'}
+                  </button>
                 </div>
               </Card>
 
@@ -1643,10 +1648,19 @@ export default function ModelSpace() {
             <div className="space-y-4">
               <Card title="Design & optimise">
                 <div className="col-span-full flex flex-wrap gap-2">
-                  <button type="button" onClick={runPipeline} disabled={!model} className={btn('from-[#15803d] to-[#166534]')}>🏗 Design structure</button>
-                  <button type="button" onClick={optimize} disabled={!model} className={btn('from-[#b45309] to-[#92400e]')}
-                    title="Grow each failing member's own section until nothing fails, then trim back">🏁 Optimize design</button>
+                  <button type="button" onClick={runPipeline} disabled={!model || !!busy} className={btn('from-[#15803d] to-[#166534]')}>
+                    {busy === 'design' ? '⏳ Designing…' : '🏗 Design structure'}
+                  </button>
+                  <button type="button" onClick={optimize} disabled={!model || !!busy} className={btn('from-[#b45309] to-[#92400e]')}
+                    title="Grow each failing member's own section until nothing fails, then trim back">
+                    {busy === 'optimize' ? '⏳ Optimizing…' : '🏁 Optimize design'}
+                  </button>
                 </div>
+                {busy && (
+                  <p className="col-span-full text-[11px] font-medium text-[#0056b3]">
+                    Running in the background — the page stays responsive; results appear when ready.
+                  </p>
+                )}
                 <p className="col-span-full text-[11px] text-slate-500">
                   The full schedules (beam/girder, column, footing) render below, each the full width of the page.
                   Click any schedule row for its step-by-step solution and plan/elevation drawings.


### PR DESCRIPTION
## Problem
On large structures the page froze during **Analyze**, **Design**, and **Optimize** — the 3D FEM solve, the design pipeline, and the optimisation loop all ran synchronously on the main thread for many seconds.

## Fix — move the heavy work off-thread
- **`engine/solverWorker.ts`** — a module Web Worker that runs `analyzeFrame3D` (+ the E-only storey-drift solve), the design pipeline (`selectBarDiameters` + `designStructure`), and `optimizeStructure`. The engine is pure over JSON-serialisable data, so it ports cleanly; requests/responses are matched by `id`.
- **`lib/useSolver.ts`** — a hook that owns the worker: `run(kind, payload)` returns a promise, and `busy` reports the in-flight job (`''` when idle) for spinners/disabled buttons. The worker is terminated on unmount.
- **ModelSpace** — `analyze` / `runPipeline` / `optimize` now post to the worker and apply results on resolve (material is still applied on the main thread — it's cheap). The three buttons show **⏳ Analyzing… / Designing… / Optimizing…**, disable while busy, and a "running in the background" note appears.

## Verification
- `tsc -b` clean; `vitest run` → **241 passed** (engine unchanged).
- Browser, 100-node / 204-member / 4-storey frame:
  - **Design** and **Analyze** complete off-thread and render results.
  - During **Optimize** the button reads "⏳ Optimizing…" and a **1,000,000-iteration loop on the main thread still ran in ~6 ms** — i.e. the page is responsive instead of frozen.
  - No console errors.

> Note: Optimize is still inherently heavy for big models (it re-solves the frame every iteration) — it just no longer blocks the UI. A natural follow-up is a **Cancel** button (terminate + recreate the worker) and a progress readout from the optimiser's step log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)