### PR TITLE
feat(api): protected calculation API service — Phase 2a (steel solvers)

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.log

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,51 @@
+# civeng-calc-api — protected calculation service
+
+The structural-design **engine runs here, server-side**, so it is never shipped
+to the browser. The SPA (hosted statically on Firebase) posts inputs to these
+endpoints cross-origin and renders the returned results. This is the real
+protection layer: clients can use the calculator but cannot read the code.
+
+> The engine source lives in `../webapp/src/engine`. The build **bundles** the
+> needed solver modules into a single `dist/server.js` (via esbuild), so the
+> deployed artifact is self-contained and does not need the webapp source.
+
+## Endpoints
+
+| Method | Path                | Body                                                  | Returns                       |
+| ------ | ------------------- | ----------------------------------------------------- | ----------------------------- |
+| GET    | `/health`           | —                                                     | `{ ok: true }`                |
+| POST   | `/api/steel/beam`   | `{ shapeName, Fy, span, Lb, Cb, wDead, wLive }`       | `{ props, flex, shear, loads }` |
+| POST   | `/api/steel/column` | `{ shapeName, Fy, L, Kx, Ky }`                        | `{ props, axial, weak }`      |
+
+More solvers (RC pipeline, frame3d, baseplate, take-off, truss) are added in
+later phases — see `HANDOFF.md`.
+
+## Local dev
+
+```bash
+cd api
+npm install
+npm run dev        # tsx watch, http://localhost:8080
+npm test           # vitest + supertest
+npm run typecheck  # tsc --noEmit
+npm run build      # esbuild bundle → dist/server.js
+npm start          # node dist/server.js
+```
+
+## Environment
+
+| Var              | Purpose                                                              |
+| ---------------- | ------------------------------------------------------------------- |
+| `PORT`           | Port to bind (injected by Render/Railway/Fly; defaults to 8080).    |
+| `ALLOWED_ORIGIN` | Comma-separated origins for CORS lock-down. Unset ⇒ reflect any.    |
+
+## Deploy to a separate Node host (Render / Railway / Fly.io)
+
+The service is a standard Node app. On any of these platforms:
+
+- **Build command:** `npm install && npm run build`
+- **Start command:** `npm start`
+- **Set** `ALLOWED_ORIGIN` to your SPA origin (e.g. `https://<project>.web.app`).
+
+Then point the SPA at it by setting `VITE_API_URL=https://<your-api-host>` in the
+webapp build environment before `npm --prefix webapp run build`.

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "civeng-calc-api",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Protected calculation API — the structural-design engine runs here, server-side, so it is never shipped to the browser.",
+  "type": "module",
+  "main": "dist/server.js",
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "start": "node dist/server.js",
+    "build": "esbuild src/server.ts --bundle --platform=node --format=esm --target=node22 --packages=external --outfile=dist/server.js",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/node": "^22.10.0",
+    "@types/supertest": "^6.0.2",
+    "esbuild": "^0.24.0",
+    "supertest": "^7.0.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.8"
+  }
+}

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,0 +1,24 @@
+import express from 'express'
+import cors from 'cors'
+import { steelRouter } from './routes/steel'
+
+// The Express app, exported without listening so tests can drive it in-process
+// (see routes/*.test.ts) and server.ts can bind it to a port for deployment.
+export function createApp() {
+  const app = express()
+
+  // CORS: the SPA is hosted on a different origin (e.g. Firebase) and calls this
+  // API cross-origin. ALLOWED_ORIGIN locks it down in production (comma-separated
+  // list); unset reflects any origin, convenient for local dev.
+  const allowed = process.env.ALLOWED_ORIGIN
+  app.use(cors(allowed ? { origin: allowed.split(',').map((o) => o.trim()) } : {}))
+
+  app.use(express.json({ limit: '256kb' }))
+
+  app.get('/health', (_req, res) => res.json({ ok: true }))
+  app.use('/api/steel', steelRouter)
+
+  return app
+}
+
+export const app = createApp()

