### PR TITLE
feat: response spectrum analysis — SRSS/CQC modal combination (phase 3)

### DIFF
--- a/webapp/src/components/ResponseSpectrumPanel.tsx
+++ b/webapp/src/components/ResponseSpectrumPanel.tsx
@@ -1,0 +1,275 @@
+import type { ResponseSpectrumResult, ModalForce } from '../engine/responseSpectrum'
+
+const f0 = (v: number) => v.toFixed(0)
+const f2 = (v: number) => v.toFixed(2)
+const f3 = (v: number) => v.toFixed(3)
+const pct = (v: number) => `${(v * 100).toFixed(1)}%`
+
+/** Dominant lateral direction of a modal force vector (0=X, 2=Z, -1=mixed/vertical). */
+function domDir(mf: ModalForce): 0 | 2 | -1 {
+  const vx = mf.baseShear[0], vz = mf.baseShear[2]
+  if (vx < 0.01 && vz < 0.01) return -1
+  return vx >= vz ? 0 : 2
+}
+
+const DIR_COLOR: Record<number, string> = { 0: '#0056b3', 2: '#15803d', [-1]: '#94a3b8' }
+
+// ── Spectrum SVG chart ────────────────────────────────────────────────────────
+function SpectrumChart({ result }: { result: ResponseSpectrumResult }) {
+  const { Ca, Cv, I, R, Ts } = result.params
+  const { modalForces } = result
+
+  const saG = (T: number): number => {
+    const plateau = (2.5 * Ca * I) / R
+    const velocity = T > 1e-9 ? (Cv * I) / (R * T) : plateau
+    const minimum = (0.11 * Ca * I) / R
+    return Math.max(minimum, Math.min(plateau, velocity))
+  }
+
+  const T1 = modalForces.length > 0 ? modalForces[0].period : 1.0
+  const Tmax = Math.max(T1 * 1.6, Ts * 5, 2.0)
+  const plateau = (2.5 * Ca * I) / R
+  const Ymax = plateau * 1.18
+
+  const VW = 480, VH = 158
+  const LEFT = 50, RIGHT = 12, TOP = 10, BOT = 30
+  const PW = VW - LEFT - RIGHT, PH = VH - TOP - BOT
+
+  const px = (T: number) => LEFT + Math.min(1, Math.max(0, T / Tmax)) * PW
+  const py = (sa: number) => TOP + (1 - Math.min(sa / Ymax, 1)) * PH
+
+  // Build polyline for 1/T decay region (smooth curve from Ts to Tmax)
+  const N = 60
+  const curvePts: string[] = [[px(0), py(plateau)].join(','), [px(Ts), py(plateau)].join(',')]
+  for (let k = 1; k <= N; k++) {
+    const T = Ts + ((Tmax - Ts) * k) / N
+    curvePts.push([px(T), py(saG(T))].join(','))
+  }
+
+  // Y ticks at 0 and plateau
+  const yTicks = [0, plateau / 2, plateau]
+  // X ticks at 0, 0.5, 1.0, 1.5, … up to Tmax
+  const xTicks: number[] = []
+  for (let T = 0; T <= Tmax + 0.01; T += 0.5) xTicks.push(parseFloat(T.toFixed(1)))
+
+  return (
+    <svg viewBox={`0 0 ${VW} ${VH}`} className="w-full" style={{ height: VH }} aria-label="Design response spectrum">
+      {/* Shaded area under curve */}
+      <polygon
+        points={[`${px(0)},${py(0)}`, ...curvePts, `${px(Tmax)},${py(0)}`].join(' ')}
+        fill="#dbeafe" opacity="0.55" />
+      {/* Spectrum curve */}
+      <polyline points={curvePts.join(' ')} fill="none" stroke="#0056b3" strokeWidth={1.8} strokeLinejoin="round" />
+
+      {/* Ts dashed vertical */}
+      <line x1={px(Ts)} y1={TOP} x2={px(Ts)} y2={TOP + PH} stroke="#f59e0b" strokeWidth={1} strokeDasharray="3,2" />
+      <text x={px(Ts) + 2} y={TOP + 10} fontSize={8.5} fill="#b45309">Ts</text>
+
+      {/* Mode markers (up to 10 to keep chart readable) */}
+      {modalForces.slice(0, 10).map((mf, i) => {
+        const d = domDir(mf)
+        const color = DIR_COLOR[d]
+        const x = px(mf.period)
+        const yDot = py(saG(mf.period))
+        return (
+          <g key={i}>
+            <line x1={x} y1={yDot} x2={x} y2={TOP + PH} stroke={color} strokeWidth={0.9}
+              strokeDasharray="2,2" opacity={0.75} />
+            <circle cx={x} cy={yDot} r={2.8} fill={color} />
+            <text x={x} y={yDot - 4} fontSize={8} fill={color} textAnchor="middle">{i + 1}</text>
+          </g>
+        )
+      })}
+
+      {/* Axes */}
+      <line x1={LEFT} y1={TOP} x2={LEFT} y2={TOP + PH} stroke="#64748b" strokeWidth={0.8} />
+      <line x1={LEFT} y1={TOP + PH} x2={LEFT + PW} y2={TOP + PH} stroke="#64748b" strokeWidth={0.8} />
+
+      {/* Y axis ticks + labels */}
+      {yTicks.map((v) => (
+        <g key={v}>
+          <line x1={LEFT - 3} y1={py(v)} x2={LEFT} y2={py(v)} stroke="#64748b" strokeWidth={0.7} />
+          <text x={LEFT - 5} y={py(v) + 3} fontSize={8.5} fill="#64748b" textAnchor="end">{v.toFixed(3)}</text>
+        </g>
+      ))}
+      <text x={11} y={TOP + PH / 2 + 3} fontSize={9} fill="#0056b3" textAnchor="middle"
+        transform={`rotate(-90,11,${TOP + PH / 2 + 3})`}>Sa/g</text>
+
+      {/* X axis ticks + labels */}
+      {xTicks.filter((T) => T <= Tmax + 0.01).map((T) => (
+        <g key={T}>
+          <line x1={px(T)} y1={TOP + PH} x2={px(T)} y2={TOP + PH + 3} stroke="#64748b" strokeWidth={0.7} />
+          <text x={px(T)} y={TOP + PH + 12} fontSize={8.5} fill="#64748b" textAnchor="middle">{T}</text>
+        </g>
+      ))}
+      <text x={LEFT + PW / 2} y={VH - 2} fontSize={9} fill="#64748b" textAnchor="middle">T (s)</text>
+
+      {/* Legend */}
+      <circle cx={LEFT + PW - 70} cy={TOP + 8} r={2.5} fill="#0056b3" />
+      <text x={LEFT + PW - 65} y={TOP + 11} fontSize={8} fill="#0056b3">X-dominant</text>
+      <circle cx={LEFT + PW - 70} cy={TOP + 20} r={2.5} fill="#15803d" />
+      <text x={LEFT + PW - 65} y={TOP + 23} fontSize={8} fill="#15803d">Z-dominant</text>
+    </svg>
+  )
+}
+
+// ── Panel ─────────────────────────────────────────────────────────────────────
+export function ResponseSpectrumPanel({
+  result, seismicT,
+}: {
+  result: ResponseSpectrumResult
+  /** Approximate period Ct·hn^0.75 from static ELF, for comparison. */
+  seismicT?: number
+}) {
+  const { params, modalForces, srss, cqc, cqcRatio } = result
+  const { Ca, Cv, I, R, Ts, staticV, zeta = 0.05 } = params
+
+  const T1 = modalForces[0]?.period ?? null
+
+  // §208.6.4.2 scaling requirement (90% of static V)
+  const needsScale = (dir: 0 | 2) => {
+    const ratio = cqcRatio[dir]
+    return ratio !== null && ratio < 0.9
+  }
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <h2 className="mb-1 text-[1.02rem] font-bold text-[#0056b3]">
+        Response Spectrum Analysis — NSCP §208.6
+      </h2>
+      <p className="mb-2 text-[11px] text-slate-400">
+        Design spectrum: Sa/g = min(2.5·Ca·I/R, Cv·I/(R·T)) ≥ 0.11·Ca·I/R.
+        {' '}Ts = {f3(Ts)} s. CQC combination (ζ = {pct(zeta)}).
+        {T1 !== null && seismicT !== undefined && (
+          <> T₁ = <span className="font-semibold text-slate-600">{f3(T1)} s</span> (modal) vs{' '}
+            T_approx = {f3(seismicT)} s (Ct·h<sub>n</sub><sup>¾</sup>).</>
+        )}
+      </p>
+
+      {/* Spectrum chart */}
+      <div className="mb-3 rounded-lg border border-slate-100 bg-slate-50 p-2">
+        <SpectrumChart result={result} />
+      </div>
+
+      {/* Parameters row */}
+      <div className="mb-3 flex flex-wrap gap-3 text-[11px] text-slate-500">
+        {[
+          ['Ca', f3(Ca)], ['Cv', f3(Cv)], ['I', f2(I)], ['R', f2(R)],
+          ['2.5CaI/R', f3(2.5 * Ca * I / R) + ' g'],
+          ['CvI/R (at 1 s)', f3(Cv * I / R) + ' g'],
+          ['min', f3(0.11 * Ca * I / R) + ' g'],
+        ].map(([k, v]) => (
+          <span key={k}><span className="font-semibold text-slate-600">{k}</span> = {v}</span>
+        ))}
+      </div>
+
+      {/* Modal base shear table */}
+      {modalForces.length > 0 && (
+        <>
+          <h3 className="mb-1 text-[0.82rem] font-semibold text-slate-600">Modal base shear</h3>
+          <div className="mb-3 overflow-x-auto">
+            <table className="min-w-full text-xs">
+              <thead>
+                <tr className="border-b border-slate-200 text-slate-500">
+                  <th className="pb-1 pr-3 text-left font-semibold">Mode</th>
+                  <th className="pb-1 pr-3 text-right font-semibold">T (s)</th>
+                  <th className="pb-1 pr-3 text-right font-semibold">Sa/g</th>
+                  <th className="pb-1 pr-3 text-right font-semibold">Sa (m/s²)</th>
+                  <th className="pb-1 pr-3 text-right font-semibold">V_x (kN)</th>
+                  <th className="pb-1 text-right font-semibold">V_z (kN)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {modalForces.map((mf) => {
+                  const d = domDir(mf)
+                  const color = DIR_COLOR[d]
+                  return (
+                    <tr key={mf.modeIdx} className="border-b border-slate-100 last:border-0 hover:bg-slate-50">
+                      <td className="py-0.5 pr-3 font-mono text-slate-700">
+                        {mf.modeIdx}
+                        {d !== -1 && (
+                          <span className="ml-1 text-[9px]" style={{ color }}>{d === 0 ? 'X' : 'Z'}</span>
+                        )}
+                      </td>
+                      <td className="py-0.5 pr-3 text-right tabular-nums font-semibold text-slate-800">{f3(mf.period)}</td>
+                      <td className="py-0.5 pr-3 text-right tabular-nums text-slate-600">{f3(mf.SaG)}</td>
+                      <td className="py-0.5 pr-3 text-right tabular-nums text-slate-600">{f2(mf.Sa)}</td>
+                      <td className="py-0.5 pr-3 text-right tabular-nums text-slate-700">{f0(mf.baseShear[0])}</td>
+                      <td className="py-0.5 text-right tabular-nums text-slate-700">{f0(mf.baseShear[2])}</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+
+      {/* Combined base shear summary */}
+      <h3 className="mb-1 text-[0.82rem] font-semibold text-slate-600">Combined base shear</h3>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-xs">
+          <thead>
+            <tr className="border-b border-slate-200 text-slate-500">
+              <th className="pb-1 pr-4 text-left font-semibold">Method</th>
+              <th className="pb-1 pr-4 text-right font-semibold">V_x (kN)</th>
+              <th className="pb-1 pr-4 text-right font-semibold">V_z (kN)</th>
+              {staticV && <th className="pb-1 pr-4 text-right font-semibold">V_x/V_static</th>}
+              {staticV && <th className="pb-1 text-right font-semibold">V_z/V_static</th>}
+            </tr>
+          </thead>
+          <tbody>
+            <tr className="border-b border-slate-100">
+              <td className="py-0.5 pr-4 text-slate-600">SRSS</td>
+              <td className="py-0.5 pr-4 text-right tabular-nums text-slate-700">{f0(srss[0])}</td>
+              <td className="py-0.5 pr-4 text-right tabular-nums text-slate-700">{f0(srss[2])}</td>
+              {staticV && <td className="py-0.5 pr-4" />}
+              {staticV && <td className="py-0.5" />}
+            </tr>
+            <tr className="border-b border-slate-100">
+              <td className="py-0.5 pr-4 font-semibold text-slate-800">CQC ←</td>
+              <td className="py-0.5 pr-4 text-right tabular-nums font-semibold text-slate-900">{f0(cqc[0])}</td>
+              <td className="py-0.5 pr-4 text-right tabular-nums font-semibold text-slate-900">{f0(cqc[2])}</td>
+              {staticV && (
+                <td className={`py-0.5 pr-4 text-right tabular-nums text-xs ${cqcRatio[0] !== null ? (cqcRatio[0]! < 0.9 ? 'text-red-600 font-semibold' : 'text-emerald-600') : 'text-slate-400'}`}>
+                  {cqcRatio[0] !== null ? pct(cqcRatio[0]!) : '—'}
+                </td>
+              )}
+              {staticV && (
+                <td className={`py-0.5 text-right tabular-nums text-xs ${cqcRatio[2] !== null ? (cqcRatio[2]! < 0.9 ? 'text-red-600 font-semibold' : 'text-emerald-600') : 'text-slate-400'}`}>
+                  {cqcRatio[2] !== null ? pct(cqcRatio[2]!) : '—'}
+                </td>
+              )}
+            </tr>
+            {staticV && (staticV[0] > 0 || staticV[2] > 0) && (
+              <tr>
+                <td className="py-0.5 pr-4 text-slate-500">Static (ELF)</td>
+                <td className="py-0.5 pr-4 text-right tabular-nums text-slate-500">{f0(staticV[0])}</td>
+                <td className="py-0.5 pr-4 text-right tabular-nums text-slate-500">{f0(staticV[2])}</td>
+                <td className="py-0.5 pr-4" />
+                <td className="py-0.5" />
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* §208.6.4.2 scaling warnings */}
+      {(needsScale(0) || needsScale(2)) && (
+        <p className="mt-2 text-[11px] text-red-600">
+          ⚠ §208.6.4.2 — CQC base shear is below 90% of the static V
+          {needsScale(0) && cqcRatio[0] !== null && ` (X: scale ×${f2(0.9 / cqcRatio[0]!)})`}
+          {needsScale(2) && cqcRatio[2] !== null && ` (Z: scale ×${f2(0.9 / cqcRatio[2]!)})`}.
+          {' '}Multiply all modal response quantities by this factor before combining with gravity effects.
+        </p>
+      )}
+
+      <p className="mt-2 text-[11px] text-slate-400">
+        Use CQC base shear (more accurate for closely-spaced modes). SRSS is shown for reference.
+        {T1 !== null && seismicT !== undefined && T1 > seismicT && (
+          <> T₁ &gt; T_approx — the static ELF base shear is conservative (short-period cap may govern).</>
+        )}
+      </p>
+    </div>
+  )
+}

--- a/webapp/src/engine/responseSpectrum.test.ts
+++ b/webapp/src/engine/responseSpectrum.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest'
+import { nscp208Spectrum, cqcCorrel, computeResponseSpectrum } from './responseSpectrum'
+import { modalAnalysis, GRAVITY } from './modal'
+import { generateGridModel } from './modelBuilder'
+import type { RectSection } from './model'
+
+const Ca = 0.44, Cv = 0.64, I = 1.0, R = 8.5
+const Ts = Cv / (2.5 * Ca)   // ≈ 0.582 s
+
+const section: RectSection = {
+  id: 'S1', name: '400×400', b: 400, h: 400, fc: 28, fy: 415,
+  barDia: 20, tieDia: 10, cover: 40, material: 'concrete',
+}
+
+// ── Design spectrum ──────────────────────────────────────────────────────────
+describe('nscp208Spectrum', () => {
+  it('plateau governs at T = 0 (velocity → ∞, capped)', () => {
+    expect(nscp208Spectrum(0, Ca, Cv, I, R)).toBeCloseTo((2.5 * Ca * I / R) * GRAVITY, 9)
+  })
+
+  it('plateau governs at T = Ts (velocity branch meets plateau)', () => {
+    // Cv·I/(R·Ts) = Cv·I·2.5·Ca/(R·Cv) = 2.5·Ca·I/R = plateau
+    expect(nscp208Spectrum(Ts, Ca, Cv, I, R)).toBeCloseTo((2.5 * Ca * I / R) * GRAVITY, 6)
+  })
+
+  it('velocity branch: Sa = Cv·I·g/(R·T) for Ts < T < T_min', () => {
+    const T = 1.0   // > Ts ≈ 0.582
+    expect(nscp208Spectrum(T, Ca, Cv, I, R)).toBeCloseTo(Cv * I * GRAVITY / (R * T), 9)
+  })
+
+  it('minimum floor governs at long periods', () => {
+    // R cancels: velocity = Cv*I/(R*T), minimum = 0.11*Ca*I/R
+    // equal when T = Cv/(0.11*Ca) = 0.64/(0.11*0.44) ≈ 13.2 s; use T = 20 s
+    expect(nscp208Spectrum(20, Ca, Cv, I, R)).toBeCloseTo(0.11 * Ca * I * GRAVITY / R, 9)
+  })
+
+  it('Sa is monotonically non-increasing (or flat)', () => {
+    const vals = [0.01, 0.1, 0.5, Ts, 1.0, 2.0, 5.0].map((T) => nscp208Spectrum(T, Ca, Cv, I, R))
+    for (let k = 1; k < vals.length; k++) expect(vals[k]).toBeLessThanOrEqual(vals[k - 1] + 1e-9)
+  })
+})
+
+// ── CQC correlation ──────────────────────────────────────────────────────────
+describe('cqcCorrel', () => {
+  it('diagonal is 1 (identical frequencies)', () => {
+    expect(cqcCorrel(5.0, 5.0, 0.05)).toBeCloseTo(1, 9)
+  })
+
+  it('approaches 0 for well-separated modes', () => {
+    expect(cqcCorrel(1, 100, 0.05)).toBeLessThan(0.01)
+  })
+
+  it('is symmetric: ρ(i,j) = ρ(j,i)', () => {
+    expect(cqcCorrel(3, 7, 0.05)).toBeCloseTo(cqcCorrel(7, 3, 0.05), 12)
+  })
+
+  it('lies in [0, 1] for a range of frequency ratios', () => {
+    for (const beta of [0.1, 0.5, 0.8, 0.95, 0.99]) {
+      const r = cqcCorrel(beta, 1, 0.05)
+      expect(r).toBeGreaterThanOrEqual(0)
+      expect(r).toBeLessThanOrEqual(1 + 1e-9)
+    }
+  })
+})
+
+// ── Full RSA ─────────────────────────────────────────────────────────────────
+describe('computeResponseSpectrum', () => {
+  const model = generateGridModel({ baysX: [6, 6], baysZ: [5], storeyH: [3.5, 3], section })
+  const modal = modalAnalysis(model, 12)!
+  const p = { Ca, Cv, I, R }
+
+  it('CQC ≥ SRSS (positive cross-correlations add to SRSS)', () => {
+    const rsa = computeResponseSpectrum(modal, p)
+    for (let dir = 0; dir < 3; dir++)
+      expect(rsa.cqc[dir]).toBeGreaterThanOrEqual(rsa.srss[dir] - 1e-6)
+  })
+
+  it('all base shears are non-negative', () => {
+    const rsa = computeResponseSpectrum(modal, p)
+    for (const mf of rsa.modalForces)
+      for (const v of mf.baseShear) expect(v).toBeGreaterThanOrEqual(-1e-9)
+    for (const v of rsa.srss) expect(v).toBeGreaterThanOrEqual(0)
+    for (const v of rsa.cqc)  expect(v).toBeGreaterThanOrEqual(0)
+  })
+
+  it('Ts = Cv/(2.5·Ca)', () => {
+    const rsa = computeResponseSpectrum(modal, p)
+    expect(rsa.params.Ts).toBeCloseTo(Cv / (2.5 * Ca), 9)
+  })
+
+  it('SRSS equals √(Σ V_i²) computed independently', () => {
+    const rsa = computeResponseSpectrum(modal, p)
+    const manual = Math.sqrt(rsa.modalForces.reduce((s, mf) => s + mf.baseShear[0] ** 2, 0))
+    expect(rsa.srss[0]).toBeCloseTo(manual, 6)
+  })
+
+  it('single mode: CQC = SRSS = Sa·effMass', () => {
+    const modal1 = { modes: [modal.modes[0]], totalMass: modal.totalMass, cumRatio: modal.cumRatio }
+    const rsa = computeResponseSpectrum(modal1, p)
+    expect(rsa.cqc[0]).toBeCloseTo(rsa.srss[0], 9)
+    const expected = modal.modes[0].effMass[0] * nscp208Spectrum(modal.modes[0].period, Ca, Cv, I, R)
+    expect(rsa.srss[0]).toBeCloseTo(expected, 6)
+  })
+
+  it('cqcRatio populated only when staticV is non-zero', () => {
+    const staticV: [number, number, number] = [500, 0, 500]
+    const rsa = computeResponseSpectrum(modal, { ...p, staticV })
+    expect(rsa.cqcRatio[0]).not.toBeNull()
+    expect(rsa.cqcRatio[1]).toBeNull()   // staticV[1] = 0
+    expect(rsa.cqcRatio[2]).not.toBeNull()
+    expect(rsa.cqcRatio[0]).toBeCloseTo(rsa.cqc[0] / 500, 9)
+  })
+
+  it('empty modes → zero base shears', () => {
+    const emptyModal = { modes: [], totalMass: [0, 0, 0] as [number,number,number], cumRatio: [0,0,0] as [number,number,number] }
+    const rsa = computeResponseSpectrum(emptyModal, p)
+    expect(rsa.srss).toEqual([0, 0, 0])
+    expect(rsa.cqc).toEqual([0, 0, 0])
+  })
+})

--- a/webapp/src/engine/responseSpectrum.ts
+++ b/webapp/src/engine/responseSpectrum.ts
@@ -1,0 +1,130 @@
+// ─────────────────────────────────────────────────────────────────────────
+// NSCP 2015 §208.6 (UBC-97 §1631) Dynamic Lateral Force Procedure —
+// Response Spectrum Analysis (RSA).
+//
+// Design spectrum (NSCP Fig. 208-3 / UBC-97 Fig. 16-3):
+//   Plateau  (T ≤ Ts):  Sa/g = 2.5·Ca·I/R      (constant acceleration)
+//   Velocity (T > Ts):  Sa/g = Cv·I/(R·T)       (constant velocity)
+//   Minimum  (all T):   Sa/g ≥ 0.11·Ca·I/R      (§208-10)
+//   Ts = Cv/(2.5·Ca)
+//
+// Per-mode base shear: V_i(dir) = m*_i(dir) · Sa(T_i)   [t · m/s² = kN]
+//   where m*_i(dir) is the effective modal mass in direction dir (tonnes).
+//
+// Modal combination:
+//   SRSS: V = √(Σ V_i²)
+//   CQC:  V = √(Σ_i Σ_j ρ_ij · V_i · V_j)
+//   CQC correlation (Wilson/Der Kiureghian 1981, ζ = 5% default):
+//     ρ_ij = 8ζ²(1+β)β^(3/2) / ((1−β²)² + 4ζ²β(1+β)²),  β = min(ωi,ωj)/max(ωi,ωj)
+//
+// Scaling (§208.6.4.2): if V_CQC < 0.9·V_static, results must be scaled up;
+//   cqcRatio = V_CQC / V_static — caller applies the ≥ 0.9 floor as needed.
+//
+// Units: T (s), Ca/Cv/Sa (g-fraction or m/s²), mass (t), V (kN).
+// ─────────────────────────────────────────────────────────────────────────
+import type { ModalResult } from './modal'
+import { GRAVITY } from './modal'
+
+export interface SpectrumParams {
+  Ca: number; Cv: number
+  I: number; R: number
+  /** Viscous damping ratio (default 0.05). */
+  zeta?: number
+  /** Static ELF base shear [X, Y, Z] kN, for §208.6.4.2 ratio (optional). */
+  staticV?: [number, number, number]
+}
+
+export interface ModalForce {
+  modeIdx: number
+  period: number
+  /** Spectral acceleration, m/s². */
+  Sa: number
+  /** Sa / g (dimensionless). */
+  SaG: number
+  /** Modal base shear per global direction [X, Y, Z], kN. */
+  baseShear: [number, number, number]
+}
+
+export interface ResponseSpectrumResult {
+  params: SpectrumParams & { Ts: number }
+  modalForces: ModalForce[]
+  /** SRSS-combined base shear per direction [X, Y, Z], kN. */
+  srss: [number, number, number]
+  /** CQC-combined base shear per direction [X, Y, Z], kN. */
+  cqc: [number, number, number]
+  /** V_CQC / V_static per direction; null when staticV not supplied or zero. */
+  cqcRatio: [number | null, number | null, number | null]
+}
+
+/** NSCP §208 elastic design spectral acceleration [m/s²] at period T. */
+export function nscp208Spectrum(T: number, Ca: number, Cv: number, I: number, R: number): number {
+  const plateau = (2.5 * Ca * I) / R
+  const velocity = T > 1e-9 ? (Cv * I) / (R * T) : plateau
+  const minimum = (0.11 * Ca * I) / R
+  return Math.max(minimum, Math.min(plateau, velocity)) * GRAVITY
+}
+
+/** CQC cross-correlation coefficient (Wilson, Der Kiureghian & Bayo 1981). */
+export function cqcCorrel(omegaI: number, omegaJ: number, zeta: number): number {
+  if (omegaI <= 0 || omegaJ <= 0) return omegaI === omegaJ ? 1 : 0
+  // β is always ≤ 1 (smaller over larger)
+  const beta = omegaI <= omegaJ ? omegaI / omegaJ : omegaJ / omegaI
+  const b2 = beta * beta
+  const num = 8 * zeta * zeta * (1 + beta) * Math.pow(beta, 1.5)
+  const den = (1 - b2) * (1 - b2) + 4 * zeta * zeta * beta * (1 + beta) * (1 + beta)
+  return den > 1e-300 ? num / den : 1
+}
+
+/**
+ * Computes modal base shears and SRSS/CQC combinations from modal analysis
+ * results and NSCP §208 design spectrum parameters.
+ */
+export function computeResponseSpectrum(
+  modal: ModalResult, p: SpectrumParams,
+): ResponseSpectrumResult {
+  const zeta = p.zeta ?? 0.05
+  const Ts = p.Cv / (2.5 * p.Ca)
+
+  if (modal.modes.length === 0) {
+    return {
+      params: { ...p, Ts }, modalForces: [],
+      srss: [0, 0, 0], cqc: [0, 0, 0], cqcRatio: [null, null, null],
+    }
+  }
+
+  const modalForces: ModalForce[] = modal.modes.map((m, i) => {
+    const Sa = nscp208Spectrum(m.period, p.Ca, p.Cv, p.I, p.R)
+    return {
+      modeIdx: i + 1,
+      period: m.period,
+      Sa,
+      SaG: Sa / GRAVITY,
+      baseShear: m.effMass.map((em) => em * Sa) as [number, number, number],
+    }
+  })
+
+  // SRSS: √(Σ V_i²)
+  const srss: [number, number, number] = [0, 1, 2].map((dir) =>
+    Math.sqrt(modalForces.reduce((s, mf) => s + mf.baseShear[dir] ** 2, 0)),
+  ) as [number, number, number]
+
+  // CQC: √(Σ_i Σ_j ρ_ij · V_i · V_j)
+  const omegas = modal.modes.map((m) => m.omega)
+  const cqc: [number, number, number] = [0, 1, 2].map((dir) => {
+    let sum = 0
+    for (let i = 0; i < modalForces.length; i++) {
+      for (let j = 0; j < modalForces.length; j++) {
+        const rho = i === j ? 1 : cqcCorrel(omegas[i], omegas[j], zeta)
+        sum += rho * modalForces[i].baseShear[dir] * modalForces[j].baseShear[dir]
+      }
+    }
+    return Math.sqrt(Math.max(0, sum))
+  }) as [number, number, number]
+
+  const cqcRatio: [number | null, number | null, number | null] = [0, 1, 2].map((dir) => {
+    const sv = p.staticV?.[dir]
+    return sv && sv > 0 ? cqc[dir] / sv : null
+  }) as [number | null, number | null, number | null]
+
+  return { params: { ...p, Ts }, modalForces, srss, cqc, cqcRatio }
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -9,6 +9,7 @@ import { distributePanel } from '../engine/tributary'
 import { type F3Analysis } from '../engine/frame3d'
 import { validateMesh, hasMeshErrors } from '../engine/meshValidation'
 import { type ModalResult } from '../engine/modal'
+import { computeResponseSpectrum, type ResponseSpectrumResult } from '../engine/responseSpectrum'
 import { type StructureDesign, type FootingPlan, type OptimizeResult, type LateralCase } from '../engine/pipeline'
 import type { SteelJoint } from '../engine/steelConnections'
 import { estimateTakeoff, costBill, type PriceList } from '../engine/takeoff'
@@ -29,6 +30,7 @@ import { ReactionsPanel } from '../components/ReactionsPanel'
 import { DisplacementTable } from '../components/DisplacementTable'
 import { ValidationPanel } from '../components/ValidationPanel'
 import { ModalPanel } from '../components/ModalPanel'
+import { ResponseSpectrumPanel } from '../components/ResponseSpectrumPanel'
 import { BeamSchematic } from '../components/BeamSchematic'
 import { ColumnSchematic } from '../components/ColumnSchematic'
 import { FootingSchematic } from '../components/FootingSchematic'
@@ -601,6 +603,7 @@ export default function ModelSpace() {
   const [selected, setSelected] = useState<string | null>(null)
   const [analysis, setAnalysis] = useState<F3Analysis | null>(null)
   const [modal, setModal] = useState<ModalResult | null>(null)
+  const [rsa, setRsa] = useState<ResponseSpectrumResult | null>(null)
   const [nModes, setNModes] = useState(12)
   const [design, setDesign] = useState<StructureDesign | null>(null)
   const [opt, setOpt] = useState<OptimizeResult | null>(null)
@@ -667,6 +670,7 @@ export default function ModelSpace() {
     setModel(m)
     setAnalysis(null)             // geometry changed — results are stale
     setModal(null)
+    setRsa(null)
     setDesign(null)
     setOpt(null)
     setExpanded(null)
@@ -703,7 +707,16 @@ export default function ModelSpace() {
   const runModal = () => {
     if (!model || busy || meshErrors) return
     run('modal', { model, nModes }).then((r) => {
-      setModal((r as { modal: ModalResult | null }).modal)
+      const m = (r as { modal: ModalResult | null }).modal
+      setModal(m)
+      if (m && m.modes.length > 0) {
+        setRsa(computeResponseSpectrum(m, {
+          Ca, Cv, I: Ie, R: Rw,
+          staticV: seis ? [seis.V, 0, seis.V] : undefined,
+        }))
+      } else {
+        setRsa(null)
+      }
     }).catch((e) => console.error('modal failed', e))
   }
 
@@ -2032,6 +2045,7 @@ export default function ModelSpace() {
                   <p className="text-sm text-slate-600">No modes found — the model has no lumped mass (add members/slabs with self-weight).</p>
                 </ResultCard>
               )}
+              {rsa && <ResponseSpectrumPanel result={rsa} seismicT={seis?.T} />}
             </div>
           )}
 


### PR DESCRIPTION
## Summary

- **Engine** (`responseSpectrum.ts`): NSCP §208.6 / UBC-97 §1631 design spectrum `Sa(T) = max(0.11CaI/R, min(2.5CaI/R, CvI/RT)) × g`; per-mode modal base shears `V_i = m*_i × Sa(T_i)`; SRSS `√(ΣV_i²)` and CQC `√(ΣΣ ρ_ij V_i V_j)` combination using the Wilson/Der Kiureghian 1981 cross-correlation coefficient.
- **UI** (`ResponseSpectrumPanel`): inline SVG design spectrum chart (plateau + 1/T decay + minimum floor, mode markers colour-coded by dominant direction); per-mode force table (T, Sa/g, V_x, V_z); SRSS vs CQC summary; §208.6.4.2 scaling warning when CQC < 90% of static ELF base shear with required scale factor shown; T₁ (modal) vs T_approx (Ct·hₙ^¾) comparison when both are available.
- **Wire-up** (`ModelSpace.tsx`): RSA runs synchronously on the main thread in `runModal`'s `.then()` using the current Ca, Cv, I, R inputs and `seis.V` as the static reference; `rsa` state cleared on geometry change.
- **Tests** (`responseSpectrum.test.ts`): 14 tests covering spectrum plateau/velocity/minimum regions, monotonicity, CQC symmetry/bounds, SRSS manual verification, single-mode degeneracy, and `cqcRatio` population.

## Notes

- The minimum floor kicks in at T = Cv/(0.11·Ca) ≈ 13.2 s for Zone 4 params (Ca=0.44, Cv=0.64) — the R factor cancels. Corrected from the initial test comment.
- CQC ≥ SRSS always (positive cross-correlation terms add to the SRSS squares); both are shown for transparency.
- RSA uses seismic params (Ca, Cv, I, R) live from the Loading tab inputs; re-run modal whenever those change.

## Test plan

- [ ] Generate a 2-bay × 1-bay × 2-storey model, add gravity loads, set Zone 4 params (Ca=0.44, Cv=0.64, I=1.0, R=8.5), generate E cases, then run Modal → spectrum chart appears with mode markers; CQC/SRSS table shows base shears; T₁ vs T_approx comparison visible
- [ ] Without E cases run first: RSA panel shows but `Static (ELF)` row is absent and no scaling warning
- [ ] Confirm 590 tests pass: `npm test`
- [ ] Confirm `npx tsc -b` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_