### PR TITLE
feat(steel): out-of-plane eccentricity — §J3.7 bolt tension + combined check

### DIFF
--- a/webapp/src/engine/steelDesign.test.ts
+++ b/webapp/src/engine/steelDesign.test.ts
@@ -4,7 +4,7 @@ import {
   deriveWSection, beamFlexure, beamShear,
   columnAxial, weakAxisFlexure, combinedLoading,
   boltShear, weldStrength, beamLoadingSimple, E_STEEL,
-  boltGroupGeom, eccentricBoltGroup, shearTabBlockShear,
+  boltGroupGeom, eccentricBoltGroup, shearTabBlockShear, outOfPlaneBoltGroup,
 } from './steelDesign'
 
 const W250x33 = shapeByName('W250x33')!
@@ -224,5 +224,51 @@ describe('shearTabBlockShear §J4.3', () => {
     const cA = shearTabBlockShear(3, 70, 40, 40, 35, 20, 10, 248, 400)
     const cB = shearTabBlockShear(4, 70, 40, 40, 35, 20, 10, 248, 400)
     expect(cB[0].phiRn).toBeGreaterThan(cA[0].phiRn)
+  })
+})
+
+describe('outOfPlaneBoltGroup §J3.7', () => {
+  const g = boltGroupGeom(3, 1, 70, 70, 40, 40)   // 3 bolts in vertical column
+  // dummy in-plane bolts with fv = 0 for isolation of tension calc
+  const zeroShear = g.bolts.map(b => ({
+    id: b.id, x: b.x, y: b.y, Vx: 0, Vy: 0, R: 0, utilShear: 0, fbr: 0, fv: 0
+  }))
+
+  it('zero e_out → all T = 0', () => {
+    const r = outOfPlaneBoltGroup(g, zeroShear, 0, 100, 'A325M', 20, true)
+    r.bolts.forEach(b => expect(b.T).toBe(0))
+    expect(r.M_op).toBe(0)
+  })
+
+  it('top bolt gets maximum tension (largest yi)', () => {
+    const r = outOfPlaneBoltGroup(g, zeroShear, 50, 100, 'A325M', 20, true)
+    // bolts ordered B1(bottom) to B3(top); top bolt yi is largest
+    const top = r.bolts.reduce((a, b) => b.yi > a.yi ? b : a, r.bolts[0])
+    expect(top.T).toBeCloseTo(r.Tmax, 6)
+    expect(r.critical).toBe(top.id)
+  })
+
+  it('T_i = M_op * yi / sumYi2 formula', () => {
+    const Vu = 80, e_out = 75
+    const r = outOfPlaneBoltGroup(g, zeroShear, e_out, Vu, 'A325M', 22, false)
+    const M_op = Vu * e_out
+    r.bolts.forEach(b => {
+      const expected = r.sumYi2 > 0 ? M_op * b.yi / r.sumYi2 : 0
+      expect(b.T).toBeCloseTo(expected, 6)
+    })
+  })
+
+  it('§J3.7 reduced tensile strength decreases with shear stress', () => {
+    const phi = 0.75, Fnt = 620, Fnv = 310
+    const withShear = [{ id: 'B3', x: 0, y: 70, Vx: 0, Vy: 0, R: 50, utilShear: 0, fbr: 0,
+      fv: 50 * 1000 / ((Math.PI/4)*20**2) }]
+    // top bolt only — provide fv for it
+    const mixed = g.bolts.map(b =>
+      b.id === 'B3' ? withShear[0] : { ...b, Vx: 0, Vy: 0, R: 0, utilShear: 0, fbr: 0, fv: 0 }
+    )
+    const r = outOfPlaneBoltGroup(g, mixed, 50, 100, 'A325M', 20, true)
+    const critB = r.bolts.find(b => b.id === 'B3')!
+    const expected = Math.min(1.3 * Fnt - (Fnt / (phi * Fnv)) * critB.frv, Fnt)
+    expect(critB.phiFnt_prime).toBeCloseTo(Math.max(0, expected), 4)
   })
 })

