### PR TITLE
feat(steel): 3D viewers, eccentric bolt groups, block shear, detailed calcs

### DIFF
--- a/webapp/src/components/ConnectionDrawing.tsx
+++ b/webapp/src/components/ConnectionDrawing.tsx
@@ -1,0 +1,130 @@
+// 2D SVG plan view of a bolt/weld group on the connection plate.
+// Coordinate system: origin at bottom-left of plate, Y up.
+// SVG has Y inverted (origin top-left) so we flip: svgY = H_px - plateY * scale.
+
+import type { BoltGroupGeom, BoltForce } from '../engine/steelDesign'
+
+const PAD = 36  // px around the plate
+
+function label(x: number, y: number, text: string, color = '#475569', fs = 10, anchor: 'middle' | 'start' | 'end' = 'middle') {
+  return <text x={x} y={y} textAnchor={anchor} fill={color} fontSize={fs} fontFamily="monospace">{text}</text>
+}
+
+function dimLine(x1: number, y1: number, x2: number, y2: number, text: string, offset: [number, number]) {
+  const mx = (x1 + x2) / 2 + offset[0], my = (y1 + y2) / 2 + offset[1]
+  return (
+    <g>
+      <line x1={x1} y1={y1} x2={x2} y2={y2} stroke="#94a3b8" strokeWidth={0.8} strokeDasharray="3,2" />
+      <text x={mx} y={my} textAnchor="middle" fill="#64748b" fontSize={9} fontFamily="monospace">{text}</text>
+    </g>
+  )
+}
+
+export function ConnectionDrawing({ geom, db, boltForces, critical, Vu, Hu, ex_load, ey_load, connType = 'bolt' }: {
+  geom: BoltGroupGeom
+  db: number
+  boltForces?: BoltForce[]
+  critical?: string
+  Vu: number; Hu: number
+  ex_load: number; ey_load: number
+  connType?: 'bolt' | 'weld'
+}) {
+  const DISP_W = 260
+  const scale = Math.min((DISP_W - 2 * PAD) / geom.plateW, (DISP_W - 2 * PAD) / geom.plateH)
+  const pw = geom.plateW * scale, ph = geom.plateH * scale
+  const svgW = pw + 2 * PAD, svgH = ph + 2 * PAD
+
+  const tx = (xmm: number) => PAD + xmm * scale
+  const ty = (ymm: number) => PAD + (geom.plateH - ymm) * scale
+
+  const r = (db / 2) * scale
+
+  // load application point in plate coords (from bottom-left)
+  const loadX = geom.Cx + ex_load, loadY = geom.Cy + ey_load
+
+  return (
+    <div className="print-avoid-break rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
+      <h3 className="mb-1.5 text-xs font-bold uppercase tracking-wide text-slate-500">
+        Connection face — {connType === 'bolt' ? 'bolt layout' : 'weld layout'}
+      </h3>
+      <svg width={svgW} height={svgH + 16} viewBox={`0 0 ${svgW} ${svgH + 16}`}>
+        {/* plate */}
+        <rect x={PAD} y={PAD} width={pw} height={ph} fill="#f1f5f9" stroke="#334155" strokeWidth={1.5} rx={1} />
+
+        {/* dimension lines */}
+        {dimLine(PAD, svgH, PAD + pw, svgH, `${geom.plateW} mm`, [0, 12])}
+        {dimLine(PAD - 18, PAD, PAD - 18, PAD + ph, `${geom.plateH} mm`, [-16, 0])}
+
+        {connType === 'bolt' ? (
+          <>
+            {/* bolt holes */}
+            {geom.bolts.map(b => {
+              const bfEntry = boltForces?.find(bf => bf.id === b.id)
+              const isCrit = b.id === critical
+              const bxPl = b.x + geom.Cx, byPl = b.y + geom.Cy
+              const cx = tx(bxPl), cy = ty(byPl)
+              const util = bfEntry?.utilShear ?? 0
+              const holeColor = isCrit ? '#dc2626' : util > 0.8 ? '#f59e0b' : '#334155'
+              return (
+                <g key={b.id}>
+                  {/* hole */}
+                  <circle cx={cx} cy={cy} r={r} fill="white" stroke={holeColor} strokeWidth={isCrit ? 2 : 1} />
+                  {/* force arrow proportional to R */}
+                  {bfEntry && bfEntry.R > 0.01 && (() => {
+                    const sc = 25 / Math.max(...(boltForces?.map(f => f.R) ?? [1]))
+                    const dx = bfEntry.Vx * sc, dy = -bfEntry.Vy * sc
+                    return <line x1={cx} y1={cy} x2={cx + dx} y2={cy + dy}
+                      stroke={isCrit ? '#dc2626' : '#3b82f6'} strokeWidth={1.4}
+                      markerEnd="url(#arrow)" />
+                  })()}
+                  {label(cx, cy - r - 2, b.id, isCrit ? '#dc2626' : '#475569', 9)}
+                  {bfEntry && label(cx, cy + r + 9, `${bfEntry.R.toFixed(1)}kN`, isCrit ? '#dc2626' : '#64748b', 8)}
+                </g>
+              )
+            })}
+            {/* edge distance labels for first bolt */}
+            {geom.bolts.length > 0 && (() => {
+              const b0 = { x: geom.bolts[0].x + geom.Cx, y: geom.bolts[0].y + geom.Cy }
+              return (
+                <>
+                  {dimLine(PAD, ty(b0.y), tx(b0.x), ty(b0.y), `ex=${b0.x.toFixed(0)}`, [0, -7])}
+                  {dimLine(tx(b0.x), PAD + ph, tx(b0.x), ty(b0.y), `ey=${b0.y.toFixed(0)}`, [18, 0])}
+                </>
+              )
+            })()}
+          </>
+        ) : (
+          <>
+            {/* weld lines (two vertical welds on plate edges) */}
+            <line x1={PAD + 3} y1={PAD + 4} x2={PAD + 3} y2={PAD + ph - 4} stroke="#f59e0b" strokeWidth={4} />
+            <line x1={PAD + pw - 3} y1={PAD + 4} x2={PAD + pw - 3} y2={PAD + ph - 4} stroke="#f59e0b" strokeWidth={4} />
+            {label(PAD + pw / 2, PAD + ph / 2, 'Weld', '#d97706', 11)}
+            {label(PAD + pw / 2, PAD + ph / 2 + 14, `L = ${geom.plateH.toFixed(0)} mm ea.`, '#d97706', 9)}
+          </>
+        )}
+
+        {/* load application point & eccentricity */}
+        {(() => {
+          const lx = tx(loadX), ly = ty(loadY)
+          return (
+            <g>
+              <circle cx={lx} cy={ly} r={4} fill="none" stroke="#16a34a" strokeWidth={1.5} strokeDasharray="3,2" />
+              {Vu > 0 && <line x1={lx} y1={ly - 24} x2={lx} y2={ly - 6}
+                stroke="#16a34a" strokeWidth={1.5} markerEnd="url(#arrow)" />}
+              {Hu !== 0 && <line x1={lx + (Hu > 0 ? -24 : 24)} y1={ly} x2={lx + (Hu > 0 ? -6 : 6)} y2={ly}
+                stroke="#16a34a" strokeWidth={1.5} markerEnd="url(#arrow)" />}
+              {label(lx + 5, ly - 26, `Vu=${Vu}kN`, '#15803d', 9, 'start')}
+            </g>
+          )
+        })()}
+
+        {/* arrowhead marker */}
+        <defs>
+          <marker id="arrow" markerWidth="6" markerHeight="6" refX="3" refY="3" orient="auto">
+            <path d="M0,0 L6,3 L0,6 Z" fill="#1d4ed8" />
+          </marker>
+        </defs>
+      </svg>
+    </div>
+  )
+}

