### PR TITLE
feat: modal analysis engine (phase 1 of 3) — periods, modes, mass participation

### DIFF
--- a/webapp/src/engine/modal.test.ts
+++ b/webapp/src/engine/modal.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest'
+import { jacobiEigen, buildSeismicMass, modalAnalysis, GRAVITY } from './modal'
+import { modelToFrame3D } from './modelBridge'
+import { solveFrame3D, type F3Load } from './frame3d'
+import { generateGridModel } from './modelBuilder'
+import { emptyModel, type RectSection, type StructuralModel } from './model'
+
+const section: RectSection = {
+  id: 'S1', name: '400×400', b: 400, h: 400, fc: 28, fy: 415,
+  barDia: 20, tieDia: 10, cover: 40, material: 'concrete',
+}
+
+// ── eigen-solver ────────────────────────────────────────────────────────────
+describe('jacobiEigen — symmetric eigen-decomposition', () => {
+  it('diagonalises a diagonal matrix', () => {
+    const { values } = jacobiEigen([[2, 0], [0, 3]])
+    expect(values.slice().sort((a, b) => a - b)).toEqual([2, 3])
+  })
+
+  it('matches the closed-form eigenpairs of [[2,1],[1,2]]', () => {
+    const { values, vectors } = jacobiEigen([[2, 1], [1, 2]])
+    expect(values.slice().sort((a, b) => a - b)[0]).toBeCloseTo(1, 9)
+    expect(values.slice().sort((a, b) => a - b)[1]).toBeCloseTo(3, 9)
+    // each eigenpair satisfies A v = λ v
+    for (let k = 0; k < 2; k++) {
+      const v = vectors[k], lam = values[k]
+      const Av = [2 * v[0] + 1 * v[1], 1 * v[0] + 2 * v[1]]
+      expect(Av[0]).toBeCloseTo(lam * v[0], 9)
+      expect(Av[1]).toBeCloseTo(lam * v[1], 9)
+    }
+  })
+
+  it('returns eigenvectors of unit length', () => {
+    const { vectors } = jacobiEigen([[4, 1, 0], [1, 3, 1], [0, 1, 2]])
+    for (const v of vectors) expect(Math.hypot(...v)).toBeCloseTo(1, 9)
+  })
+})
+
+// ── mass assembly ─────────────────────────────────────────────────────────
+describe('buildSeismicMass', () => {
+  it('conserves total member self-mass (Σ nodal = Σ member)', () => {
+    const model = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })
+    const mass = buildSeismicMass(model)
+    const total = [...mass.values()].reduce((s, m) => s + m, 0)
+
+    // independently: Σ member (b·h·L·γc)/g
+    const pos = new Map(model.nodes.map((n) => [n.id, [n.x, n.y, n.z]]))
+    let expected = 0
+    for (const m of model.members) {
+      const a = pos.get(m.i)!, b = pos.get(m.j)!
+      const L = Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2])
+      expected += (0.4 * 0.4 * 24 * L) / GRAVITY   // 400×400 concrete
+    }
+    // grid has no slabs with sdl by default; allow slab self-mass too
+    expect(total).toBeGreaterThan(0)
+    expect(total).toBeCloseTo(expected + slabMass(model), 6)
+  })
+})
+
+function slabMass(model: StructuralModel): number {
+  const pos = new Map(model.nodes.map((n) => [n.id, [n.x, n.y, n.z]]))
+  const tri = (a: number[], b: number[], c: number[]) => {
+    const u = [b[0] - a[0], b[1] - a[1], b[2] - a[2]], v = [c[0] - a[0], c[1] - a[1], c[2] - a[2]]
+    return 0.5 * Math.hypot(u[1] * v[2] - u[2] * v[1], u[2] * v[0] - u[0] * v[2], u[0] * v[1] - u[1] * v[0])
+  }
+  let m = 0
+  for (const p of model.plates) {
+    if (p.role !== 'slab') continue
+    const c = p.corners.map((id) => pos.get(id)!)
+    const area = tri(c[0], c[1], c[2]) + tri(c[0], c[2], c[3])
+    m += ((p.thickness / 1000) * 24 * area) / GRAVITY
+  }
+  return m
+}
+
+// ── closed-form SDOF column ─────────────────────────────────────────────────
+describe('modalAnalysis — SDOF cantilever column', () => {
+  // single column, base fixed; only its own self-mass. Half lumps to the fixed
+  // base (no DOF), half to the free top → an SDOF in each lateral direction.
+  const H = 4
+  const model: StructuralModel = {
+    ...emptyModel('col'),
+    nodes: [{ id: 'base', x: 0, y: 0, z: 0 }, { id: 'top', x: 0, y: H, z: 0 }],
+    sections: [section],
+    members: [{ id: 'c', i: 'base', j: 'top', role: 'column', section: 'S1' }],
+    supports: [{ node: 'base', fixity: 'fixed' }],
+  }
+
+  it('fundamental period matches 2π√(m/k) with k from a static unit load', () => {
+    const mTop = buildSeismicMass(model).get('top')!     // tonnes
+    expect(mTop).toBeGreaterThan(0)
+
+    // lateral stiffness at the top in X and Z from unit static loads
+    const br = modelToFrame3D(model)
+    const kOf = (axis: 'Fx' | 'Fz') => {
+      const load: F3Load = { kind: 'node', node: 'top', [axis]: 1, cat: 'D' } as F3Load
+      const r = solveFrame3D(br.nodes, br.members, br.supports, [load])!
+      const comp = axis === 'Fx' ? 0 : 2
+      const top = br.nodes.findIndex((n) => n.id === 'top')
+      return 1 / Math.abs(r.d[6 * top + comp])           // kN/m
+    }
+    const kx = kOf('Fx'), kz = kOf('Fz')
+    const kMin = Math.min(kx, kz)
+    const Tlong = 2 * Math.PI * Math.sqrt(mTop / kMin)   // s
+
+    const res = modalAnalysis(model, 6)!
+    expect(res.modes.length).toBeGreaterThan(0)
+    // periods are sorted descending; the longest is the weak-axis lateral mode
+    expect(res.modes[0].period).toBeCloseTo(Tlong, 4)
+  })
+
+  it('the lateral modes account for ~100% of the mass in their direction', () => {
+    const res = modalAnalysis(model, 6)!
+    // square section ⇒ kx≈kz ⇒ both lateral modes present; combined X+Z+Y → full
+    expect(res.cumRatio[0]).toBeCloseTo(1, 2)
+    expect(res.cumRatio[2]).toBeCloseTo(1, 2)
+  })
+})
+
+// ── full model sanity ───────────────────────────────────────────────────────
+describe('modalAnalysis — generated grid', () => {
+  it('returns positive periods in descending order with growing cumulative mass', () => {
+    const model = generateGridModel({ baysX: [6, 6], baysZ: [5], storeyH: [3.5, 3], section })
+    const res = modalAnalysis(model, 12)!
+    expect(res.modes.length).toBeGreaterThan(0)
+    for (const m of res.modes) {
+      expect(m.period).toBeGreaterThan(0)
+      expect(Number.isFinite(m.period)).toBe(true)
+    }
+    for (let i = 1; i < res.modes.length; i++)
+      expect(res.modes[i].period).toBeLessThanOrEqual(res.modes[i - 1].period + 1e-9)
+    // effective mass ratios are within [0,1] and accumulate
+    for (const m of res.modes)
+      for (const r of m.effMassRatio) { expect(r).toBeGreaterThanOrEqual(-1e-9); expect(r).toBeLessThanOrEqual(1 + 1e-6) }
+    expect(res.cumRatio[0]).toBeGreaterThan(0)
+  })
+
+  it('returns null for a model with no supports (singular K)', () => {
+    const model = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })
+    model.supports = []
+    expect(modalAnalysis(model)).toBeNull()
+  })
+})

