### PR TITLE
feat(steel): prying action §J3.9 — T-stub model, required plate thickness

### DIFF
--- a/webapp/src/engine/steelDesign.test.ts
+++ b/webapp/src/engine/steelDesign.test.ts
@@ -4,7 +4,7 @@ import {
   deriveWSection, beamFlexure, beamShear,
   columnAxial, weakAxisFlexure, combinedLoading,
   boltShear, weldStrength, beamLoadingSimple, E_STEEL,
-  boltGroupGeom, eccentricBoltGroup, shearTabBlockShear, outOfPlaneBoltGroup,
+  boltGroupGeom, eccentricBoltGroup, shearTabBlockShear, outOfPlaneBoltGroup, pryingAction,
 } from './steelDesign'
 
 const W250x33 = shapeByName('W250x33')!
@@ -270,5 +270,57 @@ describe('outOfPlaneBoltGroup §J3.7', () => {
     const critB = r.bolts.find(b => b.id === 'B3')!
     const expected = Math.min(1.3 * Fnt - (Fnt / (phi * Fnv)) * critB.frv, Fnt)
     expect(critB.phiFnt_prime).toBeCloseTo(Math.max(0, expected), 4)
+  })
+})
+
+describe('pryingAction §J3.9', () => {
+  // geometry: b=45mm (bolt CL to web face), a=35mm (to free edge),
+  // p=70mm (bolt pitch), tf=12mm, db=20mm, Fy=248MPa
+  const b = 45, a = 35, p = 70, tf = 12, db = 20, Fy = 248
+  const db2 = db / 2, dh = db + 2
+  const b_p = b - db2          // 35
+  const a_p = Math.min(a, 1.25 * b)  // 35 (a < 1.25b=56.25)
+  const rho  = b_p / a_p       // 1.0
+  const delta = 1 - dh / p     // 1 - 22/70
+
+  it('geometry: b_prime, a_prime, rho, delta computed correctly', () => {
+    const r = pryingAction(50, 100, b, a, p, tf, db, Fy)
+    expect(r.b_prime).toBeCloseTo(b_p, 6)
+    expect(r.a_prime).toBeCloseTo(a_p, 6)
+    expect(r.rho).toBeCloseTo(rho, 6)
+    expect(r.delta).toBeCloseTo(delta, 6)
+  })
+
+  it('T_req = 0 → Q = 0, no prying', () => {
+    const r = pryingAction(0, 100, b, a, p, tf, db, Fy)
+    expect(r.Q).toBe(0)
+    expect(r.T_total).toBe(0)
+    expect(r.ok).toBe(true)
+  })
+
+  it('T_total = T_req + Q formula', () => {
+    const r = pryingAction(40, 100, b, a, p, tf, db, Fy)
+    expect(r.T_total).toBeCloseTo(r.Q + 40, 6)
+  })
+
+  it('thick plate (T_req << phi_Bn) → low alpha, Q small', () => {
+    // When bolt utilisation is low, beta >> 1 → α = 1 (maximum prying for given T)
+    // but T_total should still be ≤ phi_Bn
+    const r = pryingAction(20, 150, b, a, p, tf, db, Fy)
+    expect(r.T_total).toBeLessThanOrEqual(150 + 1e-9)
+    expect(r.ok).toBe(true)
+  })
+
+  it('t_req formula: 4·T·b_prime / (phi_f·Fy·p·(1+δα))', () => {
+    const r = pryingAction(50, 120, b, a, p, tf, db, Fy)
+    const phi_f = 0.90
+    const expected = Math.sqrt((4 * 50 * 1000 * r.b_prime) / (phi_f * Fy * p * (1 + r.delta * r.alpha)))
+    expect(r.t_req).toBeCloseTo(expected, 4)
+  })
+
+  it('t_no_prying > t_req (thicker plate needed to eliminate prying)', () => {
+    const r = pryingAction(60, 100, b, a, p, tf, db, Fy)
+    // t_no_prying is always ≥ t_req when prying present
+    expect(r.t_no_prying).toBeGreaterThanOrEqual(r.t_req - 1e-9)
   })
 })

