### PR TITLE
Truss: extrude real sections in 3D + fix back-to-back double angles + plate-thickness gap

### DIFF
--- a/webapp/src/components/SectionShape.tsx
+++ b/webapp/src/components/SectionShape.tsx
@@ -8,12 +8,13 @@ const FILL = '#94a3b8', EDGE = '#37526e', BLUE = '#0056b3'
 export function SectionShape({ sec }: { sec: EffectiveSection }) {
   const VB = 150, pad = 22
   const s = sec.base
+  // for angles: longer leg = connected (drawn vertical), shorter = outstanding
+  const legV = Math.max(s.leg1 ?? 50, s.leg2 ?? 50), legH = Math.min(s.leg1 ?? 50, s.leg2 ?? 50)
   // overall bounding box (mm) of what we draw
   const box = (() => {
-    if (sec.double && s.leg1) return { w: 2 * (s.leg1 ?? 0) + (sec.gap ?? 10), h: s.leg2 ?? 0 }
+    if (s.family === 'L') return sec.double ? { w: 2 * legH + (sec.gap ?? 0), h: legV } : { w: legH, h: legV }
     if (s.family === 'W' || s.family === 'WT') return { w: s.bf ?? 100, h: s.d ?? 100 }
     if (s.family === 'C') return { w: (s.bf ?? 60) + (s.tw ?? 10), h: s.d ?? 100 }
-    if (s.family === 'L') return { w: s.leg1 ?? 50, h: s.leg2 ?? 50 }
     if (s.family === 'HSS') return { w: s.b ?? 100, h: s.h ?? 100 }
     return { w: s.D ?? 100, h: s.D ?? 100 }   // pipe
   })()
@@ -47,12 +48,16 @@ export function SectionShape({ sec }: { sec: EffectiveSection }) {
       </>
     }
     if (s.family === 'L') {
-      const t = px(s.t ?? 8), l1 = px(s.leg1 ?? 50), l2 = px(s.leg2 ?? 50), g = px(sec.gap ?? 10)
-      const angle = (x0: number, flip = false) => flip
-        ? <path d={`M ${x0 + l1} ${oy} h ${-t} v ${l2 - t} h ${-(l1 - t)} v ${t} h ${l1} Z`} fill={FILL} stroke={EDGE} />
-        : <path d={`M ${x0} ${oy} h ${t} v ${l2 - t} h ${l1 - t} v ${t} h ${-l1} Z`} fill={FILL} stroke={EDGE} />
-      if (sec.double) return <>{angle(ox)}{angle(ox + l1 + g, true)}</>
-      return angle(ox)
+      // vertical (connected) leg of length legV at the heel; outstanding leg of
+      // length legH along the bottom. dir = +1 → leg extends right, −1 → left.
+      const t = px(s.t ?? 8), lv = px(legV), lh = px(legH), bot = oy + H
+      const angle = (heelX: number, dir: 1 | -1) =>
+        <path d={`M ${heelX} ${bot} h ${dir * lh} v ${-t} h ${-dir * (lh - t)} v ${-(lv - t)} h ${-dir * t} Z`} fill={FILL} stroke={EDGE} />
+      if (sec.double) {
+        const g = px(sec.gap ?? 0), cxL = ox + W / 2
+        return <>{angle(cxL - g / 2, -1)}{angle(cxL + g / 2, 1)}</>   // long legs back-to-back at centre
+      }
+      return angle(ox, 1)
     }
     if (s.family === 'HSS') {
       const t = px(s.t ?? 6)

--- a/webapp/src/engine/aiscSections.ts
+++ b/webapp/src/engine/aiscSections.ts
@@ -112,8 +112,9 @@ export interface EffectiveSection {
 }
 
 /** Back-to-back double angle: A doubles; rx unchanged; ry grows by the
- *  parallel-axis shift of each leg's centroid across the gap. */
-export function doubleAngle(angle: AiscShape, gap = 10): EffectiveSection {
+ *  parallel-axis shift of each leg's centroid across the gap (= separator/gusset
+ *  plate thickness, 0 = angles touching). */
+export function doubleAngle(angle: AiscShape, gap = 0): EffectiveSection {
   const xbar = angle.xbar ?? 0
   const ry2 = Math.sqrt(angle.ry * angle.ry + (xbar + gap / 2) ** 2)
   const rx2 = angle.rx
@@ -125,7 +126,7 @@ export function doubleAngle(angle: AiscShape, gap = 10): EffectiveSection {
 }
 
 /** Resolve a chosen shape (optionally doubled) into the effective section. */
-export function effectiveSection(shape: AiscShape, double = false, gap = 10): EffectiveSection {
+export function effectiveSection(shape: AiscShape, double = false, gap = 0): EffectiveSection {
   if (double && shape.family === 'L') return doubleAngle(shape, gap)
   const rmin = shape.family === 'L' ? Math.min(shape.rz ?? shape.rx, shape.rx) : Math.min(shape.rx, shape.ry)
   return { label: shape.name, family: shape.family, A: shape.A, rx: shape.rx, ry: shape.ry, rmin, double: false, base: shape }

--- a/webapp/src/lib/sectionShapes3d.ts
+++ b/webapp/src/lib/sectionShapes3d.ts
@@ -1,0 +1,70 @@
+// Build true-scale THREE.Shape profiles (metres, centred on the member axis) for
+// an AISC EffectiveSection, so each truss member can be extruded into its actual
+// cross-section in the 3D view. Double angles are drawn BACK-TO-BACK: the longer
+// (connected) legs face each other across the separator/gusset gap, the shorter
+// outstanding legs point away.
+import * as THREE from 'three'
+import type { EffectiveSection } from '../engine/aiscSections'
+
+const poly = (pts: [number, number][]): THREE.Shape => {
+  const s = new THREE.Shape()
+  s.moveTo(pts[0][0], pts[0][1])
+  for (let i = 1; i < pts.length; i++) s.lineTo(pts[i][0], pts[i][1])
+  s.closePath()
+  return s
+}
+
+/** One L-angle: heel at (hx, -legV/2); `dir` = +1 outstanding leg to the right,
+ *  −1 to the left. Vertical (connected) leg of length legV sits at the heel. */
+function angleShape(hx: number, dir: 1 | -1, t: number, legH: number, legV: number): THREE.Shape {
+  const x0 = hx, top = legV / 2, bot = -legV / 2
+  return poly([
+    [x0, bot], [x0 + dir * legH, bot], [x0 + dir * legH, bot + t],
+    [x0 + dir * t, bot + t], [x0 + dir * t, top], [x0, top],
+  ])
+}
+
+/** Profiles for the section, in metres, centred on (0,0). Usually one shape;
+ *  a double angle returns two. HSS/Pipe carry an inner hole. */
+export function buildSectionShapes(eff: EffectiveSection): THREE.Shape[] {
+  const s = eff.base, k = 1 / 1000   // mm → m
+  if (eff.family === 'W' || eff.family === 'WT') {
+    const bf = (s.bf ?? 100) * k, d = (s.d ?? 100) * k, tf = (s.tf ?? 8) * k, tw = (s.tw ?? 6) * k
+    const X = bf / 2, Y = d / 2
+    if (eff.family === 'WT') {
+      return [poly([[-X, Y], [X, Y], [X, Y - tf], [tw / 2, Y - tf], [tw / 2, -Y], [-tw / 2, -Y], [-tw / 2, Y - tf], [-X, Y - tf]])]
+    }
+    return [poly([
+      [-X, Y], [X, Y], [X, Y - tf], [tw / 2, Y - tf], [tw / 2, -(Y - tf)], [X, -(Y - tf)],
+      [X, -Y], [-X, -Y], [-X, -(Y - tf)], [-tw / 2, -(Y - tf)], [-tw / 2, Y - tf], [-X, Y - tf],
+    ])]
+  }
+  if (eff.family === 'C') {
+    const bf = (s.bf ?? 60) * k, d = (s.d ?? 100) * k, tf = (s.tf ?? 9) * k, tw = (s.tw ?? 8) * k
+    const X = bf / 2, Y = d / 2
+    return [poly([[-X, Y], [X, Y], [X, Y - tf], [-X + tw, Y - tf], [-X + tw, -(Y - tf)], [X, -(Y - tf)], [X, -Y], [-X, -Y]])]
+  }
+  if (eff.family === 'L') {
+    const legV = Math.max(s.leg1 ?? 50, s.leg2 ?? 50) * k   // longer = connected (vertical)
+    const legH = Math.min(s.leg1 ?? 50, s.leg2 ?? 50) * k
+    const t = (s.t ?? 8) * k
+    if (eff.double) {
+      const g = (eff.gap ?? 0) * k
+      return [angleShape(-g / 2, -1, t, legH, legV), angleShape(g / 2, 1, t, legH, legV)]
+    }
+    return [angleShape(-legH / 2, 1, t, legH, legV)]   // single, centred-ish
+  }
+  if (eff.family === 'HSS') {
+    const b = (s.b ?? 100) * k, h = (s.h ?? 100) * k, t = (s.t ?? 6) * k
+    const outer = poly([[-b / 2, h / 2], [b / 2, h / 2], [b / 2, -h / 2], [-b / 2, -h / 2]])
+    const hole = poly([[-b / 2 + t, h / 2 - t], [b / 2 - t, h / 2 - t], [b / 2 - t, -(h / 2 - t)], [-b / 2 + t, -(h / 2 - t)]])
+    outer.holes.push(hole as unknown as THREE.Path)
+    return [outer]
+  }
+  // pipe / round HSS
+  const R = ((s.D ?? 100) / 2) * k, t = (s.t ?? 6) * k
+  const o = new THREE.Shape(); o.absarc(0, 0, R, 0, Math.PI * 2, false)
+  const hole = new THREE.Path(); hole.absarc(0, 0, R - t, 0, Math.PI * 2, true)
+  o.holes.push(hole)
+  return [o]
+}

--- a/webapp/src/pages/TrussSpace.tsx
+++ b/webapp/src/pages/TrussSpace.tsx
@@ -7,27 +7,38 @@ import { generateTruss, solveTruss, type TrussType } from '../engine/truss'
 import { designTruss, type MemberDesign, type TrussSection } from '../engine/trussDesign'
 import { FAMILIES, shapesOf, shapeByName, effectiveSection, type SectionFamily } from '../engine/aiscSections'
 import { SectionShape } from '../components/SectionShape'
+import { buildSectionShapes } from '../lib/sectionShapes3d'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { ReportControls } from '../components/ReportControls'
 import { f1, f2 } from '../lib/format'
 
 const TENSION = '#1d4ed8', COMPRESSION = '#dc2626', ZERO = '#94a3b8', SEL = '#f59e0b'
-const UP = new THREE.Vector3(0, 1, 0)
+const WORLD_Z = new THREE.Vector3(0, 0, 1)
 
-/** A truss member drawn as a coloured cylinder (blue = tension, red = compression). */
-function Member3D({ a, b, color, thick, selected, onPick }: {
-  a: THREE.Vector3; b: THREE.Vector3; color: string; thick: number; selected: boolean; onPick: () => void
+/** A truss member drawn as its ACTUAL cross-section extruded along the member,
+ *  coloured blue = tension / red = compression. */
+function Member3D({ a, b, shapes, color, selected, onPick }: {
+  a: THREE.Vector3; b: THREE.Vector3; shapes: THREE.Shape[]; color: string; selected: boolean; onPick: () => void
 }) {
-  const dir = useMemo(() => new THREE.Vector3().subVectors(b, a), [a, b])
-  const len = dir.length()
-  const mid = useMemo(() => new THREE.Vector3().addVectors(a, b).multiplyScalar(0.5), [a, b])
-  const quat = useMemo(() => new THREE.Quaternion().setFromUnitVectors(UP, dir.clone().normalize()), [dir])
-  const r = (selected ? 1.6 : 1) * thick
+  const len = useMemo(() => a.distanceTo(b), [a, b])
+  // basis: extrude along the member axis; section "height" points out of plane.
+  const quat = useMemo(() => {
+    const z = new THREE.Vector3().subVectors(b, a).normalize()
+    let x = new THREE.Vector3().crossVectors(z, WORLD_Z)
+    if (x.lengthSq() < 1e-9) x = new THREE.Vector3(1, 0, 0)
+    x.normalize()
+    const y = new THREE.Vector3().crossVectors(z, x).normalize()
+    return new THREE.Quaternion().setFromRotationMatrix(new THREE.Matrix4().makeBasis(x, y, z))
+  }, [a, b])
   return (
-    <mesh position={mid} quaternion={quat} onClick={(e) => { e.stopPropagation(); onPick() }}>
-      <cylinderGeometry args={[r, r, len, 10]} />
-      <meshStandardMaterial color={selected ? SEL : color} />
-    </mesh>
+    <group position={a} quaternion={quat} onClick={(e) => { e.stopPropagation(); onPick() }}>
+      {shapes.map((sh, i) => (
+        <mesh key={i}>
+          <extrudeGeometry args={[sh, { depth: len, bevelEnabled: false, steps: 1 }]} />
+          <meshStandardMaterial color={selected ? SEL : color} metalness={0.1} roughness={0.65} />
+        </mesh>
+      ))}
+    </group>
   )
 }
 
@@ -64,7 +75,7 @@ export default function TrussSpace() {
   const [family, setFamily] = useState<SectionFamily>('L')
   const [shapeName, setShapeName] = useState('L102x102x9.5')
   const [double, setDouble] = useState(true)        // double angle (2L) when family = L
-  const [gap, setGap] = useState(10)                // gusset gap, mm
+  const [gap, setGap] = useState(0)                 // separator/gusset plate thickness, mm (0 = touching)
   const [selected, setSelected] = useState<string | null>(null)
   const controlsRef = useRef<React.ComponentRef<typeof OrbitControls>>(null)
 
@@ -88,13 +99,13 @@ export default function TrussSpace() {
   }, [shapeName, family, double, gap])
   const section: TrussSection = useMemo(() => ({ A: eff.A, r: eff.rmin, E, Fy, K }), [eff, E, Fy, K])
   const design = useMemo(() => (result ? designTruss(result.forces, section) : null), [result, section])
+  const shapes3d = useMemo(() => buildSectionShapes(eff), [eff])   // true-scale section profiles for the 3D extrusion
 
   const pos = useMemo(() => {
     const map = new Map<string, THREE.Vector3>()
     model.nodes.forEach((nd) => map.set(nd.id, new THREE.Vector3(nd.x, nd.y, 0)))
     return map
   }, [model])
-  const maxAbs = Math.max(1e-6, ...(result?.forces.map((f) => Math.abs(f.N)) ?? [1]))
   const designById = useMemo(() => new Map((design?.members ?? []).map((d) => [d.id, d])), [design])
 
   const cx = span / 2, cyc = height / 2
@@ -116,7 +127,7 @@ export default function TrussSpace() {
         {/* 3D viewport */}
         <div className="no-print lg:sticky lg:top-4">
           <div className="relative h-[70vh] min-h-[420px] overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
-            <Canvas camera={{ position: [cx, cyc + height * 0.5 + 1, Math.max(span, 6) * 1.25], fov: 45 }} onPointerMissed={() => setSelected(null)}>
+            <Canvas camera={{ position: [cx - span * 0.35, cyc + height + span * 0.22, Math.max(span, 6) * 1.0], fov: 45 }} onPointerMissed={() => setSelected(null)}>
               <color attach="background" args={['#f8fafc']} />
               <ambientLight intensity={0.9} />
               <directionalLight position={[6, 12, 10]} intensity={0.8} />
@@ -124,8 +135,7 @@ export default function TrussSpace() {
                 const a = pos.get(mb.i), b = pos.get(mb.j); if (!a || !b) return null
                 const N = result?.forces.find((f) => f.id === mb.id)?.N ?? 0
                 const color = Math.abs(N) < 1e-6 ? ZERO : N > 0 ? TENSION : COMPRESSION
-                const thick = 0.03 + 0.06 * (Math.abs(N) / maxAbs)
-                return <Member3D key={mb.id} a={a} b={b} color={color} thick={thick} selected={mb.id === selected} onPick={() => setSelected(mb.id)} />
+                return <Member3D key={mb.id} a={a} b={b} shapes={shapes3d} color={color} selected={mb.id === selected} onPick={() => setSelected(mb.id)} />
               })}
               {model.nodes.map((nd) => { const p = pos.get(nd.id)!; return (
                 <mesh key={nd.id} position={p}><sphereGeometry args={[0.07, 12, 12]} /><meshStandardMaterial color="#334155" /></mesh>
@@ -178,7 +188,7 @@ export default function TrussSpace() {
                 <span>Double angle (2L, back-to-back)</span>
               </label>
             )}
-            {family === 'L' && double && <Num label="Gusset gap" unit="mm" value={gap} onChange={setGap} step="1" />}
+            {family === 'L' && double && <Num label="Separator plate thickness" unit="mm" value={gap} onChange={setGap} step="1" />}
             <Num label="Fy" unit="MPa" value={Fy} onChange={setFy} step="5" />
             <Num label="E" unit="MPa" value={E} onChange={setE} step="1000" />
             <Num label="Effective length K" value={K} onChange={setK} step="0.05" />


### PR DESCRIPTION
Addresses the three corrections.

## 1. Real sections extruded in the 3D viewport (not just the 2D drawing)
New **`lib/sectionShapes3d.ts`** builds true-scale `THREE.Shape` profiles per family (I-shape, tee, channel, single/double angle, HSS with wall hole, pipe annulus). `Member3D` now **extrudes the actual section along each member** (oriented along the member axis, section depth out of the truss plane) instead of drawing a plain cylinder. The default camera is angled (¾ view) so the profiles are visible; orbit/zoom to inspect.

## 2. Double angles are now truly BACK-TO-BACK
They were drawn toe-to-toe. Now the **longer (connected) legs face each other across the gap** and the shorter outstanding legs point away — in both the 3D extrusion and the 2D `SectionShape` drawing. (`ry` recomputes accordingly: e.g. 2L 102×102×9.5 at gap 0 → ry 41.8 mm, r_min 31.8 mm.)

## 3. Gap = separator-plate thickness, not a hardcoded 10
The double-angle gap **defaults to 0** (angles touching) and represents the **gusset/separator plate thickness** when one is present. The input is relabelled "Separator plate thickness (mm)"; the engine defaults (`doubleAngle`, `effectiveSection`) are 0.

## Verification
- `tsc -b` clean; `vitest run` → **251 passed**.
- Browser: members render as 3D extruded sections (¾ view shows the bar depth); the 2L draws back-to-back at gap 0 (ry 41.8); switching W / HSS / Pipe extrudes correctly with no console errors; load arrows point down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)