### PR TITLE
feat(beam): ρ-limits display + ACI §24.2 service deflection (Phase 3a)

### DIFF
--- a/webapp/src/engine/beamDesign.test.ts
+++ b/webapp/src/engine/beamDesign.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { designBeam, type BeamDesignInput } from './beamDesign'
+import { designBeam, beamServiceDeflection, type BeamDesignInput, type BeamDeflectionInput } from './beamDesign'
 import { beta1 } from './loads'
 
 const base: BeamDesignInput = {
@@ -138,6 +138,60 @@ describe('beam design — compression-bar layout & stirrup detailing', () => {
     const r16 = designBeam({ ...base, stirrupDia: 16 })   // ds = 16
     expect(r16.stirrupBendDia).toBe(64)
     expect(r16.stirrupHookExt).toBe(96)                   // 6·16 = 96 > 75
+  })
+})
+
+describe('beamServiceDeflection — ACI 318-14 §24.2', () => {
+  const base: BeamDeflectionInput = {
+    b: 300, h: 500, d: 440,
+    As: 1884,   // 6⌀20 mm bars
+    fc: 28, span: 6, wD: 20, wL: 15,
+  }
+
+  it('computes positive immediate and total deflections', () => {
+    const r = beamServiceDeflection(base)
+    expect(r.deltaD).toBeGreaterThan(0)
+    expect(r.deltaL).toBeGreaterThan(0)
+    expect(r.deltaTotal).toBeGreaterThan(r.deltaL)
+  })
+
+  it('Ie = Ig when section is uncracked (Ma ≤ Mcr)', () => {
+    const r = beamServiceDeflection({ ...base, wD: 0.1, wL: 0.1 })
+    expect(r.Ie).toBeCloseTo(r.Ig, 0)
+  })
+
+  it('Icr < Ig always', () => {
+    const r = beamServiceDeflection(base)
+    expect(r.Icr).toBeLessThan(r.Ig)
+  })
+
+  it('limits are L/360 and L/240', () => {
+    const r = beamServiceDeflection(base)
+    expect(r.limitL360).toBeCloseTo(6000 / 360, 6)
+    expect(r.limitL240).toBeCloseTo(6000 / 240, 6)
+  })
+
+  it('λΔ = 2.0 with no compression steel (§24.2.4.1.1)', () => {
+    const r = beamServiceDeflection(base)
+    expect(r.lambdaDelta).toBeCloseTo(2.0, 9)
+  })
+
+  it('λΔ decreases with compression steel', () => {
+    const noCompr = beamServiceDeflection(base)
+    const withCompr = beamServiceDeflection({ ...base, AsPrime: 942 })  // 3⌀20
+    expect(withCompr.lambdaDelta).toBeLessThan(noCompr.lambdaDelta)
+    const rhoP = 942 / (300 * 440)
+    expect(withCompr.lambdaDelta).toBeCloseTo(2.0 / (1 + 50 * rhoP), 9)
+  })
+
+  it('live-load check: liveOK = (deltaL ≤ L/360)', () => {
+    const r = beamServiceDeflection(base)
+    expect(r.liveOK).toBe(r.deltaL <= r.limitL360)
+  })
+
+  it('total check: totalOK = (deltaTotal ≤ L/240)', () => {
+    const r = beamServiceDeflection(base)
+    expect(r.totalOK).toBe(r.deltaTotal <= r.limitL240)
   })
 })
 

--- a/webapp/src/engine/beamDesign.ts
+++ b/webapp/src/engine/beamDesign.ts
@@ -274,3 +274,80 @@ export function designBeam(i: BeamDesignInput): BeamDesignResult {
     Vc, phiVc, region, Av, VsReq, VsMax, sReq, sMax, sAdopt,
   }
 }