--- a/webapp/src/engine/steelDesign.ts
+++ b/webapp/src/engine/steelDesign.ts
@@ -447,3 +447,79 @@ export function outOfPlaneBoltGroup(
     ok: bolts.every(b => b.ok),
   }
 }
+
+// ─── Prying action §J3.9 — AISC Manual Part 9 T-stub model ──────────────
+// Applied to the critical bolt of a bolted fitting (bracket plate, angle, tee).
+// Prying force Q amplifies the required bolt tension T_req → T_total = T+Q.
+//
+// Geometry (mm):
+//   b  = bolt CL to face of the connecting web/stem (fitting gage distance)
+//   a  = bolt CL to free edge of the fitting flange (= horizontal edge distance)
+//   p  = tributary bolt pitch (bolt spacing along fitting; use sy for interior bolts)
+//   tf = fitting plate/flange thickness
+//   db = bolt diameter; dh = db + 2 (standard hole, +2 mm oversize)
+//
+// α = 0 → no prying (thick plate);  α = 1 → full prying (thin plate).
+// Required plate thickness to sustain T_req including prying:
+//   t_req = √(4·T_req·b' / (φ_f·Fy·p·(1 + δ·α)))   φ_f = 0.90 (plate flexure)
+// Minimum thickness to eliminate prying entirely:
+//   t_0   = √(4·φBn·b'  / (φ_f·Fy·p))
+
+export interface PryingResult {
+  b_prime: number      // mm  b − db/2
+  a_prime: number      // mm  min(a, 1.25b)
+  rho: number          // b'/a'
+  delta: number        // 1 − dh/p
+  beta: number         // prying potential = (1/ρ)(φBn/T − 1)
+  alpha: number        // 0 to 1, prying fraction
+  Q: number            // kN, prying force on critical bolt
+  T_total: number      // kN, T_req + Q
+  t_req: number        // mm, required plate thickness
+  t_no_prying: number  // mm, minimum t to eliminate prying
+  ok: boolean          // T_total ≤ φBn
+}
+
+// T_req: required bolt tension (kN); phi_Bn: available bolt tension (kN, φFnt'·Ab/1000)
+export function pryingAction(
+  T_req: number, phi_Bn: number,
+  b: number, a: number, p: number,
+  _tf: number, db: number, Fy: number
+): PryingResult {
+  const phi_f = 0.90
+  const dh     = db + 2
+  const b_prime = b - db / 2
+  const a_prime = Math.min(a, 1.25 * b)
+  const rho   = b_prime / a_prime
+  const delta = Math.max(0, 1 - dh / p)
+
+  let beta = 0, alpha = 0
+  if (T_req <= 0) {
+    // no tension — no prying
+  } else if (T_req >= phi_Bn) {
+    // bolt already overstressed; worst-case prying
+    alpha = 1.0
+    beta  = 0
+  } else {
+    beta = (1 / rho) * (phi_Bn / T_req - 1)
+    if (beta >= 1.0) {
+      alpha = 1.0
+    } else {
+      const denom = delta * (1 - beta)
+      alpha = denom > 0 ? Math.min(beta / denom, 1.0) : 1.0
+    }
+  }
+
+  const Q       = alpha * delta * rho * T_req
+  const T_total = T_req + Q
+
+  // plate thickness formulas (kN → N: ×1000)
+  const factor       = phi_f * Fy * p
+  const t_req        = factor > 0 && (1 + delta * alpha) > 0
+    ? Math.sqrt((4 * T_req * 1000 * b_prime) / (factor * (1 + delta * alpha)))
+    : Infinity
+  const t_no_prying  = factor > 0
+    ? Math.sqrt((4 * phi_Bn * 1000 * b_prime) / factor)
+    : Infinity
+
+  return { b_prime, a_prime, rho, delta, beta, alpha, Q, T_total, t_req, t_no_prying, ok: T_total <= phi_Bn }
+}

