### PR TITLE
Truss Phase 3+4: BOM/take-off, Fink & scissor roofs, free-form editor, custom section

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -49,6 +49,13 @@ Latest merged work — PRs **#178, #179, #180** (main); **Truss Phase 3** open P
 - **Truss Phase 3** (`engine/trussTakeoff.ts` + `TrussSpace.tsx`): per-member
   steel weight (A × L × 7850 kg/m³), subtotals by chord kind, gusset/connection
   plate allowance (editable %), priced Bill of Materials (₱/kg, live totals).
+- **Truss Phase 4** (same PR): two more roof types — **Fink** (W-web) and
+  **scissor** (raised tie) in `engine/truss.ts` (determinate for n = 4/6/8,
+  tested); **free-form editor** (`components/TrussEditor.tsx`) to edit nodes /
+  members / supports / loaded joints live; **custom section** input (enter A, rₓ,
+  r_y directly); expanded **AISC HSS/Pipe** sizes (computed nominal geometry,
+  documented) in `engine/aiscSections.ts`. PDF export already works via the
+  browser-print path in `components/ReportControls.tsx`.
 
 ## Key paths
 - 3D RC frame page: `webapp/src/pages/ModelSpace.tsx` (route `/model`)
@@ -59,9 +66,10 @@ Latest merged work — PRs **#178, #179, #180** (main); **Truss Phase 3** open P
 - Routes + home tiles: `webapp/src/App.tsx`
 
 ## Next up — roadmap
-- Optional: bulk-load the **full AISC v15 shape database** (current set is a
-  representative subset, structured to drop the full table straight in).
-- Optional: free-form truss node/member editor; more roof types (Fink, scissor).
-- Optional: PDF export for the truss report (member schedule + BOM).
+- Optional: bulk-import the **full official AISC v15 metric table** as data
+  (CSV/JSON drop-in). Current library is a curated real-value set plus computed
+  nominal HSS/Pipe sizes; a custom-section input covers anything not tabulated.
+- Optional: save / load custom trusses (localStorage or file); drag nodes in 3D.
+- Optional: more roof forms (Fink fan/double-Fink, gambrel), wind/uplift cases.
 
