### PR TITLE
feat: pre-analysis mesh validation (fail-fast on singular meshes)

### DIFF
--- a/webapp/src/components/ValidationPanel.tsx
+++ b/webapp/src/components/ValidationPanel.tsx
@@ -1,0 +1,45 @@
+import type { MeshIssue } from '../engine/meshValidation'
+
+/** Pre-analysis mesh diagnostics (CLAUDE.md §1). Errors are fatal — the solve
+ *  would produce a singular stiffness matrix; warnings are advisory. */
+export function ValidationPanel({ issues, onSelect }: {
+  issues: MeshIssue[]
+  onSelect?: (refs: string[]) => void
+}) {
+  if (issues.length === 0) return null
+  const errors = issues.filter((i) => i.severity === 'error')
+  const warnings = issues.filter((i) => i.severity === 'warning')
+
+  const Item = ({ i }: { i: MeshIssue }) => {
+    const err = i.severity === 'error'
+    return (
+      <li className={`flex items-start gap-2 rounded px-2 py-1.5 text-xs ${err ? 'text-red-700' : 'text-amber-700'}`}>
+        <span aria-hidden className="mt-px font-bold">{err ? '✗' : '⚠'}</span>
+        <span className="flex-1">
+          {i.message}
+          {i.refs.length > 0 && onSelect && (
+            <button type="button" onClick={() => onSelect(i.refs)}
+              className="ml-1.5 rounded border border-current/30 px-1.5 py-px text-[10px] font-semibold opacity-80 hover:opacity-100">
+              show
+            </button>
+          )}
+        </span>
+      </li>
+    )
+  }
+
+  return (
+    <div className={`rounded-xl border p-4 shadow-sm ${errors.length ? 'border-red-200 bg-red-50' : 'border-amber-200 bg-amber-50'}`}>
+      <h2 className={`mb-1 text-[1.02rem] font-bold ${errors.length ? 'text-red-700' : 'text-amber-700'}`}>
+        Mesh validation — {errors.length} error{errors.length === 1 ? '' : 's'}, {warnings.length} warning{warnings.length === 1 ? '' : 's'}
+      </h2>
+      {errors.length > 0 && (
+        <p className="mb-2 text-[11px] text-red-600">Fix the errors below before analysing — they would make the stiffness matrix singular.</p>
+      )}
+      <ul className="space-y-0.5">
+        {errors.map((i, k) => <Item key={`e${k}`} i={i} />)}
+        {warnings.map((i, k) => <Item key={`w${k}`} i={i} />)}
+      </ul>
+    </div>
+  )
+}

