### PR TITLE
Add Truss Space — planar pin-jointed truss page (analyse + design)

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -8,8 +8,9 @@ import BeamAnalysis from './pages/BeamAnalysis'
 import ColumnDesign from './pages/ColumnDesign'
 import FrameAnalysis from './pages/FrameAnalysis'
 import LoadPath from './pages/LoadPath'
-// three.js is heavy — the 3D model space loads in its own lazy chunk.
+// three.js is heavy — the 3D pages load in their own lazy chunks.
 const ModelSpace = lazy(() => import('./pages/ModelSpace'))
+const TrussSpace = lazy(() => import('./pages/TrussSpace'))
 import SlabEstimate from './pages/SlabEstimate'
 import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
@@ -47,6 +48,7 @@ function Home() {
         <Tile to="/frame">Frame Analysis (2D)</Tile>
         <Tile to="/load-path">Slab Load Path</Tile>
         <Tile to="/model">3D Model Space</Tile>
+        <Tile to="/truss">Truss Space</Tile>
       </div>
 
       <h2 className="mt-8 text-lg font-semibold text-slate-800">Material estimation (quantity take-off)</h2>
@@ -76,6 +78,11 @@ export default function App() {
       <Route path="/model" element={
         <Suspense fallback={<p className="p-8 text-center text-sm text-slate-400">Loading 3D model space…</p>}>
           <ModelSpace />
+        </Suspense>
+      } />
+      <Route path="/truss" element={
+        <Suspense fallback={<p className="p-8 text-center text-sm text-slate-400">Loading truss space…</p>}>
+          <TrussSpace />
         </Suspense>
       } />
       <Route path="/estimate/slab" element={<SlabEstimate />} />

--- a/webapp/src/engine/truss.test.ts
+++ b/webapp/src/engine/truss.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { generateTruss, solveTruss, type TrussModel } from './truss'
+import { designTruss, designTrussMember } from './trussDesign'
+
+describe('truss solver — statics', () => {
+  it('single triangle: equilibrium of reactions and tension in the bottom tie', () => {
+    // pin at b0(0,0), roller at b1(4,0), apex t at (2,3); 10 kN down at apex.
+    const m: TrussModel = {
+      nodes: [{ id: 'b0', x: 0, y: 0 }, { id: 'b1', x: 4, y: 0 }, { id: 'a', x: 2, y: 3 }],
+      members: [
+        { id: 'm0', i: 'b0', j: 'b1', kind: 'bottom' },
+        { id: 'm1', i: 'b0', j: 'a', kind: 'diagonal' },
+        { id: 'm2', i: 'b1', j: 'a', kind: 'diagonal' },
+      ],
+      supports: [{ node: 'b0', ux: true, uy: true }, { node: 'b1', ux: false, uy: true }],
+      loads: [{ node: 'a', fx: 0, fy: -10 }],
+      E: 200000, A: 1500,
+    }
+    const r = solveTruss(m)!
+    // reactions: symmetric 5 kN up each; total vertical = 10
+    const Ry = r.reactions.reduce((s, x) => s + x.fy, 0)
+    expect(Ry).toBeCloseTo(10, 4)
+    expect(r.reactions.find((x) => x.node === 'b0')!.fy).toBeCloseTo(5, 4)
+    // determinate: m=3, r=3, j=3 → 3+3-6 = 0
+    expect(r.determinacy.value).toBe(0)
+    expect(r.determinacy.status).toBe('determinate')
+    // bottom chord is a tie (tension +); inclined members are struts (compression)
+    const bottom = r.forces.find((f) => f.id === 'm0')!
+    expect(bottom.N).toBeGreaterThan(0)
+    expect(r.forces.find((f) => f.id === 'm1')!.N).toBeLessThan(0)
+    // bottom tie = R·a/h projection: 5·(2/3) = 3.333 kN
+    expect(bottom.N).toBeCloseTo(10 / 3, 3)
+  })
+
+  it('generated Pratt truss is determinate, carries the load, and is symmetric', () => {
+    const m = generateTruss({ type: 'pratt', span: 12, height: 2, panels: 4, panelLoad: 10 })
+    const r = solveTruss(m)!
+    expect(r.determinacy.status).toBe('determinate')   // m + r = 2j
+    const Ry = r.reactions.reduce((s, x) => s + x.fy, 0)
+    const totalLoad = m.loads.reduce((s, l) => s + Math.abs(l.fy), 0)
+    expect(Ry).toBeCloseTo(totalLoad, 3)               // ΣRy balances the applied load
+    expect(r.maxTension).toBeGreaterThan(0)
+    expect(r.maxCompression).toBeGreaterThan(0)         // top chord in compression
+  })
+
+  it('every generator produces a stable, determinate truss', () => {
+    for (const type of ['pratt', 'howe', 'warren', 'roof'] as const) {
+      const r = solveTruss(generateTruss({ type, span: 10, height: 2.5, panels: 4, panelLoad: 8 }))
+      expect(r, type).not.toBeNull()
+      expect(r!.stable, type).toBe(true)
+    }
+  })
+})
+
+describe('truss member design (AISC LRFD)', () => {
+  const sec = { A: 1500, r: 25, E: 200000, Fy: 248 }
+  it('tension capacity = 0.9·Fy·Ag', () => {
+    const d = designTrussMember({ id: 'm', N: 100, L: 3, kind: 'bottom', i: 'a', j: 'b' }, sec)
+    expect(d.mode).toBe('tension')
+    expect(d.phiPn).toBeCloseTo((0.9 * 248 * 1500) / 1000, 3)   // 334.8 kN
+  })
+  it('compression capacity drops with slenderness and never exceeds tension', () => {
+    const short = designTrussMember({ id: 'm', N: -100, L: 1, kind: 'top', i: 'a', j: 'b' }, sec)
+    const long = designTrussMember({ id: 'm', N: -100, L: 4, kind: 'top', i: 'a', j: 'b' }, sec)
+    expect(short.mode).toBe('compression')
+    expect(long.phiPn).toBeLessThan(short.phiPn)                // longer → more slender → weaker
+    expect(short.phiPn).toBeLessThanOrEqual((0.9 * 248 * 1500) / 1000 + 1e-6)
+  })
+  it('designTruss aggregates utilisation and pass/fail', () => {
+    const forces = solveTruss(generateTruss({ type: 'warren', span: 12, height: 2, panels: 6, panelLoad: 15 }))!.forces
+    const res = designTruss(forces, sec)
+    expect(res.members).toHaveLength(forces.length)
+    expect(res.maxUtil).toBeGreaterThan(0)
+    expect(typeof res.allOK).toBe('boolean')
+  })
+})

--- a/webapp/src/engine/truss.ts
+++ b/webapp/src/engine/truss.ts
@@ -1,0 +1,172 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Planar (2D) pin-jointed truss: model, parametric generators (Pratt / Howe /
+// Warren parallel-chord + a pitched gable roof truss) and a direct-stiffness
+// solver returning member axial forces (tension +), support reactions and the
+// static-determinacy check (m + r vs 2j). Members carry axial load only.
+// Units: geometry m; E MPa (N/mm²); A mm²; loads & forces kN.
+// ─────────────────────────────────────────────────────────────────────────
+import { solveLinear, matVec } from './fem'
+
+export interface TNode { id: string; x: number; y: number }            // m, in the truss plane
+export type ChordKind = 'top' | 'bottom' | 'vertical' | 'diagonal'
+export interface TMember { id: string; i: string; j: string; kind: ChordKind }
+export interface TSupport { node: string; ux: boolean; uy: boolean }   // pin = both, roller(y) = uy only
+export interface TLoad { node: string; fx: number; fy: number }        // kN (fy < 0 = downward)
+export interface TrussModel {
+  nodes: TNode[]; members: TMember[]; supports: TSupport[]; loads: TLoad[]
+  E: number; A: number       // uniform material/section: MPa, mm²
+}
+
+export type TrussType = 'pratt' | 'howe' | 'warren' | 'roof'
+export interface TrussSpec {
+  type: TrussType
+  span: number; height: number; panels: number      // m, m, count
+  panelLoad: number                                   // kN downward at each top-chord node
+}
+
+const len = (a: TNode, b: TNode) => Math.hypot(b.x - a.x, b.y - a.y)
+
+/** Parametric truss generator. Pin at the left support, roller at the right;
+ *  a downward `panelLoad` is seeded at every loaded (top-chord) joint. */
+export function generateTruss(spec: TrussSpec): TrussModel {
+  const n = Math.max(2, Math.round(spec.panels))
+  const L = spec.span, H = spec.height, p = L / n
+  const nodes: TNode[] = []
+  const members: TMember[] = []
+  const add = (i: string, j: string, kind: ChordKind) => members.push({ id: `m${members.length}`, i, j, kind })
+
+  const roof = spec.type === 'roof'
+  const mid = n / 2
+  // bottom chord b0..bn (y = 0)
+  for (let i = 0; i <= n; i++) nodes.push({ id: `b${i}`, x: i * p, y: 0 })
+  // top chord: parallel types get a node above every panel point; the roof
+  // (gable, apex at mid-span) gets INTERIOR top nodes only — its end top nodes
+  // coincide with the supports, so the top chord springs from b0 / bn.
+  const topY = (i: number) => roof ? H * (1 - Math.abs(i * p - L / 2) / (L / 2)) : H
+  for (let i = 0; i <= n; i++) { if (roof && (i === 0 || i === n)) continue; nodes.push({ id: `t${i}`, x: i * p, y: topY(i) }) }
+  const top = (i: number) => (roof && i === 0) ? 'b0' : (roof && i === n) ? `b${n}` : `t${i}`
+
+  // chords
+  for (let i = 0; i < n; i++) add(`b${i}`, `b${i + 1}`, 'bottom')
+  for (let i = 0; i < n; i++) add(top(i), top(i + 1), 'top')
+
+  // verticals: every interior panel point (and the ends for parallel types);
+  // Warren keeps full verticals so the parallel truss stays determinate.
+  for (let i = 0; i <= n; i++) {
+    if (roof && (i === 0 || i === n)) continue   // top coincides with the support
+    add(`b${i}`, top(i), 'vertical')
+  }
+
+  // diagonals: one per panel; the roof skips the two END panels (already a
+  // triangle b–b–t), keeping every generated truss statically determinate.
+  for (let i = 0; i < n; i++) {
+    if (roof && (i === 0 || i === n - 1)) continue
+    let a: string, b: string
+    if (spec.type === 'warren') { (i % 2 === 0) ? (a = `b${i}`, b = top(i + 1)) : (a = top(i), b = `b${i + 1}`) }
+    else if (spec.type === 'howe') { (i < mid) ? (a = top(i), b = `b${i + 1}`) : (a = `b${i}`, b = top(i + 1)) }
+    else { (i < mid) ? (a = `b${i}`, b = top(i + 1)) : (a = top(i), b = `b${i + 1}`) }   // pratt + roof
+    add(a, b, 'diagonal')
+  }
+
+  const supports: TSupport[] = [
+    { node: 'b0', ux: true, uy: true },          // pin
+    { node: `b${n}`, ux: false, uy: true },        // roller
+  ]
+  // downward joint loads at the loaded chord (top chord; its end nodes coincide
+  // with the supports on a roof, so load the interior top nodes there).
+  const loaded = nodes.filter((nd) => nd.id.startsWith('t') && !(roof && (nd.id === 't0' || nd.id === `t${n}`)))
+  const loads: TLoad[] = loaded.map((nd) => ({ node: nd.id, fx: 0, fy: -Math.abs(spec.panelLoad) }))
+
+  return { nodes, members, supports, loads, E: 200000, A: 1500 }
+}
+
+export interface MemberForce { id: string; N: number; L: number; kind: ChordKind; i: string; j: string }
+export interface Reaction { node: string; fx: number; fy: number }
+export interface Determinacy { m: number; r: number; j: number; value: number; status: 'determinate' | 'indeterminate' | 'unstable' }
+export interface TrussResult {
+  forces: MemberForce[]
+  reactions: Reaction[]
+  determinacy: Determinacy
+  maxTension: number; maxCompression: number      // kN (compression reported as a positive magnitude)
+  stable: boolean
+}
+
+/** Direct-stiffness solve of a planar truss (2 DOF/node). */
+export function solveTruss(model: TrussModel): TrussResult | null {
+  const { nodes, members, supports, loads, E, A } = model
+  const idx = new Map(nodes.map((nd, k) => [nd.id, k]))
+  const j = nodes.length, ndof = 2 * j
+  const node = (id: string) => nodes[idx.get(id)!]
+
+  const r = supports.reduce((s, sup) => s + (sup.ux ? 1 : 0) + (sup.uy ? 1 : 0), 0)
+  const value = members.length + r - 2 * j     // < 0 unstable, 0 determinate, > 0 indeterminate
+
+  // global stiffness (N/mm), working in mm
+  const K = Array.from({ length: ndof }, () => new Array(ndof).fill(0))
+  const geom = members.map((mb) => {
+    const a = node(mb.i), b = node(mb.j)
+    const L = len(a, b)
+    const Lmm = L * 1000
+    const c = (b.x - a.x) / L, s = (b.y - a.y) / L
+    const k = (E * A) / Lmm                    // N/mm
+    const ia = idx.get(mb.i)! * 2, ib = idx.get(mb.j)! * 2
+    const map = [ia, ia + 1, ib, ib + 1]
+    const cc = c * c, ss = s * s, cs = c * s
+    const ke = [
+      [cc, cs, -cc, -cs], [cs, ss, -cs, -ss], [-cc, -cs, cc, cs], [-cs, -ss, cs, ss],
+    ]
+    for (let p = 0; p < 4; p++) for (let q = 0; q < 4; q++) K[map[p]][map[q]] += k * ke[p][q]
+    return { mb, L, Lmm, c, s, k, map }
+  })
+
+  // load vector (N)
+  const F = new Array(ndof).fill(0)
+  for (const ld of loads) {
+    const o = idx.get(ld.node); if (o === undefined) continue
+    F[o * 2] += ld.fx * 1000
+    F[o * 2 + 1] += ld.fy * 1000
+  }
+
+  // constrained DOFs
+  const fixed = new Set<number>()
+  for (const sup of supports) {
+    const o = idx.get(sup.node); if (o === undefined) continue
+    if (sup.ux) fixed.add(o * 2)
+    if (sup.uy) fixed.add(o * 2 + 1)
+  }
+  const free = [...Array(ndof).keys()].filter((d) => !fixed.has(d))
+
+  // reduced solve  K_ff u_f = F_f
+  const Kff = free.map((a) => free.map((b) => K[a][b]))
+  const Ff = free.map((d) => F[d])
+  const uf = solveLinear(Kff, Ff)
+  if (!uf) return { forces: [], reactions: [], determinacy: { m: members.length, r, j, value, status: 'unstable' }, maxTension: 0, maxCompression: 0, stable: false }
+
+  const u = new Array(ndof).fill(0)
+  free.forEach((d, k) => { u[d] = uf[k] })
+
+  // member axial forces (tension +) in kN
+  let maxTension = 0, maxCompression = 0
+  const forces: MemberForce[] = geom.map((g) => {
+    const [a, b, cc, dd] = g.map
+    const elong = (u[cc] - u[a]) * g.c + (u[dd] - u[b]) * g.s   // mm
+    const N = (g.k * elong) / 1000                              // kN, tension +
+    if (N > maxTension) maxTension = N
+    if (-N > maxCompression) maxCompression = -N
+    return { id: g.mb.id, N, L: g.L, kind: g.mb.kind, i: g.mb.i, j: g.mb.j }
+  })
+
+  // reactions (kN): R = K u − F at the fixed DOFs
+  const Ku = matVec(K, u)
+  const reactions: Reaction[] = supports.map((sup) => {
+    const o = idx.get(sup.node)!
+    return {
+      node: sup.node,
+      fx: sup.ux ? (Ku[o * 2] - F[o * 2]) / 1000 : 0,
+      fy: sup.uy ? (Ku[o * 2 + 1] - F[o * 2 + 1]) / 1000 : 0,
+    }
+  })
+
+  const status: Determinacy['status'] = value < 0 ? 'unstable' : value === 0 ? 'determinate' : 'indeterminate'
+  return { forces, reactions, determinacy: { m: members.length, r, j, value, status }, maxTension, maxCompression, stable: true }
+}

--- a/webapp/src/engine/trussDesign.ts
+++ b/webapp/src/engine/trussDesign.ts
@@ -1,0 +1,62 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Steel truss member capacity (AISC 360 / NSCP 2015 Ch. 5, LRFD):
+//   · Tension yielding:  φt·Pn = 0.90·Fy·Ag                       (D2)
+//   · Compression (flexural buckling, E3):
+//       λ = KL/r;  Fe = π²E/λ²;
+//       Fcr = (0.658^(Fy/Fe))·Fy   if  KL/r ≤ 4.71·√(E/Fy)        (inelastic)
+//             0.877·Fe             otherwise                       (elastic)
+//       φc·Pn = 0.90·Fcr·Ag
+// A member's utilisation is |N| / φPn for its force sign.
+// Units: A mm², r mm, E/Fy MPa, L mm, forces kN.
+// ─────────────────────────────────────────────────────────────────────────
+import type { MemberForce } from './truss'
+
+export interface TrussSection {
+  A: number          // gross area, mm²
+  r: number          // governing radius of gyration, mm
+  E: number; Fy: number   // MPa
+  K?: number         // effective-length factor (default 1.0)
+}
+
+export type MemberMode = 'tension' | 'compression' | 'zero'
+export interface MemberDesign {
+  id: string; N: number; L: number; kind: MemberForce['kind']
+  mode: MemberMode
+  slenderness: number      // KL/r
+  Fcr?: number             // MPa (compression)
+  phiPn: number            // kN
+  util: number
+  ok: boolean
+  /** §E2 — KL/r > 200 is discouraged for compression; flagged. */
+  slenderOK: boolean
+}
+
+const PHI = 0.90
+
+/** Capacity & utilisation of one member under its axial force N (kN, tension +). */
+export function designTrussMember(f: MemberForce, sec: TrussSection): MemberDesign {
+  const K = sec.K ?? 1.0
+  const Lmm = f.L * 1000
+  const slenderness = (K * Lmm) / sec.r
+  const mode: MemberMode = Math.abs(f.N) < 1e-6 ? 'zero' : f.N > 0 ? 'tension' : 'compression'
+
+  let phiPn: number, Fcr: number | undefined
+  if (mode === 'compression') {
+    const Fe = (Math.PI ** 2 * sec.E) / (slenderness * slenderness)        // MPa
+    const limit = 4.71 * Math.sqrt(sec.E / sec.Fy)
+    Fcr = slenderness <= limit ? Math.pow(0.658, sec.Fy / Fe) * sec.Fy : 0.877 * Fe
+    phiPn = (PHI * Fcr * sec.A) / 1000                                     // kN
+  } else {
+    phiPn = (PHI * sec.Fy * sec.A) / 1000                                  // tension yielding (kN)
+  }
+  const util = mode === 'zero' || phiPn <= 0 ? 0 : Math.abs(f.N) / phiPn
+  const slenderOK = mode !== 'compression' || slenderness <= 200
+  return { id: f.id, N: f.N, L: f.L, kind: f.kind, mode, slenderness, Fcr, phiPn, util, ok: util <= 1 + 1e-9 && slenderOK, slenderOK }
+}
+
+export interface TrussDesignResult { members: MemberDesign[]; maxUtil: number; allOK: boolean }
+export function designTruss(forces: MemberForce[], sec: TrussSection): TrussDesignResult {
+  const members = forces.map((f) => designTrussMember(f, sec))
+  const maxUtil = members.reduce((m, d) => Math.max(m, d.util), 0)
+  return { members, maxUtil, allOK: members.every((d) => d.ok) }
+}

--- a/webapp/src/pages/TrussSpace.tsx
+++ b/webapp/src/pages/TrussSpace.tsx
@@ -1,0 +1,234 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Canvas } from '@react-three/fiber'
+import { OrbitControls, Text } from '@react-three/drei'
+import * as THREE from 'three'
+import { generateTruss, solveTruss, type TrussType } from '../engine/truss'
+import { designTruss, type MemberDesign, type TrussSection } from '../engine/trussDesign'
+import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
+import { ReportControls } from '../components/ReportControls'
+import { f1, f2 } from '../lib/format'
+
+const TENSION = '#1d4ed8', COMPRESSION = '#dc2626', ZERO = '#94a3b8', SEL = '#f59e0b'
+const UP = new THREE.Vector3(0, 1, 0)
+
+/** A truss member drawn as a coloured cylinder (blue = tension, red = compression). */
+function Member3D({ a, b, color, thick, selected, onPick }: {
+  a: THREE.Vector3; b: THREE.Vector3; color: string; thick: number; selected: boolean; onPick: () => void
+}) {
+  const dir = useMemo(() => new THREE.Vector3().subVectors(b, a), [a, b])
+  const len = dir.length()
+  const mid = useMemo(() => new THREE.Vector3().addVectors(a, b).multiplyScalar(0.5), [a, b])
+  const quat = useMemo(() => new THREE.Quaternion().setFromUnitVectors(UP, dir.clone().normalize()), [dir])
+  const r = (selected ? 1.6 : 1) * thick
+  return (
+    <mesh position={mid} quaternion={quat} onClick={(e) => { e.stopPropagation(); onPick() }}>
+      <cylinderGeometry args={[r, r, len, 10]} />
+      <meshStandardMaterial color={selected ? SEL : color} />
+    </mesh>
+  )
+}
+
+function Support3D({ p, roller }: { p: THREE.Vector3; roller: boolean }) {
+  return (
+    <group position={[p.x, p.y - 0.18, p.z]}>
+      <mesh><coneGeometry args={[0.22, 0.36, 4]} /><meshStandardMaterial color="#0056b3" /></mesh>
+      {roller && <mesh position={[0, -0.22, 0]}><cylinderGeometry args={[0.22, 0.22, 0.06, 16]} /><meshStandardMaterial color="#0056b3" /></mesh>}
+    </group>
+  )
+}
+
+/** Downward load arrow at a loaded joint. */
+function Load3D({ p, mag }: { p: THREE.Vector3; mag: number }) {
+  const h = Math.min(1.4, 0.4 + mag / 20)
+  return (
+    <group position={[p.x, p.y + h / 2 + 0.18, p.z]}>
+      <mesh><cylinderGeometry args={[0.03, 0.03, h, 8]} /><meshStandardMaterial color="#16a34a" /></mesh>
+      <mesh position={[0, -h / 2, 0]}><coneGeometry args={[0.1, 0.18, 12]} /><meshStandardMaterial color="#16a34a" /></mesh>
+    </group>
+  )
+}
+
+export default function TrussSpace() {
+  const [type, setType] = useState<TrussType>('pratt')
+  const [span, setSpan] = useState(12)
+  const [height, setHeight] = useState(2)
+  const [panels, setPanels] = useState(4)
+  const [panelLoad, setPanelLoad] = useState(15)
+  // section & material (steel, AISC LRFD)
+  const [E, setE] = useState(200000); const [Fy, setFy] = useState(248)
+  const [A, setA] = useState(1500); const [rg, setRg] = useState(25); const [K, setK] = useState(1.0)
+  const [selected, setSelected] = useState<string | null>(null)
+  const controlsRef = useRef<React.ComponentRef<typeof OrbitControls>>(null)
+
+  // hold Shift to pan with a left-drag (right-drag also pans)
+  useEffect(() => {
+    const setPan = (on: boolean) => (e: KeyboardEvent) => {
+      if (e.key !== 'Shift') return
+      const c = controlsRef.current
+      if (c) c.mouseButtons.LEFT = on ? THREE.MOUSE.PAN : THREE.MOUSE.ROTATE
+    }
+    const d = setPan(true), u = setPan(false)
+    window.addEventListener('keydown', d); window.addEventListener('keyup', u)
+    return () => { window.removeEventListener('keydown', d); window.removeEventListener('keyup', u) }
+  }, [])
+
+  const model = useMemo(() => generateTruss({ type, span, height, panels, panelLoad }), [type, span, height, panels, panelLoad])
+  const result = useMemo(() => solveTruss(model), [model])
+  const section: TrussSection = useMemo(() => ({ A, r: rg, E, Fy, K }), [A, rg, E, Fy, K])
+  const design = useMemo(() => (result ? designTruss(result.forces, section) : null), [result, section])
+
+  const pos = useMemo(() => {
+    const map = new Map<string, THREE.Vector3>()
+    model.nodes.forEach((nd) => map.set(nd.id, new THREE.Vector3(nd.x, nd.y, 0)))
+    return map
+  }, [model])
+  const maxAbs = Math.max(1e-6, ...(result?.forces.map((f) => Math.abs(f.N)) ?? [1]))
+  const designById = useMemo(() => new Map((design?.members ?? []).map((d) => [d.id, d])), [design])
+
+  const cx = span / 2, cyc = height / 2
+  const selForce = result?.forces.find((f) => f.id === selected)
+  const selDes = selForce ? designById.get(selForce.id) : undefined
+
+  return (
+    <div className="mx-auto max-w-[1700px] p-4">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
+          <h1 className="text-2xl font-extrabold tracking-tight text-[#0056b3]">Truss Space</h1>
+          <p className="text-xs text-slate-500">Planar pin-jointed truss — generate, analyse (axial forces) &amp; design (AISC LRFD).</p>
+        </div>
+        <ReportControls title="Truss Design Report" />
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-[3fr_2fr]">
+        {/* 3D viewport */}
+        <div className="no-print lg:sticky lg:top-4">
+          <div className="relative h-[70vh] min-h-[420px] overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+            <Canvas camera={{ position: [cx, cyc + height * 0.5 + 1, Math.max(span, 6) * 1.25], fov: 45 }} onPointerMissed={() => setSelected(null)}>
+              <color attach="background" args={['#f8fafc']} />
+              <ambientLight intensity={0.9} />
+              <directionalLight position={[6, 12, 10]} intensity={0.8} />
+              {model.members.map((mb) => {
+                const a = pos.get(mb.i), b = pos.get(mb.j); if (!a || !b) return null
+                const N = result?.forces.find((f) => f.id === mb.id)?.N ?? 0
+                const color = Math.abs(N) < 1e-6 ? ZERO : N > 0 ? TENSION : COMPRESSION
+                const thick = 0.03 + 0.06 * (Math.abs(N) / maxAbs)
+                return <Member3D key={mb.id} a={a} b={b} color={color} thick={thick} selected={mb.id === selected} onPick={() => setSelected(mb.id)} />
+              })}
+              {model.nodes.map((nd) => { const p = pos.get(nd.id)!; return (
+                <mesh key={nd.id} position={p}><sphereGeometry args={[0.07, 12, 12]} /><meshStandardMaterial color="#334155" /></mesh>
+              ) })}
+              {model.supports.map((s) => { const p = pos.get(s.node); return p ? <Support3D key={s.node} p={p} roller={!s.ux} /> : null })}
+              {model.loads.map((l, i) => { const p = pos.get(l.node); return p && Math.abs(l.fy) > 1e-6 ? <Load3D key={i} p={p} mag={Math.abs(l.fy)} /> : null })}
+              {selForce && pos.get(selForce.i) && pos.get(selForce.j) && (
+                <Text position={[(pos.get(selForce.i)!.x + pos.get(selForce.j)!.x) / 2, (pos.get(selForce.i)!.y + pos.get(selForce.j)!.y) / 2 + 0.25, 0]}
+                  fontSize={0.3} color="#0f172a" anchorX="center" anchorY="middle" outlineWidth={0.012} outlineColor="#ffffff">
+                  {`${f1(selForce.N)} kN`}
+                </Text>
+              )}
+              <OrbitControls ref={controlsRef} makeDefault enablePan target={[cx, cyc, 0]} />
+            </Canvas>
+            {selForce && (
+              <div className="no-print absolute left-3 top-3 flex items-center gap-2 rounded-lg border border-[#0056b3]/30 bg-white/90 px-2.5 py-1 text-xs shadow-sm backdrop-blur">
+                <span className="font-semibold text-[#0056b3]">▣ {selForce.kind} {selForce.id}</span>
+                <span className={selForce.N >= 0 ? 'text-blue-700' : 'text-red-600'}>
+                  {f1(Math.abs(selForce.N))} kN {selForce.N >= 0 ? 'tension' : 'compression'}
+                </span>
+                {selDes && <span className="text-slate-500">util {(selDes.util * 100).toFixed(0)}%</span>}
+                <button type="button" onClick={() => setSelected(null)} className="ml-0.5 text-slate-400 hover:text-red-500">✕</button>
+              </div>
+            )}
+            <div className="no-print pointer-events-none absolute bottom-2 left-3 text-[10px] text-slate-400">
+              drag to orbit · scroll to zoom · hold <b>Shift</b> (or right-drag) to pan · <span className="text-blue-700">tension</span> / <span className="text-red-600">compression</span>
+            </div>
+          </div>
+        </div>
+
+        {/* controls + results */}
+        <div className="space-y-4">
+          <Card title="Truss geometry">
+            <Pick label="Type" value={type} onChange={(v) => setType(v as TrussType)}
+              options={[['pratt', 'Pratt'], ['howe', 'Howe'], ['warren', 'Warren'], ['roof', 'Pitched roof (gable)']]} />
+            <Num label="Span" unit="m" value={span} onChange={setSpan} step="0.5" />
+            <Num label="Height" unit="m" value={height} onChange={setHeight} step="0.25" />
+            <Num label="Panels" value={panels} onChange={(v) => setPanels(Math.max(2, Math.round(v)))} step="1" />
+            <Num label="Joint load" unit="kN" value={panelLoad} onChange={setPanelLoad} step="1" />
+          </Card>
+
+          <Card title="Section & material (steel)">
+            <Num label="Area A" unit="mm²" value={A} onChange={setA} step="50" />
+            <Num label="Radius of gyration r" unit="mm" value={rg} onChange={setRg} step="1" />
+            <Num label="E" unit="MPa" value={E} onChange={setE} step="1000" />
+            <Num label="Fy" unit="MPa" value={Fy} onChange={setFy} step="5" />
+            <Num label="Effective length K" value={K} onChange={setK} step="0.05" />
+          </Card>
+
+          {result && (
+            <ResultCard title={`Analysis — ${result.determinacy.status}`}>
+              <Row label="Determinacy m + r − 2j" value={`${result.determinacy.value}`}
+                sub={`m ${result.determinacy.m} · r ${result.determinacy.r} · j ${result.determinacy.j}`} alert={result.determinacy.status === 'unstable'} />
+              <Row label="Max tension" value={`${f1(result.maxTension)} kN`} />
+              <Row label="Max compression" value={`${f1(result.maxCompression)} kN`} />
+              {result.reactions.map((r2) => (
+                <Row key={r2.node} label={`Reaction @ ${r2.node}`} value={`${f1(r2.fy)} kN ↑`} sub={r2.fx ? `H ${f1(r2.fx)} kN` : undefined} />
+              ))}
+              {design && <Row alert={!design.allOK} label="Design" value={design.allOK ? `OK · max util ${(design.maxUtil * 100).toFixed(0)}%` : `✗ max util ${(design.maxUtil * 100).toFixed(0)}%`} />}
+            </ResultCard>
+          )}
+        </div>
+      </div>
+
+      {/* Member schedule (printable report) */}
+      {result && design && (
+        <div className="mt-6 space-y-4">
+          <h2 className="text-xl font-extrabold tracking-tight text-[#0056b3]">
+            Truss member schedule — {type} · {f1(span)} m span
+            <span className="ml-3 text-sm font-normal text-slate-500">
+              {result.determinacy.status} · A {A} mm² · Fy {Fy} MPa · max util {(design.maxUtil * 100).toFixed(0)}%
+            </span>
+          </h2>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <table className="w-full border-collapse text-xs">
+              <thead>
+                <tr className="text-left uppercase tracking-wide text-slate-500">
+                  <th className="py-1 pr-2 font-semibold">Member</th>
+                  <th className="py-1 pr-2 font-semibold">Type</th>
+                  <th className="py-1 pr-2 text-right font-semibold">L (m)</th>
+                  <th className="py-1 pr-2 text-right font-semibold">Force (kN)</th>
+                  <th className="py-1 pr-2 font-semibold">Sense</th>
+                  <th className="py-1 pr-2 text-right font-semibold">KL/r</th>
+                  <th className="py-1 pr-2 text-right font-semibold">φPn (kN)</th>
+                  <th className="py-1 text-right font-semibold">Util</th>
+                </tr>
+              </thead>
+              <tbody>
+                {result.forces.map((f) => {
+                  const d = designById.get(f.id) as MemberDesign
+                  const bad = !d.ok
+                  return (
+                    <tr key={f.id} onClick={() => setSelected(f.id)}
+                      className={`cursor-pointer border-t border-slate-100 hover:bg-blue-50/40 ${bad ? 'bg-red-50 text-red-700' : ''} ${selected === f.id ? 'bg-amber-50' : ''}`}>
+                      <td className="py-1 pr-2 font-medium">{f.id} <span className="text-slate-400">({f.i}–{f.j})</span></td>
+                      <td className="py-1 pr-2">{f.kind}</td>
+                      <td className="py-1 pr-2 text-right">{f2(f.L)}</td>
+                      <td className="py-1 pr-2 text-right">{f1(Math.abs(f.N))}</td>
+                      <td className={`py-1 pr-2 ${f.N >= 0 ? 'text-blue-700' : 'text-red-600'}`}>{d.mode === 'zero' ? '—' : f.N >= 0 ? 'T' : 'C'}</td>
+                      <td className="py-1 pr-2 text-right">{d.mode === 'compression' ? Math.round(d.slenderness) + (d.slenderOK ? '' : ' ⚠') : '—'}</td>
+                      <td className="py-1 pr-2 text-right">{f1(d.phiPn)}</td>
+                      <td className="py-1 text-right">{(d.util * 100).toFixed(0)}%</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+            <p className="mt-1 text-[11px] text-slate-400">
+              Pin-jointed planar truss (axial only). Tension yielding φPn = 0.9·Fy·Ag; compression flexural buckling per AISC §E3
+              (Fcr from KL/r, φ = 0.90). KL/r &gt; 200 flagged (⚠). Reactions: pin at the left support, roller at the right.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
A new **/truss** page focused on trusses, with the 3D-frame look & feel.

## Engine
- **`engine/truss.ts`** — planar (2D) pin-jointed truss model + parametric generators: **Pratt, Howe, Warren** (parallel-chord) and a **pitched gable roof** — all statically determinate by construction. Direct-stiffness solver (2 DOF/node) returns member **axial forces** (tension +), **support reactions** (pin + roller) and the **m + r vs 2j determinacy** status.
- **`engine/trussDesign.ts`** — steel member capacity, AISC 360 / NSCP LRFD: **tension yielding** (φPn = 0.9·Fy·Ag) and **compression flexural buckling** (§E3, Fcr from KL/r), per-member utilisation, and a KL/r ≤ 200 flag.

## Page (`pages/TrussSpace.tsx`)
- **3D viewport**: members coloured **blue = tension / red = compression** and sized by force; node spheres, pin/roller supports, downward load arrows.
- **Select** a member (click) → overlay shows id + force + utilisation, and the force is labelled in 3D; click the schedule row to select too.
- **Hold Shift** (or right-drag) to pan, like the frame page.
- **Live results**: determinacy, reactions, max tension/compression, overall pass + max utilisation.
- **Printable member schedule**: per member type, length, force (T/C), KL/r, φPn, utilisation.
- Geometry (type/span/height/panels/joint load) and section/material (A, r, E, Fy, K) are live inputs.
- Lazy `/truss` route (three.js chunk) + a "Truss Space" tile on the home page.

## Verification
- `tsc -b` clean; `vitest run` → **247 passed** (new `truss.test.ts`: single-triangle statics vs hand calc — ΣR = load, bottom tie = 10/3 kN; every generator stable & determinate and balances the load; AISC tension = 0.9·Fy·Ag and compression weakens with slenderness).
- Browser: all four types solve **determinate**; Pratt 12 m/4-panel → reactions at b0/b4, 17 members, max util 36%; the 3D renders the truss with correct tension/compression colours, supports and load arrows; no console errors.

> Scope note: this MVP is **parametric** (pick a type + dimensions) rather than a free node/member editor, and covers the canonical planar trusses + a gable roof. Free-form editing, more roof types (Fink/Howe scissor), and a material take-off can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)