### PR TITLE
feat: navbar dropdown navigation + landing-page home

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,5 +1,8 @@
-import { lazy, Suspense } from 'react'
-import { Routes, Route, Link } from 'react-router-dom'
+import { lazy, Suspense, useState } from 'react'
+import { Routes, Route } from 'react-router-dom'
+import { Navbar } from './components/Navbar'
+import { AuthModal } from './components/AuthModal'
+import Home from './pages/Home'
 import FoundationDesign from './pages/FoundationDesign'
 import PileCapDesign from './pages/PileCapDesign'
 import CombinedFootingDesign from './pages/CombinedFootingDesign'
@@ -8,6 +11,7 @@ import BeamAnalysis from './pages/BeamAnalysis'
 import ColumnDesign from './pages/ColumnDesign'
 import FrameAnalysis from './pages/FrameAnalysis'
 import LoadPath from './pages/LoadPath'
+// three.js is heavy — the 3D pages load in their own lazy chunks.
 const ModelSpace = lazy(() => import('./pages/ModelSpace'))
 const TrussSpace = lazy(() => import('./pages/TrussSpace'))
 import SteelDesign from './pages/SteelDesign'
@@ -17,126 +21,14 @@ import ColumnEstimate from './pages/ColumnEstimate'
 import BeamEstimate from './pages/BeamEstimate'
 import BoxCulvertEstimate from './pages/BoxCulvertEstimate'
 
