### PR TITLE
feat: punching shear — ACI 318-14 §22.6 engine + UI

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -18,6 +18,7 @@ import SteelDesign from './pages/SteelDesign'
 import SlabDesign from './pages/SlabDesign'
 import TorsionDesign from './pages/TorsionDesign'
 import DevLength from './pages/DevLength'
+import PunchingShear from './pages/PunchingShear'
 import SlabEstimate from './pages/SlabEstimate'
 import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
@@ -54,6 +55,7 @@ export default function App() {
         <Route path="/slab-design" element={<SlabDesign />} />
         <Route path="/torsion" element={<TorsionDesign />} />
         <Route path="/dev-length" element={<DevLength />} />
+        <Route path="/punching-shear" element={<PunchingShear />} />
         <Route path="/estimate/slab" element={<SlabEstimate />} />
         <Route path="/estimate/beam" element={<BeamEstimate />} />
         <Route path="/estimate/column" element={<ColumnEstimate />} />

--- a/webapp/src/engine/punchingShear.test.ts
+++ b/webapp/src/engine/punchingShear.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import { designPunchingShear } from './punchingShear'
+
+// Reference: interior square column 500×500, d=150, fc=28, λ=1, Vu=500 kN
+const BASE = {
+  c1: 500, c2: 500, d: 150, fc: 28, lambda: 1.0, Vu: 500,
+  position: 'interior' as const,
+}
+
+describe('designPunchingShear — critical perimeter b0', () => {
+  it('interior: b0 = 2(c1+d) + 2(c2+d)', () => {
+    const r = designPunchingShear(BASE)
+    expect(r.b0).toBeCloseTo(2 * (500 + 150) + 2 * (500 + 150), 9)  // 2600 mm
+  })
+
+  it('edge: b0 = 2(c1/2+d) + (c2+d)  (c1 ∥ free edge)', () => {
+    const r = designPunchingShear({ ...BASE, position: 'edge' })
+    expect(r.b0).toBeCloseTo(2 * (250 + 150) + (500 + 150), 9)       // 1450 mm
+  })
+
+  it('corner: b0 = (c1/2+d) + (c2/2+d)', () => {
+    const r = designPunchingShear({ ...BASE, position: 'corner' })
+    expect(r.b0).toBeCloseTo((250 + 150) + (250 + 150), 9)           // 800 mm
+  })
+
+  it('b0 increases with d (thicker slab → larger perimeter)', () => {
+    const r1 = designPunchingShear({ ...BASE, d: 100 })
+    const r2 = designPunchingShear({ ...BASE, d: 200 })
+    expect(r2.b0).toBeGreaterThan(r1.b0)
+  })
+
+  it('rectangular column: b0 uses both c1 and c2', () => {
+    const r = designPunchingShear({ ...BASE, c1: 300, c2: 600 })
+    expect(r.b0).toBeCloseTo(2 * (300 + 150) + 2 * (600 + 150), 9)
+  })
+})
+
+describe('designPunchingShear — aspect ratio and αs', () => {
+  it('betac = 1 for square column', () => {
+    expect(designPunchingShear(BASE).betac).toBeCloseTo(1, 9)
+  })
+
+  it('betac = max/min for rectangular column', () => {
+    const r = designPunchingShear({ ...BASE, c1: 400, c2: 800 })
+    expect(r.betac).toBeCloseTo(800 / 400, 9)
+  })
+
+  it('alphaS = 40 for interior', () => {
+    expect(designPunchingShear(BASE).alphaS).toBe(40)
+  })
+
+  it('alphaS = 30 for edge', () => {
+    expect(designPunchingShear({ ...BASE, position: 'edge' }).alphaS).toBe(30)
+  })
+
+  it('alphaS = 20 for corner', () => {
+    expect(designPunchingShear({ ...BASE, position: 'corner' }).alphaS).toBe(20)
+  })
+})
+
+describe('designPunchingShear — Vc equations §22.6.5.2', () => {
+  const r = designPunchingShear(BASE)
+  const sqrtFc = Math.sqrt(28)
+  const b0 = 2 * (500 + 150) + 2 * (500 + 150)  // 2600
+  const base = 1.0 * sqrtFc * b0 * 150
+
+  it('Vc3 = 0.33·λ·√f\'c·b0·d  (kN)', () => {
+    expect(r.Vc3).toBeCloseTo(0.33 * base / 1000, 6)
+  })
+
+  it('Vc1 = (0.17 + 0.33/βc)·λ·√f\'c·b0·d  (kN)', () => {
+    const expected = (0.17 + 0.33 / 1) * base / 1000
+    expect(r.Vc1).toBeCloseTo(expected, 6)
+  })
+
+  it('Vc2 = (0.083·αs·d/b0 + 0.17)·λ·√f\'c·b0·d  (kN)', () => {
+    const expected = (0.083 * 40 * 150 / b0 + 0.17) * base / 1000
+    expect(r.Vc2).toBeCloseTo(expected, 6)
+  })
+
+  it('Vc = min(Vc1, Vc2, Vc3)', () => {
+    expect(r.Vc).toBeCloseTo(Math.min(r.Vc1, r.Vc2, r.Vc3), 9)
+  })
+
+  it('for square interior column βc=1, Vc1 = 0.5·base and Vc3 = 0.33·base → Vc3 governs', () => {
+    // 0.17 + 0.33/1 = 0.50 > 0.33, so Vc1 > Vc3 → Vc3 governs over Vc1
+    expect(r.Vc).toBeCloseTo(r.Vc3, 9)
+  })
+
+  it('Vc1 governs when βc is large (elongated column)', () => {
+    // βc = 4 → Vc1 coefficient = 0.17+0.33/4 = 0.2525 < 0.33 (Vc3) → Vc1 governs
+    const r2 = designPunchingShear({ ...BASE, c1: 200, c2: 800 })
+    expect(r2.betac).toBeCloseTo(4, 9)
+    expect(r2.Vc).toBeCloseTo(r2.Vc1, 9)
+  })
+
+  it('lightweight concrete (λ=0.75) reduces all Vc values', () => {
+    const r_nw = designPunchingShear(BASE)
+    const r_lw = designPunchingShear({ ...BASE, lambda: 0.75 })
+    expect(r_lw.Vc).toBeCloseTo(r_nw.Vc * 0.75, 6)
+  })
+})
+
+describe('designPunchingShear — φVc and demand check', () => {
+  it('phiVc = 0.75 × Vc', () => {
+    const r = designPunchingShear(BASE)
+    expect(r.phiVc).toBeCloseTo(0.75 * r.Vc, 9)
+  })
+
+  it('ratio = Vu / φVc', () => {
+    const r = designPunchingShear(BASE)
+    expect(r.ratio).toBeCloseTo(500 / r.phiVc, 9)
+  })
+
+  it('ok = true when Vu ≤ φVc', () => {
+    const r = designPunchingShear({ ...BASE, Vu: 1 })   // tiny demand
+    expect(r.ok).toBe(true)
+  })
+
+  it('ok = false when Vu > φVc', () => {
+    const r = designPunchingShear({ ...BASE, Vu: 9999 })  // huge demand
+    expect(r.ok).toBe(false)
+  })
+})

--- a/webapp/src/engine/punchingShear.ts
+++ b/webapp/src/engine/punchingShear.ts
@@ -1,0 +1,78 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Two-way (punching) shear for slab–column connections.
+// ACI 318-14 §22.6.  φ = 0.75 (§21.2.1).
+// SI units: lengths mm, stress MPa, forces kN (output).
+// ─────────────────────────────────────────────────────────────────────────
+//
+// Critical perimeter b0 at d/2 from column face (§22.6.4.1):
+//   Interior : b0 = 2(c1+d) + 2(c2+d)
+//   Edge     : b0 = 2(c1/2+d) + (c2+d)   c1 ∥ free edge, c2 ⊥ free edge
+//   Corner   : b0 = (c1/2+d) + (c2/2+d)
+//
+// Three Vc equations §22.6.5.2 (SI equivalents of ACI 318M-14):
+//   Vc1 = (0.17 + 0.33/βc) λ √f'c b0 d
+//   Vc2 = (0.083 αs d/b0 + 0.17) λ √f'c b0 d
+//   Vc3 = 0.33 λ √f'c b0 d
+//   Vc  = min(Vc1, Vc2, Vc3)
+// ─────────────────────────────────────────────────────────────────────────
+
+const PHI = 0.75
+
+/** Column position relative to slab edge. */
+export type ColPosition = 'interior' | 'edge' | 'corner'
+
+export interface PunchingInput {
+  c1: number          // column dim parallel to free edge (or x for interior), mm
+  c2: number          // column dim perpendicular to free edge (or y for interior), mm
+  d: number           // effective slab depth, mm
+  fc: number          // f'c, MPa
+  lambda: number      // lightweight factor (1.0 or 0.75)
+  Vu: number          // factored column shear, kN
+  position: ColPosition
+}
+
+export interface PunchingResult {
+  b0: number          // critical perimeter, mm
+  betac: number       // long/short column aspect ratio (≥ 1)
+  alphaS: number      // αs: 40 interior / 30 edge / 20 corner
+
+  Vc1: number         // Eq. 22.6.5.2a, kN
+  Vc2: number         // Eq. 22.6.5.2b, kN
+  Vc3: number         // Eq. 22.6.5.2c, kN
+  Vc: number          // min of Vc1–Vc3, kN
+  phiVc: number       // φ·Vc, kN
+
+  ratio: number       // Vu / φVc (demand/capacity)
+  ok: boolean         // φVc ≥ Vu
+}
+
+export function designPunchingShear(i: PunchingInput): PunchingResult {
+  const { c1, c2, d, fc, lambda, position } = i
+  const sqrtFc = Math.sqrt(Math.max(fc, 1))
+
+  // Critical perimeter (§22.6.4.1)
+  const b0 =
+    position === 'interior' ? 2 * (c1 + d) + 2 * (c2 + d)
+    : position === 'edge'   ? 2 * (c1 / 2 + d) + (c2 + d)
+    :                         (c1 / 2 + d) + (c2 / 2 + d)
+
+  // Column aspect ratio
+  const betac = Math.max(c1, c2) / Math.min(c1, c2)
+
+  // αs per column location
+  const alphaS = position === 'interior' ? 40 : position === 'edge' ? 30 : 20
+
+  // Vc in N (SI equivalents of §22.6.5.2a–c)
+  const base = lambda * sqrtFc * b0 * d
+  const Vc1 = (0.17 + 0.33 / betac) * base / 1000
+  const Vc2 = (0.083 * alphaS * d / b0 + 0.17) * base / 1000
+  const Vc3 = 0.33 * base / 1000
+
+  const Vc    = Math.min(Vc1, Vc2, Vc3)
+  const phiVc = PHI * Vc
+
+  const ratio = i.Vu / phiVc
+  const ok    = ratio <= 1 + 1e-9
+
+  return { b0, betac, alphaS, Vc1, Vc2, Vc3, Vc, phiVc, ratio, ok }
+}

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -22,6 +22,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/slab-design',   name: 'Slab Design',        sub: 'Two-way DDM · ACI 318'  },
       { to: '/torsion',       name: 'Torsion Design',     sub: 'RC torsion · ACI 318-14' },
       { to: '/dev-length',    name: 'Dev & Splice',       sub: 'ACI 318-14 §25.4–25.5'   },
+      { to: '/punching-shear', name: 'Punching Shear',   sub: 'Two-way §22.6 · ACI 318' },
     ],
   },
   {

--- a/webapp/src/pages/PunchingShear.tsx
+++ b/webapp/src/pages/PunchingShear.tsx
@@ -1,0 +1,142 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { designPunchingShear, type PunchingInput, type ColPosition } from '../engine/punchingShear'
+import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
+import { ReportControls } from '../components/ReportControls'
+import { f0, f1, f2, f3 } from '../lib/format'
+
+interface FormState {
+  c1: number; c2: number         // column dimensions, mm
+  h: number                      // slab thickness, mm
+  cover: number; barDia: number  // for effective depth
+  fc: number
+  lambda: '1' | '0.75'
+  Vu: number
+  position: ColPosition
+}
+
+const DEFAULTS: FormState = {
+  c1: 500, c2: 500,
+  h: 200, cover: 25, barDia: 16,
+  fc: 28,
+  lambda: '1',
+  Vu: 500,
+  position: 'interior',
+}
+
+const POS_OPTS: [ColPosition, string][] = [
+  ['interior', 'Interior — αs = 40'],
+  ['edge',     'Edge — αs = 30  (c1 ∥ free edge)'],
+  ['corner',   'Corner — αs = 20'],
+]
+
+const REQUIRED: (keyof FormState)[] = ['c1', 'c2', 'h', 'cover', 'barDia', 'fc', 'Vu']
+
+export default function PunchingShear() {
+  const [f, setF] = useState<FormState>(DEFAULTS)
+  const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) =>
+    setF((s) => ({ ...s, [k]: v }))
+
+  const allFinite = REQUIRED.every((k) => Number.isFinite(f[k] as number))
+
+  const d = f.h - f.cover - f.barDia / 2     // effective depth
+
+  const r = useMemo((): ReturnType<typeof designPunchingShear> | null => {
+    if (!allFinite || d <= 0) return null
+    const inp: PunchingInput = {
+      c1: f.c1, c2: f.c2,
+      d,
+      fc: f.fc,
+      lambda: parseFloat(f.lambda),
+      Vu: f.Vu,
+      position: f.position,
+    }
+    return designPunchingShear(inp)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(f), allFinite, d])
+
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
+      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">
+        Punching Shear
+      </h1>
+      <p className="no-print mt-1 text-slate-600">
+        Two-way slab–column punching shear — ACI 318-14 §22.6.
+        Critical perimeter at d/2 from column face. φ = 0.75.
+      </p>
+      <ReportControls title="Punching Shear" />
+
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
+        {/* ── INPUTS ── */}
+        <div className="flex flex-col gap-6">
+          <Card title="Column">
+            <Num label="c₁ (∥ free edge / x-dir)" unit="mm" value={f.c1} onChange={set('c1')} />
+            <Num label="c₂ (⊥ free edge / y-dir)" unit="mm" value={f.c2} onChange={set('c2')} />
+            <Pick label="Position" value={f.position} onChange={set('position')}
+              options={POS_OPTS} />
+          </Card>
+
+          <Card title="Slab">
+            <Num label="Thickness h" unit="mm"      value={f.h}      onChange={set('h')} />
+            <Num label="Clear cover"  unit="mm"      value={f.cover}  onChange={set('cover')} />
+            <Num label="Bar ⌀"        unit="mm"      value={f.barDia} onChange={set('barDia')} />
+            <Num label="f'c"          unit="MPa"     value={f.fc}     onChange={set('fc')} />
+            <Pick label="λ (lightweight)" value={f.lambda} onChange={set('lambda')}
+              options={[['1', '1.0 — Normal weight'], ['0.75', '0.75 — Lightweight']]} />
+          </Card>
+
+          <Card title="Demand">
+            <Num label="Vu (factored column load)" unit="kN" value={f.Vu} onChange={set('Vu')} />
+          </Card>
+        </div>
+
+        {/* ── RESULTS ── */}
+        {r ? (
+          <div className="flex flex-col gap-6">
+            <ResultCard title="Geometry">
+              <Row label="Effective depth d"
+                value={`${f1(d)} mm`}
+                sub={`h=${f0(f.h)} − cover=${f0(f.cover)} − db/2=${f1(f.barDia/2)}`} />
+              <Row label="Column βc = c_long / c_short" value={f2(r.betac)} />
+              <Row label="αs (position factor)"          value={String(r.alphaS)} />
+              <Row label="b₀ (critical perimeter)"       value={`${f0(r.b0)} mm`} />
+            </ResultCard>
+
+            <ResultCard title="Concrete Vc — §22.6.5.2 (kN)">
+              <Row label="Vc1 — (0.17 + 0.33/βc)·λ√f'c·b₀d"
+                value={`${f1(r.Vc1)} kN`}
+                alert={r.Vc === r.Vc1} />
+              <Row label="Vc2 — (0.083αs·d/b₀ + 0.17)·λ√f'c·b₀d"
+                value={`${f1(r.Vc2)} kN`}
+                alert={r.Vc === r.Vc2 && r.Vc !== r.Vc1} />
+              <Row label="Vc3 — 0.33·λ√f'c·b₀d"
+                value={`${f1(r.Vc3)} kN`}
+                alert={r.Vc === r.Vc3 && r.Vc !== r.Vc1 && r.Vc !== r.Vc2} />
+              <Row label="Vc (governing)"  value={`${f1(r.Vc)} kN`} />
+              <Row label="φVc (φ = 0.75)"  value={`${f1(r.phiVc)} kN`} />
+            </ResultCard>
+
+            <ResultCard title="Demand Check">
+              <Row label="Vu"           value={`${f1(f.Vu)} kN`} />
+              <Row label="φVc"          value={`${f1(r.phiVc)} kN`} />
+              <Row label="Ratio Vu/φVc" value={f3(r.ratio)} alert={!r.ok} />
+              <Row label="Status"
+                value={r.ok ? 'OK — No shear reinf. required ✓' : 'FAIL — Shear reinforcement required ✗'}
+                alert={!r.ok} />
+              {!r.ok && (
+                <p className="mt-2 rounded bg-red-50 px-3 py-2 text-xs text-red-700">
+                  φVc {'<'} Vu — increase slab thickness, column size, or add stud rails / closed stirrups per §22.6.7.
+                </p>
+              )}
+            </ResultCard>
+          </div>
+        ) : (
+          <p className="self-start rounded-xl border border-slate-200 bg-white p-6 text-sm text-slate-500">
+            Fill in all inputs to see results.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **`punchingShear.ts`** — pure engine for two-way slab–column punching shear (ACI 318-14 §22.6):
  - Critical perimeter b0 at d/2 from column face for interior, edge, and corner columns
  - Column aspect ratio βc and αs factor (40/30/20)
  - Three Vc equations §22.6.5.2 (SI equivalents), governing Vc = min of all three
  - φVc (φ=0.75) vs Vu demand/capacity ratio and ok flag
- **`punchingShear.test.ts`** — 21 tests covering all three b0 formulas, αs/βc values, all three Vc equations, governing-equation selection (including large-βc case), λ scaling, φ factor, and ok flag
- **`PunchingShear.tsx`** — UI page at `/punching-shear`: column dims + position, slab h/cover/bar inputs with computed d display, result panels with governing Vc highlighted and fail-state remediation note
- **`tools.ts` + `App.tsx`** — registered in navbar and routing

All 473 tests pass; `tsc -b` clean.

## Next phase
Phase 8 — wind/seismic load combinations (NSCP 2015 §204/§208) or retaining wall design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_