--- a/webapp/src/components/SteelViewer3D.tsx
+++ b/webapp/src/components/SteelViewer3D.tsx
@@ -1,0 +1,219 @@
+// Three.js/R3F 3D scenes for the Steel Design page.
+// Three sub-components: BeamViewer3D, ColumnViewer3D, ConnectionViewer3D.
+// All share a common canvas wrapper with OrbitControls + FitView.
+
+import { useMemo } from 'react'
+import { Canvas } from '@react-three/fiber'
+import { OrbitControls, Text } from '@react-three/drei'
+import * as THREE from 'three'
+import { FitView } from './FitView'
+import type { AiscShape } from '../engine/aiscSections'
+import { effectiveSection } from '../engine/aiscSections'
+import { buildSectionShapes } from '../lib/sectionShapes3d'
+import type { BoltGroupGeom } from '../engine/steelDesign'
+
+// ─── shared helpers ────────────────────────────────────────────────────────
+
+function wShape(s: AiscShape): THREE.Shape[] {
+  return buildSectionShapes(effectiveSection(s, false))
+}
+
+function ExtrudedSection({ shapes, length, color = '#6b7280', metalness = 0.3 }: {
+  shapes: THREE.Shape[]; length: number; color?: string; metalness?: number
+}) {
+  return (
+    <>
+      {shapes.map((sh, i) => (
+        <mesh key={i}>
+          <extrudeGeometry args={[sh, { depth: length, bevelEnabled: false, steps: 1 }]} />
+          <meshStandardMaterial color={color} metalness={metalness} roughness={0.55} />
+        </mesh>
+      ))}
+    </>
+  )
+}
+
+function Arrow({ from, to, color = '#16a34a', r = 0.04, headR = 0.10, headH = 0.25 }: {
+  from: [number,number,number]; to: [number,number,number]; color?: string; r?: number; headR?: number; headH?: number
+}) {
+  const vf = new THREE.Vector3(...from), vt = new THREE.Vector3(...to)
+  const dir = new THREE.Vector3().subVectors(vt, vf)
+  const len = dir.length()
+  const mid = vf.clone().add(vt).multiplyScalar(0.5)
+  const quat = new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 1, 0), dir.clone().normalize())
+  return (
+    <group position={[mid.x, mid.y, mid.z]} quaternion={quat}>
+      <mesh position={[0, -(len / 2 - (headH + r) / 2), 0]}>
+        <cylinderGeometry args={[r, r, len - headH, 8]} />
+        <meshStandardMaterial color={color} />
+      </mesh>
+      <mesh position={[0, len / 2 - headH / 2, 0]}>
+        <coneGeometry args={[headR, headH, 12]} />
+        <meshStandardMaterial color={color} />
+      </mesh>
+    </group>
+  )
+}
+
+function CanvasWrap({ children, box }: { children: React.ReactNode; box: { min:[number,number,number]; max:[number,number,number] } }) {
+  return (
+    <div className="no-print h-72 w-full overflow-hidden rounded-xl border border-slate-200 bg-slate-900">
+      <Canvas camera={{ fov: 45, near: 0.01, far: 500 }}>
+        <ambientLight intensity={0.5} />
+        <directionalLight position={[5, 10, 5]} intensity={1.2} castShadow />
+        <directionalLight position={[-5, -3, -5]} intensity={0.4} />
+        <OrbitControls makeDefault enableDamping={false} />
+        <FitView box={box} dir={[1.2, 0.9, 1.5]} margin={1.4} />
+        {children}
+      </Canvas>
+    </div>
+  )
+}
+
+// ─── Beam 3D ───────────────────────────────────────────────────────────────
+
+function DistLoad({ span, w, step = 0.6, scale = 0.5 }: {
+  span: number; w: number; step?: number; scale?: number
+}) {
+  const h = Math.min(0.9, 0.2 + Math.abs(w) * scale)
+  const positions: number[] = []
+  for (let z = 0.1; z < span - 0.05; z += step) positions.push(z)
+  return (
+    <>
+      {positions.map((z, i) => (
+        <Arrow key={i} from={[0, h * 0.85, z]} to={[0, 0.05, z]} color="#16a34a" r={0.025} headR={0.07} headH={0.18} />
+      ))}
+      <mesh position={[0, h + 0.02, span / 2]}>
+        <boxGeometry args={[0.04, 0.04, span - 0.2]} />
+        <meshStandardMaterial color="#16a34a" />
+      </mesh>
+    </>
+  )
+}
+
+function PinSupport3D({ pos }: { pos: [number,number,number] }) {
+  return (
+    <group position={pos}>
+      <mesh position={[0, -0.12, 0]}><coneGeometry args={[0.18, 0.28, 4]} /><meshStandardMaterial color="#0056b3" /></mesh>
+      <mesh position={[0, -0.28, 0]}><boxGeometry args={[0.36, 0.04, 0.06]} /><meshStandardMaterial color="#0056b3" /></mesh>
+    </group>
+  )
+}
+
+function RollerSupport3D({ pos }: { pos: [number,number,number] }) {
+  return (
+    <group position={pos}>
+      <mesh position={[0, -0.12, 0]}><coneGeometry args={[0.18, 0.28, 4]} /><meshStandardMaterial color="#0056b3" /></mesh>
+      <mesh position={[0, -0.32, 0]}><cylinderGeometry args={[0.18, 0.18, 0.05, 16]} /><meshStandardMaterial color="#0056b3" /></mesh>
+    </group>
+  )
+}
+
+export function BeamViewer3D({ shape, span, wDead, wLive }: {
+  shape: AiscShape; span: number; wDead: number; wLive: number
+}) {
+  const shapes = useMemo(() => wShape(shape), [shape])
+  const d = (shape.d ?? 250) / 1000 / 2
+  const bf = (shape.bf ?? 150) / 1000 / 2
+  const box = useMemo<{ min:[number,number,number]; max:[number,number,number] }>(() => ({
+    min: [-bf * 2, -d * 2 - 0.4, -0.3],
+    max: [ bf * 2, d * 2 + 1.2, span + 0.3],
+  }), [bf, d, span])
+
+  return (
+    <CanvasWrap box={box}>
+      <group rotation={[-Math.PI / 2, 0, 0]}>
+        <ExtrudedSection shapes={shapes} length={span} color="#8b9fc1" />
+      </group>
+      <DistLoad span={span} w={wDead + wLive} />
+      <PinSupport3D pos={[0, -d, 0]} />
+      <RollerSupport3D pos={[0, -d, span]} />
+      <Text position={[bf + 0.15, 0, span / 2]} rotation={[0, -Math.PI / 2, 0]} fontSize={0.18} color="#e2e8f0" anchorX="center">
+        {shape.name}
+      </Text>
+    </CanvasWrap>
+  )
+}
+
+// ─── Column 3D ─────────────────────────────────────────────────────────────
+
+export function ColumnViewer3D({ shape, L, Pu, Mux }: {
+  shape: AiscShape; L: number; Pu: number; Mux: number
+}) {
+  const shapes = useMemo(() => wShape(shape), [shape])
+  const d = (shape.d ?? 250) / 1000 / 2
+  const bf = (shape.bf ?? 150) / 1000 / 2
+
+  const box = useMemo<{ min:[number,number,number]; max:[number,number,number] }>(() => ({
+    min: [-bf * 3, -0.4, -bf * 3],
+    max: [ bf * 3, L + 1.2, bf * 3],
+  }), [bf, L])
+
+  return (
+    <CanvasWrap box={box}>
+      {/* column extrudes along Y — rotate section from XY to XZ plane */}
+      <group rotation={[0, 0, 0]} position={[-d, 0, -bf]}>
+        <group rotation={[Math.PI / 2, 0, 0]}>
+          <ExtrudedSection shapes={shapes} length={L} color="#8b9fc1" />
+        </group>
+      </group>
+      {/* axial load arrow */}
+      {Pu > 0 && <Arrow from={[0, L + 0.9, 0]} to={[0, L + 0.05, 0]} color="#dc2626" headR={0.13} headH={0.3} />}
+      {/* moment arrow: horizontal arrow at top */}
+      {Mux > 0 && <Arrow from={[-0.6, L + 0.1, 0]} to={[0.1, L + 0.1, 0]} color="#f59e0b" headR={0.10} headH={0.22} />}
+      {/* fixed base */}
+      <mesh position={[0, -0.03, 0]}><boxGeometry args={[0.8, 0.06, 0.5]} /><meshStandardMaterial color="#0056b3" /></mesh>
+      <Text position={[bf + 0.35, L / 2, 0]} rotation={[0, 0, 0]} fontSize={0.18} color="#e2e8f0" anchorX="center">
+        {shape.name}
+      </Text>
+    </CanvasWrap>
+  )
+}
+
+// ─── Connection 3D ─────────────────────────────────────────────────────────
+
+export function ConnectionViewer3D({ geom, db, t_plate, critical }: {
+  geom: BoltGroupGeom; db: number; t_plate: number; critical: string
+}) {
+  const W = geom.plateW / 1000, H = geom.plateH / 1000, T = t_plate / 1000
+  const dbm = db / 1000
+
+  const box = useMemo<{ min:[number,number,number]; max:[number,number,number] }>(() => ({
+    min: [-W * 0.8, -0.1, -0.6],
+    max: [ W * 0.8 + 0.3, H + 0.1, 0.6],
+  }), [W, H])
+
+  return (
+    <CanvasWrap box={box}>
+      {/* shear tab plate */}
+      <mesh position={[W / 2, H / 2, 0]}>
+        <boxGeometry args={[W, H, T]} />
+        <meshStandardMaterial color="#a1a1aa" metalness={0.5} roughness={0.4} />
+      </mesh>
+      {/* bolts */}
+      {geom.bolts.map(b => {
+        const bx = (b.x + geom.Cx) / 1000
+        const by = (b.y + geom.Cy) / 1000
+        const isCrit = b.id === critical
+        return (
+          <group key={b.id} position={[bx, by, 0]}>
+            <mesh rotation={[Math.PI / 2, 0, 0]}>
+              <cylinderGeometry args={[dbm / 2, dbm / 2, 0.4, 12]} />
+              <meshStandardMaterial color={isCrit ? '#f59e0b' : '#d4a017'} metalness={0.7} roughness={0.3} />
+            </mesh>
+            <Text position={[dbm * 0.8, dbm * 0.8, 0.05]} fontSize={0.018} color={isCrit ? '#fbbf24' : '#e2e8f0'}>
+              {b.id}
+            </Text>
+          </group>
+        )
+      })}
+      {/* beam web stub (connected member) */}
+      <mesh position={[W + 0.06, H / 2, 0]}>
+        <boxGeometry args={[0.12, H * 1.3, 0.008]} />
+        <meshStandardMaterial color="#6b7280" metalness={0.4} roughness={0.5} />
+      </mesh>
+      {/* load arrow */}
+      <Arrow from={[W + 0.14, H * 1.1, 0]} to={[W + 0.14, H * 0.2, 0]} color="#16a34a" r={0.012} headR={0.035} headH={0.08} />
+    </CanvasWrap>
+  )
+}

--- a/webapp/src/engine/steelDesign.test.ts
+++ b/webapp/src/engine/steelDesign.test.ts
@@ -4,6 +4,7 @@ import {
   deriveWSection, beamFlexure, beamShear,
   columnAxial, weakAxisFlexure, combinedLoading,
   boltShear, weldStrength, beamLoadingSimple, E_STEEL,
+  boltGroupGeom, eccentricBoltGroup, shearTabBlockShear,
 } from './steelDesign'
 
 const W250x33 = shapeByName('W250x33')!
@@ -165,5 +166,63 @@ describe('beamLoadingSimple', () => {
     const coef = 5 * Lmm ** 4 / (384 * E_STEEL * p.Ix)
     expect(r.deltaD).toBeCloseTo(15 * coef, 8)
     expect(r.deltaL).toBeCloseTo(25 * coef, 8)
+  })
+})
+
+describe('boltGroupGeom', () => {
+  it('2×1 single column: centroid mid-height, Ip correct', () => {
+    const g = boltGroupGeom(2, 1, 70, 70, 40, 40)
+    expect(g.n).toBe(2)
+    expect(g.Cx).toBeCloseTo(40, 6)
+    expect(g.Cy).toBeCloseTo(75, 6)   // (40+110)/2
+    // bolts at y = ±35 from centroid
+    expect(g.bolts[0].y).toBeCloseTo(-35, 6)
+    expect(g.bolts[1].y).toBeCloseTo(35, 6)
+    expect(g.Ip).toBeCloseTo(2 * 35 ** 2, 6)   // all x=0
+  })
+  it('2×2 grid: Ip = 4 * (sx/2)² + 4 * (sy/2)²', () => {
+    const sx = 70, sy = 70, ex = 40, ey = 40
+    const g = boltGroupGeom(2, 2, sx, sy, ex, ey)
+    expect(g.n).toBe(4)
+    expect(g.Ip).toBeCloseTo(4 * (sx/2)**2 + 4 * (sy/2)**2, 3)
+  })
+})
+
+describe('eccentricBoltGroup', () => {
+  it('zero eccentricity: all bolts equal force V/n', () => {
+    const g = boltGroupGeom(3, 1, 70, 70, 40, 40)
+    const Vu = 90, n = 3
+    const r = eccentricBoltGroup(g, Vu, 0, 0, 0, 100, 20, 10)
+    r.bolts.forEach(b => expect(b.R).toBeCloseTo(Vu / n, 4))
+    expect(r.M).toBeCloseTo(0, 10)
+  })
+  it('critical bolt has max resultant', () => {
+    const g = boltGroupGeom(3, 1, 70, 70, 40, 40)
+    const r = eccentricBoltGroup(g, 100, 0, 50, 0, 100, 20, 10)
+    expect(r.Rmax).toBeGreaterThanOrEqual(Math.max(...r.bolts.map(b => b.R)) - 1e-9)
+  })
+  it('bearing stress = R·1000 / (db·t)', () => {
+    const g = boltGroupGeom(2, 1, 70, 70, 40, 40)
+    const db = 20, t = 10
+    const r = eccentricBoltGroup(g, 60, 0, 0, 0, 100, db, t)
+    r.bolts.forEach(b => expect(b.fbr).toBeCloseTo(b.R * 1000 / (db * t), 6))
+  })
+})
+
+describe('shearTabBlockShear §J4.3', () => {
+  it('returns two cases', () => {
+    const cases = shearTabBlockShear(3, 70, 40, 40, 35, 20, 10, 248, 400)
+    expect(cases).toHaveLength(2)
+  })
+  it('phiRn = 0.75 * min(Rn_fract, Rn_cap)', () => {
+    const cases = shearTabBlockShear(3, 70, 40, 40, 35, 20, 10, 248, 400)
+    for (const c of cases) {
+      expect(c.phiRn).toBeCloseTo(0.75 * Math.min(c.Rn_fract, c.Rn_cap), 6)
+    }
+  })
+  it('longer shear path → larger phiRn', () => {
+    const cA = shearTabBlockShear(3, 70, 40, 40, 35, 20, 10, 248, 400)
+    const cB = shearTabBlockShear(4, 70, 40, 40, 35, 20, 10, 248, 400)
+    expect(cB[0].phiRn).toBeGreaterThan(cA[0].phiRn)
   })
 })

