### PR TITLE
feat: torsion design — ACI 318-14 §22.7 engine, tests, and UI

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -16,6 +16,7 @@ const ModelSpace = lazy(() => import('./pages/ModelSpace'))
 const TrussSpace = lazy(() => import('./pages/TrussSpace'))
 import SteelDesign from './pages/SteelDesign'
 import SlabDesign from './pages/SlabDesign'
+import TorsionDesign from './pages/TorsionDesign'
 import SlabEstimate from './pages/SlabEstimate'
 import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
@@ -50,6 +51,7 @@ export default function App() {
         } />
         <Route path="/steel" element={<SteelDesign />} />
         <Route path="/slab-design" element={<SlabDesign />} />
+        <Route path="/torsion" element={<TorsionDesign />} />
         <Route path="/estimate/slab" element={<SlabEstimate />} />
         <Route path="/estimate/beam" element={<BeamEstimate />} />
         <Route path="/estimate/column" element={<ColumnEstimate />} />

--- a/webapp/src/engine/torsionDesign.test.ts
+++ b/webapp/src/engine/torsionDesign.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest'
+import { designTorsion } from './torsionDesign'
+
+// Reference section: 400 × 600 mm, cover=40, ds=12, db=20, fc=28, fy=fyt=415
+// Tu=80 kN·m, Vu=200 kN, legs=2, lambda=1
+const BASE = {
+  b: 400, h: 600, cover: 40, stirrupDia: 12, barDia: 20,
+  fc: 28, fy: 415, fyt: 415, Tu: 80, Vu: 200,
+}
+
+describe('designTorsion — section geometry', () => {
+  const r = designTorsion(BASE)
+
+  it('effective depth d = h − cover − ds − db/2', () => {
+    // 600 − 40 − 12 − 10 = 538
+    expect(r.d).toBeCloseTo(538, 9)
+  })
+
+  it('Acp = b·h  and  pcp = 2(b+h)', () => {
+    expect(r.Acp).toBeCloseTo(400 * 600, 9)
+    expect(r.pcp).toBeCloseTo(2 * (400 + 600), 9)
+  })
+
+  it('cSt = cover + ds/2', () => {
+    // 40 + 6 = 46 mm
+    expect(r.cSt).toBeCloseTo(46, 9)
+  })
+
+  it('x1, y1, Aoh, ph, Ao', () => {
+    const x1 = 400 - 2 * 46        // 308
+    const y1 = 600 - 2 * 46        // 508
+    expect(r.x1).toBeCloseTo(x1, 9)
+    expect(r.y1).toBeCloseTo(y1, 9)
+    expect(r.Aoh).toBeCloseTo(x1 * y1, 9)
+    expect(r.ph).toBeCloseTo(2 * (x1 + y1), 9)
+    expect(r.Ao).toBeCloseTo(0.85 * x1 * y1, 9)
+  })
+})
+
+describe('designTorsion — torsion thresholds §22.7.4.1 / §22.7.3', () => {
+  const r = designTorsion(BASE)
+  const sqrtFc = Math.sqrt(28)
+  const Acp2_pcp = (400 * 600) ** 2 / (2 * (400 + 600))
+
+  it('Tu_th = φ·λ·√f\'c·Acp²/(12·pcp) (kN·m)', () => {
+    const expected = 0.75 * 1 * sqrtFc * Acp2_pcp / 12 / 1e6
+    expect(r.Tu_th).toBeCloseTo(expected, 9)
+  })
+
+  it('Tcr = λ·√f\'c·Acp²/(3·pcp) (kN·m)', () => {
+    const expected = 1 * sqrtFc * Acp2_pcp / 3 / 1e6
+    expect(r.Tcr).toBeCloseTo(expected, 9)
+  })
+
+  it('Tcr/Tu_th = 4/φ = 16/3 (for λ=1, φ=0.75)', () => {
+    // Tcr uses /3, Tu_th uses /12 and ×φ → ratio = (1/3)/(φ/12) = 4/φ
+    expect(r.Tcr / r.Tu_th).toBeCloseTo(4 / 0.75, 6)
+  })
+
+  it('torsionNeeded = true when Tu ≥ Tu_th', () => {
+    // Tu=80 >> Tu_th ≈ 9.5 kN·m
+    expect(r.torsionNeeded).toBe(true)
+  })
+
+  it('torsionNeeded = false when Tu < Tu_th', () => {
+    const r2 = designTorsion({ ...BASE, Tu: 1 })   // 1 kN·m << threshold
+    expect(r2.torsionNeeded).toBe(false)
+  })
+
+  it('AtPerS = 0 when torsion not needed', () => {
+    const r2 = designTorsion({ ...BASE, Tu: 1 })
+    expect(r2.AtPerS).toBe(0)
+    expect(r2.AtPerS_min).toBe(0)
+  })
+})
+
+describe('designTorsion — shear concrete capacity', () => {
+  const r = designTorsion(BASE)
+  const sqrtFc = Math.sqrt(28)
+  const d = 600 - 40 - 12 - 20 / 2  // 538
+
+  it('Vc = λ·√f\'c·b·d / (6·1000)  (kN)', () => {
+    const expected = 1 * sqrtFc * 400 * d / (6 * 1000)
+    expect(r.Vc).toBeCloseTo(expected, 9)
+  })
+
+  it('phiVc = 0.75·Vc', () => {
+    expect(r.phiVc).toBeCloseTo(0.75 * r.Vc, 9)
+  })
+})
+
+describe('designTorsion — interaction check §22.7.7.1', () => {
+  const r = designTorsion(BASE)
+  const d = 538
+  const x1 = 308, y1 = 508
+  const Aoh = x1 * y1
+  const ph = 2 * (x1 + y1)
+  const sqrtFc = Math.sqrt(28)
+
+  it('lhs = √[(Vu/bwd)² + (Tu·ph/1.7Aoh²)²]  (MPa)', () => {
+    const vu = (200 * 1000) / (400 * d)
+    const tu = (80 * 1e6 * ph) / (1.7 * Aoh ** 2)
+    const expected = Math.sqrt(vu ** 2 + tu ** 2)
+    expect(r.lhs).toBeCloseTo(expected, 9)
+  })
+
+  it('rhs = φ·(Vc/bwd + 2/3·√f\'c)  (MPa)', () => {
+    const expected = 0.75 * (r.Vc * 1000 / (400 * d) + (2 / 3) * sqrtFc)
+    expect(r.rhs).toBeCloseTo(expected, 9)
+  })
+
+  it('interactionOK = true for the reference section', () => {
+    expect(r.interactionOK).toBe(true)
+  })
+
+  it('interactionOK = false when section is inadequate', () => {
+    // Very large torsion overwhelms the section
+    const r2 = designTorsion({ ...BASE, Tu: 500, Vu: 500 })
+    expect(r2.interactionOK).toBe(false)
+  })
+})
+
+describe('designTorsion — transverse steel At/s §22.7.6.1', () => {
+  const r = designTorsion(BASE)
+  const sqrtFc = Math.sqrt(28)
+  const Ao = 0.85 * 308 * 508
+
+  it('AtPerS = Tu·1e6 / (φ·2·Ao·fyt)', () => {
+    const expected = 80 * 1e6 / (0.75 * 2 * Ao * 415)
+    expect(r.AtPerS).toBeCloseTo(expected, 9)
+  })
+
+  it('AtPerS_min = max(0.0625√f\'c/fyt, 0.35/fyt)', () => {
+    const expected = Math.max(0.0625 * sqrtFc / 415, 0.35 / 415)
+    expect(r.AtPerS_min).toBeCloseTo(expected, 9)
+  })
+
+  it('AtPerS_design = max(AtPerS, AtPerS_min)', () => {
+    expect(r.AtPerS_design).toBeCloseTo(Math.max(r.AtPerS, r.AtPerS_min), 9)
+    // For Tu=80, AtPerS >> AtPerS_min
+    expect(r.AtPerS_design).toBeCloseTo(r.AtPerS, 9)
+  })
+})
+
+describe('designTorsion — longitudinal steel Al §22.7.5', () => {
+  const r = designTorsion(BASE)
+  const sqrtFc = Math.sqrt(28)
+  const ph = 2 * (308 + 508)
+
+  it('Al = AtPerS_design·ph·(fyt/fy)', () => {
+    const expected = r.AtPerS_design * ph * (415 / 415)
+    expect(r.Al).toBeCloseTo(expected, 9)
+  })
+
+  it('Al_min = max(0, 5√f\'c·Acp/(12·fy) − AtPerS·ph·(fyt/fy))', () => {
+    const term = 5 * sqrtFc * (400 * 600) / (12 * 415) - r.AtPerS_design * ph * (415 / 415)
+    const expected = Math.max(0, term)
+    expect(r.Al_min).toBeCloseTo(expected, 9)
+  })
+
+  it('Al_min = 0 when AtPerS is large enough to cover minimum', () => {
+    // For Tu=80 the formula Al_min is negative → clamped to 0
+    expect(r.Al_min).toBeCloseTo(0, 9)
+    expect(r.Al_design).toBeCloseTo(r.Al, 9)
+  })
+
+  it('Al_min is positive when At/s is at minimum only', () => {
+    // Use Tu just at threshold so AtPerS_design = AtPerS_min (very small)
+    const r2 = designTorsion({ ...BASE, Tu: r.Tu_th + 0.001 })
+    expect(r2.Al_min).toBeGreaterThan(0)
+  })
+})
+
+describe('designTorsion — combined stirrups and spacing', () => {
+  const r = designTorsion(BASE)
+  const d = 538
+
+  it('Vs = max(0, Vu/φ − Vc)', () => {
+    const expected = Math.max(0, 200 / 0.75 - r.Vc)
+    expect(r.Vs).toBeCloseTo(expected, 9)
+  })
+
+  it('AvPerS = Vs·1000 / (fyt·d)', () => {
+    const expected = r.Vs > 0 ? (r.Vs * 1000) / (415 * d) : 0
+    expect(r.AvPerS).toBeCloseTo(expected, 9)
+  })
+
+  it('AvPlus2At_min = max(0.0625√f\'c, 0.35)·b/fyt  (§22.5.10.5)', () => {
+    const sqrtFc = Math.sqrt(28)
+    const expected = Math.max(0.0625 * sqrtFc, 0.35) * 400 / 415
+    expect(r.AvPlus2At_min).toBeCloseTo(expected, 9)
+  })
+
+  it('AvPlus2At = max(AvPerS + 2·AtPerS_design, combined_min)', () => {
+    const raw = r.AvPerS + 2 * r.AtPerS_design
+    expect(r.AvPlus2At).toBeCloseTo(Math.max(raw, r.AvPlus2At_min), 9)
+  })
+
+  it('sReq = legs·Ab / AvPlus2At', () => {
+    const Ab = (Math.PI / 4) * 12 ** 2
+    const expected = (2 * Ab) / r.AvPlus2At
+    expect(r.sReq).toBeCloseTo(expected, 6)
+  })
+
+  it('sMax = min(ph/8, 300, d/2, 600)', () => {
+    const ph = 2 * (308 + 508)
+    const expected = Math.min(ph / 8, 300, d / 2, 600)
+    expect(r.sMax).toBeCloseTo(expected, 9)
+  })
+
+  it('sAdopt = min(sReq, sMax)', () => {
+    expect(r.sAdopt).toBeCloseTo(Math.min(r.sReq, r.sMax), 9)
+  })
+
+  it('respects legs=4 (double-leg) properly', () => {
+    const r4 = designTorsion({ ...BASE, legs: 4 })
+    const Ab = (Math.PI / 4) * 12 ** 2
+    expect(r4.sReq).toBeCloseTo((4 * Ab) / r4.AvPlus2At, 6)
+    // More legs → larger sReq (less congested)
+    expect(r4.sReq).toBeGreaterThan(r.sReq)
+  })
+})

