### PR TITLE
fix: smarter optimize progress — skip bar-sizing for steel, per-pass shrink detail

### DIFF
--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -790,7 +790,7 @@ export async function optimizeStructureAsync(
     const converged = designOK(design)
 
     if (converged) {
-      onProgress?.({ phase: 'Optimizing — trimming sections', detail: 'batch-shrinking all sections' })
+      let batchPass = 0
       let batchOk = true
       while (batchOk) {
         const batchSizes = new Map<string, RectSection>()
@@ -803,6 +803,8 @@ export async function optimizeStructureAsync(
           }
         }
         if (batchSizes.size === 0) break
+        batchPass++
+        onProgress?.({ phase: 'Optimizing — trimming sections', detail: `batch pass ${batchPass}: ${batchSizes.size} section(s) ↓` })
         const trial = settle(withSizes(work, batchSizes))
         const d = await designStructureWithPool(trial, soil, plan, opts, pool)
         if (d && designOK(d)) { work = trial; design = d } else { batchOk = false }
@@ -821,6 +823,7 @@ export async function optimizeStructureAsync(
             trialSec = { ...s0, h: s0.h - 25, name: `${s0.b}×${s0.h - 25}` }
           }
           if (!trialSec) continue
+          onProgress?.({ phase: 'Optimizing — fine-tuning', detail: s0.name })
           const trial = settle(withSizes(work, new Map([[s0.id, trialSec]])))
           const d = await designStructureWithPool(trial, soil, plan, opts, pool)
           if (d && designOK(d)) { work = trial; design = d; improved = true }
@@ -1057,8 +1060,7 @@ export function optimizeStructure(
   // Then fall back to individual 25-mm fine-tune for sections that couldn't be
   // batch-trimmed (typically the critical ones controlling the design).
   if (converged) {
-    onProgress?.({ phase: 'Optimizing — trimming sections', detail: 'batch-shrinking all sections' })
-
+    let batchPass = 0
     let batchOk = true
     while (batchOk) {
       const batchSizes = new Map<string, RectSection>()
@@ -1071,6 +1073,8 @@ export function optimizeStructure(
         }
       }
       if (batchSizes.size === 0) break
+      batchPass++
+      onProgress?.({ phase: 'Optimizing — trimming sections', detail: `batch pass ${batchPass}: ${batchSizes.size} section(s) ↓` })
       const trial = settle(withSizes(work, batchSizes))
       const d = designStructure(trial, soil, plan, opts)
       if (d && designOK(d)) { work = trial; design = d } else { batchOk = false }
@@ -1090,6 +1094,7 @@ export function optimizeStructure(
           trialSec = { ...s0, h: s0.h - 25, name: `${s0.b}×${s0.h - 25}` }
         }
         if (!trialSec) continue
+        onProgress?.({ phase: 'Optimizing — fine-tuning', detail: s0.name })
         const trial = settle(withSizes(work, new Map([[s0.id, trialSec]])))
         const d = designStructure(trial, soil, plan, opts)
         if (d && designOK(d)) { work = trial; design = d; improved = true }

--- a/webapp/src/engine/solverWorker.ts
+++ b/webapp/src/engine/solverWorker.ts
@@ -39,7 +39,11 @@ ctx.onmessage = async (e: MessageEvent<SolverRequest>) => {
       ctx.postMessage({ id: msg.id, ok: true, result: { analysis, orphans: br.orphanEdges.length, drift } })
     } else if (msg.kind === 'design') {
       let m = msg.model
-      if (msg.tryBars) { onProgress({ phase: 'Selecting bar sizes' }); m = selectBarDiameters(msg.model, msg.soil, msg.plan, msg.opts) }
+      if (msg.tryBars) {
+        const hasConcrete = msg.model.sections.some((s) => s.material !== 'steel')
+        if (hasConcrete) onProgress({ phase: 'Selecting bar sizes' })
+        m = selectBarDiameters(msg.model, msg.soil, msg.plan, msg.opts)
+      }
       const design = await designStructureAsync(m, msg.soil, msg.plan, msg.opts, onProgress)
       ctx.postMessage({ id: msg.id, ok: true, result: { model: m, design } })
     } else {


### PR DESCRIPTION
## Summary

- **`solverWorker.ts`**: "Selecting bar sizes" progress tick is now guarded by a concrete-section check (`sections.some(s => s.material !== 'steel')`). All-steel frames no longer see a misleading progress phase.
- **`pipeline.ts` (both sync `optimizeStructure` and async `optimizeStructureAsync`)**: replaced the single static `"batch-shrinking all sections"` message with a per-loop-iteration tick — `"batch pass N: M section(s) ↓"` — so the UI shows live progress as the batch loop converges. The individual fine-tune pass now emits a per-section `"Optimizing — fine-tuning · <section name>"` tick as well.

## Test plan
- [ ] All-steel frame: run Design/Optimize — confirm "Selecting bar sizes" never appears in the progress overlay
- [ ] Mixed RC/steel or RC-only frame: "Selecting bar sizes" still appears as before
- [ ] Optimize on any frame: progress shows `"batch pass 1: N section(s) ↓"`, `"batch pass 2: …"` etc. instead of the static message; fine-tune phase shows individual section names
- [ ] 554 vitest tests pass, `tsc -b` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_