### PR TITLE
Zoom-to-extents on load (frame + truss) + Truss Phase 2 (self-weight + NSCP combos)

### DIFF
--- a/webapp/src/components/FitView.tsx
+++ b/webapp/src/components/FitView.tsx
@@ -1,0 +1,40 @@
+import { useEffect } from 'react'
+import { useThree } from '@react-three/fiber'
+import * as THREE from 'three'
+import type { OrbitControls as OrbitControlsImpl } from 'three-stdlib'
+
+/**
+ * Zoom-to-extents: on mount (and whenever the model bounds change) frame the
+ * whole model so every member is visible. Keeps a fixed viewing direction and
+ * recentres the default OrbitControls on the model. Render inside a <Canvas>.
+ */
+export function FitView({ box, dir = [1, 0.8, 1], margin = 1.3 }: {
+  box: { min: [number, number, number]; max: [number, number, number] } | null
+  dir?: [number, number, number]
+  margin?: number
+}) {
+  const camera = useThree((s) => s.camera)
+  const controls = useThree((s) => s.controls) as OrbitControlsImpl | null
+  const minKey = box ? box.min.join(',') : ''
+  const maxKey = box ? box.max.join(',') : ''
+
+  useEffect(() => {
+    if (!box) return
+    const min = new THREE.Vector3(...box.min), max = new THREE.Vector3(...box.max)
+    const center = min.clone().add(max).multiplyScalar(0.5)
+    const radius = Math.max(max.clone().sub(min).length() / 2, 0.5)
+    const persp = camera as THREE.PerspectiveCamera
+    const fov = ((persp.fov ?? 45) * Math.PI) / 180
+    const dist = (radius / Math.sin(fov / 2)) * margin
+    const d = new THREE.Vector3(...dir).normalize()
+    persp.position.copy(center.clone().add(d.multiplyScalar(dist)))
+    persp.near = Math.max(dist / 100, 0.01)
+    persp.far = dist * 10
+    persp.updateProjectionMatrix()
+    if (controls) { controls.target.copy(center); controls.update() }
+    else persp.lookAt(center)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [minKey, maxKey, controls, camera])
+
+  return null
+}

--- a/webapp/src/components/SectionShape.tsx
+++ b/webapp/src/components/SectionShape.tsx
@@ -8,12 +8,13 @@ const FILL = '#94a3b8', EDGE = '#37526e', BLUE = '#0056b3'
 export function SectionShape({ sec }: { sec: EffectiveSection }) {
   const VB = 150, pad = 22
   const s = sec.base
+  // for angles: longer leg = connected (drawn vertical), shorter = outstanding
+  const legV = Math.max(s.leg1 ?? 50, s.leg2 ?? 50), legH = Math.min(s.leg1 ?? 50, s.leg2 ?? 50)
   // overall bounding box (mm) of what we draw
   const box = (() => {
-    if (sec.double && s.leg1) return { w: 2 * (s.leg1 ?? 0) + (sec.gap ?? 10), h: s.leg2 ?? 0 }
+    if (s.family === 'L') return sec.double ? { w: 2 * legH + (sec.gap ?? 0), h: legV } : { w: legH, h: legV }
     if (s.family === 'W' || s.family === 'WT') return { w: s.bf ?? 100, h: s.d ?? 100 }
     if (s.family === 'C') return { w: (s.bf ?? 60) + (s.tw ?? 10), h: s.d ?? 100 }
-    if (s.family === 'L') return { w: s.leg1 ?? 50, h: s.leg2 ?? 50 }
     if (s.family === 'HSS') return { w: s.b ?? 100, h: s.h ?? 100 }
     return { w: s.D ?? 100, h: s.D ?? 100 }   // pipe
   })()
@@ -47,12 +48,16 @@ export function SectionShape({ sec }: { sec: EffectiveSection }) {
       </>
     }
     if (s.family === 'L') {
-      const t = px(s.t ?? 8), l1 = px(s.leg1 ?? 50), l2 = px(s.leg2 ?? 50), g = px(sec.gap ?? 10)
-      const angle = (x0: number, flip = false) => flip
-        ? <path d={`M ${x0 + l1} ${oy} h ${-t} v ${l2 - t} h ${-(l1 - t)} v ${t} h ${l1} Z`} fill={FILL} stroke={EDGE} />
-        : <path d={`M ${x0} ${oy} h ${t} v ${l2 - t} h ${l1 - t} v ${t} h ${-l1} Z`} fill={FILL} stroke={EDGE} />
-      if (sec.double) return <>{angle(ox)}{angle(ox + l1 + g, true)}</>
-      return angle(ox)
+      // vertical (connected) leg of length legV at the heel; outstanding leg of
+      // length legH along the bottom. dir = +1 → leg extends right, −1 → left.
+      const t = px(s.t ?? 8), lv = px(legV), lh = px(legH), bot = oy + H
+      const angle = (heelX: number, dir: 1 | -1) =>
+        <path d={`M ${heelX} ${bot} h ${dir * lh} v ${-t} h ${-dir * (lh - t)} v ${-(lv - t)} h ${-dir * t} Z`} fill={FILL} stroke={EDGE} />
+      if (sec.double) {
+        const g = px(sec.gap ?? 0), cxL = ox + W / 2
+        return <>{angle(cxL - g / 2, -1)}{angle(cxL + g / 2, 1)}</>   // long legs back-to-back at centre
+      }
+      return angle(ox, 1)
     }
     if (s.family === 'HSS') {
       const t = px(s.t ?? 6)

--- a/webapp/src/engine/aiscSections.ts
+++ b/webapp/src/engine/aiscSections.ts
@@ -112,8 +112,9 @@ export interface EffectiveSection {
 }
 
 /** Back-to-back double angle: A doubles; rx unchanged; ry grows by the
- *  parallel-axis shift of each leg's centroid across the gap. */
-export function doubleAngle(angle: AiscShape, gap = 10): EffectiveSection {
+ *  parallel-axis shift of each leg's centroid across the gap (= separator/gusset
+ *  plate thickness, 0 = angles touching). */
+export function doubleAngle(angle: AiscShape, gap = 0): EffectiveSection {
   const xbar = angle.xbar ?? 0
   const ry2 = Math.sqrt(angle.ry * angle.ry + (xbar + gap / 2) ** 2)
   const rx2 = angle.rx
@@ -125,7 +126,7 @@ export function doubleAngle(angle: AiscShape, gap = 10): EffectiveSection {
 }
 
 /** Resolve a chosen shape (optionally doubled) into the effective section. */
-export function effectiveSection(shape: AiscShape, double = false, gap = 10): EffectiveSection {
+export function effectiveSection(shape: AiscShape, double = false, gap = 0): EffectiveSection {
   if (double && shape.family === 'L') return doubleAngle(shape, gap)
   const rmin = shape.family === 'L' ? Math.min(shape.rz ?? shape.rx, shape.rx) : Math.min(shape.rx, shape.ry)
   return { label: shape.name, family: shape.family, A: shape.A, rx: shape.rx, ry: shape.ry, rmin, double: false, base: shape }

--- a/webapp/src/engine/truss.test.ts
+++ b/webapp/src/engine/truss.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { generateTruss, solveTruss, type TrussModel } from './truss'
+import { generateTruss, solveTruss, selfWeightLoads, solveTrussEnvelope, TRUSS_COMBOS, type TrussModel } from './truss'
 import { designTruss, designTrussMember } from './trussDesign'
 
 describe('truss solver — statics', () => {
@@ -49,6 +49,37 @@ describe('truss solver — statics', () => {
       expect(r, type).not.toBeNull()
       expect(r!.stable, type).toBe(true)
     }
+  })
+})
+
+describe('truss self-weight + NSCP load combinations', () => {
+  const m = generateTruss({ type: 'pratt', span: 12, height: 2, panels: 4, panelLoad: 0 })
+
+  it('self-weight lumps the total member weight half to each end joint', () => {
+    const sw = selfWeightLoads(m, 3000)   // A = 3000 mm² = 0.003 m²
+    const total = sw.reduce((s, l) => s - l.fy, 0)   // all downward
+    const memberLen = m.members.reduce((s, mb) => {
+      const a = m.nodes.find((n) => n.id === mb.i)!, b = m.nodes.find((n) => n.id === mb.j)!
+      return s + Math.hypot(b.x - a.x, b.y - a.y)
+    }, 0)
+    expect(total).toBeCloseTo(0.003 * memberLen * 77.0, 6)   // Σ joint loads = Σ member weight
+  })
+
+  it('envelope picks the governing combo and balances the factored load', () => {
+    const loaded = [...new Set(m.loads.map((l) => l.node))]   // top-chord nodes
+    const dead = loaded.map((n) => ({ node: n, fx: 0, fy: -4 }))
+    const live = loaded.map((n) => ({ node: n, fx: 0, fy: -10 }))
+    const env = solveTrussEnvelope(m, dead, live)!
+    expect(env.stable).toBe(true)
+    // 1.2D+1.6L (1.6·10 dominates) should govern the reactions over 1.4D
+    expect(env.reactionCombo).toBe('1.2D + 1.6L')
+    const Ry = env.reactions.reduce((s, r) => s + r.fy, 0)
+    const factored = loaded.length * (1.2 * 4 + 1.6 * 10)
+    expect(Ry).toBeCloseTo(factored, 3)
+    // every member carries a combo label from the set
+    const names = TRUSS_COMBOS.map((c) => c.name)
+    expect(env.forces.every((f) => names.includes(f.combo))).toBe(true)
+    expect(env.forces).toHaveLength(m.members.length)
   })
 })
 

--- a/webapp/src/engine/truss.ts
+++ b/webapp/src/engine/truss.ts
@@ -170,3 +170,71 @@ export function solveTruss(model: TrussModel): TrussResult | null {
   const status: Determinacy['status'] = value < 0 ? 'unstable' : value === 0 ? 'determinate' : 'indeterminate'
   return { forces, reactions, determinacy: { m: members.length, r, j, value, status }, maxTension, maxCompression, stable: true }
 }
+
+// ── Phase 2: self-weight + NSCP load combinations ──────────────────────────
+const STEEL_UNIT_WT = 77.0   // kN/m³ (7850 kg/m³ · g)
+
+/** Member self-weight (kN) lumped half to each end joint as a downward load (D).
+ *  `areaMm2` = the chosen section area. */
+export function selfWeightLoads(model: TrussModel, areaMm2: number, gamma = STEEL_UNIT_WT): TLoad[] {
+  const nm = new Map(model.nodes.map((n) => [n.id, n]))
+  const w = new Map<string, number>()
+  for (const m of model.members) {
+    const a = nm.get(m.i), b = nm.get(m.j); if (!a || !b) continue
+    const wt = (areaMm2 / 1e6) * len(a, b) * gamma   // kN over the member
+    w.set(m.i, (w.get(m.i) ?? 0) + wt / 2)
+    w.set(m.j, (w.get(m.j) ?? 0) + wt / 2)
+  }
+  return [...w].map(([node, mag]) => ({ node, fx: 0, fy: -mag }))
+}
+
+/** Gravity NSCP load combinations applicable to a truss (D, L only). */
+export const TRUSS_COMBOS: { name: string; D: number; L: number }[] = [
+  { name: '1.4D', D: 1.4, L: 0 },
+  { name: '1.2D + 1.6L', D: 1.2, L: 1.6 },
+]
+
+export interface EnvForce extends MemberForce { combo: string }
+export interface TrussEnvelope {
+  forces: EnvForce[]                 // governing (max |N|) per member, with the combo
+  reactions: Reaction[]              // for the governing-gravity combo
+  reactionCombo: string
+  determinacy: Determinacy
+  maxTension: number; maxCompression: number
+  stable: boolean
+}
+
+/**
+ * Envelope a truss over the NSCP gravity combinations. Solves the Dead and Live
+ * cases once each (linear superposition) and, per member, keeps the combination
+ * giving the largest |axial force|. Reactions are reported for the combo with
+ * the greatest total vertical reaction.
+ */
+export function solveTrussEnvelope(model: TrussModel, dead: TLoad[], live: TLoad[]): TrussEnvelope | null {
+  const rD = solveTruss({ ...model, loads: dead })
+  const rL = solveTruss({ ...model, loads: live })
+  if (!rD || !rL) return null
+  if (!rD.stable) return { forces: [], reactions: [], reactionCombo: '', determinacy: rD.determinacy, maxTension: 0, maxCompression: 0, stable: false }
+
+  const forces: EnvForce[] = rD.forces.map((fD, i) => {
+    const fL = rL.forces[i]
+    let bestN = 0, bestCombo = TRUSS_COMBOS[0].name
+    for (const c of TRUSS_COMBOS) {
+      const N = c.D * fD.N + c.L * fL.N
+      if (Math.abs(N) > Math.abs(bestN)) { bestN = N; bestCombo = c.name }
+    }
+    return { ...fD, N: bestN, combo: bestCombo }
+  })
+  const maxTension = Math.max(0, ...forces.map((f) => f.N))
+  const maxCompression = Math.max(0, ...forces.map((f) => -f.N))
+
+  // reactions for the combo with the largest total vertical reaction
+  let bestTotal = -Infinity, reactions: Reaction[] = rD.reactions, reactionCombo = TRUSS_COMBOS[0].name
+  for (const c of TRUSS_COMBOS) {
+    const rx = rD.reactions.map((r, k) => ({ node: r.node, fx: c.D * r.fx + c.L * rL.reactions[k].fx, fy: c.D * r.fy + c.L * rL.reactions[k].fy }))
+    const total = rx.reduce((s, r) => s + r.fy, 0)
+    if (total > bestTotal) { bestTotal = total; reactions = rx; reactionCombo = c.name }
+  }
+
+  return { forces, reactions, reactionCombo, determinacy: rD.determinacy, maxTension, maxCompression, stable: true }
+}

--- a/webapp/src/lib/sectionShapes3d.ts
+++ b/webapp/src/lib/sectionShapes3d.ts
@@ -1,0 +1,70 @@
+// Build true-scale THREE.Shape profiles (metres, centred on the member axis) for
+// an AISC EffectiveSection, so each truss member can be extruded into its actual
+// cross-section in the 3D view. Double angles are drawn BACK-TO-BACK: the longer
+// (connected) legs face each other across the separator/gusset gap, the shorter
+// outstanding legs point away.
+import * as THREE from 'three'
+import type { EffectiveSection } from '../engine/aiscSections'
+
+const poly = (pts: [number, number][]): THREE.Shape => {
+  const s = new THREE.Shape()
+  s.moveTo(pts[0][0], pts[0][1])
+  for (let i = 1; i < pts.length; i++) s.lineTo(pts[i][0], pts[i][1])
+  s.closePath()
+  return s
+}
+
+/** One L-angle: heel at (hx, -legV/2); `dir` = +1 outstanding leg to the right,
+ *  −1 to the left. Vertical (connected) leg of length legV sits at the heel. */
+function angleShape(hx: number, dir: 1 | -1, t: number, legH: number, legV: number): THREE.Shape {
+  const x0 = hx, top = legV / 2, bot = -legV / 2
+  return poly([
+    [x0, bot], [x0 + dir * legH, bot], [x0 + dir * legH, bot + t],
+    [x0 + dir * t, bot + t], [x0 + dir * t, top], [x0, top],
+  ])
+}
+
+/** Profiles for the section, in metres, centred on (0,0). Usually one shape;
+ *  a double angle returns two. HSS/Pipe carry an inner hole. */
+export function buildSectionShapes(eff: EffectiveSection): THREE.Shape[] {
+  const s = eff.base, k = 1 / 1000   // mm → m
+  if (eff.family === 'W' || eff.family === 'WT') {
+    const bf = (s.bf ?? 100) * k, d = (s.d ?? 100) * k, tf = (s.tf ?? 8) * k, tw = (s.tw ?? 6) * k
+    const X = bf / 2, Y = d / 2
+    if (eff.family === 'WT') {
+      return [poly([[-X, Y], [X, Y], [X, Y - tf], [tw / 2, Y - tf], [tw / 2, -Y], [-tw / 2, -Y], [-tw / 2, Y - tf], [-X, Y - tf]])]
+    }
+    return [poly([
+      [-X, Y], [X, Y], [X, Y - tf], [tw / 2, Y - tf], [tw / 2, -(Y - tf)], [X, -(Y - tf)],
+      [X, -Y], [-X, -Y], [-X, -(Y - tf)], [-tw / 2, -(Y - tf)], [-tw / 2, Y - tf], [-X, Y - tf],
+    ])]
+  }
+  if (eff.family === 'C') {
+    const bf = (s.bf ?? 60) * k, d = (s.d ?? 100) * k, tf = (s.tf ?? 9) * k, tw = (s.tw ?? 8) * k
+    const X = bf / 2, Y = d / 2
+    return [poly([[-X, Y], [X, Y], [X, Y - tf], [-X + tw, Y - tf], [-X + tw, -(Y - tf)], [X, -(Y - tf)], [X, -Y], [-X, -Y]])]
+  }
+  if (eff.family === 'L') {
+    const legV = Math.max(s.leg1 ?? 50, s.leg2 ?? 50) * k   // longer = connected (vertical)
+    const legH = Math.min(s.leg1 ?? 50, s.leg2 ?? 50) * k
+    const t = (s.t ?? 8) * k
+    if (eff.double) {
+      const g = (eff.gap ?? 0) * k
+      return [angleShape(-g / 2, -1, t, legH, legV), angleShape(g / 2, 1, t, legH, legV)]
+    }
+    return [angleShape(-legH / 2, 1, t, legH, legV)]   // single, centred-ish
+  }
+  if (eff.family === 'HSS') {
+    const b = (s.b ?? 100) * k, h = (s.h ?? 100) * k, t = (s.t ?? 6) * k
+    const outer = poly([[-b / 2, h / 2], [b / 2, h / 2], [b / 2, -h / 2], [-b / 2, -h / 2]])
+    const hole = poly([[-b / 2 + t, h / 2 - t], [b / 2 - t, h / 2 - t], [b / 2 - t, -(h / 2 - t)], [-b / 2 + t, -(h / 2 - t)]])
+    outer.holes.push(hole as unknown as THREE.Path)
+    return [outer]
+  }
+  // pipe / round HSS
+  const R = ((s.D ?? 100) / 2) * k, t = (s.t ?? 6) * k
+  const o = new THREE.Shape(); o.absarc(0, 0, R, 0, Math.PI * 2, false)
+  const hole = new THREE.Path(); hole.absarc(0, 0, R - t, 0, Math.PI * 2, true)
+  o.holes.push(hole)
+  return [o]
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -27,6 +27,7 @@ import { FootingSchematic } from '../components/FootingSchematic'
 import { DimBelow, DimSide } from '../components/dims'
 import { HintButton, SeismicHint, WindHint } from '../components/LoadHints'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
+import { FitView } from '../components/FitView'
 import { f1, f2 } from '../lib/format'
 
 const AUTOSAVE_KEY = 'model-space-autosave'
@@ -847,6 +848,12 @@ export default function ModelSpace() {
     model?.nodes.forEach((n) => map.set(n.id, new THREE.Vector3(n.x, n.y, n.z)))
     return map
   }, [model])
+  // model bounds → zoom-to-extents on load / after generate
+  const modelBox = useMemo(() => {
+    if (!model || model.nodes.length === 0) return null
+    const xs = model.nodes.map((n) => n.x), ys = model.nodes.map((n) => n.y), zs = model.nodes.map((n) => n.z)
+    return { min: [Math.min(...xs), Math.min(...ys), Math.min(...zs)] as [number, number, number], max: [Math.max(...xs), Math.max(...ys), Math.max(...zs)] as [number, number, number] }
+  }, [model])
 
   const selMember: Member | undefined = model?.members.find((m) => m.id === selected)
   const selPlate: Plate | undefined = model?.plates.find((p) => p.id === selected)
@@ -948,6 +955,7 @@ export default function ModelSpace() {
                 <color attach="background" args={['#f8fafc']} />
                 <ambientLight intensity={0.85} />
                 <directionalLight position={[12, 18, 8]} intensity={0.9} />
+                <FitView box={modelBox} dir={[1, 0.8, 1]} />
                 <gridHelper args={[40, 40, '#cbd5e1', '#e2e8f0']} />
                 {model.members.map((m) => {
                   const a = nodePos.get(m.i), bb = nodePos.get(m.j)

--- a/webapp/src/pages/TrussSpace.tsx
+++ b/webapp/src/pages/TrussSpace.tsx
@@ -3,10 +3,11 @@ import { Link } from 'react-router-dom'
 import { Canvas } from '@react-three/fiber'
 import { OrbitControls, Text } from '@react-three/drei'
 import * as THREE from 'three'
-import { generateTruss, solveTruss, type TrussType } from '../engine/truss'
+import { generateTruss, solveTrussEnvelope, selfWeightLoads, type TrussType } from '../engine/truss'
 import { designTruss, type MemberDesign, type TrussSection } from '../engine/trussDesign'
 import { FAMILIES, shapesOf, shapeByName, effectiveSection, type SectionFamily } from '../engine/aiscSections'
 import { SectionShape } from '../components/SectionShape'
+import { FitView } from '../components/FitView'
 import { buildSectionShapes } from '../lib/sectionShapes3d'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { ReportControls } from '../components/ReportControls'
@@ -69,7 +70,10 @@ export default function TrussSpace() {
   const [span, setSpan] = useState(12)
   const [height, setHeight] = useState(2)
   const [panels, setPanels] = useState(4)
-  const [panelLoad, setPanelLoad] = useState(15)
+  // joint loads (kN at each loaded chord node) + self-weight (auto from section)
+  const [deadLoad, setDeadLoad] = useState(3)
+  const [liveLoad, setLiveLoad] = useState(15)
+  const [includeSW, setIncludeSW] = useState(true)
   // section & material (steel, AISC LRFD)
   const [E, setE] = useState(200000); const [Fy, setFy] = useState(248); const [K, setK] = useState(1.0)
   const [family, setFamily] = useState<SectionFamily>('L')
@@ -91,13 +95,22 @@ export default function TrussSpace() {
     return () => { window.removeEventListener('keydown', d); window.removeEventListener('keyup', u) }
   }, [])
 
-  const model = useMemo(() => generateTruss({ type, span, height, panels, panelLoad }), [type, span, height, panels, panelLoad])
-  const result = useMemo(() => solveTruss(model), [model])
+  const model = useMemo(() => generateTruss({ type, span, height, panels, panelLoad: liveLoad }), [type, span, height, panels, liveLoad])
   const eff = useMemo(() => {
     const shp = shapeByName(shapeName) ?? shapesOf(family)[0]
     return effectiveSection(shp, double && shp.family === 'L', gap)
   }, [shapeName, family, double, gap])
   const section: TrussSection = useMemo(() => ({ A: eff.A, r: eff.rmin, E, Fy, K }), [eff, E, Fy, K])
+
+  // load cases: Dead = self-weight (section-derived) + dead joint loads; Live =
+  // live joint loads. Envelope over the NSCP gravity combinations.
+  const loadedNodes = useMemo(() => [...new Set(model.loads.map((l) => l.node))], [model])
+  const dead = useMemo(() => [
+    ...(includeSW ? selfWeightLoads(model, eff.A) : []),
+    ...loadedNodes.map((n) => ({ node: n, fx: 0, fy: -deadLoad })),
+  ], [model, includeSW, eff.A, loadedNodes, deadLoad])
+  const live = useMemo(() => loadedNodes.map((n) => ({ node: n, fx: 0, fy: -liveLoad })), [loadedNodes, liveLoad])
+  const result = useMemo(() => solveTrussEnvelope(model, dead, live), [model, dead, live])
   const design = useMemo(() => (result ? designTruss(result.forces, section) : null), [result, section])
   const shapes3d = useMemo(() => buildSectionShapes(eff), [eff])   // true-scale section profiles for the 3D extrusion
 
@@ -106,11 +119,16 @@ export default function TrussSpace() {
     model.nodes.forEach((nd) => map.set(nd.id, new THREE.Vector3(nd.x, nd.y, 0)))
     return map
   }, [model])
+  const box = useMemo(() => {
+    const xs = model.nodes.map((n) => n.x), ys = model.nodes.map((n) => n.y)
+    return { min: [Math.min(...xs), Math.min(...ys), 0] as [number, number, number], max: [Math.max(...xs), Math.max(...ys), 0] as [number, number, number] }
+  }, [model])
   const designById = useMemo(() => new Map((design?.members ?? []).map((d) => [d.id, d])), [design])
 
   const cx = span / 2, cyc = height / 2
   const selForce = result?.forces.find((f) => f.id === selected)
   const selDes = selForce ? designById.get(selForce.id) : undefined
+  const serviceLoad = deadLoad + liveLoad
 
   return (
     <div className="mx-auto max-w-[1700px] p-4">
@@ -131,6 +149,7 @@ export default function TrussSpace() {
               <color attach="background" args={['#f8fafc']} />
               <ambientLight intensity={0.9} />
               <directionalLight position={[6, 12, 10]} intensity={0.8} />
+              <FitView box={box} dir={[-0.45, 0.4, 1]} />
               {model.members.map((mb) => {
                 const a = pos.get(mb.i), b = pos.get(mb.j); if (!a || !b) return null
                 const N = result?.forces.find((f) => f.id === mb.id)?.N ?? 0
@@ -141,7 +160,7 @@ export default function TrussSpace() {
                 <mesh key={nd.id} position={p}><sphereGeometry args={[0.07, 12, 12]} /><meshStandardMaterial color="#334155" /></mesh>
               ) })}
               {model.supports.map((s) => { const p = pos.get(s.node); return p ? <Support3D key={s.node} p={p} roller={!s.ux} /> : null })}
-              {model.loads.map((l, i) => { const p = pos.get(l.node); return p && Math.abs(l.fy) > 1e-6 ? <Load3D key={i} p={p} mag={Math.abs(l.fy)} /> : null })}
+              {serviceLoad > 1e-6 && loadedNodes.map((n) => { const p = pos.get(n); return p ? <Load3D key={n} p={p} mag={serviceLoad} /> : null })}
               {selForce && pos.get(selForce.i) && pos.get(selForce.j) && (
                 <Text position={[(pos.get(selForce.i)!.x + pos.get(selForce.j)!.x) / 2, (pos.get(selForce.i)!.y + pos.get(selForce.j)!.y) / 2 + 0.25, 0]}
                   fontSize={0.3} color="#0f172a" anchorX="center" anchorY="middle" outlineWidth={0.012} outlineColor="#ffffff">
@@ -174,7 +193,18 @@ export default function TrussSpace() {
             <Num label="Span" unit="m" value={span} onChange={setSpan} step="0.5" />
             <Num label="Height" unit="m" value={height} onChange={setHeight} step="0.25" />
             <Num label="Panels" value={panels} onChange={(v) => setPanels(Math.max(2, Math.round(v)))} step="1" />
-            <Num label="Joint load" unit="kN" value={panelLoad} onChange={setPanelLoad} step="1" />
+          </Card>
+
+          <Card title="Loads (NSCP combinations)">
+            <Num label="Dead joint load" unit="kN" value={deadLoad} onChange={setDeadLoad} step="1" />
+            <Num label="Live joint load" unit="kN" value={liveLoad} onChange={setLiveLoad} step="1" />
+            <label className="col-span-full flex items-center gap-2 text-sm">
+              <input type="checkbox" checked={includeSW} onChange={(e) => setIncludeSW(e.target.checked)} />
+              <span>Add member self-weight (from the section) to Dead</span>
+            </label>
+            <p className="col-span-full text-[11px] text-slate-400">
+              Members are enveloped over <b>1.4D</b> and <b>1.2D + 1.6L</b>; each is designed for its governing combination.
+            </p>
           </Card>
 
           <Card title="Section & material (AISC steel)">
@@ -207,11 +237,12 @@ export default function TrussSpace() {
             <ResultCard title={`Analysis — ${result.determinacy.status}`}>
               <Row label="Determinacy m + r − 2j" value={`${result.determinacy.value}`}
                 sub={`m ${result.determinacy.m} · r ${result.determinacy.r} · j ${result.determinacy.j}`} alert={result.determinacy.status === 'unstable'} />
-              <Row label="Max tension" value={`${f1(result.maxTension)} kN`} />
-              <Row label="Max compression" value={`${f1(result.maxCompression)} kN`} />
+              <Row label="Max tension (factored)" value={`${f1(result.maxTension)} kN`} />
+              <Row label="Max compression (factored)" value={`${f1(result.maxCompression)} kN`} />
               {result.reactions.map((r2) => (
                 <Row key={r2.node} label={`Reaction @ ${r2.node}`} value={`${f1(r2.fy)} kN ↑`} sub={r2.fx ? `H ${f1(r2.fx)} kN` : undefined} />
               ))}
+              <Row label="Reactions / forces from" value={result.reactionCombo} sub="member forces enveloped over 1.4D & 1.2D+1.6L" />
               {design && <Row alert={!design.allOK} label="Design" value={design.allOK ? `OK · max util ${(design.maxUtil * 100).toFixed(0)}%` : `✗ max util ${(design.maxUtil * 100).toFixed(0)}%`} />}
             </ResultCard>
           )}
@@ -236,6 +267,7 @@ export default function TrussSpace() {
                   <th className="py-1 pr-2 text-right font-semibold">L (m)</th>
                   <th className="py-1 pr-2 text-right font-semibold">Force (kN)</th>
                   <th className="py-1 pr-2 font-semibold">Sense</th>
+                  <th className="py-1 pr-2 font-semibold">Combo</th>
                   <th className="py-1 pr-2 text-right font-semibold">KL/r</th>
                   <th className="py-1 pr-2 text-right font-semibold">φPn (kN)</th>
                   <th className="py-1 text-right font-semibold">Util</th>
@@ -253,6 +285,7 @@ export default function TrussSpace() {
                       <td className="py-1 pr-2 text-right">{f2(f.L)}</td>
                       <td className="py-1 pr-2 text-right">{f1(Math.abs(f.N))}</td>
                       <td className={`py-1 pr-2 ${f.N >= 0 ? 'text-blue-700' : 'text-red-600'}`}>{d.mode === 'zero' ? '—' : f.N >= 0 ? 'T' : 'C'}</td>
+                      <td className="py-1 pr-2 text-slate-500">{f.combo}</td>
                       <td className="py-1 pr-2 text-right">{d.mode === 'compression' ? Math.round(d.slenderness) + (d.slenderOK ? '' : ' ⚠') : '—'}</td>
                       <td className="py-1 pr-2 text-right">{f1(d.phiPn)}</td>
                       <td className="py-1 text-right">{(d.util * 100).toFixed(0)}%</td>

--- a/webapp/src/pages/TrussSpace.tsx
+++ b/webapp/src/pages/TrussSpace.tsx
@@ -7,27 +7,38 @@ import { generateTruss, solveTruss, type TrussType } from '../engine/truss'
 import { designTruss, type MemberDesign, type TrussSection } from '../engine/trussDesign'
 import { FAMILIES, shapesOf, shapeByName, effectiveSection, type SectionFamily } from '../engine/aiscSections'
 import { SectionShape } from '../components/SectionShape'
+import { buildSectionShapes } from '../lib/sectionShapes3d'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { ReportControls } from '../components/ReportControls'
 import { f1, f2 } from '../lib/format'
 
 const TENSION = '#1d4ed8', COMPRESSION = '#dc2626', ZERO = '#94a3b8', SEL = '#f59e0b'
-const UP = new THREE.Vector3(0, 1, 0)
+const WORLD_Z = new THREE.Vector3(0, 0, 1)
 
-/** A truss member drawn as a coloured cylinder (blue = tension, red = compression). */
-function Member3D({ a, b, color, thick, selected, onPick }: {
-  a: THREE.Vector3; b: THREE.Vector3; color: string; thick: number; selected: boolean; onPick: () => void
+/** A truss member drawn as its ACTUAL cross-section extruded along the member,
+ *  coloured blue = tension / red = compression. */
+function Member3D({ a, b, shapes, color, selected, onPick }: {
+  a: THREE.Vector3; b: THREE.Vector3; shapes: THREE.Shape[]; color: string; selected: boolean; onPick: () => void
 }) {
-  const dir = useMemo(() => new THREE.Vector3().subVectors(b, a), [a, b])
-  const len = dir.length()
-  const mid = useMemo(() => new THREE.Vector3().addVectors(a, b).multiplyScalar(0.5), [a, b])
-  const quat = useMemo(() => new THREE.Quaternion().setFromUnitVectors(UP, dir.clone().normalize()), [dir])
-  const r = (selected ? 1.6 : 1) * thick
+  const len = useMemo(() => a.distanceTo(b), [a, b])
+  // basis: extrude along the member axis; section "height" points out of plane.
+  const quat = useMemo(() => {
+    const z = new THREE.Vector3().subVectors(b, a).normalize()
+    let x = new THREE.Vector3().crossVectors(z, WORLD_Z)
+    if (x.lengthSq() < 1e-9) x = new THREE.Vector3(1, 0, 0)
+    x.normalize()
+    const y = new THREE.Vector3().crossVectors(z, x).normalize()
+    return new THREE.Quaternion().setFromRotationMatrix(new THREE.Matrix4().makeBasis(x, y, z))
+  }, [a, b])
   return (
-    <mesh position={mid} quaternion={quat} onClick={(e) => { e.stopPropagation(); onPick() }}>
-      <cylinderGeometry args={[r, r, len, 10]} />
-      <meshStandardMaterial color={selected ? SEL : color} />
-    </mesh>
+    <group position={a} quaternion={quat} onClick={(e) => { e.stopPropagation(); onPick() }}>
+      {shapes.map((sh, i) => (
+        <mesh key={i}>
+          <extrudeGeometry args={[sh, { depth: len, bevelEnabled: false, steps: 1 }]} />
+          <meshStandardMaterial color={selected ? SEL : color} metalness={0.1} roughness={0.65} />
+        </mesh>
+      ))}
+    </group>
   )
 }
 
@@ -64,7 +75,7 @@ export default function TrussSpace() {
   const [family, setFamily] = useState<SectionFamily>('L')
   const [shapeName, setShapeName] = useState('L102x102x9.5')
   const [double, setDouble] = useState(true)        // double angle (2L) when family = L
-  const [gap, setGap] = useState(10)                // gusset gap, mm
+  const [gap, setGap] = useState(0)                 // separator/gusset plate thickness, mm (0 = touching)
   const [selected, setSelected] = useState<string | null>(null)
   const controlsRef = useRef<React.ComponentRef<typeof OrbitControls>>(null)
 
@@ -88,13 +99,13 @@ export default function TrussSpace() {
   }, [shapeName, family, double, gap])
   const section: TrussSection = useMemo(() => ({ A: eff.A, r: eff.rmin, E, Fy, K }), [eff, E, Fy, K])
   const design = useMemo(() => (result ? designTruss(result.forces, section) : null), [result, section])
+  const shapes3d = useMemo(() => buildSectionShapes(eff), [eff])   // true-scale section profiles for the 3D extrusion
 
   const pos = useMemo(() => {
     const map = new Map<string, THREE.Vector3>()
     model.nodes.forEach((nd) => map.set(nd.id, new THREE.Vector3(nd.x, nd.y, 0)))
     return map
   }, [model])
-  const maxAbs = Math.max(1e-6, ...(result?.forces.map((f) => Math.abs(f.N)) ?? [1]))
   const designById = useMemo(() => new Map((design?.members ?? []).map((d) => [d.id, d])), [design])
 
   const cx = span / 2, cyc = height / 2
@@ -116,7 +127,7 @@ export default function TrussSpace() {
         {/* 3D viewport */}
         <div className="no-print lg:sticky lg:top-4">
           <div className="relative h-[70vh] min-h-[420px] overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
-            <Canvas camera={{ position: [cx, cyc + height * 0.5 + 1, Math.max(span, 6) * 1.25], fov: 45 }} onPointerMissed={() => setSelected(null)}>
+            <Canvas camera={{ position: [cx - span * 0.35, cyc + height + span * 0.22, Math.max(span, 6) * 1.0], fov: 45 }} onPointerMissed={() => setSelected(null)}>
               <color attach="background" args={['#f8fafc']} />
               <ambientLight intensity={0.9} />
               <directionalLight position={[6, 12, 10]} intensity={0.8} />
@@ -124,8 +135,7 @@ export default function TrussSpace() {
                 const a = pos.get(mb.i), b = pos.get(mb.j); if (!a || !b) return null
                 const N = result?.forces.find((f) => f.id === mb.id)?.N ?? 0
                 const color = Math.abs(N) < 1e-6 ? ZERO : N > 0 ? TENSION : COMPRESSION
-                const thick = 0.03 + 0.06 * (Math.abs(N) / maxAbs)
-                return <Member3D key={mb.id} a={a} b={b} color={color} thick={thick} selected={mb.id === selected} onPick={() => setSelected(mb.id)} />
+                return <Member3D key={mb.id} a={a} b={b} shapes={shapes3d} color={color} selected={mb.id === selected} onPick={() => setSelected(mb.id)} />
               })}
               {model.nodes.map((nd) => { const p = pos.get(nd.id)!; return (
                 <mesh key={nd.id} position={p}><sphereGeometry args={[0.07, 12, 12]} /><meshStandardMaterial color="#334155" /></mesh>
@@ -178,7 +188,7 @@ export default function TrussSpace() {
                 <span>Double angle (2L, back-to-back)</span>
               </label>
             )}
-            {family === 'L' && double && <Num label="Gusset gap" unit="mm" value={gap} onChange={setGap} step="1" />}
+            {family === 'L' && double && <Num label="Separator plate thickness" unit="mm" value={gap} onChange={setGap} step="1" />}
             <Num label="Fy" unit="MPa" value={Fy} onChange={setFy} step="5" />
             <Num label="E" unit="MPa" value={E} onChange={setE} step="1000" />
             <Num label="Effective length K" value={K} onChange={setK} step="0.05" />


### PR DESCRIPTION
> ⚠️ **Stacked on #179** (the truss 3D-section PR, still open) because `main` doesn't yet contain that work and building this on plain `main` would regress/conflict with it. **Merge #179 first**, then this PR's diff reduces to just the changes below.

## 1. Zoom-to-extents on page load (both 3D pages)
New `components/FitView.tsx` (rendered inside the `<Canvas>`) frames the **whole model** on mount and whenever the bounds change (after *Generate* / on reload), keeping a fixed view direction and recentring the default OrbitControls. Wired into **3D Model Space** and **Truss Space**, so every member is visible on load instead of a fixed camera that could clip large models.

## 2. Truss Phase 2 — self-weight + NSCP load combinations
- `engine/truss.ts`:
  - `selfWeightLoads()` lumps each member's steel self-weight (from the section area, 77 kN/m³) half to its end joints as Dead.
  - `TRUSS_COMBOS` = **1.4D** and **1.2D + 1.6L**; `solveTrussEnvelope()` solves the Dead and Live cases once each (linear superposition) and, **per member, keeps the governing combination's axial force**; reactions are reported for the combo with the greatest total reaction.
- **TrussSpace**: separate **Dead / Live joint-load** inputs + a **"member self-weight"** toggle (auto from the chosen section); each member is designed for its governing combo; the schedule gains a **Combo** column and the results show the governing combo.

## Verification
- `tsc -b` clean; `vitest run` → **253 passed** (new: self-weight lumping = Σ member weight; envelope governs by 1.2D+1.6L and balances the factored load).
- Browser: both pages frame the full model on load/reload; truss shows Dead/Live + self-weight, the Combo column, governing combo 1.2D+1.6L, max util 20% (factored); no console errors.

## Phases remaining
- **Phase 3** — truss material take-off + priced Bill of Materials (steel weight by section + connection allowance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)