### PR TITLE
Truss Phase 1: AISC section library + accurate section rendering, double angles, arrow fix

### DIFF
--- a/webapp/src/components/SectionShape.tsx
+++ b/webapp/src/components/SectionShape.tsx
@@ -1,0 +1,81 @@
+import type { EffectiveSection } from '../engine/aiscSections'
+
+// Accurate-to-geometry cross-section drawing for an AISC shape (W/C/L/2L/HSS/
+// Pipe/WT). Drawn to scale inside a fixed viewBox; steel is filled, the section
+// name + the governing dimensions are labelled. Pure SVG.
+const FILL = '#94a3b8', EDGE = '#37526e', BLUE = '#0056b3'
+
+export function SectionShape({ sec }: { sec: EffectiveSection }) {
+  const VB = 150, pad = 22
+  const s = sec.base
+  // overall bounding box (mm) of what we draw
+  const box = (() => {
+    if (sec.double && s.leg1) return { w: 2 * (s.leg1 ?? 0) + (sec.gap ?? 10), h: s.leg2 ?? 0 }
+    if (s.family === 'W' || s.family === 'WT') return { w: s.bf ?? 100, h: s.d ?? 100 }
+    if (s.family === 'C') return { w: (s.bf ?? 60) + (s.tw ?? 10), h: s.d ?? 100 }
+    if (s.family === 'L') return { w: s.leg1 ?? 50, h: s.leg2 ?? 50 }
+    if (s.family === 'HSS') return { w: s.b ?? 100, h: s.h ?? 100 }
+    return { w: s.D ?? 100, h: s.D ?? 100 }   // pipe
+  })()
+  const scl = (VB - 2 * pad) / Math.max(box.w, box.h)
+  const W = box.w * scl, H = box.h * scl
+  const ox = (VB - W) / 2, oy = (VB - H) / 2
+  const px = (mm: number) => mm * scl
+
+  const shapeEl = (() => {
+    if (s.family === 'W' || s.family === 'WT') {
+      const tf = px(s.tf ?? 8), tw = px(s.tw ?? 6), cxw = ox + W / 2
+      if (s.family === 'WT') {
+        // tee: top flange + stem down
+        return <>
+          <rect x={ox} y={oy} width={W} height={tf} fill={FILL} stroke={EDGE} />
+          <rect x={cxw - tw / 2} y={oy + tf} width={tw} height={H - tf} fill={FILL} stroke={EDGE} />
+        </>
+      }
+      return <>
+        <rect x={ox} y={oy} width={W} height={tf} fill={FILL} stroke={EDGE} />
+        <rect x={ox} y={oy + H - tf} width={W} height={tf} fill={FILL} stroke={EDGE} />
+        <rect x={cxw - tw / 2} y={oy + tf} width={tw} height={H - 2 * tf} fill={FILL} stroke={EDGE} />
+      </>
+    }
+    if (s.family === 'C') {
+      const tf = px(s.tf ?? 9), tw = px(s.tw ?? 8), bf = px(s.bf ?? 60)
+      return <>
+        <rect x={ox} y={oy} width={tw} height={H} fill={FILL} stroke={EDGE} />          {/* web (back) */}
+        <rect x={ox + tw} y={oy} width={bf} height={tf} fill={FILL} stroke={EDGE} />
+        <rect x={ox + tw} y={oy + H - tf} width={bf} height={tf} fill={FILL} stroke={EDGE} />
+      </>
+    }
+    if (s.family === 'L') {
+      const t = px(s.t ?? 8), l1 = px(s.leg1 ?? 50), l2 = px(s.leg2 ?? 50), g = px(sec.gap ?? 10)
+      const angle = (x0: number, flip = false) => flip
+        ? <path d={`M ${x0 + l1} ${oy} h ${-t} v ${l2 - t} h ${-(l1 - t)} v ${t} h ${l1} Z`} fill={FILL} stroke={EDGE} />
+        : <path d={`M ${x0} ${oy} h ${t} v ${l2 - t} h ${l1 - t} v ${t} h ${-l1} Z`} fill={FILL} stroke={EDGE} />
+      if (sec.double) return <>{angle(ox)}{angle(ox + l1 + g, true)}</>
+      return angle(ox)
+    }
+    if (s.family === 'HSS') {
+      const t = px(s.t ?? 6)
+      return <>
+        <rect x={ox} y={oy} width={W} height={H} fill={FILL} stroke={EDGE} />
+        <rect x={ox + t} y={oy + t} width={W - 2 * t} height={H - 2 * t} fill="#fff" stroke={EDGE} />
+      </>
+    }
+    // pipe / round HSS
+    const t = px(s.t ?? 6), cxp = ox + W / 2, cyp = oy + H / 2, R = W / 2
+    return <>
+      <circle cx={cxp} cy={cyp} r={R} fill={FILL} stroke={EDGE} />
+      <circle cx={cxp} cy={cyp} r={R - t} fill="#fff" stroke={EDGE} />
+    </>
+  })()
+
+  return (
+    <svg viewBox={`0 0 ${VB} ${VB}`} xmlns="http://www.w3.org/2000/svg" style={{ width: '100%', maxWidth: 200, height: 'auto', fontFamily: 'Arial' }}>
+      <rect x={0.5} y={0.5} width={VB - 1} height={VB - 1} fill="#f8fafc" stroke="#e2e8f0" />
+      {shapeEl}
+      <text x={VB / 2} y={VB - 5} fontSize={9} fontWeight={700} fill={BLUE} textAnchor="middle">{sec.label}</text>
+      <text x={4} y={11} fontSize={8} fill="#64748b">A = {Math.round(sec.A)} mm²</text>
+      <text x={VB - 4} y={11} fontSize={8} fill="#64748b" textAnchor="end">r_min {sec.rmin.toFixed(1)} mm</text>
+    </svg>
+  )
+}

