### PR TITLE
feat: development & splice lengths — ACI 318-14 §25.4–§25.5

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -17,6 +17,7 @@ const TrussSpace = lazy(() => import('./pages/TrussSpace'))
 import SteelDesign from './pages/SteelDesign'
 import SlabDesign from './pages/SlabDesign'
 import TorsionDesign from './pages/TorsionDesign'
+import DevLength from './pages/DevLength'
 import SlabEstimate from './pages/SlabEstimate'
 import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
@@ -52,6 +53,7 @@ export default function App() {
         <Route path="/steel" element={<SteelDesign />} />
         <Route path="/slab-design" element={<SlabDesign />} />
         <Route path="/torsion" element={<TorsionDesign />} />
+        <Route path="/dev-length" element={<DevLength />} />
         <Route path="/estimate/slab" element={<SlabEstimate />} />
         <Route path="/estimate/beam" element={<BeamEstimate />} />
         <Route path="/estimate/column" element={<ColumnEstimate />} />

--- a/webapp/src/engine/devLength.test.ts
+++ b/webapp/src/engine/devLength.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest'
+import { calcDevLength } from './devLength'
+
+// Reference inputs — Grade 415, fc=28, db=20 (≤20 → ψs=0.8), not top, uncoated, n.w., Ψ=1.5
+const BASE = {
+  db: 20, fc: 28, fy: 415,
+  topBar: false, epoxy: 'none' as const,
+  lambda: 1.0, cbKtr_db: 1.5,
+}
+
+describe('calcDevLength — modification factors §25.4.2.4', () => {
+  it('psi_t = 1.0 for non-top bars', () => {
+    expect(calcDevLength(BASE).psi_t).toBe(1.0)
+  })
+
+  it('psi_t = 1.3 for top bars (>300 mm concrete below)', () => {
+    expect(calcDevLength({ ...BASE, topBar: true }).psi_t).toBe(1.3)
+  })
+
+  it('psi_e = 1.0 / 1.2 / 1.5 for none / light / heavy epoxy', () => {
+    expect(calcDevLength({ ...BASE, epoxy: 'none' }).psi_e).toBe(1.0)
+    expect(calcDevLength({ ...BASE, epoxy: 'coated-light' }).psi_e).toBe(1.2)
+    expect(calcDevLength({ ...BASE, epoxy: 'coated-heavy' }).psi_e).toBe(1.5)
+  })
+
+  it('psi_s = 0.8 for db ≤ 20 mm', () => {
+    expect(calcDevLength(BASE).psi_s).toBe(0.8)           // db=20
+    expect(calcDevLength({ ...BASE, db: 12 }).psi_s).toBe(0.8)
+  })
+
+  it('psi_s = 1.0 for db > 20 mm', () => {
+    expect(calcDevLength({ ...BASE, db: 25 }).psi_s).toBe(1.0)
+    expect(calcDevLength({ ...BASE, db: 32 }).psi_s).toBe(1.0)
+  })
+
+  it('psi_te = psi_t × psi_e when product ≤ 1.7', () => {
+    // top=true (1.3) × coated-light (1.2) = 1.56 < 1.7
+    const r = calcDevLength({ ...BASE, topBar: true, epoxy: 'coated-light' })
+    expect(r.psi_te).toBeCloseTo(1.3 * 1.2, 9)
+  })
+
+  it('psi_te capped at 1.7 when psi_t × psi_e > 1.7', () => {
+    // top=true (1.3) × coated-heavy (1.5) = 1.95 > 1.7
+    const r = calcDevLength({ ...BASE, topBar: true, epoxy: 'coated-heavy' })
+    expect(r.psi_te).toBeCloseTo(1.7, 9)
+  })
+})
+
+describe('calcDevLength — confinement cap §25.4.2.3', () => {
+  it('confine = cbKtr_db when ≤ 2.5', () => {
+    expect(calcDevLength({ ...BASE, cbKtr_db: 1.5 }).confine).toBeCloseTo(1.5, 9)
+    expect(calcDevLength({ ...BASE, cbKtr_db: 2.0 }).confine).toBeCloseTo(2.0, 9)
+  })
+
+  it('confine capped at 2.5', () => {
+    expect(calcDevLength({ ...BASE, cbKtr_db: 4.0 }).confine).toBeCloseTo(2.5, 9)
+  })
+})
+
+describe('calcDevLength — tension development §25.4.2.3', () => {
+  it('ld_raw = fy·ψte·ψs·db / (1.1·λ·√f\'c·Ψ)', () => {
+    const r = calcDevLength(BASE)
+    const sqrtFc = Math.sqrt(28)
+    const expected = (415 * 1.0 * 0.8 * 20) / (1.1 * 1.0 * sqrtFc * 1.5)
+    expect(r.ld_raw).toBeCloseTo(expected, 6)
+  })
+
+  it('ld = max(ld_raw, 300)', () => {
+    const r = calcDevLength(BASE)
+    expect(r.ld).toBeCloseTo(Math.max(r.ld_raw, 300), 9)
+    expect(r.ld).toBeGreaterThanOrEqual(300)
+  })
+
+  it('ld floor: 300 mm minimum applies for very small db or high confinement', () => {
+    // db=10, cbKtr_db=2.5 (max confinement) → very short raw length → floor kicks in
+    const r = calcDevLength({ ...BASE, db: 10, cbKtr_db: 2.5 })
+    expect(r.ld).toBeGreaterThanOrEqual(300)
+  })
+
+  it('larger confinement (Ψ=2.5) → shorter ld than Ψ=1.5', () => {
+    const r15 = calcDevLength({ ...BASE, cbKtr_db: 1.5 })
+    const r25 = calcDevLength({ ...BASE, cbKtr_db: 2.5 })
+    expect(r25.ld_raw).toBeLessThan(r15.ld_raw)
+  })
+
+  it('top bar increases ld (ψt=1.3)', () => {
+    const r_other = calcDevLength(BASE)
+    const r_top   = calcDevLength({ ...BASE, topBar: true })
+    expect(r_top.ld).toBeGreaterThan(r_other.ld)
+  })
+})
+
+describe('calcDevLength — compression development §25.4.9.2', () => {
+  it('ldc_1 = 0.24·fy·db / (λ·√f\'c)', () => {
+    const r = calcDevLength(BASE)
+    const sqrtFc = Math.sqrt(28)
+    const expected = (0.24 * 415 * 20) / (1.0 * sqrtFc)
+    // ldc = max(ldc_1, ldc_2, 200), so just verify ldc_1 is the leading term here
+    expect(r.ldc).toBeCloseTo(Math.max(expected, 0.043 * 415 * 20, 200), 6)
+  })
+
+  it('ldc ≥ 200 mm always', () => {
+    expect(calcDevLength(BASE).ldc).toBeGreaterThanOrEqual(200)
+  })
+
+  it('ldc = max of both formula terms and 200 mm floor', () => {
+    const r = calcDevLength(BASE)
+    const sqrtFc = Math.sqrt(28)
+    const ldc_1 = (0.24 * 415 * 20) / (1.0 * sqrtFc)
+    const ldc_2 = 0.043 * 415 * 20
+    expect(r.ldc).toBeCloseTo(Math.max(ldc_1, ldc_2, 200), 6)
+  })
+})
+
+describe('calcDevLength — tension splices §25.5.2', () => {
+  it('ls_A = 1.0 × ld (Class A)', () => {
+    const r = calcDevLength(BASE)
+    expect(r.ls_A).toBeCloseTo(r.ld, 9)
+  })
+
+  it('ls_B = 1.3 × ld (Class B)', () => {
+    const r = calcDevLength(BASE)
+    expect(r.ls_B).toBeCloseTo(1.3 * r.ld, 9)
+  })
+
+  it('ls_A ≥ 300 mm', () => {
+    expect(calcDevLength(BASE).ls_A).toBeGreaterThanOrEqual(300)
+  })
+})
+
+describe('calcDevLength — compression splices §25.5.5', () => {
+  it('lsc = 0.0725·fy·db for fy ≤ 420 MPa', () => {
+    const r = calcDevLength(BASE)  // fy=415 ≤ 420
+    const expected = Math.max(0.0725 * 415 * 20, 300)
+    expect(r.lsc).toBeCloseTo(expected, 6)
+  })
+
+  it('lsc = (0.13·fy − 24)·db for fy > 420 MPa', () => {
+    const r = calcDevLength({ ...BASE, fy: 520 })
+    const expected = Math.max((0.13 * 520 - 24) * 20, 300)
+    expect(r.lsc).toBeCloseTo(expected, 6)
+  })
+
+  it('lsc × 4/3 when f\'c < 21 MPa', () => {
+    const r_hi = calcDevLength({ ...BASE, fc: 28 })
+    const r_lo = calcDevLength({ ...BASE, fc: 17 })
+    expect(r_lo.lsc).toBeCloseTo(r_hi.lsc * (4 / 3), 6)
+  })
+
+  it('lsc ≥ 300 mm always', () => {
+    // Tiny bar, fy at limit
+    const r = calcDevLength({ ...BASE, db: 10, fy: 280 })
+    expect(r.lsc).toBeGreaterThanOrEqual(300)
+  })
+})

--- a/webapp/src/engine/devLength.ts
+++ b/webapp/src/engine/devLength.ts
@@ -1,0 +1,91 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Development and splice lengths — ACI 318-14 §25.4 + §25.5.
+// SI units: lengths mm, stress MPa.
+// Tension development: §25.4.2.3  (SI coefficient 1/1.1 ≈ 0.909).
+// Compression development: §25.4.9.2.
+// Splice — tension Class A/B: §25.5.2; compression: §25.5.5.1–2.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Epoxy-coating case for ψe factor (§25.4.2.4b). */
+export type EpoxyCase =
+  | 'none'            // uncoated / zinc-and-epoxy — ψe = 1.0
+  | 'coated-light'    // epoxy, cover ≥ 3db AND clear spacing ≥ 6db — ψe = 1.2
+  | 'coated-heavy'    // epoxy, cover < 3db OR clear spacing < 6db — ψe = 1.5
+
+const PSI_E: Record<EpoxyCase, number> = {
+  'none': 1.0,
+  'coated-light': 1.2,
+  'coated-heavy': 1.5,
+}
+
+export interface DevLengthInput {
+  db: number           // bar diameter, mm
+  fc: number           // f'c, MPa
+  fy: number           // bar yield, MPa
+  topBar: boolean      // >300 mm fresh concrete below bar at casting → ψt = 1.3
+  epoxy: EpoxyCase     // coating → ψe
+  lambda: number       // lightweight factor §19.2.4.1: 1.0 normal, 0.75 lightweight
+  cbKtr_db: number     // (cb + Ktr)/db confinement term; internally capped at 2.5
+}
+
+export interface DevLengthResult {
+  // Modification factors
+  psi_t: number        // casting-position factor
+  psi_e: number        // epoxy factor
+  psi_s: number        // bar-size factor (0.8 for db ≤ 20, 1.0 for db > 20)
+  psi_te: number       // ψt × ψe capped at 1.7 (§25.4.2.4)
+
+  // Confinement
+  confine: number      // (cb+Ktr)/db actually used (≤ 2.5)
+
+  // Tension development §25.4.2.3
+  ld_raw: number       // formula result before 300 mm floor, mm
+  ld: number           // development length in tension, mm (≥ 300)
+
+  // Compression development §25.4.9.2
+  ldc: number          // development length in compression, mm (≥ 200)
+
+  // Tension splices §25.5.2
+  ls_A: number         // Class A splice (1.0 × ld), mm (≥ 300)
+  ls_B: number         // Class B splice (1.3 × ld), mm (≥ 300)
+
+  // Compression splice §25.5.5
+  lsc: number          // compression splice length, mm (≥ 300)
+}
+
+export function calcDevLength(i: DevLengthInput): DevLengthResult {
+  const { db, fc, fy, lambda } = i
+  const sqrtFc = Math.sqrt(Math.max(fc, 1))
+
+  // §25.4.2.4 modification factors
+  const psi_t = i.topBar ? 1.3 : 1.0
+  const psi_e = PSI_E[i.epoxy]
+  const psi_s = db <= 20 ? 0.8 : 1.0                // bar-size factor
+  const psi_te = Math.min(psi_t * psi_e, 1.7)        // product cap
+
+  // §25.4.2.3 confinement term
+  const confine = Math.min(i.cbKtr_db, 2.5)
+
+  // Tension development (SI form of §25.4.2.3: coefficient = 1/1.1)
+  const ld_raw = (fy * psi_te * psi_s * db) / (1.1 * lambda * sqrtFc * confine)
+  const ld = Math.max(ld_raw, 300)
+
+  // Compression development §25.4.9.2
+  const ldc_1 = (0.24 * fy * db) / (lambda * sqrtFc)  // main formula
+  const ldc_2 = 0.043 * fy * db                        // secondary minimum
+  const ldc   = Math.max(ldc_1, ldc_2, 200)
+
+  // Tension splices §25.5.2
+  const ls_A = Math.max(1.0 * ld, 300)
+  const ls_B = Math.max(1.3 * ld, 300)
+
+  // Compression splice §25.5.5.1
+  const lsc_raw = fy <= 420
+    ? 0.0725 * fy * db
+    : (0.13 * fy - 24) * db
+  // §25.5.5.2 low-f'c correction: if f'c < 21 MPa → increase by 1/0.83 (= ×4/3)
+  const lsc_fc  = fc < 21 ? (4 / 3) : 1.0
+  const lsc     = Math.max(lsc_raw * lsc_fc, 300)
+
+  return { psi_t, psi_e, psi_s, psi_te, confine, ld_raw, ld, ldc, ls_A, ls_B, lsc }
+}

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -21,6 +21,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/steel',         name: 'Steel Design',       sub: 'AISC 360-16 LRFD'      },
       { to: '/slab-design',   name: 'Slab Design',        sub: 'Two-way DDM · ACI 318'  },
       { to: '/torsion',       name: 'Torsion Design',     sub: 'RC torsion · ACI 318-14' },
+      { to: '/dev-length',    name: 'Dev & Splice',       sub: 'ACI 318-14 §25.4–25.5'   },
     ],
   },
   {

--- a/webapp/src/pages/DevLength.tsx
+++ b/webapp/src/pages/DevLength.tsx
@@ -1,0 +1,142 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { calcDevLength, type DevLengthInput, type EpoxyCase } from '../engine/devLength'
+import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
+import { ReportControls } from '../components/ReportControls'
+import { f0, f1, f2 } from '../lib/format'
+
+const BAR_SIZES: [string, string][] = [
+  ['10', '10 mm (ø10)'],
+  ['12', '12 mm (ø12)'],
+  ['16', '16 mm (ø16)'],
+  ['20', '20 mm (ø20)'],
+  ['25', '25 mm (ø25)'],
+  ['28', '28 mm (ø28)'],
+  ['32', '32 mm (ø32)'],
+  ['36', '36 mm (ø36)'],
+]
+
+interface FormState extends Omit<DevLengthInput, 'db' | 'lambda'> {
+  db: string
+  lambda: '1' | '0.75'
+}
+
+const DEFAULTS: FormState = {
+  db: '20',
+  fc: 28, fy: 415,
+  topBar: false,
+  epoxy: 'none',
+  lambda: '1',
+  cbKtr_db: 1.5,
+}
+
+const EPOXY_OPTS: [EpoxyCase, string][] = [
+  ['none',         'Uncoated (ψe = 1.0)'],
+  ['coated-light', 'Epoxy, cover ≥ 3db (ψe = 1.2)'],
+  ['coated-heavy', 'Epoxy, cover < 3db (ψe = 1.5)'],
+]
+
+export default function DevLength() {
+  const [f, setF] = useState<FormState>(DEFAULTS)
+  const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) =>
+    setF((s) => ({ ...s, [k]: v }))
+
+  const r = useMemo(() => {
+    const db = parseFloat(f.db)
+    if (!Number.isFinite(db) || !Number.isFinite(f.fc) || !Number.isFinite(f.fy) ||
+        !Number.isFinite(f.cbKtr_db)) return null
+    return calcDevLength({
+      db, fc: f.fc, fy: f.fy,
+      topBar: f.topBar,
+      epoxy: f.epoxy,
+      lambda: parseFloat(f.lambda),
+      cbKtr_db: f.cbKtr_db,
+    })
+  }, [f])
+
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
+      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">
+        Development &amp; Splice Lengths
+      </h1>
+      <p className="no-print mt-1 text-slate-600">
+        ACI 318-14 §25.4 development + §25.5 splices. SI units (mm, MPa).
+        Tension §25.4.2.3 · Compression §25.4.9.2 · Splices §25.5.2/5.
+      </p>
+      <ReportControls title="Development & Splice Lengths" />
+
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
+        {/* ── INPUTS ── */}
+        <div className="flex flex-col gap-6">
+          <Card title="Bar &amp; Concrete">
+            <Pick label="Bar diameter db" value={f.db} onChange={set('db')} options={BAR_SIZES} />
+            <Num  label="f'c" unit="MPa" value={f.fc} onChange={set('fc')} />
+            <Num  label="fy"  unit="MPa" value={f.fy} onChange={set('fy')} />
+            <Pick label="Lightweight concrete λ" value={f.lambda} onChange={set('lambda')}
+              options={[['1', '1.0 — Normal weight'], ['0.75', '0.75 — Lightweight']]} />
+          </Card>
+
+          <Card title="Modification Factors §25.4.2.4">
+            <Pick label="Bar position" value={f.topBar ? 'top' : 'other'}
+              onChange={(v) => set('topBar')(v === 'top')}
+              options={[['other', 'Other bars (ψt = 1.0)'], ['top', 'Top bar >300 mm (ψt = 1.3)']]} />
+            <Pick label="Epoxy coating" value={f.epoxy} onChange={set('epoxy')}
+              options={EPOXY_OPTS} />
+          </Card>
+
+          <Card title="Confinement §25.4.2.3">
+            <Num label="(cb + Ktr) / db" value={f.cbKtr_db} onChange={set('cbKtr_db')}
+              step="0.1" />
+            <div className="col-span-full text-xs text-slate-500 -mt-2">
+              cb = smaller of cover-to-bar-CL or half cc spacing · Ktr = 40Atr/(s·n) · cap 2.5.
+              Use 1.5 when in doubt (conservative), 2.5 with adequate cover and ties.
+            </div>
+          </Card>
+        </div>
+
+        {/* ── RESULTS ── */}
+        {r ? (
+          <div className="flex flex-col gap-6">
+            <ResultCard title="Modification Factors">
+              <Row label="ψt — casting position" value={f2(r.psi_t)} />
+              <Row label="ψe — epoxy coating"    value={f2(r.psi_e)} />
+              <Row label="ψs — bar size"         value={f2(r.psi_s)} />
+              <Row label="ψt × ψe (≤ 1.7)"       value={f2(r.psi_te)}
+                alert={r.psi_t * r.psi_e > 1.7} />
+              <Row label="(cb+Ktr)/db used"      value={f2(r.confine)}
+                sub={r.confine < f.cbKtr_db ? 'capped at 2.5' : ''} />
+            </ResultCard>
+
+            <ResultCard title="Development Length — Tension §25.4.2.3">
+              <Row label="ℓd (formula)" value={`${f0(r.ld_raw)} mm`} />
+              <Row label="ℓd (adopted ≥ 300 mm)" value={`${f0(r.ld)} mm`}
+                sub={`${f1(r.ld / parseFloat(f.db))} db`} />
+            </ResultCard>
+
+            <ResultCard title="Development Length — Compression §25.4.9.2">
+              <Row label="ℓdc" value={`${f0(r.ldc)} mm`}
+                sub={`${f1(r.ldc / parseFloat(f.db))} db`} />
+            </ResultCard>
+
+            <ResultCard title="Tension Splices §25.5.2">
+              <Row label="Class A  (1.0 × ℓd)" value={`${f0(r.ls_A)} mm`}
+                sub="≤ 50% spliced, As ≥ 2·As,req" />
+              <Row label="Class B  (1.3 × ℓd)" value={`${f0(r.ls_B)} mm`}
+                sub="All other cases" />
+            </ResultCard>
+
+            <ResultCard title="Compression Splice §25.5.5">
+              <Row label="ℓsc" value={`${f0(r.lsc)} mm`}
+                sub={parseFloat(f.fc as unknown as string) < 21 ? '×4/3 low-f\'c applied' : ''} />
+            </ResultCard>
+          </div>
+        ) : (
+          <p className="self-start rounded-xl border border-slate-200 bg-white p-6 text-sm text-slate-500">
+            Fill in all inputs to see results.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **`devLength.ts`** — pure engine for deformed bar development and splice lengths (ACI 318-14 §25.4–§25.5, SI units):
  - Tension development §25.4.2.3: SI formula `fy·ψt·ψe·ψs·db / (1.1·λ·√f'c·Ψ)`, ψt×ψe cap at 1.7, (cb+Ktr)/db cap at 2.5, 300 mm floor
  - Compression development §25.4.9.2: `max(0.24·fy·db/(λ·√f'c), 0.043·fy·db, 200 mm)`
  - Tension splices §25.5.2: Class A (1.0×ℓd) and Class B (1.3×ℓd)
  - Compression splice §25.5.5: fy ≤ 420 / fy > 420 formulas + low-f'c (×4/3) correction
- **`devLength.test.ts`** — 24 tests covering all factors, formulas, floors, and edge cases
- **`DevLength.tsx`** — UI page at `/dev-length`: bar/material inputs, modification factor picks (top bar, epoxy, λ), confinement input with explanation, five result panels
- **`tools.ts` + `App.tsx`** — registered in navbar and routing

All 452 tests pass; `tsc -b` clean.

## Next phase
Phase 7 — punching shear design (ACI 318-14 §22.6) for two-way slabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_