--- a/webapp/src/engine/meshValidation.test.ts
+++ b/webapp/src/engine/meshValidation.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import { validateMesh, hasMeshErrors } from './meshValidation'
+import { generateGridModel } from './modelBuilder'
+import { emptyModel, type RectSection, type StructuralModel } from './model'
+
+const section: RectSection = { id: 'S1', name: '300×500', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
+
+const codes = (m: StructuralModel) => new Set(validateMesh(m).map((i) => i.code))
+
+describe('validateMesh — clean models', () => {
+  it('a generated grid has no issues', () => {
+    const model = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })
+    const issues = validateMesh(model)
+    expect(issues).toEqual([])
+    expect(hasMeshErrors(issues)).toBe(false)
+  })
+
+  it('an empty model has no issues', () => {
+    expect(validateMesh(emptyModel())).toEqual([])
+  })
+})
+
+describe('validateMesh — fatal errors', () => {
+  it('flags a member referencing a missing node', () => {
+    const model = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })
+    model.members[0] = { ...model.members[0], j: 'ghost' }
+    const issues = validateMesh(model)
+    expect(issues.some((i) => i.code === 'member-missing-node' && i.refs.includes('ghost'))).toBe(true)
+    expect(hasMeshErrors(issues)).toBe(true)
+  })
+
+  it('flags a zero-length member', () => {
+    const model = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })
+    const m = model.members[0]
+    // move node j onto node i
+    const ni = model.nodes.find((n) => n.id === m.i)!
+    model.nodes = model.nodes.map((n) => (n.id === m.j ? { ...n, x: ni.x, y: ni.y, z: ni.z } : n))
+    expect(codes(model)).toContain('zero-length-member')
+  })
+
+  it('flags a model with no supports', () => {
+    const model = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })
+    model.supports = []
+    const issues = validateMesh(model)
+    expect(issues.some((i) => i.code === 'no-supports')).toBe(true)
+    expect(hasMeshErrors(issues)).toBe(true)
+  })
+
+  it('flags an unrestrained connected component', () => {
+    // two separate columns; only the first one is supported
+    const model = emptyModel()
+    model.sections = [section]
+    model.nodes = [
+      { id: 'a0', x: 0, y: 0, z: 0 }, { id: 'a1', x: 0, y: 3, z: 0 },
+      { id: 'b0', x: 5, y: 0, z: 0 }, { id: 'b1', x: 5, y: 3, z: 0 },
+    ]
+    model.members = [
+      { id: 'ca', i: 'a0', j: 'a1', role: 'column', section: 'S1' },
+      { id: 'cb', i: 'b0', j: 'b1', role: 'column', section: 'S1' },
+    ]
+    model.supports = [{ node: 'a0', fixity: 'fixed' }]
+    const issues = validateMesh(model)
+    const rb = issues.find((i) => i.code === 'unrestrained-component')!
+    expect(rb).toBeTruthy()
+    expect(rb.refs).toEqual(expect.arrayContaining(['b0', 'b1']))
+    expect(rb.refs).not.toContain('a0')   // supported component is fine
+  })
+
+  it('flags an orphan node unless it is fully fixed', () => {
+    const model = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })
+    model.nodes = [...model.nodes, { id: 'loose', x: 99, y: 99, z: 99 }]
+    expect(codes(model)).toContain('orphan-node')
+
+    // fully fixing it downgrades to an advisory
+    model.supports = [...model.supports, { node: 'loose', fixity: 'fixed' }]
+    const issues = validateMesh(model)
+    expect(issues.some((i) => i.code === 'orphan-node')).toBe(false)
+    expect(issues.some((i) => i.code === 'isolated-node')).toBe(true)
+  })
+})
+
+describe('validateMesh — advisory warnings', () => {
+  it('warns on coincident distinct nodes without erroring', () => {
+    const model = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })
+    const first = model.nodes[0]
+    // duplicate the first node's location with a new id, and attach a member so
+    // it isn't also an orphan
+    model.nodes = [...model.nodes, { id: 'twin', x: first.x, y: first.y, z: first.z }]
+    model.members = [...model.members, { id: 'mt', i: 'twin', j: model.members[0].j, role: 'beam', section: 'S1' }]
+    const issues = validateMesh(model)
+    expect(issues.some((i) => i.code === 'coincident-nodes' && i.refs.includes('twin'))).toBe(true)
+  })
+
+  it('warns on duplicate members on the same node pair', () => {
+    const model = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })
+    const m0 = model.members[0]
+    model.members = [...model.members, { ...m0, id: `${m0.id}_dup` }]
+    const issues = validateMesh(model)
+    expect(issues.some((i) => i.code === 'duplicate-member')).toBe(true)
+  })
+})