+
+// ─── Service deflection (simple span) — ACI 318-14 §24.2 ──────────────────
+// Branson effective Ie at full service moment; long-term multiplier §24.2.4.
+// Kept separate so deflection inputs stay optional in the UI.
+
+export interface BeamDeflectionInput {
+  b: number; h: number; d: number   // section, mm
+  As: number                        // tension steel area, mm²
+  AsPrime?: number                  // compression steel area for λΔ, mm² (default 0)
+  fc: number                        // MPa
+  lambda?: number                   // lightweight factor (default 1)
+  span: number                      // simple span, m
+  wD: number; wL: number           // unfactored service loads, kN/m
+}
+
+export interface BeamDeflectionResult {
+  Ig: number; Icr: number; Mcr: number; Ie: number   // mm⁴
+  deltaD: number; deltaL: number                       // immediate, mm
+  lambdaDelta: number; deltaLong: number               // long-term dead, mm
+  deltaTotal: number                                   // long-term dead + immediate live, mm
+  limitL360: number; limitL240: number                 // mm
+  liveOK: boolean; totalOK: boolean
+}
+
+export function beamServiceDeflection(i: BeamDeflectionInput): BeamDeflectionResult {
+  const { b, h, d, As, fc, span } = i
+  const lambda = i.lambda ?? 1
+  const AsPrime = i.AsPrime ?? 0
+  const Lmm = span * 1000
+
+  // Ec = 4700√f'c (MPa), n = Es/Ec
+  const Ec = 4700 * Math.sqrt(Math.max(fc, 1))
+  const n = 200_000 / Ec
+  const Ig = (b * h ** 3) / 12
+
+  // Cracked transformed Icr (singly-reinforced — conservative when A's > 0)
+  const rhoN = (n * As) / (b * d)
+  const kNA = Math.sqrt(2 * rhoN + rhoN ** 2) - rhoN
+  const kd = kNA * d
+  const Icr = (b * kd ** 3) / 3 + n * As * (d - kd) ** 2
+
+  // Cracking moment: fr = 0.62λ√f'c (§419.2.3.1); Mcr = fr·Ig/yt
+  const fr = 0.62 * lambda * Math.sqrt(Math.max(fc, 1))
+  const Mcr = (fr * Ig) / (h / 2) / 1e6   // kN·m
+
+  // Service moment at full load (simple span): Ma = w·L²/8
+  const Ma = ((i.wD + i.wL) * span ** 2) / 8   // kN·m
+
+  // Branson effective Ie (§24.2.3.5)
+  const Ie = (() => {
+    if (Ma <= 0 || Ma <= Mcr) return Ig
+    const r = (Mcr / Ma) ** 3
+    return Math.min(Ig, r * Ig + (1 - r) * Icr)
+  })()
+
+  // Immediate deflections: δ = 5wL⁴/(384EI)
+  // w [kN/m] = w [N/mm] numerically; E [MPa = N/mm²]; I [mm⁴]; L [mm] → δ [mm]
+  const coef = (5 * Lmm ** 4) / (384 * 200_000 * Ie)
+  const deltaD = i.wD * coef
+  const deltaL = i.wL * coef
+
+  // Long-term multiplier: §24.2.4.1.1  λΔ = ξ/(1+50ρ')  ξ = 2.0 (≥5yr)
+  const rhoP = AsPrime > 0 ? AsPrime / (b * d) : 0
+  const lambdaDelta = 2.0 / (1 + 50 * rhoP)
+  const deltaLong = lambdaDelta * deltaD
+  const deltaTotal = deltaLong + deltaL   // §24.2.2 Table R24.2.2
+
+  const limitL360 = Lmm / 360
+  const limitL240 = Lmm / 240
+
+  return {
+    Ig, Icr, Mcr, Ie,
+    deltaD, deltaL, lambdaDelta, deltaLong, deltaTotal,
+    limitL360, limitL240,
+    liveOK: deltaL <= limitL360, totalOK: deltaTotal <= limitL240,
+  }
+}

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
-import { designBeam, type BeamDesignInput, type BeamDesignResult } from '../engine/beamDesign'
+import { designBeam, beamServiceDeflection, type BeamDesignInput, type BeamDesignResult } from '../engine/beamDesign'
 import type { CriticalSection } from '../engine/beamSections'
 import { BeamSchematic } from '../components/BeamSchematic'
 import { ReportControls } from '../components/ReportControls'
