### PR TITLE
feat(model): structural-steel option on the 3D model page + base-plate engine

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -65,7 +65,21 @@ Latest merged work — PRs **#178–#183** (main); **Steel Design** open PR:
   `liveLoads.ts`, …) — each with a `*.test.ts`.
 - Routes + home tiles: `webapp/src/App.tsx`
 
-- **Steel Design** (`/steel`): new page covering three AISC 360-16 LRFD tools:
+- **3D model — steel option** (`/model`): the model space now builds either
+  **reinforced concrete** (NSCP/ACI, default) **or structural steel** (AISC W).
+  Pick the material + per-role W-shapes in Properties → Frame material. Steel:
+  - FEM bridge uses AISC A/Ix/Iy/J and E = 200 GPa (`modelBridge.steelSectionProps`).
+  - Design routes steel beams/girders → §F2 flexure + §G2.1 shear; steel columns
+    → §E3 axial + §H1-1 combined (`pipeline.designSteelBeamRow/ColumnRow`).
+  - Base plates designed under every steel column support per **AISC §J8 / DG1**
+    (`engine/baseplate.ts`): concrete bearing, plate thickness, anchor-rod uplift.
+  - 3D view extrudes each steel member's true cross-section (`MemberSteel3D`).
+  - Steel tonnage in the totals; slabs/footings stay reinforced concrete.
+  - Schedules: steel beam / steel column / base-plate tables in the Design report.
+  - **Phase-2 TODO**: steel section auto-optimization (the optimizer currently only
+    grows concrete sections — steel needs a shape-ladder search), structural-steel
+    BOM line items in the costed take-off, beam connections + Lb bracing inputs.
+- **Steel Design** (`/steel`): page covering three AISC 360-16 LRFD tools:
   - **Beam design** (§F2 flexure with LTB zone badge, §G2.1 shear, service deflection L/360 & L/240).
   - **Column design** (§E3 axial Fcr, both KL/rx and KL/ry, §F6 weak-axis flexure, §H1-1 combined ratio).
   - **Connection design** (§J3.6 bolt shear + §J3.10 bearing for A325M/A490M; §J2.4 fillet weld
@@ -82,4 +96,4 @@ Latest merged work — PRs **#178–#183** (main); **Steel Design** open PR:
 - Optional: custom section input on Steel Design page (enter Sx, Zx, ry directly).
 - Optional: point-load + moment diagram for beams; stiffened web shear (§G2.2).
 
-_Tests at last handoff: 290 passing; `tsc -b` clean; production build OK._
+_Tests at last handoff: 330 passing; `tsc -b` clean; production build OK._

--- a/webapp/src/engine/baseplate.test.ts
+++ b/webapp/src/engine/baseplate.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { designBasePlate, adoptPlateThickness } from './baseplate'
+
+describe('designBasePlate §J8 / DG1', () => {
+  // W250x67-ish column: d≈257, bf≈204; Pu = 1500 kN; f'c = 28; A36 plate.
+  const base = { Pu: 1500, d: 257, bf: 204, fc: 28, Fy: 248 }
+
+  it('bearing capacity uses φc·0.85f′c·√(A2/A1)', () => {
+    const r = designBasePlate({ ...base, a2OverA1: 1 })
+    expect(r.sqrtRatio).toBeCloseTo(1, 6)
+    expect(r.fpMax).toBeCloseTo(0.65 * 0.85 * 28 * 1, 6)
+  })
+
+  it('√(A2/A1) is capped at 2.0 even for a large pier', () => {
+    const r = designBasePlate({ ...base, a2OverA1: 9 })
+    expect(r.sqrtRatio).toBe(2.0)
+  })
+
+  it('adopted plate satisfies bearing (util ≤ 1, A1 ≥ A1req)', () => {
+    const r = designBasePlate(base)
+    expect(r.A1).toBeGreaterThanOrEqual(r.A1req - 1e-6)
+    expect(r.bearingUtil).toBeLessThanOrEqual(1 + 1e-9)
+    expect(r.bearingOK).toBe(true)
+  })
+
+  it('plate covers the column footprint', () => {
+    const r = designBasePlate(base)
+    expect(r.N).toBeGreaterThanOrEqual(base.d)
+    expect(r.B).toBeGreaterThanOrEqual(base.bf)
+  })
+
+  it('cantilever ℓ = max(m, n, n′) and tReq = ℓ√(2fp/(0.9Fy))', () => {
+    const r = designBasePlate(base)
+    expect(r.ell).toBeCloseTo(Math.max(r.m, r.n, r.nPrime), 6)
+    expect(r.tReq).toBeCloseTo(r.ell * Math.sqrt((2 * r.fp) / (0.9 * 248)), 5)
+  })
+
+  it('bigger pier (higher A2/A1) → smaller required area', () => {
+    const small = designBasePlate({ ...base, a2OverA1: 1 })
+    const big = designBasePlate({ ...base, a2OverA1: 4 })
+    expect(big.A1req).toBeLessThan(small.A1req)
+  })
+
+  it('no uplift → anchors OK and zero required area', () => {
+    const r = designBasePlate(base)
+    expect(r.Tu).toBe(0)
+    expect(r.rodAbReq).toBe(0)
+    expect(r.anchorOK).toBe(true)
+  })
+
+  it('net uplift sizes anchor rods (φt·0.75·Fu)', () => {
+    const r = designBasePlate({ ...base, Tu: 200, nRods: 4, rodGrade: 'A307', rodDia: 25 })
+    const Fu = 414
+    expect(r.rodAbReq).toBeCloseTo((200 * 1000) / (4 * 0.75 * 0.75 * Fu), 4)
+    // 4 × ⌀25 A307 rods vs the demand
+    const Ab = (Math.PI / 4) * 25 * 25
+    const cap = 4 * (0.75 * 0.75 * Fu * Ab) / 1000
+    expect(r.anchorOK).toBe(cap >= 200)
+  })
+
+  it('higher Pu needs a thicker plate', () => {
+    const a = designBasePlate({ ...base, Pu: 800 })
+    const b = designBasePlate({ ...base, Pu: 2500 })
+    expect(b.tReq).toBeGreaterThan(a.tReq)
+  })
+})
+
+describe('adoptPlateThickness', () => {
+  it('rounds up to the next plate stock size', () => {
+    expect(adoptPlateThickness(11)).toBe(12)
+    expect(adoptPlateThickness(20)).toBe(20)
+    expect(adoptPlateThickness(21)).toBe(22)
+  })
+})

--- a/webapp/src/engine/baseplate.ts
+++ b/webapp/src/engine/baseplate.ts
@@ -1,0 +1,122 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Steel column base plate — AISC 360-16 §J8 + AISC Design Guide 1 (concentric
+// axial, LRFD). Bearing on concrete governs the plan area; cantilever bending
+// of the plate governs the thickness. An optional net uplift sizes the anchor
+// rods in tension (§J9 / Table J3.2).
+//
+//  · Concrete bearing §J8:  φc·Pp,  Pp = 0.85 f'c A1 √(A2/A1) ≤ 1.7 f'c A1,
+//    φc = 0.65.  √(A2/A1) capped at 2.0 (confinement benefit limit).
+//  · Plan sizing (DG1):  Δ = (0.95 d − 0.8 bf)/2;  N ≈ √A1,req + Δ;  B = A1/N.
+//  · Cantilevers:  m = (N − 0.95 d)/2,  n = (B − 0.8 bf)/2,
+//    n' = √(d·bf)/4;  ℓ = max(m, n, λn'),  λ ≈ 1 (conservative).
+//  · Thickness (DG1):  tp = ℓ·√(2 fp /(0.9 Fy)),  fp = Pu/(B·N).
+//  · Anchor rods: minimum 4; in net uplift Tu, required area
+//    Ab,req = Tu /(n_rods·φt·0.75·Fu_rod),  φt = 0.75.
+// Units: forces kN, moments kN·m, geometry mm, stress MPa.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type AnchorGrade = 'A307' | 'F1554-36' | 'F1554-55' | 'A325M'
+
+/** Nominal tensile strength Fu of common anchor-rod grades (MPa). */
+const ANCHOR_FU: Record<AnchorGrade, number> = {
+  A307: 414, 'F1554-36': 400, 'F1554-55': 517, A325M: 830,
+}
+
+export interface BasePlateInput {
+  Pu: number              // factored axial compression, kN
+  Tu?: number             // factored net uplift (tension), kN — default 0
+  d: number               // column depth, mm
+  bf: number              // column flange width, mm
+  fc: number              // concrete f'c, MPa
+  Fy?: number             // plate yield, MPa — default 248 (A36)
+  /** Supporting concrete area A2 / plate area A1 (confinement). Default 1.0
+   *  (plate fully covers the pier). Capped at 4 → √ ratio capped at 2. */
+  a2OverA1?: number
+  nRods?: number          // anchor-rod count — default 4
+  rodGrade?: AnchorGrade  // default A307
+  rodDia?: number         // anchor-rod diameter, mm — default 25
+}
+
+export interface BasePlateResult {
+  // bearing
+  sqrtRatio: number       // √(A2/A1), capped at 2.0
+  fpMax: number           // φc · bearing stress capacity, MPa
+  A1req: number           // required bearing area, mm²
+  // plan
+  N: number; B: number    // adopted plate dimensions, mm (N along d, B along bf)
+  A1: number              // provided area, mm²
+  fp: number              // actual bearing pressure, MPa
+  bearingUtil: number     // Pu / φc·Pp
+  bearingOK: boolean
+  // thickness
+  m: number; n: number; nPrime: number; ell: number   // cantilevers, mm
+  tReq: number            // required plate thickness, mm
+  // anchors
+  Tu: number
+  rodAbReq: number        // required tensile area per rod, mm²
+  rodAbProv: number       // provided area per rod, mm²
+  anchorOK: boolean
+}
+
+const PHI_C = 0.65   // §J8 bearing
+const PHI_B = 0.90   // plate flexure
+const PHI_T = 0.75   // §J3 rod tension
+
+export function designBasePlate(i: BasePlateInput): BasePlateResult {
+  const Fy = i.Fy ?? 248
+  const a2OverA1 = Math.max(1, i.a2OverA1 ?? 1)
+  const sqrtRatio = Math.min(Math.sqrt(a2OverA1), 2.0)
+  const fpMax = PHI_C * 0.85 * i.fc * sqrtRatio   // ≤ φc·1.7f'c automatically (sqrtRatio≤2)
+
+  // required bearing area from φc·Pp ≥ Pu
+  const PuN = Math.max(i.Pu, 0) * 1000            // N
+  const A1req = fpMax > 0 ? PuN / fpMax : 0
+
+  // DG1 plan sizing: keep the two cantilevers roughly balanced
+  const delta = (0.95 * i.d - 0.8 * i.bf) / 2
+  // start from a square-ish plate that respects the column footprint
+  const Nstart = Math.max(Math.sqrt(A1req) + delta, 0.95 * i.d + 40, i.d + 50)
+  let N = Math.ceil(Nstart / 10) * 10
+  let B = Math.max(A1req / N, 0.8 * i.bf + 40, i.bf + 50)
+  B = Math.ceil(B / 10) * 10
+  // grow to satisfy bearing if the rounded plate is short
+  while (N * B < A1req && N < 4000) { N += 10; B = Math.ceil(Math.max(B, A1req / N) / 10) * 10 }
+
+  const A1 = N * B
+  const fp = A1 > 0 ? PuN / A1 : 0
+  const phiPp = fpMax * A1 / 1000                 // kN
+  const bearingUtil = phiPp > 0 ? i.Pu / phiPp : Infinity
+
+  // cantilevers
+  const m = (N - 0.95 * i.d) / 2
+  const n = (B - 0.8 * i.bf) / 2
+  const nPrime = Math.sqrt(i.d * i.bf) / 4        // λ = 1 (conservative)
+  const ell = Math.max(m, n, nPrime)
+
+  // required thickness (DG1): tp = ℓ √(2 fp / (φb Fy)); fp from actual pressure
+  const tReq = ell * Math.sqrt((2 * fp) / (PHI_B * Fy))
+
+  // anchor rods in net uplift
+  const Tu = Math.max(i.Tu ?? 0, 0)
+  const nRods = i.nRods ?? 4
+  const Fu = ANCHOR_FU[i.rodGrade ?? 'A307']
+  const dia = i.rodDia ?? 25
+  const rodAbProv = (Math.PI / 4) * dia * dia
+  // φRn per rod = φt · 0.75 Fu · Ab  (0.75 = effective-area factor, §J3.6)
+  const rodCapPerRod = (PHI_T * 0.75 * Fu * rodAbProv) / 1000   // kN
+  const rodAbReq = Tu > 0 ? (Tu * 1000) / (nRods * PHI_T * 0.75 * Fu) : 0
+  const anchorOK = Tu <= 0 || (nRods * rodCapPerRod >= Tu - 1e-9)
+
+  return {
+    sqrtRatio, fpMax, A1req,
+    N, B, A1, fp, bearingUtil, bearingOK: bearingUtil <= 1 + 1e-9,
+    m, n, nPrime, ell, tReq,
+    Tu, rodAbReq, rodAbProv, anchorOK,
+  }
+}
+
+/** Round a required plate thickness up to the next common plate stock (mm). */
+export const PLATE_STOCK = [10, 12, 16, 20, 22, 25, 28, 32, 36, 40, 45, 50]
+export function adoptPlateThickness(tReq: number): number {
+  return PLATE_STOCK.find((t) => t >= tReq - 1e-6) ?? Math.ceil(tReq / 5) * 5
+}

--- a/webapp/src/engine/model.ts
+++ b/webapp/src/engine/model.ts
@@ -10,12 +10,21 @@ import type { LiveItem } from './liveLoads'
 
 export interface Node { id: string; x: number; y: number; z: number }
 
+export type SectionMaterial = 'concrete' | 'steel'
+
 export interface RectSection {
   id: string
   name: string
-  b: number; h: number          // mm
+  b: number; h: number          // mm  (concrete; for steel a bounding box ≈ bf × d)
   fc: number; fy: number
   barDia: number; tieDia: number; cover: number
+  /** Material of the member. Absent ⇒ 'concrete' (back-compatible). */
+  material?: SectionMaterial
+  /** AISC shape name (steel only), e.g. 'W310x39'. Resolved via aiscSections. */
+  shape?: string
+  /** Steel grade yield/ultimate (steel only). Defaults: Fy 248, Fu 400 (A36). */
+  steelFy?: number
+  steelFu?: number
 }
 
 export type MemberRole = 'beam' | 'girder' | 'column' | 'brace'

--- a/webapp/src/engine/modelBridge.ts
+++ b/webapp/src/engine/modelBridge.ts
@@ -9,6 +9,8 @@ import type { F3Node, F3Member, F3Support, F3Load } from './frame3d'
 import { rectJ } from './frame3d'
 import { distributePanel, type AreaLoad } from './tributary'
 import type { BeamLoad } from './beamAnalysis'
+import { shapeByName } from './aiscSections'
+import { deriveWSection, E_STEEL } from './steelDesign'
 
 export interface BridgeResult {
   nodes: F3Node[]
@@ -20,6 +22,7 @@ export interface BridgeResult {
 }
 
 function sectionProps(s: RectSection) {
+  if (s.material === 'steel') return steelSectionProps(s)
   const E = 4700 * Math.sqrt(Math.max(s.fc, 1))
   return {
     E,
@@ -29,6 +32,26 @@ function sectionProps(s: RectSection) {
     Iy: (s.h * s.b ** 3) / 12,
     J: rectJ(s.b, s.h),
   }
+}
+
+/** Steel member stiffness from its AISC shape (E = 200 GPa, G = E/2.6, ν = 0.3).
+ *  Iz (strong axis) is the section's Ix; Iy is the weak axis. Falls back to the
+ *  rectangular bounding box if the shape is unknown. */
+function steelSectionProps(s: RectSection) {
+  const E = E_STEEL, G = E / 2.6
+  const shape = s.shape ? shapeByName(s.shape) : undefined
+  if (!shape) return { E, G, A: s.b * s.h, Iz: (s.b * s.h ** 3) / 12, Iy: (s.h * s.b ** 3) / 12, J: rectJ(s.b, s.h) }
+  let Iz: number, Iy: number, J: number
+  if (shape.family === 'W' || shape.family === 'WT') {
+    const d = deriveWSection(shape)
+    Iz = d.Ix; Iy = d.Iy; J = d.J
+  } else {
+    // generic: I = A·r² about each axis; torsion ≈ box approximation
+    Iz = shape.A * shape.rx ** 2
+    Iy = shape.A * shape.ry ** 2
+    J = Iz + Iy   // polar (conservative for open shapes; exact for closed tubes)
+  }
+  return { E, G, A: shape.A, Iz, Iy, J }
 }
 
 /**

--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -109,6 +109,59 @@ describe('design pipeline — single-bay single-storey grid', () => {
   })
 })
 
+describe('steel design pipeline (AISC routing + base plates)', () => {
+  // all members steel: W310x79 (a stocky W that passes a single-bay grid)
+  function steelModel() {
+    const m = makeModel()
+    m.sections = m.sections.map((s) => ({ ...s, material: 'steel' as const, shape: 'W310x79', steelFy: 345, steelFu: 448 }))
+    return m
+  }
+  const r = designStructure(steelModel(), soil)!
+
+  it('routes members to the steel schedules, not the concrete ones', () => {
+    expect(r.beams).toHaveLength(0)
+    expect(r.columns).toHaveLength(0)
+    expect(r.steelBeams).toHaveLength(4)     // 2 beams + 2 girders
+    expect(r.steelColumns).toHaveLength(4)
+  })
+
+  it('steel beams carry φMn/φVn and an LTB zone', () => {
+    for (const b of r.steelBeams) {
+      expect(b.shape).toBe('W310x79')
+      expect(b.phiMn).toBeGreaterThan(0)
+      expect(b.phiVn).toBeGreaterThan(0)
+      expect(['plastic', 'inelastic', 'elastic']).toContain(b.ltbZone)
+      expect(b.Mu).toBeGreaterThan(0)
+    }
+  })
+
+  it('steel columns use §H1-1 combined interaction', () => {
+    for (const c of r.steelColumns) {
+      expect(c.phiPn).toBeGreaterThan(0)
+      expect(['H1-1a', 'H1-1b']).toContain(c.equation)
+      expect(c.Pu).toBeGreaterThan(0)
+      expect(c.ratio).toBeGreaterThan(0)
+    }
+  })
+
+  it('designs a base plate under every steel column support', () => {
+    expect(r.basePlates).toHaveLength(4)
+    for (const p of r.basePlates) {
+      expect(p.shape).toBe('W310x79')
+      expect(p.Pu).toBeGreaterThan(0)
+      expect(p.design.N).toBeGreaterThanOrEqual(306)   // ≥ column depth
+      expect(p.tAdopt).toBeGreaterThanOrEqual(p.design.tReq)
+    }
+  })
+
+  it('reports steel tonnage and no concrete member volume', () => {
+    expect(r.totals.steelKg).toBeGreaterThan(0)
+    expect(r.totals.concreteMembers).toBeCloseTo(0, 6)
+    // 34 m of W310x79 (A = 10000 mm²) at 7850 kg/m³
+    expect(r.totals.steelKg).toBeCloseTo(34 * (10000 / 1e6) * 7850, 0)
+  })
+})
+
 describe('beam critical sections — interior is the sagging peak', () => {
   it('a continuous multi-bay frame still sags at mid-span (not all hogging)', () => {
     const m = generateGridModel({ baysX: [6, 6], baysZ: [5], storeyH: [3.5, 3], section })

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -19,6 +19,9 @@ import { designSquareFooting, type SquareFootingResult } from './isolatedFooting
 import { designCombinedFooting, type CombinedFootingResult } from './combinedFooting'
 import { designSlabDDM, type SlabDesignResult } from './slabDDM'
 import { designShearWall, type ShearWallResult } from './shearWallDesign'
+import { shapeByName } from './aiscSections'
+import { deriveWSection, beamFlexure, beamShear, columnAxial, combinedLoading } from './steelDesign'
+import { designBasePlate, adoptPlateThickness, type BasePlateResult } from './baseplate'
 
 export interface SoilOptions {
   qAllow: number; gammaSoil: number; gammaConc: number; H: number
@@ -91,22 +94,96 @@ export interface WallScheduleRow {
 /** Per-support footing choice: isolated (default) or combined with another node. */
 export type FootingPlan = Record<string, { type: 'isolated' } | { type: 'combined'; with: string }>
 
+// ── Steel schedule rows (AISC 360-16 LRFD) ──────────────────────────────────
+export interface SteelBeamScheduleRow {
+  id: string; role: string; L: number; shape: string
+  Mu: number; Vu: number          // kN·m, kN
+  phiMn: number; phiVn: number     // kN·m, kN
+  ltbZone: string
+  utilM: number; utilV: number
+  ok: boolean
+  gov?: string
+}
+export interface SteelColumnScheduleRow {
+  id: string; L: number; shape: string
+  Pu: number; Mu: number
+  phiPn: number; phiMn: number
+  slenderness: number
+  ratio: number; equation: string  // §H1-1
+  ok: boolean
+  gov?: string
+}
+export interface BasePlateScheduleRow {
+  node: string; shape: string
+  Pu: number; Tu: number
+  design: BasePlateResult
+  tAdopt: number                   // adopted plate thickness, mm
+  ok: boolean
+}
+
 export interface StructureDesign {
   govName: string
   cases: string[]   // every load case (combo × direction) run for the envelope
   beams: BeamScheduleRow[]
   columns: ColumnScheduleRow[]
+  steelBeams: SteelBeamScheduleRow[]
+  steelColumns: SteelColumnScheduleRow[]
+  basePlates: BasePlateScheduleRow[]
   slabs: SlabScheduleRow[]
   walls: WallScheduleRow[]
   footings: FootingScheduleRow[]
   combined: CombinedScheduleRow[]
-  totals: { concreteMembers: number; concreteSlabs: number; concrete: number }
+  totals: { concreteMembers: number; concreteSlabs: number; concrete: number; steelKg: number }
   orphanEdges: number
 }
 
 export function designOK(d: StructureDesign): boolean {
   return d.beams.every((b) => b.ok) && d.columns.every((c) => c.ok)
+    && d.steelBeams.every((b) => b.ok) && d.steelColumns.every((c) => c.ok)
+    && d.basePlates.every((p) => p.ok)
     && d.footings.every((f) => f.ok) && d.combined.every((c) => c.ok)
+}
+
+// ── Steel member design (reuses steelDesign engine) ──────────────────────────
+/** Design a steel beam/girder from a member result. Lb = full length
+ *  (conservative; the slab braces the top flange for sagging but support
+ *  hogging puts the bottom flange in compression). */
+function designSteelBeamRow(mr: F3MemberResult, role: string, sec: RectSection): SteelBeamScheduleRow | null {
+  const shape = sec.shape ? shapeByName(sec.shape) : undefined
+  if (!shape || (shape.family !== 'W' && shape.family !== 'WT')) return null
+  const Fy = sec.steelFy ?? 248
+  const p = deriveWSection(shape)
+  const Mu = mr.Mmax, Vu = mr.Vmax
+  const flex = beamFlexure(shape, p, Fy, mr.L * 1000, 1.0)
+  const shear = beamShear(shape, p, Fy)
+  const utilM = flex.phiMn > 1e-9 ? Mu / flex.phiMn : Infinity
+  const utilV = shear.phiVn > 1e-9 ? Vu / shear.phiVn : Infinity
+  return {
+    id: mr.id, role, L: mr.L, shape: shape.name, Mu, Vu,
+    phiMn: flex.phiMn, phiVn: shear.phiVn, ltbZone: flex.ltbZone,
+    utilM, utilV, ok: utilM <= 1 + 1e-9 && utilV <= 1 + 1e-9,
+  }
+}
+
+/** Design a steel column from a member result (§E3 axial + §H1-1 combined). */
+function designSteelColumnRow(mr: F3MemberResult, sec: RectSection): SteelColumnScheduleRow | null {
+  const shape = sec.shape ? shapeByName(sec.shape) : undefined
+  if (!shape) return null
+  const Fy = sec.steelFy ?? 248
+  const Pu = Math.max(0, -Math.min(...mr.N))   // compression (N < 0)
+  const Mu = mr.Mmax
+  const axial = columnAxial(shape, Fy, mr.L, 1.0, 1.0)
+  let phiMn = Infinity
+  if (shape.family === 'W' || shape.family === 'WT') {
+    phiMn = beamFlexure(shape, deriveWSection(shape), Fy, mr.L * 1000, 1.0).phiMn
+  }
+  const comb = combinedLoading(Pu, axial.phiPn, Mu, phiMn)
+  return {
+    id: mr.id, L: mr.L, shape: shape.name, Pu, Mu,
+    phiPn: axial.phiPn, phiMn: Number.isFinite(phiMn) ? phiMn : 0,
+    slenderness: axial.slenderness, ratio: comb.ratio, equation: comb.equation,
+    ok: comb.ok && axial.slenderOK,
+  }
 }
 
 const beamOK = (d: BeamDesignResult) =>
@@ -283,26 +360,51 @@ export function designStructure(
   onProgress?.({ phase: 'Designing beams & columns', detail: `${model.members.length} members` })
   const beams: BeamScheduleRow[] = []
   const columns: ColumnScheduleRow[] = []
+  const steelBeams: SteelBeamScheduleRow[] = []
+  const steelColumns: SteelColumnScheduleRow[] = []
   for (const m of model.members) {
     const role = roleOf.get(m.id)
+    const sec = secOf(m.id)
+    const isSteel = sec.material === 'steel'
     if (role === 'beam' || role === 'girder') {
-      let best: BeamScheduleRow | null = null, bestSev = -1, gov = ''
-      for (const run of runs) {
-        const mr = memberOf(run, m.id); if (!mr) continue
-        const row = designBeamRow(mr, role, secOf(m.id))
-        if (row.sections.length === 0) continue
-        const sev = beamSeverity(row)
-        if (sev > bestSev) { bestSev = sev; best = row; gov = run.name }
+      if (isSteel) {
+        let best: SteelBeamScheduleRow | null = null, bestSev = -1, gov = ''
+        for (const run of runs) {
+          const mr = memberOf(run, m.id); if (!mr) continue
+          const row = designSteelBeamRow(mr, role, sec); if (!row) continue
+          const sev = (row.ok ? 0 : 1e9) + row.Mu
+          if (sev > bestSev) { bestSev = sev; best = row; gov = run.name }
+        }
+        if (best) steelBeams.push({ ...best, gov })
+      } else {
+        let best: BeamScheduleRow | null = null, bestSev = -1, gov = ''
+        for (const run of runs) {
+          const mr = memberOf(run, m.id); if (!mr) continue
+          const row = designBeamRow(mr, role, sec)
+          if (row.sections.length === 0) continue
+          const sev = beamSeverity(row)
+          if (sev > bestSev) { bestSev = sev; best = row; gov = run.name }
+        }
+        if (best) beams.push({ ...best, gov })
       }
-      if (best) beams.push({ ...best, gov })
     } else if (role === 'column') {
-      let best: ColumnScheduleRow | null = null, bestUtil = -1, gov = ''
-      for (const run of runs) {
-        const mr = memberOf(run, m.id); if (!mr) continue
-        const row = designColumnRow(mr, secOf(m.id))
-        if (row.util > bestUtil) { bestUtil = row.util; best = row; gov = run.name }
+      if (isSteel) {
+        let best: SteelColumnScheduleRow | null = null, bestRatio = -1, gov = ''
+        for (const run of runs) {
+          const mr = memberOf(run, m.id); if (!mr) continue
+          const row = designSteelColumnRow(mr, sec); if (!row) continue
+          if (row.ratio > bestRatio) { bestRatio = row.ratio; best = row; gov = run.name }
+        }
+        if (best) steelColumns.push({ ...best, gov })
+      } else {
+        let best: ColumnScheduleRow | null = null, bestUtil = -1, gov = ''
+        for (const run of runs) {
+          const mr = memberOf(run, m.id); if (!mr) continue
+          const row = designColumnRow(mr, sec)
+          if (row.util > bestUtil) { bestUtil = row.util; best = row; gov = run.name }
+        }
+        if (best) columns.push({ ...best, gov })
       }
-      if (best) columns.push({ ...best, gov })
     }
   }
 
@@ -361,15 +463,46 @@ export function designStructure(
     footings.push({ node: ru.node, P, Pu, design: d, ok: d.qNet > 0 && d.punchOK && d.beamOK, gov })
   }
 
-  // ── Concrete totals ──
+  // ── Base plates (steel columns landing on a base support) ──
+  const basePlates: BasePlateScheduleRow[] = []
+  for (const ru of runs[govIdx].result.reactions) {
+    const col = colAtNode(ru.node)
+    const fs = col ? secOf(col.id) : undefined
+    if (!col || !fs || fs.material !== 'steel') continue
+    const shape = fs.shape ? shapeByName(fs.shape) : undefined
+    if (!shape) continue
+    // envelope factored compression (max) and net uplift (most tension) across runs
+    let Pu = 0, Tu = 0
+    for (const run of runs) {
+      const i = run.result.reactions.findIndex((r) => r.node === ru.node)
+      if (i < 0) continue
+      const Fy = run.result.reactions[i].F[1]
+      if (Fy > Pu) Pu = Fy
+      if (-Fy > Tu) Tu = -Fy
+    }
+    if (Pu < 1e-6 && Tu < 1e-6) continue
+    const design = designBasePlate({
+      Pu, Tu, d: shape.d ?? Math.max(fs.b, fs.h), bf: shape.bf ?? Math.min(fs.b, fs.h),
+      fc: fs.fc, Fy: fs.steelFy ?? 248,
+    })
+    const tAdopt = adoptPlateThickness(design.tReq)
+    basePlates.push({ node: ru.node, shape: shape.name, Pu, Tu, design, tAdopt, ok: design.bearingOK && design.anchorOK })
+  }
+
+  // ── Concrete & steel totals ──
   const nm = new Map(model.nodes.map((n) => [n.id, n]))
-  let concreteMembers = 0
+  let concreteMembers = 0, steelKg = 0
   for (const m of model.members) {
     const a = nm.get(m.i), b2 = nm.get(m.j)
     if (!a || !b2) continue
     const L = Math.hypot(b2.x - a.x, b2.y - a.y, b2.z - a.z)
     const s = secOf(m.id)
-    concreteMembers += (s.b / 1000) * (s.h / 1000) * L
+    if (s.material === 'steel') {
+      const shape = s.shape ? shapeByName(s.shape) : undefined
+      if (shape) steelKg += (shape.A / 1e6) * L * 7850   // A m² × L × ρ
+    } else {
+      concreteMembers += (s.b / 1000) * (s.h / 1000) * L
+    }
   }
   let concreteSlabs = 0
   for (const p of model.plates) {
@@ -440,8 +573,8 @@ export function designStructure(
   return {
     govName: runs[govIdx].name,
     cases: runs.map((r) => r.name),
-    beams, columns, slabs, walls, footings, combined,
-    totals: { concreteMembers, concreteSlabs, concrete: concreteMembers + concreteSlabs },
+    beams, columns, steelBeams, steelColumns, basePlates, slabs, walls, footings, combined,
+    totals: { concreteMembers, concreteSlabs, concrete: concreteMembers + concreteSlabs, steelKg },
     orphanEdges: br.orphanEdges.length,
   }
 }
@@ -526,6 +659,8 @@ export interface OptimizeResult {
 
 const countFails = (d: StructureDesign): number =>
   d.beams.filter((x) => !x.ok).length + d.columns.filter((x) => !x.ok).length
+  + d.steelBeams.filter((x) => !x.ok).length + d.steelColumns.filter((x) => !x.ok).length
+  + d.basePlates.filter((x) => !x.ok).length
   + d.footings.filter((x) => !x.ok).length + d.combined.filter((x) => !x.ok).length
 
 const withSizes = (model: StructuralModel, sizes: Map<string, RectSection>): StructuralModel =>

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -28,10 +28,15 @@ import { DimBelow, DimSide } from '../components/dims'
 import { HintButton, SeismicHint, WindHint } from '../components/LoadHints'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { FitView } from '../components/FitView'
+import { shapeByName, shapesOf, effectiveSection } from '../engine/aiscSections'
+import { buildSectionShapes } from '../lib/sectionShapes3d'
 import { f1, f2 } from '../lib/format'
 
 const AUTOSAVE_KEY = 'model-space-autosave'
 const INPUTS_KEY = 'model-space-inputs'
+
+// AISC W-shape picker options for the steel material path.
+const W_SHAPE_OPTS: [string, string][] = shapesOf('W').map((s) => [s.name, s.name])
 
 /** The design inputs persisted alongside the autosaved model so a reload keeps
  *  the Geometry/Properties/Loading/etc. fields consistent with the 3D model
@@ -92,6 +97,46 @@ function Member3D({ a, b, role, selected, tint = 0, sec, onPick }: {
       <boxGeometry args={[len, ty, tz]} />
       <meshStandardMaterial color={color} />
     </mesh>
+  )
+}
+
+/** Steel member drawn as its true AISC cross-section, extruded along the member
+ *  axis (i→j). The profile is built in the local XY plane then oriented so its
+ *  extrude (+Z) runs along the member and its strong axis (depth d) stays
+ *  vertical for beams/girders. Falls back to the box Member3D if the shape is
+ *  unknown. */
+function MemberSteel3D({ a, b, role, shapeName, selected, tint = 0, onPick }: {
+  a: THREE.Vector3; b: THREE.Vector3; role: string; shapeName: string
+  selected: boolean; tint?: number; onPick: () => void
+}) {
+  const { shapes, quat, pos, len } = useMemo(() => {
+    const shape = shapeByName(shapeName)
+    const dir = new THREE.Vector3().subVectors(b, a)
+    const len = dir.length()
+    const shapes = shape ? buildSectionShapes(effectiveSection(shape, false)) : []
+    // orient local +Z (extrude dir) onto the member axis; group placed at node i
+    const quat = new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 0, 1), dir.clone().normalize())
+    return { shapes, quat, pos: a.clone(), len }
+  }, [a, b, shapeName])
+
+  const color = useMemo(() => {
+    if (selected) return SEL
+    const base = new THREE.Color('#64748b')   // steel grey
+    return tint > 0 ? `#${base.lerp(new THREE.Color('#dc2626'), tint).getHexString()}` : `#${base.getHexString()}`
+  }, [selected, tint])
+
+  if (shapes.length === 0) {
+    return <Member3D a={a} b={b} role={role} selected={selected} tint={tint} onPick={onPick} />
+  }
+  return (
+    <group position={pos} quaternion={quat} onClick={(e) => { e.stopPropagation(); onPick() }}>
+      {shapes.map((sh, i) => (
+        <mesh key={i}>
+          <extrudeGeometry args={[sh, { depth: len, bevelEnabled: false, steps: 1 }]} />
+          <meshStandardMaterial color={color} metalness={0.35} roughness={0.5} />
+        </mesh>
+      ))}
+    </group>
   )
 }
 
@@ -448,6 +493,12 @@ export default function ModelSpace() {
   const [barDia, setBarDia] = useState(n('barDia', 20)); const [tieDia, setTieDia] = useState(n('tieDia', 10))
   const [cover, setCover] = useState(n('cover', 40)); const [slabThk, setSlabThk] = useState(n('slabThk', 150))
   const [gammaC, setGammaC] = useState(n('gammaC', 24))            // concrete unit weight, kN/m³
+  // Material: 'concrete' (RC) or 'steel' (AISC W-shapes) for the frame members.
+  const [material, setMaterial] = useState<'concrete' | 'steel'>((si.material as 'concrete' | 'steel') ?? 'concrete')
+  const [colShape, setColShape] = useState(s('colShape', 'W310x79'))
+  const [girShape, setGirShape] = useState(s('girShape', 'W360x51'))
+  const [beaShape, setBeaShape] = useState(s('beaShape', 'W310x39'))
+  const [steelFy, setSteelFy] = useState(n('steelFy', 345)); const [steelFu, setSteelFu] = useState(n('steelFu', 448))
   const [qD, setQD] = useState(n('qD', 4.8)); const [qL, setQL] = useState(n('qL', 2.4))
   // Soil (for the footing stage of the design pipeline)
   const [qa, setQa] = useState(n('qa', 200)); const [Hf, setHf] = useState(n('Hf', 1.5))
@@ -533,13 +584,15 @@ export default function ModelSpace() {
         qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs,
         Vw, expo, Kzt, wDirs, assembly, pDelta, tryBars,
         concreteClass, prices, planSel,
+        material, colShape, girShape, beaShape, steelFy, steelFu,
       }))
     } catch { /* quota — ignore */ }
   }, [baysX, baysZ, storeyH, colB, colH, girB, girH, beaB, beaH,
     fc, fy, barDia, tieDia, cover, slabThk, gammaC, qD, qL,
     qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs,
     Vw, expo, Kzt, wDirs, assembly, pDelta, tryBars,
-    concreteClass, prices, planSel])
+    concreteClass, prices, planSel,
+    material, colShape, girShape, beaShape, steelFy, steelFu])
 
   const save = (m: StructuralModel | null) => {
     setModel(m)
@@ -827,9 +880,19 @@ export default function ModelSpace() {
   const generate = () => {
     const mat = { fc, fy, barDia, tieDia, cover }
     const role = (b: number, h: number, id: string): RectSection => ({ id, name: `${b}×${h}`, b, h, ...mat })
+    // steel role: bounding box b = bf, h = d from the chosen AISC shape, tagged
+    // material/shape so the bridge, design pipeline and 3D extrusion pick it up.
+    const steelRole = (shapeName: string, id: string): RectSection => {
+      const sh = shapeByName(shapeName)
+      const bf = sh?.bf ?? sh?.b ?? sh?.D ?? 200, d = sh?.d ?? sh?.h ?? sh?.D ?? 300
+      return { id, name: shapeName, b: bf, h: d, ...mat, material: 'steel', shape: shapeName, steelFy, steelFu }
+    }
+    const steel = material === 'steel'
     const m = generateGridModel({
       baysX: parseList(baysX), baysZ: parseList(baysZ), storeyH: parseList(storeyH),
-      column: role(colB, colH, 'COL'), girder: role(girB, girH, 'GIR'), beam: role(beaB, beaH, 'BEA'),
+      column: steel ? steelRole(colShape, 'COL') : role(colB, colH, 'COL'),
+      girder: steel ? steelRole(girShape, 'GIR') : role(girB, girH, 'GIR'),
+      beam: steel ? steelRole(beaShape, 'BEA') : role(beaB, beaH, 'BEA'),
       slabThickness: slabThk,
     })
     // gravity loads: member self-weight (D), slab self-weight + SDL (D), LL (L)
@@ -962,8 +1025,13 @@ export default function ModelSpace() {
                   if (!a || !bb) return null
                   const tint = govRes && govRes.Mmax > 1e-9
                     ? (memForce.get(m.id)?.Mmax ?? 0) / govRes.Mmax : 0
+                  const sec = sectionFor(m.id)
+                  if (sec?.material === 'steel' && sec.shape) {
+                    return <MemberSteel3D key={m.id} a={a} b={bb} role={m.role} shapeName={sec.shape}
+                      tint={tint * 0.85} selected={m.id === selected} onPick={() => setSelected(m.id)} />
+                  }
                   return <Member3D key={m.id} a={a} b={bb} role={m.role} tint={tint * 0.85}
-                    sec={sectionFor(m.id)} selected={m.id === selected} onPick={() => setSelected(m.id)} />
+                    sec={sec} selected={m.id === selected} onPick={() => setSelected(m.id)} />
                 })}
                 {model.plates.map((p) => {
                   const cs = p.corners.map((c) => nodePos.get(c))
@@ -1319,23 +1387,51 @@ export default function ModelSpace() {
           {/* ── PROPERTIES ── */}
           {tab === 'properties' && (
             <div className="space-y-4">
-              <Card title="Initial member sizes (mm)">
-                <p className="col-span-full -mb-1 text-[11px] text-slate-500">
-                  Each member starts from its role size and grows independently when optimised;
-                  columns are kept ≥ girders ≥ beams in width (strong-column / weak-beam).
+              <Card title="Frame material">
+                <Pick label="Members" value={material} onChange={(v) => setMaterial(v as 'concrete' | 'steel')}
+                  options={[['concrete', 'Reinforced concrete'], ['steel', 'Structural steel (AISC W)']]} />
+                <p className="col-span-full -mt-1 text-[11px] text-slate-500">
+                  {material === 'steel'
+                    ? 'Members become AISC W-shapes designed to AISC 360-16 LRFD (§F flexure, §G shear, §E/§H1 columns); base plates per §J8. Slabs/footings stay reinforced concrete.'
+                    : 'Members are reinforced concrete designed to NSCP 2015 / ACI 318-14.'}
                 </p>
-                <Num label="Column b" unit="mm" value={colB} onChange={setColB} />
-                <Num label="Column h" unit="mm" value={colH} onChange={setColH} />
-                <Num label="Girder b" unit="mm" value={girB} onChange={setGirB} />
-                <Num label="Girder h" unit="mm" value={girH} onChange={setGirH} />
-                <Num label="Beam b" unit="mm" value={beaB} onChange={setBeaB} />
-                <Num label="Beam h" unit="mm" value={beaH} onChange={setBeaH} />
-                <Num label="Slab thickness" unit="mm" value={slabThk} onChange={setSlabThk} />
               </Card>
+              {material === 'steel' ? (
+                <Card title="Steel sections (AISC W)">
+                  <Pick label="Column" value={colShape} onChange={setColShape}
+                    options={W_SHAPE_OPTS} />
+                  <Pick label="Girder" value={girShape} onChange={setGirShape}
+                    options={W_SHAPE_OPTS} />
+                  <Pick label="Beam" value={beaShape} onChange={setBeaShape}
+                    options={W_SHAPE_OPTS} />
+                  <Num label="Steel Fy" unit="MPa" value={steelFy} onChange={setSteelFy} step="5" />
+                  <Num label="Steel Fu" unit="MPa" value={steelFu} onChange={setSteelFu} step="5" />
+                  <Num label="Slab thickness" unit="mm" value={slabThk} onChange={setSlabThk} />
+                  <p className="col-span-full text-[11px] text-slate-400">
+                    Applied on the next “Generate model”. The 3D view extrudes each member's true
+                    cross-section. Concrete f′c below is still used for the base-plate bearing check.
+                  </p>
+                </Card>
+              ) : (
+                <Card title="Initial member sizes (mm)">
+                  <p className="col-span-full -mb-1 text-[11px] text-slate-500">
+                    Each member starts from its role size and grows independently when optimised;
+                    columns are kept ≥ girders ≥ beams in width (strong-column / weak-beam).
+                  </p>
+                  <Num label="Column b" unit="mm" value={colB} onChange={setColB} />
+                  <Num label="Column h" unit="mm" value={colH} onChange={setColH} />
+                  <Num label="Girder b" unit="mm" value={girB} onChange={setGirB} />
+                  <Num label="Girder h" unit="mm" value={girH} onChange={setGirH} />
+                  <Num label="Beam b" unit="mm" value={beaB} onChange={setBeaB} />
+                  <Num label="Beam h" unit="mm" value={beaH} onChange={setBeaH} />
+                  <Num label="Slab thickness" unit="mm" value={slabThk} onChange={setSlabThk} />
+                </Card>
+              )}
               <Card title="Concrete & reinforcement">
                 <p className="col-span-full -mb-1 text-[11px] text-slate-500">
                   Shared material applied to every section when you generate the grid. f′c drives Ec and the
                   flexural/shear capacities; fy the steel; ⌀ and cover the bar layout and effective depth.
+                  {material === 'steel' && ' (Used for slabs, footings and base-plate bearing.)'}
                 </p>
                 <Num label="Concrete f′c" unit="MPa" value={fc} onChange={setFc} step="0.5" />
                 <Num label="Steel fy" unit="MPa" value={fy} onChange={setFy} step="5" />
@@ -1863,6 +1959,9 @@ export default function ModelSpace() {
           ['Model', `${model?.nodes.length ?? 0} nodes · ${model?.members.length ?? 0} members · ${model?.plates.length ?? 0} slabs · ${(model?.walls ?? []).length} walls · ${model?.supports.length ?? 0} supports`],
           ['Governing case', design.govName],
           ['Concrete', `${f1(design.totals.concrete)} m³ (${f1(design.totals.concreteMembers)} members + ${f1(design.totals.concreteSlabs)} slabs)`],
+          ...(design.totals.steelKg > 0
+            ? [['Structural steel', `${f1(design.totals.steelKg)} kg (${f2(design.totals.steelKg / 1000)} t)`] as [string, string]]
+            : []),
         ]
         return (
         <div className={`mt-6 space-y-6 ${tablesHidden ? 'report-no-tables' : ''}`}>
@@ -2217,6 +2316,124 @@ export default function ModelSpace() {
               <p className="mt-1 text-[11px] text-slate-400">
                 NSCP §418.10: Vn = Acv(αc·λ√f′c + ρt·fy), φ = 0.75, capped at 0.83·Acv·√f′c. In-plane shear from the
                 enveloped strut forces; distributed web steel ρt, ρℓ ≥ 0.0025. Flexural boundary reinforcement designed separately.
+              </p>
+            </div>
+          )}
+
+          {/* Steel beam schedule (full width) — only when steel members exist */}
+          {design.steelBeams.length > 0 && (
+            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Steel beam / girder schedule — AISC 360-16 LRFD</h3>
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
+                    <th className="py-1 pr-2 font-semibold">Member</th>
+                    <th className="py-1 pr-2 font-semibold">Shape</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Mu (kN·m)</th>
+                    <th className="py-1 pr-2 text-right font-semibold">φMn</th>
+                    <th className="py-1 pr-2 font-semibold">LTB</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Vu (kN)</th>
+                    <th className="py-1 pr-2 text-right font-semibold">φVn</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Util</th>
+                    <th className="py-1 font-semibold">Case</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {design.steelBeams.map((b) => (
+                    <tr key={b.id} className={`sched-row border-t border-slate-100 ${b.ok ? '' : 'bg-red-50 text-red-700'}`}>
+                      <td className="py-1 pr-2 font-medium">{b.id}</td>
+                      <td className="py-1 pr-2">{b.shape}</td>
+                      <td className="py-1 pr-2 text-right">{f1(b.Mu)}</td>
+                      <td className="py-1 pr-2 text-right">{f1(b.phiMn)}</td>
+                      <td className="py-1 pr-2">{b.ltbZone}</td>
+                      <td className="py-1 pr-2 text-right">{f1(b.Vu)}</td>
+                      <td className="py-1 pr-2 text-right">{f1(b.phiVn)}</td>
+                      <td className="py-1 pr-2 text-right">{(Math.max(b.utilM, b.utilV) * 100).toFixed(0)}%</td>
+                      <td className="py-1 text-[11px] text-slate-500">{b.gov}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <p className="mt-1 text-[11px] text-slate-400">
+                §F2 flexure (Lb = full member length, conservative; Cb = 1.0), §G2.1 shear. Util = max(Mu/φMn, Vu/φVn).
+              </p>
+            </div>
+          )}
+
+          {/* Steel column schedule (full width) */}
+          {design.steelColumns.length > 0 && (
+            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Steel column schedule — AISC §E3 + §H1-1</h3>
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
+                    <th className="py-1 pr-2 font-semibold">Column</th>
+                    <th className="py-1 pr-2 font-semibold">Shape</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Pu (kN)</th>
+                    <th className="py-1 pr-2 text-right font-semibold">φPn</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Mu (kN·m)</th>
+                    <th className="py-1 pr-2 text-right font-semibold">KL/r</th>
+                    <th className="py-1 pr-2 font-semibold">Eq.</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Ratio</th>
+                    <th className="py-1 font-semibold">Case</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {design.steelColumns.map((c) => (
+                    <tr key={c.id} className={`sched-row border-t border-slate-100 ${c.ok ? '' : 'bg-red-50 text-red-700'}`}>
+                      <td className="py-1 pr-2 font-medium">{c.id}</td>
+                      <td className="py-1 pr-2">{c.shape}</td>
+                      <td className="py-1 pr-2 text-right">{f1(c.Pu)}</td>
+                      <td className="py-1 pr-2 text-right">{f1(c.phiPn)}</td>
+                      <td className="py-1 pr-2 text-right">{f1(c.Mu)}</td>
+                      <td className="py-1 pr-2 text-right">{c.slenderness.toFixed(0)}</td>
+                      <td className="py-1 pr-2">{c.equation}</td>
+                      <td className="py-1 pr-2 text-right">{(c.ratio * 100).toFixed(0)}%</td>
+                      <td className="py-1 text-[11px] text-slate-500">{c.gov}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <p className="mt-1 text-[11px] text-slate-400">
+                §E3 axial buckling (governing KL/r, K = 1.0), §H1-1 combined axial + flexure. Ratio ≤ 100% passes.
+              </p>
+            </div>
+          )}
+
+          {/* Base-plate schedule (full width) */}
+          {design.basePlates.length > 0 && (
+            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Base-plate schedule — AISC §J8 / Design Guide 1</h3>
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
+                    <th className="py-1 pr-2 font-semibold">Node</th>
+                    <th className="py-1 pr-2 font-semibold">Column</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Pu (kN)</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Tu (kN)</th>
+                    <th className="py-1 pr-2 font-semibold">Plate B×N×t (mm)</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Bearing</th>
+                    <th className="py-1 font-semibold">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {design.basePlates.map((p) => (
+                    <tr key={p.node} className={`sched-row border-t border-slate-100 ${p.ok ? '' : 'bg-red-50 text-red-700'}`}>
+                      <td className="py-1 pr-2 font-medium">{p.node}</td>
+                      <td className="py-1 pr-2">{p.shape}</td>
+                      <td className="py-1 pr-2 text-right">{f1(p.Pu)}</td>
+                      <td className="py-1 pr-2 text-right">{p.Tu > 0 ? f1(p.Tu) : '—'}</td>
+                      <td className="py-1 pr-2">{f1(p.design.B)} × {f1(p.design.N)} × {p.tAdopt}</td>
+                      <td className="py-1 pr-2 text-right">{(p.design.bearingUtil * 100).toFixed(0)}%</td>
+                      <td className="py-1">{p.ok ? '✓ OK' : '✗ check'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <p className="mt-1 text-[11px] text-slate-400">
+                Bearing §J8: φc·0.85f′c·√(A2/A1), φc = 0.65. Plate thickness from cantilever bending
+                t = ℓ√(2fp/(0.9Fy)); ℓ = max(m, n, n′). Uplift sizes anchor rods (φt·0.75·Fu).
+                Adopted t rounded to plate stock.
               </p>
             </div>
           )}


### PR DESCRIPTION
The 3D model space (`/model`) can now build **structural steel (AISC W)** frames as well as reinforced concrete. Concrete stays the default and its design path is completely unchanged — the steel path is additive, so every existing schedule, drawing, report and test is intact.

## How to use
Properties tab → **Frame material** → *Structural steel (AISC W)* → pick per-role W-shapes (column / girder / beam) + steel grade → **Generate model**. The 3D view extrudes each member's true cross-section; the Design report adds steel + base-plate schedules.

## What's added

### Model + FEM
- `RectSection` gains optional `material` / `shape` / `steelFy` / `steelFu` (absent ⇒ concrete, fully back-compatible)
- `modelBridge`: steel members use AISC **A / Ix / Iy / J** and **E = 200 GPa** (`steelSectionProps`) so the frame solve is correct

### Design pipeline (reuses the existing `steelDesign` engine)
- Steel **beams/girders** → §F2 flexure + §G2.1 shear (`designSteelBeamRow`, Lb = full length, conservative)
- Steel **columns** → §E3 axial buckling + §H1-1 combined (`designSteelColumnRow`)
- **Base plates** designed under every steel column support
- Additive `StructureDesign` fields `steelBeams` / `steelColumns` / `basePlates` + `totals.steelKg`; `designOK` / `countFails` updated

### New engine — `baseplate.ts` (AISC 360-16 §J8 / Design Guide 1, LRFD)
- Concrete bearing φc·0.85f′c·√(A2/A1), √ ratio capped at 2.0, φc = 0.65
- DG1 plan sizing (Δ, N, B), cantilevers m / n / n′
- Required thickness t = ℓ·√(2fp/(0.9Fy)), rounded to plate stock
- Anchor-rod uplift sizing (φt·0.75·Fu, A307 / F1554 / A325M)
- **10 unit tests**

### UI (`ModelSpace`)
- Frame-material toggle + per-role W-shape pickers + Fy/Fu (persisted)
- `MemberSteel3D` extrudes the real cross-section (same proven path as the Steel Design page)
- Design report: steel beam, steel column and base-plate schedules; structural-steel tonnage in the inputs/totals

## Tests
- New: 10 baseplate + 5 steel-pipeline (routing, φMn/φVn, §H1-1, base plates, tonnage)
- **330 passing** (was 315); `tsc -b` clean; `npm run build` OK

## Scope notes (verified honestly)
- Slabs and footings remain reinforced concrete (steel frame on RC slab/footing is the realistic case).
- **Optimizer** currently only grows concrete sections; for an all-steel model it reports pass/fail but won't auto-resize shapes — flagged as the next phase (shape-ladder search).
- Structural-steel **BOM line items** in the costed take-off are a follow-up (tonnage is already reported in totals).
- 3D verified via the shared `buildSectionShapes` + `extrudeGeometry` path already in production on `/steel`; per the repo's WebGL caveat, engine correctness is covered by unit tests rather than canvas pixels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_