--- a/webapp/src/engine/meshValidation.ts
+++ b/webapp/src/engine/meshValidation.ts
@@ -1,0 +1,144 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Mesh validation (CLAUDE.md §1). A strictly upstream, pure check that runs
+// before analysis: it catches the geometry/connectivity errors that would
+// otherwise produce a singular stiffness matrix with no explanation, and
+// reports them against the offending node/member ids. Errors are fatal (the
+// solve would fail); warnings are advisory (the solve still runs).
+//
+// What it can prove cheaply from the graph alone:
+//   • duplicate node ids, member/support refs to missing nodes
+//   • zero-length members (singular element stiffness)
+//   • a model with no supports, or a connected component with no support
+//     node (an unrestrained rigid body → singular K)
+//   • a node attached to no member whose DOFs aren't fully fixed (free DOFs
+//     with zero stiffness → singular K)
+//   • coincident distinct nodes / duplicate members (advisory)
+//
+// It deliberately does NOT try to prove full 6-DOF stability of a restrained
+// component (that needs the assembled matrix rank): it only flags components
+// with *zero* supports, which are always rigid bodies — so it never blocks a
+// valid model with a false error.
+// ─────────────────────────────────────────────────────────────────────────
+import type { StructuralModel } from './model'
+
+export type MeshSeverity = 'error' | 'warning'
+export interface MeshIssue {
+  severity: MeshSeverity
+  code: string
+  message: string
+  refs: string[]              // involved node / member ids
+}
+
+const COINCIDENT_TOL = 1e-6  // m
+
+export function validateMesh(model: StructuralModel): MeshIssue[] {
+  const issues: MeshIssue[] = []
+  const { nodes, members, supports } = model
+
+  // ── node id integrity ──────────────────────────────────────────────────
+  const seen = new Set<string>()
+  const dupIds = new Set<string>()
+  for (const n of nodes) (seen.has(n.id) ? dupIds : seen).add(n.id)
+  for (const id of dupIds)
+    issues.push({ severity: 'error', code: 'duplicate-node-id', refs: [id],
+      message: `Duplicate node id "${id}" — node ids must be unique.` })
+
+  const nodeById = new Map(nodes.map((n) => [n.id, n]))
+
+  // ── member ref integrity & zero-length ──────────────────────────────────
+  const pairSeen = new Map<string, string>()   // "i|j" (sorted) → first member id
+  for (const m of members) {
+    const a = nodeById.get(m.i), b = nodeById.get(m.j)
+    if (!a || !b) {
+      const missing = [!a ? m.i : null, !b ? m.j : null].filter(Boolean) as string[]
+      issues.push({ severity: 'error', code: 'member-missing-node', refs: [m.id, ...missing],
+        message: `Member ${m.id} references missing node(s) ${missing.join(', ')}.` })
+      continue
+    }
+    if (Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z) < COINCIDENT_TOL)
+      issues.push({ severity: 'error', code: 'zero-length-member', refs: [m.id],
+        message: `Member ${m.id} has zero length (nodes ${m.i} and ${m.j} coincide) — its stiffness is singular.` })
+
+    const key = [m.i, m.j].sort().join('|')
+    const prev = pairSeen.get(key)
+    if (prev) issues.push({ severity: 'warning', code: 'duplicate-member', refs: [prev, m.id],
+      message: `Members ${prev} and ${m.id} span the same nodes — stiffness is doubled.` })
+    else pairSeen.set(key, m.id)
+  }
+
+  // ── coincident distinct nodes (advisory: usually an unmerged mesh) ───────
+  const byCoord = new Map<string, string[]>()
+  for (const n of nodes) {
+    const k = `${Math.round(n.x / COINCIDENT_TOL)},${Math.round(n.y / COINCIDENT_TOL)},${Math.round(n.z / COINCIDENT_TOL)}`
+    ;(byCoord.get(k) ?? byCoord.set(k, []).get(k)!).push(n.id)
+  }
+  for (const ids of byCoord.values())
+    if (ids.length > 1)
+      issues.push({ severity: 'warning', code: 'coincident-nodes', refs: ids,
+        message: `Nodes ${ids.join(', ')} share the same location — merge them if they should be one joint.` })
+
+  // ── support ref integrity ───────────────────────────────────────────────
+  const supById = new Map(supports.map((s) => [s.node, s]))
+  for (const s of supports)
+    if (!nodeById.has(s.node))
+      issues.push({ severity: 'error', code: 'support-missing-node', refs: [s.node],
+        message: `Support references missing node ${s.node}.` })
+
+  // ── restraint / rigid-body checks ───────────────────────────────────────
+  const validSupports = supports.filter((s) => nodeById.has(s.node))
+  if (validSupports.length === 0) {
+    if (nodes.length > 0)
+      issues.push({ severity: 'error', code: 'no-supports', refs: [],
+        message: 'Model has no supports — the structure is an unrestrained rigid body (singular K).' })
+    return issues  // every component is a rigid body; one message is enough
+  }
+
+  // Nodes attached to ≥1 valid member, and the union-find over them.
+  const inMember = new Set<string>()
+  const parent = new Map<string, string>()
+  const find = (x: string): string => {
+    let r = x
+    while (parent.get(r) !== r) r = parent.get(r)!
+    while (parent.get(x) !== r) { const nx = parent.get(x)!; parent.set(x, r); x = nx }
+    return r
+  }
+  const add = (id: string) => { if (!parent.has(id)) parent.set(id, id) }
+  for (const m of members) {
+    if (!nodeById.has(m.i) || !nodeById.has(m.j)) continue
+    inMember.add(m.i); inMember.add(m.j)
+    add(m.i); add(m.j)
+    parent.set(find(m.i), find(m.j))
+  }
+
+  // Each connected component must contain at least one support node.
+  const compNodes = new Map<string, string[]>()
+  for (const id of parent.keys()) {
+    const r = find(id)
+    ;(compNodes.get(r) ?? compNodes.set(r, []).get(r)!).push(id)
+  }
+  for (const ids of compNodes.values()) {
+    if (ids.some((id) => supById.has(id))) continue
+    const sample = ids.slice(0, 5)
+    issues.push({ severity: 'error', code: 'unrestrained-component', refs: sample,
+      message: `${ids.length} connected node(s) (${sample.join(', ')}${ids.length > sample.length ? ', …' : ''}) have no support — this part of the model is an unrestrained rigid body (singular K).` })
+  }
+
+  // ── orphan nodes (no member): free DOFs with no stiffness ───────────────
+  for (const n of nodes) {
+    if (inMember.has(n.id)) continue
+    const sup = supById.get(n.id)
+    if (sup?.fixity === 'fixed')
+      issues.push({ severity: 'warning', code: 'isolated-node', refs: [n.id],
+        message: `Node ${n.id} is attached to no member (fully fixed, so harmless but unused).` })
+    else
+      issues.push({ severity: 'error', code: 'orphan-node', refs: [n.id],
+        message: `Node ${n.id} is attached to no member; its free DOFs have no stiffness (singular K).` })
+  }
+
+  return issues
+}
+
+/** True if any issue is fatal (analysis would fail). */
+export function hasMeshErrors(issues: MeshIssue[]): boolean {
+  return issues.some((i) => i.severity === 'error')
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -7,6 +7,7 @@ import { generateGridModel, removeElements, removeNode, buildGravityLoads, split
 import type { StructuralModel, Member, Plate, RectSection, ModelLoad, MemberRole } from '../engine/model'
 import { distributePanel } from '../engine/tributary'
 import { type F3Analysis } from '../engine/frame3d'
+import { validateMesh, hasMeshErrors } from '../engine/meshValidation'
 import { type StructureDesign, type FootingPlan, type OptimizeResult, type LateralCase } from '../engine/pipeline'
 import type { SteelJoint } from '../engine/steelConnections'
 import { estimateTakeoff, costBill, type PriceList } from '../engine/takeoff'
@@ -25,6 +26,7 @@ import { Diagram } from '../components/Diagram'
 import { MemberForcesTable } from '../components/MemberForcesTable'
 import { ReactionsPanel } from '../components/ReactionsPanel'
 import { DisplacementTable } from '../components/DisplacementTable'
+import { ValidationPanel } from '../components/ValidationPanel'
 import { BeamSchematic } from '../components/BeamSchematic'
 import { ColumnSchematic } from '../components/ColumnSchematic'
 import { FootingSchematic } from '../components/FootingSchematic'
@@ -679,7 +681,7 @@ export default function ModelSpace() {
   const anaOpts = { f1: fLive, pDelta, lateral, seismicSystem }
 
   const analyze = () => {
-    if (!model || busy) return
+    if (!model || busy || meshErrors) return   // §1 fail-fast: don't solve a singular mesh
     const axis: 'x' | 'z' = (eDirs[0] ?? '+X').includes('X') ? 'x' : 'z'
     // 3D FEM + storey drift run in the worker so the UI stays responsive.
     run('analyze', {
@@ -795,7 +797,7 @@ export default function ModelSpace() {
   }
 
   const runPipeline = () => {
-    if (!model || busy) return
+    if (!model || busy || meshErrors) return
     setOpt(null)
     // material is applied on the main thread (cheap); the FEM + bar selection +
     // designStructure run in the worker so the page never freezes.
@@ -810,7 +812,7 @@ export default function ModelSpace() {
   }
 
   const optimize = () => {
-    if (!model || busy) return
+    if (!model || busy || meshErrors) return
     run('optimize', {
       model: applyMaterial(model), soil, plan: footingPlan(), opts: anaOpts, tryBars, maxIter: 30,
     }).then((raw) => {
@@ -1030,6 +1032,11 @@ export default function ModelSpace() {
   const memberLen = selMember
     ? nodePos.get(selMember.i)!.distanceTo(nodePos.get(selMember.j)!)
     : 0
+
+  // Pre-analysis mesh diagnostics (§1) — drives the validation panel and the
+  // fail-fast guard on the Analyze button.
+  const meshIssues = useMemo(() => (model ? validateMesh(model) : []), [model])
+  const meshErrors = hasMeshErrors(meshIssues)
 
   // Member-length lookup (m) for the statics self-check in the reactions panel.
   const memberLenById = useMemo(() => {
@@ -1894,12 +1901,15 @@ export default function ModelSpace() {
                   {pDelta ? ' Frame solved with the geometric-stiffness P-Δ iteration.' : ' First-order (linear) frame solve.'}
                 </p>
                 <div className="col-span-full">
-                  <button type="button" onClick={analyze} disabled={!model || !!busy} className={btn('from-[#0e7490] to-[#155e75]')}>
+                  <button type="button" onClick={analyze} disabled={!model || !!busy || meshErrors} className={btn('from-[#0e7490] to-[#155e75]')}>
                     {busy === 'analyze' ? '⏳ Analyzing…' : '▶ Analyze (3D FEM)'}
                   </button>
+                  {meshErrors && <p className="mt-1 text-[11px] font-medium text-red-600">Resolve the mesh errors below to enable analysis.</p>}
                 </div>
                 {busy === 'analyze' && <SolverProgress p={progress} />}
               </Card>
+
+              {model && <ValidationPanel issues={meshIssues} />}
 
               {gov && govRes && (
                 <ResultCard title={`Analysis — ${gov.combo.name} governs`}>
@@ -1983,14 +1993,19 @@ export default function ModelSpace() {
             <div className="space-y-4">
               <Card title="Design & optimise">
                 <div className="col-span-full flex flex-wrap gap-2">
-                  <button type="button" onClick={runPipeline} disabled={!model || !!busy} className={btn('from-[#15803d] to-[#166534]')}>
+                  <button type="button" onClick={runPipeline} disabled={!model || !!busy || meshErrors} className={btn('from-[#15803d] to-[#166534]')}>
                     {busy === 'design' ? '⏳ Designing…' : '🏗 Design structure'}
                   </button>
-                  <button type="button" onClick={optimize} disabled={!model || !!busy} className={btn('from-[#b45309] to-[#92400e]')}
+                  <button type="button" onClick={optimize} disabled={!model || !!busy || meshErrors} className={btn('from-[#b45309] to-[#92400e]')}
                     title="Grow each failing member's own section until nothing fails, then trim back">
                     {busy === 'optimize' ? '⏳ Optimizing…' : '🏁 Optimize design'}
                   </button>
                 </div>
+                {meshErrors && (
+                  <p className="col-span-full text-[11px] font-medium text-red-600">
+                    Mesh has errors — fix them in the Analysis tab before designing.
+                  </p>
+                )}
                 {busy && <SolverProgress p={progress} />}
                 {busy && (
                   <p className="col-span-full text-[11px] font-medium text-[#0056b3]">


### PR DESCRIPTION
Implements the mesh-validation layer from the engineering guide (§1): a strictly **upstream**, pure check that runs before the solver and reports the geometry/connectivity errors that would otherwise produce a singular stiffness matrix with no explanation — naming the specific node/member ids at fault.

## Engine — `webapp/src/engine/meshValidation.ts` (pure, unit-tested)

**Errors** (fatal — solve would be singular):
- duplicate node ids
- member or support references to a missing node
- zero-length members (singular element stiffness)
- model with no supports (unrestrained rigid body)
- a connected component with no support node (rigid body)
- orphan nodes (attached to no member) whose DOFs aren't fully fixed — free DOFs with zero stiffness

**Warnings** (advisory — solve still runs):
- coincident distinct nodes (unmerged mesh)
- duplicate members on the same node pair (doubled stiffness)

It only flags components with **zero** supports, so it never blocks a valid model with a false positive — a clean generated grid yields no issues (covered by a test). It deliberately doesn't attempt full 6-DOF stability proof of a *restrained* component (that needs the assembled matrix rank); those rarer mechanisms still surface as a failed solve.

## UI

- **`ValidationPanel`** in the Analysis tab lists errors (red) / warnings (amber) with the offending ids.
- **Analyze / Design / Optimize** are disabled and short-circuit when the mesh has errors, so the user gets a clear diagnostic instead of a silently failed solve (§1 "fail fast with a clear error").

## Test plan
- [x] 566 vitest tests pass (9 new in `meshValidation.test.ts`)
- [x] `npx tsc -b` clean
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_