--- a/webapp/src/engine/modal.ts
+++ b/webapp/src/engine/modal.ts
@@ -1,0 +1,247 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Modal (free-vibration) analysis — CLAUDE.md §6, phase 1 (engine).
+//
+// Solves the generalised eigenproblem [K]{φ} = ω²[M]{φ} for the lowest modes
+// and reports natural periods, circular frequencies and the effective modal
+// mass participation per global direction.
+//
+// Layering (per the guide): the mass matrix is built by its own function; the
+// eigen-solver is a pure routine that knows nothing about how K or M were
+// assembled; participation is pure post-processing on (period, shape) tuples.
+//
+// Mass model: LUMPED translational mass. Each member's self-mass and each
+// slab's self-mass + superimposed dead load are lumped to nodes; only the
+// three translational DOFs carry mass (rotational inertia neglected, the usual
+// lumped-mass simplification). Because that leaves the rotational DOFs
+// mass-less, we avoid the singular-M generalised eigenproblem by working with
+// the flexibility form: the eigenvalues of M^½ F_mm M^½ are 1/ω², where F_mm
+// is the flexibility (= K⁻¹) restricted to the massive DOFs. This reduces the
+// problem to the number of massive translational DOFs and is unconditionally
+// well-posed once K is non-singular (guaranteed by mesh validation).
+//
+// Units: K in kN/m, mass in tonnes (Mg) → ω in rad/s, T in seconds.
+//   mass[t] = weight[kN] / g.   member/slab weights use GAMMA_C/GAMMA_S kN/m³.
+// ─────────────────────────────────────────────────────────────────────────
+import type { StructuralModel } from './model'
+import { precomputeFrame } from './frame3d'
+import { modelToFrame3D } from './modelBridge'
+import { luSolve } from './fem'
+import { GAMMA_C, GAMMA_S } from './modelBuilder'
+import { shapeByName } from './aiscSections'
+import { sdlItemKPa } from './deadLoads'
+import { validateMesh, hasMeshErrors } from './meshValidation'
+
+export const GRAVITY = 9.81  // m/s²
+
+export interface Mode {
+  /** Natural period, seconds. */
+  period: number
+  /** Circular frequency, rad/s. */
+  omega: number
+  /** Cyclic frequency, Hz. */
+  freq: number
+  /** Effective modal mass in each global direction [X, Y, Z], tonnes. */
+  effMass: [number, number, number]
+  /** Effective modal mass as a fraction of the total mass, per direction. */
+  effMassRatio: [number, number, number]
+}
+
+export interface ModalResult {
+  modes: Mode[]
+  /** Total lumped mass per global direction, tonnes. */
+  totalMass: [number, number, number]
+  /** Cumulative effective-mass ratio across the returned modes, per direction. */
+  cumRatio: [number, number, number]
+}
+
+// ── mass assembly ──────────────────────────────────────────────────────────
+
+const triArea = (a: number[], b: number[], c: number[]): number => {
+  const u = [b[0] - a[0], b[1] - a[1], b[2] - a[2]]
+  const v = [c[0] - a[0], c[1] - a[1], c[2] - a[2]]
+  const cx = u[1] * v[2] - u[2] * v[1]
+  const cy = u[2] * v[0] - u[0] * v[2]
+  const cz = u[0] * v[1] - u[1] * v[0]
+  return 0.5 * Math.hypot(cx, cy, cz)
+}
+
+/**
+ * Lumped seismic mass per node (tonnes), from member self-weight and slab
+ * self-weight + superimposed dead load. Each contribution is split equally to
+ * the element's nodes. Live load and applied point/area live are excluded
+ * (phase-1 dead-load mass source).
+ */
+export function buildSeismicMass(model: StructuralModel): Map<string, number> {
+  const mass = new Map<string, number>()
+  const pos = new Map(model.nodes.map((n) => [n.id, [n.x, n.y, n.z]]))
+  const add = (id: string, m: number) => mass.set(id, (mass.get(id) ?? 0) + m)
+  const secById = new Map(model.sections.map((s) => [s.id, s]))
+
+  // members: self-weight → mass, half to each end node
+  for (const mem of model.members) {
+    const a = pos.get(mem.i), b = pos.get(mem.j)
+    if (!a || !b) continue
+    const L = Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2])  // m
+    const sec = secById.get(mem.section)
+    if (!sec || L === 0) continue
+    let wPerL: number  // kN/m
+    if (sec.material === 'steel') {
+      const shape = sec.shape ? shapeByName(sec.shape) : undefined
+      wPerL = (shape ? shape.A / 1e6 : (sec.b / 1000) * (sec.h / 1000)) * GAMMA_S
+    } else {
+      wPerL = (sec.b / 1000) * (sec.h / 1000) * GAMMA_C
+    }
+    const halfMass = (wPerL * L) / GRAVITY / 2   // tonnes per end
+    add(mem.i, halfMass)
+    add(mem.j, halfMass)
+  }
+
+  // slabs: self-weight (γc·t) + superimposed dead, split to the 4 corners
+  for (const p of model.plates) {
+    if (p.role !== 'slab') continue
+    const c = p.corners.map((id) => pos.get(id)).filter(Boolean) as number[][]
+    if (c.length !== 4) continue
+    const area = triArea(c[0], c[1], c[2]) + triArea(c[0], c[2], c[3])  // m²
+    const selfKPa = (p.thickness / 1000) * GAMMA_C                       // kN/m²
+    const sdlKPa = (p.sdlItems ?? []).reduce((s, it) => s + sdlItemKPa(it), 0)
+    const weight = (selfKPa + sdlKPa) * area                            // kN
+    const quarter = weight / GRAVITY / 4
+    for (const id of p.corners) add(id, quarter)
+  }
+
+  return mass
+}
+
+// ── symmetric eigen-solver (cyclic Jacobi) ──────────────────────────────────
+
+/**
+ * Eigen-decomposition of a symmetric n×n matrix by cyclic Jacobi rotations.
+ * Returns eigenvalues and eigenvectors (vectors[k] is the k-th column / mode).
+ */
+export function jacobiEigen(Ain: number[][], maxSweeps = 100): { values: number[]; vectors: number[][] } {
+  const n = Ain.length
+  const A = Ain.map((r) => [...r])
+  const V: number[][] = Array.from({ length: n }, (_, i) => Array.from({ length: n }, (_, j) => (i === j ? 1 : 0)))
+  if (n === 0) return { values: [], vectors: [] }
+
+  const offNorm = () => {
+    let s = 0
+    for (let i = 0; i < n; i++) for (let j = i + 1; j < n; j++) s += A[i][j] * A[i][j]
+    return Math.sqrt(s)
+  }
+
+  for (let sweep = 0; sweep < maxSweeps; sweep++) {
+    if (offNorm() < 1e-14) break
+    for (let p = 0; p < n; p++) {
+      for (let q = p + 1; q < n; q++) {
+        if (Math.abs(A[p][q]) < 1e-300) continue
+        const app = A[p][p], aqq = A[q][q], apq = A[p][q]
+        const phi = 0.5 * Math.atan2(2 * apq, aqq - app)
+        const c = Math.cos(phi), s = Math.sin(phi)
+        for (let k = 0; k < n; k++) {
+          const akp = A[k][p], akq = A[k][q]
+          A[k][p] = c * akp - s * akq
+          A[k][q] = s * akp + c * akq
+        }
+        for (let k = 0; k < n; k++) {
+          const apk = A[p][k], aqk = A[q][k]
+          A[p][k] = c * apk - s * aqk
+          A[q][k] = s * apk + c * aqk
+        }
+        for (let k = 0; k < n; k++) {
+          const vkp = V[k][p], vkq = V[k][q]
+          V[k][p] = c * vkp - s * vkq
+          V[k][q] = s * vkp + c * vkq
+        }
+      }
+    }
+  }
+
+  const values = A.map((_, i) => A[i][i])
+  const vectors = Array.from({ length: n }, (_, k) => V.map((row) => row[k]))  // columns
+  return { values, vectors }
+}
+
+// ── orchestration ───────────────────────────────────────────────────────────
+
+interface MassDof { fpos: number; dir: 0 | 1 | 2; mass: number }
+
+/**
+ * Modal analysis of a structural model. Returns the lowest `nModes` modes with
+ * natural periods and effective mass participation, or null if the stiffness
+ * matrix is singular (run mesh validation first) or there is no mass.
+ */
+export function modalAnalysis(model: StructuralModel, nModes = 12): ModalResult | null {
+  // A mesh with errors (e.g. no supports → rigid-body modes) makes K singular
+  // in ways luFactor's pivot tolerance may not catch; gate on validation.
+  if (hasMeshErrors(validateMesh(model))) return null
+  const br = modelToFrame3D(model)
+  const precomp = precomputeFrame(br.nodes, br.members, br.supports)
+  if (!precomp.Kff || precomp.Kff.n === 0) return null
+
+  const massByNode = buildSeismicMass(model)
+
+  // collect the massive, free translational DOFs
+  const massDofs: MassDof[] = []
+  const totalMass: [number, number, number] = [0, 0, 0]
+  for (const [nodeId, m] of massByNode) {
+    if (m <= 0) continue
+    const ni = precomp.idx.get(nodeId)
+    if (ni === undefined) continue
+    for (let dir = 0 as 0 | 1 | 2; dir < 3; dir = (dir + 1) as 0 | 1 | 2) {
+      const gdof = 6 * ni + dir
+      const fpos = precomp.freeIdx.get(gdof)
+      if (fpos === undefined) continue  // restrained DOF → mass cannot vibrate
+      totalMass[dir] += m              // participation is measured against free mass
+      massDofs.push({ fpos, dir, mass: m })
+    }
+  }
+  const p = massDofs.length
+  if (p === 0) return null
+
+  // flexibility restricted to the massive DOFs: F_mm[a][b] = (K⁻¹ e_b)[a]
+  const Fmm: number[][] = Array.from({ length: p }, () => new Array(p).fill(0))
+  const e = new Array(precomp.Kff.n).fill(0)
+  for (let b = 0; b < p; b++) {
+    e.fill(0)
+    e[massDofs[b].fpos] = 1
+    const x = luSolve(precomp.Kff, e)
+    for (let a = 0; a < p; a++) Fmm[a][b] = x[massDofs[a].fpos]
+  }
+
+  // symmetrise: Ã = M^½ F_mm M^½ (SPD); eigenvalues are 1/ω²
+  const sm = massDofs.map((d) => Math.sqrt(d.mass))
+  const A: number[][] = Array.from({ length: p }, (_, a) =>
+    Array.from({ length: p }, (_, b) => 0.5 * (Fmm[a][b] + Fmm[b][a]) * sm[a] * sm[b]))
+  const { values, vectors } = jacobiEigen(A)
+
+  // lowest modes = largest eigenvalues (μ = 1/ω²)
+  const order = values.map((_, i) => i).filter((i) => values[i] > 1e-300)
+    .sort((i, j) => values[j] - values[i])
+    .slice(0, Math.min(nModes, p))
+
+  const modes: Mode[] = order.map((i) => {
+    const mu = values[i]
+    const omega = 1 / Math.sqrt(mu)
+    const psi = vectors[i]
+    // mode shape on massive DOFs: φ = M^-½ ψ
+    const phi = psi.map((v, a) => v / sm[a])
+    // generalised modal mass M* = φᵀ M φ ; participation Lr = φᵀ M ιr
+    let Mstar = 0
+    const L: [number, number, number] = [0, 0, 0]
+    for (let a = 0; a < p; a++) {
+      const mp = massDofs[a].mass * phi[a]
+      Mstar += mp * phi[a]
+      L[massDofs[a].dir] += mp
+    }
+    const effMass: [number, number, number] = [L[0] * L[0] / Mstar, L[1] * L[1] / Mstar, L[2] * L[2] / Mstar]
+    const effMassRatio: [number, number, number] = [0, 1, 2].map((r) =>
+      totalMass[r] > 0 ? effMass[r] / totalMass[r] : 0) as [number, number, number]
+    return { period: 2 * Math.PI / omega, omega, freq: omega / (2 * Math.PI), effMass, effMassRatio }
+  })
+
+  const cum: [number, number, number] = [0, 1, 2].map((r) =>
+    modes.reduce((s, m) => s + m.effMassRatio[r], 0)) as [number, number, number]
+
+  return { modes, totalMass, cumRatio: cum }
+}