--- a/webapp/src/engine/steelDesign.ts
+++ b/webapp/src/engine/steelDesign.ts
@@ -373,3 +373,77 @@ export function shearTabBlockShear(
     mkCase('§J4.3 Case B — shear path from top edge', (nRows - 1) * sy + ey_top),
   ]
 }
+
+// ─── Out-of-plane eccentricity §J3.7 ─────────────────────────────────────
+// Load Vu applied at perpendicular distance e_out from the bolt group plane
+// produces out-of-plane moment M_op = Vu·e_out (kN·mm).
+// Neutral axis at the bottom bolt row (plate bearing against column flange).
+// Bolt tension: T_i = M_op · yi / Σyi²  (yi = height above lowest bolt, mm).
+// Combined shear + tension interaction per §J3.7 (LRFD):
+//   φFnt' = min(1.3·Fnt − (Fnt/(φ·Fnv))·frv, Fnt) ≥ 0
+//   utilisation = T_i / (φ·Fnt'·Ab/1000) ≤ 1.0
+
+const BOLT_Fnt: Record<BoltGrade, number> = { A325M: 620, A490M: 780 }
+
+export interface OutOfPlaneBolt {
+  id: string
+  yi: number           // mm from lowest bolt (neutral axis)
+  T: number            // kN, bolt tension
+  frt: number          // MPa, tension stress = T·1000/Ab
+  frv: number          // MPa, shear stress from in-plane analysis
+  phiFnt_prime: number // MPa, reduced tensile strength (§J3.7)
+  phiTn: number        // kN, available bolt tension capacity
+  util: number         // T / phiTn
+  ok: boolean
+}
+
+export interface OutOfPlaneResult {
+  M_op: number
+  Fnt: number; Fnv: number; Ab: number
+  sumYi2: number       // mm², Σyi²
+  bolts: OutOfPlaneBolt[]
+  critical: string     // bolt id with maximum tension
+  Tmax: number; phiTn_crit: number
+  ok: boolean
+}
+
+export function outOfPlaneBoltGroup(
+  geom: BoltGroupGeom,
+  inPlaneBolts: BoltForce[],
+  e_out: number,        // mm, perpendicular to bolt group plane
+  Vu: number,           // kN, applied shear
+  boltGrade: BoltGrade,
+  db: number,           // mm
+  threadInPlane: boolean
+): OutOfPlaneResult {
+  const phi = PHI_J
+  const Fnt = BOLT_Fnt[boltGrade]
+  const Fnv = boltGrade === 'A325M'
+    ? (threadInPlane ? 310 : 372)
+    : (threadInPlane ? 372 : 457)
+  const Ab = (Math.PI / 4) * db * db
+  const M_op = Vu * e_out   // kN·mm
+
+  const absYs = geom.bolts.map(b => b.y + geom.Cy)
+  const yMin  = Math.min(...absYs)
+  const yis   = absYs.map(y => y - yMin)
+  const sumYi2 = yis.reduce((s, yi) => s + yi * yi, 0)
+
+  const bolts: OutOfPlaneBolt[] = geom.bolts.map((b, i) => {
+    const yi  = yis[i]
+    const T   = sumYi2 > 0 ? (M_op * yi) / sumYi2 : 0
+    const frv = inPlaneBolts.find(ip => ip.id === b.id)?.fv ?? 0
+    const frt = (T * 1000) / Ab
+    const phiFnt_prime = Math.max(0, Math.min(1.3 * Fnt - (Fnt / (phi * Fnv)) * frv, Fnt))
+    const phiTn = (phi * phiFnt_prime * Ab) / 1000
+    const util = phiTn > 0 ? T / phiTn : (T > 0 ? Infinity : 0)
+    return { id: b.id, yi, T, frt, frv, phiFnt_prime, phiTn, util, ok: util <= 1.0 }
+  })
+
+  const ci = bolts.reduce((mi, _, i) => bolts[i].T > bolts[mi].T ? i : mi, 0)
+  return {
+    M_op, Fnt, Fnv, Ab, sumYi2, bolts,
+    critical: bolts[ci].id, Tmax: bolts[ci].T, phiTn_crit: bolts[ci].phiTn,
+    ok: bolts.every(b => b.ok),
+  }
+}

