### PR TITLE
feat: mode-shape visualization — animated 3D deformed skeleton

### DIFF
--- a/webapp/src/components/ModalPanel.tsx
+++ b/webapp/src/components/ModalPanel.tsx
@@ -7,7 +7,11 @@ const pct = (v: number) => `${(v * 100).toFixed(1)}%`
 /** Cumulative-mass cell colour: green once the ≥90% NSCP threshold is reached. */
 const cumCls = (v: number) => (v >= 0.9 ? 'text-emerald-600 font-semibold' : 'text-slate-500')
 
-export function ModalPanel({ result }: { result: ModalResult }) {
+export function ModalPanel({ result, selectedMode, onSelectMode }: {
+  result: ModalResult
+  selectedMode?: number | null
+  onSelectMode?: (idx: number | null) => void
+}) {
   const { modes, totalMass, cumRatio } = result
   // running cumulative effective-mass ratio per direction, mode by mode
   const cum: [number, number, number] = [0, 0, 0]
@@ -18,6 +22,7 @@ export function ModalPanel({ result }: { result: ModalResult }) {
       <p className="mb-3 text-[11px] text-slate-400">
         Lumped-mass free vibration. Effective modal mass per global direction; the cumulative column turns green at the
         NSCP 208.5.5 ≥90% threshold. Total mass {f2(totalMass[0])} t (X), {f2(totalMass[1])} t (Y), {f2(totalMass[2])} t (Z).
+        {onSelectMode && <span className="ml-1">Click <span className="font-semibold text-violet-600">3D</span> to animate the mode shape in the canvas.</span>}
       </p>
 
       <div className="overflow-x-auto">
@@ -34,6 +39,7 @@ export function ModalPanel({ result }: { result: ModalResult }) {
               <th className="pb-1.5 pr-3 text-right font-semibold">Σmₓ</th>
               <th className="pb-1.5 pr-3 text-right font-semibold">Σm_y</th>
               <th className="pb-1.5 text-right font-semibold">Σm_z</th>
+              {onSelectMode && <th className="pb-1.5 pl-2" />}
             </tr>
           </thead>
           <tbody>
@@ -41,8 +47,9 @@ export function ModalPanel({ result }: { result: ModalResult }) {
               cum[0] += m.effMassRatio[0]; cum[1] += m.effMassRatio[1]; cum[2] += m.effMassRatio[2]
               const dom = m.effMassRatio.indexOf(Math.max(...m.effMassRatio))
               const domLabel = m.effMassRatio[dom] > 0.5 ? ['X', 'Y', 'Z'][dom] : ''
+              const active = selectedMode === i
               return (
-                <tr key={i} className="border-b border-slate-100 last:border-0 hover:bg-slate-50">
+                <tr key={i} className={`border-b border-slate-100 last:border-0 hover:bg-slate-50 ${active ? 'bg-violet-50' : ''}`}>
                   <td className="py-1 pr-3 font-mono text-slate-700">{i + 1}{domLabel && <span className="ml-1 text-[10px] text-slate-400">{domLabel}</span>}</td>
                   <td className="py-1 pr-3 text-right tabular-nums font-semibold text-slate-800">{f3(m.period)}</td>
                   <td className="py-1 pr-3 text-right tabular-nums text-slate-600">{f2(m.freq)}</td>
@@ -53,6 +60,18 @@ export function ModalPanel({ result }: { result: ModalResult }) {
                   <td className={`py-1 pr-3 text-right tabular-nums ${cumCls(cum[0])}`}>{pct(cum[0])}</td>
                   <td className={`py-1 pr-3 text-right tabular-nums ${cumCls(cum[1])}`}>{pct(cum[1])}</td>
                   <td className={`py-1 text-right tabular-nums ${cumCls(cum[2])}`}>{pct(cum[2])}</td>
+                  {onSelectMode && (
+                    <td className="py-1 pl-2">
+                      <button type="button"
+                        onClick={() => onSelectMode(active ? null : i)}
+                        title={active ? 'Hide mode shape' : 'Animate mode shape in 3D view'}
+                        className={`rounded px-1.5 py-0.5 text-[10px] font-semibold transition ${
+                          active ? 'bg-violet-100 text-violet-700' : 'text-slate-400 hover:text-violet-600'
+                        }`}>
+                        {active ? '◉' : '◎'} 3D
+                      </button>
+                    </td>
+                  )}
                 </tr>
               )
             })}

--- a/webapp/src/engine/modal.test.ts
+++ b/webapp/src/engine/modal.test.ts
@@ -115,6 +115,21 @@ describe('modalAnalysis — SDOF cantilever column', () => {
     expect(res.cumRatio[0]).toBeCloseTo(1, 2)
     expect(res.cumRatio[2]).toBeCloseTo(1, 2)
   })
+
+  it('mode shape is a record with max |component| = 1 and only the free top node', () => {
+    const res = modalAnalysis(model, 6)!
+    for (const mode of res.modes) {
+      const vals = Object.values(mode.shape)
+      expect(vals.length).toBeGreaterThan(0)
+      // max absolute component must be exactly 1 (normalization)
+      const maxAbs = Math.max(...vals.flatMap((v) => v.map(Math.abs)))
+      expect(maxAbs).toBeCloseTo(1, 9)
+      // fixed base node carries no mass → not in shape
+      expect(mode.shape['base']).toBeUndefined()
+      // free top node is present
+      expect(mode.shape['top']).toBeDefined()
+    }
+  })
 })
 
 // ── full model sanity ───────────────────────────────────────────────────────

--- a/webapp/src/engine/modal.ts
+++ b/webapp/src/engine/modal.ts
@@ -44,6 +44,10 @@ export interface Mode {
   effMass: [number, number, number]
   /** Effective modal mass as a fraction of the total mass, per direction. */
   effMassRatio: [number, number, number]
+  /** Node-displacement mode shape: node id → [ux, uy, uz].
+   *  Normalized so max|component| = 1. Only massive free translational DOFs
+   *  have non-zero entries. JSON-safe (plain object). */
+  shape: Record<string, [number, number, number]>
 }
 
 export interface ModalResult {
@@ -164,7 +168,7 @@ export function jacobiEigen(Ain: number[][], maxSweeps = 100): { values: number[
 
 // ── orchestration ───────────────────────────────────────────────────────────
 
-interface MassDof { fpos: number; dir: 0 | 1 | 2; mass: number }
+interface MassDof { fpos: number; dir: 0 | 1 | 2; mass: number; nodeId: string }
 
 /**
  * Modal analysis of a structural model. Returns the lowest `nModes` modes with
@@ -193,7 +197,7 @@ export function modalAnalysis(model: StructuralModel, nModes = 12): ModalResult 
       const fpos = precomp.freeIdx.get(gdof)
       if (fpos === undefined) continue  // restrained DOF → mass cannot vibrate
       totalMass[dir] += m              // participation is measured against free mass
-      massDofs.push({ fpos, dir, mass: m })
+      massDofs.push({ fpos, dir, mass: m, nodeId })
     }
   }
   const p = massDofs.length
@@ -237,7 +241,23 @@ export function modalAnalysis(model: StructuralModel, nModes = 12): ModalResult 
     const effMass: [number, number, number] = [L[0] * L[0] / Mstar, L[1] * L[1] / Mstar, L[2] * L[2] / Mstar]
     const effMassRatio: [number, number, number] = [0, 1, 2].map((r) =>
       totalMass[r] > 0 ? effMass[r] / totalMass[r] : 0) as [number, number, number]
-    return { period: 2 * Math.PI / omega, omega, freq: omega / (2 * Math.PI), effMass, effMassRatio }
+
+    // build per-node shape (node id → [ux, uy, uz]) from massive DOFs only
+    const rawShape: Record<string, [number, number, number]> = {}
+    for (let a = 0; a < p; a++) {
+      const { nodeId, dir } = massDofs[a]
+      if (!rawShape[nodeId]) rawShape[nodeId] = [0, 0, 0]
+      rawShape[nodeId][dir] = phi[a]
+    }
+    // normalize to max|component| = 1
+    let maxPhi = 0
+    for (const v of Object.values(rawShape)) maxPhi = Math.max(maxPhi, Math.abs(v[0]), Math.abs(v[1]), Math.abs(v[2]))
+    const shape: Record<string, [number, number, number]> = {}
+    for (const [id, v] of Object.entries(rawShape)) {
+      shape[id] = maxPhi > 0 ? [v[0] / maxPhi, v[1] / maxPhi, v[2] / maxPhi] : v
+    }
+
+    return { period: 2 * Math.PI / omega, omega, freq: omega / (2 * Math.PI), effMass, effMassRatio, shape }
   })
 
   const cum: [number, number, number] = [0, 1, 2].map((r) =>

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
-import { Canvas } from '@react-three/fiber'
+import { Canvas, useFrame } from '@react-three/fiber'
 import { OrbitControls, Text } from '@react-three/drei'
 import * as THREE from 'three'
 import { generateGridModel, removeElements, removeNode, buildGravityLoads, splitSharedSections } from '../engine/modelBuilder'
@@ -260,6 +260,51 @@ function Wall3D({ tA, tB, bA, bB, shear }: { tA: THREE.Vector3; tB: THREE.Vector
       </>}
     </group>
   )
+}
+
+/** Animated mode-shape skeleton. Lines are updated imperatively in useFrame
+ *  (no re-render per frame) to show sinusoidal oscillation of the given mode. */
+function ModeShapePlayer({ shape, nodePos, members, amp }: {
+  shape: Record<string, [number, number, number]>
+  nodePos: Map<string, THREE.Vector3>
+  members: { id: string; i: string; j: string }[]
+  amp: number
+}) {
+  const ampRef = useRef(amp)
+  ampRef.current = amp
+  const shapeRef = useRef(shape)
+  shapeRef.current = shape
+
+  const { group, lineGeos } = useMemo(() => {
+    const g = new THREE.Group()
+    const geos: { i: string; j: string; geo: THREE.BufferGeometry }[] = []
+    for (const m of members) {
+      const aO = nodePos.get(m.i), bO = nodePos.get(m.j)
+      if (!aO || !bO) continue
+      const geo = new THREE.BufferGeometry()
+      geo.setAttribute('position', new THREE.BufferAttribute(
+        new Float32Array([aO.x, aO.y, aO.z, bO.x, bO.y, bO.z]), 3))
+      g.add(new THREE.Line(geo, new THREE.LineBasicMaterial({ color: '#7c3aed' })))
+      geos.push({ i: m.i, j: m.j, geo })
+    }
+    return { group: g, lineGeos: geos }
+  }, [members, nodePos])
+
+  useFrame(({ clock }) => {
+    const scale = ampRef.current * Math.sin(clock.elapsedTime * Math.PI * 1.2)
+    const sh = shapeRef.current
+    for (const { i, j, geo } of lineGeos) {
+      const aO = nodePos.get(i), bO = nodePos.get(j)
+      if (!aO || !bO) continue
+      const da = sh[i], db = sh[j]
+      const pos = geo.attributes.position as THREE.BufferAttribute
+      pos.setXYZ(0, aO.x + (da?.[0] ?? 0) * scale, aO.y + (da?.[1] ?? 0) * scale, aO.z + (da?.[2] ?? 0) * scale)
+      pos.setXYZ(1, bO.x + (db?.[0] ?? 0) * scale, bO.y + (db?.[1] ?? 0) * scale, bO.z + (db?.[2] ?? 0) * scale)
+      pos.needsUpdate = true
+    }
+  })
+
+  return <primitive object={group} />
 }
 
 // ── Load glyphs ─────────────────────────────────────────────────────────────
@@ -603,6 +648,8 @@ export default function ModelSpace() {
   const [selected, setSelected] = useState<string | null>(null)
   const [analysis, setAnalysis] = useState<F3Analysis | null>(null)
   const [modal, setModal] = useState<ModalResult | null>(null)
+  const [modeShapeIdx, setModeShapeIdx] = useState<number | null>(null)
+  const [modeAmp, setModeAmp] = useState(1.5)
   const [rsa, setRsa] = useState<ResponseSpectrumResult | null>(null)
   const [nModes, setNModes] = useState(12)
   const [design, setDesign] = useState<StructureDesign | null>(null)
@@ -706,6 +753,7 @@ export default function ModelSpace() {
 
   const runModal = () => {
     if (!model || busy || meshErrors) return
+    setModeShapeIdx(null)    // stale shape from prior run
     run('modal', { model, nModes }).then((r) => {
       const m = (r as { modal: ModalResult | null }).modal
       setModal(m)
@@ -1184,6 +1232,14 @@ export default function ModelSpace() {
                   return <Wall3D key={w.id} tA={tA} tB={tB} bA={bA} bB={bB} shear={w.shearWall} />
                 })}
                 {showLoads && <Loads3D model={model} nodePos={nodePos} />}
+                {modal && modeShapeIdx !== null && modal.modes[modeShapeIdx] && (
+                  <ModeShapePlayer
+                    shape={modal.modes[modeShapeIdx].shape}
+                    nodePos={nodePos}
+                    members={model.members}
+                    amp={modeAmp}
+                  />
+                )}
                 <OrbitControls ref={controlsRef} makeDefault enablePan target={[6, 3, 2.5]} />
               </Canvas>
             ) : (
@@ -2130,7 +2186,30 @@ export default function ModelSpace() {
 
               {model && <ValidationPanel issues={meshIssues} />}
 
-              {modal && modal.modes.length > 0 && <ModalPanel result={modal} />}
+              {modal && modal.modes.length > 0 && (
+                <ModalPanel result={modal} selectedMode={modeShapeIdx} onSelectMode={setModeShapeIdx} />
+              )}
+              {modal && modeShapeIdx !== null && modal.modes[modeShapeIdx] && (
+                <div className="rounded-xl border border-violet-200 bg-violet-50 p-4 shadow-sm">
+                  <div className="mb-2 flex items-center justify-between">
+                    <h3 className="text-[1.02rem] font-bold text-violet-700">
+                      Mode {modeShapeIdx + 1} shape — T = {modal.modes[modeShapeIdx].period.toFixed(3)} s
+                    </h3>
+                    <button type="button" onClick={() => setModeShapeIdx(null)}
+                      className="rounded px-2 py-0.5 text-xs font-semibold text-violet-500 hover:bg-violet-100">✕ Close</button>
+                  </div>
+                  <label className="flex flex-col gap-1 text-sm">
+                    <span className="font-medium text-violet-700">Visual amplitude: {modeAmp.toFixed(1)} m</span>
+                    <input type="range" min={0.3} max={5} step={0.1} value={modeAmp}
+                      onChange={(e) => setModeAmp(parseFloat(e.target.value))}
+                      className="accent-violet-600" />
+                  </label>
+                  <p className="mt-1.5 text-[11px] text-violet-500">
+                    Purple skeleton oscillates in the 3D canvas (visual only — not structural displacement).
+                    Switch to any other tab; the animation continues while the panel is visible.
+                  </p>
+                </div>
+              )}
               {modal && modal.modes.length === 0 && (
                 <ResultCard title="Modal analysis">
                   <p className="text-sm text-slate-600">No modes found — the model has no lumped mass (add members/slabs with self-weight).</p>


### PR DESCRIPTION
## Summary

- **Engine** (`modal.ts`): `Mode` now carries `shape: Record<string, [number, number, number]>` — the per-node translational displacement vector for each mode, normalized so `max|component| = 1`. Built from the massive free translational DOFs already computed during eigensolution. Plain object (not Map) so it survives `postMessage` serialization through the solver worker.
- **UI** (`ModalPanel.tsx`): Optional `onSelectMode`/`selectedMode` props add a per-row `◎ 3D` toggle button. Active row is tinted violet.
- **UI** (`ModelSpace.tsx`): New `ModeShapePlayer` R3F component renders an animated purple skeleton inside the Canvas using `useFrame` + direct `BufferAttribute` updates (zero React re-renders per frame). An amplitude slider (0.3–5 m visual scale) in a violet card below the mode table controls exaggeration. Animation clears on re-run or on ✕.

## How it works

`ModeShapePlayer` creates one `THREE.Line` per member at mount time (via `useMemo`). Each `useFrame` tick recomputes `scale = amp × sin(t × π × 1.2)` and updates the two endpoint `BufferAttribute` entries for every line imperatively — no virtual DOM diffing, no re-render overhead.

## Files changed

| File | What changed |
|---|---|
| `engine/modal.ts` | `MassDof` gets `nodeId`; `Mode` gets `shape`; normalization + shape build in the mode loop |
| `engine/modal.test.ts` | New test: shape normalization, top-node presence, base-node absence |
| `components/ModalPanel.tsx` | `onSelectMode`/`selectedMode` props; `◎ 3D` button column |
| `pages/ModelSpace.tsx` | `useFrame` import; `ModeShapePlayer` component; `modeShapeIdx`/`modeAmp` state; canvas integration; amplitude card in Modal tab |

## Test plan

- [x] `npm test` — 598/598 pass
- [x] `npx tsc -b` — zero errors
- [ ] Generate a 2-storey model → Modal tab → Run → click `◎ 3D` on Mode 1 → purple skeleton oscillates in the 3D canvas
- [ ] Adjust amplitude slider → deformation scale changes in real time
- [ ] Click ✕ Close → animation stops
- [ ] Re-run modal → animation cleared automatically

## Remaining phase

- **PR C** — Rigid floor diaphragm (master-slave constraints for in-plane lateral DOFs per storey)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_