--- a/webapp/src/engine/modelBuilder.ts
+++ b/webapp/src/engine/modelBuilder.ts
@@ -136,8 +136,8 @@ export function removeNode(model: StructuralModel, nodeId: string): StructuralMo
   }
 }
 
-const GAMMA_C = 24    // kN/m³, default concrete unit weight
-const GAMMA_S = 78.5  // kN/m³, structural steel
+export const GAMMA_C = 24    // kN/m³, default concrete unit weight
+export const GAMMA_S = 78.5  // kN/m³, structural steel
 
 /**
  * Build the gravity load set: member SELF-WEIGHT (D, kN/m from the section),

--- a/webapp/src/engine/solverWorker.ts
+++ b/webapp/src/engine/solverWorker.ts
@@ -9,6 +9,7 @@
 import type { StructuralModel } from './model'
 import { modelToFrame3D } from './modelBridge'
 import { analyzeFrame3D, solveFrame3D, applyF3Combo, type F3AnalyzeOpts } from './frame3d'
+import { modalAnalysis } from './modal'
 import { driftCheck } from './seismic'
 import { designStructureAsync, optimizeStructureAsync, selectBarDiameters, type SoilOptions, type FootingPlan, type AnalyzeOptions } from './pipeline'
 import type { SolveProgress } from './progress'
@@ -18,6 +19,7 @@ export type SolverRequest =
   | { id: number; kind: 'analyze'; model: StructuralModel; opts: F3AnalyzeOpts; drift: DriftReq }
   | { id: number; kind: 'design'; model: StructuralModel; soil: SoilOptions; plan: FootingPlan; opts: AnalyzeOptions; tryBars: boolean }
   | { id: number; kind: 'optimize'; model: StructuralModel; soil: SoilOptions; plan: FootingPlan; opts: AnalyzeOptions; tryBars: boolean; maxIter: number }
+  | { id: number; kind: 'modal'; model: StructuralModel; nModes: number }
 
 const ctx = self as unknown as Worker
 
@@ -37,6 +39,10 @@ ctx.onmessage = async (e: MessageEvent<SolverRequest>) => {
         drift = sol ? driftCheck(msg.model, br.nodes, sol.d, msg.drift.R, msg.drift.T, msg.drift.axis) : null
       }
       ctx.postMessage({ id: msg.id, ok: true, result: { analysis, orphans: br.orphanEdges.length, drift } })
+    } else if (msg.kind === 'modal') {
+      onProgress({ phase: 'Modal analysis' })
+      const modal = modalAnalysis(msg.model, msg.nModes)
+      ctx.postMessage({ id: msg.id, ok: true, result: { modal } })
     } else if (msg.kind === 'design') {
       let m = msg.model
       if (msg.tryBars) {


### PR DESCRIPTION
**Phase 1 of 3** for modal/dynamic analysis (CLAUDE.md §6). This PR is the pure **engine foundation**; the UI tab and response-spectrum come in later phases.

## What it computes

Solves the generalised eigenproblem **[K]{φ} = ω²[M]{φ}** for the lowest modes and reports, per mode: natural **period**, circular/cyclic frequency, and **effective modal mass participation** in each global direction.

## How (the interesting part)

Lumped mass leaves the rotational DOFs massless, so **M is singular** and the generalised eigenproblem is ill-posed as written. Instead I work in the **flexibility form**: the eigenvalues of `M^½ · F_mm · M^½` are `1/ω²`, where `F_mm` is the flexibility (K⁻¹) restricted to the massive translational DOFs. This is unconditionally well-posed once K is non-singular and reduces the problem size to the number of massive DOFs. Eigenpairs come from a pure cyclic-**Jacobi** solver.

Gated on **mesh validation** — a rigid-body model (e.g. no supports) returns `null` rather than garbage, since `luFactor`'s pivot tolerance won't always catch near-singular K.

## Layering (per the guide)

- `buildSeismicMass(model)` — lumped mass from member + slab self-weight/SDL, its own function
- `jacobiEigen()` — pure symmetric eigen-solver, knows nothing about structures
- `modalAnalysis()` — orchestrates; participation is pure post-processing on (period, shape)

Units: K in kN/m, mass in tonnes → ω in rad/s, T in seconds. Wired through the solver worker (`modal` request) so Phase 2 is purely additive.

## Tests (8 new, `modal.test.ts`)
- Jacobi vs closed-form eigenpairs of `[[2,1],[1,2]]`; unit eigenvectors
- **SDOF cantilever**: fundamental period matches `2π√(m/k)` with `k` from a static unit-load solve (4-dp), and lateral modes carry ~100% of the mass
- Mass conservation (Σ nodal = Σ member + slab)
- Grid sanity: positive periods in descending order, ratios in [0,1]; `null` on a no-support model

## Test plan
- [x] 574 vitest tests pass
- [x] `npx tsc -b` clean
- [x] `npm run build` succeeds

## Next phases
- **Phase 2** — Modal tab: run button, periods/participation table, mode-shape display
- **Phase 3** — Response spectrum (SRSS/CQC), replacing the approximate seismic T

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_