### PR TITLE
feat: NSCP 2015 §203.3 load combinations calculator (Phase 9)

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -25,6 +25,7 @@ import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
 import BeamEstimate from './pages/BeamEstimate'
 import BoxCulvertEstimate from './pages/BoxCulvertEstimate'
+import LoadCombinations from './pages/LoadCombinations'
 
 export default function App() {
   const [auth, setAuth] = useState<'login' | 'signup' | null>(null)
@@ -63,6 +64,7 @@ export default function App() {
         <Route path="/estimate/column" element={<ColumnEstimate />} />
         <Route path="/estimate/chb" element={<ChbEstimate />} />
         <Route path="/estimate/box-culvert" element={<BoxCulvertEstimate />} />
+        <Route path="/load-combinations" element={<LoadCombinations />} />
       </Routes>
       {auth && <AuthModal mode={auth} onClose={() => setAuth(null)} />}
     </>

--- a/webapp/src/engine/loadCombinations.test.ts
+++ b/webapp/src/engine/loadCombinations.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import { calcLoadCombinations, type LoadDemands } from './loadCombinations'
+
+// Reference: D=10, L=5, Lr=2, W=8, E=12
+const BASE: LoadDemands = { D: 10, L: 5, Lr: 2, W: 8, E: 12 }
+
+describe('calcLoadCombinations — individual combos', () => {
+  const { combos } = calcLoadCombinations(BASE)
+  const by = (id: string) => combos.find(c => c.id === id)!
+
+  it('combo 1: 1.4D = 14', () => {
+    expect(by('1').value).toBeCloseTo(1.4 * 10, 9)
+  })
+
+  it('combo 2: 1.2D + 1.6L + 0.5Lr = 12 + 8 + 1 = 21', () => {
+    expect(by('2').value).toBeCloseTo(1.2 * 10 + 1.6 * 5 + 0.5 * 2, 9)
+  })
+
+  it('combo 3a: 1.2D + 1.6Lr + 1.0L = 12 + 3.2 + 5 = 20.2', () => {
+    expect(by('3a').value).toBeCloseTo(1.2 * 10 + 1.6 * 2 + 1.0 * 5, 9)
+  })
+
+  it('combo 3b: 1.2D + 1.6Lr + 0.5W = 12 + 3.2 + 4 = 19.2', () => {
+    expect(by('3b').value).toBeCloseTo(1.2 * 10 + 1.6 * 2 + 0.5 * 8, 9)
+  })
+
+  it('combo 3c: 1.2D + 1.6Lr − 0.5W = 12 + 3.2 − 4 = 11.2', () => {
+    expect(by('3c').value).toBeCloseTo(1.2 * 10 + 1.6 * 2 - 0.5 * 8, 9)
+  })
+
+  it('combo 4a: 1.2D + 1.0W + 1.0L + 0.5Lr = 12 + 8 + 5 + 1 = 26', () => {
+    expect(by('4a').value).toBeCloseTo(1.2 * 10 + 1.0 * 8 + 1.0 * 5 + 0.5 * 2, 9)
+  })
+
+  it('combo 4b: 1.2D − 1.0W + 1.0L + 0.5Lr = 12 − 8 + 5 + 1 = 10', () => {
+    expect(by('4b').value).toBeCloseTo(1.2 * 10 - 1.0 * 8 + 1.0 * 5 + 0.5 * 2, 9)
+  })
+
+  it('combo 5a: 0.9D + 1.0W = 9 + 8 = 17', () => {
+    expect(by('5a').value).toBeCloseTo(0.9 * 10 + 1.0 * 8, 9)
+  })
+
+  it('combo 5b: 0.9D − 1.0W = 9 − 8 = 1', () => {
+    expect(by('5b').value).toBeCloseTo(0.9 * 10 - 1.0 * 8, 9)
+  })
+
+  it('combo 6a: 1.2D + 1.0E + 1.0L = 12 + 12 + 5 = 29', () => {
+    expect(by('6a').value).toBeCloseTo(1.2 * 10 + 1.0 * 12 + 1.0 * 5, 9)
+  })
+
+  it('combo 6b: 1.2D − 1.0E + 1.0L = 12 − 12 + 5 = 5', () => {
+    expect(by('6b').value).toBeCloseTo(1.2 * 10 - 1.0 * 12 + 1.0 * 5, 9)
+  })
+
+  it('combo 7a: 0.9D + 1.0E = 9 + 12 = 21', () => {
+    expect(by('7a').value).toBeCloseTo(0.9 * 10 + 1.0 * 12, 9)
+  })
+
+  it('combo 7b: 0.9D − 1.0E = 9 − 12 = −3', () => {
+    expect(by('7b').value).toBeCloseTo(0.9 * 10 - 1.0 * 12, 9)
+  })
+})
+
+describe('calcLoadCombinations — envelope', () => {
+  const r = calcLoadCombinations(BASE)
+
+  it('13 combinations returned', () => {
+    expect(r.combos).toHaveLength(13)
+  })
+
+  it('maxCombo = 6a with value 29', () => {
+    expect(r.maxCombo.id).toBe('6a')
+    expect(r.maxCombo.value).toBeCloseTo(29, 9)
+  })
+
+  it('minCombo = 7b with value −3', () => {
+    expect(r.minCombo.id).toBe('7b')
+    expect(r.minCombo.value).toBeCloseTo(-3, 9)
+  })
+
+  it('zero loads → all combos = 0', () => {
+    const { combos } = calcLoadCombinations({ D: 0, L: 0, Lr: 0, W: 0, E: 0 })
+    combos.forEach(c => expect(c.value).toBeCloseTo(0, 9))
+  })
+
+  it('only dead load: max = combo 1 = 1.4D', () => {
+    const { maxCombo } = calcLoadCombinations({ D: 10, L: 0, Lr: 0, W: 0, E: 0 })
+    expect(maxCombo.id).toBe('1')
+    expect(maxCombo.value).toBeCloseTo(14, 9)
+  })
+
+  it('factors stored on each combo', () => {
+    const c = r.combos.find(c => c.id === '2')!
+    expect(c.fD).toBeCloseTo(1.2, 9)
+    expect(c.fL).toBeCloseTo(1.6, 9)
+    expect(c.fLr).toBeCloseTo(0.5, 9)
+    expect(c.fW).toBeCloseTo(0, 9)
+    expect(c.fE).toBeCloseTo(0, 9)
+  })
+})

--- a/webapp/src/engine/loadCombinations.ts
+++ b/webapp/src/engine/loadCombinations.ts
@@ -1,0 +1,61 @@
+// ─────────────────────────────────────────────────────────────────────────
+// NSCP 2015 §203.3 Strength Design (LRFD) Load Combinations.
+// Ref: NSCP 2015 Table 203-1  (mirrors ASCE 7-10 §2.3.2 with NSCP notation)
+// SI units — loads in any consistent unit (kN, kN/m, kN/m², etc.)
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface LoadDemands {
+  D:  number   // Dead load
+  L:  number   // Live load (floor)
+  Lr: number   // Roof live load
+  W:  number   // Wind load (magnitude; ±W applied per combo)
+  E:  number   // Earthquake load (magnitude; ±E applied per combo)
+}
+
+export interface ComboResult {
+  id:     string   // e.g. '1', '3a', '4b'
+  label:  string   // human-readable expression
+  value:  number   // computed factored load
+  fD:  number; fL:  number; fLr: number; fW: number; fE: number
+}
+
+export interface LoadCombResult {
+  combos:   ComboResult[]
+  maxCombo: ComboResult   // combo with largest value
+  minCombo: ComboResult   // combo with smallest value
+}
+
+// Each row: [id, label, fD, fL, fLr, fW, fE]
+type ComboSpec = [string, string, number, number, number, number, number]
+
+const COMBOS: ComboSpec[] = [
+  ['1',  '1.4D',                               1.4,  0,    0,    0,    0   ],
+  ['2',  '1.2D + 1.6L + 0.5Lr',               1.2,  1.6,  0.5,  0,    0   ],
+  ['3a', '1.2D + 1.6Lr + 1.0L',               1.2,  1.0,  1.6,  0,    0   ],
+  ['3b', '1.2D + 1.6Lr + 0.5W',               1.2,  0,    1.6,  0.5,  0   ],
+  ['3c', '1.2D + 1.6Lr − 0.5W',               1.2,  0,    1.6, -0.5,  0   ],
+  ['4a', '1.2D + 1.0W + 1.0L + 0.5Lr',        1.2,  1.0,  0.5,  1.0,  0   ],
+  ['4b', '1.2D − 1.0W + 1.0L + 0.5Lr',        1.2,  1.0,  0.5, -1.0,  0   ],
+  ['5a', '0.9D + 1.0W',                        0.9,  0,    0,    1.0,  0   ],
+  ['5b', '0.9D − 1.0W',                        0.9,  0,    0,   -1.0,  0   ],
+  ['6a', '1.2D + 1.0E + 1.0L',                1.2,  1.0,  0,    0,    1.0 ],
+  ['6b', '1.2D − 1.0E + 1.0L',                1.2,  1.0,  0,    0,   -1.0 ],
+  ['7a', '0.9D + 1.0E',                        0.9,  0,    0,    0,    1.0 ],
+  ['7b', '0.9D − 1.0E',                        0.9,  0,    0,    0,   -1.0 ],
+]
+
+export function calcLoadCombinations(d: LoadDemands): LoadCombResult {
+  const combos: ComboResult[] = COMBOS.map(([id, label, fD, fL, fLr, fW, fE]) => ({
+    id, label, fD, fL, fLr, fW, fE,
+    value: fD * d.D + fL * d.L + fLr * d.Lr + fW * d.W + fE * d.E,
+  }))
+
+  let maxCombo = combos[0]
+  let minCombo = combos[0]
+  for (const c of combos) {
+    if (c.value > maxCombo.value) maxCombo = c
+    if (c.value < minCombo.value) minCombo = c
+  }
+
+  return { combos, maxCombo, minCombo }
+}

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -23,7 +23,8 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/torsion',       name: 'Torsion Design',     sub: 'RC torsion · ACI 318-14' },
       { to: '/dev-length',    name: 'Dev & Splice',       sub: 'ACI 318-14 §25.4–25.5'   },
       { to: '/punching-shear', name: 'Punching Shear',   sub: 'Two-way §22.6 · ACI 318' },
-      { to: '/retaining-wall', name: 'Retaining Wall',  sub: 'Cantilever · Rankine'     },
+      { to: '/retaining-wall',   name: 'Retaining Wall',   sub: 'Cantilever · Rankine'     },
+      { to: '/load-combinations', name: 'Load Combinations', sub: 'NSCP 2015 §203.3 LRFD'   },
     ],
   },
   {

--- a/webapp/src/pages/LoadCombinations.tsx
+++ b/webapp/src/pages/LoadCombinations.tsx
@@ -1,0 +1,112 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { calcLoadCombinations, type LoadDemands } from '../engine/loadCombinations'
+import { Num, Card } from '../components/qty'
+import { ReportControls } from '../components/ReportControls'
+import { f2 } from '../lib/format'
+
+const DEFAULTS: LoadDemands = { D: 0, L: 0, Lr: 0, W: 0, E: 0 }
+
+export default function LoadCombinations() {
+  const [d, setD] = useState<LoadDemands>(DEFAULTS)
+  const set = <K extends keyof LoadDemands>(k: K) => (v: number) =>
+    setD(s => ({ ...s, [k]: v }))
+
+  const allFinite = Object.values(d).every(Number.isFinite)
+  const r = useMemo(
+    () => (allFinite ? calcLoadCombinations(d) : null),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [JSON.stringify(d), allFinite],
+  )
+
+  return (
+    <div className="mx-auto max-w-4xl p-6">
+      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
+      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">
+        Load Combinations
+      </h1>
+      <p className="no-print mt-1 text-slate-600">
+        NSCP 2015 §203.3 Strength Design (LRFD) — 13 factored combinations.
+        Enter unfactored characteristic loads; the table shows every factored result
+        with the governing (max/min) envelope highlighted.
+      </p>
+      <ReportControls title="NSCP 2015 Load Combinations" />
+
+      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1fr_2fr]">
+        {/* ── INPUTS ── */}
+        <Card title="Unfactored Loads">
+          <Num label="D — Dead load"       value={d.D}  onChange={set('D')} />
+          <Num label="L — Floor live"      value={d.L}  onChange={set('L')} />
+          <Num label="Lr — Roof live"      value={d.Lr} onChange={set('Lr')} />
+          <Num label="W — Wind"            value={d.W}  onChange={set('W')} />
+          <Num label="E — Earthquake"      value={d.E}  onChange={set('E')} />
+          <p className="mt-2 text-xs text-slate-400">
+            Any consistent unit (kN, kN/m, kPa, …). W and E enter as positive magnitudes;
+            the ±W/±E sign is handled by each combination.
+          </p>
+        </Card>
+
+        {/* ── RESULTS TABLE ── */}
+        {r ? (
+          <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm">
+            <div className="border-b border-slate-100 bg-slate-50 px-4 py-2.5">
+              <span className="text-sm font-semibold text-slate-700">Factored Load Combinations</span>
+              <span className="ml-3 text-xs text-slate-400">NSCP 2015 §203.3</span>
+            </div>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-slate-100 text-left text-xs text-slate-500">
+                  <th className="px-3 py-2 font-medium">No.</th>
+                  <th className="px-3 py-2 font-medium">Combination</th>
+                  <th className="px-3 py-2 text-right font-medium">Value</th>
+                </tr>
+              </thead>
+              <tbody>
+                {r.combos.map(c => {
+                  const isMax = c.id === r.maxCombo.id
+                  const isMin = c.id === r.minCombo.id
+                  const highlight = isMax
+                    ? 'bg-green-50'
+                    : isMin && r.minCombo.value < 0
+                    ? 'bg-red-50'
+                    : ''
+                  return (
+                    <tr key={c.id} className={`border-b border-slate-50 ${highlight}`}>
+                      <td className="px-3 py-2 font-mono text-slate-400">{c.id}</td>
+                      <td className="px-3 py-2 text-slate-700">{c.label}</td>
+                      <td className="px-3 py-2 text-right font-semibold tabular-nums">
+                        {f2(c.value)}
+                        {isMax && (
+                          <span className="ml-1.5 rounded bg-green-100 px-1 py-0.5 text-[10px] font-semibold text-green-700">MAX</span>
+                        )}
+                        {isMin && r.minCombo.value < 0 && (
+                          <span className="ml-1.5 rounded bg-red-100 px-1 py-0.5 text-[10px] font-semibold text-red-700">MIN</span>
+                        )}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+            <div className="flex gap-6 border-t border-slate-100 bg-slate-50 px-4 py-3 text-sm">
+              <div>
+                <span className="text-slate-500">Max (governing):</span>
+                <span className="ml-1.5 font-bold text-green-700">{f2(r.maxCombo.value)}</span>
+                <span className="ml-1 text-slate-400 text-xs">combo {r.maxCombo.id}</span>
+              </div>
+              <div>
+                <span className="text-slate-500">Min:</span>
+                <span className="ml-1.5 font-bold text-slate-700">{f2(r.minCombo.value)}</span>
+                <span className="ml-1 text-slate-400 text-xs">combo {r.minCombo.id}</span>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <p className="self-start rounded-xl border border-slate-200 bg-white p-6 text-sm text-slate-500">
+            Fill in load values to see factored combinations.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **Engine** `webapp/src/engine/loadCombinations.ts` — `calcLoadCombinations()` computes all 13 NSCP 2015 §203.3 LRFD factored combinations (1, 2, 3a/b/c, 4a/b, 5a/b, 6a/b, 7a/b) including ±W and ±E variants; returns per-combo values plus max/min envelope
- **Tests** `webapp/src/engine/loadCombinations.test.ts` — 19 new tests (reference: D=10, L=5, Lr=2, W=8, E=12 → max=29 combo 6a, min=−3 combo 7b); 527 total passing
- **UI** `webapp/src/pages/LoadCombinations.tsx` at `/load-combinations` — five load inputs (D/L/Lr/W/E), full 13-row results table with MAX/MIN badges and envelope summary row; added to navbar Structural category

## Test plan

- [ ] All 13 combo values match hand calculations for reference case
- [ ] MAX badge on combo 6a (value 29), MIN badge on combo 7b (value −3)
- [ ] Zero inputs → all rows show 0
- [ ] Dead-only case → combo 1 governs at 1.4D
- [ ] Tool appears in navbar under Structural → Load Combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_