### PR TITLE
fix: DRRB compression bar stacking direction + d' formula substitution

### DIFF
--- a/webapp/src/components/BeamSchematic.tsx
+++ b/webapp/src/components/BeamSchematic.tsx
@@ -102,8 +102,8 @@ export function BeamSchematic({
   const yCom = hogging
     ? y0 + hh - (cover + stirrupDia + dbC / 2) * s
     : y0 + (cover + stirrupDia + dbC / 2) * s
-  const tenY = (li: number) => yTen + sgn * li * pitch          // toward mid-depth
-  const comY = (li: number) => yCom - sgn * li * pitchC
+  const tenY = (li: number) => yTen - sgn * li * pitch          // toward mid-depth
+  const comY = (li: number) => yCom + sgn * li * pitchC
 
   // When the layout diverges, clip the drawing at the neutral axis (measured
   // from the compression face): tension layers stay on their side, compression

--- a/webapp/src/lib/beamSolution.ts
+++ b/webapp/src/lib/beamSolution.ts
@@ -23,7 +23,7 @@ export function buildBeamSolution(i: BeamDesignInput, r: BeamDesignResult): Solu
     lines: [
       txt('d_t is the depth to the extreme (bottom) tension layer; d is the depth to the centroid of the whole bar group — they coincide for a single layer, and d < d_t once the bars need more than one layer (see the bar-layout step).'),
       eq(String.raw`d_t = h - cover - d_s - \tfrac{d_b}{2} = ${sn0(i.h)} - ${sn0(i.cover)} - ${sn0(i.stirrupDia)} - ${sn1(i.barDia / 2)} = ${sn1(r.dt)}\ \text{mm}`),
-      eq(String.raw`d' = cover + d_s + \tfrac{d_b'}{2} = ${sn1(r.dPrime)}\ \text{mm},\qquad d = \mathbf{${sn1(d)}}\ \text{mm}${multiLayer ? String.raw`\ (\text{after } ${r.layerIters}\ \text{layout passes})` : ''}`),
+      eq(String.raw`d' = cover + d_s + \tfrac{d_b'}{2}${r.comprYBar > 0 ? String.raw` + \bar{y}'` : ''} = ${sn0(i.cover)} + ${sn0(i.stirrupDia)} + ${sn1(dbC / 2)}${r.comprYBar > 0 ? ` + ${sn1(r.comprYBar)}` : ''} = ${sn1(r.dPrime)}\ \text{mm},\qquad d = \mathbf{${sn1(d)}}\ \text{mm}${multiLayer ? String.raw`\ (\text{after } ${r.layerIters}\ \text{layout passes})` : ''}`),
     ],
   })
 


### PR DESCRIPTION
## Summary

- **BeamSchematic.tsx — compression/tension bar layer direction**: `comY(li)` was using `yCom - sgn·li·pitchC`, which for sagging (sgn=1) moved each successive compression layer *up* and out of the section top. Fixed to `yCom + sgn·li·pitchC` so layers stack toward mid-depth. Matching fix for `tenY`: changed `yTen + sgn·li·pitch` → `yTen - sgn·li·pitch`. Both sagging and hogging cases now stack correctly.

- **beamSolution.ts — d' formula display**: Step 1 now substitutes the actual values (cover + stirrupDia + dbC/2) into the formula rather than showing only the result. For DRRB sections with more than one compression layer, the ȳ′ (comprYBar) term is also shown so the formula fully accounts for the bar-group centroid drop.

## Test plan
- [ ] All 554 vitest tests pass
- [ ] `npx tsc -b` compiles clean
- [ ] DRRB drawing: second/third compression-bar layers appear inside the section, stacked toward mid-depth
- [ ] d' formula in worked solution shows actual numbers, e.g. `d' = cover + dₛ + db'/2 = 40 + 10 + 8.0 = 58.0 mm`
- [ ] Multi-layer DRRB formula shows: `d' = cover + dₛ + db'/2 + ȳ' = 40 + 10 + 8.0 + 41.0 = 99.0 mm`
- [ ] Hogging sections draw symmetrically (tension at top, compression at bottom, layers toward mid-depth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_