--- a/webapp/src/engine/aiscSections.test.ts
+++ b/webapp/src/engine/aiscSections.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { AISC_SHAPES, shapesOf, shapeByName, effectiveSection, doubleAngle } from './aiscSections'
+
+describe('AISC section library', () => {
+  it('every shape has area + radii and a unique name', () => {
+    const names = new Set<string>()
+    for (const s of AISC_SHAPES) {
+      expect(s.A).toBeGreaterThan(0)
+      expect(s.rx).toBeGreaterThan(0)
+      expect(s.ry).toBeGreaterThan(0)
+      expect(names.has(s.name)).toBe(false)
+      names.add(s.name)
+    }
+    expect(shapesOf('L').length).toBeGreaterThan(0)
+    expect(shapesOf('HSS').every((s) => s.family === 'HSS')).toBe(true)
+  })
+
+  it('single section r_min governs (angle uses rz; tube uses min rx/ry)', () => {
+    const ang = effectiveSection(shapeByName('L102x102x9.5')!, false)
+    expect(ang.A).toBe(1850)
+    expect(ang.rmin).toBeCloseTo(20.1, 3)            // rz of the single angle
+    const hss = effectiveSection(shapeByName('HSS152x102x6.4')!)
+    expect(hss.rmin).toBeCloseTo(38.0, 3)            // min(rx 53, ry 38)
+  })
+
+  it('double angle doubles the area and increases ry across the gap', () => {
+    const L = shapeByName('L102x102x9.5')!
+    const d = doubleAngle(L, 10)
+    expect(d.double).toBe(true)
+    expect(d.A).toBeCloseTo(2 * L.A, 6)
+    expect(d.rx).toBeCloseTo(L.rx, 6)                // unchanged about the geometric x
+    expect(d.ry).toBeGreaterThan(L.ry)              // parallel-axis shift across the gap
+    expect(d.rmin).toBeCloseTo(Math.min(d.rx, d.ry), 6)
+    // wider gap → larger ry
+    expect(doubleAngle(L, 20).ry).toBeGreaterThan(d.ry)
+  })
+
+  it('effectiveSection only doubles angle families', () => {
+    const w = effectiveSection(shapeByName('W250x33')!, true)   // double flag ignored for W
+    expect(w.double).toBe(false)
+    expect(w.A).toBe(4190)
+  })
+})