--- a/api/src/routes/steel.test.ts
+++ b/api/src/routes/steel.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import { app } from '../app'
+
+describe('POST /api/steel/beam', () => {
+  const body = { shapeName: 'W310x38.7', Fy: 345, span: 6, Lb: 2, Cb: 1, wDead: 15, wLive: 25 }
+
+  it('returns the full design result set for a valid request', async () => {
+    const res = await request(app).post('/api/steel/beam').send(body)
+    expect(res.status).toBe(200)
+    expect(res.body.props.Ix).toBeGreaterThan(0)
+    expect(res.body.flex.phiMn).toBeGreaterThan(0)
+    expect(res.body.shear.phiVn).toBeGreaterThan(0)
+    expect(res.body.loads.Mu).toBeGreaterThan(0)
+    // Server result must equal the client engine for the same inputs (no drift).
+    expect(res.body.loads.wu).toBeCloseTo(Math.max(1.4 * 15, 1.2 * 15 + 1.6 * 25), 6)
+  })
+
+  it('rejects an unknown shape with 400', async () => {
+    const res = await request(app).post('/api/steel/beam').send({ ...body, shapeName: 'W999x999' })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/Unknown shape/)
+  })
+
+  it('rejects non-numeric inputs with 400', async () => {
+    const res = await request(app).post('/api/steel/beam').send({ ...body, span: 'six' })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('POST /api/steel/column', () => {
+  it('returns axial + weak-axis results for a valid request', async () => {
+    const res = await request(app)
+      .post('/api/steel/column')
+      .send({ shapeName: 'W250x67', Fy: 345, L: 4, Kx: 1, Ky: 1 })
+    expect(res.status).toBe(200)
+    expect(res.body.axial.phiPn).toBeGreaterThan(0)
+    expect(res.body.axial.slenderness).toBeGreaterThan(0)
+    expect(res.body.weak.phiMny).toBeGreaterThan(0)
+  })
+})
+
+describe('GET /health', () => {
+  it('reports ok', async () => {
+    const res = await request(app).get('/health')
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+  })
+})

--- a/api/src/routes/steel.ts
+++ b/api/src/routes/steel.ts
@@ -1,0 +1,48 @@
+import { Router } from 'express'
+import { shapeByName } from '../../../webapp/src/engine/aiscSections'
+import {
+  deriveWSection,
+  beamFlexure,
+  beamShear,
+  beamLoadingSimple,
+  columnAxial,
+  weakAxisFlexure,
+} from '../../../webapp/src/engine/steelDesign'
+
+// Protected AISC 360-16 LRFD steel solvers. The engine modules above are bundled
+// into this service at build time and run server-side only — they are never sent
+// to the browser. The SPA posts inputs here and renders the returned results.
+export const steelRouter = Router()
+
+const allNumbers = (vals: unknown[]) =>
+  vals.every((v) => typeof v === 'number' && Number.isFinite(v))
+
+// POST /api/steel/beam — §F2 flexure, §G2.1 shear, service deflection.
+// Mirrors the synchronous logic the BeamTab used to run client-side.
+steelRouter.post('/beam', (req, res) => {
+  const { shapeName, Fy, span, Lb, Cb, wDead, wLive } = req.body ?? {}
+  const shape = typeof shapeName === 'string' ? shapeByName(shapeName) : undefined
+  if (!shape) return res.status(400).json({ error: `Unknown shape: ${String(shapeName)}` })
+  if (!allNumbers([Fy, span, Lb, Cb, wDead, wLive]))
+    return res.status(400).json({ error: 'Fy, span, Lb, Cb, wDead, wLive must be finite numbers' })
+
+  const props = deriveWSection(shape)
+  const flex = beamFlexure(shape, props, Fy, Lb * 1000, Cb)
+  const shear = beamShear(shape, props, Fy)
+  const loads = beamLoadingSimple({ wDead, wLive, L: span }, props.Ix)
+  return res.json({ props, flex, shear, loads })
+})
+
+// POST /api/steel/column — §E3 axial Fcr (both axes) + §F6 weak-axis flexure.
+steelRouter.post('/column', (req, res) => {
+  const { shapeName, Fy, L, Kx, Ky } = req.body ?? {}
+  const shape = typeof shapeName === 'string' ? shapeByName(shapeName) : undefined
+  if (!shape) return res.status(400).json({ error: `Unknown shape: ${String(shapeName)}` })
+  if (!allNumbers([Fy, L, Kx, Ky]))
+    return res.status(400).json({ error: 'Fy, L, Kx, Ky must be finite numbers' })
+
+  const props = deriveWSection(shape)
+  const axial = columnAxial(shape, Fy, L, Kx, Ky)
+  const weak = weakAxisFlexure(shape, props, Fy)
+  return res.json({ props, axial, weak })
+})

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -1,0 +1,8 @@
+import { app } from './app'
+
+// Bind to the host-provided port (Render/Railway/Fly all inject PORT) on all
+// interfaces. This is the entry point for the deployed Node service.
+const PORT = Number(process.env.PORT) || 8080
+app.listen(PORT, () => {
+  console.log(`[calc-api] listening on :${PORT}`)
+})

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "verbatimModuleSyntax": false
+  },
+  "include": ["src/**/*.ts", "../webapp/src/engine/**/*.ts"]
+}

--- a/webapp/src/lib/calcApi.ts
+++ b/webapp/src/lib/calcApi.ts
@@ -1,0 +1,63 @@
+// Client for the protected calculation API. The structural-design solvers run
+// server-side (see /api), so this module ships only fetch calls — never the
+// engine logic. Types below are `import type` only: TypeScript erases them at
+// build time, so importing them from the engine does NOT bundle any engine code
+// into the browser. Keep it that way (no value imports from ../engine here).
+import type {
+  DerivedBeamProps,
+  BeamFlexureResult,
+  BeamShearResult,
+  BeamLoadsResult,
+  ColumnAxialResult,
+  WeakAxisResult,
+} from '../engine/steelDesign'
+
+// Base URL from the build env. Empty ⇒ same-origin (local dev / future
+// same-origin hosting); a full origin for the separate Node host in production.
+const BASE = import.meta.env.VITE_API_URL ?? ''
+
+async function post<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const detail = (await res.json().catch(() => null)) as { error?: string } | null
+    throw new Error(detail?.error ?? `Calculation API error (${res.status})`)
+  }
+  return (await res.json()) as T
+}
+
+export interface BeamCalcInput {
+  shapeName: string
+  Fy: number
+  span: number
+  Lb: number
+  Cb: number
+  wDead: number
+  wLive: number
+}
+export interface BeamCalcResult {
+  props: DerivedBeamProps
+  flex: BeamFlexureResult
+  shear: BeamShearResult
+  loads: BeamLoadsResult
+}
+export const calcBeam = (input: BeamCalcInput) =>
+  post<BeamCalcResult>('/api/steel/beam', input)
+
+export interface ColumnCalcInput {
+  shapeName: string
+  Fy: number
+  L: number
+  Kx: number
+  Ky: number
+}
+export interface ColumnCalcResult {
+  props: DerivedBeamProps
+  axial: ColumnAxialResult
+  weak: WeakAxisResult
+}
+export const calcColumn = (input: ColumnCalcInput) =>
+  post<ColumnCalcResult>('/api/steel/column', input)

