### PR TITLE
feat: seismic column tie-detailing — wire engine to pipeline and UI

### DIFF
--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -42,6 +42,10 @@ export interface AnalyzeOptions {
    *  with an E (or W) factor is run once per E (or W) case and the design is
    *  enveloped per member — STAAD-style. */
   lateral?: LateralCase[]
+  /** Seismic lateral resisting system — drives column tie detailing per NSCP 2015 §418.
+   *  'smf' = Special Moment Frame (§418.7.5), 'imf' = Intermediate (§418.4.3).
+   *  Default 'gravity' (ordinary ties only, §425.7.2). */
+  seismicSystem?: 'gravity' | 'imf' | 'smf'
 }
 
 export interface BeamSectionDesign {
@@ -60,7 +64,18 @@ export interface ColumnScheduleRow {
   id: string; L: number
   Pu: number; Mu: number; e: number
   bars: number; phiPn: number; util: number
+  /** Gravity-only tie spacing (§425.7.2), mm. */
   tieSpacing: number
+  /** Final governing tie spacing (seismic confinement if applicable), mm. */
+  tieSpacingFinal: number
+  /** Human-readable label for the governing tie-spacing clause. */
+  tieSpacingLabel: string
+  /** Seismic confinement zone length ℓo, mm (smf/imf only). */
+  seismicLoZone?: number
+  /** Max tie spacing within confinement zone, mm (smf/imf only). */
+  seismicSConf?: number
+  /** Max tie spacing outside confinement zone, mm (smf only). */
+  seismicSOut?: number
   ok: boolean
   gov?: string
 }
@@ -256,10 +271,14 @@ function designBeamRow(mr: F3MemberResult, role: string, sec: RectSection): Beam
 
 /** Column capacity for a given section and a known factored P/M demand (no frame
  *  solve — bar diameter does not change demands, so this is reused for bar trials). */
-function designColumnFromPM(sec: RectSection, Pu: number, Mu: number) {
+function designColumnFromPM(
+  sec: RectSection, Pu: number, Mu: number,
+  system: 'gravity' | 'imf' | 'smf' = 'gravity', columnLength?: number,
+) {
   const ax = designAxialColumn({
     shape: 'tied', b: sec.b, h: sec.h, cover: sec.cover,
     barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, Pu,
+    system, columnLength,
   })
   let phiPn = ax.phiPnMax
   const e = Pu > 1e-9 ? Mu / Pu : 0
@@ -272,17 +291,35 @@ function designColumnFromPM(sec: RectSection, Pu: number, Mu: number) {
     phiPn = Math.min(cap.phi * cap.Pn, 0.65 * inter.PnMax)
   }
   const util = phiPn > 1e-9 ? Pu / phiPn : Infinity
-  return { e, bars: ax.bars, Ast: ax.Ast, phiPn, util, tieSpacing: ax.tieSpacing, ok: util <= 1 + 1e-9 && ax.rhoOK }
+  return {
+    e, bars: ax.bars, Ast: ax.Ast, phiPn, util,
+    tieSpacing: ax.tieSpacing,
+    tieSpacingFinal: ax.tieSpacingFinal,
+    tieSpacingLabel: ax.tieSpacingLabel,
+    seismicLoZone: ax.seismicLoZone,
+    seismicSConf: ax.seismicSConf,
+    seismicSOut: ax.seismicSOut,
+    ok: util <= 1 + 1e-9 && ax.rhoOK,
+  }
 }
 
 /** Design one column from a single run's member result. */
-function designColumnRow(mr: F3MemberResult, sec: RectSection): ColumnScheduleRow {
+function designColumnRow(
+  mr: F3MemberResult, sec: RectSection,
+  system: 'gravity' | 'imf' | 'smf' = 'gravity',
+): ColumnScheduleRow {
   const Pu = Math.max(0, -Math.min(...mr.N))           // compression (N < 0)
   const Mu = mr.Mmax
-  const r = designColumnFromPM(sec, Pu, Mu)
+  const r = designColumnFromPM(sec, Pu, Mu, system, mr.L * 1000)   // L m → mm
   return {
     id: mr.id, L: mr.L, Pu, Mu, e: r.e, bars: r.bars, phiPn: r.phiPn, util: r.util,
-    tieSpacing: r.tieSpacing, ok: r.ok,
+    tieSpacing: r.tieSpacing,
+    tieSpacingFinal: r.tieSpacingFinal,
+    tieSpacingLabel: r.tieSpacingLabel,
+    seismicLoZone: r.seismicLoZone,
+    seismicSConf: r.seismicSConf,
+    seismicSOut: r.seismicSOut,
+    ok: r.ok,
   }
 }
 
@@ -425,9 +462,10 @@ export function designStructure(
         if (best) steelColumns.push({ ...best, gov })
       } else {
         let best: ColumnScheduleRow | null = null, bestUtil = -1, gov = ''
+        const sysOpts = opts.seismicSystem ?? 'gravity'
         for (const run of runs) {
           const mr = memberOf(run, m.id); if (!mr) continue
-          const row = designColumnRow(mr, sec)
+          const row = designColumnRow(mr, sec, sysOpts)
           if (row.util > bestUtil) { bestUtil = row.util; best = row; gov = run.name }
         }
         if (best) columns.push({ ...best, gov })

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -662,7 +662,11 @@ export default function ModelSpace() {
   // §203.3.1: f₁ = 1.0 for assembly/garage or live load > 4.8 kPa, else 0.5.
   const fLive = assembly || qL > 4.8 ? 1.0 : 0.5
   const lateral = [...eCases, ...wCases]
-  const anaOpts = { f1: fLive, pDelta, lateral }
+  // Infer seismic lateral system from R for column tie-detailing.
+  // Only applies when E loads are present (user clicked "Generate E cases").
+  const hasELoads = model?.loads.some((l) => l.cat === 'E') ?? false
+  const seismicSystem: 'gravity' | 'imf' | 'smf' = hasELoads ? (Rw >= 8 ? 'smf' : Rw >= 5 ? 'imf' : 'gravity') : 'gravity'
+  const anaOpts = { f1: fLive, pDelta, lateral, seismicSystem }
 
   const analyze = () => {
     if (!model || busy) return
@@ -1780,14 +1784,39 @@ export default function ModelSpace() {
                   <button type="button" onClick={generateE} disabled={!model || eDirs.length === 0}
                     className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50 disabled:opacity-40">⚡ Generate E cases</button>
                   {seis && (
-                    <p className="mt-1 text-xs text-slate-500">
-                      T = {seis.T.toFixed(3)} s · W = {f1(seis.W)} kN · V = {f1(seis.V)} kN
-                      {seis.V === seis.Vmax ? ' (2.5CaIW/R cap governs)'
-                        : seis.Vsrc > 0 && seis.V === seis.Vsrc ? ' (Zone-4 0.8ZNvIW/R floor governs)'
-                          : seis.V === seis.Vmin ? ' (0.11CaIW floor governs)' : ''}
-                      {seis.Ft > 0 ? ` · Ft = ${f1(seis.Ft)} kN` : ''} — {eCases.length} cat-E case{eCases.length === 1 ? '' : 's'} ({eDirs.join(', ') || 'none'}).
-                      {Zf >= 0.4 ? ` Zone-4 floor = ${f1(seis.Vsrc)} kN.` : ' (Zone-4 floor off: Z < 0.4)'}
-                    </p>
+                    <div className="mt-1 space-y-1">
+                      <p className="text-xs text-slate-500">
+                        T = {seis.T.toFixed(3)} s · W = {f1(seis.W)} kN · V = {f1(seis.V)} kN
+                        {seis.V === seis.Vmax ? ' (2.5CaIW/R cap governs)'
+                          : seis.Vsrc > 0 && seis.V === seis.Vsrc ? ' (Zone-4 0.8ZNvIW/R floor governs)'
+                            : seis.V === seis.Vmin ? ' (0.11CaIW floor governs)' : ''}
+                        {seis.Ft > 0 ? ` · Ft = ${f1(seis.Ft)} kN` : ''} — {eCases.length} cat-E case{eCases.length === 1 ? '' : 's'} ({eDirs.join(', ') || 'none'}).
+                        {Zf >= 0.4 ? ` Zone-4 floor = ${f1(seis.Vsrc)} kN.` : ' (Zone-4 floor off: Z < 0.4)'}
+                      </p>
+                      <table className="w-full border-collapse text-xs">
+                        <thead>
+                          <tr className="text-left uppercase tracking-wide text-slate-400">
+                            <th className="py-0.5 pr-2 font-semibold">Level (m)</th>
+                            <th className="py-0.5 pr-2 text-right font-semibold">wx (kN)</th>
+                            <th className="py-0.5 pr-2 text-right font-semibold">Fx (kN)</th>
+                            <th className="py-0.5 text-right font-semibold">Nodes</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {seis.storeys.map((s) => (
+                            <tr key={s.elevation} className="border-t border-slate-100">
+                              <td className="py-0.5 pr-2">{f1(s.elevation)}</td>
+                              <td className="py-0.5 pr-2 text-right">{f1(s.wx)}</td>
+                              <td className="py-0.5 pr-2 text-right font-medium text-[#7c3aed]">{f1(s.Fx)}</td>
+                              <td className="py-0.5 text-right text-slate-400">{s.nodes}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                      <p className="text-[10px] text-slate-400">
+                        System: <b>{seismicSystem.toUpperCase()}</b> (R = {Rw}) — column tie detailing uses {seismicSystem === 'smf' ? 'NSCP §418.7.5 SMF confinement' : seismicSystem === 'imf' ? 'NSCP §418.4.3 IMF hinge zone' : '§425.7.2 gravity ties only'}.
+                      </p>
+                    </div>
                   )}
                 </div>
               </Card>
@@ -2196,7 +2225,7 @@ export default function ModelSpace() {
                       <td className="py-1 pr-2">{cs?.name}</td>
                       <td className="py-1 pr-2 text-right">{f1(c.Pu)}</td>
                       <td className="py-1 pr-2 text-right">{f1(c.Mu)}</td>
-                      <td className="py-1 pr-2">{c.bars}⌀{cs?.barDia} · ties @{Math.round(c.tieSpacing)}</td>
+                      <td className="py-1 pr-2">{c.bars}⌀{cs?.barDia} · ties @{Math.round(c.tieSpacingFinal)}{c.seismicSConf !== undefined ? ' ✱' : ''}</td>
                       <td className="py-1 pr-2 text-right">{(c.util * 100).toFixed(0)}%</td>
                       <td className="py-1 text-slate-400">{c.gov}</td>
                     </tr>,
@@ -2207,12 +2236,23 @@ export default function ModelSpace() {
                             {wantSol && <WorkedSolution steps={columnRowSolution(cs, c)} title={`${c.id} — worked solution`} />}
                             {wantDraw && (
                             <div className="space-y-3 self-start rounded-lg border border-slate-200 bg-white p-3">
-                              <ColumnElevation Lh={c.L} b={cs.b} bars={c.bars} tieSpacing={c.tieSpacing} />
+                              <ColumnElevation Lh={c.L} b={cs.b} bars={c.bars} tieSpacing={c.tieSpacingFinal} />
                               <div className="border-t border-slate-100 pt-2">
                                 <p className="mb-1 text-[11px] font-semibold text-[#0056b3]">SECTION</p>
                                 <ColumnSchematic shape="tied" b={cs.b} h={cs.h} cover={cs.cover}
-                                  barDia={cs.barDia} tieDia={cs.tieDia} bars={c.bars} tieSpacing={c.tieSpacing} />
+                                  barDia={cs.barDia} tieDia={cs.tieDia} bars={c.bars} tieSpacing={c.tieSpacingFinal} />
                               </div>
+                              {c.seismicSConf !== undefined && (
+                                <div className="border-t border-slate-100 pt-2 text-[11px] text-slate-600">
+                                  <p className="mb-0.5 font-semibold text-[#0056b3]">Seismic confinement ({seismicSystem.toUpperCase()})</p>
+                                  <p>Confinement zone ℓo = {Math.round(c.seismicLoZone!)} mm</p>
+                                  <p>Ties within ℓo @ {Math.round(c.seismicSConf)} mm <span className="text-slate-400">({c.tieSpacingLabel})</span></p>
+                                  {c.seismicSOut !== undefined && c.seismicSOut !== c.tieSpacing && (
+                                    <p>Ties outside ℓo @ {Math.round(c.seismicSOut)} mm</p>
+                                  )}
+                                  <p className="mt-0.5 text-slate-400">✱ Seismic controls over §425.7.2 gravity tie spacing ({Math.round(c.tieSpacing)} mm)</p>
+                                </div>
+                              )}
                             </div>
                             )}
                           </div>


### PR DESCRIPTION
## Summary

The seismic column confinement engine in `columnDesign.ts` (§418.7.5 SMF, §418.4.3 IMF) was fully implemented but never connected to the design pipeline or shown in the UI. This PR completes that chain end-to-end.

### Engine — `pipeline.ts`
- Add `seismicSystem?: 'gravity' | 'imf' | 'smf'` to `AnalyzeOptions`
- Extend `ColumnScheduleRow` with `tieSpacingFinal`, `tieSpacingLabel`, `seismicLoZone`, `seismicSConf`, `seismicSOut`
- `designColumnFromPM` now accepts `system` + `columnLength` (member L×1000 mm) and returns all seismic fields
- `designStructure` threads `opts.seismicSystem` down to each concrete column row

### UI — `ModelSpace.tsx`
- **Infer system from R** when E loads are present: R ≥ 8 → `smf`, R ≥ 5 → `imf`, else `gravity`; pass into `anaOpts`
- **Column schedule main row**: shows `tieSpacingFinal` (seismically-governed spacing) and a `✱` badge when seismic controls over the §425.7.2 gravity tie
- **Expanded column row**: shows confinement zone ℓo, tie spacing within and outside ℓo, governing clause (§418.7.5 SMF / §418.4.3 IMF), and note comparing with gravity tie spacing
- **Seismic loading card**: full per-floor storey force table (hx, wx, Fx, node count) and inferred system label displayed after "Generate E cases"

## Before / After
| Before | After |
|--------|-------|
| Column ties always showed §425.7.2 gravity spacing | Shows seismically-governed spacing with ✱ marker |
| Seismic summary: T, W, V only (one line) | Full storey force table per floor + system label |
| Confinement zone length/spacing: computed but invisible | Shown in expanded column row |

All 544 tests pass; `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_