### PR TITLE
feat: analysis tab — reactions/statics check (recovered) + nodal displacement table

### DIFF
--- a/webapp/src/components/DisplacementTable.tsx
+++ b/webapp/src/components/DisplacementTable.tsx
@@ -1,0 +1,137 @@
+import { useState } from 'react'
+import type { F3Analysis } from '../engine/frame3d'
+
+// Nodal displacements live in the solved vector d as [ux,uy,uz,θx,θy,θz] per
+// node at d[6·i + dof], where i is the node's position in model order.
+// Translations are metres (→ mm here); rotations are radians (→ mrad).
+interface DispRow {
+  id: string
+  y: number
+  ux: number; uy: number; uz: number   // mm
+  rx: number; ry: number; rz: number   // mrad
+}
+
+const mm = (v: number) => (v * 1000).toFixed(2)       // m → mm
+const mr = (v: number) => (v * 1000).toFixed(3)       // rad → mrad
+
+function rowFrom(id: string, y: number, d: number[], i: number): DispRow {
+  return {
+    id, y,
+    ux: d[6 * i], uy: d[6 * i + 1], uz: d[6 * i + 2],
+    rx: d[6 * i + 3], ry: d[6 * i + 4], rz: d[6 * i + 5],
+  }
+}
+
+const pickExtreme = (a: number, b: number) => (Math.abs(b) > Math.abs(a) ? b : a)
+
+export function DisplacementTable({
+  analysis,
+  nodes,
+}: {
+  analysis: F3Analysis
+  nodes: { id: string; y: number }[]
+}) {
+  const validCombos = analysis.perCombo.map((run, i) => ({ run, i })).filter(({ run }) => !!run.result)
+  const [active, setActive] = useState<'envelope' | number>('envelope')
+
+  // Stable display order: by elevation then id (reads floor-by-floor), but the
+  // d-vector index is the original model order, so carry it through.
+  const indexed = nodes.map((n, i) => ({ ...n, i }))
+  const ordered = [...indexed].sort((a, b) => a.y - b.y || a.id.localeCompare(b.id))
+
+  function buildEnvelope(): DispRow[] {
+    return ordered.map((n) => {
+      const acc: DispRow = { id: n.id, y: n.y, ux: 0, uy: 0, uz: 0, rx: 0, ry: 0, rz: 0 }
+      for (const { run } of validCombos) {
+        const r = rowFrom(n.id, n.y, run.result!.d, n.i)
+        acc.ux = pickExtreme(acc.ux, r.ux); acc.uy = pickExtreme(acc.uy, r.uy); acc.uz = pickExtreme(acc.uz, r.uz)
+        acc.rx = pickExtreme(acc.rx, r.rx); acc.ry = pickExtreme(acc.ry, r.ry); acc.rz = pickExtreme(acc.rz, r.rz)
+      }
+      return acc
+    })
+  }
+
+  function buildCombo(idx: number): DispRow[] {
+    const res = analysis.perCombo[idx].result
+    if (!res) return []
+    return ordered.map((n) => rowFrom(n.id, n.y, res.d, n.i))
+  }
+
+  const rows = active === 'envelope' ? buildEnvelope() : buildCombo(active)
+
+  const gmax = rows.reduce(
+    (a, r) => ({
+      ux: Math.max(a.ux, Math.abs(r.ux)), uy: Math.max(a.uy, Math.abs(r.uy)), uz: Math.max(a.uz, Math.abs(r.uz)),
+      rx: Math.max(a.rx, Math.abs(r.rx)), ry: Math.max(a.ry, Math.abs(r.ry)), rz: Math.max(a.rz, Math.abs(r.rz)),
+    }),
+    { ux: 0, uy: 0, uz: 0, rx: 0, ry: 0, rz: 0 }
+  )
+
+  const tabCls = (on: boolean) =>
+    `rounded px-2.5 py-1 text-xs font-semibold transition-colors ${
+      on ? 'bg-[#0056b3] text-white' : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+    }`
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <h2 className="mb-1 text-[1.02rem] font-bold text-[#0056b3]">Nodal Displacements</h2>
+      <p className="mb-3 text-[11px] text-slate-400">Translations in mm, rotations in mrad. Envelope shows the signed extreme across combinations.</p>
+
+      <div className="mb-3 flex flex-wrap gap-1">
+        <button type="button" onClick={() => setActive('envelope')} className={tabCls(active === 'envelope')}>
+          Envelope
+        </button>
+        {validCombos.map(({ run, i }) => (
+          <button
+            key={i}
+            type="button"
+            onClick={() => setActive(i)}
+            className={`${tabCls(active === i)} ${i === analysis.govIdx ? 'ring-1 ring-[#0056b3] ring-offset-1' : ''}`}
+          >
+            {run.combo.name}{i === analysis.govIdx ? ' ★' : ''}
+          </button>
+        ))}
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-xs">
+          <thead>
+            <tr className="border-b border-slate-200 text-slate-500">
+              <th className="pb-1.5 pr-3 text-left font-semibold">Node</th>
+              <th className="pb-1.5 pr-3 text-right font-semibold">Elev (m)</th>
+              <th className="pb-1.5 pr-3 text-right font-semibold">ux (mm)</th>
+              <th className="pb-1.5 pr-3 text-right font-semibold">uy (mm)</th>
+              <th className="pb-1.5 pr-3 text-right font-semibold">uz (mm)</th>
+              <th className="pb-1.5 pr-3 text-right font-semibold">θx (mrad)</th>
+              <th className="pb-1.5 pr-3 text-right font-semibold">θy (mrad)</th>
+              <th className="pb-1.5 text-right font-semibold">θz (mrad)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.id} className="border-b border-slate-100 last:border-0 hover:bg-slate-50">
+                <td className="py-1 pr-3 font-mono text-slate-700">{r.id}</td>
+                <td className="py-1 pr-3 text-right tabular-nums text-slate-500">{r.y.toFixed(2)}</td>
+                <td className="py-1 pr-3 text-right tabular-nums text-slate-800">{mm(r.ux)}</td>
+                <td className="py-1 pr-3 text-right tabular-nums text-slate-800">{mm(r.uy)}</td>
+                <td className="py-1 pr-3 text-right tabular-nums text-slate-800">{mm(r.uz)}</td>
+                <td className="py-1 pr-3 text-right tabular-nums text-slate-800">{mr(r.rx)}</td>
+                <td className="py-1 pr-3 text-right tabular-nums text-slate-800">{mr(r.ry)}</td>
+                <td className="py-1 text-right tabular-nums text-slate-800">{mr(r.rz)}</td>
+              </tr>
+            ))}
+            <tr className="border-t-2 border-slate-300 bg-slate-50 font-bold">
+              <td className="py-1.5 pr-3 text-slate-700" colSpan={2}>MAX |·|</td>
+              <td className="py-1.5 pr-3 text-right tabular-nums text-[#0056b3]">{mm(gmax.ux)}</td>
+              <td className="py-1.5 pr-3 text-right tabular-nums text-[#0056b3]">{mm(gmax.uy)}</td>
+              <td className="py-1.5 pr-3 text-right tabular-nums text-[#0056b3]">{mm(gmax.uz)}</td>
+              <td className="py-1.5 pr-3 text-right tabular-nums text-[#0056b3]">{mr(gmax.rx)}</td>
+              <td className="py-1.5 pr-3 text-right tabular-nums text-[#0056b3]">{mr(gmax.ry)}</td>
+              <td className="py-1.5 text-right tabular-nums text-[#0056b3]">{mr(gmax.rz)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/webapp/src/components/ReactionsPanel.tsx
+++ b/webapp/src/components/ReactionsPanel.tsx
@@ -1,0 +1,137 @@
+import { useState } from 'react'
+import type { F3Analysis, F3Reaction } from '../engine/frame3d'
+import { appliedResultant } from '../engine/frame3d'
+
+const f1 = (v: number) => v.toFixed(1)
+const f2 = (v: number) => v.toFixed(2)
+
+/** Sum reactions over each global axis → [ΣFx, ΣFy, ΣFz, ΣMx, ΣMy, ΣMz]. */
+function reactionTotals(reactions: F3Reaction[]) {
+  return reactions.reduce(
+    (a, r) => {
+      a.Fx += r.F[0]; a.Fy += r.F[1]; a.Fz += r.F[2]
+      a.Mx += r.M[0]; a.My += r.M[1]; a.Mz += r.M[2]
+      return a
+    },
+    { Fx: 0, Fy: 0, Fz: 0, Mx: 0, My: 0, Mz: 0 }
+  )
+}
+
+export function ReactionsPanel({
+  analysis,
+  memberLen,
+}: {
+  analysis: F3Analysis
+  memberLen: (memberId: string) => number
+}) {
+  const validCombos = analysis.perCombo.map((run, i) => ({ run, i })).filter(({ run }) => !!run.result)
+  const [active, setActive] = useState<number>(analysis.govIdx)
+  const sel = analysis.perCombo[active]?.result ? active : (validCombos[0]?.i ?? analysis.govIdx)
+
+  const run = analysis.perCombo[sel]
+  const res = run?.result
+  if (!res) return null
+
+  const reactions = [...res.reactions].sort((a, b) => a.node.localeCompare(b.node))
+  const rt = reactionTotals(reactions)
+
+  // Statics self-check: applied resultant should balance the reaction resultant.
+  const applied = appliedResultant(run.factored, memberLen)
+  const resid: [number, number, number] = [applied[0] + rt.Fx, applied[1] + rt.Fy, applied[2] + rt.Fz]
+  const scale = Math.max(Math.abs(rt.Fx), Math.abs(rt.Fy), Math.abs(rt.Fz), Math.abs(applied[1]), 1e-9)
+  const residPct = (Math.max(...resid.map(Math.abs)) / scale) * 100
+  const ok = residPct < 1
+
+  const tabCls = (on: boolean) =>
+    `rounded px-2.5 py-1 text-xs font-semibold transition-colors ${
+      on ? 'bg-[#0056b3] text-white' : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+    }`
+
+  const axes: [string, 0 | 1 | 2][] = [['X', 0], ['Y', 1], ['Z', 2]]
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <h2 className="mb-3 text-[1.02rem] font-bold text-[#0056b3]">Support Reactions &amp; Statics Check</h2>
+
+      <div className="mb-3 flex flex-wrap gap-1">
+        {validCombos.map(({ run: r, i }) => (
+          <button
+            key={i}
+            type="button"
+            onClick={() => setActive(i)}
+            className={`${tabCls(sel === i)} ${i === analysis.govIdx ? 'ring-1 ring-[#0056b3] ring-offset-1' : ''}`}
+          >
+            {r.combo.name}{i === analysis.govIdx ? ' ★' : ''}
+          </button>
+        ))}
+      </div>
+
+      {/* Statics self-check — STAAD-style ΣApplied vs ΣReactions */}
+      <div className={`mb-3 rounded-lg border p-2.5 text-xs ${ok ? 'border-emerald-200 bg-emerald-50' : 'border-red-200 bg-red-50'}`}>
+        <div className={`mb-1 font-bold ${ok ? 'text-emerald-700' : 'text-red-700'}`}>
+          {ok ? '✓ Equilibrium satisfied' : '✗ Equilibrium residual high'} — max residual {residPct.toExponential(1)}% of load
+        </div>
+        <table className="w-full">
+          <thead>
+            <tr className="text-slate-500">
+              <th className="text-left font-medium">Axis</th>
+              <th className="text-right font-medium">ΣApplied (kN)</th>
+              <th className="text-right font-medium">ΣReactions (kN)</th>
+              <th className="text-right font-medium">Residual (kN)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {axes.map(([name, k]) => (
+              <tr key={name} className="text-slate-700">
+                <td className="text-left font-mono">{name}</td>
+                <td className="text-right tabular-nums">{f2(applied[k])}</td>
+                <td className="text-right tabular-nums">{f2([rt.Fx, rt.Fy, rt.Fz][k])}</td>
+                <td className="text-right tabular-nums">{f2(resid[k])}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-xs">
+          <thead>
+            <tr className="border-b border-slate-200 text-slate-500">
+              <th className="pb-1.5 pr-3 text-left font-semibold">Node</th>
+              <th className="pb-1.5 pr-3 text-left font-semibold">Fixity</th>
+              <th className="pb-1.5 pr-3 text-right font-semibold">Fx (kN)</th>
+              <th className="pb-1.5 pr-3 text-right font-semibold">Fy (kN)</th>
+              <th className="pb-1.5 pr-3 text-right font-semibold">Fz (kN)</th>
+              <th className="pb-1.5 pr-3 text-right font-semibold">Mx (kN·m)</th>
+              <th className="pb-1.5 pr-3 text-right font-semibold">My (kN·m)</th>
+              <th className="pb-1.5 text-right font-semibold">Mz (kN·m)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {reactions.map((r) => (
+              <tr key={r.node} className="border-b border-slate-100 last:border-0 hover:bg-slate-50">
+                <td className="py-1 pr-3 font-mono text-slate-700">{r.node}</td>
+                <td className="py-1 pr-3 capitalize text-slate-500">{r.fixity}</td>
+                <td className="py-1 pr-3 text-right tabular-nums text-slate-800">{f1(r.F[0])}</td>
+                <td className="py-1 pr-3 text-right tabular-nums text-slate-800">{f1(r.F[1])}</td>
+                <td className="py-1 pr-3 text-right tabular-nums text-slate-800">{f1(r.F[2])}</td>
+                <td className="py-1 pr-3 text-right tabular-nums text-slate-800">{f1(r.M[0])}</td>
+                <td className="py-1 pr-3 text-right tabular-nums text-slate-800">{f1(r.M[1])}</td>
+                <td className="py-1 text-right tabular-nums text-slate-800">{f1(r.M[2])}</td>
+              </tr>
+            ))}
+            <tr className="border-t-2 border-slate-300 bg-slate-50 font-bold">
+              <td className="py-1.5 pr-3 text-slate-700" colSpan={2}>Σ</td>
+              <td className="py-1.5 pr-3 text-right tabular-nums text-[#0056b3]">{f1(rt.Fx)}</td>
+              <td className="py-1.5 pr-3 text-right tabular-nums text-[#0056b3]">{f1(rt.Fy)}</td>
+              <td className="py-1.5 pr-3 text-right tabular-nums text-[#0056b3]">{f1(rt.Fz)}</td>
+              <td className="py-1.5 pr-3 text-right tabular-nums text-[#0056b3]">{f1(rt.Mx)}</td>
+              <td className="py-1.5 pr-3 text-right tabular-nums text-[#0056b3]">{f1(rt.My)}</td>
+              <td className="py-1.5 text-right tabular-nums text-[#0056b3]">{f1(rt.Mz)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/webapp/src/engine/frame3d.test.ts
+++ b/webapp/src/engine/frame3d.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { solveFrame3D, analyzeFrame3D, rectJ, precomputeFrame, solveWithGeometry, serializePrecomp, deserializePrecomp, type F3Node, type F3Member, type F3Support, type F3Load } from './frame3d'
+import { solveFrame3D, analyzeFrame3D, rectJ, precomputeFrame, solveWithGeometry, serializePrecomp, deserializePrecomp, appliedResultant, type F3Node, type F3Member, type F3Support, type F3Load } from './frame3d'
 import { solveFrame2D } from './frame2d'
 import { generateGridModel } from './modelBuilder'
 import { modelToFrame3D } from './modelBridge'
@@ -221,5 +221,46 @@ describe('serializePrecomp / deserializePrecomp — postMessage roundtrip', () =
     expect(r2).not.toBeNull()
     for (let i = 0; i < r1.d.length; i++) expect(r2.d[i]).toBeCloseTo(r1.d[i], 9)
     expect(r2.Mmax).toBeCloseTo(r1.Mmax, 9)
+  })
+})
+
+describe('appliedResultant — statics self-check (§8)', () => {
+  const noLen = () => 0
+
+  it('sums node loads per global axis', () => {
+    const loads: F3Load[] = [
+      { kind: 'node', node: 'a', Fx: 10, Fy: -50, Fz: 5, cat: 'D' },
+      { kind: 'node', node: 'b', Fx: -4, Fy: -20, cat: 'L' },
+    ]
+    expect(appliedResultant(loads, noLen)).toEqual([6, -70, 5])
+  })
+
+  it('integrates member gravity loads (UDL w·L, VDL ½(w1+w2)·Δ, point P) into −Y', () => {
+    const loads: F3Load[] = [
+      { kind: 'member-udl', member: 'm1', w: 10, cat: 'D' },                              // 10·4 = 40
+      { kind: 'member-vdl', member: 'm2', x1: 0, x2: 6, w1: 0, w2: 8, cat: 'D' },         // ½·8·6 = 24
+      { kind: 'member-point', member: 'm3', a: 1.5, P: 12, cat: 'L' },                    // 12
+    ]
+    const len = (id: string) => ({ m1: 4, m2: 6, m3: 3 }[id] ?? 0)
+    expect(appliedResultant(loads, len)).toEqual([0, -(40 + 24 + 12), 0])
+  })
+
+  it('balances the reactions for a slab-loaded grid: ΣApplied + ΣReactions ≈ 0', () => {
+    const section: RectSection = { id: 'S1', name: '300×500', b, h, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
+    const model = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })
+    model.loads = model.plates.map((p) => ({ kind: 'area', plate: p.id, q: 5, cat: 'D' }))
+    const br = modelToFrame3D(model)
+    const res = analyzeFrame3D(br.nodes, br.members, br.supports, br.loads)!
+    const gov = res.perCombo[res.govIdx]
+    const pos = new Map(br.nodes.map((n) => [n.id, n]))
+    const len = (id: string) => {
+      const m = br.members.find((mm) => mm.id === id)!
+      const a = pos.get(m.i)!, c = pos.get(m.j)!
+      return Math.hypot(a.x - c.x, a.y - c.y, a.z - c.z)
+    }
+    const applied = appliedResultant(gov.factored, len)
+    const reac: [number, number, number] = [0, 1, 2].map((k) =>
+      gov.result!.reactions.reduce((s, q) => s + q.F[k], 0)) as [number, number, number]
+    for (let k = 0; k < 3; k++) expect(applied[k] + reac[k]).toBeCloseTo(0, 2)
   })
 })

--- a/webapp/src/engine/frame3d.ts
+++ b/webapp/src/engine/frame3d.ts
@@ -73,6 +73,27 @@ export function applyF3Combo(loads: F3Load[], factors: Partial<Record<LoadCatego
     })
 }
 