@@ -66,6 +66,9 @@ export default function BeamDesign() {
   }, [params])
 
   const [f, setF] = useState<FormState>({ ...DEFAULTS, ...(handoff.multi ? {} : handoff.single) })
+  const [span, setSpan] = useState<number>(NaN)
+  const [svcWD, setSvcWD] = useState<number>(NaN)
+  const [svcWL, setSvcWL] = useState<number>(NaN)
   const [multi, setMulti] = useState<boolean>(handoff.multi)
   const [sections, setSections] = useState<SecRow[]>(handoff.multi ? handoff.sections : DEF_SECTIONS)
   const [selId, setSelId] = useState<number | null>(handoff.multi ? handoff.sections[0].id : null)
@@ -106,6 +109,15 @@ export default function BeamDesign() {
     [r, f, demand.Mu, demand.Vu],
   )
 
+  const deflection = useMemo(() => {
+    if (!r || !Number.isFinite(span) || !Number.isFinite(svcWD) || !Number.isFinite(svcWL)) return null
+    return beamServiceDeflection({
+      b: f.b, h: f.h, d: r.d, As: r.As,
+      AsPrime: r.mode === 'DRRB' ? r.AsPrime : 0,
+      fc: f.fc, span, wD: svcWD, wL: svcWL,
+    })
+  }, [r, f.b, f.h, f.fc, span, svcWD, svcWL])
+
   const stirrupText = (rr: BeamDesignResult) =>
     rr.region === 'designed' || rr.region === 'minimum'
       ? `⌀${f.stirrupDia} ${f.legs}-leg @ ${f0(rr.sAdopt)} mm`
