### PR TITLE
feat: Phase 2 — parallel load-case solves via Web Worker pool

### DIFF
--- a/webapp/src/engine/frame3d.test.ts
+++ b/webapp/src/engine/frame3d.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { solveFrame3D, analyzeFrame3D, rectJ, type F3Node, type F3Member, type F3Support, type F3Load } from './frame3d'
+import { solveFrame3D, analyzeFrame3D, rectJ, precomputeFrame, solveWithGeometry, serializePrecomp, deserializePrecomp, type F3Node, type F3Member, type F3Support, type F3Load } from './frame3d'
 import { solveFrame2D } from './frame2d'
 import { generateGridModel } from './modelBuilder'
 import { modelToFrame3D } from './modelBridge'
@@ -175,5 +175,51 @@ describe('frame3d — P-Δ second order (vertical cantilever, L = 4)', () => {
       [...lat, { kind: 'node', node: 'top', Fy: -P, cat: 'D' }], { pDelta: true })!
     // second-order base moment = H·L + P·Δ > first-order H·L
     expect(Math.abs(r.members[0].My[0])).toBeGreaterThan(H * L)
+  })
+})
+
+describe('serializePrecomp / deserializePrecomp — postMessage roundtrip', () => {
+  const nodes: F3Node[] = [
+    { id: 'a', x: 0, y: 0, z: 0 },
+    { id: 'b', x: 0, y: 3, z: 0 },
+    { id: 'c', x: 4, y: 3, z: 0 },
+  ]
+  const E2 = 25000, G2 = E2 / 2.4
+  const members: F3Member[] = [
+    { id: 'm1', i: 'a', j: 'b', E: E2, G: G2, A: 150000, Iz: 10416666667, Iy: 3750000000, J: 4e9 },
+    { id: 'm2', i: 'b', j: 'c', E: E2, G: G2, A: 150000, Iz: 10416666667, Iy: 3750000000, J: 4e9 },
+  ]
+  const supports: F3Support[] = [{ node: 'a', fixity: 'fixed' }]
+  const loads: F3Load[] = [{ kind: 'node', node: 'c', Fy: -50, cat: 'D' }]
+
+  it('roundtrip preserves all scalar fields', () => {
+    const p = precomputeFrame(nodes, members, supports)
+    const s = serializePrecomp(p)
+    const q = deserializePrecomp(s)
+    expect(q.ndof).toBe(p.ndof)
+    expect(q.free).toEqual(p.free)
+    expect(q.nodes).toEqual(p.nodes)
+    expect(q.members).toEqual(p.members)
+    expect(q.supports).toEqual(p.supports)
+    expect(q.Kff_raw).toEqual(p.Kff_raw)
+    expect(q.Kff?.n).toBe(p.Kff?.n)
+  })
+
+  it('freeIdx Map is reconstructed correctly', () => {
+    const p = precomputeFrame(nodes, members, supports)
+    const q = deserializePrecomp(serializePrecomp(p))
+    for (const [k, v] of p.freeIdx) expect(q.freeIdx.get(k)).toBe(v)
+    expect(q.freeIdx.size).toBe(p.freeIdx.size)
+  })
+
+  it('solveWithGeometry gives identical results on the deserialized precomp', () => {
+    const p = precomputeFrame(nodes, members, supports)
+    const q = deserializePrecomp(serializePrecomp(p))
+    const r1 = solveWithGeometry(p, loads)!
+    const r2 = solveWithGeometry(q, loads)!
+    expect(r1).not.toBeNull()
+    expect(r2).not.toBeNull()
+    for (let i = 0; i < r1.d.length; i++) expect(r2.d[i]).toBeCloseTo(r1.d[i], 9)
+    expect(r2.Mmax).toBeCloseTo(r1.Mmax, 9)
   })
 })