+/**
+ * Resultant of an applied (already factored) load set in global axes, as
+ * [ΣFx, ΣFy, ΣFz] (kN). Member gravity loads act in global −Y; their resultant
+ * is the integral over the loaded length (UDL: w·L, VDL: ½(w1+w2)·Δ, point: P),
+ * matching the equivalent nodal loads the solver assembles. Used for the
+ * statics self-check ΣApplied + ΣReactions ≈ 0 (§8 — equilibrium sanity).
+ */
+export function appliedResultant(loads: F3Load[], memberLen: (id: string) => number): [number, number, number] {
+  let fx = 0, fy = 0, fz = 0
+  for (const ld of loads) {
+    if (ld.kind === 'node') { fx += ld.Fx ?? 0; fy += ld.Fy ?? 0; fz += ld.Fz ?? 0 }
+    else if (ld.kind === 'member-udl') { fy -= ld.w * memberLen(ld.member) }
+    else if (ld.kind === 'member-vdl') {
+      const L = memberLen(ld.member)
+      const x1 = Math.max(0, ld.x1), x2 = Math.min(L, ld.x2)
+      if (x2 > x1) fy -= 0.5 * (ld.w1 + ld.w2) * (x2 - x1)
+    } else { fy -= ld.P }
+  }
+  return [fx, fy, fz]
+}
+
 /** Local 12×12 stiffness. */
 function kLocal(EA: number, GJ: number, EIy: number, EIz: number, L: number): number[][] {
   const k = Array.from({ length: 12 }, () => new Array(12).fill(0))

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -23,6 +23,7 @@ import { WorkedSolution } from '../components/WorkedSolution'
 import { beamSectionSolution, columnRowSolution, footingRowSolution, combinedRowSolution } from '../lib/modelSpaceSolutions'
 import { Diagram } from '../components/Diagram'
 import { MemberForcesTable } from '../components/MemberForcesTable'
+import { ReactionsPanel } from '../components/ReactionsPanel'
 import { BeamSchematic } from '../components/BeamSchematic'
 import { ColumnSchematic } from '../components/ColumnSchematic'
 import { FootingSchematic } from '../components/FootingSchematic'
@@ -1029,6 +1030,16 @@ export default function ModelSpace() {
     ? nodePos.get(selMember.i)!.distanceTo(nodePos.get(selMember.j)!)
     : 0
 
+  // Member-length lookup (m) for the statics self-check in the reactions panel.
+  const memberLenById = useMemo(() => {
+    const map = new Map<string, number>()
+    model?.members.forEach((mm) => {
+      const a = nodePos.get(mm.i), b = nodePos.get(mm.j)
+      if (a && b) map.set(mm.id, a.distanceTo(b))
+    })
+    return (id: string) => map.get(id) ?? 0
+  }, [model, nodePos])
+
   const download = () => {
     if (!model) return
     const blob = new Blob([JSON.stringify(model, null, 2)], { type: 'application/json' })
@@ -1901,6 +1912,10 @@ export default function ModelSpace() {
 
               {analysis && model && (
                 <MemberForcesTable analysis={analysis} members={model.members} sectionFor={sectionFor} />
+              )}
+
+              {analysis && model && (
+                <ReactionsPanel analysis={analysis} memberLen={memberLenById} />
               )}
 
               {drift && seis && (

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -24,6 +24,7 @@ import { beamSectionSolution, columnRowSolution, footingRowSolution, combinedRow
 import { Diagram } from '../components/Diagram'
 import { MemberForcesTable } from '../components/MemberForcesTable'
 import { ReactionsPanel } from '../components/ReactionsPanel'
+import { DisplacementTable } from '../components/DisplacementTable'
 import { BeamSchematic } from '../components/BeamSchematic'
 import { ColumnSchematic } from '../components/ColumnSchematic'
 import { FootingSchematic } from '../components/FootingSchematic'
@@ -1916,6 +1917,10 @@ export default function ModelSpace() {
 
               {analysis && model && (
                 <ReactionsPanel analysis={analysis} memberLen={memberLenById} />
+              )}
+
+              {analysis && model && (
+                <DisplacementTable analysis={analysis} nodes={model.nodes} />
               )}
 
               {drift && seis && (


### PR DESCRIPTION
Continues the STAAD-style analysis-tab work. Recovers the **reactions + statics check** that was orphaned when #223 merged only the forces-table commit, and adds the **nodal displacement table**.

## 1. Support Reactions + Statics self-check (recovered from #223)

- Per-support reaction table (Fx,Fy,Fz,Mx,My,Mz) with a Σ totals row, selectable per combination (governing combo ringed/★).
- **STAAD-style statics check** (guide §8): ΣApplied vs ΣReactions per global axis, with residual % and pass/fail badge — catches assembly / BC / load-equivalent bugs.
- New pure engine helper `appliedResultant()` integrates the applied load set via a **different code path** than reaction recovery, so the two cross-check by construction.
- Files: `webapp/src/components/ReactionsPanel.tsx`, `appliedResultant()` in `frame3d.ts`.

## 2. Nodal Displacement table (new)

- Per-node ux,uy,uz (mm) and θx,θy,θz (mrad), read from `d[6·i + dof]` in model-node order — the same indexing the storey-drift check uses.
- Envelope tab (signed extreme across combinations) + one tab per combo, governing combo ringed/★ — consistent with the forces & reactions tables.
- Rows ordered by elevation then id (reads floor-by-floor); MAX |·| row.
- File: `webapp/src/components/DisplacementTable.tsx`.

## Test plan
- [x] 557 vitest tests pass (incl. 3 for `appliedResultant` with equilibrium balance on a slab-loaded grid)
- [x] `npx tsc -b` clean
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_