--- a/webapp/src/engine/torsionDesign.ts
+++ b/webapp/src/engine/torsionDesign.ts
@@ -1,0 +1,146 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Torsion design for a rectangular RC section.
+// NSCP 2015 / ACI 318-14 §22.7 (torsion) + §22.5 (shear) + §9.7.6 (spacing).
+// SI units throughout: lengths mm, forces kN, moments kN·m, stress MPa.
+// φ = 0.75 for shear and torsion (§21.2.1).
+// ─────────────────────────────────────────────────────────────────────────
+
+const PHI = 0.75
+
+export interface TorsionInput {
+  b: number; h: number          // overall dimensions, mm
+  cover: number                 // clear cover to stirrup outer face, mm
+  stirrupDia: number            // ds, mm
+  barDia: number                // main bar db (to find d), mm
+  fc: number; fy: number        // MPa
+  fyt: number                   // stirrup yield, MPa
+  Tu: number                    // factored torsion, kN·m
+  Vu: number                    // factored shear, kN
+  legs?: number                 // closed-stirrup legs (default 2)
+  lambda?: number               // lightweight factor (default 1)
+}
+
+export interface TorsionResult {
+  // Section geometry
+  d: number                     // effective depth (single layer), mm
+  Acp: number; pcp: number      // gross section mm², mm
+  cSt: number                   // cover to stirrup CL = cover + ds/2, mm
+  x1: number; y1: number        // inner (stirrup CL) dimensions, mm
+  Aoh: number                   // area enclosed by stirrup CL, mm²
+  ph: number                    // perimeter of Aoh, mm
+  Ao: number                    // 0.85·Aoh, mm²
+
+  // Torsional thresholds (SI — §22.7.4.1 / §22.7.3)
+  Tu_th: number                 // threshold: φ·λ·√f'c·Acp²/(12·pcp), kN·m
+  Tcr: number                   // cracking torsion: λ·√f'c·Acp²/(3·pcp), kN·m
+  torsionNeeded: boolean        // Tu ≥ Tu_th
+
+  // Shear
+  Vc: number; phiVc: number     // kN
+
+  // Section interaction check §22.7.7.1
+  lhs: number                   // √[(Vu/bwd)² + (Tu·ph/1.7Aoh²)²], MPa
+  rhs: number                   // φ·(Vc/bwd + (2/3)√f'c), MPa
+  interactionOK: boolean
+
+  // Transverse torsional steel per leg §22.7.6.1
+  AtPerS: number                // At/s from Tu, mm²/mm
+  AtPerS_min: number            // minimum per §22.7.6.1(b)
+  AtPerS_design: number         // governing
+
+  // Longitudinal torsional steel §22.7.5
+  Al: number                    // At/s·ph·(fyt/fy), mm²
+  Al_min: number                // minimum §22.7.5.2
+  Al_design: number             // governing
+
+  // Combined stirrup design
+  Vs: number                    // required shear-steel capacity, kN
+  AvPerS: number                // Av/s (all shear legs), mm²/mm
+  AvPlus2At: number             // (Av + 2At)/s governing, mm²/mm
+  AvPlus2At_min: number         // minimum §22.5.10.5 (combined), mm²/mm
+  sReq: number                  // required stirrup spacing, mm
+  sMax: number                  // max spacing = min(ph/8, 300, d/2, 600), mm
+  sAdopt: number                // min(sReq, sMax), mm
+}
+
+export function designTorsion(i: TorsionInput): TorsionResult {
+  const lambda = i.lambda ?? 1
+  const legs = i.legs ?? 2
+  const { b, h, cover, fc, fy, fyt } = i
+  const ds = i.stirrupDia, db = i.barDia
+  const sqrtFc = Math.sqrt(Math.max(fc, 1))
+
+  // Effective depth (single bottom layer)
+  const d = h - cover - ds - db / 2
+
+  // Gross section
+  const Acp = b * h
+  const pcp = 2 * (b + h)
+
+  // Stirrup centerline geometry
+  const cSt = cover + ds / 2
+  const x1 = b - 2 * cSt
+  const y1 = h - 2 * cSt
+  const Aoh = x1 * y1
+  const ph = 2 * (x1 + y1)
+  const Ao = 0.85 * Aoh
+
+  // Threshold and cracking torsion (§22.7.4.1, §22.7.3 — SI, result in kN·m)
+  const Acp2_pcp = (Acp * Acp) / pcp               // mm³
+  const Tu_th = PHI * lambda * sqrtFc * Acp2_pcp / 12 / 1e6
+  const Tcr   = lambda * sqrtFc * Acp2_pcp / 3 / 1e6
+  const torsionNeeded = i.Tu >= Tu_th - 1e-9
+
+  // Shear concrete capacity
+  const Vc    = (lambda * sqrtFc * b * d) / (6 * 1000)  // kN
+  const phiVc = PHI * Vc
+
+  // Interaction check §22.7.7.1 (all terms in MPa)
+  const vu    = (i.Vu * 1000) / (b * d)               // Vu/(bw·d), MPa
+  const tu    = (i.Tu * 1e6 * ph) / (1.7 * Aoh * Aoh) // Tu·ph/(1.7·Aoh²), MPa
+  const lhs   = Math.sqrt(vu * vu + tu * tu)
+  const rhs   = PHI * (Vc * 1000 / (b * d) + (2 / 3) * sqrtFc)
+  const interactionOK = lhs <= rhs + 1e-9
+
+  // Transverse torsional steel per leg §22.7.6.1(a)
+  const Tu_Nmm    = i.Tu * 1e6
+  const AtPerS    = torsionNeeded ? Tu_Nmm / (PHI * 2 * Ao * fyt) : 0
+  // §22.7.6.1(b) minimum (SI): max(0.0625√f'c/fyt, 0.35/fyt) per leg
+  const AtPerS_min = torsionNeeded ? Math.max(0.0625 * sqrtFc / fyt, 0.35 / fyt) : 0
+  const AtPerS_design = Math.max(AtPerS, AtPerS_min)
+
+  // Longitudinal torsional steel §22.7.5.1
+  const Al     = AtPerS_design * ph * (fyt / fy)
+  // §22.7.5.2 minimum
+  const Al_min = Math.max(0, 5 * sqrtFc * Acp / (12 * fy) - AtPerS_design * ph * (fyt / fy))
+  const Al_design = Math.max(Al, Al_min)
+
+  // Combined stirrups
+  const Vs        = Math.max(0, i.Vu / PHI - Vc)             // kN
+  const AvPerS    = Vs > 0 ? (Vs * 1000) / (fyt * d) : 0    // mm²/mm (all legs)
+  const AvPlus2At_raw = AvPerS + 2 * AtPerS_design            // mm²/mm
+
+  // Combined minimum §22.5.10.5: max(0.0625√f'c, 0.35)·bw/fyt
+  const AvPlus2At_min = Math.max(0.0625 * sqrtFc, 0.35) * b / fyt
+  const AvPlus2At     = Math.max(AvPlus2At_raw, torsionNeeded ? AvPlus2At_min : 0)
+
+  // Required spacing for `legs`-leg closed stirrup of diameter ds
+  const Ab   = (Math.PI / 4) * ds * ds
+  const sReq = AvPlus2At > 0 ? (legs * Ab) / AvPlus2At : Infinity
+
+  // Maximum spacing §9.7.6.3.2 (torsion) + §9.7.6.2.2 (shear)
+  const sMax = Math.min(ph / 8, 300, d / 2, 600)
+
+  const sAdopt = Math.min(sReq, sMax)
+
+  return {
+    d, Acp, pcp, cSt, x1, y1, Aoh, ph, Ao,
+    Tu_th, Tcr, torsionNeeded,
+    Vc, phiVc,
+    lhs, rhs, interactionOK,
+    AtPerS, AtPerS_min, AtPerS_design,
+    Al, Al_min, Al_design,
+    Vs, AvPerS, AvPlus2At, AvPlus2At_min,
+    sReq, sMax, sAdopt,
+  }
+}

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -20,6 +20,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/truss',         name: 'Truss Space',        sub: 'Plane truss solver'    },
       { to: '/steel',         name: 'Steel Design',       sub: 'AISC 360-16 LRFD'      },
       { to: '/slab-design',   name: 'Slab Design',        sub: 'Two-way DDM · ACI 318'  },