--- a/webapp/src/engine/steelDesign.ts
+++ b/webapp/src/engine/steelDesign.ts
@@ -258,3 +258,118 @@ export function beamLoadingSimple(bl: BeamLoadInput, Ix_mm4: number): BeamLoadsR
     limL240: Lmm / 240,
   }
 }
+
+// ─── Bolt group geometry ──────────────────────────────────────────────────
+// Bolt positions relative to the group centroid (mm).
+// Grid is nRows (vertical) × nCols (horizontal), spacing sx / sy,
+// edge distances ex (horizontal) and ey (vertical) from plate edges.
+
+export interface BoltPos { id: string; x: number; y: number }
+
+export interface BoltGroupGeom {
+  bolts: BoltPos[]   // positions relative to centroid, mm
+  n: number
+  Cx: number; Cy: number   // centroid distance from bottom-left origin, mm
+  Ip: number               // Σ(x² + y²), mm²
+  plateW: number; plateH: number   // minimum plate size, mm
+}
+
+export function boltGroupGeom(
+  nRows: number, nCols: number,
+  sx: number, sy: number,
+  ex: number, ey: number
+): BoltGroupGeom {
+  const abs: BoltPos[] = []
+  for (let r = 0; r < nRows; r++)
+    for (let c = 0; c < nCols; c++)
+      abs.push({ id: `B${r * nCols + c + 1}`, x: ex + c * sx, y: ey + r * sy })
+  const n   = abs.length
+  const Cx  = abs.reduce((s, b) => s + b.x, 0) / n
+  const Cy  = abs.reduce((s, b) => s + b.y, 0) / n
+  const bolts = abs.map(b => ({ id: b.id, x: b.x - Cx, y: b.y - Cy }))
+  const Ip  = bolts.reduce((s, b) => s + b.x ** 2 + b.y ** 2, 0)
+  return { bolts, n, Cx, Cy, Ip, plateW: 2 * ex + (nCols - 1) * sx, plateH: 2 * ey + (nRows - 1) * sy }
+}
+
+// ─── In-plane eccentric bolt group — elastic (vector) method ─────────────
+// Forces Pu (+Y = up) and Hu (+X = right) applied at offset (ex_load, ey_load)
+// from the bolt centroid. Positive ex_load → load is to the RIGHT of centroid.
+// M (CCW +) = Pu·ex_load − Hu·ey_load  [kN·mm]
+// Each bolt force: direct V/n + moment contribution M·(-yi, xi)/Ip.
+
+export interface BoltForce {
+  id: string; x: number; y: number
+  Vx: number; Vy: number   // kN, force components
+  R: number                // kN, resultant
+  utilShear: number        // R / phiRn_bolt
+  fbr: number              // MPa, bearing stress = R·1000 / (db·t)
+  fv: number               // MPa, average shear stress = R·1000 / Ab
+}
+
+export interface EccentricBoltResult {
+  bolts: BoltForce[]
+  critical: string   // bolt id of max resultant
+  Rmax: number       // kN
+  M: number          // kN·mm
+}
+
+export function eccentricBoltGroup(
+  geom: BoltGroupGeom,
+  Pu: number, Hu: number,
+  ex_load: number, ey_load: number,
+  phiRn: number,
+  db: number, t_plate: number
+): EccentricBoltResult {
+  const { bolts, n, Ip } = geom
+  const Ab = (Math.PI / 4) * db * db
+  const M  = Pu * ex_load - Hu * ey_load
+  const bf: BoltForce[] = bolts.map(b => {
+    const Vx = Hu / n - M * b.y / Ip
+    const Vy = Pu / n + M * b.x / Ip
+    const R  = Math.sqrt(Vx ** 2 + Vy ** 2)
+    return { ...b, Vx, Vy, R, utilShear: phiRn > 0 ? R / phiRn : Infinity,
+             fbr: (R * 1000) / (db * t_plate), fv: (R * 1000) / Ab }
+  })
+  const ci = bf.reduce((mi, _, i) => bf[i].R > bf[mi].R ? i : mi, 0)
+  return { bolts: bf, critical: bf[ci].id, Rmax: bf[ci].R, M }
+}
+
+// ─── Block shear §J4.3 ────────────────────────────────────────────────────
+// Rn = min(0.6·Fu·Anv + Ubs·Fu·Ant,  0.6·Fy·Agv + Ubs·Fu·Ant)  φ = 0.75
+// Two standard paths for a shear tab / single bolt column are returned.
+
+export interface BlockShearCase {
+  label: string
+  Agv: number; Anv: number; Agt: number; Ant: number; Ubs: number
+  Rn_fract: number   // shear fracture + tension fracture, kN
+  Rn_cap: number     // shear yield cap, kN
+  Rn: number; phiRn: number   // kN
+}
+
+// shear tab: nRows bolts in one vertical column, spacing sy, edge distances
+// ey_top (top) / ey_bot (bottom) / ex_edge (horizontal to free edge).
+export function shearTabBlockShear(
+  nRows: number, sy: number,
+  ey_top: number, ey_bot: number, ex_edge: number,
+  db: number, t: number,
+  Fy: number, Fu: number
+): BlockShearCase[] {
+  const dh  = db + 2   // hole diameter (+2 mm oversize)
+  const Agt = t * ex_edge
+  const Ant = Agt - 0.5 * dh * t
+
+  const mkCase = (label: string, Lv: number): BlockShearCase => {
+    const Agv = t * Lv
+    const Anv = Agv - (nRows - 0.5) * dh * t
+    const Ubs = 1.0
+    const Rn_fract = (0.6 * Fu * Math.max(0, Anv) + Ubs * Fu * Math.max(0, Ant)) / 1000
+    const Rn_cap   = (0.6 * Fy * Agv                + Ubs * Fu * Math.max(0, Ant)) / 1000
+    const Rn = Math.min(Rn_fract, Rn_cap)
+    return { label, Agv, Anv: Math.max(0, Anv), Agt, Ant: Math.max(0, Ant), Ubs, Rn_fract, Rn_cap, Rn, phiRn: 0.75 * Rn }
+  }
+
+  return [
+    mkCase('§J4.3 Case A — shear path from bottom edge (governs for short end distance at bottom)', (nRows - 1) * sy + ey_bot),
+    mkCase('§J4.3 Case B — shear path from top edge', (nRows - 1) * sy + ey_top),
+  ]
+}