--- a/webapp/src/pages/SteelDesign.tsx
+++ b/webapp/src/pages/SteelDesign.tsx
@@ -6,6 +6,7 @@ import {
   deriveWSection, beamFlexure, beamShear, columnAxial,
   weakAxisFlexure, combinedLoading, boltShear, weldStrength,
   beamLoadingSimple, boltGroupGeom, eccentricBoltGroup, shearTabBlockShear,
+  outOfPlaneBoltGroup,
 } from '../engine/steelDesign'
 import type { BoltGrade, ElectrodeClass } from '../engine/steelDesign'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
@@ -306,8 +307,9 @@ function ConnectionTab() {
   const [tPlate,     setTPlate]     = useState(10)
   const [FuPlate,    setFuPlate]    = useState(400)
   const [FyPlate,    setFyPlate]    = useState(248)
-  const [ex_load,    setExLoad]     = useState(0)   // eccentricity from bolt centroid
+  const [ex_load,    setExLoad]     = useState(0)   // in-plane eccentricity from bolt centroid
   const [ey_load,    setEyLoad]     = useState(0)
+  const [e_out,      setEOut]       = useState(0)   // out-of-plane eccentricity (perpendicular to plate)
   // weld
   const [electrode,  setElectrode]  = useState<ElectrodeClass>('E70')
   const [wSize,      setWSize]      = useState(8)
@@ -324,6 +326,12 @@ function ConnectionTab() {
   const eccentric = useMemo(() =>
     eccentricBoltGroup(geom, Vu, Hu, ex_load, ey_load, phiRnBolt.phiRn, db, tPlate),
     [geom, Vu, Hu, ex_load, ey_load, phiRnBolt, db, tPlate]
+  )
+  const outOfPlane = useMemo(() =>
+    e_out > 0
+      ? outOfPlaneBoltGroup(geom, eccentric.bolts, e_out, Vu, boltGrade, db, threads === 'yes')
+      : null,
+    [geom, eccentric.bolts, e_out, Vu, boltGrade, db, threads]
   )
   const blockShearCases = useMemo(() =>
     shearTabBlockShear(nRows, sy, ey, ey, ex_edge, db, tPlate, FyPlate, FuPlate),
@@ -377,6 +385,19 @@ function ConnectionTab() {
           ]
         })(),
       },
+      ...(outOfPlane ? [{
+        title: `Out-of-plane eccentricity §J3.7 — e_out = ${e_out} mm`,
+        lines: [
+          { tex: `M_{op} = V_u \\cdot e_{out} = ${Vu} \\times ${e_out} = ${outOfPlane.M_op.toFixed(0)}\\text{ kN·mm}` },
+          { tex: `\\text{Neutral axis at bottom bolt. }\\sum y_i^2 = ${outOfPlane.sumYi2.toFixed(0)}\\text{ mm}^2` },
+          { tex: `T_i = \\frac{M_{op} \\cdot y_i}{\\sum y_i^2}\\quad (y_i \\text{ measured from lowest bolt})` },
+          { tex: `T_{\\max} = ${f2(outOfPlane.Tmax)}\\text{ kN on bolt }\\textit{${outOfPlane.critical}}` },
+          { tex: `\\text{AISC Table J3.2: } F_{nt} = ${outOfPlane.Fnt}\\text{ MPa},\\; F_{nv} = ${outOfPlane.Fnv}\\text{ MPa}` },
+          { tex: `\\phi F_{nt}' = \\min\\!\\left(1.3 F_{nt} - \\frac{F_{nt}}{\\phi F_{nv}} f_{rv},\\; F_{nt}\\right) \\geq 0\\quad \\S J3.7` },
+          { tex: `\\phi T_n = \\phi F_{nt}' A_b / 1000 = ${f2(outOfPlane.phiTn_crit)}\\text{ kN/bolt}` },
+          { tex: `\\text{Utilisation} = T_{\\max} / (\\phi T_n) = ${(outOfPlane.Tmax / outOfPlane.phiTn_crit * 100).toFixed(0)}\\%\\quad ${outOfPlane.ok ? '\\checkmark' : '\\times'}` },
+        ],
+      }] : []),
       {
         title: 'Block shear §J4.3 (shear tab, single bolt line)',
         lines: blockShearCases.flatMap(c => [
@@ -388,7 +409,7 @@ function ConnectionTab() {
         ]),
       },
     ]