@@ -137,6 +149,12 @@ export default function BeamDesign() {
             <Num label={<KTex tex="f'_c" />} unit="MPa" value={f.fc} onChange={set('fc')} />
             <Num label={<KTex tex="f_y" />} unit="MPa" value={f.fy} onChange={set('fy')} />
             <Num label={<KTex tex="f_{yt}" />} unit="MPa" value={f.fyt} onChange={set('fyt')} />
+          </Card>
+
+          <Card title="Serviceability (optional)">
+            <Num label="Simple span" unit="m" value={span} onChange={setSpan} />
+            <Num label={<>Dead load <KTex tex="w_D" /></>} unit="kN/m" value={svcWD} onChange={setSvcWD} />
+            <Num label={<>Live load <KTex tex="w_L" /></>} unit="kN/m" value={svcWL} onChange={setSvcWL} />
           </Card>
 
           <Card title="Factored demands">
@@ -251,6 +269,9 @@ export default function BeamDesign() {
                 sub={`φMn,max=${f1(r.phiMnMax)} kN·m`} />
               <Row label="Tension steel" value={`${r.bars} ⌀${f.barDia} mm`}
                 sub={`As=${f0(r.As)} mm² · ${r.usedMin ? 'ρ_min' : `ρ=${r.rho.toFixed(4)}`}`} />
+              <Row label="ρ limits"
+                value={`ρ=${r.rho.toFixed(4)}`}
+                sub={`ρ_min=${r.rhoMin.toFixed(4)} · ρ_b=${r.rhoB.toFixed(4)} · ρ_max=${r.rhoMax.toFixed(4)}`} />
               <Row label="Layers" value={r.layers.length > 1 ? `${r.layers.length} (${r.layers.join(' + ')})` : '1'}
                 sub={`s_clear=${f0(r.sClear)} ≥ ${f0(r.sMinClear)} mm`} />
               {r.mode === 'DRRB' && (
@@ -275,6 +296,25 @@ export default function BeamDesign() {
                 sub={r.region === 'designed' ? `s_req=${f0(r.sReq)} · s_max=${f0(r.sMax)} mm` : undefined} />
               <Row label="Hooks (135°)" value={`ext ${f0(r.stirrupHookExt)} mm`}
                 sub={`bend Ø ${f0(r.stirrupBendDia)} mm (4ds)`} />
+            </ResultCard>
+          )}
+          {deflection && (
+            <ResultCard title="Serviceability — ACI 318-14 §24.2">
+              <Row label={<><KTex tex="I_g" /> (gross)</>} value={`${(deflection.Ig / 1e6).toFixed(0)} ×10⁶ mm⁴`} />
+              <Row label={<><KTex tex="I_{cr}" /> (cracked)</>} value={`${(deflection.Icr / 1e6).toFixed(0)} ×10⁶ mm⁴`} />
+              <Row label={<><KTex tex="M_{cr}" /></>} value={`${deflection.Mcr.toFixed(1)} kN·m`} />
+              <Row label={<><KTex tex="I_e" /> (Branson)</>} value={`${(deflection.Ie / 1e6).toFixed(0)} ×10⁶ mm⁴`} />
+              <Row label={<>Immed. dead <KTex tex="\delta_D" /></>} value={`${deflection.deltaD.toFixed(1)} mm`} />
+              <Row label={<>Immed. live <KTex tex="\delta_L" /></>} value={`${deflection.deltaL.toFixed(1)} mm`}
+                alert={!deflection.liveOK}
+                sub={`L/360 = ${deflection.limitL360.toFixed(1)} mm${deflection.liveOK ? ' ✓' : ' ✗'}`} />
+              <Row label={<>Long-term <KTex tex="\lambda_\Delta" /></>}
+                value={deflection.lambdaDelta.toFixed(3)}
+                sub="ξ=2.0 (≥5 yr), §24.2.4.1.1" />
+              <Row label={<>Total <KTex tex="\delta_{total}" /></>}
+                value={`${deflection.deltaTotal.toFixed(1)} mm`}
+                alert={!deflection.totalOK}
+                sub={`L/240 = ${deflection.limitL240.toFixed(1)} mm${deflection.totalOK ? ' ✓' : ' ✗'}`} />
             </ResultCard>
           )}
         </div>


### PR DESCRIPTION
## Summary

- **`beamDesign.ts`** — new `beamServiceDeflection()` engine function (ACI 318-14 §24.2):
  - Branson effective Ie = (Mcr/Ma)³·Ig + [1−(Mcr/Ma)³]·Icr ≤ Ig
  - Immediate deflections δD and δL via 5wL⁴/384EI
  - Long-term multiplier λΔ = ξ/(1+50ρ'), ξ=2.0 (≥5 yr), §24.2.4.1.1
  - L/360 live-load check and L/240 total (long-term dead + live) check
- **`beamDesign.test.ts`** — 8 new tests: cracked vs uncracked Ie, λΔ = 2.0 (no compr. steel), λΔ reduction with A's, limit assertions; 338 tests total, all green
- **`BeamDesign.tsx`** — three UI additions:
  - **ρ limits row** in the results card: shows ρ_min · ρ_b · ρ_max alongside the actual ρ
  - **Serviceability (optional) card** in the left column: span (m), wD and wL (kN/m)
  - **Serviceability ResultCard** in the right column (appears only when all three inputs are filled): Ig, Icr, Mcr, Ie, δD, δL vs L/360, λΔ, δtotal vs L/240 — alerts on failure

## Test plan

- [ ] Enter a beam (b=300, h=500, fc=28, fy=415, Mu=180, Vu=150) — verify ρ limits row appears in results
- [ ] Fill Serviceability card (span=6 m, wD=20, wL=15 kN/m) — verify deflection card appears with Ig, Icr, Mcr, δD, δL, δtotal
- [ ] Set very low loads (wD=0.1, wL=0.1) — verify Ie ≈ Ig (uncracked)
- [ ] Add DRRB compression steel (Mu=400) — verify λΔ < 2.0 in deflection card
- [ ] Leave one serviceability field blank — verify deflection card does not appear

## Remaining phases

- **3b** — Wire `eccentricFooting.ts` to a UI page
- **3c** — Two-way slab design page (`slabDDM.ts`)
- **3d** — P-M interaction table (diagram already exists)
- **4** — Tests for `fem.ts`, `trussDesign.ts`, `deadLoads.ts`, `liveLoads.ts`
- **5** — Torsion engine + UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_