### PR TITLE
fix: column elevation units, SMF step-8 override, W-shape labels, member progress

### DIFF
--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -415,7 +415,8 @@ function designFromRuns(
   const memberOf = (run: FrameRun, id: string) => run.result.members.find((m) => m.id === id)
 
   // ── Beams & girders — per-member worst case across all runs ──
-  onProgress?.({ phase: 'Designing beams & columns', detail: `${model.members.length} members` })
+  const totalMems = model.members.length
+  let memDone = 0
   const beams: BeamScheduleRow[] = []
   const columns: ColumnScheduleRow[] = []
   const steelBeams: SteelBeamScheduleRow[] = []
@@ -424,6 +425,8 @@ function designFromRuns(
     const role = roleOf.get(m.id)
     const sec = secOf(m.id)
     const isSteel = sec.material === 'steel'
+    const roleLabel = role === 'beam' ? 'beam' : role === 'girder' ? 'girder' : role === 'column' ? 'column' : role ?? ''
+    onProgress?.({ phase: 'Designing members', current: ++memDone, total: totalMems, detail: `${m.id} (${roleLabel} ${sec.b}×${sec.h})` })
     if (role === 'beam' || role === 'girder') {
       if (isSteel) {
         let best: SteelBeamScheduleRow | null = null, bestSev = -1, gov = ''

--- a/webapp/src/lib/columnSolution.ts
+++ b/webapp/src/lib/columnSolution.ts
@@ -16,7 +16,19 @@ const eq = (tex: string): SolutionLine => ({ tex })
 const tieGovernTex = (g: string): string =>
   g === '16d_b' ? '16d_b' : g === '48d_tie' ? '48d_{tie}' : String.raw`\text{least dim.}`
 
-export function axialColumnSolution(i: AxialColumnInput, r: AxialColumnResult): SolutionStep[] {
+/** Optional seismic override data passed to axialColumnSolution. When present,
+ *  the tie-detailing step shows the governing (seismic) spacing instead of gravity. */
+export interface SeismicTieOverride {
+  system: 'smf' | 'imf'
+  tieSpacingFinal: number   // governing final spacing (mm)
+  seismicSConf: number      // within confinement zone (mm)
+  seismicLoZone: number     // confinement zone length (mm)
+  tieSpacingLabel: string   // clause label
+  seismicSOut?: number      // outside confinement zone (mm)
+  gravitySpacing: number    // §425.7.2 baseline, for the override note
+}
+
+export function axialColumnSolution(i: AxialColumnInput, r: AxialColumnResult, seismic?: SeismicTieOverride): SolutionStep[] {
   const tied = i.shape === 'tied'
   const steps: SolutionStep[] = []
 
@@ -58,14 +70,23 @@ export function axialColumnSolution(i: AxialColumnInput, r: AxialColumnResult): 
   })
 
   if (tied) {
-    steps.push({
-      title: 'Tie detailing (§425.7.2)',
-      lines: [
-        txt(`Ties at least ⌀${r.tieDiaMin} mm for ⌀${i.barDia} longitudinal bars; spacing the least of 16·d_b, 48·d_tie, and the least column dimension.`),
-        eq(String.raw`s \le \min(16\times ${i.barDia},\ 48\times ${i.tieDia},\ ${sn0(Math.min(i.b ?? 0, i.h ?? 0))}) = ${sn0(r.tieSpacing)}\ \text{mm}\quad(${tieGovernTex(r.tieGovern)})`),
-      ],
-      note: `Provide ⌀${Math.max(i.tieDia, r.tieDiaMin)} mm ties @ ${sn0(r.tieSpacing)} mm.`,
-    })
+    if (seismic) {
+      // Seismic system governs — show both the §425.7.2 gravity baseline and the
+      // seismic confinement requirement that supersedes it.
+      const sysRef = seismic.system === 'smf' ? '§418.7.5 SMF' : '§418.4.3 IMF'
+      const outside = seismic.seismicSOut !== undefined && seismic.seismicSOut !== seismic.gravitySpacing
+        ? ` @ ${sn0(seismic.seismicSOut)} mm outside ℓo` : ''
+      steps.push({
+        title: `Tie detailing — ${seismic.system.toUpperCase()} governs (§425.7.2 + ${sysRef})`,
+        lines: [
+          txt(`§425.7.2 gravity tie check: ties at least ⌀${r.tieDiaMin} mm; spacing the least of 16·d_b, 48·d_tie, and the least column dimension.`),
+          eq(String.raw`s_{grav} \le \min(16\times ${i.barDia},\ 48\times ${i.tieDia},\ ${sn0(Math.min(i.b ?? 0, i.h ?? 0))}) = ${sn0(seismic.gravitySpacing)}\ \text{mm}\quad(${tieGovernTex(r.tieGovern)})`),
+          txt(`${sysRef} confinement zone ℓo = ${sn0(seismic.seismicLoZone)} mm controls — seismic spacing replaces gravity spacing.`),
+          eq(String.raw`s_{conf} = ${sn0(seismic.seismicSConf)}\ \text{mm within}\ \ell_o\quad(${seismic.tieSpacingLabel})`),
+        ],
+        note: `⌀${Math.max(i.tieDia, r.tieDiaMin)} mm ties @ ${sn0(seismic.seismicSConf)} mm within ℓo = ${sn0(seismic.seismicLoZone)} mm${outside}. (${sysRef} controls over §425.7.2 @ ${sn0(seismic.gravitySpacing)} mm)`,
+      })
+    }
   } else {
     steps.push({
       title: 'Spiral detailing (§425.7.3)',

--- a/webapp/src/lib/modelSpaceSolutions.ts
+++ b/webapp/src/lib/modelSpaceSolutions.ts
@@ -6,7 +6,7 @@ import type { BeamSectionDesign, ColumnScheduleRow, FootingScheduleRow, Combined
 import type { CombinedFootingInput } from '../engine/combinedFooting'
 import { designAxialColumn, interaction, capacityAtEccentricity } from '../engine/columnDesign'
 import { buildBeamSolution } from './beamSolution'
-import { axialColumnSolution, eccentricColumnSolution } from './columnSolution'
+import { axialColumnSolution, eccentricColumnSolution, type SeismicTieOverride } from './columnSolution'
 import { buildFoundationSolution, type SolutionCtx } from './foundationSolution'
 import { buildCombinedFootingSolution } from './combinedFootingSolution'
 import type { SolutionStep } from './solution'
@@ -33,7 +33,19 @@ export function columnRowSolution(sec: RectSection, row: ColumnScheduleRow): Sol
     const ic = { b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, numBars: ax.bars }
     steps.push(...eccentricColumnSolution(ic, interaction(ic), row.Pu, row.Mu, capacityAtEccentricity(ic, row.e)))
   }
-  steps.push(...axialColumnSolution(base, ax))
+  const seismic: SeismicTieOverride | undefined =
+    row.seismicSConf !== undefined && row.seismicLoZone !== undefined
+      ? {
+          system: row.tieSpacingLabel.toLowerCase().includes('smf') ? 'smf' : 'imf',
+          tieSpacingFinal: row.tieSpacingFinal,
+          seismicSConf: row.seismicSConf,
+          seismicLoZone: row.seismicLoZone,
+          tieSpacingLabel: row.tieSpacingLabel,
+          seismicSOut: row.seismicSOut,
+          gravitySpacing: row.tieSpacing,
+        }
+      : undefined
+  steps.push(...axialColumnSolution(base, ax, seismic))
   return steps
 }
 

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -174,11 +174,18 @@ function SolverProgress({ p }: { p: SolveProgress | null }) {
   return (
     <div className="col-span-full rounded-lg border border-[#0056b3]/30 bg-blue-50/60 p-2.5">
       <div className="flex items-center justify-between text-[11px] font-semibold text-[#0056b3]">
-        <span>⏳ {p.phase}{p.total && p.current ? ` — ${p.current}/${p.total}` : ''}</span>
-        {pct !== null && <span>{pct}%</span>}
+        <span>⏳ {p.phase}</span>
+        <span className="tabular-nums text-slate-500">
+          {p.total && p.current ? `${p.current} / ${p.total}` : ''}{pct !== null ? ` · ${pct}%` : ''}
+        </span>
       </div>
-      {p.detail && <div className="mt-0.5 truncate text-[11px] text-slate-500">{p.detail}</div>}
-      <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-blue-100">
+      {p.detail && (
+        <div className="mt-1 flex items-center gap-1.5 text-[11px] text-slate-600">
+          <span className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-[#0056b3] opacity-70" />
+          <span className="truncate font-mono">{p.detail}</span>
+        </div>
+      )}
+      <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-blue-100">
         {pct !== null
           ? <div className="h-full rounded-full bg-[#0056b3] transition-all duration-150" style={{ width: `${pct}%` }} />
           : <div className="h-full w-1/3 animate-pulse rounded-full bg-[#0056b3]" />}
@@ -455,7 +462,7 @@ function BeamRebarElevation({ L, h, sections }: {
 /** Rebar elevation of a column, drawn to scale (height ∝ Lh, width ∝ b), with
  *  longitudinal bars, ties at spacing and dimension lines. viewBox width
  *  matches ColumnSchematic (320) so its text matches the section below it. */
-function ColumnElevation({ Lh, b, bars, tieSpacing }: { Lh: number; b: number; bars: number; tieSpacing: number }): ReactNode {
+function ColumnElevation({ Lh, b, barDia, tieDia, bars, tieSpacing }: { Lh: number; b: number; barDia: number; tieDia: number; bars: number; tieSpacing: number }): ReactNode {
   const W = 320, top = 24, availH = 230
   const scl = availH / Math.max(Lh, 0.5)                 // px per metre
   const colW = Math.max(30, (b / 1000) * scl)            // to scale with height
@@ -466,7 +473,7 @@ function ColumnElevation({ Lh, b, bars, tieSpacing }: { Lh: number; b: number; b
   return (
     <svg viewBox={`0 0 ${W} ${H}`} xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet"
       style={{ width: '100%', height: 'auto', fontFamily: 'Arial, sans-serif' }}>
-      <text x={12} y={14} fontSize={11} fontWeight={700} fill="#0056b3">ELEVATION — {bars}⌀ · ties @{Math.round(tieSpacing)}</text>
+      <text x={12} y={14} fontSize={11} fontWeight={700} fill="#0056b3">ELEVATION — {bars}⌀{barDia} · ties ⌀{tieDia} @{Math.round(tieSpacing)} mm</text>
       <rect x={x0} y={y0} width={colW} height={availH} fill="#fff" stroke="#37526e" strokeWidth={1.4} />
       <line x1={x0 + 6} y1={y0} x2={x0 + 6} y2={y1} stroke="#dc2626" strokeWidth={1.6} />
       <line x1={x1 - 6} y1={y0} x2={x1 - 6} y2={y1} stroke="#dc2626" strokeWidth={1.6} />
@@ -475,7 +482,7 @@ function ColumnElevation({ Lh, b, bars, tieSpacing }: { Lh: number; b: number; b
         return <line key={k} x1={x0 + 3} y1={y} x2={x1 - 3} y2={y} stroke="#94a3b8" strokeWidth={0.7} />
       })}
       <DimSide yA={y0} yB={y1} featX={x0} dX={x0 - 14} label={`H = ${Lh} m`} side="left" />
-      <DimBelow xA={x0} xB={x1} featY={y1} dY={dimY} label={`b = ${b}`} />
+      <DimBelow xA={x0} xB={x1} featY={y1} dY={dimY} label={`b = ${b} mm`} />
     </svg>
   )
 }
@@ -506,14 +513,14 @@ function WShapeSection({ shape, d, bf, tf, tw }: { shape: string; d: number; bf:
       <rect x={x0} y={y0 + sh - stf} width={sw} height={stf} fill="#bfdbfe" stroke="#0056b3" strokeWidth={0.8} />
       {/* bf dim arrow */}
       <line x1={x0} y1={VH - 10} x2={x0 + sw} y2={VH - 10} stroke="#64748b" strokeWidth={0.8} markerStart="url(#arr)" markerEnd="url(#arr)" />
-      <text x={VW / 2} y={VH - 2} textAnchor="middle" {...textStyle}>bf={Math.round(bf)}</text>
+      <text x={VW / 2} y={VH - 2} textAnchor="middle" {...textStyle}>bf={Math.round(bf)} mm</text>
       {/* d dim arrow */}
       <line x1={VW - 10} y1={y0} x2={VW - 10} y2={y0 + sh} stroke="#64748b" strokeWidth={0.8} />
-      <text x={VW - 2} y={(y0 + y0 + sh) / 2} textAnchor="middle" {...textStyle} transform={`rotate(-90,${VW - 2},${(y0 + y0 + sh) / 2})`}>d={Math.round(d)}</text>
+      <text x={VW - 2} y={(y0 + y0 + sh) / 2} textAnchor="middle" {...textStyle} transform={`rotate(-90,${VW - 2},${(y0 + y0 + sh) / 2})`}>d={Math.round(d)} mm</text>
       {/* tf label */}
-      <text x={x0 - 2} y={y0 + stf / 2 + 3} textAnchor="end" {...textStyle}>tf={tf.toFixed(1)}</text>
+      <text x={x0 - 2} y={y0 + stf / 2 + 3} textAnchor="end" {...textStyle}>tf={tf.toFixed(1)} mm</text>
       {/* tw label */}
-      <text x={webX - 2} y={(VH) / 2 + 3} textAnchor="end" {...textStyle}>tw={tw.toFixed(1)}</text>
+      <text x={webX - 2} y={(VH) / 2 + 3} textAnchor="end" {...textStyle}>tw={tw.toFixed(1)} mm</text>
       {/* arrow marker def */}
       <defs>
         <marker id="arr" markerWidth={4} markerHeight={4} refX={2} refY={2} orient="auto">
@@ -2236,7 +2243,7 @@ export default function ModelSpace() {
                             {wantSol && <WorkedSolution steps={columnRowSolution(cs, c)} title={`${c.id} — worked solution`} />}
                             {wantDraw && (
                             <div className="space-y-3 self-start rounded-lg border border-slate-200 bg-white p-3">
-                              <ColumnElevation Lh={c.L} b={cs.b} bars={c.bars} tieSpacing={c.tieSpacingFinal} />
+                              <ColumnElevation Lh={c.L} b={cs.b} barDia={cs.barDia} tieDia={cs.tieDia} bars={c.bars} tieSpacing={c.tieSpacingFinal} />
                               <div className="border-t border-slate-100 pt-2">
                                 <p className="mb-1 text-[11px] font-semibold text-[#0056b3]">SECTION</p>
                                 <ColumnSchematic shape="tied" b={cs.b} h={cs.h} cover={cs.cover}


### PR DESCRIPTION
## Issues fixed

### 1 — "6⌀" looked like "diameter 6 mm" in elevation title
`ColumnElevation` title was `6⌀ · ties @100` — the `⌀` immediately after a number reads as a diameter, not a count. Added `barDia` and `tieDia` props and changed the title to the explicit form:
> `ELEVATION — 6⌀20 · ties ⌀10 @100 mm`

### 2 — Missing "mm" unit on elevation b dimension
`DimBelow` label was `b = 400` — now `b = 400 mm`.

### 3 — Step 8 overwritten by SMF when seismic governs
`axialColumnSolution` now accepts an optional `SeismicTieOverride`. When present (SMF or IMF):
- Step title becomes `Tie detailing — SMF governs (§425.7.2 + §418.7.5 SMF)`
- Body shows the §425.7.2 gravity baseline equation first, then the confinement zone requirement that supersedes it
- Note reads: `⌀10 mm ties @ 100 mm within ℓo = 583 mm … (SMF controls over §425.7.2 @ 320 mm)`
- The separate "Seismic confinement" card below the drawing is unchanged (still shown for the section schematic)

`columnRowSolution` in `modelSpaceSolutions.ts` extracts the seismic fields from `ColumnScheduleRow` and passes them through.

### 4 — W-shape dimension labels missing units
`WShapeSection` SVG labels now read `bf=250 mm`, `d=400 mm`, `tf=12.7 mm`, `tw=8.9 mm`.

### 5 — Live solver progress shows what member is being processed
`designFromRuns` in `pipeline.ts` now emits one progress tick per member:
```
phase: 'Designing members', current: 3, total: 12, detail: 'B1 (beam 400×600)'
```
`SolverProgress` UI updated: detail line is now monospace with a blue dot indicator; count shown as `n / total · %` inline with the phase name.

## Tests
554 passing, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_