--- a/webapp/src/engine/aiscSections.ts
+++ b/webapp/src/engine/aiscSections.ts
@@ -1,0 +1,132 @@
+// ─────────────────────────────────────────────────────────────────────────
+// AISC steel shape library (metric values, mm / mm²). A representative,
+// extensible set across the common families used in trusses & frames:
+//   W (wide flange), C (channel), L (single angle), HSS (rect / square),
+//   round HSS / Pipe, WT (structural tee). Single angles can be paired into a
+//   back-to-back DOUBLE ANGLE (2L) with a gusset gap.
+// Each shape carries gross area A, radii of gyration, and the geometry needed
+// to draw an accurate cross-section. Add rows freely — the renderer keys off
+// `family` + the geometry fields.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type SectionFamily = 'W' | 'C' | 'L' | 'HSS' | 'PIPE' | 'WT'
+
+export interface AiscShape {
+  name: string
+  family: SectionFamily
+  A: number                 // gross area, mm²
+  rx: number; ry: number    // radii of gyration, mm
+  rz?: number               // minor principal radius (single angles), mm
+  xbar?: number             // centroid from the back of leg (angles), mm
+  // geometry for rendering, mm
+  d?: number; bf?: number; tf?: number; tw?: number   // W / C / WT
+  leg1?: number; leg2?: number; t?: number            // L (+ HSS wall t)
+  b?: number; h?: number                              // HSS rect/square
+  D?: number                                          // round HSS / pipe (+ t)
+}
+
+/** Wide-flange (W) shapes. */
+const W: AiscShape[] = [
+  { name: 'W150x18', family: 'W', A: 2290, rx: 65, ry: 24.9, d: 153, bf: 102, tf: 7.1, tw: 5.8 },
+  { name: 'W200x22', family: 'W', A: 2860, rx: 84, ry: 22.3, d: 206, bf: 102, tf: 8.0, tw: 6.2 },
+  { name: 'W200x46', family: 'W', A: 5890, rx: 89, ry: 51.8, d: 203, bf: 203, tf: 11.0, tw: 7.2 },
+  { name: 'W250x33', family: 'W', A: 4190, rx: 105, ry: 35.0, d: 258, bf: 146, tf: 9.1, tw: 6.1 },
+  { name: 'W250x67', family: 'W', A: 8580, rx: 110, ry: 51.1, d: 257, bf: 204, tf: 15.7, tw: 8.9 },
+  { name: 'W310x39', family: 'W', A: 4940, rx: 129, ry: 38.4, d: 310, bf: 165, tf: 9.7, tw: 5.8 },
+  { name: 'W310x79', family: 'W', A: 10000, rx: 132, ry: 63.9, d: 306, bf: 254, tf: 14.6, tw: 8.8 },
+  { name: 'W360x51', family: 'W', A: 6450, rx: 149, ry: 39.6, d: 355, bf: 171, tf: 11.6, tw: 7.2 },
+]
+
+/** Channels (C). */
+const C: AiscShape[] = [
+  { name: 'C150x19.3', family: 'C', A: 2470, rx: 61.0, ry: 17.0, d: 152, bf: 54.8, tf: 8.7, tw: 11.1 },
+  { name: 'C200x27.9', family: 'C', A: 3550, rx: 80.0, ry: 19.5, d: 203, bf: 64.0, tf: 9.9, tw: 7.7 },
+  { name: 'C250x37', family: 'C', A: 4740, rx: 99.0, ry: 22.0, d: 254, bf: 73.0, tf: 11.0, tw: 9.6 },
+  { name: 'C310x45', family: 'C', A: 5690, rx: 122, ry: 24.0, d: 305, bf: 80.5, tf: 12.7, tw: 13.0 },
+]
+
+/** Equal-leg single angles (L) — rx = ry (geometric), rz = minor principal. */
+const L: AiscShape[] = [
+  { name: 'L51x51x6.4', family: 'L', A: 605, rx: 15.6, ry: 15.6, rz: 9.9, xbar: 14.7, leg1: 51, leg2: 51, t: 6.4 },
+  { name: 'L64x64x6.4', family: 'L', A: 768, rx: 19.9, ry: 19.9, rz: 12.6, xbar: 17.5, leg1: 64, leg2: 64, t: 6.4 },
+  { name: 'L76x76x6.4', family: 'L', A: 929, rx: 23.8, ry: 23.8, rz: 15.1, xbar: 20.6, leg1: 76, leg2: 76, t: 6.4 },
+  { name: 'L76x76x9.5', family: 'L', A: 1370, rx: 23.5, ry: 23.5, rz: 14.9, xbar: 21.9, leg1: 76, leg2: 76, t: 9.5 },
+  { name: 'L102x102x9.5', family: 'L', A: 1850, rx: 31.8, ry: 31.8, rz: 20.1, xbar: 27.2, leg1: 102, leg2: 102, t: 9.5 },
+  { name: 'L102x102x12.7', family: 'L', A: 2420, rx: 31.4, ry: 31.4, rz: 19.9, xbar: 28.4, leg1: 102, leg2: 102, t: 12.7 },
+  { name: 'L127x127x12.7', family: 'L', A: 3060, rx: 39.4, ry: 39.4, rz: 24.9, xbar: 34.5, leg1: 127, leg2: 127, t: 12.7 },
+  { name: 'L152x152x12.7', family: 'L', A: 3710, rx: 47.5, ry: 47.5, rz: 30.1, xbar: 40.9, leg1: 152, leg2: 152, t: 12.7 },
+  { name: 'L152x152x19', family: 'L', A: 5410, rx: 46.9, ry: 46.9, rz: 29.8, xbar: 43.4, leg1: 152, leg2: 152, t: 19.0 },
+]
+
+/** Square & rectangular HSS. */
+const HSS: AiscShape[] = [
+  { name: 'HSS76x76x6.4', family: 'HSS', A: 1600, rx: 28.2, ry: 28.2, b: 76, h: 76, t: 6.4 },
+  { name: 'HSS102x102x6.4', family: 'HSS', A: 2230, rx: 38.6, ry: 38.6, b: 102, h: 102, t: 6.4 },
+  { name: 'HSS102x102x9.5', family: 'HSS', A: 3160, rx: 37.5, ry: 37.5, b: 102, h: 102, t: 9.5 },
+  { name: 'HSS127x127x6.4', family: 'HSS', A: 2860, rx: 48.9, ry: 48.9, b: 127, h: 127, t: 6.4 },
+  { name: 'HSS152x152x9.5', family: 'HSS', A: 4920, rx: 57.6, ry: 57.6, b: 152, h: 152, t: 9.5 },
+  { name: 'HSS152x102x6.4', family: 'HSS', A: 2860, rx: 53.0, ry: 38.0, b: 102, h: 152, t: 6.4 },
+  { name: 'HSS203x102x6.4', family: 'HSS', A: 3550, rx: 68.0, ry: 39.0, b: 102, h: 203, t: 6.4 },
+]
+
+/** Round HSS / standard pipe. */
+const PIPE: AiscShape[] = [
+  { name: 'PIPE 3 STD', family: 'PIPE', A: 1390, rx: 29.5, ry: 29.5, D: 88.9, t: 5.5 },
+  { name: 'PIPE 4 STD', family: 'PIPE', A: 2010, rx: 38.4, ry: 38.4, D: 114.3, t: 6.0 },
+  { name: 'PIPE 5 STD', family: 'PIPE', A: 2700, rx: 47.8, ry: 47.8, D: 141.3, t: 6.6 },
+  { name: 'PIPE 6 STD', family: 'PIPE', A: 3470, rx: 57.2, ry: 57.2, D: 168.3, t: 7.1 },
+  { name: 'HSS114x6.4', family: 'PIPE', A: 2150, rx: 38.0, ry: 38.0, D: 114, t: 6.4 },
+]
+
+/** Structural tees (WT). */
+const WT: AiscShape[] = [
+  { name: 'WT100x10.5', family: 'WT', A: 1340, rx: 27.5, ry: 23.0, d: 103, bf: 102, tf: 7.1, tw: 5.8 },
+  { name: 'WT155x26', family: 'WT', A: 3310, rx: 43.0, ry: 38.0, d: 157, bf: 153, tf: 10.9, tw: 7.1 },
+  { name: 'WT180x29.5', family: 'WT', A: 3760, rx: 50.0, ry: 38.4, d: 181, bf: 153, tf: 11.6, tw: 7.5 },
+]
+
+export const AISC_SHAPES: AiscShape[] = [...W, ...C, ...L, ...HSS, ...PIPE, ...WT]
+export const FAMILIES: { id: SectionFamily; label: string }[] = [
+  { id: 'W', label: 'W — Wide flange' },
+  { id: 'C', label: 'C — Channel' },
+  { id: 'L', label: 'L — Angle' },
+  { id: 'HSS', label: 'HSS — Rect/Square tube' },
+  { id: 'PIPE', label: 'Pipe / Round HSS' },
+  { id: 'WT', label: 'WT — Tee' },
+]
+
+export const shapesOf = (family: SectionFamily) => AISC_SHAPES.filter((s) => s.family === family)
+export const shapeByName = (name: string) => AISC_SHAPES.find((s) => s.name === name)
+
+/** Effective section actually used by a member: a single shape, or — for angles
+ *  — a back-to-back DOUBLE ANGLE (2L) with a gusset gap. */
+export interface EffectiveSection {
+  label: string
+  family: SectionFamily
+  A: number                 // mm²
+  rmin: number              // governing radius of gyration, mm
+  rx: number; ry: number
+  double: boolean
+  base: AiscShape
+  gap?: number              // mm (2L)
+}
+
+/** Back-to-back double angle: A doubles; rx unchanged; ry grows by the
+ *  parallel-axis shift of each leg's centroid across the gap. */
+export function doubleAngle(angle: AiscShape, gap = 10): EffectiveSection {
+  const xbar = angle.xbar ?? 0
+  const ry2 = Math.sqrt(angle.ry * angle.ry + (xbar + gap / 2) ** 2)
+  const rx2 = angle.rx
+  return {
+    label: `2L ${angle.name.replace(/^L/, '')} (gap ${gap})`,
+    family: 'L', A: 2 * angle.A, rx: rx2, ry: ry2, rmin: Math.min(rx2, ry2),
+    double: true, base: angle, gap,
+  }
+}
+
+/** Resolve a chosen shape (optionally doubled) into the effective section. */
+export function effectiveSection(shape: AiscShape, double = false, gap = 10): EffectiveSection {
+  if (double && shape.family === 'L') return doubleAngle(shape, gap)
+  const rmin = shape.family === 'L' ? Math.min(shape.rz ?? shape.rx, shape.rx) : Math.min(shape.rx, shape.ry)
+  return { label: shape.name, family: shape.family, A: shape.A, rx: shape.rx, ry: shape.ry, rmin, double: false, base: shape }
+}

