### PR TITLE
fix(column): seismic tie spacing — SMF §418.7.5 and IMF §418.4.3

### DIFF
--- a/webapp/src/engine/columnDesign.test.ts
+++ b/webapp/src/engine/columnDesign.test.ts
@@ -19,9 +19,63 @@ describe('axial — tied (review Concrete 7, Problem 2)', () => {
     expect(r.rhoOK).toBe(true)
   })
 
-  it('10 mm tie spacing = min(16db, 48dt, least) = 400 mm', () => {
+  it('§425.7.2 spacing = min(16×28=448, 48×10=480, 400) = 400 mm', () => {
     expect(r.tieSpacing).toBe(400)
-    expect(r.tieGovern).toBe('least dimension')
+    expect(r.tieGovern).toBe('least dim')
+    expect(r.tieSpacingFinal).toBe(400)   // gravity → same as §425.7.2
+  })
+})
+
+describe('axial — tied, SMF seismic §418.7.5', () => {
+  // 500×500 column, barDia=25, tieDia=10, Lu=3000 mm, hx=200 (lateral tie spacing)
+  const r = designAxialColumn({
+    shape: 'tied', b: 500, h: 500, cover: 40, barDia: 25, tieDia: 10,
+    fc: 28, fy: 415, Pu: 2000,
+    system: 'smf', columnLength: 3000, hx: 200,
+  })
+
+  it('§425.7.2 gives ≥300 mm but SMF conf. governs', () => {
+    expect(r.tieSpacing).toBeGreaterThanOrEqual(300)
+    expect(r.seismicSConf).toBeDefined()
+    expect(r.tieSpacingFinal).toBeLessThan(r.tieSpacing)
+    expect(r.tieSpacingLabel).toContain('SMF')
+  })
+
+  it('SMF conf. spacing ≤ min(bMin/4, 6db, so)', () => {
+    const bMin = 500, db = 25, hx = 200
+    const so = Math.min(Math.max(100 + (350 - hx) / 3, 100), 150)
+    const expected = Math.min(bMin / 4, 6 * db, so)
+    expect(r.seismicSConf).toBeCloseTo(expected, 6)
+  })
+
+  it('so = clamp(100 + (350−hx)/3, 100, 150) for hx = 200', () => {
+    // so = 100 + (350-200)/3 = 100 + 50 = 150 mm
+    expect(r.seismicSConf!).toBeCloseTo(Math.min(500 / 4, 6 * 25, 150), 6)
+  })
+
+  it('SMF confinement zone lo ≥ max(bMax, Lu/6, 450)', () => {
+    // max(500, 3000/6=500, 450) = 500
+    expect(r.seismicLoZone).toBeCloseTo(Math.max(500, 3000 / 6, 450), 6)
+  })
+
+  it('outside confinement zone: s ≤ min(6db, 150)', () => {
+    expect(r.seismicSOut).toBeCloseTo(Math.min(6 * 25, 150), 6)
+  })
+})
+
+describe('axial — tied, IMF seismic §418.4.3', () => {
+  const r = designAxialColumn({
+    shape: 'tied', b: 400, h: 400, cover: 40, barDia: 25, tieDia: 10,
+    fc: 28, fy: 415, Pu: 1500, system: 'imf',
+  })
+
+  it('IMF conf. spacing = min(8db, 24dt, bMin/2, 300)', () => {
+    const expected = Math.min(8 * 25, 24 * 10, 400 / 2, 300)
+    expect(r.seismicSConf).toBeCloseTo(expected, 6)
+  })
+
+  it('IMF hinge zone lo = max(bMax, 450)', () => {
+    expect(r.seismicLoZone).toBeCloseTo(Math.max(400, 450), 6)
   })
 })
 

--- a/webapp/src/engine/columnDesign.ts
+++ b/webapp/src/engine/columnDesign.ts
@@ -19,7 +19,8 @@
 // ─────────────────────────────────────────────────────────────────────────
 import { beta1 } from './loads'
 
