### PR TITLE
feat: modal analysis tab (phase 2 of 3) — periods & mass-participation UI

### DIFF
--- a/webapp/src/components/ModalPanel.tsx
+++ b/webapp/src/components/ModalPanel.tsx
@@ -1,0 +1,70 @@
+import type { ModalResult } from '../engine/modal'
+
+const f3 = (v: number) => v.toFixed(3)
+const f2 = (v: number) => v.toFixed(2)
+const pct = (v: number) => `${(v * 100).toFixed(1)}%`
+
+/** Cumulative-mass cell colour: green once the ≥90% NSCP threshold is reached. */
+const cumCls = (v: number) => (v >= 0.9 ? 'text-emerald-600 font-semibold' : 'text-slate-500')
+
+export function ModalPanel({ result }: { result: ModalResult }) {
+  const { modes, totalMass, cumRatio } = result
+  // running cumulative effective-mass ratio per direction, mode by mode
+  const cum: [number, number, number] = [0, 0, 0]
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <h2 className="mb-1 text-[1.02rem] font-bold text-[#0056b3]">Modal Analysis — natural periods &amp; mass participation</h2>
+      <p className="mb-3 text-[11px] text-slate-400">
+        Lumped-mass free vibration. Effective modal mass per global direction; the cumulative column turns green at the
+        NSCP 208.5.5 ≥90% threshold. Total mass {f2(totalMass[0])} t (X), {f2(totalMass[1])} t (Y), {f2(totalMass[2])} t (Z).
+      </p>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-xs">
+          <thead>
+            <tr className="border-b border-slate-200 text-slate-500">
+              <th className="pb-1.5 pr-3 text-left font-semibold">Mode</th>
+              <th className="pb-1.5 pr-3 text-right font-semibold">T (s)</th>
+              <th className="pb-1.5 pr-3 text-right font-semibold">f (Hz)</th>
+              <th className="pb-1.5 pr-3 text-right font-semibold">ω (rad/s)</th>
+              <th className="pb-1.5 pr-3 text-right font-semibold">mₓ</th>
+              <th className="pb-1.5 pr-3 text-right font-semibold">m_y</th>
+              <th className="pb-1.5 pr-3 text-right font-semibold">m_z</th>
+              <th className="pb-1.5 pr-3 text-right font-semibold">Σmₓ</th>
+              <th className="pb-1.5 pr-3 text-right font-semibold">Σm_y</th>
+              <th className="pb-1.5 text-right font-semibold">Σm_z</th>
+            </tr>
+          </thead>
+          <tbody>
+            {modes.map((m, i) => {
+              cum[0] += m.effMassRatio[0]; cum[1] += m.effMassRatio[1]; cum[2] += m.effMassRatio[2]
+              const dom = m.effMassRatio.indexOf(Math.max(...m.effMassRatio))
+              const domLabel = m.effMassRatio[dom] > 0.5 ? ['X', 'Y', 'Z'][dom] : ''
+              return (
+                <tr key={i} className="border-b border-slate-100 last:border-0 hover:bg-slate-50">
+                  <td className="py-1 pr-3 font-mono text-slate-700">{i + 1}{domLabel && <span className="ml-1 text-[10px] text-slate-400">{domLabel}</span>}</td>
+                  <td className="py-1 pr-3 text-right tabular-nums font-semibold text-slate-800">{f3(m.period)}</td>
+                  <td className="py-1 pr-3 text-right tabular-nums text-slate-600">{f2(m.freq)}</td>
+                  <td className="py-1 pr-3 text-right tabular-nums text-slate-600">{f2(m.omega)}</td>
+                  <td className="py-1 pr-3 text-right tabular-nums text-slate-700">{pct(m.effMassRatio[0])}</td>
+                  <td className="py-1 pr-3 text-right tabular-nums text-slate-700">{pct(m.effMassRatio[1])}</td>
+                  <td className="py-1 pr-3 text-right tabular-nums text-slate-700">{pct(m.effMassRatio[2])}</td>
+                  <td className={`py-1 pr-3 text-right tabular-nums ${cumCls(cum[0])}`}>{pct(cum[0])}</td>
+                  <td className={`py-1 pr-3 text-right tabular-nums ${cumCls(cum[1])}`}>{pct(cum[1])}</td>
+                  <td className={`py-1 text-right tabular-nums ${cumCls(cum[2])}`}>{pct(cum[2])}</td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {(cumRatio[0] < 0.9 || cumRatio[2] < 0.9) && (
+        <p className="mt-2 text-[11px] text-amber-600">
+          ⚠ Cumulative lateral mass is below 90% (X {pct(cumRatio[0])}, Z {pct(cumRatio[2])}) — request more modes for a code-compliant response-spectrum base.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -8,6 +8,7 @@ import type { StructuralModel, Member, Plate, RectSection, ModelLoad, MemberRole
 import { distributePanel } from '../engine/tributary'
 import { type F3Analysis } from '../engine/frame3d'
 import { validateMesh, hasMeshErrors } from '../engine/meshValidation'
+import { type ModalResult } from '../engine/modal'
 import { type StructureDesign, type FootingPlan, type OptimizeResult, type LateralCase } from '../engine/pipeline'
 import type { SteelJoint } from '../engine/steelConnections'
 import { estimateTakeoff, costBill, type PriceList } from '../engine/takeoff'
@@ -27,6 +28,7 @@ import { MemberForcesTable } from '../components/MemberForcesTable'
 import { ReactionsPanel } from '../components/ReactionsPanel'
 import { DisplacementTable } from '../components/DisplacementTable'
 import { ValidationPanel } from '../components/ValidationPanel'
+import { ModalPanel } from '../components/ModalPanel'
 import { BeamSchematic } from '../components/BeamSchematic'
 import { ColumnSchematic } from '../components/ColumnSchematic'
 import { FootingSchematic } from '../components/FootingSchematic'
@@ -404,13 +406,14 @@ function DirPicker({ value, onChange }: { value: string[]; onChange: (v: string[
 }
 
 // ── Right-panel tabs ────────────────────────────────────────────────────────
-type Tab = 'geometry' | 'properties' | 'supports' | 'loading' | 'analysis' | 'design'
+type Tab = 'geometry' | 'properties' | 'supports' | 'loading' | 'analysis' | 'modal' | 'design'
 const TABS: { id: Tab; label: string }[] = [
   { id: 'geometry', label: 'Geometry' },
   { id: 'properties', label: 'Properties' },
   { id: 'supports', label: 'Supports' },
   { id: 'loading', label: 'Loading' },
   { id: 'analysis', label: 'Analysis' },
+  { id: 'modal', label: 'Modal' },
   { id: 'design', label: 'Design' },
 ]
 function TabBtn({ id, label, active, onClick }: { id: Tab; label: string; active: boolean; onClick: (t: Tab) => void }) {
@@ -597,6 +600,8 @@ export default function ModelSpace() {
   })
   const [selected, setSelected] = useState<string | null>(null)
   const [analysis, setAnalysis] = useState<F3Analysis | null>(null)
+  const [modal, setModal] = useState<ModalResult | null>(null)
+  const [nModes, setNModes] = useState(12)
   const [design, setDesign] = useState<StructureDesign | null>(null)
   const [opt, setOpt] = useState<OptimizeResult | null>(null)
   const [expanded, setExpanded] = useState<string | null>(null)   // open schedule-row solution
@@ -661,6 +666,7 @@ export default function ModelSpace() {
   const save = (m: StructuralModel | null) => {
     setModel(m)
     setAnalysis(null)             // geometry changed — results are stale
+    setModal(null)
     setDesign(null)
     setOpt(null)
     setExpanded(null)
@@ -692,6 +698,13 @@ export default function ModelSpace() {
       setAnalysis(res.analysis)
       setDrift(res.drift)
     }).catch((e) => console.error('analyze failed', e))
+  }
+
+  const runModal = () => {
+    if (!model || busy || meshErrors) return
+    run('modal', { model, nModes }).then((r) => {
+      setModal((r as { modal: ModalResult | null }).modal)
+    }).catch((e) => console.error('modal failed', e))
   }
 
   // Re-sign / re-axis a base node-load set into a directional case.
@@ -1983,6 +1996,40 @@ export default function ModelSpace() {
                   )}
                   <button type="button" onClick={() => { save(removeElements(model, new Set([selPlate.id]))); setSelected(null) }}
                     className="mt-2 rounded-lg border border-red-300 px-3 py-1.5 text-sm font-semibold text-red-600 hover:bg-red-50">Delete slab</button>
+                </ResultCard>
+              )}
+            </div>
+          )}
+
+          {/* ── MODAL ── */}
+          {tab === 'modal' && (
+            <div className="space-y-4">
+              <Card title="Modal analysis options">
+                <label className="flex flex-col text-sm">
+                  <span className="mb-1 font-medium text-slate-600">Number of modes</span>
+                  <input type="number" min={1} max={50} step={1} value={nModes}
+                    onChange={(e) => setNModes(Math.max(1, Math.min(50, Math.round(parseFloat(e.target.value) || 1))))}
+                    className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none focus:ring-1 focus:ring-[#0056b3]" />
+                </label>
+                <p className="col-span-full text-[11px] text-slate-500">
+                  Lumped-mass free vibration ([K]−ω²[M]). Mass from member &amp; slab self-weight (dead). Request enough
+                  modes to accumulate ≥90% of the lateral mass (NSCP 208.5.5).
+                </p>
+                <div className="col-span-full">
+                  <button type="button" onClick={runModal} disabled={!model || !!busy || meshErrors} className={btn('from-[#7c3aed] to-[#5b21b6]')}>
+                    {busy === 'modal' ? '⏳ Solving modes…' : '〰 Run modal analysis'}
+                  </button>
+                  {meshErrors && <p className="mt-1 text-[11px] font-medium text-red-600">Resolve the mesh errors in the Analysis tab to enable modal analysis.</p>}
+                </div>
+                {busy === 'modal' && <SolverProgress p={progress} />}
+              </Card>
+
+              {model && <ValidationPanel issues={meshIssues} />}
+
+              {modal && modal.modes.length > 0 && <ModalPanel result={modal} />}
+              {modal && modal.modes.length === 0 && (
+                <ResultCard title="Modal analysis">
+                  <p className="text-sm text-slate-600">No modes found — the model has no lumped mass (add members/slabs with self-weight).</p>
                 </ResultCard>
               )}
             </div>


### PR DESCRIPTION
**Phase 2 of 3** for modal/dynamic analysis (§6) — the UI tab. Builds on the phase-1 engine (#226); this phase is UI-only since the worker `modal` path already exists.

## What's added

A new **Modal** tab (between Analysis and Design):

- **Number-of-modes** input + **Run modal analysis** button. Runs in the worker so the page stays responsive; disabled and short-circuited when the mesh has errors (consistent with Analyze/Design).
- **`ModalPanel`** — per-mode table:
  - T (s), f (Hz), ω (rad/s)
  - effective mass participation per direction (mₓ / m_y / m_z)
  - running **cumulative** Σmₓ / Σm_y / Σm_z columns that turn **green** at the NSCP 208.5.5 **≥90%** threshold
  - dominant-direction tag (X/Y/Z) per mode; total mass per direction shown
- Warns when cumulative lateral mass is below 90% (request more modes).
- Modal results invalidate on geometry edits, like the analysis results.

## Test plan
- [x] 574 vitest tests pass
- [x] `npx tsc -b` clean
- [x] `npm run build` succeeds

Verified via tests + build (no live browser render available here).

## Next
- **Phase 3** — Response spectrum (SRSS/CQC) on these modes, replacing the approximate seismic T and producing modal base shear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_