--- a/webapp/src/pages/TrussSpace.tsx
+++ b/webapp/src/pages/TrussSpace.tsx
@@ -5,6 +5,8 @@ import { OrbitControls, Text } from '@react-three/drei'
 import * as THREE from 'three'
 import { generateTruss, solveTruss, type TrussType } from '../engine/truss'
 import { designTruss, type MemberDesign, type TrussSection } from '../engine/trussDesign'
+import { FAMILIES, shapesOf, shapeByName, effectiveSection, type SectionFamily } from '../engine/aiscSections'
+import { SectionShape } from '../components/SectionShape'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { ReportControls } from '../components/ReportControls'
 import { f1, f2 } from '../lib/format'
@@ -38,13 +40,15 @@ function Support3D({ p, roller }: { p: THREE.Vector3; roller: boolean }) {
   )
 }
 
-/** Downward load arrow at a loaded joint. */
+/** Downward load arrow at a loaded joint — head at the bottom, pointing DOWN. */
 function Load3D({ p, mag }: { p: THREE.Vector3; mag: number }) {
   const h = Math.min(1.4, 0.4 + mag / 20)
+  const head = 0.18
   return (
-    <group position={[p.x, p.y + h / 2 + 0.18, p.z]}>
-      <mesh><cylinderGeometry args={[0.03, 0.03, h, 8]} /><meshStandardMaterial color="#16a34a" /></mesh>
-      <mesh position={[0, -h / 2, 0]}><coneGeometry args={[0.1, 0.18, 12]} /><meshStandardMaterial color="#16a34a" /></mesh>
+    <group position={[p.x, p.y + 0.18, p.z]}>
+      {/* shaft sits above the joint; arrowhead at the joint, apex pointing down */}
+      <mesh position={[0, head + (h - head) / 2, 0]}><cylinderGeometry args={[0.03, 0.03, h - head, 8]} /><meshStandardMaterial color="#16a34a" /></mesh>
+      <mesh position={[0, head / 2, 0]} rotation={[Math.PI, 0, 0]}><coneGeometry args={[0.1, head, 12]} /><meshStandardMaterial color="#16a34a" /></mesh>
     </group>
   )
 }
