### PR TITLE
Phase 12: steel connection design + joint schedule + column flange orientation

### DIFF
--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -22,6 +22,7 @@ import { designShearWall, type ShearWallResult } from './shearWallDesign'
 import { shapeByName, nextHeavierW, nextLighterW, type AiscShape } from './aiscSections'
 import { deriveWSection, beamFlexure, beamShear, columnAxial, combinedLoading } from './steelDesign'
 import { designBasePlate, adoptPlateThickness, type BasePlateResult } from './baseplate'
+import { designSteelJoints, type SteelJoint } from './steelConnections'
 
 export interface SoilOptions {
   qAllow: number; gammaSoil: number; gammaConc: number; H: number
@@ -140,6 +141,7 @@ export interface StructureDesign {
   steelBeams: SteelBeamScheduleRow[]
   steelColumns: SteelColumnScheduleRow[]
   basePlates: BasePlateScheduleRow[]
+  joints: SteelJoint[]               // beam-to-column connections (steel frames only)
   slabs: SlabScheduleRow[]
   walls: WallScheduleRow[]
   footings: FootingScheduleRow[]
@@ -595,13 +597,17 @@ export function designStructure(
     walls.push({ id: w.id, member: w.member, lw, hw, thickness: w.thickness, Vu, design, ok: design.shearOK, gov })
   }
 
-  return {
+  const partialDesign = {
     govName: runs[govIdx].name,
     cases: runs.map((r) => r.name),
-    beams, columns, steelBeams, steelColumns, basePlates, slabs, walls, footings, combined,
+    beams, columns, steelBeams, steelColumns, basePlates,
+    joints: [] as SteelJoint[],
+    slabs, walls, footings, combined,
     totals: { concreteMembers, concreteSlabs, concrete: concreteMembers + concreteSlabs, steelKg },
     orphanEdges: br.orphanEdges.length,
   }
+  partialDesign.joints = designSteelJoints(model, partialDesign)
+  return partialDesign
 }
 
 // ── Bar-diameter selection ────────────────────────────────────────────────

--- a/webapp/src/engine/steelConnections.test.ts
+++ b/webapp/src/engine/steelConnections.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { generateGridModel, buildGravityLoads } from './modelBuilder'
+import { designStructure } from './pipeline'
+import { designSteelJoints } from './steelConnections'
+import type { RectSection } from './model'
+
+const steelSection: RectSection = {
+  id: 'S1', name: 'W310x79', b: 306, h: 310,
+  fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40,
+  material: 'steel', shape: 'W310x79', steelFy: 345, steelFu: 448,
+}
+const soil = { qAllow: 200, gammaSoil: 18, gammaConc: 24, H: 1.5 }
+
+function makeModel() {
+  const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section: steelSection })
+  m.loads = buildGravityLoads(m, 4.8, 2.4)
+  return m
+}
+
+describe('steel joint / connection design', () => {
+  const m = makeModel()
+  const design = designStructure(m, soil)!
+  const joints = designSteelJoints(m, design)
+
+  it('produces at least one joint for a steel frame', () => {
+    expect(joints.length).toBeGreaterThan(0)
+  })
+
+  it('every joint has a valid column shape and at least one connection', () => {
+    for (const j of joints) {
+      expect(j.columnShape.startsWith('W')).toBe(true)
+      expect(j.connections.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('shear tab: plate capacity and weld capacity both ≥ Vu', () => {
+    const shearJoints = joints.flatMap((j) => j.connections.filter((c) => c.connType === 'shear-tab'))
+    expect(shearJoints.length).toBeGreaterThan(0)
+    for (const c of shearJoints) {
+      expect(c.tab.phiVn).toBeGreaterThanOrEqual(c.Vu - 1e-6)
+      expect(c.tab.phiWeldVn).toBeGreaterThanOrEqual(c.Vu - 1e-6)
+    }
+  })
+
+  it('bolt group: n × φRn ≥ Vu for each connection', () => {
+    for (const j of joints) {
+      for (const c of j.connections) {
+        expect(c.bolts.n * c.bolts.phiRnKn).toBeGreaterThanOrEqual(c.Vu - 1e-6)
+        expect(c.bolts.dia).toBe(20)              // M20
+      }
+    }
+  })
+
+  it('moment connection flange capacity ≥ flange force when used', () => {
+    const momConns = joints.flatMap((j) => j.connections.filter((c) => c.connType === 'moment-flange-weld'))
+    for (const c of momConns) {
+      expect(c.flange).toBeTruthy()
+      expect(c.flange!.phiCapKn).toBeGreaterThanOrEqual(c.flange!.Tf - 1e-6)
+    }
+  })
+
+  it('strong-axis direction: primary beams frame into column flange face', () => {
+    // In a single-bay-X frame, the girder spans in X;
+    // the column strong axis should be X so the girder hits the flange.
+    for (const j of joints) {
+      const flangeConns = j.connections.filter((c) => c.faceType === 'flange')
+      // Connections in the strong-axis direction should be flange connections
+      const strongConns = j.connections.filter((c) => c.spanDir === j.strongAxisDir)
+      for (const c of strongConns) expect(c.faceType).toBe('flange')
+      void flangeConns  // ensures at least the loop ran
+    }
+  })
+
+  it('joint ok flag = all connections ok', () => {
+    for (const j of joints) {
+      expect(j.ok).toBe(j.connections.every((c) => c.ok))
+    }
+  })
+
+  it('returns empty array for concrete-only model', () => {
+    const rcSec: RectSection = { id: 'RC', name: '300x500', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
+    const rcModel = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section: rcSec })
+    rcModel.loads = buildGravityLoads(rcModel, 4.8, 2.4)
+    const rcDesign = designStructure(rcModel, soil)!
+    expect(designSteelJoints(rcModel, rcDesign)).toHaveLength(0)
+  })
+})

--- a/webapp/src/engine/steelConnections.ts
+++ b/webapp/src/engine/steelConnections.ts
@@ -1,0 +1,263 @@
+/**
+ * AISC 360-16 / AISC Steel Construction Manual (SCM) — beam-to-column
+ * connection design for simple shear tabs and partial-depth end-plate /
+ * flange-weld moment connections.
+ *
+ * Conventions (consistent with pipeline.ts):
+ *   forces  kN, kN·m
+ *   lengths m
+ *   sections mm, mm², mm⁴
+ *   stresses MPa
+ */
+import type { StructuralModel, Node as ModelNode } from './model'
+import type { StructureDesign, SteelBeamScheduleRow } from './pipeline'
+
+// ── Material constants ──────────────────────────────────────────────────────
+const PHI_SHEAR_BOLT = 0.75           // AISC §J3.6
+const FNV_A325 = 495                  // MPa  (threads excluded from shear plane)
+const A_M20   = Math.PI / 4 * 20 * 20  // 314.16 mm² — M20 bolt
+const PHI_RN_BOLT_KN = PHI_SHEAR_BOLT * FNV_A325 * A_M20 / 1000  // ≈ 116.5 kN/bolt
+
+const PHI_PLATE_YIELD = 1.0           // AISC §J4.2 shear yielding
+const FY_PLATE = 248                  // MPa  A36
+const FU_PLATE = 400                  // MPa
+const FEXX = 480                      // MPa  E70XX electrode
+const PHI_WELD = 0.75
+
+/** Capacity of a single fillet weld (one side) per unit length: kN/mm */
+const phiWeldPerMm = (w: number) => PHI_WELD * 0.6 * FEXX * 0.707 * w / 1000
+
+const PHI_CJP = 0.9                   // AISC Table J2.5 complete-joint-penetration
+const MOMENT_CONN_THRESHOLD = 0.2     // use moment conn when Mu/φMn > this
+
+// ── Plate stock ──────────────────────────────────────────────────────────────
+const PLATE_STOCK = [6, 8, 10, 12, 16, 19, 22, 25] // mm, standard stock
+function adoptPlate(t: number): number {
+  return PLATE_STOCK.find((s) => s >= t - 1e-6) ?? PLATE_STOCK[PLATE_STOCK.length - 1]
+}
+
+// ── Types ────────────────────────────────────────────────────────────────────
+export type ConnFaceType = 'flange' | 'web'
+export type ConnType     = 'shear-tab' | 'moment-flange-weld'
+export type SpanDir      = 'x' | 'z' | 'other'
+
+export interface BoltGroup {
+  n: number         // number of bolts
+  dia: number       // bolt diameter mm (20 = M20)
+  pitchMm: number   // bolt pitch mm
+  edgeMm: number    // edge distance mm
+  phiRnKn: number   // design strength per bolt, kN
+}
+
+export interface ShearTab {
+  t: number         // plate thickness mm (adopted from stock)
+  wMm: number       // plate width mm (horizontal)
+  hMm: number       // plate height mm
+  weldSizeMm: number // fillet weld leg size mm (each side)
+  phiVn: number     // shear tab plate capacity kN
+  phiWeldVn: number // weld capacity kN
+}
+
+export interface FlangeMomentConn {
+  Tf: number        // design flange force kN  (= Mu / (d - tf))
+  flangeArea: number // beam flange area mm²
+  phiCapKn: number  // φ·Fu·A_flange (CJP) kN
+  ok: boolean
+}
+
+export interface BeamConnection {
+  beamId: string
+  role: string
+  spanDir: SpanDir
+  faceType: ConnFaceType  // which column face the beam frames into
+  connType: ConnType
+  Vu: number              // design shear kN
+  Mu: number              // design moment kN·m
+  bolts: BoltGroup
+  tab: ShearTab
+  flange?: FlangeMomentConn
+  ok: boolean
+}
+
+export interface SteelJoint {
+  nodeId: string
+  columnShape: string
+  columnId: string
+  /** Strong axis direction of this column (X = flanges face ±X, depth d in X).
+   *  The column's primary moment frame direction. */
+  strongAxisDir: 'x' | 'z'
+  connections: BeamConnection[]
+  ok: boolean
+}
+
+// ── Core design functions ─────────────────────────────────────────────────────
+
+/** Design a single-plate shear tab for the given end shear Vu (kN). */
+function designShearTab(Vu: number): ShearTab {
+  const pitchMm = 75, edgeMm = 40
+
+  // bolt group (single shear)
+  const nBolts = Math.max(2, Math.ceil(Vu / PHI_RN_BOLT_KN))
+  const hMm = (nBolts - 1) * pitchMm + 2 * edgeMm      // plate height
+  const wMm = 80                                          // plate width (horiz.)
+
+  // plate thickness from shear yielding (governs over rupture for typical cases)
+  const tReq = Vu * 1000 / (PHI_PLATE_YIELD * 0.6 * FY_PLATE * hMm)
+  const t = adoptPlate(Math.max(6, tReq))
+
+  // weld: two fillet welds (both sides of plate) along height h
+  const weldReq = Vu / (2 * phiWeldPerMm(1) * hMm)      // size for 1 mm × area
+  const weldSizeMm = Math.max(5, Math.ceil(weldReq))      // min 5 mm, round up
+
+  const phiVn = PHI_PLATE_YIELD * 0.6 * FY_PLATE * t * hMm / 1000
+  const phiWeldVn = 2 * phiWeldPerMm(weldSizeMm) * hMm
+
+  return { t, wMm, hMm, weldSizeMm, phiVn, phiWeldVn }
+}
+
+/** Design the flange groove weld for moment transfer. Tf = Mu / lever arm (kN).
+ *  Uses complete joint penetration (CJP) with φFu strength. */
+function designFlangeConn(Mu: number, d: number, tf: number, bf: number): FlangeMomentConn {
+  const leverArm = Math.max(d - tf, 1)    // mm
+  const Tf = (Mu * 1e6) / leverArm / 1000  // kN  (Mu kN·m → N·mm, ÷ mm → N, ÷1000 → kN)
+  const flangeArea = bf * tf               // mm²
+  const phiCapKn = PHI_CJP * FU_PLATE * flangeArea / 1000  // kN
+  return { Tf, flangeArea, phiCapKn, ok: phiCapKn >= Tf - 1e-6 }
+}
+
+/**
+ * Determine the span direction of a beam member from its two node positions.
+ * 'x' if primarily horizontal-X, 'z' if primarily horizontal-Z.
+ */
+function spanDirOf(ni: ModelNode, nj: ModelNode): SpanDir {
+  const dx = Math.abs(nj.x - ni.x)
+  const dz = Math.abs(nj.z - ni.z)
+  if (dx < 1e-4 && dz < 1e-4) return 'other'  // vertical or diagonal
+  return dx >= dz ? 'x' : 'z'
+}
+
+/**
+ * Design connections at every beam-to-column joint in a steel frame.
+ * A joint is a node where at least one column and one beam/girder meet.
+ */
+export function designSteelJoints(
+  model: StructuralModel,
+  design: StructureDesign,
+): SteelJoint[] {
+  if (design.steelBeams.length === 0 && design.steelColumns.length === 0) return []
+
+  const nodeMap  = new Map<string, ModelNode>(model.nodes.map((n) => [n.id, n]))
+  const beamRow  = new Map<string, SteelBeamScheduleRow>(design.steelBeams.map((b) => [b.id, b]))
+  const colIds   = new Set<string>(design.steelColumns.map((c) => c.id))
+
+  // Build adj: node → list of member ids that touch it
+  const adj = new Map<string, string[]>()
+  for (const m of model.members) {
+    ;[m.i, m.j].forEach((n) => {
+      if (!adj.has(n)) adj.set(n, [])
+      adj.get(n)!.push(m.id)
+    })
+  }
+
+  // memberId → member
+  const memMap = new Map(model.members.map((m) => [m.id, m]))
+
+  const joints: SteelJoint[] = []
+
+  // Find all nodes that host a column AND at least one beam/girder
+  const processedNodes = new Set<string>()
+
+  for (const col of design.steelColumns) {
+    const colMem = memMap.get(col.id); if (!colMem) continue
+    // both the i-node (base) and j-node (top) of the column are potential joint nodes
+    for (const nodeId of [colMem.i, colMem.j]) {
+      if (processedNodes.has(nodeId)) continue
+      processedNodes.add(nodeId)
+
+      const neighbours = adj.get(nodeId) ?? []
+      // beam/girder members at this node
+      const beamMems = neighbours.filter((mid) => {
+        const mem = memMap.get(mid); if (!mem) return false
+        return mem.role === 'beam' || mem.role === 'girder'
+      })
+      if (beamMems.length === 0) continue
+
+      // Determine column strong-axis direction from the count of X vs Z beams
+      let xCount = 0, zCount = 0
+      for (const mid of beamMems) {
+        const mem = memMap.get(mid)!
+        const ni = nodeMap.get(mem.i)!, nj = nodeMap.get(mem.j)!
+        if (spanDirOf(ni, nj) === 'x') xCount++
+        else zCount++
+      }
+      // Strong axis faces the direction with more beams (girder direction)
+      // If equal, default to X (primary frame direction)
+      const strongAxisDir: 'x' | 'z' = xCount >= zCount ? 'x' : 'z'
+
+      const connections: BeamConnection[] = []
+
+      for (const mid of beamMems) {
+        const mem = memMap.get(mid)!
+        const ni = nodeMap.get(mem.i)!, nj = nodeMap.get(mem.j)!
+        const sDir = spanDirOf(ni, nj)
+
+        // The column face the beam frames into
+        const faceType: ConnFaceType = sDir === strongAxisDir ? 'flange' : 'web'
+
+        const row = beamRow.get(mid)
+        // If no design row (can happen for non-designed members): use a minimal shear
+        const Vu = row?.Vu ?? 5
+        const Mu = row?.Mu ?? 0
+        const phiMn = row?.phiMn ?? 1
+
+        // Connection type: use moment connection when moment demand is significant
+        const useMoment = phiMn > 1e-9 && (Mu / phiMn) > MOMENT_CONN_THRESHOLD
+
+        const tab = designShearTab(Vu)
+        const bolts: BoltGroup = {
+          n: Math.max(2, Math.ceil(Vu / PHI_RN_BOLT_KN)),
+          dia: 20, pitchMm: 75, edgeMm: 40, phiRnKn: PHI_RN_BOLT_KN,
+        }
+
+        let flangeConn: FlangeMomentConn | undefined
+        if (useMoment && row) {
+          flangeConn = designFlangeConn(Mu, row.d, row.tf, row.bf)
+        }
+
+        const boltOk = bolts.n * PHI_RN_BOLT_KN >= Vu - 1e-6
+        const tabOk  = tab.phiVn >= Vu - 1e-6 && tab.phiWeldVn >= Vu - 1e-6
+        const flangeOk = !flangeConn || flangeConn.ok
+
+        connections.push({
+          beamId: mid,
+          role: mem.role,
+          spanDir: sDir,
+          faceType,
+          connType: useMoment ? 'moment-flange-weld' : 'shear-tab',
+          Vu, Mu,
+          bolts,
+          tab,
+          flange: flangeConn,
+          ok: boltOk && tabOk && flangeOk,
+        })
+      }
+
+      if (connections.length === 0) continue
+
+      // Find the column member id connected to this node (may be i or j)
+      const colAtNode = neighbours.find((mid) => colIds.has(mid)) ?? col.id
+      const colDesign = design.steelColumns.find((c) => c.id === colAtNode) ?? design.steelColumns.find((c) => c.id === col.id)!
+
+      joints.push({
+        nodeId,
+        columnShape: colDesign.shape,
+        columnId: colAtNode,
+        strongAxisDir,
+        connections,
+        ok: connections.every((c) => c.ok),
+      })
+    }
+  }
+
+  return joints
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -8,6 +8,7 @@ import type { StructuralModel, Member, Plate, RectSection, ModelLoad, MemberRole
 import { distributePanel } from '../engine/tributary'
 import { type F3Analysis } from '../engine/frame3d'
 import { type StructureDesign, type FootingPlan, type OptimizeResult, type LateralCase } from '../engine/pipeline'
+import type { SteelJoint } from '../engine/steelConnections'
 import { estimateTakeoff, costBill, type PriceList } from '../engine/takeoff'
 import { footingLayout } from '../engine/footingLayout'
 import { useSolver } from '../lib/useSolver'
@@ -116,8 +117,15 @@ function MemberSteel3D({ a, b, role, shapeName, selected, tint = 0, onPick }: {
     const shapes = shape ? buildSectionShapes(effectiveSection(shape, false)) : []
     // orient local +Z (extrude dir) onto the member axis; group placed at node i
     const quat = new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 0, 1), dir.clone().normalize())
+    // For columns (primarily vertical), pre-rotate the section 90° around local Z
+    // so the depth d aligns with global X and the flanges face ±X.
+    // X-direction girders then frame into the column FLANGE FACE (strong-axis connection).
+    if (role === 'column') {
+      const rPre = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 0, 1), -Math.PI / 2)
+      quat.multiply(rPre)
+    }
     return { shapes, quat, pos: a.clone(), len }
-  }, [a, b, shapeName])
+  }, [a, b, shapeName, role])
 
   const color = useMemo(() => {
     if (selected) return SEL
@@ -2655,6 +2663,78 @@ export default function ModelSpace() {
                 Bearing §J8: φc·0.85f′c·√(A2/A1), φc = 0.65. Plate thickness from cantilever bending
                 t = ℓ√(2fp/(0.9Fy)); ℓ = max(m, n, n′). Uplift sizes anchor rods (φt·0.75·Fu).
                 Adopted t rounded to plate stock.
+              </p>
+            </div>
+          )}
+
+          {/* Steel connection schedule — only for steel frames */}
+          {design.joints.length > 0 && (
+            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Steel connection schedule — AISC SCM</h3>
+              <p className="mb-2 text-[11px] text-slate-500">
+                Columns oriented with depth <em>d</em> in X (flanges face ±X); X-direction girders land on the column <strong>flange</strong> face (strong-axis moment connection), Z-direction beams land on the column <strong>web</strong> face (shear tab). Bolts: M20 A325 single-shear (φRₙ = 116.5 kN/bolt). Welds: E70XX fillet, both sides of plate.
+              </p>
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
+                    <th className="py-1 pr-2 font-semibold">Node</th>
+                    <th className="py-1 pr-2 font-semibold">Col. shape</th>
+                    <th className="py-1 pr-2 font-semibold">Beam</th>
+                    <th className="py-1 pr-2 font-semibold">Dir</th>
+                    <th className="py-1 pr-2 font-semibold">Face</th>
+                    <th className="py-1 pr-2 font-semibold">Type</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Vu (kN)</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Mu (kN·m)</th>
+                    <th className="py-1 pr-2 font-semibold">Bolts</th>
+                    <th className="py-1 pr-2 font-semibold">Plate t×h</th>
+                    <th className="py-1 pr-2 font-semibold">Weld</th>
+                    <th className="py-1 font-semibold">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(design.joints as SteelJoint[]).flatMap((j) =>
+                    j.connections.map((c, ci) => (
+                      <tr key={`${j.nodeId}-${c.beamId}`}
+                        className={`border-t border-slate-100 ${c.ok ? '' : 'bg-red-50 text-red-700'}`}>
+                        {ci === 0 && (
+                          <td className="py-1 pr-2 font-medium align-top" rowSpan={j.connections.length}>
+                            {j.nodeId}
+                            <div className="text-[10px] text-slate-400">{j.strongAxisDir.toUpperCase()}-axis</div>
+                          </td>
+                        )}
+                        {ci === 0 && (
+                          <td className="py-1 pr-2 font-mono align-top" rowSpan={j.connections.length}>{j.columnShape}</td>
+                        )}
+                        <td className="py-1 pr-2 font-medium">{c.beamId}</td>
+                        <td className="py-1 pr-2 uppercase">{c.spanDir}</td>
+                        <td className={`py-1 pr-2 font-semibold ${c.faceType === 'flange' ? 'text-blue-700' : 'text-slate-600'}`}>
+                          {c.faceType}
+                        </td>
+                        <td className="py-1 pr-2 text-[11px]">
+                          {c.connType === 'moment-flange-weld' ? 'Moment (CJP flange)' : 'Shear tab'}
+                        </td>
+                        <td className="py-1 pr-2 text-right">{f1(c.Vu)}</td>
+                        <td className="py-1 pr-2 text-right">{f1(c.Mu)}</td>
+                        <td className="py-1 pr-2 text-[11px]">{c.bolts.n} × M{c.bolts.dia} A325</td>
+                        <td className="py-1 pr-2 text-[11px]">{c.tab.t}×{Math.round(c.tab.hMm)} mm</td>
+                        <td className="py-1 pr-2 text-[11px]">
+                          {c.tab.weldSizeMm}mm E70
+                          {c.flange && <span className="ml-1 text-blue-600">+ CJP flg</span>}
+                        </td>
+                        <td className="py-1 text-[11px]">
+                          <span className={c.ok ? 'text-green-700' : 'text-red-600'}>{c.ok ? '✓ OK' : '✗ NG'}</span>
+                          {c.flange && (
+                            <div className="text-[10px] text-slate-400">Tf={f1(c.flange.Tf)} kN</div>
+                          )}
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+              <p className="mt-1 text-[11px] text-slate-400">
+                Shear tab: A36 plate (Fy=248, Fu=400 MPa), M20 A325 bolts @ 75 mm pitch, 40 mm edge. Plate shear yielding φ=1.0 (§J4.2).
+                Moment connection: CJP groove weld at beam flanges, φFu·A_flange (§J2.6). Weld = E70XX fillet both sides of shear tab.
               </p>
             </div>
           )}


### PR DESCRIPTION
## Summary

- **Connection design engine** (`steelConnections.ts`) — AISC SCM beam-to-column connections for all steel frames
- **Connection schedule UI** — per-joint, per-beam table in the Results tab
- **Correct 3D column flange orientation** — W-shape columns now have their depth *d* in the X direction so girders connect to the column **flange face**

---

## Connection design engine (`steelConnections.ts`)

`designSteelJoints(model, design)` → `SteelJoint[]`

For every node where a steel column meets beam/girder members:

| Rule | Detail |
|---|---|
| **Connection type** | Shear tab when Mu/φMn ≤ 0.2 (simple); Moment-flange-weld (CJP + shear tab) when Mu/φMn > 0.2 |
| **Bolt group** | M20 A325 single-shear: φRₙ = 0.75 × 0.6 × 495 MPa × 314 mm² = **116.5 kN/bolt** |
| **Shear tab plate** | A36 (Fy=248, Fu=400 MPa), sized by shear yielding §J4.2 (φ=1.0), rounded to standard stock (6/8/10/12/16 mm); E70XX fillet both sides |
| **Moment connection** | CJP groove weld at beam flanges; Tf = Mu/(d−tf); capacity = φ·Fu·bf·tf |
| **Strong-axis direction** | Joint counts X-vs-Z beams → picks the majority direction; those beams land on the column **flange face** (stronger moment path) |

8 new tests in `steelConnections.test.ts` — all passing.

---

## Column 3D orientation fix (`MemberSteel3D`)

**Before**: W-shape columns extruded with the section's default orientation → flanges faced ±Z, so Z-direction beams got the flange face and X-direction girders got the web face.

**After**: Columns pre-rotate the section −90° around local Z before aligning to the member axis. Result:
- Depth *d* is in global **X** direction
- Flanges face **±X** → X-direction **girders** connect to the column **flange face** ✓ (AISC moment-frame convention)
- Z-direction beams connect to the column **web face** → shear-tab connection

---

## Connection schedule UI

New table between the base-plate schedule and the footing schedule:

| Column | Content |
|---|---|
| Node | node ID + strong-axis badge (X/Z) |
| Col. shape | W-shape name |
| Beam | member ID |
| Dir | X or Z span direction |
| Face | **flange** (blue) or web |
| Type | Shear tab / Moment (CJP flange) |
| Vu / Mu | kN, kN·m |
| Bolts | `n × M20 A325` |
| Plate | `t × h mm` |
| Weld | `w mm E70` + CJP flange note + Tf |
| Status | ✓ OK / ✗ NG |

---

## Files changed

| File | Role |
|---|---|
| `engine/steelConnections.ts` | New — connection design engine |
| `engine/steelConnections.test.ts` | New — 8 tests |
| `engine/pipeline.ts` | Add `joints: SteelJoint[]` to `StructureDesign`; call `designSteelJoints` |
| `pages/ModelSpace.tsx` | Column flange orientation fix + connection schedule table |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_