### PR TITLE
fix: add vercel.json SPA rewrite for client-side routing

### DIFF
--- a/webapp/vercel.json
+++ b/webapp/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## Summary

- Adds `webapp/vercel.json` with a catch-all rewrite so Vercel serves `index.html` for every path, letting React Router handle routing client-side.
- Without this, any direct navigation or page refresh to a route like `/steel`, `/concrete`, etc. returns a Vercel 404 instead of loading the app.

## Root cause

Vercel's static hosting looks for a matching file (e.g. `/steel.html`) — when none exists it returns 404. The rewrite rule fixes this by falling back to `index.html` for all unmatched paths.

## Test plan
- [ ] Merge and let Vercel redeploy
- [ ] Navigate to `/steel` directly in the browser — page should load
- [ ] Refresh while on `/steel` — should not 404
- [ ] Steel Design API calls should resolve (no more "API error" badge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_