### PR TITLE
feat: optimizer varies b as well as h, batch-shrinks only low-utilisation sections

### DIFF
--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -272,7 +272,7 @@ describe('optimizeStructure', () => {
     // the column was never GROWN by the beam failures (width/height ≤ start);
     // shrink may trim it, but beam failures must not enlarge it.
     const col = r.model.sections.find((s) => s.id === m.members.find((x) => x.role === 'column')!.section)!
-    expect(col.b).toBe(300)
+    expect(col.b).toBeLessThanOrEqual(300)   // not grown by beam failures; shrink may reduce it
     expect(col.h).toBeLessThanOrEqual(500)
     expect(designOK(r.design)).toBe(true)
   })

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -791,6 +791,7 @@ export async function optimizeStructureAsync(
 
     if (converged) {
       let batchPass = 0
+      // Phase 1 — shrink h (or step to lighter W-shape for steel)
       let batchOk = true
       while (batchOk) {
         const batchSizes = new Map<string, RectSection>()
@@ -804,29 +805,55 @@ export async function optimizeStructureAsync(
         }
         if (batchSizes.size === 0) break
         batchPass++
-        onProgress?.({ phase: 'Optimizing — trimming sections', detail: `batch pass ${batchPass}: ${batchSizes.size} section(s) ↓` })
+        onProgress?.({ phase: 'Optimizing — trimming sections', detail: `batch pass ${batchPass}: ${batchSizes.size} section(s) h↓` })
         const trial = settle(withSizes(work, batchSizes))
         const d = await designStructureWithPool(trial, soil, plan, opts, pool)
         if (d && designOK(d)) { work = trial; design = d } else { batchOk = false }
       }
+      // Phase 2 — shrink b for RC sections (As = ρ·b·d; narrower b may still satisfy demand)
+      let bBatchOk = true
+      while (bBatchOk) {
+        const batchSizes = new Map<string, RectSection>()
+        for (const s0 of work.sections) {
+          if (s0.material !== 'steel' && s0.b - 25 >= 200)
+            batchSizes.set(s0.id, { ...s0, b: s0.b - 25, name: `${s0.b - 25}×${s0.h}` })
+        }
+        if (batchSizes.size === 0) break
+        batchPass++
+        onProgress?.({ phase: 'Optimizing — trimming sections', detail: `batch pass ${batchPass}: ${batchSizes.size} section(s) b↓` })
+        const trial = settle(withSizes(work, batchSizes))
+        const d = await designStructureWithPool(trial, soil, plan, opts, pool)
+        if (d && designOK(d)) { work = trial; design = d } else { bBatchOk = false }
+      }
 
+      // Fine-tune: per-section — try h↓ first, then b↓ if h can't shrink or fails
       let improved = true, guard = 0
       while (improved && guard++ < 4) {
         improved = false
         for (const s0 of work.sections) {
-          let trialSec: RectSection | null = null
           if (s0.material === 'steel' && s0.shape) {
             const lighter = nextLighterW(s0.shape)
-            if (lighter) trialSec = applyShape(s0, lighter)
+            if (!lighter) continue
+            onProgress?.({ phase: 'Optimizing — fine-tuning', detail: s0.name })
+            const trial = settle(withSizes(work, new Map([[s0.id, applyShape(s0, lighter)]])))
+            const d = await designStructureWithPool(trial, soil, plan, opts, pool)
+            if (d && designOK(d)) { work = trial; design = d; improved = true }
           } else {
-            if (s0.h - 25 < 300) continue
-            trialSec = { ...s0, h: s0.h - 25, name: `${s0.b}×${s0.h - 25}` }
+            if (s0.h - 25 >= 300) {
+              onProgress?.({ phase: 'Optimizing — fine-tuning', detail: `${s0.name} h↓` })
+              const hSec = { ...s0, h: s0.h - 25, name: `${s0.b}×${s0.h - 25}` }
+              const trial = settle(withSizes(work, new Map([[s0.id, hSec]])))
+              const d = await designStructureWithPool(trial, soil, plan, opts, pool)
+              if (d && designOK(d)) { work = trial; design = d; improved = true; continue }
+            }
+            if (s0.b - 25 >= 200) {
+              onProgress?.({ phase: 'Optimizing — fine-tuning', detail: `${s0.name} b↓` })
+              const bSec = { ...s0, b: s0.b - 25, name: `${s0.b - 25}×${s0.h}` }
+              const trial = settle(withSizes(work, new Map([[s0.id, bSec]])))
+              const d = await designStructureWithPool(trial, soil, plan, opts, pool)
+              if (d && designOK(d)) { work = trial; design = d; improved = true }
+            }
           }
-          if (!trialSec) continue
-          onProgress?.({ phase: 'Optimizing — fine-tuning', detail: s0.name })
-          const trial = settle(withSizes(work, new Map([[s0.id, trialSec]])))
-          const d = await designStructureWithPool(trial, soil, plan, opts, pool)
-          if (d && designOK(d)) { work = trial; design = d; improved = true }
         }
       }
       if (tryBars) {
@@ -1061,6 +1088,7 @@ export function optimizeStructure(
   // batch-trimmed (typically the critical ones controlling the design).
   if (converged) {
     let batchPass = 0
+    // Phase 1 — shrink h (or step to lighter W-shape for steel)
     let batchOk = true
     while (batchOk) {
       const batchSizes = new Map<string, RectSection>()
@@ -1074,30 +1102,55 @@ export function optimizeStructure(
       }
       if (batchSizes.size === 0) break
       batchPass++
-      onProgress?.({ phase: 'Optimizing — trimming sections', detail: `batch pass ${batchPass}: ${batchSizes.size} section(s) ↓` })
+      onProgress?.({ phase: 'Optimizing — trimming sections', detail: `batch pass ${batchPass}: ${batchSizes.size} section(s) h↓` })
       const trial = settle(withSizes(work, batchSizes))
       const d = designStructure(trial, soil, plan, opts)
       if (d && designOK(d)) { work = trial; design = d } else { batchOk = false }
     }
+    // Phase 2 — shrink b for RC sections (As = ρ·b·d; narrower b may still satisfy demand)
+    let bBatchOk = true
+    while (bBatchOk) {
+      const batchSizes = new Map<string, RectSection>()
+      for (const s0 of work.sections) {
+        if (s0.material !== 'steel' && s0.b - 25 >= 200)
+          batchSizes.set(s0.id, { ...s0, b: s0.b - 25, name: `${s0.b - 25}×${s0.h}` })
+      }
+      if (batchSizes.size === 0) break
+      batchPass++
+      onProgress?.({ phase: 'Optimizing — trimming sections', detail: `batch pass ${batchPass}: ${batchSizes.size} section(s) b↓` })
+      const trial = settle(withSizes(work, batchSizes))
+      const d = designStructure(trial, soil, plan, opts)
+      if (d && designOK(d)) { work = trial; design = d } else { bBatchOk = false }
+    }
 
-    // Individual fine-tune: catch sections the batch couldn't trim
+    // Fine-tune: per-section — try h↓ first, then b↓ if h can't shrink or fails
     let improved = true, guard = 0
     while (improved && guard++ < 4) {
       improved = false
       for (const s0 of work.sections) {
-        let trialSec: RectSection | null = null
         if (s0.material === 'steel' && s0.shape) {
           const lighter = nextLighterW(s0.shape)
-          if (lighter) trialSec = applyShape(s0, lighter)
+          if (!lighter) continue
+          onProgress?.({ phase: 'Optimizing — fine-tuning', detail: s0.name })
+          const trial = settle(withSizes(work, new Map([[s0.id, applyShape(s0, lighter)]])))
+          const d = designStructure(trial, soil, plan, opts)
+          if (d && designOK(d)) { work = trial; design = d; improved = true }
         } else {
-          if (s0.h - 25 < 300) continue
-          trialSec = { ...s0, h: s0.h - 25, name: `${s0.b}×${s0.h - 25}` }
+          if (s0.h - 25 >= 300) {
+            onProgress?.({ phase: 'Optimizing — fine-tuning', detail: `${s0.name} h↓` })
+            const hSec = { ...s0, h: s0.h - 25, name: `${s0.b}×${s0.h - 25}` }
+            const trial = settle(withSizes(work, new Map([[s0.id, hSec]])))
+            const d = designStructure(trial, soil, plan, opts)
+            if (d && designOK(d)) { work = trial; design = d; improved = true; continue }
+          }
+          if (s0.b - 25 >= 200) {
+            onProgress?.({ phase: 'Optimizing — fine-tuning', detail: `${s0.name} b↓` })
+            const bSec = { ...s0, b: s0.b - 25, name: `${s0.b - 25}×${s0.h}` }
+            const trial = settle(withSizes(work, new Map([[s0.id, bSec]])))
+            const d = designStructure(trial, soil, plan, opts)
+            if (d && designOK(d)) { work = trial; design = d; improved = true }
+          }
         }
-        if (!trialSec) continue
-        onProgress?.({ phase: 'Optimizing — fine-tuning', detail: s0.name })
-        const trial = settle(withSizes(work, new Map([[s0.id, trialSec]])))
-        const d = designStructure(trial, soil, plan, opts)
-        if (d && designOK(d)) { work = trial; design = d; improved = true }
       }
     }
     // final bar re-detail at the trimmed sizes for the most economical layout

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -791,11 +791,15 @@ export async function optimizeStructureAsync(
 
     if (converged) {
       let batchPass = 0
-      // Phase 1 — shrink h (or step to lighter W-shape for steel)
+      // Phase 1 — shrink h (or step to lighter W-shape for steel); only sections
+      // with utilisation clearly below capacity are included so one tight section
+      // does not poison the entire batch.
       let batchOk = true
       while (batchOk) {
+        const utilPerSec = sectionUtilMap(design, memSecId)
         const batchSizes = new Map<string, RectSection>()
         for (const s0 of work.sections) {
+          if ((utilPerSec.get(s0.id) ?? 0) >= 0.80) continue
           if (s0.material === 'steel' && s0.shape) {
             const lighter = nextLighterW(s0.shape)
             if (lighter) batchSizes.set(s0.id, applyShape(s0, lighter))
@@ -813,8 +817,10 @@ export async function optimizeStructureAsync(
       // Phase 2 — shrink b for RC sections (As = ρ·b·d; narrower b may still satisfy demand)
       let bBatchOk = true
       while (bBatchOk) {
+        const utilPerSec = sectionUtilMap(design, memSecId)
         const batchSizes = new Map<string, RectSection>()
         for (const s0 of work.sections) {
+          if ((utilPerSec.get(s0.id) ?? 0) >= 0.80) continue
           if (s0.material !== 'steel' && s0.b - 25 >= 200)
             batchSizes.set(s0.id, { ...s0, b: s0.b - 25, name: `${s0.b - 25}×${s0.h}` })
         }
@@ -988,6 +994,25 @@ function buildUtilMap(
   return out
 }
 
+/** Max demand/capacity ratio for every section across all member types (passing and failing). */
+function sectionUtilMap(design: StructureDesign, memSecId: Map<string, string>): Map<string, number> {
+  const out = new Map<string, number>()
+  const bump = (sid: string | undefined, u: number) => {
+    if (sid) out.set(sid, Math.max(out.get(sid) ?? 0, u))
+  }
+  for (const b of design.beams) {
+    const u = b.sections.reduce((mx, sec) => {
+      const mn = sec.design.phiMnMax
+      return Math.max(mx, mn > 1e-9 ? Math.abs(sec.Mu) / mn : 0)
+    }, 0)
+    bump(memSecId.get(b.id), u)
+  }
+  for (const c of design.columns)      bump(memSecId.get(c.id), c.util)
+  for (const b of design.steelBeams)   bump(memSecId.get(b.id), Math.max(b.utilM, b.utilV))
+  for (const c of design.steelColumns) bump(memSecId.get(c.id), c.ratio)
+  return out
+}
+
 /**
  * Grow a section by the estimated number of steps to satisfy a given demand/capacity
  * ratio (util = Mu/φMn ≥ 1).
@@ -1088,11 +1113,14 @@ export function optimizeStructure(
   // batch-trimmed (typically the critical ones controlling the design).
   if (converged) {
     let batchPass = 0
-    // Phase 1 — shrink h (or step to lighter W-shape for steel)
+    // Phase 1 — shrink h; only sections with utilisation clearly below capacity are
+    // included so one tight section does not reject the whole batch.
     let batchOk = true
     while (batchOk) {
+      const utilPerSec = sectionUtilMap(design, memSecId)
       const batchSizes = new Map<string, RectSection>()
       for (const s0 of work.sections) {
+        if ((utilPerSec.get(s0.id) ?? 0) >= 0.80) continue
         if (s0.material === 'steel' && s0.shape) {
           const lighter = nextLighterW(s0.shape)
           if (lighter) batchSizes.set(s0.id, applyShape(s0, lighter))
@@ -1110,8 +1138,10 @@ export function optimizeStructure(
     // Phase 2 — shrink b for RC sections (As = ρ·b·d; narrower b may still satisfy demand)
     let bBatchOk = true
     while (bBatchOk) {
+      const utilPerSec = sectionUtilMap(design, memSecId)
       const batchSizes = new Map<string, RectSection>()
       for (const s0 of work.sections) {
+        if ((utilPerSec.get(s0.id) ?? 0) >= 0.80) continue
         if (s0.material !== 'steel' && s0.b - 25 >= 200)
           batchSizes.set(s0.id, { ...s0, b: s0.b - 25, name: `${s0.b - 25}×${s0.h}` })
       }


### PR DESCRIPTION
## Summary

Two commits that were orphaned when PR #216 was merged early:

- **`b`-shrink in optimizer**: adds a second batch-shrink phase (and fine-tune fallback) that reduces section width `b` in 25 mm steps (floor 200 mm) after the `h`-shrink converges. Since `As = ρ·b·d`, both dimensions matter — a narrower section can still satisfy demand with the same depth, and the optimizer now finds that trade-off.

- **Utilisation filter on batch shrink**: both the `h` and `b` batch loops now call `sectionUtilMap` each pass and skip sections with demand/capacity ≥ 0.80. Previously, one tight section (util ≈ 0.95) could reject an entire batch even when ten other sections had util ≈ 0.40 and plenty of headroom. Fine-tune keeps trying all sections individually — individual failures don't poison the group.

## Test plan
- [ ] `optimizeStructure` on a concrete frame — confirm sections shrink in both `h` and `b` directions
- [ ] Progress overlay shows `h↓` and `b↓` batch passes separately
- [ ] 554 vitest tests pass, `tsc -b` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_