### PR TITLE
Live solver progress for analyze / design / optimize

### DIFF
--- a/webapp/src/engine/frame3d.ts
+++ b/webapp/src/engine/frame3d.ts
@@ -11,6 +11,7 @@
 // ─────────────────────────────────────────────────────────────────────────
 import { solveLinear, matVec, hermite, gauss5Vec } from './fem'
 import { nscpCombos, type Combo, type LoadCategory } from './beamAnalysis'
+import type { ProgressFn } from './progress'
 
 /** Second-order (P-Δ) options for the frame solve. */
 export interface PDeltaOpts { pDelta?: boolean; maxIter?: number; tol?: number }
@@ -382,16 +383,18 @@ export interface F3AnalyzeOpts extends PDeltaOpts {
 
 export function analyzeFrame3D(
   nodes: F3Node[], members: F3Member[], supports: F3Support[], loads: F3Load[],
-  opts?: F3AnalyzeOpts,
+  opts?: F3AnalyzeOpts, onProgress?: ProgressFn,
 ): F3Analysis | null {
   const perCombo: F3ComboRun[] = []
   let govIdx = -1, govM = -1
-  for (const combo of nscpCombos(opts?.f1 ?? 1.0)) {
+  const combos = nscpCombos(opts?.f1 ?? 1.0)
+  combos.forEach((combo, i) => {
+    onProgress?.({ phase: 'Analyzing load cases', current: i + 1, total: combos.length, detail: combo.name })
     const factored = applyF3Combo(loads, combo.f)
-    if (factored.length === 0) { perCombo.push({ combo, result: null, factored, skipped: true }); continue }
+    if (factored.length === 0) { perCombo.push({ combo, result: null, factored, skipped: true }); return }
     const r = solveFrame3D(nodes, members, supports, factored, opts)
     perCombo.push({ combo, result: r, factored, skipped: false })
     if (r && r.Mmax > govM) { govM = r.Mmax; govIdx = perCombo.length - 1 }
-  }
+  })
   return govIdx < 0 ? null : { perCombo, govIdx }
 }

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -11,7 +11,8 @@ import type { StructuralModel, RectSection, ModelLoad } from './model'
 import { enforceSectionHierarchy, refreshSelfWeight } from './modelBuilder'
 import { modelToFrame3D } from './modelBridge'
 import { solveFrame3D, applyF3Combo, type F3Result, type F3MemberResult, type F3Load } from './frame3d'
-import { nscpCombos } from './beamAnalysis'
+import { nscpCombos, type Combo } from './beamAnalysis'
+import type { ProgressFn } from './progress'
 import { designBeam, type BeamDesignResult } from './beamDesign'
 import { designAxialColumn, capacityAtEccentricity, interaction } from './columnDesign'
 import { designSquareFooting, type SquareFootingResult } from './isolatedFooting'
@@ -188,7 +189,7 @@ interface FrameRun { name: string; result: F3Result }
 
 /** Build the load cases to envelope: every NSCP combination, expanded once per
  *  directional lateral case (E/W) when the combination carries that factor. */
-function buildRuns(model: StructuralModel, opts: AnalyzeOptions) {
+function buildRuns(model: StructuralModel, opts: AnalyzeOptions, onProgress?: ProgressFn) {
   // gravity (everything except lateral E/W) is bridged once — includes the
   // slab tributary line loads and member self-weight; lateral cases are pure
   // node loads applied on top per direction.
@@ -207,7 +208,8 @@ function buildRuns(model: StructuralModel, opts: AnalyzeOptions) {
   const eCases = lateral.filter((c) => c.kind === 'E')
   const wCases = lateral.filter((c) => c.kind === 'W')
 
-  const runs: FrameRun[] = []
+  // expand every combo into its directional variants up front so progress has a total
+  const tasks: { name: string; combo: Combo; lat: F3Load[] }[] = []
   for (const combo of nscpCombos(opts.f1 ?? 1.0)) {
     const hasE = (combo.f.E ?? 0) !== 0
     const hasW = (combo.f.W ?? 0) !== 0
@@ -215,18 +217,23 @@ function buildRuns(model: StructuralModel, opts: AnalyzeOptions) {
       hasE && eCases.length ? eCases.map((c) => ({ tag: c.name, lat: c.loads.map(toF3) }))
         : hasW && wCases.length ? wCases.map((c) => ({ tag: c.name, lat: c.loads.map(toF3) }))
           : [{ tag: '', lat: [] }]
-    for (const v of variants) {
-      const factored = applyF3Combo([...br.loads, ...v.lat], combo.f)
-      if (!factored.length) continue
-      const result = solveFrame3D(br.nodes, br.members, br.supports, factored, opts)
-      if (result) runs.push({ name: combo.name + (v.tag ? ` · ${v.tag}` : ''), result })
-    }
+    for (const v of variants) tasks.push({ name: combo.name + (v.tag ? ` · ${v.tag}` : ''), combo, lat: v.lat })
   }
+
+  const runs: FrameRun[] = []
+  tasks.forEach((t, i) => {
+    onProgress?.({ phase: 'Solving load cases', current: i + 1, total: tasks.length, detail: t.name })
+    const factored = applyF3Combo([...br.loads, ...t.lat], t.combo.f)
+    if (!factored.length) return
+    const result = solveFrame3D(br.nodes, br.members, br.supports, factored, opts)
+    if (result) runs.push({ name: t.name, result })
+  })
   return { br, runs }
 }
 
 export function designStructure(
   model: StructuralModel, soil: SoilOptions, plan: FootingPlan = {}, opts: AnalyzeOptions = {},
+  onProgress?: ProgressFn,
 ): StructureDesign | null {
   if (model.members.length === 0) return null
   // each member designs with its OWN section; footings use the section of the
@@ -239,7 +246,7 @@ export function designStructure(
   const colAtNode = (node: string) => model.members.find((m) => m.role === 'column' && (m.i === node || m.j === node))
   const footSec = (node: string) => { const c = colAtNode(node); return c ? secOf(c.id) : fallbackSec }
 
-  const { br, runs } = buildRuns(model, opts)
+  const { br, runs } = buildRuns(model, opts, onProgress)
   if (runs.length === 0) return null
   // headline governing run = largest overall bending response
   let govIdx = 0
@@ -273,6 +280,7 @@ export function designStructure(
   const memberOf = (run: FrameRun, id: string) => run.result.members.find((m) => m.id === id)
 
   // ── Beams & girders — per-member worst case across all runs ──
+  onProgress?.({ phase: 'Designing beams & columns', detail: `${model.members.length} members` })
   const beams: BeamScheduleRow[] = []
   const columns: ColumnScheduleRow[] = []
   for (const m of model.members) {
@@ -299,6 +307,7 @@ export function designStructure(
   }
 
   // ── Footings (base supports) — isolated by default, combined per plan ──
+  onProgress?.({ phase: 'Designing footings & slabs' })
   const nodeXYZ = new Map(model.nodes.map((n) => [n.id, n]))
   const paired = new Set<string>()
   const combined: CombinedScheduleRow[] = []
@@ -535,26 +544,30 @@ const growOne = (s: RectSection): RectSection =>
  */
 export function optimizeStructure(
   model: StructuralModel, soil: SoilOptions, plan: FootingPlan = {}, maxIter = 30,
-  opts: AnalyzeOptions = {}, tryBars = false,
+  opts: AnalyzeOptions = {}, tryBars = false, onProgress?: ProgressFn,
 ): OptimizeResult | null {
   if (model.members.length === 0) return null
   const memSecId = new Map(model.members.map((m) => [m.id, m.section]))
   // sizes & self-weight kept consistent at every step (self-weight uses the
   // footing concrete unit weight so a custom γc feeds the gravity demands).
   const settle = (m: StructuralModel) => refreshSelfWeight(enforceSectionHierarchy(m), soil.gammaConc)
+  // wrap the per-solve progress with the current optimise phase so the bar shows
+  // the load-case sweep happening inside each iteration.
+  const sub = (label: string): ProgressFn | undefined =>
+    onProgress && ((p) => onProgress({ ...p, phase: `${label} · ${p.phase}` }))
   // re-detail the bars (cheapest design variable) before measuring fails, so a
   // member that only needs a bigger bar is not grown unnecessarily.
-  const detail = (m: StructuralModel, d: StructureDesign): { m: StructuralModel; d: StructureDesign } => {
+  const detail = (m: StructuralModel, d: StructureDesign, label: string): { m: StructuralModel; d: StructureDesign } => {
     if (!tryBars) return { m, d }
     const m2 = selectBarDiameters(m, soil, plan, opts, d)
-    return m2 === m ? { m, d } : { m: m2, d: designStructure(m2, soil, plan, opts) ?? d }
+    return m2 === m ? { m, d } : { m: m2, d: designStructure(m2, soil, plan, opts, sub(label)) ?? d }
   }
   let work = settle(model)                            // start width-consistent
   const steps: OptimizeStep[] = []
 
-  let design = designStructure(work, soil, plan, opts)
+  let design = designStructure(work, soil, plan, opts, sub('Optimize · initial'))
   if (!design) return null
-  ;({ m: work, d: design } = detail(work, design))
+  ;({ m: work, d: design } = detail(work, design, 'Optimize · initial'))
   steps.push({ iter: 0, grown: 0, fails: countFails(design), ok: designOK(design) })
 
   // GROW: bump every failing member's own section, re-enforce the hierarchy and
@@ -565,17 +578,19 @@ export function optimizeStructure(
     for (const b of design.beams) if (!b.ok) { const s = memSecId.get(b.id); if (s) failSids.add(s) }
     for (const c of design.columns) if (!c.ok) { const s = memSecId.get(c.id); if (s) failSids.add(s) }
     if (failSids.size === 0) break                   // only footings fail — not a section problem
+    onProgress?.({ phase: 'Optimizing — growing sections', current: iter, total: maxIter, detail: `iteration ${iter}: ${failSids.size} member(s) grown, ${countFails(design)} failing` })
     const sizes = new Map(work.sections.map((s) => [s.id, failSids.has(s.id) ? growOne(s) : s]))
     work = settle(withSizes(work, sizes))
-    const d = designStructure(work, soil, plan, opts)
+    const d = designStructure(work, soil, plan, opts, sub(`Optimize iter ${iter}`))
     if (!d) break
-    ;({ m: work, d: design } = detail(work, d))
+    ;({ m: work, d: design } = detail(work, d, `Optimize iter ${iter}`))
     steps.push({ iter, grown: failSids.size, fails: countFails(design), ok: designOK(design) })
   }
   const converged = designOK(design)
 
   // SHRINK: trim each member's depth while the whole structure still passes.
   if (converged) {
+    onProgress?.({ phase: 'Optimizing — trimming sections', detail: 'shrinking depths while the design still passes' })
     let improved = true, guard = 0
     while (improved && guard++ < 4) {
       improved = false

--- a/webapp/src/engine/progress.ts
+++ b/webapp/src/engine/progress.ts
@@ -1,0 +1,10 @@
+// Progress reporting for the off-thread solvers. The analysis / design /
+// optimise routines call an optional ProgressFn as they work; the worker
+// forwards each tick to the main thread so the UI can show what is computing.
+export interface SolveProgress {
+  phase: string                 // e.g. 'Analyzing load cases', 'Optimizing'
+  current?: number              // step index (1-based) when a count is known
+  total?: number                // total steps when known → determinate bar
+  detail?: string               // free text, e.g. the load-case or element name
+}
+export type ProgressFn = (p: SolveProgress) => void

--- a/webapp/src/engine/solverWorker.ts
+++ b/webapp/src/engine/solverWorker.ts
@@ -11,6 +11,7 @@ import { modelToFrame3D } from './modelBridge'
 import { analyzeFrame3D, solveFrame3D, applyF3Combo, type F3AnalyzeOpts } from './frame3d'
 import { driftCheck } from './seismic'
 import { designStructure, optimizeStructure, selectBarDiameters, type SoilOptions, type FootingPlan, type AnalyzeOptions } from './pipeline'
+import type { SolveProgress } from './progress'
 
 type DriftReq = { hasSeis: boolean; T: number; R: number; axis: 'x' | 'z'; pDelta: boolean }
 export type SolverRequest =
@@ -22,23 +23,27 @@ const ctx = self as unknown as Worker
 
 ctx.onmessage = (e: MessageEvent<SolverRequest>) => {
   const msg = e.data
+  // forward progress ticks to the main thread (delivered while the worker runs)
+  const onProgress = (p: SolveProgress) => ctx.postMessage({ id: msg.id, progress: p })
   try {
     if (msg.kind === 'analyze') {
       const br = modelToFrame3D(msg.model)
-      const analysis = analyzeFrame3D(br.nodes, br.members, br.supports, br.loads, msg.opts)
+      const analysis = analyzeFrame3D(br.nodes, br.members, br.supports, br.loads, msg.opts, onProgress)
       let drift = null
       if (msg.drift.hasSeis) {
+        onProgress({ phase: 'Storey-drift check' })
         const eOnly = applyF3Combo(br.loads, { E: 1 })
         const sol = eOnly.length ? solveFrame3D(br.nodes, br.members, br.supports, eOnly, { pDelta: msg.drift.pDelta }) : null
         drift = sol ? driftCheck(msg.model, br.nodes, sol.d, msg.drift.R, msg.drift.T, msg.drift.axis) : null
       }
       ctx.postMessage({ id: msg.id, ok: true, result: { analysis, orphans: br.orphanEdges.length, drift } })
     } else if (msg.kind === 'design') {
-      const m = msg.tryBars ? selectBarDiameters(msg.model, msg.soil, msg.plan, msg.opts) : msg.model
-      const design = designStructure(m, msg.soil, msg.plan, msg.opts)
+      let m = msg.model
+      if (msg.tryBars) { onProgress({ phase: 'Selecting bar sizes' }); m = selectBarDiameters(msg.model, msg.soil, msg.plan, msg.opts) }
+      const design = designStructure(m, msg.soil, msg.plan, msg.opts, onProgress)
       ctx.postMessage({ id: msg.id, ok: true, result: { model: m, design } })
     } else {
-      const result = optimizeStructure(msg.model, msg.soil, msg.plan, msg.maxIter, msg.opts, msg.tryBars)
+      const result = optimizeStructure(msg.model, msg.soil, msg.plan, msg.maxIter, msg.opts, msg.tryBars, onProgress)
       ctx.postMessage({ id: msg.id, ok: true, result })
     }
   } catch (err) {

--- a/webapp/src/lib/useSolver.ts
+++ b/webapp/src/lib/useSolver.ts
@@ -1,30 +1,35 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { SolverRequest } from '../engine/solverWorker'
+import type { SolveProgress } from '../engine/progress'
 
 type Kind = SolverRequest['kind']
 type PayloadByKind = { [K in Kind]: Omit<Extract<SolverRequest, { kind: K }>, 'id' | 'kind'> }
+type WorkerMsg = { id: number; ok?: boolean; result?: unknown; error?: string; progress?: SolveProgress }
 
 /**
  * Runs the heavy FEM/design/optimise work in a Web Worker so the page never
  * freezes. `run(kind, payload)` returns a promise with the worker result; `busy`
- * reflects the in-flight job kind ('' when idle) for spinners / disabled buttons.
+ * reflects the in-flight job kind ('' when idle) for spinners / disabled buttons;
+ * `progress` is the latest tick from the worker (null when idle).
  */
 export function useSolver() {
   const worker = useRef<Worker | null>(null)
   const pending = useRef(new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>())
   const nextId = useRef(1)
   const [busy, setBusy] = useState<'' | Kind>('')
+  const [progress, setProgress] = useState<SolveProgress | null>(null)
 
   useEffect(() => {
     const w = new Worker(new URL('../engine/solverWorker.ts', import.meta.url), { type: 'module' })
-    w.onmessage = (e: MessageEvent<{ id: number; ok: boolean; result?: unknown; error?: string }>) => {
-      const { id, ok, result, error } = e.data
+    w.onmessage = (e: MessageEvent<WorkerMsg>) => {
+      const { id, ok, result, error, progress: prog } = e.data
+      if (prog) { if (pending.current.has(id)) setProgress(prog); return }   // progress tick
       const p = pending.current.get(id); if (!p) return
       pending.current.delete(id)
-      if (pending.current.size === 0) setBusy('')
+      if (pending.current.size === 0) { setBusy(''); setProgress(null) }
       if (ok) p.resolve(result); else p.reject(new Error(error ?? 'solver failed'))
     }
-    w.onerror = (e) => { for (const p of pending.current.values()) p.reject(new Error(e.message)); pending.current.clear(); setBusy('') }
+    w.onerror = (e) => { for (const p of pending.current.values()) p.reject(new Error(e.message)); pending.current.clear(); setBusy(''); setProgress(null) }
     worker.current = w
     return () => { w.terminate(); pending.current.clear() }
   }, [])
@@ -34,11 +39,12 @@ export function useSolver() {
     if (!w) return Promise.reject(new Error('solver not ready'))
     const id = nextId.current++
     setBusy(kind)
+    setProgress(null)
     return new Promise<unknown>((resolve, reject) => {
       pending.current.set(id, { resolve, reject })
       w.postMessage({ id, kind, ...payload })
     })
   }, [])
 
-  return { busy, run }
+  return { busy, run, progress }
 }

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -11,6 +11,7 @@ import { type StructureDesign, type FootingPlan, type OptimizeResult, type Later
 import { estimateTakeoff, costBill, type PriceList } from '../engine/takeoff'
 import { footingLayout } from '../engine/footingLayout'
 import { useSolver } from '../lib/useSolver'
+import type { SolveProgress } from '../engine/progress'
 import { TABLE_204_1, TABLE_204_2, sdlItemKPa, sdlTotal, type SdlItem } from '../engine/deadLoads'
 import { TABLE_205_1, TABLE_206 } from '../engine/liveLoads'
 import type { ConcreteClass } from '../engine/quantities'
@@ -98,6 +99,27 @@ function Slab3D({ corners, selected, onPick }: {
       <boxGeometry args={[sx * 0.96, 0.1, sz * 0.96]} />
       <meshStandardMaterial color={selected ? SEL : '#7ba6d4'} transparent opacity={selected ? 0.85 : 0.45} />
     </mesh>
+  )
+}
+
+/** Live solver-progress card: phase, detail, and a determinate (current/total)
+ *  or indeterminate bar. Renders nothing when idle. */
+function SolverProgress({ p }: { p: SolveProgress | null }) {
+  if (!p) return null
+  const pct = p.total && p.current ? Math.min(100, Math.round((p.current / p.total) * 100)) : null
+  return (
+    <div className="col-span-full rounded-lg border border-[#0056b3]/30 bg-blue-50/60 p-2.5">
+      <div className="flex items-center justify-between text-[11px] font-semibold text-[#0056b3]">
+        <span>⏳ {p.phase}{p.total && p.current ? ` — ${p.current}/${p.total}` : ''}</span>
+        {pct !== null && <span>{pct}%</span>}
+      </div>
+      {p.detail && <div className="mt-0.5 truncate text-[11px] text-slate-500">{p.detail}</div>}
+      <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-blue-100">
+        {pct !== null
+          ? <div className="h-full rounded-full bg-[#0056b3] transition-all duration-150" style={{ width: `${pct}%` }} />
+          : <div className="h-full w-1/3 animate-pulse rounded-full bg-[#0056b3]" />}
+      </div>
+    </div>
   )
 }
 
@@ -466,7 +488,7 @@ export default function ModelSpace() {
   const [wallMember, setWallMember] = useState(''); const [wallH, setWallH] = useState(3)
   const [wallT, setWallT] = useState(150); const [wallShear, setWallShear] = useState(false)
   const fileRef = useRef<HTMLInputElement>(null)
-  const { busy, run } = useSolver()   // off-thread FEM/design/optimise
+  const { busy, run, progress } = useSolver()   // off-thread FEM/design/optimise
 
   const save = (m: StructuralModel | null) => {
     setModel(m)
@@ -1576,6 +1598,7 @@ export default function ModelSpace() {
                     {busy === 'analyze' ? '⏳ Analyzing…' : '▶ Analyze (3D FEM)'}
                   </button>
                 </div>
+                {busy === 'analyze' && <SolverProgress p={progress} />}
               </Card>
 
               {gov && govRes && (
@@ -1656,6 +1679,7 @@ export default function ModelSpace() {
                     {busy === 'optimize' ? '⏳ Optimizing…' : '🏁 Optimize design'}
                   </button>
                 </div>
+                {busy && <SolverProgress p={progress} />}
                 {busy && (
                   <p className="col-span-full text-[11px] font-medium text-[#0056b3]">
                     Running in the background — the page stays responsive; results appear when ready.


### PR DESCRIPTION
Follow-up to the worker offload (#173): now that the heavy work runs off the main thread, surface **what it's actually computing** instead of just a spinner.

## How
- **`engine/progress.ts`** — shared `SolveProgress { phase, current?, total?, detail? }` + `ProgressFn`.
- **Engines emit ticks** via an optional `onProgress`:
  - `analyzeFrame3D` / `buildRuns` → the **load-case sweep** (`Solving load cases — 3/7 · 1.2D + 1.6L`).
  - `designStructure` → `Designing beams & columns`, `Designing footings & slabs`.
  - `optimizeStructure` → per iteration (`Optimizing — growing sections — iteration 4: 6 grown, 3 failing`) and `trimming sections`, wrapping the inner per-solve ticks with the iteration label so the bar keeps moving.
- **`solverWorker`** posts each tick as `{ id, progress }` (delivered to the main thread while it keeps computing).
- **`useSolver`** exposes a `progress` state (cleared on start/finish).
- **UI** — a `SolverProgress` card (phase + detail + determinate/indeterminate bar) under the Analyze and Design/Optimize buttons.

## Verification
- `tsc -b` clean; `vitest run` → **241 passed**.
- Browser, 204-member / 100-node frame: progress streamed live — `Optimize · initial · Solving load cases 1/7…7/7` with real combo names (`1.4D`, `0.9D + 1.0E`) → `Designing beams & columns 204 members` → `Optimizing — trimming sections` — while the page stayed responsive (the UI poll ran during the worker computation). No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)