+      { to: '/torsion',       name: 'Torsion Design',     sub: 'RC torsion · ACI 318-14' },
     ],
   },
   {

--- a/webapp/src/pages/TorsionDesign.tsx
+++ b/webapp/src/pages/TorsionDesign.tsx
@@ -1,0 +1,148 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { designTorsion, type TorsionInput } from '../engine/torsionDesign'
+import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
+import { ReportControls } from '../components/ReportControls'
+import { f1, f2, f3 } from '../lib/format'
+
+interface FormState extends Omit<TorsionInput, 'legs' | 'lambda'> {
+  legs: 2 | 4
+  lambda: 1 | 0.75
+}
+
+const DEFAULTS: FormState = {
+  b: 400, h: 600, cover: 40, stirrupDia: 12, barDia: 20,
+  fc: 28, fy: 415, fyt: 415,
+  Tu: 80, Vu: 200,
+  legs: 2, lambda: 1,
+}
+
+const REQUIRED: (keyof FormState)[] = [
+  'b', 'h', 'cover', 'stirrupDia', 'barDia', 'fc', 'fy', 'fyt', 'Tu', 'Vu',
+]
+
+export default function TorsionDesign() {
+  const [f, setF] = useState<FormState>(DEFAULTS)
+  const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) =>
+    setF((s) => ({ ...s, [k]: v }))
+
+  const allFinite = REQUIRED.every((k) => Number.isFinite(f[k] as number))
+
+  const r = useMemo(
+    () => (allFinite ? designTorsion(f) : null),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [JSON.stringify(f), allFinite],
+  )
+
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
+      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">
+        Torsion Design
+      </h1>
+      <p className="no-print mt-1 text-slate-600">
+        Rectangular RC section — ACI 318-14 §22.7 combined shear + torsion. SI units (mm, kN, MPa).
+      </p>
+      <ReportControls title="Torsion Design" />
+
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
+        {/* ── INPUTS ── */}
+        <div className="flex flex-col gap-6">
+          <Card title="Section">
+            <Num label="Width b" unit="mm"    value={f.b}    onChange={set('b')} />
+            <Num label="Height h" unit="mm"   value={f.h}    onChange={set('h')} />
+            <Num label="Clear cover" unit="mm" value={f.cover} onChange={set('cover')} />
+            <Num label="Stirrup ⌀ dₛ" unit="mm" value={f.stirrupDia} onChange={set('stirrupDia')} />
+            <Num label="Main bar ⌀ db" unit="mm" value={f.barDia}    onChange={set('barDia')} />
+            <Pick label="Stirrup legs" value={String(f.legs) as '2'|'4'}
+              onChange={(v) => set('legs')(Number(v) as 2 | 4)}
+              options={[['2', '2 legs'], ['4', '4 legs']]} />
+          </Card>
+
+          <Card title="Materials">
+            <Num label="f'c" unit="MPa" value={f.fc}  onChange={set('fc')} />
+            <Num label="fy (main)"  unit="MPa" value={f.fy}  onChange={set('fy')} />
+            <Num label="fyt (stirrup)" unit="MPa" value={f.fyt} onChange={set('fyt')} />
+            <Pick label="λ (lightweight)" value={String(f.lambda) as '1'|'0.75'}
+              onChange={(v) => set('lambda')(Number(v) as 1 | 0.75)}
+              options={[['1', '1.0 (normal weight)'], ['0.75', '0.75 (lightweight)']]} />
+          </Card>
+
+          <Card title="Demands">
+            <Num label="Tu (factored torsion)" unit="kN·m" value={f.Tu} onChange={set('Tu')} />
+            <Num label="Vu (factored shear)"  unit="kN"   value={f.Vu}  onChange={set('Vu')} />
+          </Card>
+        </div>
+
+        {/* ── RESULTS ── */}
+        {r ? (
+          <div className="flex flex-col gap-6">
+            <ResultCard title="Section Geometry">
+              <Row label="Effective depth d"          value={`${f1(r.d)} mm`} />
+              <Row label="Gross area Acp"             value={`${f1(r.Acp)} mm²`}   sub={`pcp = ${f1(r.pcp)} mm`} />
+              <Row label="Cover to stirrup CL cSt"   value={`${f1(r.cSt)} mm`} />
+              <Row label="Inner dims x₁ × y₁"        value={`${f1(r.x1)} × ${f1(r.y1)} mm`} />
+              <Row label="Aoh (enclosed area)"        value={`${f1(r.Aoh)} mm²`} />
+              <Row label="ph (perimeter Aoh)"         value={`${f1(r.ph)} mm`} />
+              <Row label="Ao = 0.85·Aoh"             value={`${f1(r.Ao)} mm²`} />
+            </ResultCard>
+
+            <ResultCard title="Torsion Thresholds §22.7">
+              <Row label="Threshold Tu,th"
+                value={`${f2(r.Tu_th)} kN·m`}
+                sub={`Tu = ${f2(f.Tu)} kN·m`}
+                alert={!r.torsionNeeded && false} />
+              <Row label="Cracking Tcr"               value={`${f2(r.Tcr)} kN·m`} />
+              <Row label="Torsion reinforcement"
+                value={r.torsionNeeded ? 'Required' : 'Not required'}
+                alert={!r.torsionNeeded} />
+            </ResultCard>
+
+            <ResultCard title="Shear Capacity">
+              <Row label="φVc"  value={`${f1(r.phiVc)} kN`} sub={`Vc = ${f1(r.Vc)} kN`} />
+              <Row label="Vs required" value={`${f1(r.Vs)} kN`} />
+            </ResultCard>
+
+            <ResultCard title="Section Interaction §22.7.7.1">
+              <Row label="LHS √[(Vu/bwd)² + (Tu·ph/1.7Aoh²)²]"
+                value={`${f3(r.lhs)} MPa`} />
+              <Row label="RHS φ·(Vc/bwd + ⅔√f'c)"
+                value={`${f3(r.rhs)} MPa`} />
+              <Row label="Interaction check"
+                value={r.interactionOK ? 'OK ✓' : 'FAIL ✗'}
+                alert={!r.interactionOK} />
+            </ResultCard>
+
+            <ResultCard title="Transverse Steel At/s §22.7.6.1">
+              <Row label="At/s (torsion)"          value={`${f3(r.AtPerS)} mm²/mm`} />
+              <Row label="At/s minimum"            value={`${f3(r.AtPerS_min)} mm²/mm`} />
+              <Row label="At/s design"             value={`${f3(r.AtPerS_design)} mm²/mm`} />
+            </ResultCard>
+
+            <ResultCard title="Longitudinal Steel Al §22.7.5">
+              <Row label="Al (formula)"            value={`${f1(r.Al)} mm²`} />
+              <Row label="Al minimum"              value={`${f1(r.Al_min)} mm²`} />
+              <Row label="Al design"               value={`${f1(r.Al_design)} mm²`} />
+            </ResultCard>
+
+            <ResultCard title="Combined Stirrup Design">
+              <Row label="Av/s (shear legs)"       value={`${f3(r.AvPerS)} mm²/mm`} />
+              <Row label="(Av+2At)/s required"     value={`${f3(r.AvPlus2At)} mm²/mm`} />
+              <Row label="(Av+2At)/s minimum"      value={`${f3(r.AvPlus2At_min)} mm²/mm`} />
+              <Row label="s required"              value={`${f1(r.sReq)} mm`} />
+              <Row label="s max (§9.7.6)"          value={`${f1(r.sMax)} mm`}
+                sub={`ph/8=${f1(r.ph/8)} · d/2=${f1(r.d/2)}`} />
+              <Row label="s adopted"
+                value={`${f1(r.sAdopt)} mm`}
+                alert={!r.interactionOK} />
+            </ResultCard>
+          </div>
+        ) : (
+          <p className="self-start rounded-xl border border-slate-200 bg-white p-6 text-sm text-slate-500">
+            Fill in all inputs to see results.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **`torsionDesign.ts`** — pure engine for rectangular RC torsion design (ACI 318-14 §22.7 + §22.5 + §9.7.6): threshold/cracking torsion, shear–torsion interaction check, transverse steel At/s, longitudinal steel Al, combined (Av+2At)/s, required and maximum stirrup spacing
- **`torsionDesign.test.ts`** — 31 tests covering all derived quantities (geometry, thresholds, Vc, interaction LHS/RHS, At/s, Al, combined stirrups, spacing)
- **`TorsionDesign.tsx`** — UI page at `/torsion`: section / materials / demands inputs, seven result panels with pass/fail alerts on interaction and spacing
- **`tools.ts` + `App.tsx`** — registered in navbar and routing

All 428 tests pass; `tsc -b` clean.

## Next phase
Phase 6 — development/splice length output (ACI 318-14 §25.4–§25.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_