### PR TITLE
Steel Design page — beams, columns and connections (AISC 360-16 LRFD)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -35,7 +35,7 @@ npm run build    # typecheck + production build
 ```
 
 ## Current state (all merged to `main`)
-Latest merged work — PRs **#178, #179, #180** (main); **Truss Phase 3** open PR:
+Latest merged work — PRs **#178–#183** (main); **Steel Design** open PR:
 - **Truss Space** (`/truss`): planar pin-jointed truss — generate (Pratt / Howe /
   Warren / pitched-roof), analyse axial forces, AISC-LRFD member design.
 - **AISC section library** (`webapp/src/engine/aiscSections.ts`) — W/C/L/HSS/Pipe/
@@ -65,11 +65,21 @@ Latest merged work — PRs **#178, #179, #180** (main); **Truss Phase 3** open P
   `liveLoads.ts`, …) — each with a `*.test.ts`.
 - Routes + home tiles: `webapp/src/App.tsx`
 
+- **Steel Design** (`/steel`): new page covering three AISC 360-16 LRFD tools:
+  - **Beam design** (§F2 flexure with LTB zone badge, §G2.1 shear, service deflection L/360 & L/240).
+  - **Column design** (§E3 axial Fcr, both KL/rx and KL/ry, §F6 weak-axis flexure, §H1-1 combined ratio).
+  - **Connection design** (§J3.6 bolt shear + §J3.10 bearing for A325M/A490M; §J2.4 fillet weld
+    per mm for E70–E100 electrodes). Required count / required length shown live.
+  - Pure engine: `webapp/src/engine/steelDesign.ts` + 26 tests.
+  - Uses the existing AISC W-shape library; section properties (Ix, Sx, Zx, J, rts) derived from geometry.
+
 ## Next up — roadmap
 - Optional: bulk-import the **full official AISC v15 metric table** as data
   (CSV/JSON drop-in). Current library is a curated real-value set plus computed
   nominal HSS/Pipe sizes; a custom-section input covers anything not tabulated.
 - Optional: save / load custom trusses (localStorage or file); drag nodes in 3D.
 - Optional: more roof forms (Fink fan/double-Fink, gambrel), wind/uplift cases.
+- Optional: custom section input on Steel Design page (enter Sx, Zx, ry directly).
+- Optional: point-load + moment diagram for beams; stiffened web shear (§G2.2).
 
-_Tests at last handoff: 264 passing; `tsc -b` clean; production build OK._
+_Tests at last handoff: 290 passing; `tsc -b` clean; production build OK._

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -11,6 +11,7 @@ import LoadPath from './pages/LoadPath'
 // three.js is heavy — the 3D pages load in their own lazy chunks.
 const ModelSpace = lazy(() => import('./pages/ModelSpace'))
 const TrussSpace = lazy(() => import('./pages/TrussSpace'))
+import SteelDesign from './pages/SteelDesign'
 import SlabEstimate from './pages/SlabEstimate'
 import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
@@ -49,6 +50,7 @@ function Home() {
         <Tile to="/load-path">Slab Load Path</Tile>
         <Tile to="/model">3D Model Space</Tile>
         <Tile to="/truss">Truss Space</Tile>
+        <Tile to="/steel">Steel Design</Tile>
       </div>
 
       <h2 className="mt-8 text-lg font-semibold text-slate-800">Material estimation (quantity take-off)</h2>
@@ -85,6 +87,7 @@ export default function App() {
           <TrussSpace />
         </Suspense>
       } />
+      <Route path="/steel" element={<SteelDesign />} />
       <Route path="/estimate/slab" element={<SlabEstimate />} />
       <Route path="/estimate/beam" element={<BeamEstimate />} />
       <Route path="/estimate/column" element={<ColumnEstimate />} />

--- a/webapp/src/engine/steelDesign.test.ts
+++ b/webapp/src/engine/steelDesign.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest'
+import { shapeByName } from './aiscSections'
+import {
+  deriveWSection, beamFlexure, beamShear,
+  columnAxial, weakAxisFlexure, combinedLoading,
+  boltShear, weldStrength, beamLoadingSimple, E_STEEL,
+} from './steelDesign'
+
+const W250x33 = shapeByName('W250x33')!
+const p = deriveWSection(W250x33)
+
+describe('deriveWSection', () => {
+  it('Ix from box formula matches tabulated value ±2 %', () => {
+    // Official W250x33 Ix ≈ 48.5e6 mm⁴
+    expect(p.Ix).toBeGreaterThan(47e6)
+    expect(p.Ix).toBeLessThan(50e6)
+  })
+  it('Zx from first-moment formula matches tabulated value ±2 %', () => {
+    // Official W250x33 Zx ≈ 418 000 mm³
+    expect(p.Zx).toBeGreaterThan(410_000)
+    expect(p.Zx).toBeLessThan(430_000)
+  })
+  it('hw = d − 2·tf', () => {
+    const { d, tf } = W250x33
+    expect(p.hw).toBeCloseTo(d! - 2 * tf!, 5)
+  })
+  it('rts is positive', () => {
+    expect(p.rts).toBeGreaterThan(0)
+  })
+})
+
+describe('beamFlexure §F2', () => {
+  const Fy = 345
+  it('Lb = 0 → plastic zone, phiMn = 0.9·Fy·Zx', () => {
+    const r = beamFlexure(W250x33, p, Fy, 0)
+    expect(r.ltbZone).toBe('plastic')
+    expect(r.phiMn).toBeCloseTo(0.9 * Fy * p.Zx / 1e6, 4)
+  })
+  it('Lb = 1 m (< Lp) → plastic', () => {
+    expect(beamFlexure(W250x33, p, Fy, 1000).ltbZone).toBe('plastic')
+  })
+  it('large Lb → elastic or inelastic, phiMn < Mp·0.9', () => {
+    const r = beamFlexure(W250x33, p, Fy, 10_000)
+    expect(r.phiMn).toBeLessThan(0.9 * r.Mp)
+    expect(['inelastic', 'elastic']).toContain(r.ltbZone)
+  })
+  it('W250x33 A992 compact flange and web', () => {
+    const r = beamFlexure(W250x33, p, 345, 0)
+    expect(r.compactFlange).toBe(true)
+    expect(r.compactWeb).toBe(true)
+    expect(r.compact).toBe(true)
+  })
+  it('Cb > 1 increases Mn but not above Mp', () => {
+    const r1 = beamFlexure(W250x33, p, Fy, 5000, 1.0)
+    const r2 = beamFlexure(W250x33, p, Fy, 5000, 1.5)
+    expect(r2.phiMn).toBeGreaterThanOrEqual(r1.phiMn)
+    expect(r2.Mn).toBeLessThanOrEqual(r2.Mp + 1e-9)
+  })
+})
+
+describe('beamShear §G2.1', () => {
+  it('compact web → phiV = 1.0, Cv1 = 1.0', () => {
+    const r = beamShear(W250x33, p, 345)
+    expect(r.phiV).toBe(1.0)
+    expect(r.Cv1).toBe(1.0)
+  })
+  it('phiVn = phiV · 0.6 · Fy · d · tw', () => {
+    const Fy = 345
+    const r = beamShear(W250x33, p, Fy)
+    const expected = (r.phiV * 0.6 * Fy * W250x33.d! * W250x33.tw!) / 1000
+    expect(r.phiVn).toBeCloseTo(expected, 6)
+  })
+})
+
+describe('columnAxial §E3', () => {
+  it('short column approaches Fy · A', () => {
+    const r = columnAxial(W250x33, 345, 0.5, 1, 1)
+    expect(r.phiPn).toBeLessThanOrEqual(0.9 * 345 * W250x33.A / 1000 + 1e-6)
+    expect(r.phiPn).toBeGreaterThan(0.85 * 345 * W250x33.A / 1000)
+  })
+  it('governing slenderness = max(KxL/rx, KyL/ry)', () => {
+    const r = columnAxial(W250x33, 345, 4, 1, 1)
+    const rx = W250x33.rx, ry = W250x33.ry
+    expect(r.slendernessX).toBeCloseTo(1 * 4000 / rx, 6)
+    expect(r.slendernessY).toBeCloseTo(1 * 4000 / ry, 6)
+    expect(r.slenderness).toBeCloseTo(Math.max(r.slendernessX, r.slendernessY), 6)
+  })
+  it('slenderOK false when KL/r > 200', () => {
+    const r = columnAxial(W250x33, 345, 15, 1, 1)
+    expect(r.slenderOK).toBe(false)
+  })
+})
+
+describe('weakAxisFlexure §F6', () => {
+  it('phiMny > 0', () => {
+    expect(weakAxisFlexure(W250x33, p, 345).phiMny).toBeGreaterThan(0)
+  })
+})
+
+describe('combinedLoading §H1-1', () => {
+  it('H1-1a: Pu/φPn ≥ 0.2 → ratio = pr + 8/9·mr', () => {
+    const r = combinedLoading(500, 1000, 100, 200, 0, Infinity)
+    // pr = 0.5 ≥ 0.2 → H1-1a
+    expect(r.equation).toBe('H1-1a')
+    expect(r.ratio).toBeCloseTo(0.5 + (8 / 9) * (100 / 200), 10)
+  })
+  it('H1-1b: Pu/φPn < 0.2 → ratio = pr/2 + mr', () => {
+    const r = combinedLoading(100, 1000, 100, 200, 0, Infinity)
+    // pr = 0.1 < 0.2 → H1-1b
+    expect(r.equation).toBe('H1-1b')
+    expect(r.ratio).toBeCloseTo(0.1 / 2 + 100 / 200, 10)
+  })
+  it('ok flag reflects ≤ 1.0', () => {
+    // pr=0.8 + 8/9*0.8 = 1.511 > 1 → fails
+    expect(combinedLoading(160, 200, 160, 200).ok).toBe(false)
+    const r = combinedLoading(100, 1000, 10, 200)
+    expect(r.ok).toBe(r.ratio <= 1.0)
+  })
+})
+
+describe('boltShear §J3.6 + §J3.10', () => {
+  it('A325M d=19, threads in plane → phiRn_shear = 0.75·310·π/4·19²/1000', () => {
+    const r = boltShear('A325M', 19, 50, 10, 400, true)
+    const Ab = Math.PI / 4 * 19 ** 2
+    expect(r.phiRn_shear).toBeCloseTo(0.75 * 310 * Ab / 1000, 5)
+  })
+  it('bearing governs when plate is thin', () => {
+    // thin plate → small phiRn_bearing
+    const r = boltShear('A325M', 22, 50, 6, 400, false)
+    expect(r.phiRn_bearing).toBeLessThan(r.phiRn_shear)
+    expect(r.phiRn).toBe(r.phiRn_bearing)
+  })
+  it('n_reqd = ceil(Vu / phiRn)', () => {
+    const r = boltShear('A490M', 22, 200, 12, 400)
+    expect(r.n_reqd).toBe(Math.ceil(200 / r.phiRn))
+  })
+})
+
+describe('weldStrength §J2.4', () => {
+  it('E70 weld size 8 mm → phiRnw = 0.75·0.6·482·0.707·8/1000 kN/mm', () => {
+    const r = weldStrength('E70', 8, 100)
+    expect(r.phiRnw).toBeCloseTo(0.75 * 0.6 * 482 * 0.707 * 8 / 1000, 8)
+  })
+  it('L_reqd = Vu / phiRnw', () => {
+    const Vu = 150
+    const r = weldStrength('E70', 8, Vu)
+    expect(r.L_reqd).toBeCloseTo(Vu / r.phiRnw, 6)
+  })
+})
+
+describe('beamLoadingSimple', () => {
+  it('wu = max(1.4D, 1.2D+1.6L)', () => {
+    const r = beamLoadingSimple({ wDead: 20, wLive: 30, L: 6 }, p.Ix)
+    expect(r.wu).toBeCloseTo(Math.max(1.4 * 20, 1.2 * 20 + 1.6 * 30), 10)
+  })
+  it('Mu = wu·L²/8, Vu = wu·L/2', () => {
+    const r = beamLoadingSimple({ wDead: 10, wLive: 20, L: 8 }, p.Ix)
+    expect(r.Mu).toBeCloseTo(r.wu * 64 / 8, 10)
+    expect(r.Vu).toBeCloseTo(r.wu * 8 / 2, 10)
+  })
+  it('deflections use 5wL⁴/384EI', () => {
+    const bl = { wDead: 15, wLive: 25, L: 7 }
+    const r = beamLoadingSimple(bl, p.Ix)
+    const Lmm = 7000
+    const coef = 5 * Lmm ** 4 / (384 * E_STEEL * p.Ix)
+    expect(r.deltaD).toBeCloseTo(15 * coef, 8)
+    expect(r.deltaL).toBeCloseTo(25 * coef, 8)
+  })
+})

--- a/webapp/src/engine/steelDesign.ts
+++ b/webapp/src/engine/steelDesign.ts
@@ -1,0 +1,260 @@
+// Steel member and connection design — AISC 360-16, LRFD.
+// Units throughout: geometry mm, forces kN, stresses MPa, moments kN·m.
+// Sections are AiscShape from aiscSections (W-family only for beam/column).
+
+import type { AiscShape } from './aiscSections'
+
+export const E_STEEL = 200_000  // MPa
+
+const PHI_B = 0.90   // §F1 flexure
+const PHI_C = 0.90   // §E1 compression
+const PHI_J = 0.75   // §J connections
+
+// ─── Derived beam properties from W-shape geometry ────────────────────────
+// Ix via box-subtraction (exact for sharp-corner I); Iy via A·ry² (tabulated
+// ry is accurate); J by uniform-thickness formula (conservative ~40–60% low
+// for W-shapes — Lr may be 10–20% shorter than tabulated; LTB results are
+// conservative). Zx by first-moment formula (exact for sharp-corner I).
+
+export interface DerivedBeamProps {
+  Ix: number    // mm⁴
+  Sx: number    // mm³, elastic strong-axis section modulus
+  Zx: number    // mm³, plastic strong-axis section modulus
+  Iy: number    // mm⁴
+  Zy: number    // mm³, plastic weak-axis section modulus
+  J: number     // mm⁴, torsional constant (uniform-t approx)
+  ho: number    // mm, distance between flange centroids ≈ d − tf
+  rts: number   // mm, effective radius of gyration (§F2-7)
+  hw: number    // mm, clear web depth = d − 2·tf
+}
+
+export function deriveWSection(s: AiscShape): DerivedBeamProps {
+  const { A, ry, d, bf, tf, tw } = s
+  if (d == null || bf == null || tf == null || tw == null) throw new Error('W-section geometry missing')
+  const hw = d - 2 * tf
+  const Ix = (bf * d ** 3 - (bf - tw) * hw ** 3) / 12
+  const Sx = Ix / (d / 2)
+  const Zx = bf * tf * (d - tf) + (tw * hw * hw) / 4
+  const Iy = A * ry * ry
+  const Zy = tf * bf * bf / 2 + hw * tw * tw / 4
+  const J = (2 * bf * tf ** 3 + hw * tw ** 3) / 3
+  const ho = d - tf
+  const Cw = (Iy * ho * ho) / 4
+  const rts = Math.sqrt(Math.sqrt(Iy * Cw) / Sx)
+  return { Ix, Sx, Zx, Iy, Zy, J, ho, rts, hw }
+}
+
+// ─── Beam flexure §F2 (doubly-symmetric I, compact or near-compact) ───────
+
+export interface BeamFlexureResult {
+  Mp: number          // kN·m, Fy·Zx
+  Lp: number          // mm, §F2-5
+  Lr: number          // mm, §F2-6
+  ltbZone: 'plastic' | 'inelastic' | 'elastic'
+  Mn: number          // kN·m
+  phiMn: number       // kN·m
+  lambdaF: number; lambdaPF: number; compactFlange: boolean
+  lambdaW: number; lambdaPW: number; compactWeb: boolean
+  compact: boolean
+}
+
+export function beamFlexure(
+  s: AiscShape, p: DerivedBeamProps,
+  Fy: number, Lb: number, Cb = 1.0
+): BeamFlexureResult {
+  const E = E_STEEL
+  const { ry, bf, tf, tw } = s
+  const { Sx, Zx, J, ho, hw, rts } = p
+
+  const lambdaF  = bf! / (2 * tf!)
+  const lambdaPF = 0.38 * Math.sqrt(E / Fy)
+  const lambdaW  = hw / tw!
+  const lambdaPW = 3.76 * Math.sqrt(E / Fy)
+  const compactFlange = lambdaF <= lambdaPF
+  const compactWeb    = lambdaW <= lambdaPW
+  const compact = compactFlange && compactWeb
+
+  const Mp = (Fy * Zx) / 1e6   // kN·m
+  const Lp = 1.76 * ry * Math.sqrt(E / Fy)
+  const c  = J / (Sx * ho)
+  const Lr = 1.95 * rts * (E / (0.7 * Fy)) *
+             Math.sqrt(c + Math.sqrt(c * c + 6.76 * ((0.7 * Fy) / E) ** 2))
+
+  let Mn: number, ltbZone: BeamFlexureResult['ltbZone']
+  if (Lb <= Lp) {
+    ltbZone = 'plastic'; Mn = Mp
+  } else if (Lb <= Lr) {
+    ltbZone = 'inelastic'
+    Mn = Cb * (Mp - (Mp - 0.7 * Fy * Sx / 1e6) * ((Lb - Lp) / (Lr - Lp)))
+    Mn = Math.min(Mn, Mp)
+  } else {
+    ltbZone = 'elastic'
+    const Fcr = (Cb * Math.PI ** 2 * E) / (Lb / rts) ** 2 *
+                Math.sqrt(1 + 0.078 * (J / (Sx * ho)) * (Lb / rts) ** 2)
+    Mn = Math.min((Fcr * Sx) / 1e6, Mp)
+  }
+
+  return { Mp, Lp, Lr, ltbZone, Mn, phiMn: PHI_B * Mn,
+           lambdaF, lambdaPF, compactFlange, lambdaW, lambdaPW, compactWeb, compact }
+}
+
+// ─── Beam shear §G2.1 ─────────────────────────────────────────────────────
+// Hot-rolled I-shapes: h/tw ≤ 2.24√(E/Fy) → φv = 1.0, Cv1 = 1.0 (§G2.1a).
+// Slender webs use §G2.1(b) with kv = 5.34 (unstiffened).
+
+export interface BeamShearResult {
+  Aw: number; Cv1: number; phiV: number; phiVn: number; hwTw: number
+}
+
+export function beamShear(s: AiscShape, p: DerivedBeamProps, Fy: number): BeamShearResult {
+  const E = E_STEEL
+  const Aw   = s.d! * s.tw!
+  const hwTw = p.hw / s.tw!
+  let Cv1: number, phiV: number
+  if (hwTw <= 2.24 * Math.sqrt(E / Fy)) {
+    Cv1 = 1.0; phiV = 1.0
+  } else {
+    const kv = 5.34
+    const lim1 = 1.10 * Math.sqrt(kv * E / Fy)
+    const lim2 = 1.37 * Math.sqrt(kv * E / Fy)
+    Cv1  = hwTw <= lim1 ? 1.0 : hwTw <= lim2 ? lim1 / hwTw : (1.51 * kv * E) / (Fy * hwTw * hwTw)
+    phiV = 0.9
+  }
+  return { Aw, Cv1, phiV, phiVn: (phiV * 0.6 * Fy * Aw * Cv1) / 1000, hwTw }
+}
+
+// ─── Column axial §E3 ──────────────────────────────────────────────────────
+// Both axes checked; governing (larger) KL/r controls Fcr.
+// L in metres; returns phiPn in kN.
+
+export interface ColumnAxialResult {
+  slendernessX: number; slendernessY: number; slenderness: number
+  Fcr: number; phiPn: number; slenderOK: boolean
+}
+
+export function columnAxial(
+  s: AiscShape, Fy: number, L: number, Kx: number, Ky: number
+): ColumnAxialResult {
+  const E = E_STEEL
+  const Lmm = L * 1000
+  const slendernessX = (Kx * Lmm) / s.rx
+  const slendernessY = (Ky * Lmm) / s.ry
+  const slenderness  = Math.max(slendernessX, slendernessY)
+  const limit = 4.71 * Math.sqrt(E / Fy)
+  const Fe  = (Math.PI ** 2 * E) / slenderness ** 2
+  const Fcr = slenderness <= limit ? Math.pow(0.658, Fy / Fe) * Fy : 0.877 * Fe
+  return {
+    slendernessX, slendernessY, slenderness, Fcr,
+    phiPn: (PHI_C * Fcr * s.A) / 1000,
+    slenderOK: slenderness <= 200,
+  }
+}
+
+// ─── Weak-axis flexure §F6 ────────────────────────────────────────────────
+// Compact W-shapes, no LTB about weak axis → Mny = Mp_y = Fy·Zy ≤ 1.6·Fy·Sy.
+
+export interface WeakAxisResult { Sy: number; Zy: number; phiMny: number }
+
+export function weakAxisFlexure(s: AiscShape, p: DerivedBeamProps, Fy: number): WeakAxisResult {
+  const Sy  = (2 * p.Iy) / s.bf!
+  const cap = Math.min(p.Zy, 1.6 * Sy)   // §F6-1 cap
+  return { Sy, Zy: p.Zy, phiMny: (PHI_B * Fy * cap) / 1e6 }
+}
+
+// ─── Combined loading §H1-1 ───────────────────────────────────────────────
+// Muy / phiMny defaults to 0 when no weak-axis moment is applied.
+
+export interface CombinedResult { ratio: number; equation: 'H1-1a' | 'H1-1b'; ok: boolean }
+
+export function combinedLoading(
+  Pu: number, phiPn: number,
+  Mux: number, phiMnx: number,
+  Muy = 0, phiMny = Infinity
+): CombinedResult {
+  const pr = Pu / phiPn
+  const mr = Mux / phiMnx + (phiMny > 0 ? Muy / phiMny : 0)
+  const [ratio, equation]: [number, CombinedResult['equation']] =
+    pr >= 0.2
+      ? [pr + (8 / 9) * mr, 'H1-1a']
+      : [pr / 2 + mr, 'H1-1b']
+  return { ratio, equation, ok: ratio <= 1.0 }
+}
+
+// ─── Bolt shear §J3.6 + bearing §J3.10 ───────────────────────────────────
+// Bolt shear: φRn = 0.75·Fnv·Ab per bolt (Table J3.2, metric bolts).
+// Bearing:    φRn = 0.75·2.4·Fu·d·t per bolt (standard holes, §J3.10).
+
+export type BoltGrade = 'A325M' | 'A490M'
+
+export interface BoltResult {
+  Ab: number; Fnv: number
+  phiRn_shear: number   // kN per bolt
+  phiRn_bearing: number // kN per bolt
+  phiRn: number         // governing
+  n_reqd: number        // bolts required for Vu
+}
+
+export function boltShear(
+  grade: BoltGrade, db: number,
+  Vu: number, t_conn: number, Fu_conn: number,
+  threadsInPlane = true
+): BoltResult {
+  const Ab  = (Math.PI / 4) * db * db
+  const Fnv = grade === 'A325M'
+    ? (threadsInPlane ? 310 : 372)
+    : (threadsInPlane ? 372 : 457)   // Table J3.2
+  const phiRn_shear   = (PHI_J * Fnv * Ab) / 1000
+  const phiRn_bearing = (PHI_J * 2.4 * Fu_conn * db * t_conn) / 1000
+  const phiRn  = Math.min(phiRn_shear, phiRn_bearing)
+  return { Ab, Fnv, phiRn_shear, phiRn_bearing, phiRn, n_reqd: Math.ceil(Vu / phiRn) }
+}
+
+// ─── Fillet weld §J2.4 ────────────────────────────────────────────────────
+// Effective throat = 0.707·w (equal-leg fillet), 60° loading angle → θ = 0°.
+// φRnw = 0.75·0.6·Fexx·0.707·w  per unit length (kN/mm).
+
+export type ElectrodeClass = 'E70' | 'E80' | 'E90' | 'E100'
+
+export interface WeldResult {
+  Fexx: number
+  phiRnw: number   // kN/mm per mm of weld length
+  L_reqd: number   // mm total weld length for Vu
+}
+
+export function weldStrength(electrode: ElectrodeClass, wSize: number, Vu: number): WeldResult {
+  const Fexx: Record<ElectrodeClass, number> = { E70: 482, E80: 550, E90: 620, E100: 690 }
+  const Fex  = Fexx[electrode]
+  const phiRnw = (PHI_J * 0.6 * Fex * 0.707 * wSize) / 1000   // kN/mm
+  return { Fexx: Fex, phiRnw, L_reqd: phiRnw > 0 ? Vu / phiRnw : Infinity }
+}
+
+// ─── Beam loading (simple span, uniform load) → Mu, Vu, deflections ───────
+// Deflection: δ = 5wL⁴/(384EI); w in kN/m = N/mm numerically.
+
+export interface BeamLoadInput { wDead: number; wLive: number; L: number }
+
+export interface BeamLoadsResult {
+  wu: number   // kN/m, factored (max of 1.4D, 1.2D+1.6L)
+  Mu: number   // kN·m
+  Vu: number   // kN
+  deltaD: number  // mm, dead-load deflection (unfactored)
+  deltaL: number  // mm, live-load deflection
+  limL360: number // mm, L/360
+  limL240: number // mm, L/240
+}
+
+export function beamLoadingSimple(bl: BeamLoadInput, Ix_mm4: number): BeamLoadsResult {
+  const { wDead, wLive, L } = bl
+  const wu   = Math.max(1.4 * wDead, 1.2 * wDead + 1.6 * wLive)
+  const Mu   = (wu * L * L) / 8
+  const Vu   = (wu * L) / 2
+  const Lmm  = L * 1000
+  const coef = (5 * Lmm ** 4) / (384 * E_STEEL * Ix_mm4)
+  return {
+    wu, Mu, Vu,
+    deltaD: wDead * coef,
+    deltaL: wLive * coef,
+    limL360: Lmm / 360,
+    limL240: Lmm / 240,
+  }
+}

--- a/webapp/src/pages/SteelDesign.tsx
+++ b/webapp/src/pages/SteelDesign.tsx
@@ -1,0 +1,375 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { shapesOf, shapeByName } from '../engine/aiscSections'
+import type { AiscShape } from '../engine/aiscSections'
+import {
+  deriveWSection, beamFlexure, beamShear, columnAxial,
+  weakAxisFlexure, combinedLoading, boltShear, weldStrength,
+  beamLoadingSimple,
+} from '../engine/steelDesign'
+import type { BoltGrade, ElectrodeClass } from '../engine/steelDesign'
+import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
+import { ReportControls } from '../components/ReportControls'
+import { f1, f2, f3 } from '../lib/format'
+
+type Tab = 'beam' | 'column' | 'connection'
+type Grade = 'A36' | 'A572G50'
+type ConnType = 'bolt' | 'weld'
+
+const GRADES: Record<Grade, { Fy: number; Fu: number; label: string }> = {
+  A36:    { Fy: 248, Fu: 400, label: 'A36 / SS400 (Fy = 248 MPa)' },
+  A572G50: { Fy: 345, Fu: 448, label: 'A572 Gr50 / A992 (Fy = 345 MPa)' },
+}
+
+const W_SHAPES = shapesOf('W')
+const wName = (s: AiscShape) => s.name
+
+function shapeOrFirst(name: string): AiscShape {
+  return shapeByName(name) ?? W_SHAPES[0]
+}
+
+const badge = (zone: string) => {
+  const cls = zone === 'plastic' ? 'bg-green-100 text-green-800'
+            : zone === 'inelastic' ? 'bg-amber-100 text-amber-800'
+            : 'bg-red-100 text-red-800'
+  return <span className={`ml-2 rounded px-1.5 py-0.5 text-[10px] font-bold uppercase ${cls}`}>{zone} LTB</span>
+}
+
+const ok = (pass: boolean, val: string) => (
+  <span className={pass ? 'text-green-700 font-semibold' : 'text-red-700 font-semibold'}>{val} {pass ? '✓' : '✗'}</span>
+)
+
+// ─── Beam Tab ──────────────────────────────────────────────────────────────
+function BeamTab() {
+  const [shapeName, setShapeName] = useState('W310x39')
+  const [grade, setGrade]         = useState<Grade>('A572G50')
+  const [span, setSpan]           = useState(6)
+  const [Lb, setLb]               = useState(2)
+  const [Cb, setCb]               = useState(1.0)
+  const [wDead, setWDead]         = useState(15)
+  const [wLive, setWLive]         = useState(25)
+
+  const { Fy } = GRADES[grade]
+  const shape = useMemo(() => shapeOrFirst(shapeName), [shapeName])
+  const props = useMemo(() => deriveWSection(shape), [shape])
+
+  const flex  = useMemo(() => beamFlexure(shape, props, Fy, Lb * 1000, Cb), [shape, props, Fy, Lb, Cb])
+  const shear = useMemo(() => beamShear(shape, props, Fy), [shape, props, Fy])
+  const loads = useMemo(() => beamLoadingSimple({ wDead, wLive, L: span }, props.Ix), [wDead, wLive, span, props])
+
+  const utilM = flex.phiMn > 0 ? loads.Mu / flex.phiMn : Infinity
+  const utilV = shear.phiVn > 0 ? loads.Vu / shear.phiVn : Infinity
+
+  return (
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
+      <div className="space-y-5">
+        <Card title="Section">
+          <label className="flex flex-col text-sm col-span-full">
+            <span className="mb-1 font-medium text-slate-600">W-shape</span>
+            <select value={shapeName} onChange={(e) => setShapeName(e.target.value)}
+              className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none">
+              {W_SHAPES.map((s) => <option key={s.name} value={s.name}>{s.name}</option>)}
+            </select>
+          </label>
+          <Pick label="Steel grade" value={grade} onChange={(v) => setGrade(v as Grade)}
+            options={Object.entries(GRADES).map(([k, v]) => [k as Grade, v.label])} />
+        </Card>
+
+        <Card title="Span & bracing">
+          <Num label="Span L" unit="m" value={span} onChange={setSpan} />
+          <Num label="Unbraced Lb" unit="m" value={Lb} onChange={setLb} />
+          <Num label="Cb (moment gradient)" value={Cb} onChange={setCb} />
+        </Card>
+
+        <Card title="Uniform loads (service)">
+          <Num label="Dead wD" unit="kN/m" value={wDead} onChange={setWDead} />
+          <Num label="Live wL" unit="kN/m" value={wLive} onChange={setWLive} />
+        </Card>
+      </div>
+
+      <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
+        <ResultCard title="Section properties">
+          <Row label="A" value={`${shape.A.toLocaleString()} mm²`} />
+          <Row label="Ix" value={`${(props.Ix / 1e6).toFixed(1)} × 10⁶ mm⁴`} />
+          <Row label="Sx" value={`${(props.Sx / 1e3).toFixed(0)} × 10³ mm³`} />
+          <Row label="Zx" value={`${(props.Zx / 1e3).toFixed(0)} × 10³ mm³`} />
+          <Row label="ry" value={`${shape.ry} mm`} />
+          <Row label="Lp" value={`${f2(flex.Lp / 1000)} m`} sub="yielding limit" />
+          <Row label="Lr" value={`${f2(flex.Lr / 1000)} m`} sub="elastic LTB limit (conservative J)" />
+        </ResultCard>
+
+        <ResultCard title="Compact section (Table B4.1b)">
+          <Row label="λf = bf/2tf" value={f2(flex.lambdaF)} sub={`λpf = ${f2(flex.lambdaPF)}`} />
+          <Row label="Flange" value={ok(flex.compactFlange, flex.compactFlange ? 'compact' : 'non-compact')} />
+          <Row label="λw = hw/tw" value={f1(flex.lambdaW)} sub={`λpw = ${f1(flex.lambdaPW)}`} />
+          <Row label="Web" value={ok(flex.compactWeb, flex.compactWeb ? 'compact' : 'non-compact')} />
+        </ResultCard>
+
+        <ResultCard title="Factored demands">
+          <Row label="wu" value={`${f2(loads.wu)} kN/m`} sub="max(1.4D, 1.2D+1.6L)" />
+          <Row label="Mu" value={`${f1(loads.Mu)} kN·m`} />
+          <Row label="Vu" value={`${f1(loads.Vu)} kN`} />
+        </ResultCard>
+
+        <ResultCard title="Flexure §F2">
+          <Row label={<>φMn {badge(flex.ltbZone)}</>} value={`${f1(flex.phiMn)} kN·m`} />
+          <Row alert={utilM > 1} label="Mu / φMn" value={ok(utilM <= 1, `${(utilM * 100).toFixed(0)} %`)} />
+        </ResultCard>
+
+        <ResultCard title="Shear §G2.1">
+          <Row label="Aw = d·tw" value={`${shear.Aw.toFixed(0)} mm²`} />
+          <Row label="φv" value={shear.phiV.toFixed(1)} sub={`Cv1 = ${shear.Cv1.toFixed(2)}`} />
+          <Row label="φVn" value={`${f1(shear.phiVn)} kN`} />
+          <Row alert={utilV > 1} label="Vu / φVn" value={ok(utilV <= 1, `${(utilV * 100).toFixed(0)} %`)} />
+        </ResultCard>
+
+        <ResultCard title="Deflection (unfactored)">
+          <Row label="δD (dead)" value={`${f2(loads.deltaD)} mm`} />
+          <Row label="δL (live)" value={`${f2(loads.deltaL)} mm`} sub={`limit L/360 = ${f2(loads.limL360)} mm`} />
+          <Row alert={loads.deltaL > loads.limL360}
+            label="δL ≤ L/360" value={ok(loads.deltaL <= loads.limL360, `${f2(loads.deltaL)} mm`)} />
+          <Row alert={loads.deltaD + loads.deltaL > loads.limL240}
+            label="δtotal ≤ L/240" value={ok(loads.deltaD + loads.deltaL <= loads.limL240,
+              `${f2(loads.deltaD + loads.deltaL)} mm`)} sub={`limit = ${f2(loads.limL240)} mm`} />
+        </ResultCard>
+      </div>
+    </div>
+  )
+}
+
+// ─── Column Tab ────────────────────────────────────────────────────────────
+function ColumnTab() {
+  const [shapeName, setShapeName] = useState('W250x67')
+  const [grade, setGrade]         = useState<Grade>('A572G50')
+  const [L, setL]                 = useState(4)
+  const [Kx, setKx]               = useState(1.0)
+  const [Ky, setKy]               = useState(1.0)
+  const [loadInput, setLoadInput] = useState<'direct' | 'DL'>('DL')
+  const [dead, setDead]           = useState(800)
+  const [live, setLive]           = useState(500)
+  const [PuDir, setPuDir]         = useState(1944)
+  const [Mux, setMux]             = useState(80)
+  const [Muy, setMuy]             = useState(0)
+
+  const { Fy } = GRADES[grade]
+  const shape = useMemo(() => shapeOrFirst(shapeName), [shapeName])
+  const props = useMemo(() => deriveWSection(shape), [shape])
+  const Pu  = loadInput === 'DL' ? Math.max(1.4 * dead, 1.2 * dead + 1.6 * live) : PuDir
+
+  const axial  = useMemo(() => columnAxial(shape, Fy, L, Kx, Ky), [shape, Fy, L, Kx, Ky])
+  const flexX  = useMemo(() => beamFlexure(shape, props, Fy, L * 1000, 1.0), [shape, props, Fy, L])
+  const flexY  = useMemo(() => weakAxisFlexure(shape, props, Fy), [shape, props, Fy])
+  const comb   = useMemo(
+    () => combinedLoading(Pu, axial.phiPn, Mux, flexX.phiMn, Muy, flexY.phiMny),
+    [Pu, axial, Mux, flexX, Muy, flexY]
+  )
+
+  return (
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
+      <div className="space-y-5">
+        <Card title="Section">
+          <label className="flex flex-col text-sm col-span-full">
+            <span className="mb-1 font-medium text-slate-600">W-shape</span>
+            <select value={shapeName} onChange={(e) => setShapeName(e.target.value)}
+              className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none">
+              {W_SHAPES.map((s) => <option key={s.name} value={wName(s)}>{s.name}</option>)}
+            </select>
+          </label>
+          <Pick label="Steel grade" value={grade} onChange={(v) => setGrade(v as Grade)}
+            options={Object.entries(GRADES).map(([k, v]) => [k as Grade, v.label])} />
+        </Card>
+
+        <Card title="Column geometry">
+          <Num label="Height L" unit="m" value={L} onChange={setL} />
+          <Num label="Kx (x-axis)" value={Kx} onChange={setKx} />
+          <Num label="Ky (y-axis)" value={Ky} onChange={setKy} />
+        </Card>
+
+        <Card title="Loads">
+          <Pick label="Axial input" value={loadInput} onChange={(v) => setLoadInput(v as 'direct' | 'DL')}
+            options={[['DL', 'Service D & L'], ['direct', 'Factored Pu']]} />
+          {loadInput === 'DL' ? <>
+            <Num label="Dead D" unit="kN" value={dead} onChange={setDead} />
+            <Num label="Live L" unit="kN" value={live} onChange={setLive} />
+          </> : (
+            <Num label="Pu" unit="kN" value={PuDir} onChange={setPuDir} />
+          )}
+          <Num label="Mux (strong)" unit="kN·m" value={Mux} onChange={setMux} />
+          <Num label="Muy (weak)" unit="kN·m" value={Muy} onChange={setMuy} />
+        </Card>
+      </div>
+
+      <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
+        <ResultCard title="Section properties">
+          <Row label="A" value={`${shape.A.toLocaleString()} mm²`} />
+          <Row label="rx" value={`${shape.rx} mm`} />
+          <Row label="ry" value={`${shape.ry} mm`} />
+          <Row label="Zx" value={`${(props.Zx / 1e3).toFixed(0)} × 10³ mm³`} />
+        </ResultCard>
+
+        <ResultCard title="Axial §E3">
+          <Row label="KxL/rx" value={f1(axial.slendernessX)} />
+          <Row label="KyL/ry" value={f1(axial.slendernessY)} />
+          <Row alert={!axial.slenderOK}
+            label="KL/r (governing)" value={`${f1(axial.slenderness)}${axial.slenderOK ? '' : ' > 200 ✗'}`} />
+          <Row label="Fcr" value={`${f1(axial.Fcr)} MPa`} />
+          <Row label="φPn" value={`${f1(axial.phiPn)} kN`} />
+          <Row label="Pu" value={`${f1(Pu)} kN`} sub={`${(Pu / axial.phiPn * 100).toFixed(0)} %`} />
+        </ResultCard>
+
+        <ResultCard title="Flexure">
+          <Row label="φMnx (strong)" value={`${f1(flexX.phiMn)} kN·m`} sub={flexX.ltbZone} />
+          <Row label="φMny (weak §F6)" value={`${f1(flexY.phiMny)} kN·m`} />
+        </ResultCard>
+
+        <ResultCard title={`Combined §${comb.equation}`}>
+          <Row label="Pu / φPn" value={f3(Pu / axial.phiPn)} />
+          <Row label="Mux / φMnx" value={f3(Mux / flexX.phiMn)} />
+          {Muy > 0 && <Row label="Muy / φMny" value={f3(Muy / flexY.phiMny)} />}
+          <Row alert={!comb.ok}
+            label="Combined ratio" value={ok(comb.ok, `${(comb.ratio * 100).toFixed(0)} %`)} />
+        </ResultCard>
+      </div>
+    </div>
+  )
+}
+
+// ─── Connection Tab ─────────────────────────────────────────────────────────
+function ConnectionTab() {
+  const [connType, setConnType]       = useState<ConnType>('bolt')
+  const [Vu, setVu]                   = useState(150)
+  // bolt
+  const [boltGrade, setBoltGrade]     = useState<BoltGrade>('A325M')
+  const [db, setDb]                   = useState(19)
+  const [nBolts, setNBolts]           = useState(3)
+  const [tConn, setTConn]             = useState(10)
+  const [FuConn, setFuConn]           = useState(400)
+  const [threads, setThreads]         = useState<'yes' | 'no'>('yes')
+  // weld
+  const [electrode, setElectrode]     = useState<ElectrodeClass>('E70')
+  const [wSize, setWSize]             = useState(8)
+  const [weldLen, setWeldLen]         = useState(200)
+
+  const bolt = useMemo(
+    () => boltShear(boltGrade, db, Vu, tConn, FuConn, threads === 'yes'),
+    [boltGrade, db, Vu, tConn, FuConn, threads]
+  )
+  const weld = useMemo(() => weldStrength(electrode, wSize, Vu), [electrode, wSize, Vu])
+
+  const boltCapacity = nBolts * bolt.phiRn
+  const weldCapacity = weldLen * weld.phiRnw
+  const utilBolt = Vu / boltCapacity
+  const utilWeld = Vu / weldCapacity
+
+  return (
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
+      <div className="space-y-5">
+        <Card title="Connection">
+          <Pick label="Type" value={connType} onChange={(v) => setConnType(v as ConnType)}
+            options={[['bolt', 'Bolted (§J3)'], ['weld', 'Fillet weld (§J2.4)']]} />
+          <Num label="Applied Vu" unit="kN" value={Vu} onChange={setVu} />
+        </Card>
+
+        {connType === 'bolt' ? (
+          <Card title="Bolt group">
+            <Pick label="Grade" value={boltGrade} onChange={(v) => setBoltGrade(v as BoltGrade)}
+              options={[['A325M', 'A325M (F10T equiv)'], ['A490M', 'A490M (F13T equiv)']]} />
+            <Num label="Bolt diameter db" unit="mm" value={db} onChange={setDb} />
+            <Num label="Number of bolts n" value={nBolts} onChange={setNBolts} />
+            <Pick label="Threads in shear plane" value={threads} onChange={(v) => setThreads(v as 'yes' | 'no')}
+              options={[['yes', 'Yes (N)'], ['no', 'No (X)']]} />
+            <Num label="Plate thickness t" unit="mm" value={tConn} onChange={setTConn} />
+            <Num label="Plate Fu" unit="MPa" value={FuConn} onChange={setFuConn} />
+          </Card>
+        ) : (
+          <Card title="Fillet weld">
+            <Pick label="Electrode" value={electrode} onChange={(v) => setElectrode(v as ElectrodeClass)}
+              options={[['E70', 'E70XX (Fexx 482 MPa)'], ['E80', 'E80XX (550 MPa)'],
+                        ['E90', 'E90XX (620 MPa)'],    ['E100', 'E100XX (690 MPa)']]} />
+            <Num label="Weld size w" unit="mm" value={wSize} onChange={setWSize} />
+            <Num label="Total weld length" unit="mm" value={weldLen} onChange={setWeldLen} />
+          </Card>
+        )}
+      </div>
+
+      <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
+        {connType === 'bolt' ? (
+          <ResultCard title="Bolt design §J3.6 / §J3.10">
+            <Row label="Ab (bolt area)" value={`${bolt.Ab.toFixed(0)} mm²`} />
+            <Row label="Fnv" value={`${bolt.Fnv} MPa`} />
+            <Row label="φRn shear / bolt" value={`${f2(bolt.phiRn_shear)} kN`} />
+            <Row label="φRn bearing / bolt" value={`${f2(bolt.phiRn_bearing)} kN`} sub="governs if shown bold" />
+            <Row label="φRn / bolt (governing)" value={<b>{f2(bolt.phiRn)} kN</b>} />
+            <Row label="Bolts required" value={`${bolt.n_reqd}`} sub={`for Vu = ${Vu} kN`} />
+            <Row label={`Capacity (${nBolts} bolts)`} value={`${f1(boltCapacity)} kN`} />
+            <Row alert={utilBolt > 1}
+              label={`Vu / (${nBolts} × φRn)`}
+              value={ok(utilBolt <= 1, `${(utilBolt * 100).toFixed(0)} %`)} />
+          </ResultCard>
+        ) : (
+          <ResultCard title="Fillet weld §J2.4">
+            <Row label="Fexx" value={`${weld.Fexx} MPa`} />
+            <Row label="Throat (0.707w)" value={`${(0.707 * wSize).toFixed(1)} mm`} />
+            <Row label="φRnw / mm length" value={`${f3(weld.phiRnw)} kN/mm`} />
+            <Row label="Required length" value={`${f1(weld.L_reqd)} mm`} sub={`for Vu = ${Vu} kN`} />
+            <Row label={`Capacity (${weldLen} mm)`} value={`${f1(weldCapacity)} kN`} />
+            <Row alert={utilWeld > 1}
+              label={`Vu / (${weldLen} mm × φRnw)`}
+              value={ok(utilWeld <= 1, `${(utilWeld * 100).toFixed(0)} %`)} />
+            <p className="mt-2 text-[10px] text-slate-400">
+              Divide total length by 2 for two-sided welds. Check minimum weld size
+              per AISC Table J2.4 (governed by thicker connected part).
+            </p>
+          </ResultCard>
+        )}
+
+        <div className="print-avoid-break rounded-xl border border-slate-100 bg-slate-50 p-4 text-[11px] text-slate-500 space-y-1">
+          <p className="font-semibold text-slate-600">Notes</p>
+          <p>• Bolt shear: one shear plane. Multiply n by number of shear planes for lap/splice.</p>
+          <p>• Bearing per bolt: standard holes, no deformation limit state (§J3.10). Check edge distance ≥ 1.5d, spacing ≥ 3d (§J3.3).</p>
+          <p>• Weld capacity is for a single pass, direct shear (θ = 0°). §J2.4(b) allows a 50% increase for transverse loading.</p>
+          <p>• Block shear (§J4.3) and net section (§J4.1) should be checked separately.</p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── Main page ─────────────────────────────────────────────────────────────
+export default function SteelDesign() {
+  const [tab, setTab] = useState<Tab>('beam')
+
+  const tabBtn = (t: Tab, label: string) => (
+    <button type="button"
+      onClick={() => setTab(t)}
+      className={`rounded-md px-4 py-1.5 text-sm font-semibold transition
+        ${tab === t ? 'bg-[#0056b3] text-white shadow' : 'text-slate-600 hover:bg-slate-100'}`}>
+      {label}
+    </button>
+  )
+
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
+      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Steel Design</h1>
+      <p className="no-print mt-1 text-slate-600">
+        AISC 360-16 LRFD — steel beams (§F/G, flexure + shear + deflection),
+        columns (§E3 + §H1-1 combined), and connections (bolts §J3, fillet welds §J2.4).
+        W-shapes from the same AISC library used in Truss Space.
+      </p>
+      <ReportControls title="Steel Design Report" />
+
+      <div className="no-print mt-5 mb-6 flex gap-2 rounded-xl border border-slate-200 bg-white p-1.5 shadow-sm w-fit">
+        {tabBtn('beam',       'Beam')}
+        {tabBtn('column',     'Column')}
+        {tabBtn('connection', 'Connection')}
+      </div>
+
+      <div className="mt-2">
+        {tab === 'beam'       && <BeamTab />}
+        {tab === 'column'     && <ColumnTab />}
+        {tab === 'connection' && <ConnectionTab />}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
New `/steel` page covering the three core steel design checks per AISC 360-16 LRFD.

## What's added

### Engine (`webapp/src/engine/steelDesign.ts`)
Pure calculation module — no React. All properties derived analytically from the existing AISC W-shape library (no new data tables needed):
- `deriveWSection()` — computes Ix (box-subtraction formula), Sx, Zx, Iy, Zy, J, rts, hw from `AiscShape` geometry
- `beamFlexure()` — AISC 360 §F2: Mp, Lp, Lr, LTB zone (plastic / inelastic / elastic), φMn; compact flange & web checks (Table B4.1b)
- `beamShear()` — §G2.1: φv = 1.0 for compact hot-rolled webs (h/tw ≤ 2.24√(E/Fy)), Cv1 for slender webs
- `columnAxial()` — §E3: Fcr (inelastic/elastic buckling), both KxL/rx and KyL/ry, φPn
- `weakAxisFlexure()` — §F6: φMny = φ·Fy·Zy (compact W-shape, no weak-axis LTB)
- `combinedLoading()` — §H1-1a / H1-1b
- `boltShear()` — §J3.6 shear (A325M/A490M, threads-in-plane flag) + §J3.10 bearing; governing φRn, required bolt count
- `weldStrength()` — §J2.4 fillet weld: 0.707-throat, E70–E100 electrodes; φRnw per mm, required length
- `beamLoadingSimple()` — factored wu/Mu/Vu (uniform load) + service deflections (5wL⁴/384EI)

### Page (`webapp/src/pages/SteelDesign.tsx`)
Route `/steel`, three tabs:

**Beam** — W-shape picker, steel grade (A36 / A572 Gr50), span, unbraced Lb, Cb, dead/live loads.  
Results: section properties, compact flags, LTB-zone badge (green/amber/red), φMn, φVn, δL vs L/360 and δtotal vs L/240.

**Column** — W-shape picker, grade, column height, Kx/Ky, service D+L or direct Pu, Mux, Muy.  
Results: slenderness both axes, Fcr, φPn, φMnx (beam flexure), φMny (§F6), §H1-1 combined ratio with pass/fail colour.

**Connection** — toggle bolt / fillet weld.  
Bolt: grade, diameter, n bolts, threads-in-plane, plate t and Fu → φRn shear and bearing per bolt, required count, group utilisation.  
Weld: electrode class, weld size, total weld length → φRnw/mm, required length, utilisation.

### Tests (`webapp/src/engine/steelDesign.test.ts`)
26 new tests covering every exported function. Full suite: **290 passing**.

### Note on J (torsional constant)
J is computed by the uniform-thickness open-section formula (1/3 Σbf·tf³ + hw·tw³). This underestimates the true J by roughly 40–60% for typical W-shapes because fillet-radius contributions are not modelled. The effect is conservative: Lr is shorter than tabulated and Fcr in the elastic-LTB zone is lower. Use AISC Manual tabulated J when checking critical members near the Lr boundary.

## Verification
- `npm test` → **290 passing** (36 files)
- `npx tsc -b` → clean
- `npm run build` → production build OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_