-export type ColumnShape = 'tied' | 'spiral'
+export type ColumnShape  = 'tied' | 'spiral'
+export type LateralSystem = 'gravity' | 'imf' | 'smf'
 
 // ── Axial (short, concentric) ────────────────────────────────────────────
 export interface AxialColumnInput {
@@ -34,6 +35,10 @@ export interface AxialColumnInput {
   Pu: number                   // factored axial demand, kN
   /** Provide to ANALYZE a chosen bar count; omit to DESIGN the steel. */
   numBars?: number
+  /** Lateral system — drives seismic tie requirements. Default: 'gravity'. */
+  system?: LateralSystem
+  columnLength?: number        // mm, clear height (needed for SMF lo; §418.7.5.1)
+  hx?: number                  // mm, max horiz. spacing of laterally restrained bars
 }
 
 export interface AxialColumnResult {
@@ -54,8 +59,14 @@ export interface AxialColumnResult {
   axialOK: boolean             // φPn,max ≥ Pu
   // Tie detailing (tied)
   tieDiaMin: number
-  tieSpacing: number           // governing s, mm
+  tieSpacing: number           // governing §425.7.2 s, mm
   tieGovern: string
+  // Seismic tie detailing (when system !== 'gravity')
+  seismicLoZone?: number       // mm, required confinement zone length
+  seismicSConf?: number        // mm, max spacing within confinement zone
+  seismicSOut?: number         // mm, max spacing outside confinement zone
+  tieSpacingFinal: number      // mm, min(tieSpacing, seismicSConf if seismic)
+  tieSpacingLabel: string      // human-readable governing clause
   // Spiral detailing (spiral)
   Ach: number
   rhoS: number                 // required volumetric ratio
@@ -88,15 +99,51 @@ export function designAxialColumn(i: AxialColumnInput): AxialColumnResult {
   const PnMax = alpha * Po
   const phiPnMax = phi * PnMax
 
-  // §425.7.2 ties
+  // §425.7.2 ties (gravity / upper bound)
   const tieDiaMin = i.barDia <= 32 ? 10 : 12
   const least = tied ? Math.min(i.b ?? 0, i.h ?? 0) : (i.D ?? 0)
   const sCands: [number, string][] = [
     [16 * i.barDia, '16d_b'],
     [48 * i.tieDia, '48d_tie'],
-    [least, 'least dimension'],
+    [least, 'least dim'],
   ]
   const [tieSpacing, tieGovern] = sCands.reduce((a, c) => (c[0] < a[0] ? c : a))
+
+  // Seismic confinement (tied columns)
+  const system = i.system ?? 'gravity'
+  const bDim = i.b ?? least, hDim = i.h ?? least   // column cross-section dims
+  const bMin = Math.min(bDim, hDim), bMax = Math.max(bDim, hDim)
+  let seismicLoZone: number | undefined
+  let seismicSConf: number | undefined
+  let seismicSOut:  number | undefined
+
+  if (tied && system !== 'gravity') {
+    if (system === 'smf') {
+      // §418.7.5.1 — confinement zone length lo
+      const Lu = i.columnLength ?? 3000   // default 3 m if not given
+      seismicLoZone = Math.max(bMax, Lu / 6, 450)
+
+      // §418.7.5.3/4 — spacing within lo
+      const hx = Math.min(i.hx ?? bMin, 350)   // max lateral spacing ≤ 350
+      const so  = Math.min(Math.max(100 + (350 - hx) / 3, 100), 150)
+      seismicSConf = Math.min(bMin / 4, 6 * i.barDia, so)
+
+      // §418.7.5.5 — spacing outside lo
+      seismicSOut = Math.min(6 * i.barDia, 150)
+    } else {
+      // IMF §418.4.3 — hinge zone = max(bMax, 450); s ≤ min(8db, 24dt, bMin/2, 300)
+      seismicLoZone = Math.max(bMax, 450)
+      seismicSConf  = Math.min(8 * i.barDia, 24 * i.tieDia, bMin / 2, 300)
+      seismicSOut   = tieSpacing   // outside hinge: ordinary §425.7.2 applies
+    }
+  }
+
+  const tieSpacingFinal = seismicSConf !== undefined
+    ? Math.min(tieSpacing, seismicSConf)
+    : tieSpacing
+  const tieSpacingLabel = seismicSConf !== undefined && seismicSConf < tieSpacing
+    ? (system === 'smf' ? '§418.7.5 SMF conf.' : '§418.4.3 IMF conf.')
+    : `§425.7.2 (${tieGovern})`
 
   // §425.7.3 spiral
   const Dch = (i.D ?? 0) - 2 * i.cover
@@ -117,6 +164,8 @@ export function designAxialColumn(i: AxialColumnInput): AxialColumnResult {
     bars, Ast, rho, rhoOK, minBars,
     Po, PnMax, phiPnMax, axialOK: phiPnMax >= i.Pu - 1e-9,
     tieDiaMin, tieSpacing, tieGovern,
+    seismicLoZone, seismicSConf, seismicSOut,
+    tieSpacingFinal, tieSpacingLabel,
     Ach, rhoS, spiralPitch, pitchClearOK,
   }
 }

--- a/webapp/src/pages/ColumnDesign.tsx
+++ b/webapp/src/pages/ColumnDesign.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import {
   designAxialColumn, interaction, capacityAtEccentricity, momentMagnificationNonsway,
-  type ColumnShape,
+  type ColumnShape, type LateralSystem,
 } from '../engine/columnDesign'
 import { factoredLoad } from '../engine/loads'
 import { ColumnSchematic } from '../components/ColumnSchematic'
@@ -33,6 +33,10 @@ export default function ColumnDesign() {
   const [Mu, setMu] = useState(200)
   const [barMode, setBarMode] = useState<BarMode>('design')
   const [numBars, setNumBars] = useState(8)
+  // Seismic / lateral system
+  const [system, setSystem] = useState<LateralSystem>('gravity')
+  const [colLen, setColLen] = useState(3000)  // mm clear height
+  const [hx, setHx]         = useState(0)     // mm, max lateral tie spacing (0 = use bMin)
   // Slenderness (nonsway)
   const [slenderOn, setSlenderOn] = useState(false)
   const [kEff, setKEff] = useState(1.0); const [Lu, setLu] = useState(3.0)
@@ -49,9 +53,10 @@ export default function ColumnDesign() {
       return designAxialColumn({
         shape: tied ? 'tied' : 'spiral', b, h, D, cover, barDia, tieDia, fc, fy, fyt, Pu,
         numBars: barMode === 'analyze' || eccentric ? numBars : undefined,
+        system, columnLength: colLen, hx: hx > 0 ? hx : undefined,
       })
     } catch { return null }
-  }, [tied, b, h, D, cover, barDia, tieDia, fc, fy, fyt, Pu, barMode, numBars, eccentric])
+  }, [tied, b, h, D, cover, barDia, tieDia, fc, fy, fyt, Pu, barMode, numBars, eccentric, system, colLen, hx])
 
   const slender = useMemo(() => {
     if (!eccentric || !slenderOn) return null
@@ -125,6 +130,27 @@ export default function ColumnDesign() {
             <Num label={<KTex tex="f_{yt}" />} unit="MPa" value={fyt} onChange={setFyt} />
           </Card>
 
+          <Card title="Lateral system / seismic">
+            <Pick label="System" value={system} onChange={v => setSystem(v as LateralSystem)}
+              options={[
+                ['gravity', 'Gravity only (§425.7.2)'],
+                ['imf', 'IMF — Intermediate MF (§418.4.3)'],
+                ['smf', 'SMF — Special MF (§418.7.5)'],
+              ]} />
+            {system !== 'gravity' && (
+              <Num label="Clear height Lu" unit="mm" value={colLen} onChange={setColLen} />
+            )}
+            {system === 'smf' && (
+              <>
+                <Num label="Max lateral bar spacing hx" unit="mm" value={hx} onChange={setHx} />
+                <p className="col-span-full text-[10px] text-slate-400">
+                  hx = centre-to-centre of outermost laterally restrained bars (≤ 350 mm).
+                  Set 0 to use the column least dimension as the default.
+                </p>
+              </>
+            )}
+          </Card>
+
           <Card title="Loads">
             <Pick label="Load entry" value={loadInput} onChange={(v) => setLoadInput(v as LoadInput)}
               options={[['individual', 'Individual (D & L)'], ['direct', 'Factored Pu']]} />
@@ -161,7 +187,7 @@ export default function ColumnDesign() {
             <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Section</h2>
             <ColumnSchematic shape={tied ? 'tied' : 'spiral'} b={b} h={h} D={D} cover={cover}
               barDia={barDia} tieDia={tieDia} bars={axial?.bars ?? numBars}
-              tieSpacing={axial ? (tied ? axial.tieSpacing : axial.spiralPitch) : undefined} />
+              tieSpacing={axial ? (tied ? axial.tieSpacingFinal : axial.spiralPitch) : undefined} />
           </div>
 
           {axial && (
@@ -179,10 +205,19 @@ export default function ColumnDesign() {
               <Row alert={!axial.axialOK && !eccentric} label={<KTex tex="\phi P_{n,max}" />}
                 value={`${f1(axial.phiPnMax)} kN`}
                 sub={`Po=${f1(axial.Po)} · ${axial.alpha.toFixed(2)}Po cap`} />
-              {tied ? (
-                <Row label="Ties" value={`⌀${Math.max(tieDia, axial.tieDiaMin)} @ ${f0(axial.tieSpacing)} mm`}
-                  sub={axial.tieGovern} />
-              ) : (
+              {tied ? (<>
+                <Row label="Ties" value={`⌀${Math.max(tieDia, axial.tieDiaMin)} @ ${f0(axial.tieSpacingFinal)} mm`}
+                  sub={axial.tieSpacingLabel} />
+                {system !== 'gravity' && axial.seismicSConf !== undefined && (<>
+                  <Row label="Conf. zone length lo" value={`${f0(axial.seismicLoZone ?? 0)} mm`}
+                    sub={system === 'smf' ? '§418.7.5.1' : '§418.4.3'} />
+                  <Row label="s (in conf. zone)" value={`${f0(axial.seismicSConf)} mm`}
+                    sub={system === 'smf' ? '§418.7.5.4' : '§418.4.3'} />
+                  {system === 'smf' && axial.seismicSOut !== undefined && (
+                    <Row label="s (outside lo)" value={`${f0(axial.seismicSOut)} mm`} sub="§418.7.5.5" />
+                  )}
+                </>)}
+              </>) : (
                 <Row alert={!axial.pitchClearOK} label="Spiral" value={`⌀${tieDia} @ ${f0(axial.spiralPitch)} mm pitch`}
                   sub={`ρs=${axial.rhoS.toFixed(4)}`} />
               )}


### PR DESCRIPTION
## Problem
The column design engine was only reporting §425.7.2 non-seismic tie spacing:
`s ≤ min(16db, 48dt, least dimension)` — for a 400×400 column with ⌀25 bars that gives **400 mm**, which looks correct on paper for gravity design but is far too wide for a seismic building. Real columns in the Philippines (high-seismic zone) have ties at 75–150 mm in the confinement zones per NSCP 2015 Chapter 18.

## Root cause
The engine had no concept of lateral system type. §418 seismic provisions were not implemented.

## Fix

### Engine (`columnDesign.ts`)
New input fields on `AxialColumnInput`:
| Field | Type | Purpose |
|-------|------|---------|
| `system` | `'gravity' \| 'imf' \| 'smf'` | Lateral system — drives seismic clause |
| `columnLength` | mm | Clear height Lu (for SMF lo check) |
| `hx` | mm | Max horiz. spacing of laterally restrained bars (SMF so formula) |

**SMF (Special Moment Frame) §418.7.5:**
- Confinement zone length: lo ≥ max(bMax, Lu/6, 450 mm)
- Spacing **inside** lo: s ≤ min(bMin/4, 6db, so) where so = clamp(100 + (350−hx)/3, 100, 150)
- Spacing **outside** lo: s ≤ min(6db, 150 mm)

**IMF (Intermediate Moment Frame) §418.4.3:**
- Hinge zone: lo = max(bMax, 450 mm)
- Spacing in zone: s ≤ min(8db, 24dt, bMin/2, 300 mm)

New result fields: `seismicLoZone`, `seismicSConf`, `seismicSOut`, `tieSpacingFinal` (min of §425.7.2 and seismic), `tieSpacingLabel` (governing clause).

### UI (`ColumnDesign.tsx`)
- New **"Lateral system / seismic"** card: gravity / IMF / SMF selector, clear height, hx input
- Ties result row now shows `tieSpacingFinal` — the seismically corrected spacing
- Extra rows appear for SMF/IMF: confinement zone length lo, s (inside lo), s (outside lo)
- The 2D ColumnSchematic now draws ties at `tieSpacingFinal` (visible on the section view)

### Tests (`columnDesign.test.ts`)
7 new unit tests for SMF and IMF seismic spacing, so formula, lo length, sOut.

**315 tests passing, TypeScript clean.**

## Example — 500×500 SMF column, ⌀25 bars, hx = 200 mm
| Clause | Spacing |
|--------|---------|
| §425.7.2 (non-seismic) | 500 mm |
| §418.7.5 SMF conf. zone | **125 mm** |
| §418.7.5 outside zone | 150 mm |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_