--- a/webapp/src/engine/frame3d.ts
+++ b/webapp/src/engine/frame3d.ts
@@ -115,7 +115,7 @@ function kgLocal(N: number, L: number): number[][] {
   return k
 }
 
-type V3 = [number, number, number]
+export type V3 = [number, number, number]
 const sub = (a: V3, b: V3): V3 => [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
 const cross = (a: V3, b: V3): V3 => [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]]
 const dot = (a: V3, b: V3): number => a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
@@ -144,7 +144,7 @@ const mul = (A: number[][], B: number[][]): number[][] =>
 const transpose = (A: number[][]): number[][] => A[0].map((_, j) => A.map((row) => row[j]))
 
 // ── Geometry-only member data (load-independent) ──────────────────────────
-interface MemberGeom {
+export interface MemberGeom {
   L: number; R: [V3, V3, V3]
   kl: number[][]; T: number[][]; kg: number[][]
   dofs: number[]
@@ -288,6 +288,39 @@ export function precomputeFrame(
 
   const Kff = luFactor(Kff_raw)   // null if singular; {n:0} if nf===0
   return { nm, idx, nodes, members, supports, geoms, ndof, free, freeIdx, Kff, Kff_raw }
+}
+
+/** Plain-JSON-serializable form of FramePrecomp — Maps become entry arrays for postMessage. */
+export interface FramePrecompSerial {
+  nodes: F3Node[]
+  members: F3Member[]
+  supports: F3Support[]
+  geoms: MemberGeom[]
+  ndof: number
+  free: number[]
+  freeIdxEntries: [number, number][]
+  Kff: LUFactor | null
+  Kff_raw: number[][]
+}
+
+export function serializePrecomp(p: FramePrecomp): FramePrecompSerial {
+  return {
+    nodes: p.nodes, members: p.members, supports: p.supports,
+    geoms: p.geoms, ndof: p.ndof, free: p.free,
+    freeIdxEntries: [...p.freeIdx],
+    Kff: p.Kff, Kff_raw: p.Kff_raw,
+  }
+}
+
+export function deserializePrecomp(s: FramePrecompSerial): FramePrecomp {
+  return {
+    nm: new Map(s.nodes.map((n) => [n.id, n])),
+    idx: new Map(s.nodes.map((n, i) => [n.id, i])),
+    nodes: s.nodes, members: s.members, supports: s.supports,
+    geoms: s.geoms, ndof: s.ndof, free: s.free,
+    freeIdx: new Map(s.freeIdxEntries),
+    Kff: s.Kff, Kff_raw: s.Kff_raw,
+  }
 }
 
 function postprocessMember(m: F3Member, g: MemberGeom, ml: MemberLoads, d: number[]): F3MemberResult {

--- a/webapp/src/engine/framePool.ts
+++ b/webapp/src/engine/framePool.ts
@@ -1,0 +1,81 @@
+// Fan-out pool of frame-solve workers. Each worker holds one pre-factored
+// FramePrecomp; the pool distributes solve() calls across idle workers using
+// a FIFO queue so all N workers stay busy during a batch of load cases.
+import type { FramePrecompSerial, F3Load, F3Result, PDeltaOpts } from './frame3d'
+
+interface PendingTask {
+  id: number
+  loads: F3Load[]
+  opts?: PDeltaOpts
+  resolve: (r: F3Result | null) => void
+}
+
+export class FramePool {
+  private readonly ws: Worker[]
+  private queue: PendingTask[] = []
+  private idle: number[] = []
+  private pending = new Map<number, (r: F3Result | null) => void>()
+  private seq = 0
+
+  constructor(size = Math.min(navigator.hardwareConcurrency ?? 4, 8)) {
+    this.ws = Array.from({ length: size }, (_, i) => {
+      const w = new Worker(new URL('./frameWorker.ts', import.meta.url), { type: 'module' })
+      w.onmessage = ({ data }) => this.recv(i, data)
+      return w
+    })
+  }
+
+  /** Broadcast new precomp to all workers and wait until all are ready. */
+  async init(serial: FramePrecompSerial): Promise<void> {
+    this.idle = []
+    this.queue = []
+    this.pending.clear()
+    await Promise.all(
+      this.ws.map((w, i) =>
+        new Promise<void>((resolve) => {
+          w.onmessage = ({ data }: MessageEvent<{ kind: string }>) => {
+            if (data.kind === 'ready') {
+              w.onmessage = ({ data: d }) => this.recv(i, d)
+              this.idle.push(i)
+              resolve()
+            }
+          }
+          w.postMessage({ kind: 'init', serial })
+        }),
+      ),
+    )
+  }
+
+  solve(loads: F3Load[], opts?: PDeltaOpts): Promise<F3Result | null> {
+    const id = this.seq++
+    return new Promise((resolve) => {
+      if (this.idle.length > 0) {
+        const wi = this.idle.shift()!
+        this.pending.set(id, resolve)
+        this.ws[wi].postMessage({ kind: 'solve', id, loads, opts })
+      } else {
+        this.queue.push({ id, loads, opts, resolve })
+      }
+    })
+  }
+
+  private recv(wi: number, data: { kind: string; id?: number; result?: F3Result | null }) {
+    if (data.kind !== 'result' || data.id === undefined) return
+    const cb = this.pending.get(data.id)
+    if (cb) { this.pending.delete(data.id); cb(data.result ?? null) }
+    if (this.queue.length > 0) {
+      const { id, loads, opts, resolve } = this.queue.shift()!
+      this.pending.set(id, resolve)
+      this.ws[wi].postMessage({ kind: 'solve', id, loads, opts })
+    } else {
+      this.idle.push(wi)
+    }
+  }
+
+  terminate(): void {
+    this.ws.forEach((w) => w.terminate())
+    this.idle = []
+    this.queue = []
+    this.pending.clear()
+  }
+}

--- a/webapp/src/engine/frameWorker.ts
+++ b/webapp/src/engine/frameWorker.ts
@@ -1,0 +1,26 @@
+/// <reference lib="webworker" />
+// Minimal frame-solve worker: receives one FramePrecompSerial via 'init' then
+// handles 'solve' requests using that pre-factored stiffness (O(n²) per solve).
+import { deserializePrecomp, solveWithGeometry } from './frame3d'
+import type { FramePrecompSerial, FramePrecomp, F3Load, PDeltaOpts, F3Result } from './frame3d'
+
+type InMsg =
+  | { kind: 'init'; serial: FramePrecompSerial }
+  | { kind: 'solve'; id: number; loads: F3Load[]; opts?: PDeltaOpts }
+
+type OutMsg =
+  | { kind: 'ready' }
+  | { kind: 'result'; id: number; result: F3Result | null }
+
+const ctx = self as unknown as Worker
+let precomp: FramePrecomp | null = null
+
+ctx.onmessage = ({ data }: MessageEvent<InMsg>) => {
+  if (data.kind === 'init') {
+    precomp = deserializePrecomp(data.serial)
+    ctx.postMessage({ kind: 'ready' } satisfies OutMsg)
+  } else {
+    const result = precomp ? solveWithGeometry(precomp, data.loads, data.opts) : null
+    ctx.postMessage({ kind: 'result', id: data.id, result } satisfies OutMsg)
+  }
+}

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -10,7 +10,9 @@
 import type { StructuralModel, RectSection, ModelLoad } from './model'
 import { enforceSectionHierarchy, refreshSelfWeight } from './modelBuilder'
 import { modelToFrame3D } from './modelBridge'
-import { precomputeFrame, solveWithGeometry, applyF3Combo, type F3Result, type F3MemberResult, type F3Load } from './frame3d'
+import { precomputeFrame, solveWithGeometry, applyF3Combo, serializePrecomp, type F3Result, type F3MemberResult, type F3Load } from './frame3d'
+import type { BridgeResult } from './modelBridge'
+import { FramePool } from './framePool'
 import { nscpCombos, type Combo } from './beamAnalysis'
 import type { ProgressFn } from './progress'
 import { designBeam, type BeamDesignResult } from './beamDesign'
@@ -373,13 +375,15 @@ function buildRuns(model: StructuralModel, opts: AnalyzeOptions, onProgress?: Pr
   return { br, runs, precomp }
 }
 
-export function designStructure(
-  model: StructuralModel, soil: SoilOptions, plan: FootingPlan = {}, opts: AnalyzeOptions = {},
+/** All member/footing/slab design given pre-solved FEM results. Shared by the
+ *  synchronous and async paths to avoid code duplication. */
+function designFromRuns(
+  model: StructuralModel, soil: SoilOptions, plan: FootingPlan, opts: AnalyzeOptions,
+  br: BridgeResult, runs: FrameRun[],
+  serviceRes: F3Result | null, dRes: F3Result | null, lRes: F3Result | null,
   onProgress?: ProgressFn,
 ): StructureDesign | null {
-  if (model.members.length === 0) return null
-  // each member designs with its OWN section; footings use the section of the
-  // column that lands on the support node.
+  if (runs.length === 0) return null
   const fallbackSec: RectSection = model.sections[0]
     ?? { id: '', name: '', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
   const secById = new Map(model.sections.map((s) => [s.id, s]))
@@ -388,22 +392,10 @@ export function designStructure(
   const colAtNode = (node: string) => model.members.find((m) => m.role === 'column' && (m.i === node || m.j === node))
   const footSec = (node: string) => { const c = colAtNode(node); return c ? secOf(c.id) : fallbackSec }
 
-  const { br, runs, precomp } = buildRuns(model, opts, onProgress)
-  if (runs.length === 0) return null
   // headline governing run = largest overall bending response
   let govIdx = 0
   runs.forEach((r, i) => { if (r.result.Mmax > runs[govIdx].result.Mmax) govIdx = i })
 
-  // Service (unfactored gravity) + D-only / L-only solves for the footing
-  // bearing check and the combined-footing dl/ll split (direction-independent).
-  // All reuse the same pre-factored K from buildRuns (same geometry).
-  const serviceLoads = applyF3Combo(br.loads, { D: 1, L: 1, Lr: 1, S: 1, R: 1 })
-  const serviceRes: F3Result | null = serviceLoads.length
-    ? solveWithGeometry(precomp, serviceLoads, opts) : null
-  const dLoads = applyF3Combo(br.loads, { D: 1 })
-  const lLoads = applyF3Combo(br.loads, { L: 1 })
-  const dRes = dLoads.length ? solveWithGeometry(precomp, dLoads, opts) : null
-  const lRes = lLoads.length ? solveWithGeometry(precomp, lLoads, opts) : null
   const serviceAt = (node: string) => {
     const i = serviceRes?.reactions.findIndex((r) => r.node === node) ?? -1
     return i >= 0 ? Math.max(0, serviceRes!.reactions[i].F[1]) : 0
@@ -648,6 +640,203 @@ export function designStructure(
   }
   partialDesign.joints = designSteelJoints(model, partialDesign)
   return partialDesign
+}
+
+export function designStructure(
+  model: StructuralModel, soil: SoilOptions, plan: FootingPlan = {}, opts: AnalyzeOptions = {},
+  onProgress?: ProgressFn,
+): StructureDesign | null {
+  if (model.members.length === 0) return null
+  const { br, runs, precomp } = buildRuns(model, opts, onProgress)
+  const serviceLoads = applyF3Combo(br.loads, { D: 1, L: 1, Lr: 1, S: 1, R: 1 })
+  const serviceRes = serviceLoads.length ? solveWithGeometry(precomp, serviceLoads, opts) : null
+  const dLoads = applyF3Combo(br.loads, { D: 1 })
+  const lLoads = applyF3Combo(br.loads, { L: 1 })
+  const dRes = dLoads.length ? solveWithGeometry(precomp, dLoads, opts) : null
+  const lRes = lLoads.length ? solveWithGeometry(precomp, lLoads, opts) : null
+  return designFromRuns(model, soil, plan, opts, br, runs, serviceRes, dRes, lRes, onProgress)
+}
+
+/** Solve load cases in parallel using a pre-initialised FramePool.
+ *  Returns the same `{ br, runs }` as buildRuns but with solves fanned across workers. */
+async function buildRunsParallel(
+  model: StructuralModel, opts: AnalyzeOptions, pool: FramePool, onProgress?: ProgressFn,
+): Promise<{ br: BridgeResult; runs: FrameRun[] }> {
+  const gravityModel = { ...model, loads: model.loads.filter((l) => l.cat !== 'E' && l.cat !== 'W') }
+  const br = modelToFrame3D(gravityModel)
+
+  let lateral = opts.lateral ?? []
+  if (lateral.length === 0) {
+    const eL = model.loads.filter((l) => l.kind === 'node' && l.cat === 'E')
+    const wL = model.loads.filter((l) => l.kind === 'node' && l.cat === 'W')
+    if (eL.length) lateral = [...lateral, { name: 'E', kind: 'E' as const, loads: eL }]
+    if (wL.length) lateral = [...lateral, { name: 'W', kind: 'W' as const, loads: wL }]
+  }
+  const toF3 = (l: ModelLoad): F3Load =>
+    ({ kind: 'node', node: (l as { node: string }).node, Fx: (l as { Fx?: number }).Fx, Fy: (l as { Fy?: number }).Fy, Fz: (l as { Fz?: number }).Fz, cat: l.cat })
+  const eCases = lateral.filter((c) => c.kind === 'E')
+  const wCases = lateral.filter((c) => c.kind === 'W')
+
+  const tasks: { name: string; combo: Combo; lat: F3Load[] }[] = []
+  for (const combo of nscpCombos(opts.f1 ?? 1.0)) {
+    const hasE = (combo.f.E ?? 0) !== 0
+    const hasW = (combo.f.W ?? 0) !== 0
+    const variants: { tag: string; lat: F3Load[] }[] =
+      hasE && eCases.length ? eCases.map((c) => ({ tag: c.name, lat: c.loads.map(toF3) }))
+        : hasW && wCases.length ? wCases.map((c) => ({ tag: c.name, lat: c.loads.map(toF3) }))
+          : [{ tag: '', lat: [] }]
+    for (const v of variants) tasks.push({ name: combo.name + (v.tag ? ` · ${v.tag}` : ''), combo, lat: v.lat })
+  }
+
+  const precomp = precomputeFrame(br.nodes, br.members, br.supports)
+  await pool.init(serializePrecomp(precomp))
+
+  onProgress?.({ phase: 'Solving load cases', current: 0, total: tasks.length })
+  let done = 0
+  const promises = tasks.map(async (t) => {
+    const factored = applyF3Combo([...br.loads, ...t.lat], t.combo.f)
+    if (!factored.length) return null
+    const result = await pool.solve(factored, opts)
+    onProgress?.({ phase: 'Solving load cases', current: ++done, total: tasks.length, detail: t.name })
+    return result ? { name: t.name, result } satisfies FrameRun : null
+  })
+  const settled = await Promise.all(promises)
+  const runs = settled.filter((r): r is FrameRun => r !== null)
+  return { br, runs }
+}
+
+async function designStructureWithPool(
+  model: StructuralModel, soil: SoilOptions, plan: FootingPlan, opts: AnalyzeOptions,
+  pool: FramePool, onProgress?: ProgressFn,
+): Promise<StructureDesign | null> {
+  if (model.members.length === 0) return null
+  const { br, runs } = await buildRunsParallel(model, opts, pool, onProgress)
+
+  // Service / D / L solves also go through the pool (workers already hold the precomp)
+  const serviceLoads = applyF3Combo(br.loads, { D: 1, L: 1, Lr: 1, S: 1, R: 1 })
+  const dLoads = applyF3Combo(br.loads, { D: 1 })
+  const lLoads = applyF3Combo(br.loads, { L: 1 })
+  const [serviceRes, dRes, lRes] = await Promise.all([
+    serviceLoads.length ? pool.solve(serviceLoads, opts) : Promise.resolve(null),
+    dLoads.length ? pool.solve(dLoads, opts) : Promise.resolve(null),
+    lLoads.length ? pool.solve(lLoads, opts) : Promise.resolve(null),
+  ])
+
+  return designFromRuns(model, soil, plan, opts, br, runs, serviceRes, dRes, lRes, onProgress)
+}
+
+/** Async (Worker-pool) version of designStructure. Spawns N frame-solve workers
+ *  and fans the 20–30 load-case solves across them for near-linear speed-up. */
+export async function designStructureAsync(
+  model: StructuralModel, soil: SoilOptions, plan: FootingPlan = {}, opts: AnalyzeOptions = {},
+  onProgress?: ProgressFn,
+): Promise<StructureDesign | null> {
+  const pool = new FramePool()
+  try {
+    return await designStructureWithPool(model, soil, plan, opts, pool, onProgress)
+  } finally {
+    pool.terminate()
+  }
+}
+
+/** Async version of optimizeStructure. Reuses a single FramePool across all
+ *  iterations to amortise worker-spawn cost (~100 ms). */
+export async function optimizeStructureAsync(
+  model: StructuralModel, soil: SoilOptions, plan: FootingPlan = {}, maxIter = 30,
+  opts: AnalyzeOptions = {}, tryBars = false, onProgress?: ProgressFn,
+): Promise<OptimizeResult | null> {
+  if (model.members.length === 0) return null
+  const pool = new FramePool()
+  try {
+    const memSecId = new Map(model.members.map((m) => [m.id, m.section]))
+    const secRole = new Map<string, string>(model.members.map((m) => [m.section, m.role]))
+    const settle = (m: StructuralModel) => refreshSelfWeight(enforceSectionHierarchy(m), soil.gammaConc)
+    const sub = (label: string): ProgressFn | undefined =>
+      onProgress && ((p) => onProgress({ ...p, phase: `${label} · ${p.phase}` }))
+    const detail = async (m: StructuralModel, d: StructureDesign, label: string): Promise<{ m: StructuralModel; d: StructureDesign }> => {
+      if (!tryBars) return { m, d }
+      const m2 = selectBarDiameters(m, soil, plan, opts, d)
+      if (m2 === m) return { m, d }
+      const d2 = await designStructureWithPool(m2, soil, plan, opts, pool, sub(label))
+      return { m: m2, d: d2 ?? d }
+    }
+
+    let work = settle(model)
+    const steps: OptimizeStep[] = []
+
+    let design = await designStructureWithPool(work, soil, plan, opts, pool, sub('Optimize · initial'))
+    if (!design) return null
+    ;({ m: work, d: design } = await detail(work, design, 'Optimize · initial'))
+    steps.push({ iter: 0, grown: 0, fails: countFails(design), ok: designOK(design) })
+
+    let iter = 0
+    while (!designOK(design) && iter++ < maxIter) {
+      const utils = buildUtilMap(design, memSecId)
+      if (utils.size === 0) break
+      onProgress?.({ phase: 'Optimizing — growing sections', current: iter, total: maxIter, detail: `iteration ${iter}: ${utils.size} member(s) grown, ${countFails(design)} failing` })
+      const sizes = new Map(work.sections.map((s) => {
+        const u = utils.get(s.id)
+        return [s.id, u !== undefined ? jumpSection(s, u, secRole.get(s.id) ?? '') : s]
+      }))
+      work = settle(withSizes(work, sizes))
+      const d = await designStructureWithPool(work, soil, plan, opts, pool, sub(`Optimize iter ${iter}`))
+      if (!d) break
+      ;({ m: work, d: design } = await detail(work, d, `Optimize iter ${iter}`))
+      steps.push({ iter, grown: utils.size, fails: countFails(design), ok: designOK(design) })
+    }
+    const converged = designOK(design)
+
+    if (converged) {
+      onProgress?.({ phase: 'Optimizing — trimming sections', detail: 'batch-shrinking all sections' })
+      let batchOk = true
+      while (batchOk) {
+        const batchSizes = new Map<string, RectSection>()
+        for (const s0 of work.sections) {
+          if (s0.material === 'steel' && s0.shape) {
+            const lighter = nextLighterW(s0.shape)
+            if (lighter) batchSizes.set(s0.id, applyShape(s0, lighter))
+          } else if (s0.h - 25 >= 300) {
+            batchSizes.set(s0.id, { ...s0, h: s0.h - 25, name: `${s0.b}×${s0.h - 25}` })
+          }
+        }
+        if (batchSizes.size === 0) break
+        const trial = settle(withSizes(work, batchSizes))
+        const d = await designStructureWithPool(trial, soil, plan, opts, pool)
+        if (d && designOK(d)) { work = trial; design = d } else { batchOk = false }
+      }
+
+      let improved = true, guard = 0
+      while (improved && guard++ < 4) {
+        improved = false
+        for (const s0 of work.sections) {
+          let trialSec: RectSection | null = null
+          if (s0.material === 'steel' && s0.shape) {
+            const lighter = nextLighterW(s0.shape)
+            if (lighter) trialSec = applyShape(s0, lighter)
+          } else {
+            if (s0.h - 25 < 300) continue
+            trialSec = { ...s0, h: s0.h - 25, name: `${s0.b}×${s0.h - 25}` }
+          }
+          if (!trialSec) continue
+          const trial = settle(withSizes(work, new Map([[s0.id, trialSec]])))
+          const d = await designStructureWithPool(trial, soil, plan, opts, pool)
+          if (d && designOK(d)) { work = trial; design = d; improved = true }
+        }
+      }
+      if (tryBars) {
+        const m2 = selectBarDiameters(work, soil, plan, opts, design)
+        if (m2 !== work) {
+          const d = await designStructureWithPool(m2, soil, plan, opts, pool)
+          if (d) { work = m2; design = d }
+        }
+      }
+      steps.push({ iter: iter + 1, grown: 0, fails: 0, ok: true })
+    }
+
+    return { design, model: work, steps, converged }
+  } finally {
+    pool.terminate()
+  }
 }
 
 // ── Bar-diameter selection ────────────────────────────────────────────────

--- a/webapp/src/engine/solverWorker.ts
+++ b/webapp/src/engine/solverWorker.ts
@@ -10,7 +10,7 @@ import type { StructuralModel } from './model'
 import { modelToFrame3D } from './modelBridge'
 import { analyzeFrame3D, solveFrame3D, applyF3Combo, type F3AnalyzeOpts } from './frame3d'
 import { driftCheck } from './seismic'
-import { designStructure, optimizeStructure, selectBarDiameters, type SoilOptions, type FootingPlan, type AnalyzeOptions } from './pipeline'
+import { designStructureAsync, optimizeStructureAsync, selectBarDiameters, type SoilOptions, type FootingPlan, type AnalyzeOptions } from './pipeline'
 import type { SolveProgress } from './progress'
 
 type DriftReq = { hasSeis: boolean; T: number; R: number; axis: 'x' | 'z'; pDelta: boolean }
@@ -21,7 +21,7 @@ export type SolverRequest =
 
 const ctx = self as unknown as Worker
 
-ctx.onmessage = (e: MessageEvent<SolverRequest>) => {
+ctx.onmessage = async (e: MessageEvent<SolverRequest>) => {
   const msg = e.data
   // forward progress ticks to the main thread (delivered while the worker runs)
   const onProgress = (p: SolveProgress) => ctx.postMessage({ id: msg.id, progress: p })
@@ -40,10 +40,10 @@ ctx.onmessage = (e: MessageEvent<SolverRequest>) => {
     } else if (msg.kind === 'design') {
       let m = msg.model
       if (msg.tryBars) { onProgress({ phase: 'Selecting bar sizes' }); m = selectBarDiameters(msg.model, msg.soil, msg.plan, msg.opts) }
-      const design = designStructure(m, msg.soil, msg.plan, msg.opts, onProgress)
+      const design = await designStructureAsync(m, msg.soil, msg.plan, msg.opts, onProgress)
       ctx.postMessage({ id: msg.id, ok: true, result: { model: m, design } })
     } else {
-      const result = optimizeStructure(msg.model, msg.soil, msg.plan, msg.maxIter, msg.opts, msg.tryBars, onProgress)
+      const result = await optimizeStructureAsync(msg.model, msg.soil, msg.plan, msg.maxIter, msg.opts, msg.tryBars, onProgress)
       ctx.postMessage({ id: msg.id, ok: true, result })
     }
   } catch (err) {


### PR DESCRIPTION
## What this does

Fans the 20–30 NSCP combination solves across N Web Worker instances so multiple load cases run simultaneously, turning the sequential O(n²) loop into a parallel fan-out.

## Changes

### `frame3d.ts`
- Export `V3` and `MemberGeom` (previously internal)
- Add `FramePrecompSerial` — plain-JSON form of `FramePrecomp` with Maps as entry arrays, safe for `postMessage`
- Add `serializePrecomp` / `deserializePrecomp` — roundtrip through structured-clone boundary

### `frameWorker.ts` (new)
Minimal Web Worker: receives one `FramePrecompSerial` via `init`, then handles `solve` messages using the deserialized precomp — O(n²) per load case, no re-factoring.

### `framePool.ts` (new)
`FramePool` class:
- Spawns N workers (`navigator.hardwareConcurrency`, capped at 8)
- `init(serial)` — broadcasts precomp to all workers, waits for `ready`
- `solve(loads, opts)` — queues a load-case solve, returns `Promise<F3Result | null>`; FIFO work-queue keeps all workers busy
- `terminate()` — shuts down all workers

### `pipeline.ts`
- Extract `designFromRuns(br, runs, serviceRes, dRes, lRes, ...)` — shared design logic (beams, columns, footings, slabs, walls) used by both sync and async paths
- `designStructure` is now a thin wrapper: `buildRuns` → `designFromRuns`
- `buildRunsParallel` — same task expansion as `buildRuns` but fans solves through the pool
- `designStructureAsync` — creates pool, calls `buildRunsParallel` + parallel service/D/L solves, calls `designFromRuns`, terminates pool
- `optimizeStructureAsync` — creates **one long-lived pool** reused across all grow/shrink iterations (amortises ~100 ms worker-spawn cost); otherwise mirrors `optimizeStructure`

### `solverWorker.ts`
- `onmessage` handler made `async`
- `design` and `optimize` paths now call `designStructureAsync` / `optimizeStructureAsync` so the nested worker pool is active during each run

## Test coverage
- 3 new roundtrip tests in `frame3d.test.ts`: scalar fields, `freeIdx` Map reconstruction, and `solveWithGeometry` identity on the deserialized precomp
- **554 tests pass**, `npx tsc -b` clean

## Remaining phases
- Phase 3 (optional): progress streaming from pool workers back through `solverWorker` to the UI progress bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_