-  }, [phiRnBolt, geom, eccentric, blockShearCases, boltGrade, db, nRows, nCols, tPlate, FuPlate, FyPlate, threads, Vu, Hu, ex_load, ey_load])
+  }, [phiRnBolt, geom, eccentric, outOfPlane, blockShearCases, boltGrade, db, nRows, nCols, tPlate, FuPlate, FyPlate, threads, Vu, Hu, ex_load, ey_load, e_out])
 
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.2fr_0.9fr_1fr]">
@@ -418,9 +439,13 @@ function ConnectionTab() {
             <Num label="Edge dist horiz ex" unit="mm" value={ex_edge} onChange={setExEdge} />
           </Card>
           <Card title="Eccentricity (load point from bolt centroid)">
-            <Num label="Horizontal e_x" unit="mm" value={ex_load} onChange={setExLoad} />
-            <Num label="Vertical e_y" unit="mm" value={ey_load} onChange={setEyLoad} />
-            <p className="col-span-full text-[10px] text-slate-400">Positive e_x = load is to the RIGHT of the bolt centroid.</p>
+            <Num label="In-plane e_x" unit="mm" value={ex_load} onChange={setExLoad} />
+            <Num label="In-plane e_y" unit="mm" value={ey_load} onChange={setEyLoad} />
+            <Num label="Out-of-plane e_out" unit="mm" value={e_out} onChange={setEOut} />
+            <p className="col-span-full text-[10px] text-slate-400">
+              e_x/e_y: in-plane offset (→ moment in bolt group plane, §J3.6/elastic method).{' '}
+              e_out: perpendicular distance from plate face to load (→ bolt tension + §J3.7 interaction).
+            </p>
           </Card>
           <Card title="Plate / connected part">
             <Num label="Plate thickness t" unit="mm" value={tPlate} onChange={setTPlate} />
@@ -502,6 +527,42 @@ function ConnectionTab() {
               label="Governing block shear"
               value={ok(Vu <= govBlockShear.phiRn, `${f1(govBlockShear.phiRn)} kN`)} />
           </ResultCard>
+
+          {outOfPlane && (
+            <ResultCard title="Out-of-plane eccentricity §J3.7">
+              <Row label="M_op = Vu·e_out" value={`${outOfPlane.M_op.toFixed(0)} kN·mm`} />
+              <Row label="Σyi²" value={`${outOfPlane.sumYi2.toFixed(0)} mm²`} />
+              <Row label="Critical bolt (max T)" value={outOfPlane.critical}
+                sub={`T = ${f2(outOfPlane.Tmax)} kN`} />
+              <Row label="φTn (reduced)" value={`${f2(outOfPlane.phiTn_crit)} kN`}
+                sub={`φFnt' = ${outOfPlane.bolts.find(b=>b.id===outOfPlane.critical)?.phiFnt_prime.toFixed(0)} MPa`} />
+              <Row alert={!outOfPlane.ok}
+                label="Combined check (§J3.7)"
+                value={ok(outOfPlane.ok, outOfPlane.ok ? 'PASS' : 'FAIL')} />
+              <div className="col-span-full overflow-x-auto">
+                <table className="mt-1 w-full text-xs">
+                  <thead><tr className="text-left text-slate-400">
+                    <th className="pr-2 pb-1">id</th>
+                    <th className="pr-2 pb-1">yi mm</th>
+                    <th className="pr-2 pb-1">T kN</th>
+                    <th className="pr-2 pb-1">frv MPa</th>
+                    <th className="pb-1">util</th>
+                  </tr></thead>
+                  <tbody>
+                    {outOfPlane.bolts.map(b => (
+                      <tr key={b.id} className={b.id === outOfPlane.critical ? 'font-semibold text-amber-700' : ''}>
+                        <td className="pr-2">{b.id}</td>
+                        <td className="pr-2">{b.yi.toFixed(0)}</td>
+                        <td className="pr-2">{f2(b.T)}</td>
+                        <td className="pr-2">{f1(b.frv)}</td>
+                        <td className={b.util > 1 ? 'text-red-600' : ''}>{(b.util*100).toFixed(0)}%</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </ResultCard>
+          )}
         </>) : (
           <ResultCard title="Fillet weld §J2.4">
             <Row label="φRnw / mm" value={`${f3(weld.phiRnw)} kN/mm`} />


### PR DESCRIPTION
Implements the out-of-plane eccentricity analysis that was explicitly requested but deferred from PR #185.

## What's added

### Engine (`steelDesign.ts`) — `outOfPlaneBoltGroup()`
- **Moment**: M_op = Vu × e_out (kN·mm), where e_out is the perpendicular distance from the bolt group plane to the load application point (e.g. a bracket plate projecting from a column face)
- **Neutral axis** at the bottom bolt row — plate bears against the column in compression, bolts above carry tension
- **Bolt tension**: T_i = M_op × yi / Σyi² (yi measured upward from lowest bolt)
- **§J3.7 combined shear + tension**: φFnt' = min(1.3·Fnt − (Fnt/(φ·Fnv))·frv, Fnt) ≥ 0; utilisation = T_i / (φ·Fnt'·Ab/1000)
- Per-bolt output: yi, T, frt, frv, φFnt', φTn, util, ok
- AISC Table J3.2 tensile strengths: A325M Fnt = 620 MPa, A490M Fnt = 780 MPa

### Tests (`steelDesign.test.ts`)
4 new unit tests:
1. Zero e_out → all T = 0
2. Top bolt gets maximum tension (largest yi)
3. T_i = M_op·yi/Σyi² formula check
4. §J3.7 reduced φFnt' decreases with increasing shear stress

**Suite: 302 tests passing.**

### UI (`SteelDesign.tsx` — ConnectionTab)
- New **e_out** input in the Eccentricity card alongside in-plane e_x/e_y, with a tooltip explaining the distinction
- **Out-of-plane results card** (conditional, appears when e_out > 0): M_op, Σyi², critical bolt + max T, φTn (reduced), combined check pass/fail, per-bolt table (yi / T / frv / util %)
- **WorkedSolution step** injected between the in-plane and block shear steps when e_out > 0 — shows the full §J3.7 derivation in KaTeX

## Notes
- Prying action per §J3.9 (additional tension from bending of the fitting) requires fitting geometry (flange/gusset thickness, gage, tributary length) and is a further refinement beyond this scope. The current check conservatively ignores prying — add prying when the connected plate is thin relative to the bolt spacing.
- In-plane + out-of-plane act simultaneously; the engine reads in-plane shear stress frv directly from the `eccentricBoltGroup` output so both eccentricities are combined correctly in the §J3.7 interaction.

## Verification
- `npm test` → **302 passing**
- `npx tsc -b` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_