--- a/webapp/src/pages/SteelDesign.tsx
+++ b/webapp/src/pages/SteelDesign.tsx
@@ -1,370 +1,553 @@
-import { useMemo, useState } from 'react'
+import { lazy, Suspense, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { shapesOf, shapeByName } from '../engine/aiscSections'
 import type { AiscShape } from '../engine/aiscSections'
 import {
   deriveWSection, beamFlexure, beamShear, columnAxial,
   weakAxisFlexure, combinedLoading, boltShear, weldStrength,
-  beamLoadingSimple,
+  beamLoadingSimple, boltGroupGeom, eccentricBoltGroup, shearTabBlockShear,
 } from '../engine/steelDesign'
 import type { BoltGrade, ElectrodeClass } from '../engine/steelDesign'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { ReportControls } from '../components/ReportControls'
+import { WorkedSolution } from '../components/WorkedSolution'
+import { ConnectionDrawing } from '../components/ConnectionDrawing'
+import type { SolutionStep } from '../lib/solution'
 import { f1, f2, f3 } from '../lib/format'
+import { sn1, sn2, sn3 } from '../lib/solution'
 
-type Tab = 'beam' | 'column' | 'connection'
+const BeamViewer3D      = lazy(() => import('../components/SteelViewer3D').then(m => ({ default: m.BeamViewer3D })))
+const ColumnViewer3D    = lazy(() => import('../components/SteelViewer3D').then(m => ({ default: m.ColumnViewer3D })))
+const ConnectionViewer3D = lazy(() => import('../components/SteelViewer3D').then(m => ({ default: m.ConnectionViewer3D })))
+
+type Tab   = 'beam' | 'column' | 'connection'
 type Grade = 'A36' | 'A572G50'
 type ConnType = 'bolt' | 'weld'
 
 const GRADES: Record<Grade, { Fy: number; Fu: number; label: string }> = {
-  A36:    { Fy: 248, Fu: 400, label: 'A36 / SS400 (Fy = 248 MPa)' },
-  A572G50: { Fy: 345, Fu: 448, label: 'A572 Gr50 / A992 (Fy = 345 MPa)' },
+  A36:     { Fy: 248, Fu: 400, label: 'A36 / SS400  (Fy 248 MPa)' },
+  A572G50: { Fy: 345, Fu: 448, label: 'A572 Gr50 / A992  (Fy 345 MPa)' },
 }
-
 const W_SHAPES = shapesOf('W')
-const wName = (s: AiscShape) => s.name
 
-function shapeOrFirst(name: string): AiscShape {
-  return shapeByName(name) ?? W_SHAPES[0]
-}
+function shapeOrFirst(name: string): AiscShape { return shapeByName(name) ?? W_SHAPES[0] }
 
+const ok = (pass: boolean, v: string) => (
+  <span className={pass ? 'font-semibold text-green-700' : 'font-semibold text-red-700'}>{v} {pass ? '✓' : '✗'}</span>
+)
 const badge = (zone: string) => {
-  const cls = zone === 'plastic' ? 'bg-green-100 text-green-800'
-            : zone === 'inelastic' ? 'bg-amber-100 text-amber-800'
-            : 'bg-red-100 text-red-800'
-  return <span className={`ml-2 rounded px-1.5 py-0.5 text-[10px] font-bold uppercase ${cls}`}>{zone} LTB</span>
+  const cls = zone === 'plastic' ? 'bg-green-100 text-green-800' : zone === 'inelastic' ? 'bg-amber-100 text-amber-800' : 'bg-red-100 text-red-800'
+  return <span className={`ml-1.5 rounded px-1.5 py-0.5 text-[10px] font-bold uppercase ${cls}`}>{zone}</span>
 }
-
-const ok = (pass: boolean, val: string) => (
-  <span className={pass ? 'text-green-700 font-semibold' : 'text-red-700 font-semibold'}>{val} {pass ? '✓' : '✗'}</span>
+const Spinner = () => <div className="flex h-72 items-center justify-center rounded-xl border border-slate-200 bg-slate-900 text-sm text-slate-400">Loading 3D…</div>
+const ShapePick = ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+  <label className="col-span-full flex flex-col text-sm">
+    <span className="mb-1 font-medium text-slate-600">W-shape</span>
+    <select value={value} onChange={e => onChange(e.target.value)}
+      className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none">
+      {W_SHAPES.map(s => <option key={s.name} value={s.name}>{s.name}</option>)}
+    </select>
+  </label>
 )
 
-// ─── Beam Tab ──────────────────────────────────────────────────────────────
+// ─── Beam Tab ─────────────────────────────────────────────────────────────
+
 function BeamTab() {
   const [shapeName, setShapeName] = useState('W310x39')
   const [grade, setGrade]         = useState<Grade>('A572G50')
-  const [span, setSpan]           = useState(6)
-  const [Lb, setLb]               = useState(2)
-  const [Cb, setCb]               = useState(1.0)
-  const [wDead, setWDead]         = useState(15)
-  const [wLive, setWLive]         = useState(25)
+  const [span,  setSpan]          = useState(6)
+  const [Lb,    setLb]            = useState(2)
+  const [Cb,    setCb]            = useState(1.0)
+  const [wD,    setWD]            = useState(15)
+  const [wL,    setWL]            = useState(25)
 
   const { Fy } = GRADES[grade]
-  const shape = useMemo(() => shapeOrFirst(shapeName), [shapeName])
-  const props = useMemo(() => deriveWSection(shape), [shape])
+  const shape  = useMemo(() => shapeOrFirst(shapeName), [shapeName])
+  const props  = useMemo(() => deriveWSection(shape), [shape])
+  const flex   = useMemo(() => beamFlexure(shape, props, Fy, Lb * 1000, Cb), [shape, props, Fy, Lb, Cb])
+  const shear  = useMemo(() => beamShear(shape, props, Fy), [shape, props, Fy])
+  const loads  = useMemo(() => beamLoadingSimple({ wDead: wD, wLive: wL, L: span }, props.Ix), [wD, wL, span, props])
 
-  const flex  = useMemo(() => beamFlexure(shape, props, Fy, Lb * 1000, Cb), [shape, props, Fy, Lb, Cb])
-  const shear = useMemo(() => beamShear(shape, props, Fy), [shape, props, Fy])
-  const loads = useMemo(() => beamLoadingSimple({ wDead, wLive, L: span }, props.Ix), [wDead, wLive, span, props])
+  const utilM = loads.Mu / flex.phiMn, utilV = loads.Vu / shear.phiVn
 
-  const utilM = flex.phiMn > 0 ? loads.Mu / flex.phiMn : Infinity
-  const utilV = shear.phiVn > 0 ? loads.Vu / shear.phiVn : Infinity
+  const steps = useMemo((): SolutionStep[] => {
+    const E = 200000
+    return [
+      {
+        title: 'Factored loads (NSCP/AISC load combos)',
+        lines: [
+          { tex: `w_u = \\max(1.4 \\times ${sn1(wD)},\\; 1.2 \\times ${sn1(wD)} + 1.6 \\times ${sn1(wL)}) = ${sn1(loads.wu)}\\text{ kN/m}` },
+          { tex: `M_u = \\frac{w_u L^2}{8} = \\frac{${sn1(loads.wu)} \\times ${sn1(span)}^2}{8} = ${sn1(loads.Mu)}\\text{ kN·m}` },
+          { tex: `V_u = \\frac{w_u L}{2} = ${sn1(loads.Vu)}\\text{ kN}` },
+        ],
+      },
+      {
+        title: 'Compact section (Table B4.1b)',
+        lines: [
+          { tex: `\\lambda_f = \\frac{b_f}{2t_f} = \\frac{${shape.bf}}{2 \\times ${shape.tf}} = ${sn2(flex.lambdaF)}` },
+          { tex: `\\lambda_{pf} = 0.38\\sqrt{E/F_y} = 0.38\\sqrt{${E}/${Fy}} = ${sn2(flex.lambdaPF)}\\quad ${flex.compactFlange ? '\\checkmark\\text{ compact}' : '\\text{non-compact}'}` },
+          { tex: `\\lambda_w = h_w / t_w = ${sn1(props.hw)} / ${shape.tw} = ${sn1(flex.lambdaW)}\\quad \\lambda_{pw} = ${sn1(flex.lambdaPW)}\\quad ${flex.compactWeb ? '\\checkmark' : '\\times'}` },
+        ],
+      },
+      {
+        title: 'Flexural capacity §F2 — lateral-torsional buckling',
+        lines: [
+          { tex: `M_p = F_y Z_x = ${Fy} \\times ${(props.Zx / 1000).toFixed(0)} \\times 10^3\\text{ mm}^3 = ${sn1(flex.Mp)}\\text{ kN·m}` },
+          { tex: `L_p = 1.76\\, r_y \\sqrt{E/F_y} = 1.76 \\times ${shape.ry} \\times \\sqrt{${E}/${Fy}} = ${sn1(flex.Lp)}\\text{ mm} = ${sn2(flex.Lp/1000)}\\text{ m}` },
+          { tex: `L_r = ${sn1(flex.Lr)}\\text{ mm} = ${sn2(flex.Lr/1000)}\\text{ m}` },
+          { text: `L_b = ${Lb} m → zone: ${flex.ltbZone.toUpperCase()}` },
+          { tex: `M_n = ${sn1(flex.Mn)}\\text{ kN·m}\\quad \\phi M_n = 0.90 \\times ${sn1(flex.Mn)} = ${sn1(flex.phiMn)}\\text{ kN·m}` },
+          { tex: `\\text{Utilisation} = \\frac{M_u}{\\phi M_n} = \\frac{${sn1(loads.Mu)}}{${sn1(flex.phiMn)}} = ${sn2(utilM)}\\quad ${utilM <= 1 ? '\\checkmark' : '\\times'}` },
+        ],
+      },
+      {
+        title: 'Shear capacity §G2.1',
+        lines: [
+          { tex: `A_w = d \\cdot t_w = ${shape.d} \\times ${shape.tw} = ${shear.Aw.toFixed(0)}\\text{ mm}^2` },
+          { tex: `h/t_w = ${sn1(shear.hwTw)}\\quad 2.24\\sqrt{E/F_y} = ${sn1(2.24 * Math.sqrt(200000 / Fy))}\\quad C_{v1} = ${sn2(shear.Cv1)},\\; \\phi_v = ${shear.phiV}` },
+          { tex: `\\phi V_n = \\phi_v \\cdot 0.6 F_y A_w C_{v1} = ${sn2(shear.phiVn)}\\text{ kN}` },
+        ],
+      },
+      {
+        title: 'Deflection (unfactored service loads)',
+        lines: [
+          { tex: `\\delta = \\frac{5wL^4}{384EI}` },
+          { tex: `\\delta_L = ${sn2(loads.deltaL)}\\text{ mm}\\quad L/360 = ${sn2(loads.limL360)}\\text{ mm}\\quad ${loads.deltaL <= loads.limL360 ? '\\checkmark' : '\\times EXCEEDS'}` },
+          { tex: `\\delta_{D+L} = ${sn2(loads.deltaD + loads.deltaL)}\\text{ mm}\\quad L/240 = ${sn2(loads.limL240)}\\text{ mm}\\quad ${loads.deltaD + loads.deltaL <= loads.limL240 ? '\\checkmark' : '\\times EXCEEDS'}` },
+        ],
+      },
+    ]
+  }, [shape, props, flex, shear, loads, Fy, wD, wL, span, Lb, utilM])
 
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
       <div className="space-y-5">
-        <Card title="Section">
-          <label className="flex flex-col text-sm col-span-full">
-            <span className="mb-1 font-medium text-slate-600">W-shape</span>
-            <select value={shapeName} onChange={(e) => setShapeName(e.target.value)}
-              className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none">
-              {W_SHAPES.map((s) => <option key={s.name} value={s.name}>{s.name}</option>)}
-            </select>
-          </label>
-          <Pick label="Steel grade" value={grade} onChange={(v) => setGrade(v as Grade)}
+        <Card title="Section & grade">
+          <ShapePick value={shapeName} onChange={setShapeName} />
+          <Pick label="Steel grade" value={grade} onChange={v => setGrade(v as Grade)}
             options={Object.entries(GRADES).map(([k, v]) => [k as Grade, v.label])} />
         </Card>
-
         <Card title="Span & bracing">
           <Num label="Span L" unit="m" value={span} onChange={setSpan} />
           <Num label="Unbraced Lb" unit="m" value={Lb} onChange={setLb} />
           <Num label="Cb (moment gradient)" value={Cb} onChange={setCb} />
         </Card>
-
-        <Card title="Uniform loads (service)">
-          <Num label="Dead wD" unit="kN/m" value={wDead} onChange={setWDead} />
-          <Num label="Live wL" unit="kN/m" value={wLive} onChange={setWLive} />
+        <Card title="Uniform service loads">
+          <Num label="Dead wD" unit="kN/m" value={wD} onChange={setWD} />
+          <Num label="Live wL" unit="kN/m" value={wL} onChange={setWL} />
         </Card>
       </div>
 
-      <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
+      <div className="space-y-4 lg:sticky lg:top-4 lg:self-start">
+        <Suspense fallback={<Spinner />}>
+          <BeamViewer3D shape={shape} span={span} wDead={wD} wLive={wL} />
+        </Suspense>
+
         <ResultCard title="Section properties">
-          <Row label="A" value={`${shape.A.toLocaleString()} mm²`} />
-          <Row label="Ix" value={`${(props.Ix / 1e6).toFixed(1)} × 10⁶ mm⁴`} />
-          <Row label="Sx" value={`${(props.Sx / 1e3).toFixed(0)} × 10³ mm³`} />
-          <Row label="Zx" value={`${(props.Zx / 1e3).toFixed(0)} × 10³ mm³`} />
-          <Row label="ry" value={`${shape.ry} mm`} />
-          <Row label="Lp" value={`${f2(flex.Lp / 1000)} m`} sub="yielding limit" />
-          <Row label="Lr" value={`${f2(flex.Lr / 1000)} m`} sub="elastic LTB limit (conservative J)" />
+          <Row label="A"  value={`${shape.A.toLocaleString()} mm²`} />
+          <Row label="Ix" value={`${(props.Ix/1e6).toFixed(1)} ×10⁶ mm⁴`} />
+          <Row label="Sx" value={`${(props.Sx/1e3).toFixed(0)} ×10³ mm³`} />
+          <Row label="Zx" value={`${(props.Zx/1e3).toFixed(0)} ×10³ mm³`} />
+          <Row label="Lp / Lr" value={`${f2(flex.Lp/1000)} / ${f2(flex.Lr/1000)} m`} />
         </ResultCard>
-
-        <ResultCard title="Compact section (Table B4.1b)">
-          <Row label="λf = bf/2tf" value={f2(flex.lambdaF)} sub={`λpf = ${f2(flex.lambdaPF)}`} />
-          <Row label="Flange" value={ok(flex.compactFlange, flex.compactFlange ? 'compact' : 'non-compact')} />
-          <Row label="λw = hw/tw" value={f1(flex.lambdaW)} sub={`λpw = ${f1(flex.lambdaPW)}`} />
-          <Row label="Web" value={ok(flex.compactWeb, flex.compactWeb ? 'compact' : 'non-compact')} />
+        <ResultCard title={`Flexure §F2 ${badge(flex.ltbZone)}`}>
+          <Row label="φMn" value={`${f1(flex.phiMn)} kN·m`} />
+          <Row alert={utilM>1} label="Mu / φMn" value={ok(utilM<=1, `${(utilM*100).toFixed(0)} %`)} />
         </ResultCard>
-
-        <ResultCard title="Factored demands">
-          <Row label="wu" value={`${f2(loads.wu)} kN/m`} sub="max(1.4D, 1.2D+1.6L)" />
-          <Row label="Mu" value={`${f1(loads.Mu)} kN·m`} />
-          <Row label="Vu" value={`${f1(loads.Vu)} kN`} />
-        </ResultCard>
-
-        <ResultCard title="Flexure §F2">
-          <Row label={<>φMn {badge(flex.ltbZone)}</>} value={`${f1(flex.phiMn)} kN·m`} />
-          <Row alert={utilM > 1} label="Mu / φMn" value={ok(utilM <= 1, `${(utilM * 100).toFixed(0)} %`)} />
-        </ResultCard>
-
         <ResultCard title="Shear §G2.1">
-          <Row label="Aw = d·tw" value={`${shear.Aw.toFixed(0)} mm²`} />
-          <Row label="φv" value={shear.phiV.toFixed(1)} sub={`Cv1 = ${shear.Cv1.toFixed(2)}`} />
-          <Row label="φVn" value={`${f1(shear.phiVn)} kN`} />
-          <Row alert={utilV > 1} label="Vu / φVn" value={ok(utilV <= 1, `${(utilV * 100).toFixed(0)} %`)} />
+          <Row label="φVn" value={`${f1(shear.phiVn)} kN`} sub={`Cv1=${shear.Cv1.toFixed(2)}`} />
+          <Row alert={utilV>1} label="Vu / φVn" value={ok(utilV<=1, `${(utilV*100).toFixed(0)} %`)} />
         </ResultCard>
+        <ResultCard title="Deflection">
+          <Row alert={loads.deltaL>loads.limL360} label="δL ≤ L/360" value={ok(loads.deltaL<=loads.limL360, `${f2(loads.deltaL)} mm`)} />
+          <Row alert={loads.deltaD+loads.deltaL>loads.limL240} label="δtotal ≤ L/240" value={ok(loads.deltaD+loads.deltaL<=loads.limL240, `${f2(loads.deltaD+loads.deltaL)} mm`)} />
+        </ResultCard>
+      </div>
 
-        <ResultCard title="Deflection (unfactored)">
-          <Row label="δD (dead)" value={`${f2(loads.deltaD)} mm`} />
-          <Row label="δL (live)" value={`${f2(loads.deltaL)} mm`} sub={`limit L/360 = ${f2(loads.limL360)} mm`} />
-          <Row alert={loads.deltaL > loads.limL360}
-            label="δL ≤ L/360" value={ok(loads.deltaL <= loads.limL360, `${f2(loads.deltaL)} mm`)} />
-          <Row alert={loads.deltaD + loads.deltaL > loads.limL240}
-            label="δtotal ≤ L/240" value={ok(loads.deltaD + loads.deltaL <= loads.limL240,
-              `${f2(loads.deltaD + loads.deltaL)} mm`)} sub={`limit = ${f2(loads.limL240)} mm`} />
-        </ResultCard>
+      <div className="col-span-full">
+        <WorkedSolution steps={steps} title="Beam Design — step-by-step (AISC 360-16 §F, §G)" />
       </div>
     </div>
   )
 }
 
 // ─── Column Tab ────────────────────────────────────────────────────────────