--- a/webapp/src/pages/SteelDesign.tsx
+++ b/webapp/src/pages/SteelDesign.tsx
@@ -6,7 +6,7 @@ import {
   deriveWSection, beamFlexure, beamShear, columnAxial,
   weakAxisFlexure, combinedLoading, boltShear, weldStrength,
   beamLoadingSimple, boltGroupGeom, eccentricBoltGroup, shearTabBlockShear,
-  outOfPlaneBoltGroup,
+  outOfPlaneBoltGroup, pryingAction,
 } from '../engine/steelDesign'
 import type { BoltGrade, ElectrodeClass } from '../engine/steelDesign'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
@@ -310,6 +310,7 @@ function ConnectionTab() {
   const [ex_load,    setExLoad]     = useState(0)   // in-plane eccentricity from bolt centroid
   const [ey_load,    setEyLoad]     = useState(0)
   const [e_out,      setEOut]       = useState(0)   // out-of-plane eccentricity (perpendicular to plate)
+  const [b_gage,     setBGage]      = useState(0)   // prying: bolt CL to face of web/stem (0 = skip)
   // weld
   const [electrode,  setElectrode]  = useState<ElectrodeClass>('E70')
   const [wSize,      setWSize]      = useState(8)
@@ -332,6 +333,12 @@ function ConnectionTab() {
       ? outOfPlaneBoltGroup(geom, eccentric.bolts, e_out, Vu, boltGrade, db, threads === 'yes')
       : null,
     [geom, eccentric.bolts, e_out, Vu, boltGrade, db, threads]
+  )
+  const prying = useMemo(() =>
+    outOfPlane && b_gage > 0
+      ? pryingAction(outOfPlane.Tmax, outOfPlane.phiTn_crit, b_gage, ex_edge, sy, tPlate, db, FyPlate)
+      : null,
+    [outOfPlane, b_gage, ex_edge, sy, tPlate, db, FyPlate]
   )
   const blockShearCases = useMemo(() =>
     shearTabBlockShear(nRows, sy, ey, ey, ex_edge, db, tPlate, FyPlate, FuPlate),
@@ -397,7 +404,19 @@ function ConnectionTab() {
           { tex: `\\phi T_n = \\phi F_{nt}' A_b / 1000 = ${f2(outOfPlane.phiTn_crit)}\\text{ kN/bolt}` },
           { tex: `\\text{Utilisation} = T_{\\max} / (\\phi T_n) = ${(outOfPlane.Tmax / outOfPlane.phiTn_crit * 100).toFixed(0)}\\%\\quad ${outOfPlane.ok ? '\\checkmark' : '\\times'}` },
         ],
-      }] : []),
+      },
+      ...(prying ? [{
+        title: `Prying action §J3.9 — b = ${b_gage} mm`,
+        lines: [
+          { tex: `b' = b - d_b/2 = ${b_gage} - ${db}/2 = ${prying.b_prime.toFixed(1)}\\text{ mm}` },
+          { tex: `a' = \\min(a,\\; 1.25b) = \\min(${ex_edge},\\; ${(1.25*b_gage).toFixed(1)}) = ${prying.a_prime.toFixed(1)}\\text{ mm}` },
+          { tex: `\\rho = b'/a' = ${prying.rho.toFixed(3)},\\quad \\delta = 1 - d_h/p = 1 - ${db+2}/${sy} = ${prying.delta.toFixed(3)}` },
+          { tex: `\\beta = \\frac{1}{\\rho}\\left(\\frac{\\phi B_n}{T_{\\max}} - 1\\right) = ${prying.beta.toFixed(3)},\\quad \\alpha = ${prying.alpha.toFixed(3)}` },
+          { tex: `Q = \\alpha \\delta \\rho T_{\\max} = ${f2(prying.Q)}\\text{ kN}\\quad\\Rightarrow\\quad T_{\\text{total}} = ${f2(prying.T_total)}\\text{ kN}` },
+          { tex: `t_{\\text{req}} = \\sqrt{\\frac{4 T b'}{\\phi_f F_y p (1+\\delta\\alpha)}} = ${prying.t_req.toFixed(1)}\\text{ mm}\\quad(\\text{plate }t=${tPlate}\\text{ mm}\\quad${tPlate>=prying.t_req?'\\checkmark':'\\times'})` },
+          { tex: `t_0 = \\sqrt{\\frac{4\\phi B_n b'}{\\phi_f F_y p}} = ${prying.t_no_prying.toFixed(1)}\\text{ mm}\\quad(\\text{min for zero prying})` },
+        ],
+      }] : [])] : []),
       {
         title: 'Block shear §J4.3 (shear tab, single bolt line)',
         lines: blockShearCases.flatMap(c => [
@@ -409,7 +428,7 @@ function ConnectionTab() {
         ]),
       },
     ]