-// ─── Navbar ───────────────────────────────────────────────────────────────────
-
-function Navbar() {
-  return (
-    <nav className="sticky top-0 z-50 flex h-11 items-center gap-3 border-b border-white/10 bg-black px-5">
-      <Link to="/" className="flex items-center gap-2.5">
-        <span className="text-[11px] font-black tracking-[0.2em] text-white uppercase">CivEng</span>
-        <span className="hidden h-3.5 w-px bg-white/20 sm:block" />
-        <span className="hidden text-[10px] tracking-wide text-slate-500 sm:block">Structural Toolkit</span>
-      </Link>
-      <div className="ml-auto flex items-center gap-4">
-        <span className="hidden text-[9px] font-bold tracking-widest text-slate-600 uppercase sm:block">NSCP 2015</span>
-        <span className="hidden text-[9px] font-bold tracking-widest text-slate-600 uppercase sm:block">ACI 318-14</span>
-        <span className="hidden text-[9px] font-bold tracking-widest text-slate-600 uppercase sm:block">AISC 360</span>
-      </div>
-    </nav>
-  )
-}
-
-// ─── Home ─────────────────────────────────────────────────────────────────────
-
-interface ToolDef { to: string; name: string; sub: string }
-
-const DESIGN_TOOLS: ToolDef[] = [
-  { to: '/foundation',    name: 'Foundation Design',  sub: 'Isolated pad · NSCP 2015'  },
-  { to: '/pile-cap',      name: 'Pile Cap Design',    sub: 'Group pile cap'             },
-  { to: '/combined',      name: 'Combined Footing',   sub: 'Rectangular / trapezoidal' },
-  { to: '/beam-design',   name: 'Beam Design',        sub: 'RC beam · ACI 318-14'      },
-  { to: '/beam-analysis', name: 'Beam Analysis',      sub: 'FEM multi-span solver'     },
-  { to: '/column-design', name: 'Column Design',      sub: 'RC column · biaxial'       },
-  { to: '/frame',         name: 'Frame Analysis',     sub: '2D stiffness method'       },
-  { to: '/load-path',     name: 'Slab Load Path',     sub: 'Two-way tributary'         },
-  { to: '/model',         name: '3D Model Space',     sub: 'BIM-lite viewer'           },
-  { to: '/truss',         name: 'Truss Space',        sub: 'Plane truss solver'        },
-  { to: '/steel',         name: 'Steel Design',       sub: 'AISC 360-16 LRFD'         },
-]
-
-const ESTIMATE_TOOLS: ToolDef[] = [
-  { to: '/estimate/slab',        name: 'Slab',        sub: 'Concrete + rebar'  },
-  { to: '/estimate/beam',        name: 'Beam',        sub: 'Volume & weight'   },
-  { to: '/estimate/column',      name: 'Column',      sub: 'Concrete + rebar'  },
-  { to: '/estimate/chb',         name: 'CHB Wall',    sub: 'Block count'       },
-  { to: '/estimate/box-culvert', name: 'Box Culvert', sub: 'Culvert estimate'  },
-]
-
-function ToolCard({ to, name, sub }: ToolDef) {
-  return (
-    <Link to={to}
-      className="group flex flex-col border border-slate-200 bg-white p-5 transition-colors duration-100 hover:border-[#0056b3] hover:bg-[#f4f8ff]">
-      <span className="text-[9px] font-bold uppercase tracking-widest text-slate-400 group-hover:text-[#0056b3]">
-        {sub}
-      </span>
-      <span className="mt-1.5 text-sm font-semibold text-slate-800">{name}</span>
-      <span className="mt-4 text-xs text-slate-300 group-hover:text-[#0056b3]">→</span>
-    </Link>
-  )
-}
-
-function ToolSection({ label, tools }: { label: string; tools: ToolDef[] }) {
-  return (
-    <section>
-      <div className="mb-3 flex items-center gap-4">
-        <span className="text-[9px] font-bold uppercase tracking-[0.18em] text-slate-400">{label}</span>
-        <div className="h-px flex-1 bg-slate-200" />
-      </div>
-      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
-        {tools.map(t => <ToolCard key={t.to} {...t} />)}
-      </div>
-    </section>
-  )
-}
-
-function Home() {
-  return (
-    <div className="min-h-screen bg-slate-50">
-      {/* Hero */}
-      <div className="border-b border-slate-200 bg-white">
-        <div className="mx-auto max-w-5xl px-6 py-14">
-          <div className="flex items-stretch gap-5">
-            <div className="w-[3px] bg-[#0056b3]" />
-            <div>
-              <p className="text-[9px] font-bold uppercase tracking-[0.22em] text-[#0056b3]">
-                Philippines · NSCP 2015 · ACI 318-14 · AISC 360-16
-              </p>
-              <h1 className="mt-3 text-4xl font-black leading-none tracking-tight text-slate-900 sm:text-5xl">
-                Civil Engineering<br />Toolkit
-              </h1>
-              <p className="mt-4 max-w-lg text-sm leading-relaxed text-slate-500">
-                Structural design solvers and material take-off estimators built on a typed
-                calculation engine. Every tool computes live and outputs a printable report.
-              </p>
-              <div className="mt-6 flex items-center gap-6 text-xs text-slate-400">
-                <span><strong className="text-slate-700">11</strong> design tools</span>
-                <div className="h-3 w-px bg-slate-200" />
-                <span><strong className="text-slate-700">5</strong> estimators</span>
-                <div className="h-3 w-px bg-slate-200" />
-                <span><strong className="text-slate-700">Server-side</strong> solvers</span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Tool grid */}
-      <div className="mx-auto max-w-5xl space-y-10 px-6 py-10">
-        <ToolSection label="Structural Design" tools={DESIGN_TOOLS} />
-        <ToolSection label="Quantity Take-Off" tools={ESTIMATE_TOOLS} />
-      </div>
-    </div>
-  )
-}
-
-// ─── App ──────────────────────────────────────────────────────────────────────
-
 export default function App() {
+  const [auth, setAuth] = useState<'login' | 'signup' | null>(null)
+
   return (
     <>
-      <Navbar />
+      <Navbar onAuth={setAuth} />
       <Routes>
-        <Route path="/" element={<Home />} />
+        <Route path="/" element={<Home onAuth={setAuth} />} />
         <Route path="/foundation" element={<FoundationDesign />} />
         <Route path="/pile-cap" element={<PileCapDesign />} />
         <Route path="/combined" element={<CombinedFootingDesign />} />
@@ -162,6 +54,7 @@ export default function App() {
         <Route path="/estimate/chb" element={<ChbEstimate />} />
         <Route path="/estimate/box-culvert" element={<BoxCulvertEstimate />} />
       </Routes>
+      {auth && <AuthModal mode={auth} onClose={() => setAuth(null)} />}
     </>
   )
 }

--- a/webapp/src/components/AuthModal.tsx
+++ b/webapp/src/components/AuthModal.tsx
@@ -1,0 +1,44 @@
+import { useEffect } from 'react'
+
+// Lightweight auth dialog. Accounts aren't wired to a backend yet, so this is
+// an honest "coming soon" placeholder rather than a non-functional form.
+export function AuthModal({ mode, onClose }: { mode: 'login' | 'signup'; onClose: () => void }) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const isSignup = mode === 'signup'
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 p-4" onClick={onClose}>
+      <div className="w-full max-w-sm border border-slate-200 bg-white" onClick={e => e.stopPropagation()}>
+        <div className="flex items-center justify-between border-b border-slate-100 px-5 py-3">
+          <span className="text-sm font-bold uppercase tracking-wider text-slate-800">
+            {isSignup ? 'Create account' : 'Log in'}
+          </span>
+          <button onClick={onClose} className="text-slate-400 hover:text-slate-700">✕</button>
+        </div>
+        <div className="space-y-3 p-5">
+          <label className="flex flex-col text-xs font-medium text-slate-600">
+            Email
+            <input type="email" disabled placeholder="you@example.com"
+              className="mt-1 cursor-not-allowed bg-slate-50 text-slate-400" />
+          </label>
+          <label className="flex flex-col text-xs font-medium text-slate-600">
+            Password
+            <input type="password" disabled placeholder="••••••••"
+              className="mt-1 cursor-not-allowed bg-slate-50 text-slate-400" />
+          </label>
+          <div className="border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+            Accounts &amp; saved projects are coming soon. All tools work without an account today.
+          </div>
+          <button disabled
+            className="w-full cursor-not-allowed bg-slate-300 px-4 py-2 text-sm font-semibold text-white">
+            {isSignup ? 'Sign up' : 'Log in'} — soon
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/webapp/src/components/Navbar.tsx
+++ b/webapp/src/components/Navbar.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { TOOL_CATEGORIES, type ToolCategory } from '../lib/tools'
+
+// Flat, sharp-cornered top navigation. Tool calculators live in category
+// dropdowns; auth actions sit on the right. Hidden in print via `no-print`.
+
+function Dropdown({ category, open, onToggle, onClose }: {
+  category: ToolCategory
+  open: boolean
+  onToggle: () => void
+  onClose: () => void
+}) {
+  return (
+    <div className="relative">
+      <button onClick={onToggle}
+        className={`flex h-11 items-center gap-1.5 px-3 text-xs font-semibold tracking-wide transition-colors ${
+          open ? 'bg-white/10 text-white' : 'text-slate-300 hover:text-white'}`}>
+        {category.label}
+        <span className={`text-[8px] transition-transform ${open ? 'rotate-180' : ''}`}>▼</span>
+      </button>
+      {open && (
+        <div className="absolute left-0 top-11 z-50 w-64 border border-slate-200 bg-white shadow-xl">
+          {category.tools.map(t => (
+            <Link key={t.to} to={t.to} onClick={onClose}
+              className="group flex flex-col border-b border-slate-100 px-4 py-2.5 last:border-0 hover:bg-[#f4f8ff]">
+              <span className="text-sm font-medium text-slate-800 group-hover:text-[#0056b3]">{t.name}</span>
+              <span className="text-[10px] uppercase tracking-wider text-slate-400">{t.sub}</span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function Navbar({ onAuth }: { onAuth: (mode: 'login' | 'signup') => void }) {
+  const [openIdx, setOpenIdx] = useState<number | null>(null)
+  const [mobileOpen, setMobileOpen] = useState(false)
+  const ref = useRef<HTMLElement>(null)
+
+  // Close any open dropdown on outside click or Escape.
+  useEffect(() => {
+    const onDoc = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpenIdx(null)
+    }
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') { setOpenIdx(null); setMobileOpen(false) } }
+    document.addEventListener('mousedown', onDoc)
+    document.addEventListener('keydown', onKey)
+    return () => { document.removeEventListener('mousedown', onDoc); document.removeEventListener('keydown', onKey) }
+  }, [])
+
+  return (
+    <nav ref={ref} className="no-print sticky top-0 z-50 border-b border-white/10 bg-black">
+      <div className="flex h-11 items-center px-4 sm:px-5">
+        <Link to="/" onClick={() => setOpenIdx(null)} className="flex items-center gap-2.5">
+          <span className="text-[11px] font-black uppercase tracking-[0.2em] text-white">CivEng</span>
+          <span className="hidden h-3.5 w-px bg-white/20 sm:block" />
+          <span className="hidden text-[10px] tracking-wide text-slate-500 sm:block">Structural Toolkit</span>
+        </Link>
+
+        {/* Desktop dropdowns */}
+        <div className="ml-6 hidden items-center md:flex">
+          {TOOL_CATEGORIES.map((c, i) => (
+            <Dropdown key={c.label} category={c}
+              open={openIdx === i}
+              onToggle={() => setOpenIdx(openIdx === i ? null : i)}
+              onClose={() => setOpenIdx(null)} />
+          ))}
+          <span className="flex h-11 cursor-default items-center px-3 text-xs font-semibold tracking-wide text-slate-600">
+            More <span className="ml-1.5 rounded-none bg-white/10 px-1 py-0.5 text-[8px] uppercase text-slate-400">soon</span>
+          </span>
+        </div>
+
+        {/* Auth (desktop) */}
+        <div className="ml-auto hidden items-center gap-2 md:flex">
+          <button onClick={() => onAuth('login')}
+            className="px-3 py-1.5 text-xs font-semibold text-slate-300 hover:text-white">
+            Log in
+          </button>
+          <button onClick={() => onAuth('signup')}
+            className="bg-[#0056b3] px-3.5 py-1.5 text-xs font-semibold text-white hover:bg-[#0066d6]">
+            Sign up
+          </button>
+        </div>
+
+        {/* Mobile toggle */}
+        <button onClick={() => setMobileOpen(o => !o)}
+          className="ml-auto flex h-8 w-8 items-center justify-center text-white md:hidden">
+          <span className="text-lg leading-none">{mobileOpen ? '✕' : '☰'}</span>
+        </button>
+      </div>
+
+      {/* Mobile panel */}
+      {mobileOpen && (
+        <div className="border-t border-white/10 bg-black px-4 pb-4 md:hidden">
+          {TOOL_CATEGORIES.map(c => (
+            <div key={c.label} className="py-2">
+              <p className="px-1 py-1.5 text-[9px] font-bold uppercase tracking-[0.18em] text-slate-500">{c.label}</p>
+              <div className="grid grid-cols-2 gap-1">
+                {c.tools.map(t => (
+                  <Link key={t.to} to={t.to} onClick={() => setMobileOpen(false)}
+                    className="border border-white/10 px-2.5 py-2 text-xs text-slate-200 hover:border-[#0056b3] hover:text-white">
+                    {t.name}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          ))}
+          <div className="mt-2 flex gap-2 border-t border-white/10 pt-3">
+            <button onClick={() => { setMobileOpen(false); onAuth('login') }}
+              className="flex-1 border border-white/15 px-3 py-2 text-xs font-semibold text-slate-200">Log in</button>
+            <button onClick={() => { setMobileOpen(false); onAuth('signup') }}
+              className="flex-1 bg-[#0056b3] px-3 py-2 text-xs font-semibold text-white">Sign up</button>
+          </div>
+        </div>
+      )}
+    </nav>
+  )
+}

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -1,0 +1,34 @@
+// Single source of truth for the app's tool catalog. Consumed by the navbar
+// dropdowns and the home page. Add new categories here as they ship.
+
+export interface ToolDef { to: string; name: string; sub: string }
+export interface ToolCategory { label: string; tools: ToolDef[] }
+
+export const TOOL_CATEGORIES: ToolCategory[] = [
+  {
+    label: 'Structural',
+    tools: [
+      { to: '/foundation',    name: 'Foundation Design',  sub: 'Isolated pad footing'  },
+      { to: '/pile-cap',      name: 'Pile Cap Design',    sub: 'Group pile cap'        },
+      { to: '/combined',      name: 'Combined Footing',   sub: 'Two-column footing'    },
+      { to: '/beam-design',   name: 'Beam Design',        sub: 'RC beam · ACI 318-14'  },
+      { to: '/beam-analysis', name: 'Beam Analysis',      sub: 'FEM multi-span'        },
+      { to: '/column-design', name: 'Column Design',      sub: 'RC column · biaxial'   },
+      { to: '/frame',         name: 'Frame Analysis',     sub: '2D stiffness method'   },
+      { to: '/load-path',     name: 'Slab Load Path',     sub: 'Two-way tributary'     },
+      { to: '/model',         name: '3D Model Space',     sub: 'BIM-lite viewer'       },
+      { to: '/truss',         name: 'Truss Space',        sub: 'Plane truss solver'    },
+      { to: '/steel',         name: 'Steel Design',       sub: 'AISC 360-16 LRFD'      },
+    ],
+  },
+  {
+    label: 'Quantity Take-Off',
+    tools: [
+      { to: '/estimate/slab',        name: 'Slab',        sub: 'Concrete + rebar' },
+      { to: '/estimate/beam',        name: 'Beam',        sub: 'Volume & weight'  },
+      { to: '/estimate/column',      name: 'Column',      sub: 'Concrete + rebar' },
+      { to: '/estimate/chb',         name: 'CHB Wall',    sub: 'Block count'      },
+      { to: '/estimate/box-culvert', name: 'Box Culvert', sub: 'Culvert estimate' },
+    ],
+  },
+]

--- a/webapp/src/pages/Home.tsx
+++ b/webapp/src/pages/Home.tsx
@@ -1,0 +1,141 @@
+import { Link } from 'react-router-dom'
+import { TOOL_CATEGORIES } from '../lib/tools'
+
+// Flat structural-frame line illustration — distributed load on a portal frame
+// with a hint of the bending diagram. Pure SVG, no assets, scales cleanly.
+function FrameIllustration() {
+  return (
+    <svg viewBox="0 0 320 240" className="h-full w-full" fill="none" stroke="currentColor">
+      {/* distributed load arrows */}
+      <g className="text-[#0056b3]" strokeWidth={1.5}>
+        {[40, 80, 120, 160, 200, 240, 280].map(x => (
+          <line key={x} x1={x} y1={22} x2={x} y2={48} markerEnd="url(#arrow)" />
+        ))}
+        <line x1={36} y1={22} x2={284} y2={22} strokeWidth={2} />
+      </g>
+      {/* portal frame */}
+      <g className="text-slate-800" strokeWidth={3} strokeLinecap="square">
+        <line x1={40} y1={50} x2={280} y2={50} />
+        <line x1={40} y1={50} x2={40} y2={200} />
+        <line x1={280} y1={50} x2={280} y2={200} />
+      </g>
+      {/* supports */}
+      <g className="text-slate-800" strokeWidth={2}>
+        <polygon points="40,200 28,216 52,216" className="fill-slate-800" />
+        <polygon points="280,200 268,216 292,216" className="fill-slate-800" />
+        <line x1={20} y1={216} x2={60} y2={216} />
+        <line x1={260} y1={216} x2={300} y2={216} />
+      </g>
+      {/* bending hint */}
+      <path d="M40 90 Q160 150 280 90" className="text-[#0056b3]" strokeWidth={1.5} strokeDasharray="4 4" />
+      <defs>
+        <marker id="arrow" markerWidth="6" markerHeight="6" refX="3" refY="5" orient="auto">
+          <path d="M0,0 L3,6 L6,0" className="fill-[#0056b3]" stroke="none" />
+        </marker>
+      </defs>
+    </svg>
+  )
+}
+
+interface Sample { to: string; tag: string; title: string; desc: string }
+const SAMPLES: Sample[] = [
+  { to: '/beam-design',   tag: 'ACI 318-14', title: 'RC Beam — flexure & shear',
+    desc: 'Size a 300×500 beam for Mu = 180 kN·m, get rebar and stirrup spacing with a worked solution.' },
+  { to: '/steel',         tag: 'AISC 360-16', title: 'Steel Beam — LRFD',
+    desc: 'Check a W-shape for §F2 flexure and §G2 shear with live utilization and a 3D section.' },
+  { to: '/frame',         tag: '2D FEM',      title: 'Portal Frame — analysis',
+    desc: 'Solve member forces and reactions on a 2D frame using the direct stiffness method.' },
+]
+
+export default function Home({ onAuth }: { onAuth: (mode: 'login' | 'signup') => void }) {
+  const toolCount = TOOL_CATEGORIES.reduce((n, c) => n + c.tools.length, 0)
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      {/* Hero */}
+      <section className="border-b border-slate-200 bg-white">
+        <div className="mx-auto grid max-w-6xl items-center gap-10 px-6 py-16 lg:grid-cols-[1.1fr_0.9fr] lg:py-24">
+          <div>
+            <p className="text-[10px] font-bold uppercase tracking-[0.22em] text-[#0056b3]">
+              NSCP 2015 · ACI 318-14 · AISC 360-16
+            </p>
+            <h1 className="mt-4 text-4xl font-black leading-[1.05] tracking-tight text-slate-900 sm:text-6xl">
+              Structural design,<br />computed live.
+            </h1>
+            <p className="mt-5 max-w-xl text-base leading-relaxed text-slate-500">
+              A suite of design solvers and material take-off estimators built on a typed
+              calculation engine. Every input recomputes instantly and exports a clean,
+              code-referenced report — no spreadsheets, no black boxes.
+            </p>
+            <div className="mt-8 flex flex-wrap items-center gap-3">
+              <Link to="/beam-design"
+                className="bg-[#0056b3] px-6 py-3 text-sm font-semibold text-white hover:bg-[#0066d6]">
+                Open a calculator →
+              </Link>
+              <button onClick={() => onAuth('signup')}
+                className="border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 hover:border-slate-800">
+                Create account
+              </button>
+            </div>
+            <div className="mt-10 flex items-center gap-7 text-xs text-slate-400">
+              <span><strong className="text-slate-800">{toolCount}</strong> tools</span>
+              <div className="h-3 w-px bg-slate-200" />
+              <span><strong className="text-slate-800">Server-side</strong> solvers</span>
+              <div className="h-3 w-px bg-slate-200" />
+              <span><strong className="text-slate-800">PDF</strong> reports</span>
+            </div>
+          </div>
+          <div className="flex items-center justify-center border border-slate-200 bg-slate-50 p-8">
+            <div className="h-64 w-full max-w-sm">
+              <FrameIllustration />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Standards strip */}
+      <section className="border-b border-slate-200 bg-black">
+        <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-4">
+          {['Reinforced Concrete', 'Structural Steel', 'Foundations', 'Frame & Truss Analysis', 'Quantity Take-Off'].map(s => (
+            <span key={s} className="text-[10px] font-bold uppercase tracking-[0.15em] text-slate-400">{s}</span>
+          ))}
+        </div>
+      </section>
+
+      {/* Sample / test cases */}
+      <section className="mx-auto max-w-6xl px-6 py-16">
+        <div className="mb-6 flex items-center gap-4">
+          <span className="text-[10px] font-bold uppercase tracking-[0.18em] text-slate-400">Try a sample</span>
+          <div className="h-px flex-1 bg-slate-200" />
+        </div>
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+          {SAMPLES.map(s => (
+            <Link key={s.to} to={s.to}
+              className="group flex flex-col border border-slate-200 bg-white p-6 transition-colors hover:border-[#0056b3] hover:bg-[#f4f8ff]">
+              <span className="text-[9px] font-bold uppercase tracking-widest text-slate-400 group-hover:text-[#0056b3]">{s.tag}</span>
+              <span className="mt-2 text-base font-semibold text-slate-900">{s.title}</span>
+              <span className="mt-2 text-xs leading-relaxed text-slate-500">{s.desc}</span>
+              <span className="mt-5 text-xs font-semibold text-[#0056b3] opacity-0 transition-opacity group-hover:opacity-100">
+                Open tool →
+              </span>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {/* Closing CTA */}
+      <section className="border-t border-slate-200 bg-white">
+        <div className="mx-auto flex max-w-6xl flex-col items-start justify-between gap-6 px-6 py-12 sm:flex-row sm:items-center">
+          <div>
+            <h2 className="text-xl font-bold text-slate-900">Browse every tool from the menu.</h2>
+            <p className="mt-1 text-sm text-slate-500">Pick a category in the top navigation — Structural or Quantity Take-Off.</p>
+          </div>
+          <button onClick={() => onAuth('signup')}
+            className="bg-[#0056b3] px-6 py-3 text-sm font-semibold text-white hover:bg-[#0066d6]">
+            Create free account
+          </button>
+        </div>
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Builds on the merged #195. Moves all calculators into navbar dropdowns and turns the home page into a marketing landing page.

### Navbar (`components/Navbar.tsx`)
- Sticky flat black bar, sharp corners, on every page (`no-print` so reports stay clean)
- **Category dropdowns**: `Structural` and `Quantity Take-Off`, plus a disabled `More — soon` slot for future categories
- Click-to-open with outside-click + Escape to close
- Responsive: collapses to a hamburger panel listing all tools on mobile
- `Log in` / `Sign up` actions on the right

### Home (`pages/Home.tsx`)
- **Hero**: large headline, copy, primary CTA ("Open a calculator") + "Create account", and an inline SVG portal-frame illustration (distributed load, supports, bending hint) — no image assets
- **Standards strip**: black band listing domains
- **"Try a sample"**: three test-case cards (RC beam, steel beam, portal frame) linking to real tools
- **Closing CTA**: sign-up prompt

### Supporting
- `lib/tools.ts` — single source of truth for the tool catalog, shared by navbar + home
- `components/AuthModal.tsx` — honest "coming soon" dialog (no auth backend yet; all tools work without an account)

## Design
Flat, no border radius, monochrome base with `#0056b3` accent. Hover = border + tint only.

## Test plan
- [x] `npx tsc -b` — no errors
- [x] `npm test` — 330 tests pass
- [ ] Verify dropdowns open/close and links route after deploy
- [ ] Verify mobile hamburger panel
- [ ] Confirm navbar hidden in print/PDF reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_