+
 function ColumnTab() {
   const [shapeName, setShapeName] = useState('W250x67')
   const [grade, setGrade]         = useState<Grade>('A572G50')
-  const [L, setL]                 = useState(4)
-  const [Kx, setKx]               = useState(1.0)
-  const [Ky, setKy]               = useState(1.0)
-  const [loadInput, setLoadInput] = useState<'direct' | 'DL'>('DL')
-  const [dead, setDead]           = useState(800)
-  const [live, setLive]           = useState(500)
+  const [L,     setL]             = useState(4)
+  const [Kx,    setKx]            = useState(1.0)
+  const [Ky,    setKy]            = useState(1.0)
+  const [dlMode, setDlMode]       = useState<'DL'|'direct'>('DL')
+  const [dead,  setDead]          = useState(800)
+  const [live,  setLive]          = useState(500)
   const [PuDir, setPuDir]         = useState(1944)
-  const [Mux, setMux]             = useState(80)
-  const [Muy, setMuy]             = useState(0)
+  const [Mux,   setMux]           = useState(80)
+  const [Muy,   setMuy]           = useState(0)
 
   const { Fy } = GRADES[grade]
-  const shape = useMemo(() => shapeOrFirst(shapeName), [shapeName])
-  const props = useMemo(() => deriveWSection(shape), [shape])
-  const Pu  = loadInput === 'DL' ? Math.max(1.4 * dead, 1.2 * dead + 1.6 * live) : PuDir
+  const shape  = useMemo(() => shapeOrFirst(shapeName), [shapeName])
+  const props  = useMemo(() => deriveWSection(shape), [shape])
+  const Pu = dlMode === 'DL' ? Math.max(1.4*dead, 1.2*dead+1.6*live) : PuDir
 
   const axial  = useMemo(() => columnAxial(shape, Fy, L, Kx, Ky), [shape, Fy, L, Kx, Ky])
-  const flexX  = useMemo(() => beamFlexure(shape, props, Fy, L * 1000, 1.0), [shape, props, Fy, L])
+  const flexX  = useMemo(() => beamFlexure(shape, props, Fy, L*1000, 1.0), [shape, props, Fy, L])
   const flexY  = useMemo(() => weakAxisFlexure(shape, props, Fy), [shape, props, Fy])
-  const comb   = useMemo(
-    () => combinedLoading(Pu, axial.phiPn, Mux, flexX.phiMn, Muy, flexY.phiMny),
-    [Pu, axial, Mux, flexX, Muy, flexY]
-  )
+  const comb   = useMemo(() => combinedLoading(Pu, axial.phiPn, Mux, flexX.phiMn, Muy, flexY.phiMny), [Pu, axial, Mux, flexX, Muy, flexY])
+
+  const steps = useMemo((): SolutionStep[] => {
+    const E = 200000
+    return [
+      {
+        title: 'Factored axial load',
+        lines: dlMode === 'DL' ? [
+          { tex: `P_u = \\max(1.4D,\\;1.2D+1.6L) = \\max(${sn1(1.4*dead)},\\;${sn1(1.2*dead+1.6*live)}) = ${sn1(Pu)}\\text{ kN}` },
+        ] : [{ tex: `P_u = ${sn1(Pu)}\\text{ kN (direct input)}` }],
+      },
+      {
+        title: 'Slenderness and critical stress §E3',
+        lines: [
+          { tex: `KL/r_x = \\frac{${Kx}\\times${L*1000}}{${shape.rx}} = ${sn1(axial.slendernessX)}` },
+          { tex: `KL/r_y = \\frac{${Ky}\\times${L*1000}}{${shape.ry}} = ${sn1(axial.slendernessY)}\\quad \\text{(governing = }${sn1(axial.slenderness)})` },
+          { tex: `4.71\\sqrt{E/F_y} = 4.71\\sqrt{${E}/${Fy}} = ${sn1(4.71*Math.sqrt(E/Fy))}` },
+          { tex: `F_{cr} = ${sn2(axial.Fcr)}\\text{ MPa}\\quad \\phi P_n = 0.90 \\times ${sn2(axial.Fcr)} \\times ${shape.A} / 1000 = ${sn1(axial.phiPn)}\\text{ kN}` },
+        ],
+        note: axial.slenderOK ? undefined : 'KL/r > 200 — slenderness exceeds §E2 advisory limit.',
+      },
+      {
+        title: 'Flexural capacities',
+        lines: [
+          { tex: `\\phi M_{nx} = ${sn1(flexX.phiMn)}\\text{ kN·m}\\quad (\\text{${flexX.ltbZone} zone, §F2})` },
+          { tex: `\\phi M_{ny} = 0.90 F_y Z_y = ${sn1(flexY.phiMny)}\\text{ kN·m}\\quad (\\text{§F6, weak-axis})` },
+        ],
+      },
+      {
+        title: `Combined loading §H1-1 (equation ${comb.equation})`,
+        lines: comb.equation === 'H1-1a' ? [
+          { tex: `P_u/\\phi P_n = ${sn3(Pu/axial.phiPn)} \\geq 0.2 \\Rightarrow \\text{use §H1-1a}` },
+          { tex: `\\frac{P_u}{\\phi P_n} + \\frac{8}{9}\\!\\left(\\frac{M_{ux}}{\\phi M_{nx}} + \\frac{M_{uy}}{\\phi M_{ny}}\\right) = ${sn3(Pu/axial.phiPn)} + \\frac{8}{9}(${sn3(Mux/flexX.phiMn)} + ${sn3(Muy > 0 ? Muy/flexY.phiMny : 0)}) = ${sn3(comb.ratio)}\\quad${comb.ok?'\\checkmark':'\\times'}` },
+        ] : [
+          { tex: `P_u/\\phi P_n = ${sn3(Pu/axial.phiPn)} < 0.2 \\Rightarrow \\text{use §H1-1b}` },
+          { tex: `\\frac{P_u}{2\\phi P_n} + \\left(\\frac{M_{ux}}{\\phi M_{nx}} + \\frac{M_{uy}}{\\phi M_{ny}}\\right) = ${sn3(comb.ratio)}\\quad${comb.ok?'\\checkmark':'\\times'}` },
+        ],
+      },
+    ]
+  }, [shape, axial, flexX, flexY, comb, Pu, Mux, Muy, Kx, Ky, L, Fy, dead, live, dlMode])
 
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
       <div className="space-y-5">
-        <Card title="Section">
-          <label className="flex flex-col text-sm col-span-full">
-            <span className="mb-1 font-medium text-slate-600">W-shape</span>
-            <select value={shapeName} onChange={(e) => setShapeName(e.target.value)}
-              className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none">
-              {W_SHAPES.map((s) => <option key={s.name} value={wName(s)}>{s.name}</option>)}
-            </select>
-          </label>
-          <Pick label="Steel grade" value={grade} onChange={(v) => setGrade(v as Grade)}
+        <Card title="Section & grade">
+          <ShapePick value={shapeName} onChange={setShapeName} />
+          <Pick label="Steel grade" value={grade} onChange={v => setGrade(v as Grade)}
             options={Object.entries(GRADES).map(([k, v]) => [k as Grade, v.label])} />
         </Card>
-
         <Card title="Column geometry">
           <Num label="Height L" unit="m" value={L} onChange={setL} />
-          <Num label="Kx (x-axis)" value={Kx} onChange={setKx} />
-          <Num label="Ky (y-axis)" value={Ky} onChange={setKy} />
+          <Num label="Kx" value={Kx} onChange={setKx} />
+          <Num label="Ky" value={Ky} onChange={setKy} />
         </Card>
-
         <Card title="Loads">
-          <Pick label="Axial input" value={loadInput} onChange={(v) => setLoadInput(v as 'direct' | 'DL')}
-            options={[['DL', 'Service D & L'], ['direct', 'Factored Pu']]} />
-          {loadInput === 'DL' ? <>
+          <Pick label="Axial input" value={dlMode} onChange={v => setDlMode(v as 'DL'|'direct')}
+            options={[['DL','Service D & L'],['direct','Factored Pu']]} />
+          {dlMode === 'DL' ? <>
             <Num label="Dead D" unit="kN" value={dead} onChange={setDead} />
             <Num label="Live L" unit="kN" value={live} onChange={setLive} />
-          </> : (
-            <Num label="Pu" unit="kN" value={PuDir} onChange={setPuDir} />
-          )}
-          <Num label="Mux (strong)" unit="kN·m" value={Mux} onChange={setMux} />
-          <Num label="Muy (weak)" unit="kN·m" value={Muy} onChange={setMuy} />
+          </> : <Num label="Pu" unit="kN" value={PuDir} onChange={setPuDir} />}
+          <Num label="Mux (strong-axis)" unit="kN·m" value={Mux} onChange={setMux} />
+          <Num label="Muy (weak-axis)" unit="kN·m" value={Muy} onChange={setMuy} />
         </Card>
       </div>
 
-      <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
-        <ResultCard title="Section properties">
-          <Row label="A" value={`${shape.A.toLocaleString()} mm²`} />
-          <Row label="rx" value={`${shape.rx} mm`} />
-          <Row label="ry" value={`${shape.ry} mm`} />
-          <Row label="Zx" value={`${(props.Zx / 1e3).toFixed(0)} × 10³ mm³`} />
-        </ResultCard>
-
+      <div className="space-y-4 lg:sticky lg:top-4 lg:self-start">
+        <Suspense fallback={<Spinner />}>
+          <ColumnViewer3D shape={shape} L={L} Pu={Pu} Mux={Mux} />
+        </Suspense>
         <ResultCard title="Axial §E3">
-          <Row label="KxL/rx" value={f1(axial.slendernessX)} />
-          <Row label="KyL/ry" value={f1(axial.slendernessY)} />
-          <Row alert={!axial.slenderOK}
-            label="KL/r (governing)" value={`${f1(axial.slenderness)}${axial.slenderOK ? '' : ' > 200 ✗'}`} />
+          <Row label="KL/rx" value={f1(axial.slendernessX)} />
+          <Row label="KL/ry" value={f1(axial.slendernessY)} sub="governing" />
+          <Row alert={!axial.slenderOK} label="KL/r" value={`${f1(axial.slenderness)}${axial.slenderOK?'':' > 200 ✗'}`} />
           <Row label="Fcr" value={`${f1(axial.Fcr)} MPa`} />
           <Row label="φPn" value={`${f1(axial.phiPn)} kN`} />
-          <Row label="Pu" value={`${f1(Pu)} kN`} sub={`${(Pu / axial.phiPn * 100).toFixed(0)} %`} />
         </ResultCard>
-
         <ResultCard title="Flexure">
-          <Row label="φMnx (strong)" value={`${f1(flexX.phiMn)} kN·m`} sub={flexX.ltbZone} />
-          <Row label="φMny (weak §F6)" value={`${f1(flexY.phiMny)} kN·m`} />
+          <Row label="φMnx" value={`${f1(flexX.phiMn)} kN·m`} sub={flexX.ltbZone} />
+          <Row label="φMny §F6" value={`${f1(flexY.phiMny)} kN·m`} />
         </ResultCard>
-
         <ResultCard title={`Combined §${comb.equation}`}>
-          <Row label="Pu / φPn" value={f3(Pu / axial.phiPn)} />
-          <Row label="Mux / φMnx" value={f3(Mux / flexX.phiMn)} />
-          {Muy > 0 && <Row label="Muy / φMny" value={f3(Muy / flexY.phiMny)} />}
-          <Row alert={!comb.ok}
-            label="Combined ratio" value={ok(comb.ok, `${(comb.ratio * 100).toFixed(0)} %`)} />
+          <Row alert={!comb.ok} label="Combined ratio" value={ok(comb.ok, `${(comb.ratio*100).toFixed(0)} %`)} />
         </ResultCard>
+      </div>
+
+      <div className="col-span-full">
+        <WorkedSolution steps={steps} title="Column Design — step-by-step (AISC 360-16 §E3, §H1-1)" />
       </div>
     </div>
   )
 }
 
 // ─── Connection Tab ─────────────────────────────────────────────────────────