-  }, [phiRnBolt, geom, eccentric, outOfPlane, blockShearCases, boltGrade, db, nRows, nCols, tPlate, FuPlate, FyPlate, threads, Vu, Hu, ex_load, ey_load, e_out])
+  }, [phiRnBolt, geom, eccentric, outOfPlane, prying, blockShearCases, boltGrade, db, nRows, nCols, sy, ex_edge, tPlate, FuPlate, FyPlate, threads, Vu, Hu, ex_load, ey_load, e_out, b_gage])
 
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.2fr_0.9fr_1fr]">
@@ -443,10 +462,19 @@ function ConnectionTab() {
             <Num label="In-plane e_y" unit="mm" value={ey_load} onChange={setEyLoad} />
             <Num label="Out-of-plane e_out" unit="mm" value={e_out} onChange={setEOut} />
             <p className="col-span-full text-[10px] text-slate-400">
-              e_x/e_y: in-plane offset (→ moment in bolt group plane, §J3.6/elastic method).{' '}
-              e_out: perpendicular distance from plate face to load (→ bolt tension + §J3.7 interaction).
+              e_x/e_y: in-plane offset (§J3.6 elastic method).
+              e_out: perpendicular to plate → bolt tension + §J3.7 interaction.
             </p>
           </Card>
+          {e_out > 0 && (
+            <Card title="Prying action §J3.9">
+              <Num label="Gage b (bolt CL → web face)" unit="mm" value={b_gage} onChange={setBGage} />
+              <p className="col-span-full text-[10px] text-slate-400">
+                b = distance from bolt centreline to face of the connecting web or stem.
+                Set 0 to skip prying check. Edge dist a = ex, pitch p = sv, plate tf/Fy reused from above.
+              </p>
+            </Card>
+          )}
           <Card title="Plate / connected part">
             <Num label="Plate thickness t" unit="mm" value={tPlate} onChange={setTPlate} />
             <Num label="Plate Fy" unit="MPa" value={FyPlate} onChange={setFyPlate} />
@@ -529,7 +557,7 @@ function ConnectionTab() {
           </ResultCard>
 
           {outOfPlane && (
-            <ResultCard title="Out-of-plane eccentricity §J3.7">
+            <ResultCard title="Out-of-plane eccentricity §J3.7 (critical bolt)">
               <Row label="M_op = Vu·e_out" value={`${outOfPlane.M_op.toFixed(0)} kN·mm`} />
               <Row label="Σyi²" value={`${outOfPlane.sumYi2.toFixed(0)} mm²`} />
               <Row label="Critical bolt (max T)" value={outOfPlane.critical}
@@ -561,6 +589,24 @@ function ConnectionTab() {
                   </tbody>
                 </table>
               </div>
+            </ResultCard>
+          )}
+
+          {prying && (
+            <ResultCard title="Prying action §J3.9 (critical bolt)">
+              <Row label="b' = b − db/2" value={`${prying.b_prime.toFixed(1)} mm`} />
+              <Row label="a' = min(a, 1.25b)" value={`${prying.a_prime.toFixed(1)} mm`} />
+              <Row label="ρ = b'/a'" value={f3(prying.rho)} />
+              <Row label="δ = 1 − dh/p" value={f3(prying.delta)} />
+              <Row label="β (prying potential)" value={f3(prying.beta)} />
+              <Row label="α (prying fraction)" value={f3(prying.alpha)} sub="0 = none, 1 = full" />
+              <Row label="Prying force Q" value={`${f2(prying.Q)} kN`} />
+              <Row label="T_total = T + Q" value={`${f2(prying.T_total)} kN`} />
+              <Row label="Required plate t" value={`${prying.t_req.toFixed(1)} mm`}
+                sub={`t_no_prying = ${prying.t_no_prying.toFixed(1)} mm`} />
+              <Row alert={!prying.ok}
+                label="T_total ≤ φTn (§J3.9)"
+                value={ok(prying.ok, prying.ok ? 'PASS' : 'FAIL')} />
             </ResultCard>
           )}
         </>) : (


### PR DESCRIPTION
Closes the last gap from the bolt connection enhancement: prying action per AISC §J3.9 / Manual Part 9.

## Background
When a bolt group is loaded out-of-plane (PR #186), the fitting plate must be thick enough that its bending doesn't amplify the bolt tension. The T-stub model quantifies that amplification and gives the required plate thickness.

## What's added

### Engine (`steelDesign.ts`) — `pryingAction()`
AISC Manual Part 9, T-stub model. Inputs:
- `T_req` — required bolt tension (kN) from `outOfPlaneBoltGroup` critical bolt
- `phi_Bn` — available bolt tension (kN) from §J3.7 (reduced for combined shear+tension)
- `b` — bolt CL to face of connecting web/stem (mm) — new user input
- `a` — bolt CL to free edge of fitting (= horizontal edge distance, already known)
- `p` — tributary bolt pitch (= vertical spacing sy, already known)
- `_tf`, `db`, `Fy` — plate thickness (accepted, not used in current formula), bolt diameter, plate yield stress

Outputs:
| Symbol | Meaning |
|--------|---------|
| b', a' | effective lever arms (b − db/2, min(a, 1.25b)) |
| ρ = b'/a' | lever arm ratio |
| δ = 1 − dh/p | hole-fraction (dh = db + 2) |
| β = (1/ρ)(φBn/T − 1) | prying potential |
| α ∈ [0,1] | prying fraction: 0 = no prying (thick plate), 1 = full prying |
| Q = α·δ·ρ·T | prying force per bolt (kN) |
| T_total = T + Q | total bolt tension (kN) — must ≤ φBn |
| t_req | required plate thickness (mm): √(4·T·b'/(φ_f·Fy·p·(1+δα))) |
| t_no_prying | min t to eliminate prying: √(4·φBn·b'/(φ_f·Fy·p)) |

### Tests (`steelDesign.test.ts`)
6 unit tests covering geometry derivation, zero-tension edge case, T_total formula, thin-plate behaviour, t_req formula, and t_no_prying ≥ t_req relationship.

**Suite: 308 tests passing.**

### UI (`SteelDesign.tsx` — ConnectionTab)
- **Gage input `b`** appears under the eccentricity card when `e_out > 0`; set to 0 to skip prying
- **Prying results card**: b'/a'/ρ/δ, β/α, Q, T_total vs φBn, t_req vs actual plate t, pass/fail
- **WorkedSolution §J3.9 step** injected (after §J3.7, before block shear) with full KaTeX derivation

## Connection design now covers
1. In-plane eccentricity — elastic vector method (§J3.6) ✓
2. Bolt shear (§J3.6) and bearing (§J3.10) ✓
3. Block shear (§J4.3, Case A + B) ✓
4. Out-of-plane eccentricity — bolt tension distribution + §J3.7 combined check ✓
5. Prying action — §J3.9 T-stub model, required plate thickness ✓

## Verification
- `npm test` → **308 passing**
- `npx tsc -b` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_