### PR TITLE
feat: cantilever retaining wall — Rankine stability + ACI 318-14 stem design

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -19,6 +19,7 @@ import SlabDesign from './pages/SlabDesign'
 import TorsionDesign from './pages/TorsionDesign'
 import DevLength from './pages/DevLength'
 import PunchingShear from './pages/PunchingShear'
+import RetainingWall from './pages/RetainingWall'
 import SlabEstimate from './pages/SlabEstimate'
 import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
@@ -56,6 +57,7 @@ export default function App() {
         <Route path="/torsion" element={<TorsionDesign />} />
         <Route path="/dev-length" element={<DevLength />} />
         <Route path="/punching-shear" element={<PunchingShear />} />
+        <Route path="/retaining-wall" element={<RetainingWall />} />
         <Route path="/estimate/slab" element={<SlabEstimate />} />
         <Route path="/estimate/beam" element={<BeamEstimate />} />
         <Route path="/estimate/column" element={<ColumnEstimate />} />

--- a/webapp/src/engine/retainingWall.test.ts
+++ b/webapp/src/engine/retainingWall.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest'
+import { designRetainingWall } from './retainingWall'
+
+// Reference: 3 m stem, 500 mm base, 300 mm stem, 500 toe, 1500 heel
+// Soil γ=18 kN/m³, φ=30°, q_sur=0, μ=0.5, qa=200 kPa
+// Concrete fc=28, fy=415, cover=75, db=16
+const BASE = {
+  Hs: 3000, tb: 500, ts: 300, bt: 500, bh: 1500,
+  gamma_s: 18, phi_deg: 30, q_sur: 0, mu: 0.5, qa: 200,
+  fc: 28, fy: 415, cover: 75, barDia: 16,
+}
+
+describe('designRetainingWall — geometry', () => {
+  const r = designRetainingWall(BASE)
+
+  it('B = (bt + ts + bh) / 1000 in metres', () => {
+    expect(r.B).toBeCloseTo((500 + 300 + 1500) / 1000, 9)  // 2.3 m
+  })
+
+  it('H = (Hs + tb) / 1000 in metres', () => {
+    expect(r.H).toBeCloseTo((3000 + 500) / 1000, 9)  // 3.5 m
+  })
+
+  it('Ka = tan²(45 − φ/2) for φ=30° → 1/3', () => {
+    expect(r.Ka).toBeCloseTo(1 / 3, 9)
+  })
+})
+
+describe('designRetainingWall — earth pressure', () => {
+  const r = designRetainingWall(BASE)
+
+  it('Pa = ½·Ka·γs·H²', () => {
+    const expected = 0.5 * (1 / 3) * 18 * 3.5 ** 2
+    expect(r.Pa).toBeCloseTo(expected, 6)  // ≈ 36.75 kN/m
+  })
+
+  it('Pq = 0 when surcharge = 0', () => {
+    expect(r.Pq).toBeCloseTo(0, 9)
+  })
+
+  it('Pq = Ka·q·H when surcharge > 0', () => {
+    const r2 = designRetainingWall({ ...BASE, q_sur: 10 })
+    expect(r2.Pq).toBeCloseTo((1 / 3) * 10 * 3.5, 6)
+  })
+
+  it('Fh = Pa + Pq', () => {
+    expect(r.Fh).toBeCloseTo(r.Pa + r.Pq, 9)
+  })
+
+  it('MO = Pa·H/3 + Pq·H/2', () => {
+    const expected = r.Pa * (3.5 / 3) + r.Pq * (3.5 / 2)
+    expect(r.MO).toBeCloseTo(expected, 6)
+  })
+})
+
+describe('designRetainingWall — vertical loads', () => {
+  const r = designRetainingWall(BASE)
+  const gc = 23.6
+
+  it('W_stem = γc·ts·Hs (per m)', () => {
+    expect(r.W_stem).toBeCloseTo(gc * 0.3 * 3.0, 6)
+  })
+
+  it('arm_stem = bt + ts/2', () => {
+    expect(r.arm_stem).toBeCloseTo(0.5 + 0.15, 9)
+  })
+
+  it('W_base = γc·B·tb', () => {
+    expect(r.W_base).toBeCloseTo(gc * 2.3 * 0.5, 6)
+  })
+
+  it('arm_base = B/2', () => {
+    expect(r.arm_base).toBeCloseTo(2.3 / 2, 9)
+  })
+
+  it('W_soil = γs·bh·hs', () => {
+    expect(r.W_soil).toBeCloseTo(18 * 1.5 * 3.0, 6)
+  })
+
+  it('arm_soil = bt + ts + bh/2', () => {
+    expect(r.arm_soil).toBeCloseTo(0.5 + 0.3 + 0.75, 9)
+  })
+
+  it('W_sur = q_sur·bh  (= 0 here)', () => {
+    expect(r.W_sur).toBeCloseTo(0, 9)
+  })
+
+  it('sumV = sum of all vertical loads', () => {
+    expect(r.sumV).toBeCloseTo(r.W_stem + r.W_base + r.W_soil + r.W_sur, 9)
+  })
+
+  it('MR = sum of W·arm', () => {
+    const expected =
+      r.W_stem * r.arm_stem + r.W_base * r.arm_base +
+      r.W_soil * r.arm_soil + r.W_sur * r.arm_sur
+    expect(r.MR).toBeCloseTo(expected, 9)
+  })
+})
+
+describe('designRetainingWall — stability', () => {
+  const r = designRetainingWall(BASE)
+
+  it('FS_OT = MR / MO', () => {
+    expect(r.FS_OT).toBeCloseTo(r.MR / r.MO, 9)
+  })
+
+  it('FS_SL = μ·ΣV / Fh', () => {
+    expect(r.FS_SL).toBeCloseTo(0.5 * r.sumV / r.Fh, 9)
+  })
+
+  it('reference wall is stable (FS_OT > 2 and FS_SL > 1.5)', () => {
+    expect(r.stableOT).toBe(true)
+    expect(r.stableSL).toBe(true)
+  })
+
+  it('stableOT = false when FS_OT < 2 (narrow heel)', () => {
+    const r2 = designRetainingWall({ ...BASE, bh: 200 })
+    expect(r2.stableOT).toBe(false)
+  })
+
+  it('stableSL = false when μ is very small', () => {
+    const r2 = designRetainingWall({ ...BASE, mu: 0.1 })
+    expect(r2.stableSL).toBe(false)
+  })
+})
+
+describe('designRetainingWall — bearing pressure', () => {
+  const r = designRetainingWall(BASE)
+
+  it('xbar = (MR − MO) / ΣV', () => {
+    expect(r.xbar).toBeCloseTo((r.MR - r.MO) / r.sumV, 9)
+  })
+
+  it('e = B/2 − xbar', () => {
+    expect(r.e).toBeCloseTo(r.B / 2 - r.xbar, 9)
+  })
+
+  it('q_max = (ΣV/B)·(1 + 6e/B)', () => {
+    const q_avg = r.sumV / r.B
+    expect(r.q_max).toBeCloseTo(q_avg * (1 + 6 * r.e / r.B), 6)
+  })
+
+  it('q_min = (ΣV/B)·(1 − 6e/B)', () => {
+    const q_avg = r.sumV / r.B
+    expect(r.q_min).toBeCloseTo(q_avg * (1 - 6 * r.e / r.B), 6)
+  })
+
+  it('reference wall: bearingOK and tensionOK', () => {
+    expect(r.bearingOK).toBe(true)
+    expect(r.tensionOK).toBe(true)
+  })
+
+  it('bearingOK = false when qa is too small', () => {
+    const r2 = designRetainingWall({ ...BASE, qa: 10 })
+    expect(r2.bearingOK).toBe(false)
+  })
+})
+
+describe('designRetainingWall — stem design', () => {
+  const r = designRetainingWall(BASE)
+  const hs = 3.0, Ka = 1 / 3
+
+  it('d_stem = ts − cover − barDia/2', () => {
+    expect(r.d_stem).toBeCloseTo(300 - 75 - 8, 9)
+  })
+
+  it('Pa_stem = ½·Ka·γs·Hs²', () => {
+    expect(r.Pa_stem).toBeCloseTo(0.5 * Ka * 18 * hs ** 2, 6)
+  })
+
+  it('Mu_stem = Pa_stem·Hs/3 + Pq_stem·Hs/2', () => {
+    const expected = r.Pa_stem * (hs / 3) + r.Pq_stem * (hs / 2)
+    expect(r.Mu_stem).toBeCloseTo(expected, 6)
+  })
+
+  it('Vc_stem = φ·(√f\'c/6)·b·d / 1000  (kN/m, b=1000 mm)', () => {
+    const expected = 0.75 * (Math.sqrt(28) / 6) * 1000 * r.d_stem / 1000
+    expect(r.Vc_stem).toBeCloseTo(expected, 6)
+  })
+
+  it('As_design ≥ As_min', () => {
+    expect(r.As_design).toBeGreaterThanOrEqual(r.As_min - 1e-9)
+  })
+
+  it('As_design ≥ As_stem (formula value)', () => {
+    expect(r.As_design).toBeGreaterThanOrEqual(r.As_stem - 1e-9)
+  })
+
+  it('higher surcharge → larger Mu_stem', () => {
+    const r2 = designRetainingWall({ ...BASE, q_sur: 20 })
+    expect(r2.Mu_stem).toBeGreaterThan(r.Mu_stem)
+  })
+})

--- a/webapp/src/engine/retainingWall.ts
+++ b/webapp/src/engine/retainingWall.ts
@@ -1,0 +1,185 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Cantilever retaining wall — stability + stem RC design.
+// Earth pressure: Rankine active theory.
+// Stability: NSCP 2015 §307 (FS_OT ≥ 2.0, FS_SL ≥ 1.5).
+// Stem design: ACI 318-14 §22.5 (shear) + §22.2 (flexure), φ=0.75/0.90.
+// SI units throughout: geometry mm, forces kN/m, moments kN·m/m, σ kPa.
+// ─────────────────────────────────────────────────────────────────────────
+//
+// Wall cross-section (per unit length):
+//
+//            |← ts →|
+//            +-------+  ← top of wall
+//            | stem  |
+//     H_s    |       |
+//   ─────────+───────+──────────  ← top of base
+//   |← bt →|← ts →|←── bh ──→|
+//   |           base           |
+//   |___________________________|  tb
+//
+// Retained height for earth pressure: H = Hs + tb (includes base thickness).
+// Moments taken about the toe (front edge of base).
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface RetainingWallInput {
+  // Geometry (mm)
+  Hs: number       // stem height, top of base to top of wall
+  tb: number       // base thickness
+  ts: number       // stem width at base
+  bt: number       // toe projection from front stem face to toe
+  bh: number       // heel projection from back stem face to heel
+
+  // Soil
+  gamma_s: number  // unit weight of retained soil, kN/m³
+  phi_deg: number  // angle of internal friction, degrees
+  q_sur: number    // uniform surcharge on retained fill, kPa (0 = none)
+  mu: number       // coefficient of friction, base slab vs. soil
+  qa: number       // allowable bearing pressure, kPa
+
+  // Concrete
+  fc: number       // f'c, MPa
+  fy: number       // bar yield, MPa
+  cover: number    // clear cover to main bar (retained side of stem), mm
+  barDia: number   // main stem bar diameter, mm
+  gamma_c?: number // unit weight of concrete, kN/m³ (default 23.6)
+}
+
+export interface RetainingWallResult {
+  // Derived geometry
+  B: number        // total base width (bt + ts + bh), m
+  H: number        // total retained height (Hs + tb), m
+  Ka: number       // Rankine active coefficient
+
+  // Earth pressure forces (kN per m length)
+  Pa: number       // active resultant: ½·Ka·γs·H²
+  Pq: number       // surcharge resultant: Ka·q·H
+  Fh: number       // total horizontal: Pa + Pq
+
+  // Vertical loads per m (kN/m) and moment arms from toe (m)
+  W_stem: number; arm_stem: number
+  W_base: number; arm_base: number
+  W_soil: number; arm_soil: number
+  W_sur:  number; arm_sur:  number
+  sumV: number     // ΣV total vertical, kN/m
+  MR: number       // total restoring moment about toe, kN·m/m
+  MO: number       // total overturning moment about toe, kN·m/m
+
+  // Stability factors of safety
+  FS_OT: number    // overturning (≥ 2.0)
+  FS_SL: number    // sliding (≥ 1.5)
+  stableOT: boolean
+  stableSL: boolean
+
+  // Bearing pressures (kPa)
+  xbar: number     // resultant location from toe, m
+  e: number        // eccentricity from base midpoint (+ = toward toe)
+  q_max: number    // at toe
+  q_min: number    // at heel
+  bearingOK: boolean
+  tensionOK: boolean  // q_min ≥ 0
+
+  // Stem design — per m width at base of stem (kN/m, kN·m/m, mm²/m)
+  d_stem: number
+  Pa_stem: number; Pq_stem: number
+  Vu_stem: number   // Pa_stem + Pq_stem, kN/m
+  Mu_stem: number   // Pa_stem·Hs/3 + Pq_stem·Hs/2, kN·m/m
+  Vc_stem: number   // φVc = 0.75·(√f'c/6)·1000·d, kN/m
+  shearOK: boolean
+
+  As_stem: number   // from flexure (may be < As_min)
+  As_min: number    // §9.6.1.2 max(0.25√f'c/fy, 1.4/fy)·b·d
+  As_design: number // governing
+}
+
+export function designRetainingWall(i: RetainingWallInput): RetainingWallResult {
+  const gamma_c = i.gamma_c ?? 23.6
+
+  // Dimensions in metres
+  const hs = i.Hs / 1000
+  const t_b = i.tb / 1000
+  const t_s = i.ts / 1000
+  const b_t = i.bt / 1000
+  const b_h = i.bh / 1000
+  const B   = b_t + t_s + b_h
+  const H   = hs + t_b
+
+  // Rankine Ka (Eq. Ka = tan²(45 − φ/2))
+  const phi = i.phi_deg * (Math.PI / 180)
+  const Ka  = Math.tan(Math.PI / 4 - phi / 2) ** 2
+
+  // Horizontal forces
+  const Pa  = 0.5 * Ka * i.gamma_s * H * H
+  const Pq  = Ka * i.q_sur * H
+  const Fh  = Pa + Pq
+
+  // Overturning moment about toe
+  const MO = Pa * (H / 3) + Pq * (H / 2)
+
+  // Vertical loads and arms from toe
+  const W_stem = gamma_c * t_s * hs
+  const arm_stem = b_t + t_s / 2
+
+  const W_base = gamma_c * B * t_b
+  const arm_base = B / 2
+
+  const W_soil = i.gamma_s * b_h * hs
+  const arm_soil = b_t + t_s + b_h / 2
+
+  const W_sur = i.q_sur * b_h
+  const arm_sur = b_t + t_s + b_h / 2
+
+  const sumV = W_stem + W_base + W_soil + W_sur
+  const MR   = W_stem * arm_stem + W_base * arm_base +
+               W_soil * arm_soil + W_sur * arm_sur
+
+  // Stability
+  const FS_OT = MR / MO
+  const FS_SL = (i.mu * sumV) / Fh
+
+  // Bearing pressure
+  const xbar = (MR - MO) / sumV
+  const e    = B / 2 - xbar
+  const q_avg = sumV / B
+  const q_max = q_avg * (1 + 6 * e / B)
+  const q_min = q_avg * (1 - 6 * e / B)
+
+  // Stem design at base of stem
+  const sqrtFc = Math.sqrt(Math.max(i.fc, 1))
+  const b = 1000   // mm — per unit length
+  const d_stem = i.ts - i.cover - i.barDia / 2
+
+  const Pa_stem = 0.5 * Ka * i.gamma_s * hs * hs   // kN/m
+  const Pq_stem = Ka * i.q_sur * hs                 // kN/m
+  const Vu_stem = Pa_stem + Pq_stem
+  const Mu_stem = Pa_stem * (hs / 3) + Pq_stem * (hs / 2)  // kN·m/m
+
+  // Shear §22.5.5 (simplified): φVc = φ·(λ√f'c/6)·b·d (kN/m, λ=1)
+  const Vc_stem = 0.75 * (sqrtFc / 6) * b * d_stem / 1000
+
+  // Flexure §22.2 (b = 1000 mm/m)
+  const Rn  = (Mu_stem * 1e6 / 0.9) / (b * d_stem * d_stem)
+  const m   = i.fy / (0.85 * i.fc)
+  const rho = (1 / m) * (1 - Math.sqrt(Math.max(0, 1 - 2 * m * Rn / i.fy)))
+  const As_stem = rho * b * d_stem
+
+  // Minimum §9.6.1.2
+  const rho_min  = Math.max(0.25 * sqrtFc / i.fy, 1.4 / i.fy)
+  const As_min   = rho_min * b * d_stem
+  const As_design = Math.max(As_stem, As_min)
+
+  return {
+    B, H, Ka,
+    Pa, Pq, Fh,
+    W_stem, arm_stem, W_base, arm_base, W_soil, arm_soil, W_sur, arm_sur,
+    sumV, MR, MO,
+    FS_OT, FS_SL,
+    stableOT: FS_OT >= 2.0 - 1e-9,
+    stableSL: FS_SL >= 1.5 - 1e-9,
+    xbar, e, q_max, q_min,
+    bearingOK: q_max <= i.qa + 1e-9,
+    tensionOK: q_min >= -1e-9,
+    d_stem, Pa_stem, Pq_stem, Vu_stem, Mu_stem, Vc_stem,
+    shearOK: Vu_stem <= Vc_stem + 1e-9,
+    As_stem, As_min, As_design,
+  }
+}

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -23,6 +23,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/torsion',       name: 'Torsion Design',     sub: 'RC torsion · ACI 318-14' },
       { to: '/dev-length',    name: 'Dev & Splice',       sub: 'ACI 318-14 §25.4–25.5'   },
       { to: '/punching-shear', name: 'Punching Shear',   sub: 'Two-way §22.6 · ACI 318' },
+      { to: '/retaining-wall', name: 'Retaining Wall',  sub: 'Cantilever · Rankine'     },
     ],
   },
   {

--- a/webapp/src/pages/RetainingWall.tsx
+++ b/webapp/src/pages/RetainingWall.tsx
@@ -1,0 +1,161 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { designRetainingWall, type RetainingWallInput } from '../engine/retainingWall'
+import { Num, Card, ResultCard, Row } from '../components/qty'
+import { ReportControls } from '../components/ReportControls'
+import { f1, f2, f3 } from '../lib/format'
+
+type FormState = RetainingWallInput & { gamma_c: number }
+
+const DEFAULTS: FormState = {
+  Hs: 3000, tb: 500, ts: 300, bt: 500, bh: 1500,
+  gamma_s: 18, phi_deg: 30, q_sur: 0, mu: 0.5, qa: 200,
+  fc: 28, fy: 415, cover: 75, barDia: 16, gamma_c: 23.6,
+}
+
+const REQUIRED: (keyof FormState)[] = [
+  'Hs', 'tb', 'ts', 'bt', 'bh',
+  'gamma_s', 'phi_deg', 'mu', 'qa',
+  'fc', 'fy', 'cover', 'barDia', 'gamma_c',
+]
+
+function Status({ ok, label }: { ok: boolean; label: string }) {
+  return (
+    <span className={`rounded px-1.5 py-0.5 text-xs font-semibold ${ok ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'}`}>
+      {ok ? '✓' : '✗'} {label}
+    </span>
+  )
+}
+
+export default function RetainingWall() {
+  const [f, setF] = useState<FormState>(DEFAULTS)
+  const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) =>
+    setF((s) => ({ ...s, [k]: v }))
+
+  const allFinite = REQUIRED.every((k) => Number.isFinite(f[k] as number))
+    && Number.isFinite(f.q_sur)
+
+  const r = useMemo(
+    () => (allFinite ? designRetainingWall(f) : null),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [JSON.stringify(f), allFinite],
+  )
+
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
+      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">
+        Retaining Wall Design
+      </h1>
+      <p className="no-print mt-1 text-slate-600">
+        Cantilever RC retaining wall — Rankine active pressure, NSCP 2015 stability checks,
+        ACI 318-14 stem design. All forces per metre of wall length.
+      </p>
+      <ReportControls title="Retaining Wall Design" />
+
+      {/* Schematic legend */}
+      <pre className="no-print mt-3 rounded-lg border border-slate-200 bg-slate-50 p-3 text-[0.65rem] leading-tight text-slate-500">
+{`         |← ts →|
+         +-------+  ← top (Hs)
+         | stem  |
+─────────+───────+──────────  ← top of base
+|← bt →|← ts →|←── bh ──→|
+|           base  (tb)      |`}
+      </pre>
+
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
+        {/* ── INPUTS ── */}
+        <div className="flex flex-col gap-6">
+          <Card title="Geometry (mm)">
+            <Num label="Stem height Hs"    unit="mm" value={f.Hs}  onChange={set('Hs')} />
+            <Num label="Base thickness tb" unit="mm" value={f.tb}  onChange={set('tb')} />
+            <Num label="Stem width ts"     unit="mm" value={f.ts}  onChange={set('ts')} />
+            <Num label="Toe projection bt" unit="mm" value={f.bt}  onChange={set('bt')} />
+            <Num label="Heel projection bh" unit="mm" value={f.bh} onChange={set('bh')} />
+          </Card>
+
+          <Card title="Soil Parameters">
+            <Num label="γs — soil unit weight" unit="kN/m³" value={f.gamma_s} onChange={set('gamma_s')} />
+            <Num label="φ — friction angle"    unit="°"     value={f.phi_deg} onChange={set('phi_deg')} />
+            <Num label="Surcharge q"           unit="kPa"   value={f.q_sur}   onChange={set('q_sur')} />
+            <Num label="μ — base friction"     value={f.mu}                   onChange={set('mu')} />
+            <Num label="qa — allowable bearing" unit="kPa"  value={f.qa}      onChange={set('qa')} />
+          </Card>
+
+          <Card title="Concrete &amp; Steel">
+            <Num label="f'c"              unit="MPa" value={f.fc}      onChange={set('fc')} />
+            <Num label="fy"               unit="MPa" value={f.fy}      onChange={set('fy')} />
+            <Num label="Cover (stem)"     unit="mm"  value={f.cover}   onChange={set('cover')} />
+            <Num label="Main bar ⌀"       unit="mm"  value={f.barDia}  onChange={set('barDia')} />
+            <Num label="γc — concrete unit weight" unit="kN/m³" value={f.gamma_c} onChange={set('gamma_c')} />
+          </Card>
+        </div>
+
+        {/* ── RESULTS ── */}
+        {r ? (
+          <div className="flex flex-col gap-6">
+            <ResultCard title="Summary">
+              <div className="flex flex-wrap gap-2 pb-2">
+                <Status ok={r.stableOT}  label={`OT FS=${f2(r.FS_OT)}`} />
+                <Status ok={r.stableSL}  label={`SL FS=${f2(r.FS_SL)}`} />
+                <Status ok={r.bearingOK} label={`Bearing ${f1(r.q_max)} kPa`} />
+                <Status ok={r.tensionOK} label={r.tensionOK ? 'No tension' : 'Heel tension!'} />
+                <Status ok={r.shearOK}   label="Stem shear" />
+              </div>
+              <Row label="Base width B"      value={`${f2(r.B)} m`} />
+              <Row label="Retained height H" value={`${f2(r.H)} m`} />
+              <Row label="Ka (Rankine)"      value={f3(r.Ka)} />
+            </ResultCard>
+
+            <ResultCard title="Earth Pressure">
+              <Row label="Active Pa = ½Ka·γs·H²" value={`${f1(r.Pa)} kN/m`} />
+              <Row label="Surcharge Pq = Ka·q·H"  value={`${f1(r.Pq)} kN/m`} />
+              <Row label="Total Fh"               value={`${f1(r.Fh)} kN/m`} />
+              <Row label="Overturning MO"         value={`${f1(r.MO)} kN·m/m`} />
+            </ResultCard>
+
+            <ResultCard title="Vertical Loads">
+              <Row label="W_stem" value={`${f1(r.W_stem)} kN/m`} sub={`arm ${f2(r.arm_stem)} m`} />
+              <Row label="W_base" value={`${f1(r.W_base)} kN/m`} sub={`arm ${f2(r.arm_base)} m`} />
+              <Row label="W_soil" value={`${f1(r.W_soil)} kN/m`} sub={`arm ${f2(r.arm_soil)} m`} />
+              {r.W_sur > 0 && <Row label="W_sur" value={`${f1(r.W_sur)} kN/m`} sub={`arm ${f2(r.arm_sur)} m`} />}
+              <Row label="ΣV"             value={`${f1(r.sumV)} kN/m`} />
+              <Row label="Restoring MR"   value={`${f1(r.MR)} kN·m/m`} />
+            </ResultCard>
+
+            <ResultCard title="Stability Checks">
+              <Row label="FS overturning (≥ 2.0)" value={f2(r.FS_OT)} alert={!r.stableOT} />
+              <Row label="FS sliding (≥ 1.5)"     value={f2(r.FS_SL)} alert={!r.stableSL} />
+            </ResultCard>
+
+            <ResultCard title="Bearing Pressure">
+              <Row label="Resultant x̄ from toe" value={`${f2(r.xbar)} m`} />
+              <Row label="Eccentricity e"        value={`${f3(r.e)} m`} sub={`B/6 = ${f3(r.B/6)} m`} />
+              <Row label="q_max (toe)"
+                value={`${f1(r.q_max)} kPa`}
+                sub={`qa = ${f.qa} kPa`}
+                alert={!r.bearingOK} />
+              <Row label="q_min (heel)"
+                value={`${f1(r.q_min)} kPa`}
+                alert={!r.tensionOK} />
+            </ResultCard>
+
+            <ResultCard title="Stem Design (at base)">
+              <Row label="Effective depth d"  value={`${f1(r.d_stem)} mm`} />
+              <Row label="Vu (shear demand)"  value={`${f1(r.Vu_stem)} kN/m`} />
+              <Row label="φVc"                value={`${f1(r.Vc_stem)} kN/m`} alert={!r.shearOK} />
+              <Row label="Mu (moment demand)" value={`${f1(r.Mu_stem)} kN·m/m`} />
+              <Row label="As required"        value={`${f1(r.As_stem)} mm²/m`} />
+              <Row label="As minimum"         value={`${f1(r.As_min)} mm²/m`} />
+              <Row label="As design"          value={`${f1(r.As_design)} mm²/m`} />
+            </ResultCard>
+          </div>
+        ) : (
+          <p className="self-start rounded-xl border border-slate-200 bg-white p-6 text-sm text-slate-500">
+            Fill in all inputs to see results.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **`retainingWall.ts`** — pure engine for cantilever RC retaining wall design:
  - Rankine active earth pressure Ka = tan²(45−φ/2), Pa, surcharge Pq
  - Vertical loads (stem, base, soil, surcharge) with moment arms from toe
  - Stability: FS_OT = MR/MO (≥ 2.0), FS_SL = μΣV/Fh (≥ 1.5)
  - Trapezoidal bearing pressure q_max/q_min, eccentricity check
  - Stem design at base: Vu, φVc (§22.5), Mu, required As, As_min (§9.6.1.2)
- **`retainingWall.test.ts`** — 35 tests across all calculation stages
- **`RetainingWall.tsx`** — UI at `/retaining-wall`: geometry/soil/concrete inputs with ASCII cross-section legend, summary status chips (OT · SL · bearing · heel tension · stem shear), six result panels
- **`tools.ts` + `App.tsx`** — registered in navbar and routing

All 508 tests pass; `tsc -b` clean.

## Next phase
Phase 9 — NSCP 2015 load combinations (§203) with dead/live/wind/seismic inputs and envelope demand table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_