-_Tests at last handoff: 262 passing; `tsc -b` clean._
+_Tests at last handoff: 264 passing; `tsc -b` clean; production build OK._

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -35,7 +35,7 @@ npm run build    # typecheck + production build
 ```
 
 ## Current state (all merged to `main`)
-Latest merged work — PRs **#178, #179, #180**:
+Latest merged work — PRs **#178, #179, #180** (main); **Truss Phase 3** open PR:
 - **Truss Space** (`/truss`): planar pin-jointed truss — generate (Pratt / Howe /
   Warren / pitched-roof), analyse axial forces, AISC-LRFD member design.
 - **AISC section library** (`webapp/src/engine/aiscSections.ts`) — W/C/L/HSS/Pipe/
@@ -46,6 +46,9 @@ Latest merged work — PRs **#178, #179, #180**:
 - **Zoom-to-extents on load** for both 3D pages (`components/FitView.tsx`).
 - **Truss Phase 2**: member self-weight from the section + NSCP gravity
   combinations (1.4D, 1.2D+1.6L) enveloped per member (`engine/truss.ts`).
+- **Truss Phase 3** (`engine/trussTakeoff.ts` + `TrussSpace.tsx`): per-member
+  steel weight (A × L × 7850 kg/m³), subtotals by chord kind, gusset/connection
+  plate allowance (editable %), priced Bill of Materials (₱/kg, live totals).
 
 ## Key paths
 - 3D RC frame page: `webapp/src/pages/ModelSpace.tsx` (route `/model`)
@@ -56,11 +59,9 @@ Latest merged work — PRs **#178, #179, #180**:
 - Routes + home tiles: `webapp/src/App.tsx`
 
 ## Next up — roadmap
-- **Truss Phase 3**: truss material take-off + **priced Bill of Materials**
-  (steel weight by section + connection/gusset allowance), mirroring the frame
-  page's BOM/BOQ.
 - Optional: bulk-load the **full AISC v15 shape database** (current set is a
   representative subset, structured to drop the full table straight in).
 - Optional: free-form truss node/member editor; more roof types (Fink, scissor).
+- Optional: PDF export for the truss report (member schedule + BOM).
 
-_Tests at last handoff: 253 passing; `tsc -b` clean._
+_Tests at last handoff: 262 passing; `tsc -b` clean._

--- a/webapp/src/components/TrussEditor.tsx
+++ b/webapp/src/components/TrussEditor.tsx
@@ -1,0 +1,149 @@
+// Free-form truss editor: edit the node coordinates, members, supports and
+// loaded joints of a TrussModel directly. Emits a new model on every change so
+// the page re-solves, re-designs and re-takes-off live. Deleting a node also
+// drops any member / support / load that referenced it. Load magnitudes are
+// driven by the page's Dead / Live joint-load fields — the load list here just
+// selects WHICH joints are loaded (consistent with the parametric generator).
+import type { TrussModel, TNode, TMember, ChordKind } from '../engine/truss'
+
+const KINDS: ChordKind[] = ['top', 'bottom', 'vertical', 'diagonal']
+
+const numCls = 'w-16 rounded border border-slate-300 px-1 py-0.5 text-right text-xs'
+const selCls = 'rounded border border-slate-300 px-1 py-0.5 text-xs'
+const delBtn = 'rounded px-1.5 text-red-500 hover:bg-red-50'
+const addBtn = 'mt-1 rounded-md border border-[#0056b3]/40 bg-[#0056b3]/5 px-2 py-0.5 text-xs font-semibold text-[#0056b3] hover:bg-[#0056b3]/10'
+
+export function TrussEditor({ model, onChange, onReset }: {
+  model: TrussModel; onChange: (m: TrussModel) => void; onReset: () => void
+}) {
+  const ids = model.nodes.map((n) => n.id)
+  const set = (patch: Partial<TrussModel>) => onChange({ ...model, ...patch })
+  const fresh = (prefix: string, used: string[]) => { let k = used.length; while (used.includes(`${prefix}${k}`)) k++; return `${prefix}${k}` }
+
+  // nodes
+  const editNode = (i: number, p: Partial<TNode>) => set({ nodes: model.nodes.map((n, k) => (k === i ? { ...n, ...p } : n)) })
+  const addNode = () => set({ nodes: [...model.nodes, { id: fresh('n', ids), x: 0, y: 0 }] })
+  const delNode = (id: string) => set({
+    nodes: model.nodes.filter((n) => n.id !== id),
+    members: model.members.filter((m) => m.i !== id && m.j !== id),
+    supports: model.supports.filter((s) => s.node !== id),
+    loads: model.loads.filter((l) => l.node !== id),
+  })
+  // members
+  const editMember = (i: number, p: Partial<TMember>) => set({ members: model.members.map((m, k) => (k === i ? { ...m, ...p } : m)) })
+  const addMember = () => set({ members: [...model.members, { id: fresh('m', model.members.map((m) => m.id)), i: ids[0] ?? '', j: ids[1] ?? ids[0] ?? '', kind: 'diagonal' }] })
+  const delMember = (i: number) => set({ members: model.members.filter((_, k) => k !== i) })
+  // supports
+  const editSupport = (i: number, p: Partial<{ node: string; ux: boolean; uy: boolean }>) => set({ supports: model.supports.map((s, k) => (k === i ? { ...s, ...p } : s)) })
+  const addSupport = () => set({ supports: [...model.supports, { node: ids[0] ?? '', ux: true, uy: true }] })
+  const delSupport = (i: number) => set({ supports: model.supports.filter((_, k) => k !== i) })
+  // loaded joints (magnitude from the page's Dead/Live fields → marker fy = −1)
+  const addLoad = () => set({ loads: [...model.loads, { node: ids[0] ?? '', fx: 0, fy: -1 }] })
+  const editLoad = (i: number, node: string) => set({ loads: model.loads.map((l, k) => (k === i ? { ...l, node } : l)) })
+  const delLoad = (i: number) => set({ loads: model.loads.filter((_, k) => k !== i) })
+
+  const nodePick = (value: string, onPick: (v: string) => void) => (
+    <select className={selCls} value={value} onChange={(e) => onPick(e.target.value)}>
+      {ids.map((id) => <option key={id} value={id}>{id}</option>)}
+    </select>
+  )
+
+  return (
+    <fieldset className="no-print rounded-xl border border-amber-300 bg-amber-50/40 p-4 shadow-sm">
+      <legend className="flex items-center gap-2 px-2 text-[1.02rem] font-bold text-[#0056b3]">
+        ✎ Free-form editor
+        <button type="button" onClick={onReset} className="rounded-md border border-slate-300 bg-white px-2 py-0.5 text-xs font-semibold text-slate-600 hover:bg-slate-50">↺ Back to parametric</button>
+      </legend>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {/* Nodes */}
+        <div>
+          <h4 className="mb-1 text-xs font-bold uppercase tracking-wide text-slate-500">Nodes (m)</h4>
+          <div className="max-h-48 overflow-y-auto pr-1">
+            <table className="w-full text-xs">
+              <thead><tr className="text-left text-slate-400"><th className="pr-2">id</th><th className="pr-2">x</th><th className="pr-2">y</th><th /></tr></thead>
+              <tbody>
+                {model.nodes.map((n, i) => (
+                  <tr key={n.id}>
+                    <td className="pr-2 font-medium">{n.id}</td>
+                    <td className="pr-2"><input type="number" step="0.25" className={numCls} value={n.x} onChange={(e) => editNode(i, { x: Number(e.target.value) })} /></td>
+                    <td className="pr-2"><input type="number" step="0.25" className={numCls} value={n.y} onChange={(e) => editNode(i, { y: Number(e.target.value) })} /></td>
+                    <td><button type="button" className={delBtn} onClick={() => delNode(n.id)} title="delete node">✕</button></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <button type="button" className={addBtn} onClick={addNode}>+ node</button>
+        </div>
+
+        {/* Members */}
+        <div>
+          <h4 className="mb-1 text-xs font-bold uppercase tracking-wide text-slate-500">Members</h4>
+          <div className="max-h-48 overflow-y-auto pr-1">
+            <table className="w-full text-xs">
+              <thead><tr className="text-left text-slate-400"><th className="pr-2">id</th><th className="pr-2">i</th><th className="pr-2">j</th><th className="pr-2">kind</th><th /></tr></thead>
+              <tbody>
+                {model.members.map((m, i) => (
+                  <tr key={m.id}>
+                    <td className="pr-2 font-medium">{m.id}</td>
+                    <td className="pr-2">{nodePick(m.i, (v) => editMember(i, { i: v }))}</td>
+                    <td className="pr-2">{nodePick(m.j, (v) => editMember(i, { j: v }))}</td>
+                    <td className="pr-2">
+                      <select className={selCls} value={m.kind} onChange={(e) => editMember(i, { kind: e.target.value as ChordKind })}>
+                        {KINDS.map((k) => <option key={k} value={k}>{k}</option>)}
+                      </select>
+                    </td>
+                    <td><button type="button" className={delBtn} onClick={() => delMember(i)} title="delete member">✕</button></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <button type="button" className={addBtn} onClick={addMember}>+ member</button>
+        </div>
+
+        {/* Supports */}
+        <div>
+          <h4 className="mb-1 text-xs font-bold uppercase tracking-wide text-slate-500">Supports</h4>
+          <table className="w-full text-xs">
+            <thead><tr className="text-left text-slate-400"><th className="pr-2">node</th><th className="pr-2">ux</th><th className="pr-2">uy</th><th /></tr></thead>
+            <tbody>
+              {model.supports.map((s, i) => (
+                <tr key={i}>
+                  <td className="pr-2">{nodePick(s.node, (v) => editSupport(i, { node: v }))}</td>
+                  <td className="pr-2"><input type="checkbox" checked={s.ux} onChange={(e) => editSupport(i, { ux: e.target.checked })} /></td>
+                  <td className="pr-2"><input type="checkbox" checked={s.uy} onChange={(e) => editSupport(i, { uy: e.target.checked })} /></td>
+                  <td><button type="button" className={delBtn} onClick={() => delSupport(i)} title="delete support">✕</button></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <button type="button" className={addBtn} onClick={addSupport}>+ support</button>
+        </div>
+
+        {/* Loaded joints */}
+        <div>
+          <h4 className="mb-1 text-xs font-bold uppercase tracking-wide text-slate-500">Loaded joints</h4>
+          <table className="w-full text-xs">
+            <thead><tr className="text-left text-slate-400"><th className="pr-2">node</th><th /></tr></thead>
+            <tbody>
+              {model.loads.map((l, i) => (
+                <tr key={i}>
+                  <td className="pr-2">{nodePick(l.node, (v) => editLoad(i, v))}</td>
+                  <td><button type="button" className={delBtn} onClick={() => delLoad(i)} title="delete load">✕</button></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <button type="button" className={addBtn} onClick={addLoad}>+ loaded joint</button>
+          <p className="mt-1 text-[10px] text-slate-400">Magnitudes come from the Dead / Live joint-load fields above.</p>
+        </div>
+      </div>
+      <p className="mt-2 text-[11px] text-slate-500">
+        Pin = both ux &amp; uy; roller = uy only. Keep the truss statically stable (m + r = 2j) — the analysis card flags an
+        unstable layout. Switch back to parametric anytime; your edits are discarded.
+      </p>
+    </fieldset>
+  )
+}

--- a/webapp/src/engine/aiscSections.test.ts
+++ b/webapp/src/engine/aiscSections.test.ts
@@ -40,4 +40,21 @@ describe('AISC section library', () => {
     expect(w.double).toBe(false)
     expect(w.A).toBe(4190)
   })
+
+  it('computed nominal tubes match the sharp-corner geometry formulas', () => {
+    // square HSS127x127x9.5: A = b² − (b−2t)²
+    const sq = shapeByName('HSS127x127x9.5')!
+    const bi = 127 - 2 * 9.5
+    expect(sq.A).toBe(Math.round(127 * 127 - bi * bi))
+    expect(sq.rx).toBeCloseTo(sq.ry!, 6)                 // square → rx = ry
+    // rectangular HSS254x152x9.5: deeper section is stiffer about x (rx > ry)
+    const rect = shapeByName('HSS254x152x9.5')!
+    expect(rect.h).toBe(254); expect(rect.b).toBe(152)
+    expect(rect.rx).toBeGreaterThan(rect.ry!)
+    // round pipe: A = π/4·(D² − (D−2t)²)
+    const p = shapeByName('PIPE 8 STD')!
+    const Di = 219.1 - 2 * 8.2
+    expect(p.A).toBe(Math.round((Math.PI / 4) * (219.1 ** 2 - Di ** 2)))
+    expect(p.rx).toBeCloseTo(Math.sqrt(219.1 ** 2 + Di ** 2) / 4, 1)
+  })
 })

--- a/webapp/src/engine/aiscSections.ts
+++ b/webapp/src/engine/aiscSections.ts
@@ -58,7 +58,31 @@ const L: AiscShape[] = [
   { name: 'L152x152x19', family: 'L', A: 5410, rx: 46.9, ry: 46.9, rz: 29.8, xbar: 43.4, leg1: 152, leg2: 152, t: 19.0 },
 ]
 
-/** Square & rectangular HSS. */
+// ── Computed (nominal-geometry) tube generators ─────────────────────────────
+// Sharp-corner thin-wall model: A, I and r from the nominal outer dimensions and
+// wall thickness (no corner radii). Values run a few % over a real cold-formed
+// HSS of the same call-out, but give a consistent, table-free way to extend the
+// square / rectangular / round families. Use the tabulated rows above when an
+// exact match exists; these fill the gaps.
+const r1 = (v: number) => Math.round(v * 10) / 10
+/** Rectangular (or square) HSS h(deep)×b(wide)×t, all mm. */
+function hssRect(h: number, b: number, t: number): AiscShape {
+  const hi = h - 2 * t, bi = b - 2 * t
+  const A = b * h - bi * hi
+  const Ix = (b * h ** 3 - bi * hi ** 3) / 12          // about the strong (depth) axis
+  const Iy = (h * b ** 3 - hi * bi ** 3) / 12
+  return { name: `HSS${h}x${b}x${t}`, family: 'HSS', A: Math.round(A), rx: r1(Math.sqrt(Ix / A)), ry: r1(Math.sqrt(Iy / A)), b, h, t }
+}
+const hssSq = (b: number, t: number) => hssRect(b, b, t)
+/** Round HSS / pipe, outer diameter D and wall t, mm. */
+function pipe(name: string, D: number, t: number): AiscShape {
+  const Di = D - 2 * t
+  const A = (Math.PI / 4) * (D * D - Di * Di)
+  const r = Math.sqrt(D * D + Di * Di) / 4
+  return { name, family: 'PIPE', A: Math.round(A), rx: r1(r), ry: r1(r), D, t }
+}
+
+/** Square & rectangular HSS — tabulated (real) rows plus computed nominal sizes. */
 const HSS: AiscShape[] = [
   { name: 'HSS76x76x6.4', family: 'HSS', A: 1600, rx: 28.2, ry: 28.2, b: 76, h: 76, t: 6.4 },
   { name: 'HSS102x102x6.4', family: 'HSS', A: 2230, rx: 38.6, ry: 38.6, b: 102, h: 102, t: 6.4 },
@@ -67,15 +91,21 @@ const HSS: AiscShape[] = [
   { name: 'HSS152x152x9.5', family: 'HSS', A: 4920, rx: 57.6, ry: 57.6, b: 152, h: 152, t: 9.5 },
   { name: 'HSS152x102x6.4', family: 'HSS', A: 2860, rx: 53.0, ry: 38.0, b: 102, h: 152, t: 6.4 },
   { name: 'HSS203x102x6.4', family: 'HSS', A: 3550, rx: 68.0, ry: 39.0, b: 102, h: 203, t: 6.4 },
+  // computed nominal extensions (square + rectangular)
+  hssSq(64, 4.8), hssSq(89, 6.4), hssSq(127, 9.5), hssSq(178, 9.5), hssSq(203, 12.7),
+  hssRect(127, 76, 6.4), hssRect(203, 102, 9.5), hssRect(254, 152, 9.5),
 ]
 
-/** Round HSS / standard pipe. */
+/** Round HSS / standard pipe — tabulated rows plus computed nominal diameters. */
 const PIPE: AiscShape[] = [
   { name: 'PIPE 3 STD', family: 'PIPE', A: 1390, rx: 29.5, ry: 29.5, D: 88.9, t: 5.5 },
   { name: 'PIPE 4 STD', family: 'PIPE', A: 2010, rx: 38.4, ry: 38.4, D: 114.3, t: 6.0 },
   { name: 'PIPE 5 STD', family: 'PIPE', A: 2700, rx: 47.8, ry: 47.8, D: 141.3, t: 6.6 },
   { name: 'PIPE 6 STD', family: 'PIPE', A: 3470, rx: 57.2, ry: 57.2, D: 168.3, t: 7.1 },
   { name: 'HSS114x6.4', family: 'PIPE', A: 2150, rx: 38.0, ry: 38.0, D: 114, t: 6.4 },
+  // computed nominal extensions
+  pipe('PIPE 8 STD', 219.1, 8.2), pipe('PIPE 10 STD', 273.0, 9.3),
+  pipe('HSS168x6.4', 168, 6.4), pipe('HSS219x6.4', 219, 6.4),
 ]
 
 /** Structural tees (WT). */

--- a/webapp/src/engine/truss.test.ts
+++ b/webapp/src/engine/truss.test.ts
@@ -44,11 +44,26 @@ describe('truss solver — statics', () => {
   })
 
   it('every generator produces a stable, determinate truss', () => {
-    for (const type of ['pratt', 'howe', 'warren', 'roof'] as const) {
-      const r = solveTruss(generateTruss({ type, span: 10, height: 2.5, panels: 4, panelLoad: 8 }))
-      expect(r, type).not.toBeNull()
-      expect(r!.stable, type).toBe(true)
+    for (const type of ['pratt', 'howe', 'warren', 'roof', 'fink', 'scissor'] as const) {
+      for (const panels of [4, 6, 8]) {
+        const r = solveTruss(generateTruss({ type, span: 10, height: 2.5, panels, panelLoad: 8 }))
+        expect(r, `${type} n=${panels}`).not.toBeNull()
+        expect(r!.stable, `${type} n=${panels}`).toBe(true)
+        expect(r!.determinacy.status, `${type} n=${panels}`).toBe('determinate')
+        const Ry = r!.reactions.reduce((s, x) => s + x.fy, 0)
+        const load = generateTruss({ type, span: 10, height: 2.5, panels, panelLoad: 8 }).loads.reduce((s, l) => s - l.fy, 0)
+        expect(Ry, `${type} n=${panels}`).toBeCloseTo(load, 3)   // statics balance
+      }
     }
+  })
+
+  it('scissor raises the bottom-chord tie to a mid-span apex', () => {
+    const m = generateTruss({ type: 'scissor', span: 12, height: 3, panels: 6, panelLoad: 10 })
+    const ends = m.nodes.filter((n) => n.id === 'b0' || n.id === 'b6')
+    expect(ends.every((n) => n.y === 0)).toBe(true)             // supports stay at y = 0
+    const apexBottom = m.nodes.find((n) => n.id === 'b3')!       // mid-span tie node
+    expect(apexBottom.y).toBeGreaterThan(0)                      // raised (vaulted ceiling)
+    expect(apexBottom.y).toBeLessThan(3)                         // below the top apex
   })
 })
 

--- a/webapp/src/engine/truss.ts
+++ b/webapp/src/engine/truss.ts
@@ -17,7 +17,7 @@ export interface TrussModel {
   E: number; A: number       // uniform material/section: MPa, mm²
 }
 
-export type TrussType = 'pratt' | 'howe' | 'warren' | 'roof'
+export type TrussType = 'pratt' | 'howe' | 'warren' | 'roof' | 'fink' | 'scissor'
 export interface TrussSpec {
   type: TrussType
   span: number; height: number; panels: number      // m, m, count
@@ -25,6 +25,12 @@ export interface TrussSpec {
 }
 
 const len = (a: TNode, b: TNode) => Math.hypot(b.x - a.x, b.y - a.y)
+
+/** Roof (gable) types: apex at mid-span, end top nodes coincide with the
+ *  supports. `scissor` additionally raises the bottom chord toward mid-span. */
+const isGable = (t: TrussType) => t === 'roof' || t === 'fink' || t === 'scissor'
+/** Scissor tie raised at mid-span as a fraction of the truss height. */
+const SCISSOR_RISE = 0.45
 
 /** Parametric truss generator. Pin at the left support, roller at the right;
  *  a downward `panelLoad` is seeded at every loaded (top-chord) joint. */
@@ -35,16 +41,19 @@ export function generateTruss(spec: TrussSpec): TrussModel {
   const members: TMember[] = []
   const add = (i: string, j: string, kind: ChordKind) => members.push({ id: `m${members.length}`, i, j, kind })
 
-  const roof = spec.type === 'roof'
+  const gable = isGable(spec.type)
   const mid = n / 2
-  // bottom chord b0..bn (y = 0)
-  for (let i = 0; i <= n; i++) nodes.push({ id: `b${i}`, x: i * p, y: 0 })
-  // top chord: parallel types get a node above every panel point; the roof
-  // (gable, apex at mid-span) gets INTERIOR top nodes only — its end top nodes
+  // bottom chord b0..bn. Flat for parallel/roof trusses; a SCISSOR raises the
+  // tie to a mid-span apex (vaulted ceiling), supports staying at y = 0.
+  const botY = (i: number) =>
+    spec.type === 'scissor' ? SCISSOR_RISE * H * (1 - Math.abs(i * p - L / 2) / (L / 2)) : 0
+  for (let i = 0; i <= n; i++) nodes.push({ id: `b${i}`, x: i * p, y: botY(i) })
+  // top chord: parallel types get a node above every panel point; gable types
+  // (apex at mid-span) get INTERIOR top nodes only — their end top nodes
   // coincide with the supports, so the top chord springs from b0 / bn.
-  const topY = (i: number) => roof ? H * (1 - Math.abs(i * p - L / 2) / (L / 2)) : H
-  for (let i = 0; i <= n; i++) { if (roof && (i === 0 || i === n)) continue; nodes.push({ id: `t${i}`, x: i * p, y: topY(i) }) }
-  const top = (i: number) => (roof && i === 0) ? 'b0' : (roof && i === n) ? `b${n}` : `t${i}`
+  const topY = (i: number) => gable ? H * (1 - Math.abs(i * p - L / 2) / (L / 2)) : H
+  for (let i = 0; i <= n; i++) { if (gable && (i === 0 || i === n)) continue; nodes.push({ id: `t${i}`, x: i * p, y: topY(i) }) }
+  const top = (i: number) => (gable && i === 0) ? 'b0' : (gable && i === n) ? `b${n}` : `t${i}`
 
   // chords
   for (let i = 0; i < n; i++) add(`b${i}`, `b${i + 1}`, 'bottom')
@@ -53,18 +62,19 @@ export function generateTruss(spec: TrussSpec): TrussModel {
   // verticals: every interior panel point (and the ends for parallel types);
   // Warren keeps full verticals so the parallel truss stays determinate.
   for (let i = 0; i <= n; i++) {
-    if (roof && (i === 0 || i === n)) continue   // top coincides with the support
+    if (gable && (i === 0 || i === n)) continue   // top coincides with the support
     add(`b${i}`, top(i), 'vertical')
   }
 
-  // diagonals: one per panel; the roof skips the two END panels (already a
+  // diagonals: one per panel; gable types skip the two END panels (already a
   // triangle b–b–t), keeping every generated truss statically determinate.
   for (let i = 0; i < n; i++) {
-    if (roof && (i === 0 || i === n - 1)) continue
+    if (gable && (i === 0 || i === n - 1)) continue
     let a: string, b: string
     if (spec.type === 'warren') { (i % 2 === 0) ? (a = `b${i}`, b = top(i + 1)) : (a = top(i), b = `b${i + 1}`) }
+    else if (spec.type === 'fink') { (i % 2 === 0) ? (a = `b${i}`, b = top(i + 1)) : (a = top(i), b = `b${i + 1}`) }  // W-pattern web
     else if (spec.type === 'howe') { (i < mid) ? (a = top(i), b = `b${i + 1}`) : (a = `b${i}`, b = top(i + 1)) }
-    else { (i < mid) ? (a = `b${i}`, b = top(i + 1)) : (a = top(i), b = `b${i + 1}`) }   // pratt + roof
+    else { (i < mid) ? (a = `b${i}`, b = top(i + 1)) : (a = top(i), b = `b${i + 1}`) }   // pratt + roof + scissor
     add(a, b, 'diagonal')
   }
 
@@ -73,8 +83,8 @@ export function generateTruss(spec: TrussSpec): TrussModel {
     { node: `b${n}`, ux: false, uy: true },        // roller
   ]
   // downward joint loads at the loaded chord (top chord; its end nodes coincide
-  // with the supports on a roof, so load the interior top nodes there).
-  const loaded = nodes.filter((nd) => nd.id.startsWith('t') && !(roof && (nd.id === 't0' || nd.id === `t${n}`)))
+  // with the supports on a gable, so load the interior top nodes there).
+  const loaded = nodes.filter((nd) => nd.id.startsWith('t') && !(gable && (nd.id === 't0' || nd.id === `t${n}`)))
   const loads: TLoad[] = loaded.map((nd) => ({ node: nd.id, fx: 0, fy: -Math.abs(spec.panelLoad) }))
 
   return { nodes, members, supports, loads, E: 200000, A: 1500 }

--- a/webapp/src/engine/trussTakeoff.test.ts
+++ b/webapp/src/engine/trussTakeoff.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { generateTruss, solveTrussEnvelope, selfWeightLoads, type EnvForce } from './truss'
+import { effectiveSection } from './aiscSections'
+import { trussTakeoff, costTrussBill } from './trussTakeoff'
+
+const STEEL_DENSITY = 7850   // kg/m³
+
+function makeForces(): EnvForce[] {
+  const model = generateTruss({ type: 'pratt', span: 12, height: 2, panels: 4, panelLoad: 10 })
+  const eff = effectiveSection({ name: 'L102x102x9.5', family: 'L', A: 1890, rx: 31.7, ry: 31.7, rz: 20.1 } as Parameters<typeof effectiveSection>[0])
+  const dead = [
+    ...selfWeightLoads(model, eff.A),
+    ...model.loads.map((l) => ({ ...l, fy: l.fy })),
+  ]
+  const live = model.loads.map((l) => ({ ...l }))
+  const env = solveTrussEnvelope(model, dead, live)!
+  return env.forces
+}
+
+describe('trussTakeoff', () => {
+  const eff = effectiveSection({ name: 'L102x102x9.5', family: 'L', A: 1890, rx: 31.7, ry: 31.7, rz: 20.1 } as Parameters<typeof effectiveSection>[0])
+  const forces = makeForces()
+
+  it('computes kgPerM from section area', () => {
+    const t = trussTakeoff(forces, eff)
+    const expected = (eff.A / 1e6) * STEEL_DENSITY
+    expect(t.kgPerM).toBeCloseTo(expected, 6)
+  })
+
+  it('per-member weight = L × kgPerM', () => {
+    const t = trussTakeoff(forces, eff)
+    for (const m of t.byMember) {
+      expect(m.netWeightKg).toBeCloseTo(m.L * t.kgPerM, 9)
+    }
+  })
+
+  it('netSteelKg is the sum of all member weights', () => {
+    const t = trussTakeoff(forces, eff)
+    const sum = t.byMember.reduce((s, m) => s + m.netWeightKg, 0)
+    expect(t.netSteelKg).toBeCloseTo(sum, 9)
+  })
+
+  it('default 10 % gusset allowance', () => {
+    const t = trussTakeoff(forces, eff)
+    expect(t.gussetFraction).toBe(0.10)
+    expect(t.gussetKg).toBeCloseTo(t.netSteelKg * 0.10, 9)
+    expect(t.totalKg).toBeCloseTo(t.netSteelKg * 1.10, 9)
+  })
+
+  it('custom gusset fraction is applied', () => {
+    const t = trussTakeoff(forces, eff, { gussetFraction: 0.15 })
+    expect(t.gussetKg).toBeCloseTo(t.netSteelKg * 0.15, 9)
+  })
+
+  it('byKind subtotals sum to the net total', () => {
+    const t = trussTakeoff(forces, eff)
+    const kindNet = t.byKind.reduce((s, k) => s + k.netKg, 0)
+    expect(kindNet).toBeCloseTo(t.netSteelKg, 6)
+  })
+
+  it('all members accounted for in byKind', () => {
+    const t = trussTakeoff(forces, eff)
+    const kindCount = t.byKind.reduce((s, k) => s + k.members, 0)
+    expect(kindCount).toBe(t.byMember.length)
+  })
+})
+
+describe('costTrussBill', () => {
+  const eff = effectiveSection({ name: 'L102x102x9.5', family: 'L', A: 1890, rx: 31.7, ry: 31.7, rz: 20.1 } as Parameters<typeof effectiveSection>[0])
+  const forces = makeForces()
+  const t = trussTakeoff(forces, eff)
+
+  it('bill total = net steel + gusset at the same unit price', () => {
+    const bill = costTrussBill(t, { steelKg: 80 })
+    expect(bill.total).toBeCloseTo(t.totalKg * 80, 4)
+  })
+
+  it('two rows: sections and gusset plates', () => {
+    const bill = costTrussBill(t, { steelKg: 80 })
+    expect(bill.rows).toHaveLength(2)
+    expect(bill.rows[0].qty).toBeCloseTo(t.netSteelKg, 6)
+    expect(bill.rows[1].qty).toBeCloseTo(t.gussetKg, 6)
+  })
+})

--- a/webapp/src/engine/trussTakeoff.ts
+++ b/webapp/src/engine/trussTakeoff.ts
@@ -1,0 +1,91 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Truss steel material take-off + priced Bill of Materials (Truss Phase 3).
+// All members share one cross-section (the EffectiveSection from aiscSections).
+// A connection/gusset plate allowance (default 10 % of net steel) is added on
+// top of the member steel to cover gusset plates and field welding/bolting.
+// Units: geometry m; area mm²; linear density kg/m; weight kg; prices PHP (₱).
+// ─────────────────────────────────────────────────────────────────────────
+import type { ChordKind, EnvForce } from './truss'
+import type { EffectiveSection } from './aiscSections'
+
+const STEEL_DENSITY = 7850   // kg/m³
+
+export interface TrussMemberQty {
+  id: string
+  kind: ChordKind
+  L: number            // m
+  kgPerM: number       // linear density for the chosen section
+  netWeightKg: number  // L × kgPerM
+}
+
+export interface TrussKindSubtotal {
+  kind: ChordKind
+  members: number
+  lengthM: number
+  netKg: number
+}
+
+export interface TrussTakeoffResult {
+  byMember: TrussMemberQty[]
+  section: string            // effective section label
+  areaMm2: number            // mm²
+  kgPerM: number             // kg/m
+  netSteelKg: number         // fabricated member steel
+  gussetFraction: number     // e.g. 0.10
+  gussetKg: number           // netSteelKg × gussetFraction
+  totalKg: number            // net + gusset
+  byKind: TrussKindSubtotal[]
+}
+
+export interface TrussTakeoffOptions {
+  /** Fraction of net steel weight added for gusset/connection plates (default 0.10). */
+  gussetFraction?: number
+}
+
+export function trussTakeoff(
+  forces: EnvForce[],
+  eff: EffectiveSection,
+  opts: TrussTakeoffOptions = {},
+): TrussTakeoffResult {
+  const gussetFraction = Math.max(0, opts.gussetFraction ?? 0.10)
+  const areaMm2 = eff.A
+  const kgPerM = (areaMm2 / 1e6) * STEEL_DENSITY
+
+  const byMember: TrussMemberQty[] = forces.map((f) => ({
+    id: f.id, kind: f.kind, L: f.L, kgPerM, netWeightKg: f.L * kgPerM,
+  }))
+
+  const netSteelKg = byMember.reduce((s, m) => s + m.netWeightKg, 0)
+  const gussetKg = netSteelKg * gussetFraction
+  const totalKg = netSteelKg + gussetKg
+
+  const kindOrder: ChordKind[] = ['top', 'bottom', 'vertical', 'diagonal']
+  const byKind: TrussKindSubtotal[] = kindOrder
+    .map((kind) => {
+      const ms = byMember.filter((m) => m.kind === kind)
+      return { kind, members: ms.length, lengthM: ms.reduce((s, m) => s + m.L, 0), netKg: ms.reduce((s, m) => s + m.netWeightKg, 0) }
+    })
+    .filter((k) => k.members > 0)
+
+  return { byMember, section: eff.label, areaMm2, kgPerM, netSteelKg, gussetFraction, gussetKg, totalKg, byKind }
+}
+
+// ── Pricing ────────────────────────────────────────────────────────────────
+export interface TrussPriceList {
+  steelKg: number   // ₱ per kg (applies to both sections and gusset plates)
+}
+
+export interface TrussBomRow {
+  item: string; qty: number; unit: string; unitPrice: number; amount: number
+}
+export interface TrussBom { rows: TrussBomRow[]; total: number }
+
+export function costTrussBill(t: TrussTakeoffResult, p: TrussPriceList): TrussBom {
+  const row = (item: string, qty: number, unit: string, unitPrice: number): TrussBomRow =>
+    ({ item, qty, unit, unitPrice, amount: qty * unitPrice })
+  const rows: TrussBomRow[] = [
+    row('Structural steel sections', t.netSteelKg, 'kg', p.steelKg),
+    row(`Gusset / connection plates (${(t.gussetFraction * 100).toFixed(0)}% allowance)`, t.gussetKg, 'kg', p.steelKg),
+  ]
+  return { rows, total: rows.reduce((s, r) => s + r.amount, 0) }
+}

--- a/webapp/src/pages/TrussSpace.tsx
+++ b/webapp/src/pages/TrussSpace.tsx
@@ -3,11 +3,12 @@ import { Link } from 'react-router-dom'
 import { Canvas } from '@react-three/fiber'
 import { OrbitControls, Text } from '@react-three/drei'
 import * as THREE from 'three'
-import { generateTruss, solveTrussEnvelope, selfWeightLoads, type TrussType } from '../engine/truss'
+import { generateTruss, solveTrussEnvelope, selfWeightLoads, type TrussType, type TrussModel } from '../engine/truss'
 import { designTruss, type MemberDesign, type TrussSection } from '../engine/trussDesign'
-import { FAMILIES, shapesOf, shapeByName, effectiveSection, type SectionFamily } from '../engine/aiscSections'
+import { FAMILIES, shapesOf, shapeByName, effectiveSection, type SectionFamily, type EffectiveSection } from '../engine/aiscSections'
 import { trussTakeoff, costTrussBill } from '../engine/trussTakeoff'
 import { SectionShape } from '../components/SectionShape'
+import { TrussEditor } from '../components/TrussEditor'
 import { FitView } from '../components/FitView'
 import { buildSectionShapes } from '../lib/sectionShapes3d'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
@@ -84,6 +85,11 @@ export default function TrussSpace() {
   const [selected, setSelected] = useState<string | null>(null)
   const [steelUnitPrice, setSteelUnitPrice] = useState(80)       // ₱ per kg
   const [gussetPct, setGussetPct] = useState(10)                 // % connection allowance
+  // free-form editor: when non-null, this model replaces the parametric one
+  const [custom, setCustom] = useState<TrussModel | null>(null)
+  // custom section: enter A & radii directly instead of picking an AISC shape
+  const [customSec, setCustomSec] = useState(false)
+  const [csA, setCsA] = useState(1500); const [csRx, setCsRx] = useState(30); const [csRy, setCsRy] = useState(30)
   const controlsRef = useRef<React.ComponentRef<typeof OrbitControls>>(null)
 
   // hold Shift to pan with a left-drag (right-drag also pans)
@@ -98,11 +104,18 @@ export default function TrussSpace() {
     return () => { window.removeEventListener('keydown', d); window.removeEventListener('keyup', u) }
   }, [])
 
-  const model = useMemo(() => generateTruss({ type, span, height, panels, panelLoad: liveLoad }), [type, span, height, panels, liveLoad])
-  const eff = useMemo(() => {
+  const generated = useMemo(() => generateTruss({ type, span, height, panels, panelLoad: liveLoad }), [type, span, height, panels, liveLoad])
+  const model = custom ?? generated
+  const eff: EffectiveSection = useMemo(() => {
+    if (customSec) {
+      const A = Math.max(1, csA), rx = Math.max(0.1, csRx), ry = Math.max(0.1, csRy)
+      const side = Math.sqrt(A)   // illustrative square profile (drawing only)
+      return { label: `Custom (A ${Math.round(A)} mm²)`, family: 'HSS', A, rx, ry, rmin: Math.min(rx, ry), double: false,
+        base: { name: 'custom', family: 'HSS', A, rx, ry, b: side, h: side, t: side / 2 } }
+    }
     const shp = shapeByName(shapeName) ?? shapesOf(family)[0]
     return effectiveSection(shp, double && shp.family === 'L', gap)
-  }, [shapeName, family, double, gap])
+  }, [customSec, csA, csRx, csRy, shapeName, family, double, gap])
   const section: TrussSection = useMemo(() => ({ A: eff.A, r: eff.rmin, E, Fy, K }), [eff, E, Fy, K])
 
   // load cases: Dead = self-weight (section-derived) + dead joint loads; Live =
@@ -115,7 +128,14 @@ export default function TrussSpace() {
   const live = useMemo(() => loadedNodes.map((n) => ({ node: n, fx: 0, fy: -liveLoad })), [loadedNodes, liveLoad])
   const result = useMemo(() => solveTrussEnvelope(model, dead, live), [model, dead, live])
   const design = useMemo(() => (result ? designTruss(result.forces, section) : null), [result, section])
-  const shapes3d = useMemo(() => buildSectionShapes(eff), [eff])   // true-scale section profiles for the 3D extrusion
+  const shapes3d = useMemo(() => {
+    if (customSec) {   // illustrative solid square (no real profile for a custom section)
+      const h = Math.sqrt(eff.A) / 1000 / 2
+      const sq = new THREE.Shape(); sq.moveTo(-h, -h); sq.lineTo(h, -h); sq.lineTo(h, h); sq.lineTo(-h, h); sq.closePath()
+      return [sq]
+    }
+    return buildSectionShapes(eff)   // true-scale section profiles for the 3D extrusion
+  }, [eff, customSec])
   const takeoff = useMemo(
     () => result ? trussTakeoff(result.forces, eff, { gussetFraction: gussetPct / 100 }) : null,
     [result, eff, gussetPct],
@@ -137,7 +157,7 @@ export default function TrussSpace() {
   }, [model])
   const designById = useMemo(() => new Map((design?.members ?? []).map((d) => [d.id, d])), [design])
 
-  const cx = span / 2, cyc = height / 2
+  const cx = (box.min[0] + box.max[0]) / 2, cyc = (box.min[1] + box.max[1]) / 2   // orbit target = model centre
   const selForce = result?.forces.find((f) => f.id === selected)
   const selDes = selForce ? designById.get(selForce.id) : undefined
   const serviceLoad = deadLoad + liveLoad
@@ -199,13 +219,21 @@ export default function TrussSpace() {
 
         {/* controls + results */}
         <div className="space-y-4">
-          <Card title="Truss geometry">
-            <Pick label="Type" value={type} onChange={(v) => setType(v as TrussType)}
-              options={[['pratt', 'Pratt'], ['howe', 'Howe'], ['warren', 'Warren'], ['roof', 'Pitched roof (gable)']]} />
-            <Num label="Span" unit="m" value={span} onChange={setSpan} step="0.5" />
-            <Num label="Height" unit="m" value={height} onChange={setHeight} step="0.25" />
-            <Num label="Panels" value={panels} onChange={(v) => setPanels(Math.max(2, Math.round(v)))} step="1" />
-          </Card>
+          {custom ? (
+            <TrussEditor model={custom} onChange={setCustom} onReset={() => { setCustom(null); setSelected(null) }} />
+          ) : (
+            <Card title="Truss geometry">
+              <Pick label="Type" value={type} onChange={(v) => setType(v as TrussType)}
+                options={[['pratt', 'Pratt'], ['howe', 'Howe'], ['warren', 'Warren'], ['roof', 'Pitched roof (gable)'], ['fink', 'Fink (W-web)'], ['scissor', 'Scissor (raised tie)']]} />
+              <Num label="Span" unit="m" value={span} onChange={setSpan} step="0.5" />
+              <Num label="Height" unit="m" value={height} onChange={setHeight} step="0.25" />
+              <Num label="Panels" value={panels} onChange={(v) => setPanels(Math.max(2, Math.round(v)))} step="1" />
+              <button type="button" onClick={() => { setCustom(structuredClone(generated)); setSelected(null) }}
+                className="col-span-full mt-1 rounded-md border border-[#0056b3]/40 bg-[#0056b3]/5 px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:bg-[#0056b3]/10">
+                ✎ Customize this truss (free-form editor)
+              </button>
+            </Card>
+          )}
 
           <Card title="Loads (NSCP combinations)">
             <Num label="Dead joint load" unit="kN" value={deadLoad} onChange={setDeadLoad} step="1" />
@@ -220,22 +248,36 @@ export default function TrussSpace() {
           </Card>
 
           <Card title="Section & material (AISC steel)">
-            <Pick label="Family" value={family} onChange={(v) => { const fam = v as SectionFamily; setFamily(fam); setShapeName(shapesOf(fam)[0].name) }}
-              options={FAMILIES.map((f) => [f.id, f.label])} />
-            <Pick label="Shape" value={shapeName} onChange={setShapeName}
-              options={shapesOf(family).map((s) => [s.name, s.name])} />
-            {family === 'L' && (
-              <label className="col-span-full flex items-center gap-2 text-sm">
-                <input type="checkbox" checked={double} onChange={(e) => setDouble(e.target.checked)} />
-                <span>Double angle (2L, back-to-back)</span>
-              </label>
+            <label className="col-span-full flex items-center gap-2 text-sm">
+              <input type="checkbox" checked={customSec} onChange={(e) => setCustomSec(e.target.checked)} />
+              <span>Custom section (enter area &amp; radii directly)</span>
+            </label>
+            {customSec ? (
+              <>
+                <Num label="Area A" unit="mm²" value={csA} onChange={setCsA} step="50" />
+                <Num label="r_x" unit="mm" value={csRx} onChange={setCsRx} step="1" />
+                <Num label="r_y" unit="mm" value={csRy} onChange={setCsRy} step="1" />
+              </>
+            ) : (
+              <>
+                <Pick label="Family" value={family} onChange={(v) => { const fam = v as SectionFamily; setFamily(fam); setShapeName(shapesOf(fam)[0].name) }}
+                  options={FAMILIES.map((f) => [f.id, f.label])} />
+                <Pick label="Shape" value={shapeName} onChange={setShapeName}
+                  options={shapesOf(family).map((s) => [s.name, s.name])} />
+                {family === 'L' && (
+                  <label className="col-span-full flex items-center gap-2 text-sm">
+                    <input type="checkbox" checked={double} onChange={(e) => setDouble(e.target.checked)} />
+                    <span>Double angle (2L, back-to-back)</span>
+                  </label>
+                )}
+                {family === 'L' && double && <Num label="Separator plate thickness" unit="mm" value={gap} onChange={setGap} step="1" />}
+              </>
             )}
-            {family === 'L' && double && <Num label="Separator plate thickness" unit="mm" value={gap} onChange={setGap} step="1" />}
             <Num label="Fy" unit="MPa" value={Fy} onChange={setFy} step="5" />
             <Num label="E" unit="MPa" value={E} onChange={setE} step="1000" />
             <Num label="Effective length K" value={K} onChange={setK} step="0.05" />
             <div className="col-span-full flex items-center gap-3 border-t border-slate-100 pt-2">
-              <SectionShape sec={eff} />
+              {!customSec && <SectionShape sec={eff} />}
               <div className="text-[11px] text-slate-500">
                 <div className="font-semibold text-[#0056b3]">{eff.label}</div>
                 <div>A = {Math.round(eff.A)} mm²</div>
@@ -265,7 +307,7 @@ export default function TrussSpace() {
       {result && design && (
         <div className="mt-6 space-y-4">
           <h2 className="text-xl font-extrabold tracking-tight text-[#0056b3]">
-            Truss member schedule — {type} · {f1(span)} m span
+            Truss member schedule — {custom ? 'custom truss' : `${type} · ${f1(span)} m span`}
             <span className="ml-3 text-sm font-normal text-slate-500">
               {result.determinacy.status} · {eff.label} · Fy {Fy} MPa · max util {(design.maxUtil * 100).toFixed(0)}%
             </span>

--- a/webapp/src/pages/TrussSpace.tsx
+++ b/webapp/src/pages/TrussSpace.tsx
@@ -6,6 +6,7 @@ import * as THREE from 'three'
 import { generateTruss, solveTrussEnvelope, selfWeightLoads, type TrussType } from '../engine/truss'
 import { designTruss, type MemberDesign, type TrussSection } from '../engine/trussDesign'
 import { FAMILIES, shapesOf, shapeByName, effectiveSection, type SectionFamily } from '../engine/aiscSections'
+import { trussTakeoff, costTrussBill } from '../engine/trussTakeoff'
 import { SectionShape } from '../components/SectionShape'
 import { FitView } from '../components/FitView'
 import { buildSectionShapes } from '../lib/sectionShapes3d'
@@ -81,6 +82,8 @@ export default function TrussSpace() {
   const [double, setDouble] = useState(true)        // double angle (2L) when family = L
   const [gap, setGap] = useState(0)                 // separator/gusset plate thickness, mm (0 = touching)
   const [selected, setSelected] = useState<string | null>(null)
+  const [steelUnitPrice, setSteelUnitPrice] = useState(80)       // ₱ per kg
+  const [gussetPct, setGussetPct] = useState(10)                 // % connection allowance
   const controlsRef = useRef<React.ComponentRef<typeof OrbitControls>>(null)
 
   // hold Shift to pan with a left-drag (right-drag also pans)
@@ -113,6 +116,15 @@ export default function TrussSpace() {
   const result = useMemo(() => solveTrussEnvelope(model, dead, live), [model, dead, live])
   const design = useMemo(() => (result ? designTruss(result.forces, section) : null), [result, section])
   const shapes3d = useMemo(() => buildSectionShapes(eff), [eff])   // true-scale section profiles for the 3D extrusion
+  const takeoff = useMemo(
+    () => result ? trussTakeoff(result.forces, eff, { gussetFraction: gussetPct / 100 }) : null,
+    [result, eff, gussetPct],
+  )
+  const bill = useMemo(
+    () => takeoff ? costTrussBill(takeoff, { steelKg: steelUnitPrice }) : null,
+    [takeoff, steelUnitPrice],
+  )
+  const peso = (v: number) => `₱${v.toLocaleString('en-PH', { maximumFractionDigits: 0 })}`
 
   const pos = useMemo(() => {
     const map = new Map<string, THREE.Vector3>()
@@ -298,6 +310,156 @@ export default function TrussSpace() {
               Pin-jointed planar truss (axial only). Tension yielding φPn = 0.9·Fy·Ag; compression flexural buckling per AISC §E3
               (Fcr from KL/r, φ = 0.90). KL/r &gt; 200 flagged (⚠). Reactions: pin at the left support, roller at the right.
             </p>
+          </div>
+        </div>
+      )}
+
+      {/* ── Material take-off / priced Bill of Materials ── */}
+      {takeoff && bill && (
+        <div className="mt-6 space-y-4 break-before-page">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h2 className="text-xl font-extrabold tracking-tight text-[#0056b3]">
+              Material Take-off &amp; Bill of Materials
+              <span className="ml-3 text-sm font-normal text-slate-500">{takeoff.section}</span>
+            </h2>
+          </div>
+
+          {/* Summary tiles */}
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+            {[
+              ['Members', `${takeoff.byMember.length}`],
+              ['Section A', `${Math.round(takeoff.areaMm2)} mm²`],
+              ['Net steel', `${f1(takeoff.netSteelKg)} kg`],
+              [`Gusset (${gussetPct}%)`, `${f1(takeoff.gussetKg)} kg`],
+              ['Total steel', `${f1(takeoff.totalKg)} kg`],
+            ].map(([k, v]) => (
+              <div key={k} className="rounded-lg border border-slate-200 bg-white p-2 text-center shadow-sm">
+                <div className="text-[11px] uppercase tracking-wide text-slate-500">{k}</div>
+                <div className="text-base font-bold text-[#0056b3]">{v}</div>
+              </div>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            {/* Per-member table */}
+            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Steel by member</h3>
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="text-left uppercase tracking-wide text-slate-500">
+                    <th className="py-1 pr-2 font-semibold">Member</th>
+                    <th className="py-1 pr-2 font-semibold">Kind</th>
+                    <th className="py-1 pr-2 text-right font-semibold">L (m)</th>
+                    <th className="py-1 pr-2 text-right font-semibold">kg/m</th>
+                    <th className="py-1 text-right font-semibold">Net (kg)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {takeoff.byMember.map((m) => (
+                    <tr key={m.id} className="border-t border-slate-100">
+                      <td className="py-0.5 pr-2 font-medium">{m.id}</td>
+                      <td className="py-0.5 pr-2 capitalize text-slate-500">{m.kind}</td>
+                      <td className="py-0.5 pr-2 text-right">{f2(m.L)}</td>
+                      <td className="py-0.5 pr-2 text-right">{f2(m.kgPerM)}</td>
+                      <td className="py-0.5 text-right">{f2(m.netWeightKg)}</td>
+                    </tr>
+                  ))}
+                  <tr className="border-t border-slate-200 font-semibold">
+                    <td colSpan={4} className="py-1 pr-2">Total</td>
+                    <td className="py-1 text-right">{f1(takeoff.netSteelKg)} kg</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            {/* By-kind subtotals + priced BOM */}
+            <div className="space-y-4">
+              <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">By element kind</h3>
+                <table className="w-full border-collapse text-xs">
+                  <thead>
+                    <tr className="text-left uppercase tracking-wide text-slate-500">
+                      <th className="py-1 pr-2 font-semibold">Kind</th>
+                      <th className="py-1 pr-2 text-right font-semibold">Members</th>
+                      <th className="py-1 pr-2 text-right font-semibold">Length (m)</th>
+                      <th className="py-1 text-right font-semibold">Net (kg)</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {takeoff.byKind.map((k) => (
+                      <tr key={k.kind} className="border-t border-slate-100">
+                        <td className="py-0.5 pr-2 capitalize font-medium">{k.kind}</td>
+                        <td className="py-0.5 pr-2 text-right">{k.members}</td>
+                        <td className="py-0.5 pr-2 text-right">{f2(k.lengthM)}</td>
+                        <td className="py-0.5 text-right">{f2(k.netKg)}</td>
+                      </tr>
+                    ))}
+                    <tr className="border-t border-slate-200 font-semibold">
+                      <td className="py-1 pr-2">Total</td>
+                      <td className="py-1 pr-2 text-right">{takeoff.byMember.length}</td>
+                      <td className="py-1 pr-2 text-right">{f2(takeoff.byKind.reduce((s, k) => s + k.lengthM, 0))}</td>
+                      <td className="py-1 text-right">{f1(takeoff.netSteelKg)} kg</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+
+              {/* Priced BOM */}
+              <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+                  <h3 className="text-[1.02rem] font-bold text-[#0056b3]">Priced Bill of Materials</h3>
+                  <div className="flex flex-wrap items-center gap-3 text-xs">
+                    <label className="flex items-center gap-1 text-slate-600">
+                      Steel price
+                      <input type="number" value={steelUnitPrice} min={1} step={5}
+                        onChange={(e) => setSteelUnitPrice(Math.max(1, Number(e.target.value)))}
+                        className="no-print ml-1 w-20 rounded border border-slate-300 px-1 py-0.5 text-right text-xs"
+                      />
+                      <span>₱/kg</span>
+                    </label>
+                    <label className="flex items-center gap-1 text-slate-600">
+                      Gusset
+                      <input type="number" value={gussetPct} min={0} max={50} step={1}
+                        onChange={(e) => setGussetPct(Math.min(50, Math.max(0, Number(e.target.value))))}
+                        className="no-print ml-1 w-16 rounded border border-slate-300 px-1 py-0.5 text-right text-xs"
+                      />
+                      <span>%</span>
+                    </label>
+                  </div>
+                </div>
+                <table className="w-full border-collapse text-xs">
+                  <thead>
+                    <tr className="text-left uppercase tracking-wide text-slate-500">
+                      <th className="py-1 pr-2 font-semibold">Item</th>
+                      <th className="py-1 pr-2 text-right font-semibold">Qty</th>
+                      <th className="py-1 pr-2 font-semibold">Unit</th>
+                      <th className="py-1 pr-2 text-right font-semibold">Unit price</th>
+                      <th className="py-1 text-right font-semibold">Amount (₱)</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {bill.rows.map((r) => (
+                      <tr key={r.item} className="border-t border-slate-100">
+                        <td className="py-0.5 pr-2">{r.item}</td>
+                        <td className="py-0.5 pr-2 text-right">{f1(r.qty)}</td>
+                        <td className="py-0.5 pr-2">{r.unit}</td>
+                        <td className="py-0.5 pr-2 text-right">{peso(r.unitPrice)}</td>
+                        <td className="py-0.5 text-right">{peso(r.amount)}</td>
+                      </tr>
+                    ))}
+                    <tr className="border-t-2 border-slate-300 font-bold">
+                      <td colSpan={4} className="py-1 pr-2">Total</td>
+                      <td className="py-1 text-right">{peso(bill.total)}</td>
+                    </tr>
+                  </tbody>
+                </table>
+                <p className="mt-1 text-[11px] text-slate-400">
+                  Section steel weight = A × L × 7850 kg/m³ per member.
+                  Gusset / connection plate allowance added as a fraction of the section steel.
+                  Prices in Philippine Peso (₱); edit to match current market rates.
+                </p>
+              </div>
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
Continues the Truss Space work. Two commits:

## Phase 3 — steel take-off + priced Bill of Materials
New engine `webapp/src/engine/trussTakeoff.ts`:
- **`trussTakeoff()`** — per-member steel weight (`A × L × 7850 kg/m³`), subtotals by chord kind (top/bottom/vertical/diagonal), and a configurable **gusset/connection-plate allowance** (default 10 % of net steel).
- **`costTrussBill()`** — prices the take-off at a user `₱/kg` rate → sections + gusset-plate rows.

`TrussSpace.tsx` gains a full **Material Take-off & BOM** section below the member schedule: summary tiles, per-member table, by-kind subtotals, and a **priced BOM** with live-editable steel unit price and gusset %.

## Phase 4 — remaining roadmap items
- **More roof types** in `engine/truss.ts`: **Fink** (W-pattern web) and **scissor** (mid-span raised tie / vaulted ceiling). Both statically determinate and stable for n = 4/6/8 — tests assert determinacy, stability and statics balance.
- **Free-form editor** (`components/TrussEditor.tsx`): edit node coordinates, members (i/j/kind), supports (ux/uy) and loaded joints directly; the page re-solves, re-designs and re-takes-off live. Deleting a node cascades to its members/supports/loads. Toggle in and out of parametric mode.
- **Custom section**: enter `A, rₓ, r_y` directly (the design engine only needs `A` and `r`), so any tabulated shape can be analysed without a library entry.
- **AISC library**: extended **HSS** (square + rectangular) and round **Pipe** families with computed nominal-geometry sizes (sharp-corner thin-wall model — exact by formula, documented). Existing tabulated rows are untouched; formula tests added.
- **PDF export**: already provided by the browser-print path in `components/ReportControls.tsx` (the new BOM prints with `break-before-page`).

### Note on the "full AISC v15 database"
Rather than fabricate thousands of section properties from memory (which would undermine design accuracy, per the repo's engineering rules), I extended the tube families via exact nominal geometry and added a **custom-section input** so any official tabulated shape can be used by entering its real `A`/`r`. A true bulk CSV/JSON import of the full table remains a clean future drop-in — the structure already supports it.

## Verification
- `npm test` → **264 passing** (35 files)
- `npx tsc -b` → clean
- `npm run build` → production build OK

_Browser preview tooling isn't available in this remote environment, so UI was verified via the full unit suite, typecheck and production build; the new UI is straightforward composition over already-tested engine modules and existing component patterns._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_