-function ConnectionTab() {
-  const [connType, setConnType]       = useState<ConnType>('bolt')
-  const [Vu, setVu]                   = useState(150)
-  // bolt
-  const [boltGrade, setBoltGrade]     = useState<BoltGrade>('A325M')
-  const [db, setDb]                   = useState(19)
-  const [nBolts, setNBolts]           = useState(3)
-  const [tConn, setTConn]             = useState(10)
-  const [FuConn, setFuConn]           = useState(400)
-  const [threads, setThreads]         = useState<'yes' | 'no'>('yes')
-  // weld
-  const [electrode, setElectrode]     = useState<ElectrodeClass>('E70')
-  const [wSize, setWSize]             = useState(8)
-  const [weldLen, setWeldLen]         = useState(200)
 
-  const bolt = useMemo(
-    () => boltShear(boltGrade, db, Vu, tConn, FuConn, threads === 'yes'),
-    [boltGrade, db, Vu, tConn, FuConn, threads]
+function ConnectionTab() {
+  const [connType,   setConnType]   = useState<ConnType>('bolt')
+  const [Vu,         setVu]         = useState(150)
+  const [Hu,         setHu]         = useState(0)
+  // bolt layout
+  const [boltGrade,  setBoltGrade]  = useState<BoltGrade>('A325M')
+  const [db,         setDb]         = useState(20)
+  const [nRows,      setNRows]      = useState(3)
+  const [nCols,      setNCols]      = useState(1)
+  const [sy,         setSy]         = useState(70)
+  const [sx,         setSx]         = useState(70)
+  const [ey,         setEy]         = useState(40)
+  const [ex_edge,    setExEdge]     = useState(35)  // horizontal edge distance
+  const [threads,    setThreads]    = useState<'yes'|'no'>('yes')
+  const [tPlate,     setTPlate]     = useState(10)
+  const [FuPlate,    setFuPlate]    = useState(400)
+  const [FyPlate,    setFyPlate]    = useState(248)
+  const [ex_load,    setExLoad]     = useState(0)   // eccentricity from bolt centroid
+  const [ey_load,    setEyLoad]     = useState(0)
+  // weld
+  const [electrode,  setElectrode]  = useState<ElectrodeClass>('E70')
+  const [wSize,      setWSize]      = useState(8)
+
+  // bolt calcs
+  const phiRnBolt = useMemo(() =>
+    boltShear(boltGrade, db, Vu, tPlate, FuPlate, threads === 'yes'),
+    [boltGrade, db, Vu, tPlate, FuPlate, threads]
+  )
+  const geom = useMemo(() =>
+    boltGroupGeom(nRows, nCols, sx, sy, ex_edge, ey),
+    [nRows, nCols, sx, sy, ex_edge, ey]
+  )
+  const eccentric = useMemo(() =>
+    eccentricBoltGroup(geom, Vu, Hu, ex_load, ey_load, phiRnBolt.phiRn, db, tPlate),
+    [geom, Vu, Hu, ex_load, ey_load, phiRnBolt, db, tPlate]
+  )
+  const blockShearCases = useMemo(() =>
+    shearTabBlockShear(nRows, sy, ey, ey, ex_edge, db, tPlate, FyPlate, FuPlate),
+    [nRows, sy, ey, ex_edge, db, tPlate, FyPlate, FuPlate]
   )
   const weld = useMemo(() => weldStrength(electrode, wSize, Vu), [electrode, wSize, Vu])
+  const weldCapacity = useMemo(() => geom.plateH * weld.phiRnw, [geom, weld])
 
-  const boltCapacity = nBolts * bolt.phiRn
-  const weldCapacity = weldLen * weld.phiRnw
-  const utilBolt = Vu / boltCapacity
-  const utilWeld = Vu / weldCapacity
+  const govBlockShear = blockShearCases.reduce((mn, c) => c.phiRn < mn.phiRn ? c : mn, blockShearCases[0])
+
+  const boltSteps = useMemo((): SolutionStep[] => {
+    const { Fnv, Ab, phiRn_shear, phiRn_bearing, phiRn } = phiRnBolt
+    const { n, Ip } = geom
+    const M = eccentric.M
+    return [
+      {
+        title: `Bolt shear capacity §J3.6 — ${boltGrade}, d_b = ${db} mm`,
+        lines: [
+          { tex: `A_b = \\frac{\\pi}{4} d_b^2 = \\frac{\\pi}{4}(${db})^2 = ${Ab.toFixed(0)}\\text{ mm}^2` },
+          { tex: `F_{nv} = ${Fnv}\\text{ MPa}\\quad (${threads==='yes'?'threads in shear plane, N':'threads excluded, X'})` },
+          { tex: `\\phi R_{n,\\text{shear}} = 0.75 F_{nv} A_b = 0.75 \\times ${Fnv} \\times ${Ab.toFixed(0)} / 1000 = ${sn2(phiRn_shear)}\\text{ kN/bolt}` },
+        ],
+      },
+      {
+        title: `Bearing on plate §J3.10 — t = ${tPlate} mm, F_u = ${FuPlate} MPa`,
+        lines: [
+          { tex: `\\phi R_{n,\\text{br}} = 0.75 \\times 2.4 F_u d_b t = 0.75 \\times 2.4 \\times ${FuPlate} \\times ${db} \\times ${tPlate} / 1000 = ${sn2(phiRn_bearing)}\\text{ kN/bolt}` },
+          { tex: `\\phi R_n\\text{ (governing)} = \\min(${sn2(phiRn_shear)},\\;${sn2(phiRn_bearing)}) = ${sn2(phiRn)}\\text{ kN/bolt}` },
+        ],
+      },
+      {
+        title: `Bolt group (${nRows} × ${nCols} = ${n} bolts) — in-plane eccentricity (elastic method)`,
+        lines: [
+          { tex: `I_p = \\sum(x_i^2 + y_i^2) = ${Ip.toFixed(0)}\\text{ mm}^2` },
+          { tex: `M = V_u \\cdot e_x - H_u \\cdot e_y = ${Vu} \\times ${ex_load} - ${Hu} \\times ${ey_load} = ${M.toFixed(0)}\\text{ kN·mm}` },
+          { text: `Direct shear per bolt: Vx = Hu/n = ${(Hu/n).toFixed(2)} kN,  Vy = Vu/n = ${(Vu/n).toFixed(2)} kN` },
+          { tex: `V_{x,i} = H_u/n - M y_i / I_p\\quad V_{y,i} = V_u/n + M x_i / I_p` },
+          { tex: `R_{\\max} = ${sn2(eccentric.Rmax)}\\text{ kN on bolt }\\textit{${eccentric.critical}}` },
+          { tex: `\\text{Utilisation} = R_{\\max} / (\\phi R_n) = ${sn2(eccentric.Rmax)} / ${sn2(phiRn)} = ${sn2(eccentric.Rmax/phiRn)}\\quad ${eccentric.Rmax<=phiRn?'\\checkmark':'\\times'}` },
+        ],
+      },
+      {
+        title: 'Bearing stress and shear stress on critical bolt',
+        lines: (() => {
+          const crit = eccentric.bolts.find(b => b.id === eccentric.critical)
+          if (!crit) return []
+          const Ab = (Math.PI/4)*db*db
+          return [
+            { tex: `f_{br} = \\frac{R_{\\max}}{d_b \\cdot t} = \\frac{${sn2(eccentric.Rmax)} \\times 1000}{${db} \\times ${tPlate}} = ${sn1(crit.fbr)}\\text{ MPa}\\quad \\phi F_{br} = 0.75 \\times 2.4 \\times ${FuPlate} = ${sn1(0.75*2.4*FuPlate)}\\text{ MPa}\\quad ${crit.fbr <= 0.75*2.4*FuPlate ? '\\checkmark':'\\times'}` },
+            { tex: `f_v = \\frac{R_{\\max}}{A_b} = \\frac{${sn2(eccentric.Rmax)} \\times 1000}{${Ab.toFixed(0)}} = ${sn1(crit.fv)}\\text{ MPa}\\quad \\phi F_{nv} = 0.75 \\times ${Fnv} = ${sn1(0.75*Fnv)}\\text{ MPa}\\quad ${crit.fv <= 0.75*Fnv ? '\\checkmark':'\\times'}` },
+          ]
+        })(),
+      },
+      {
+        title: 'Block shear §J4.3 (shear tab, single bolt line)',
+        lines: blockShearCases.flatMap(c => [
+          { text: c.label },
+          { tex: `A_{gv} = ${c.Agv.toFixed(0)}\\text{ mm}^2\\quad A_{nv} = ${c.Anv.toFixed(0)}\\text{ mm}^2\\quad A_{nt} = ${c.Ant.toFixed(0)}\\text{ mm}^2` },
+          { tex: `R_{n,\\text{fract}} = 0.6 F_u A_{nv} + U_{bs} F_u A_{nt} = ${sn1(c.Rn_fract)}\\text{ kN}` },
+          { tex: `\\text{cap } = 0.6 F_y A_{gv} + U_{bs} F_u A_{nt} = ${sn1(c.Rn_cap)}\\text{ kN}` },
+          { tex: `\\phi R_n = 0.75 \\times ${sn1(Math.min(c.Rn_fract,c.Rn_cap))} = ${sn1(c.phiRn)}\\text{ kN}\\quad ${Vu<=c.phiRn?'\\checkmark':'\\times'}` },
+        ]),
+      },
+    ]
+  }, [phiRnBolt, geom, eccentric, blockShearCases, boltGrade, db, nRows, nCols, tPlate, FuPlate, FyPlate, threads, Vu, Hu, ex_load, ey_load])
 
   return (
-    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.2fr_0.9fr_1fr]">
+      {/* ── inputs ── */}
       <div className="space-y-5">
         <Card title="Connection">
-          <Pick label="Type" value={connType} onChange={(v) => setConnType(v as ConnType)}
-            options={[['bolt', 'Bolted (§J3)'], ['weld', 'Fillet weld (§J2.4)']]} />
+          <Pick label="Type" value={connType} onChange={v => setConnType(v as ConnType)}
+            options={[['bolt','Bolted (§J3)'],['weld','Fillet weld (§J2.4)']]} />
           <Num label="Applied Vu" unit="kN" value={Vu} onChange={setVu} />
+          <Num label="Applied Hu (horizontal)" unit="kN" value={Hu} onChange={setHu} />
         </Card>
 
-        {connType === 'bolt' ? (
-          <Card title="Bolt group">
-            <Pick label="Grade" value={boltGrade} onChange={(v) => setBoltGrade(v as BoltGrade)}
-              options={[['A325M', 'A325M (F10T equiv)'], ['A490M', 'A490M (F13T equiv)']]} />
-            <Num label="Bolt diameter db" unit="mm" value={db} onChange={setDb} />
-            <Num label="Number of bolts n" value={nBolts} onChange={setNBolts} />
-            <Pick label="Threads in shear plane" value={threads} onChange={(v) => setThreads(v as 'yes' | 'no')}
-              options={[['yes', 'Yes (N)'], ['no', 'No (X)']]} />
-            <Num label="Plate thickness t" unit="mm" value={tConn} onChange={setTConn} />
-            <Num label="Plate Fu" unit="MPa" value={FuConn} onChange={setFuConn} />
+        {connType === 'bolt' ? (<>
+          <Card title="Bolt properties">
+            <Pick label="Grade" value={boltGrade} onChange={v => setBoltGrade(v as BoltGrade)}
+              options={[['A325M','A325M (F10T)'],['A490M','A490M (F13T)']]} />
+            <Num label="Diameter db" unit="mm" value={db} onChange={setDb} />
+            <Pick label="Threads in shear plane" value={threads} onChange={v => setThreads(v as 'yes'|'no')}
+              options={[['yes','Yes (N)'],['no','No (X)']]} />
           </Card>
-        ) : (
+          <Card title="Bolt pattern">
+            <Num label="Rows (vertical) nR" value={nRows} onChange={setNRows} />
+            <Num label="Cols (horizontal) nC" value={nCols} onChange={setNCols} />
+            <Num label="Vertical spacing sv" unit="mm" value={sy} onChange={setSy} />
+            <Num label="Horizontal spacing sh" unit="mm" value={sx} onChange={setSx} />
+            <Num label="Edge dist vertical ey" unit="mm" value={ey} onChange={setEy} />
+            <Num label="Edge dist horiz ex" unit="mm" value={ex_edge} onChange={setExEdge} />
+          </Card>
+          <Card title="Eccentricity (load point from bolt centroid)">
+            <Num label="Horizontal e_x" unit="mm" value={ex_load} onChange={setExLoad} />
+            <Num label="Vertical e_y" unit="mm" value={ey_load} onChange={setEyLoad} />
+            <p className="col-span-full text-[10px] text-slate-400">Positive e_x = load is to the RIGHT of the bolt centroid.</p>
+          </Card>
+          <Card title="Plate / connected part">
+            <Num label="Plate thickness t" unit="mm" value={tPlate} onChange={setTPlate} />
+            <Num label="Plate Fy" unit="MPa" value={FyPlate} onChange={setFyPlate} />
+            <Num label="Plate Fu" unit="MPa" value={FuPlate} onChange={setFuPlate} />
+          </Card>
+        </>) : (
           <Card title="Fillet weld">
-            <Pick label="Electrode" value={electrode} onChange={(v) => setElectrode(v as ElectrodeClass)}
-              options={[['E70', 'E70XX (Fexx 482 MPa)'], ['E80', 'E80XX (550 MPa)'],
-                        ['E90', 'E90XX (620 MPa)'],    ['E100', 'E100XX (690 MPa)']]} />
+            <Pick label="Electrode" value={electrode} onChange={v => setElectrode(v as ElectrodeClass)}
+              options={[['E70','E70XX (482 MPa)'],['E80','E80XX (550 MPa)'],['E90','E90XX (620 MPa)'],['E100','E100XX (690 MPa)']]} />
             <Num label="Weld size w" unit="mm" value={wSize} onChange={setWSize} />
-            <Num label="Total weld length" unit="mm" value={weldLen} onChange={setWeldLen} />
+            <Card title="Plate (for weld group geometry)">
+              <Num label="Rows nR (for length)" value={nRows} onChange={setNRows} />
+              <Num label="Vert spacing sv" unit="mm" value={sy} onChange={setSy} />
+              <Num label="Edge dist ey" unit="mm" value={ey} onChange={setEy} />
+            </Card>
           </Card>
         )}
       </div>
 
-      <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
-        {connType === 'bolt' ? (
-          <ResultCard title="Bolt design §J3.6 / §J3.10">
-            <Row label="Ab (bolt area)" value={`${bolt.Ab.toFixed(0)} mm²`} />
-            <Row label="Fnv" value={`${bolt.Fnv} MPa`} />
-            <Row label="φRn shear / bolt" value={`${f2(bolt.phiRn_shear)} kN`} />
-            <Row label="φRn bearing / bolt" value={`${f2(bolt.phiRn_bearing)} kN`} sub="governs if shown bold" />
-            <Row label="φRn / bolt (governing)" value={<b>{f2(bolt.phiRn)} kN</b>} />
-            <Row label="Bolts required" value={`${bolt.n_reqd}`} sub={`for Vu = ${Vu} kN`} />
-            <Row label={`Capacity (${nBolts} bolts)`} value={`${f1(boltCapacity)} kN`} />
-            <Row alert={utilBolt > 1}
-              label={`Vu / (${nBolts} × φRn)`}
-              value={ok(utilBolt <= 1, `${(utilBolt * 100).toFixed(0)} %`)} />
+      {/* ── 2D drawing + 3D ── */}
+      <div className="space-y-4">
+        <ConnectionDrawing
+          geom={geom} db={db}
+          boltForces={connType === 'bolt' ? eccentric.bolts : undefined}
+          critical={connType === 'bolt' ? eccentric.critical : undefined}
+          Vu={Vu} Hu={Hu} ex_load={geom.Cx + ex_load} ey_load={geom.Cy + ey_load}
+          connType={connType}
+        />
+        <Suspense fallback={<Spinner />}>
+          <ConnectionViewer3D geom={geom} db={db} t_plate={tPlate} critical={connType === 'bolt' ? eccentric.critical : ''} />
+        </Suspense>
+      </div>
+
+      {/* ── results ── */}
+      <div className="space-y-4 lg:sticky lg:top-4 lg:self-start">
+        {connType === 'bolt' ? (<>
+          <ResultCard title="Bolt capacity / bolt">
+            <Row label="φRn shear" value={`${f2(phiRnBolt.phiRn_shear)} kN`} />
+            <Row label="φRn bearing" value={`${f2(phiRnBolt.phiRn_bearing)} kN`} />
+            <Row label="φRn governing" value={<b>{f2(phiRnBolt.phiRn)} kN</b>} />
           </ResultCard>
-        ) : (
+          <ResultCard title={`Eccentric group (${geom.n} bolts)`}>
+            <Row label="Ip" value={`${geom.Ip.toFixed(0)} mm²`} />
+            <Row label="In-plane M" value={`${eccentric.M.toFixed(0)} kN·mm`} />
+            <Row label="Critical bolt" value={eccentric.critical} sub={`R = ${f2(eccentric.Rmax)} kN`} />
+            <Row alert={eccentric.Rmax > phiRnBolt.phiRn}
+              label="Rmax / φRn"
+              value={ok(eccentric.Rmax <= phiRnBolt.phiRn, `${(eccentric.Rmax/phiRnBolt.phiRn*100).toFixed(0)} %`)} />
+          </ResultCard>
+          <ResultCard title="Per-bolt forces">
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead><tr className="text-left text-slate-400">
+                  <th className="pr-2 pb-1">id</th><th className="pr-2 pb-1">Vx kN</th><th className="pr-2 pb-1">Vy kN</th>
+                  <th className="pr-2 pb-1">R kN</th><th className="pb-1">fbr MPa</th>
+                </tr></thead>
+                <tbody>
+                  {eccentric.bolts.map(b => (
+                    <tr key={b.id} className={b.id === eccentric.critical ? 'font-semibold text-amber-700' : ''}>
+                      <td className="pr-2">{b.id}</td>
+                      <td className="pr-2">{f2(b.Vx)}</td>
+                      <td className="pr-2">{f2(b.Vy)}</td>
+                      <td className="pr-2">{f2(b.R)}</td>
+                      <td>{f1(b.fbr)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </ResultCard>
+          <ResultCard title="Block shear §J4.3">
+            {blockShearCases.map(c => (
+              <Row key={c.label} alert={Vu > c.phiRn}
+                label={<span className="text-[10px]">{c.label.replace('§J4.3 ', '')}</span>}
+                value={ok(Vu <= c.phiRn, `φRn = ${f1(c.phiRn)} kN`)} />
+            ))}
+            <Row alert={Vu > govBlockShear.phiRn}
+              label="Governing block shear"
+              value={ok(Vu <= govBlockShear.phiRn, `${f1(govBlockShear.phiRn)} kN`)} />
+          </ResultCard>
+        </>) : (
           <ResultCard title="Fillet weld §J2.4">
-            <Row label="Fexx" value={`${weld.Fexx} MPa`} />
-            <Row label="Throat (0.707w)" value={`${(0.707 * wSize).toFixed(1)} mm`} />
-            <Row label="φRnw / mm length" value={`${f3(weld.phiRnw)} kN/mm`} />
-            <Row label="Required length" value={`${f1(weld.L_reqd)} mm`} sub={`for Vu = ${Vu} kN`} />
-            <Row label={`Capacity (${weldLen} mm)`} value={`${f1(weldCapacity)} kN`} />
-            <Row alert={utilWeld > 1}
-              label={`Vu / (${weldLen} mm × φRnw)`}
-              value={ok(utilWeld <= 1, `${(utilWeld * 100).toFixed(0)} %`)} />
-            <p className="mt-2 text-[10px] text-slate-400">
-              Divide total length by 2 for two-sided welds. Check minimum weld size
-              per AISC Table J2.4 (governed by thicker connected part).
-            </p>
+            <Row label="φRnw / mm" value={`${f3(weld.phiRnw)} kN/mm`} />
+            <Row label="Required length" value={`${f1(weld.L_reqd)} mm`} sub={`plate H = ${f1(geom.plateH)} mm`} />
+            <Row alert={Vu > weldCapacity}
+              label="Vu vs capacity"
+              value={ok(Vu <= weldCapacity, `${f1(weldCapacity)} kN`)}
+              sub={`2 × ${geom.plateH.toFixed(0)} mm` } />
           </ResultCard>
         )}
-
-        <div className="print-avoid-break rounded-xl border border-slate-100 bg-slate-50 p-4 text-[11px] text-slate-500 space-y-1">
-          <p className="font-semibold text-slate-600">Notes</p>
-          <p>• Bolt shear: one shear plane. Multiply n by number of shear planes for lap/splice.</p>
-          <p>• Bearing per bolt: standard holes, no deformation limit state (§J3.10). Check edge distance ≥ 1.5d, spacing ≥ 3d (§J3.3).</p>
-          <p>• Weld capacity is for a single pass, direct shear (θ = 0°). §J2.4(b) allows a 50% increase for transverse loading.</p>
-          <p>• Block shear (§J4.3) and net section (§J4.1) should be checked separately.</p>
-        </div>
       </div>
+
+      {connType === 'bolt' && (
+        <div className="col-span-full">
+          <WorkedSolution steps={boltSteps} title="Connection Design — step-by-step (AISC 360-16 §J3, §J4)" />
+        </div>
+      )}
     </div>
   )
 }
 
 // ─── Main page ─────────────────────────────────────────────────────────────
+
 export default function SteelDesign() {
   const [tab, setTab] = useState<Tab>('beam')
-
   const tabBtn = (t: Tab, label: string) => (
-    <button type="button"
-      onClick={() => setTab(t)}
-      className={`rounded-md px-4 py-1.5 text-sm font-semibold transition
-        ${tab === t ? 'bg-[#0056b3] text-white shadow' : 'text-slate-600 hover:bg-slate-100'}`}>
+    <button type="button" onClick={() => setTab(t)}
+      className={`rounded-md px-4 py-1.5 text-sm font-semibold transition ${tab === t ? 'bg-[#0056b3] text-white shadow' : 'text-slate-600 hover:bg-slate-100'}`}>
       {label}
     </button>
   )
-
   return (
-    <div className="mx-auto max-w-6xl p-6">
+    <div className="mx-auto max-w-7xl p-6">
       <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
       <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Steel Design</h1>
       <p className="no-print mt-1 text-slate-600">
-        AISC 360-16 LRFD — steel beams (§F/G, flexure + shear + deflection),
-        columns (§E3 + §H1-1 combined), and connections (bolts §J3, fillet welds §J2.4).
-        W-shapes from the same AISC library used in Truss Space.
+        AISC 360-16 LRFD — beams (§F/G + deflections), columns (§E3 + §H1-1), connections
+        (bolt group with in-plane eccentricity, bearing/shear stresses, block shear §J4.3;
+        fillet welds §J2.4). 3D scene + 2D layout + step-by-step solution on every tab.
       </p>
       <ReportControls title="Steel Design Report" />
-
       <div className="no-print mt-5 mb-6 flex gap-2 rounded-xl border border-slate-200 bg-white p-1.5 shadow-sm w-fit">
         {tabBtn('beam',       'Beam')}
         {tabBtn('column',     'Column')}
         {tabBtn('connection', 'Connection')}
       </div>
-
       <div className="mt-2">
         {tab === 'beam'       && <BeamTab />}
         {tab === 'column'     && <ColumnTab />}


### PR DESCRIPTION
Enhancement of the Steel Design page (PR #184) with 3D viewers, full eccentric bolt group analysis, block shear checks, and step-by-step worked solutions.

## What's added

### New components
- **`SteelViewer3D.tsx`** — Three.js/R3F 3D viewers for all three tabs:
  - `BeamViewer3D`: extruded W-section, distributed load arrows, pin/roller supports, FitView
  - `ColumnViewer3D`: vertical W-section, axial (red) and moment (amber) load arrows, fixed base
  - `ConnectionViewer3D`: plate + bolt cylinders (critical bolt highlighted) + beam web stub
- **`ConnectionDrawing.tsx`** — SVG 2D plan view:
  - Bolt holes with per-bolt force arrows (scaled to Rmax), critical bolt in red
  - Weld layout (two vertical weld lines)
  - Dimension lines for plate W×H, edge distances
  - Load application point with Vu/Hu arrows

### Engine extensions (`steelDesign.ts`)
- `boltGroupGeom(nRows, nCols, sx, sy, ex, ey)` — grid layout, centroid, Ip = Σ(x²+y²)
- `eccentricBoltGroup(...)` — elastic vector method; M = Pu·ex − Hu·ey (kN·mm); per-bolt Vx/Vy/R, bearing stress fbr = R·1000/(db·t), shear stress fv = R·1000/Ab
- `shearTabBlockShear(...)` — §J4.3, two cases (Case A shear from bottom, Case B shear from top); φ = 0.75

### Connection tab redesign (3-column layout)
- Left: joint type selector, bolt/weld grade, bolt pattern grid (nRows×nCols, pitch, edge distances), eccentricity inputs, plate geometry
- Centre: ConnectionDrawing SVG + ConnectionViewer3D (lazy, Suspense)
- Right (sticky): φRn per bolt, eccentric group summary (Ip, M, Rmax vs φRn, utilisation), per-bolt force table (Vx/Vy/R/fbr), block shear cases A+B
- Full-width: 5-step WorkedSolution (bolt shear §J3.6 → bearing §J3.10 → eccentric group → stress checks → block shear §J4.3)

## Tests
8 new tests for the three new engine functions. Full suite: **298 passing** (36 files).

## Note — out-of-plane eccentricity
In-plane eccentricity (bracket plate, shear tab) is fully implemented. Out-of-plane eccentricity (beam framing into column flange with moment) requires bolt tension + prying action (§J3.6/J3.9) — not included in this phase; flagged for a future PR.

## Verification
- `npm test` → **298 passing**
- `npx tsc -b` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_