@@ -56,8 +60,11 @@ export default function TrussSpace() {
   const [panels, setPanels] = useState(4)
   const [panelLoad, setPanelLoad] = useState(15)
   // section & material (steel, AISC LRFD)
-  const [E, setE] = useState(200000); const [Fy, setFy] = useState(248)
-  const [A, setA] = useState(1500); const [rg, setRg] = useState(25); const [K, setK] = useState(1.0)
+  const [E, setE] = useState(200000); const [Fy, setFy] = useState(248); const [K, setK] = useState(1.0)
+  const [family, setFamily] = useState<SectionFamily>('L')
+  const [shapeName, setShapeName] = useState('L102x102x9.5')
+  const [double, setDouble] = useState(true)        // double angle (2L) when family = L
+  const [gap, setGap] = useState(10)                // gusset gap, mm
   const [selected, setSelected] = useState<string | null>(null)
   const controlsRef = useRef<React.ComponentRef<typeof OrbitControls>>(null)
 
@@ -75,7 +82,11 @@ export default function TrussSpace() {
 
   const model = useMemo(() => generateTruss({ type, span, height, panels, panelLoad }), [type, span, height, panels, panelLoad])
   const result = useMemo(() => solveTruss(model), [model])
-  const section: TrussSection = useMemo(() => ({ A, r: rg, E, Fy, K }), [A, rg, E, Fy, K])
+  const eff = useMemo(() => {
+    const shp = shapeByName(shapeName) ?? shapesOf(family)[0]
+    return effectiveSection(shp, double && shp.family === 'L', gap)
+  }, [shapeName, family, double, gap])
+  const section: TrussSection = useMemo(() => ({ A: eff.A, r: eff.rmin, E, Fy, K }), [eff, E, Fy, K])
   const design = useMemo(() => (result ? designTruss(result.forces, section) : null), [result, section])
 
   const pos = useMemo(() => {
@@ -156,12 +167,30 @@ export default function TrussSpace() {
             <Num label="Joint load" unit="kN" value={panelLoad} onChange={setPanelLoad} step="1" />
           </Card>
 
-          <Card title="Section & material (steel)">
-            <Num label="Area A" unit="mm²" value={A} onChange={setA} step="50" />
-            <Num label="Radius of gyration r" unit="mm" value={rg} onChange={setRg} step="1" />
-            <Num label="E" unit="MPa" value={E} onChange={setE} step="1000" />
+          <Card title="Section & material (AISC steel)">
+            <Pick label="Family" value={family} onChange={(v) => { const fam = v as SectionFamily; setFamily(fam); setShapeName(shapesOf(fam)[0].name) }}
+              options={FAMILIES.map((f) => [f.id, f.label])} />
+            <Pick label="Shape" value={shapeName} onChange={setShapeName}
+              options={shapesOf(family).map((s) => [s.name, s.name])} />
+            {family === 'L' && (
+              <label className="col-span-full flex items-center gap-2 text-sm">
+                <input type="checkbox" checked={double} onChange={(e) => setDouble(e.target.checked)} />
+                <span>Double angle (2L, back-to-back)</span>
+              </label>
+            )}
+            {family === 'L' && double && <Num label="Gusset gap" unit="mm" value={gap} onChange={setGap} step="1" />}
             <Num label="Fy" unit="MPa" value={Fy} onChange={setFy} step="5" />
+            <Num label="E" unit="MPa" value={E} onChange={setE} step="1000" />
             <Num label="Effective length K" value={K} onChange={setK} step="0.05" />
+            <div className="col-span-full flex items-center gap-3 border-t border-slate-100 pt-2">
+              <SectionShape sec={eff} />
+              <div className="text-[11px] text-slate-500">
+                <div className="font-semibold text-[#0056b3]">{eff.label}</div>
+                <div>A = {Math.round(eff.A)} mm²</div>
+                <div>rx {eff.rx.toFixed(1)} · ry {eff.ry.toFixed(1)} mm</div>
+                <div>r_min = {eff.rmin.toFixed(1)} mm (governs buckling)</div>
+              </div>
+            </div>
           </Card>
 
           {result && (
@@ -185,7 +214,7 @@ export default function TrussSpace() {
           <h2 className="text-xl font-extrabold tracking-tight text-[#0056b3]">
             Truss member schedule — {type} · {f1(span)} m span
             <span className="ml-3 text-sm font-normal text-slate-500">
-              {result.determinacy.status} · A {A} mm² · Fy {Fy} MPa · max util {(design.maxUtil * 100).toFixed(0)}%
+              {result.determinacy.status} · {eff.label} · Fy {Fy} MPa · max util {(design.maxUtil * 100).toFixed(0)}%
             </span>
           </h2>
           <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">


### PR DESCRIPTION
First phase of expanding Truss Space (more phases below).

## Arrow fix
The green joint-load arrow's head pointed **up (at its own tail)**. The cone is now flipped to point **down** at the loaded joint.

## AISC steel sections (selectable as a member section)
- **`engine/aiscSections.ts`** — a metric AISC shape library across families: **W** (wide flange), **C** (channel), **L** (angle), **HSS** (rect/square), round **HSS/Pipe**, **WT** (tee). Each shape carries area, radii of gyration, and the geometry to draw it.
  - `effectiveSection()` resolves the chosen shape; `doubleAngle()` pairs equal-leg angles **back-to-back (2L)** — area doubles, `ry` grows by the parallel-axis shift across the gusset gap, and `r_min` governs buckling.
- **`components/SectionShape.tsx`** — pure-SVG, **to-scale cross-section** for every family (I-shape, channel, single/double angle, hollow rect tube, pipe annulus, tee), labelled with name + A + r_min.
- **TrussSpace** — the member section is now picked from the AISC library (family + shape, with a **double-angle toggle + gusset gap** for angles) instead of raw A/r inputs; the drawn section's A and r_min feed the AISC LRFD member design.

## Verification
- `tsc -b` clean; `vitest run` → **251 passed** (new `aiscSections.test.ts`: unique shapes; r_min governs; 2L doubles area & raises ry with the gap; double-flag ignored for non-angles).
- Browser: default **2L 102×102×9.5** renders the back-to-back angle (A 3700, ry 45.3); switching to **W150×18** renders the I-section and updates the design (max util 24%); the load arrows point down; no console errors.

> Coverage: this is a solid representative set per family (dozens of shapes), structured so the full AISC v15 database drops straight in — say the word if you want me to bulk-load the complete table.

## Remaining phases (queued, as you asked — "add them all in phases")
- **Phase 2** — truss self-weight (from the chosen section) + NSCP load combinations on the joint loads.
- **Phase 3** — truss material take-off + priced Bill of Materials (steel weight by section, gusset/connection allowance), matching the frame page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)