### PR TITLE
chore(build): harden production bundle (phase 1 of engine protection)

### DIFF
--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -8,16 +8,26 @@ import tailwindcss from '@tailwindcss/vite'
 // go under /static (not /assets) to avoid colliding with the legacy
 // /assets mount, so the old .html pages keep working alongside it.
 // https://vite.dev/config/
-export default defineConfig({
+//
+// `command` is 'build' for production (`vite build`) and 'serve' for dev and
+// for the Vitest run, so the production-only hardening below never affects dev
+// ergonomics or the test pipeline.
+export default defineConfig(({ command }) => ({
   base: '/',
   plugins: [react(), tailwindcss()],
+  // Production hardening: strip console/debugger so the shipped engine bundle
+  // leaks nothing at runtime and is harder to read. Source maps are off (the
+  // default, set explicitly) so the original TypeScript is never published.
+  esbuild: command === 'build' ? { drop: ['console', 'debugger'] } : {},
   build: {
     outDir: '../public/app',
     assetsDir: 'static',
     emptyOutDir: true,
+    sourcemap: false,
+    minify: 'esbuild',
   },
   test: {
     environment: 'node',
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
   },
-})
+}))


### PR DESCRIPTION
## Summary

Phase 1 of protecting the calculation engine for public deployment — **build hardening**.

Production builds now:
- **Emit no source maps** (`build.sourcemap: false`, explicit) — the original TypeScript engine is never published alongside the bundle.
- **Strip all `console`/`debugger` statements** via esbuild `drop`.
- Both are scoped to `vite build` only (via the `command` guard), so **dev and the Vitest pipeline are unaffected**.

### Honest scope note
This is a **deterrent, not a lock**. Client-side JavaScript can always be reverse-engineered. Real protection for the crown-jewel solvers comes in **Phase 2 (hybrid server-side API)** — see below.

## Verification
- [x] `npx tsc -b` — clean
- [x] `npm test` — 330 passing
- [x] `npm run build` — succeeds; **0 source-map files emitted**; **0 of our `console.*` calls survive** (one remaining hit is a vendored library's `console.error` fallback reference, not a call statement, and carries none of our logic)

## Next phase (needs your input)
Phase 2 = move the highest-value solvers behind an API on the existing Express backend (`src/backend/`). Key open question: **where this deploys** — current `firebase.json` is static Hosting only, so server-side calc needs Cloud Functions/Run + a rewrite, or hosting the Express app elsewhere. I'll confirm the target with you before building it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_