--- a/webapp/src/vite-env.d.ts
+++ b/webapp/src/vite-env.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** Base URL of the protected calculation API (e.g. https://calc-api.onrender.com).
+   *  Empty string ⇒ same-origin. Set per-deploy in the build environment. */
+  readonly VITE_API_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## What this is

Phase 2a of protecting the calculation engine for public deployment. A new `api/` Express/TypeScript service runs the structural-design solvers **server-side** — they are bundled into `dist/server.js` at deploy time and **never shipped to the browser**. The SPA posts inputs and renders the returned results.

## New endpoints

| Method | Path | Body | Returns |
|--------|------|------|---------|
| GET | `/health` | — | `{ ok: true }` |
| POST | `/api/steel/beam` | `{ shapeName, Fy, span, Lb, Cb, wDead, wLive }` | `{ props, flex, shear, loads }` |
| POST | `/api/steel/column` | `{ shapeName, Fy, L, Kx, Ky }` | `{ props, axial, weak }` |

## Architecture decisions

- **Engine bundled server-side** via esbuild — `dist/server.js` is 43 kB; the SPA gets only typed fetch calls (`webapp/src/lib/calcApi.ts`), which use `import type` only so zero engine code leaks into the browser bundle.
- **CORS locked** to `ALLOWED_ORIGIN` env var in production (comma-separated origins); unset = any origin for local dev.
- **`VITE_API_URL`** env var wires the SPA to the live API base URL at webapp build time; declared in `vite-env.d.ts` for strict typing.
- **Drawing helpers stay client-side** (`SectionShape`, `lib/sectionShapes3d`, etc.) — they are pure geometry with no proprietary design logic, and must stay synchronous for live canvas/3D updates.

## Tests

- [x] 5 new API tests (`supertest` + `vitest`) covering valid inputs, unknown shape, non-numeric inputs, health check
- [x] 330 existing SPA tests still pass, typecheck clean on both packages
- [x] `npm run build` in `api/` produces a clean standalone bundle

## Deploy (see `api/README.md`)

Point any Node host (Render / Railway / Fly.io) at `api/`:
- Build: `npm install && npm run build`
- Start: `npm start`
- Set `ALLOWED_ORIGIN=https://<your-spa>.web.app`
- Set `VITE_API_URL=https://<your-api-host>` in the webapp build env before `npm --prefix webapp run build`

## Next phase (Phase 2b)

Wire the live pages (`SteelDesign.tsx`, `ModelSpace.tsx`, `TrussSpace.tsx`, …) to call these endpoints instead of importing from the engine directly. The engine imports are dropped from those pages; the browser bundle shrinks accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_