### PR TITLE
feat: rigid floor diaphragm — constraint elimination per storey (PR C)

### DIFF
--- a/webapp/src/engine/diaphragm.ts
+++ b/webapp/src/engine/diaphragm.ts
@@ -1,0 +1,30 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Rigid floor diaphragm — identifies which nodes share in-plane DOFs.
+//
+// Each storey in the structural model corresponds to one diaphragm plane.
+// All nodes at a storey elevation are grouped; the first node is the master
+// and the rest are slaves. The constraint is:
+//   ux_s = ux_m − (z_s − z_m)·θy_m     (rigid body, y is up)
+//   uz_s = uz_m + (x_s − x_m)·θy_m
+//   θy_s = θy_m
+// ─────────────────────────────────────────────────────────────────────────
+import type { StructuralModel } from './model'
+import type { F3DiaphragmGroup } from './frame3d'
+
+const YTOL = 1e-4   // m; elevation matching tolerance
+
+/**
+ * Builds rigid floor diaphragm groups from the model's storey elevations.
+ * Only storeys with ≥2 nodes at that elevation produce a group.
+ */
+export function buildDiaphragmGroups(model: StructuralModel): F3DiaphragmGroup[] {
+  if (!model.storeys || model.storeys.length === 0) return []
+  const groups: F3DiaphragmGroup[] = []
+  for (const storey of model.storeys) {
+    const atLevel = model.nodes.filter((n) => Math.abs(n.y - storey.elevation) < YTOL)
+    if (atLevel.length < 2) continue
+    const [master, ...rest] = atLevel
+    groups.push({ masterNode: master.id, slaveNodes: rest.map((n) => n.id) })
+  }
+  return groups
+}

--- a/webapp/src/engine/frame3d.test.ts
+++ b/webapp/src/engine/frame3d.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { solveFrame3D, analyzeFrame3D, rectJ, precomputeFrame, solveWithGeometry, serializePrecomp, deserializePrecomp, appliedResultant, type F3Node, type F3Member, type F3Support, type F3Load } from './frame3d'
+import { solveFrame3D, analyzeFrame3D, rectJ, precomputeFrame, solveWithGeometry, serializePrecomp, deserializePrecomp, appliedResultant, type F3Node, type F3Member, type F3Support, type F3Load, type F3DiaphragmGroup } from './frame3d'
 import { solveFrame2D } from './frame2d'
 import { generateGridModel } from './modelBuilder'
 import { modelToFrame3D } from './modelBridge'
@@ -371,5 +371,70 @@ describe('appliedResultant — statics self-check (§8)', () => {
     const reac: [number, number, number] = [0, 1, 2].map((k) =>
       gov.result!.reactions.reduce((s, q) => s + q.F[k], 0)) as [number, number, number]
     for (let k = 0; k < 3; k++) expect(applied[k] + reac[k]).toBeCloseTo(0, 2)
+  })
+})
+
+// ── Rigid floor diaphragm ─────────────────────────────────────────────────
+describe('rigid floor diaphragm — precomputeFrame + solveWithGeometry', () => {
+  // Two columns at (0,0,0)→(0,3,0) and (6,0,0)→(6,3,0), both fixed at base.
+  // A lateral nodal load at the left column top (Fx = 1 kN).
+  // Without diaphragm: each column resists independently (equal stiffness → 0.5 kN each).
+  // With diaphragm: floor constraint forces equal Ux at both tops; same result here
+  //   since they are symmetric, but θy of both tops must also be equal.
+  const nodes: F3Node[] = [
+    { id: 'bL', x: 0, y: 0, z: 0 }, { id: 'tL', x: 0, y: 3, z: 0 },
+    { id: 'bR', x: 6, y: 0, z: 0 }, { id: 'tR', x: 6, y: 3, z: 0 },
+  ]
+  const Iy = (h * b ** 3) / 12  // weak axis
+  const colSec: F3Member = { id: 'cL', i: 'bL', j: 'tL', E, G, A, Iy, Iz, J }
+  const colR: F3Member = { ...colSec, id: 'cR', i: 'bR', j: 'tR' }
+  const supports: F3Support[] = [
+    { node: 'bL', fixity: 'fixed' }, { node: 'bR', fixity: 'fixed' },
+  ]
+  const loads: F3Load[] = [{ kind: 'node', node: 'tL', Fx: 1, cat: 'D' }]
+
+  it('without diaphragm: left column takes all sway (right column uninvited)', () => {
+    const r = solveFrame3D(nodes, [colSec, colR], supports, loads)!
+    // Without diaphragm the nodes are independent; right top should barely move
+    const tL = nodes.findIndex((n) => n.id === 'tL')
+    const tR = nodes.findIndex((n) => n.id === 'tR')
+    // tR has no direct load → zero horizontal displacement
+    expect(Math.abs(r.d[6 * tR + 0])).toBeCloseTo(0, 9)
+    expect(Math.abs(r.d[6 * tL + 0])).toBeGreaterThan(1e-6)
+  })
+
+  it('with diaphragm: both column tops have equal Ux', () => {
+    const dia: F3DiaphragmGroup[] = [{ masterNode: 'tL', slaveNodes: ['tR'] }]
+    const pc = precomputeFrame(nodes, [colSec, colR], supports, dia)
+    const r = solveWithGeometry(pc, loads)!
+    const tL = nodes.findIndex((n) => n.id === 'tL')
+    const tR = nodes.findIndex((n) => n.id === 'tR')
+    expect(r.d[6 * tL + 0]).toBeCloseTo(r.d[6 * tR + 0], 9)
+    // Both columns resist: total reaction = 1 kN
+    const sumRx = r.reactions.reduce((s, q) => s + q.F[0], 0)
+    expect(sumRx).toBeCloseTo(-1, 6)
+  })
+
+  it('with diaphragm: arm effect — slave at dz offset shares θy with master', () => {
+    // Master at (0,3,0), slave at (6,3,2) — has both dx and dz arm
+    const nodes2: F3Node[] = [
+      { id: 'bL', x: 0, y: 0, z: 0 }, { id: 'tL', x: 0, y: 3, z: 0 },
+      { id: 'bR', x: 6, y: 0, z: 2 }, { id: 'tR', x: 6, y: 3, z: 2 },
+    ]
+    const colSec2: F3Member = { ...colSec, id: 'cL2', i: 'bL', j: 'tL' }
+    const colR2: F3Member = { ...colSec, id: 'cR2', i: 'bR', j: 'tR' }
+    const dia: F3DiaphragmGroup[] = [{ masterNode: 'tL', slaveNodes: ['tR'] }]
+    const pc = precomputeFrame(nodes2, [colSec2, colR2], supports, dia)
+    const r = solveWithGeometry(pc, loads)!
+    expect(r).not.toBeNull()
+    // Rigid body kinematics: ux_tR = ux_tL − dz·θy_tL; dz = 2, dx = 6
+    const tL = nodes2.findIndex((n) => n.id === 'tL')
+    const tR = nodes2.findIndex((n) => n.id === 'tR')
+    const ux_m = r.d[6 * tL + 0], θy_m = r.d[6 * tL + 4]
+    const ux_s = r.d[6 * tR + 0]
+    const dz = nodes2[tR].z - nodes2[tL].z   // = 2
+    expect(ux_s).toBeCloseTo(ux_m - dz * θy_m, 6)
+    // Slave θy must equal master θy
+    expect(r.d[6 * tR + 4]).toBeCloseTo(θy_m, 9)
   })
 })

--- a/webapp/src/engine/frame3d.ts
+++ b/webapp/src/engine/frame3d.ts
@@ -37,6 +37,16 @@ export interface F3Support {
   kx?: number; ky?: number; kz?: number
 }
 
+/**
+ * Rigid floor diaphragm group: one master node and its slave nodes at the same
+ * storey level. The constraint ties the in-plane DOFs {ux, uz, θy} of each
+ * slave to the master via rigid body kinematics (arm effect included).
+ */
+export interface F3DiaphragmGroup {
+  masterNode: string
+  slaveNodes: string[]
+}
+
 export type F3Load =
   | { kind: 'node'; node: string; Fx?: number; Fy?: number; Fz?: number; Mx?: number; My?: number; Mz?: number; cat: LoadCategory }
   | { kind: 'member-udl'; member: string; w: number; cat: LoadCategory }                       // kN/m, global −Y
@@ -210,8 +220,13 @@ export interface FramePrecomp {
   ndof: number
   free: number[]
   freeIdx: Map<number, number>   // global DOF → position in free[]
-  Kff: LUFactor | null           // null = singular or no free DOFs
-  Kff_raw: number[][]            // un-factored Kff; needed as P-Δ elastic baseline
+  Kff: LUFactor | null           // factored K (K_ind when diaphragm active)
+  Kff_raw: number[][]            // un-factored nf×nf elastic stiffness (P-Δ baseline)
+  /** Diaphragm constraint transformation rows (present when rigid floor diaphragm active).
+   *  diaT[k] = sparse row of T for the k-th free DOF; T maps free→independent DOFs. */
+  diaT?: { ind: number; coeff: number }[][]
+  /** Number of independent DOFs (< free.length when diaphragm active). */
+  diaNi?: number
 }
 
 /**
@@ -368,10 +383,123 @@ function computeMemberLoads(geom: MemberGeom, m: F3Member, loads: F3Load[]): Mem
   }
 }
 
+type TEntry = { ind: number; coeff: number }
+
+/**
+ * Build the diaphragm constraint transformation T (nf × ni). Each row represents
+ * one free DOF: identity for independent DOFs, rigid-body expression for slaves.
+ *
+ * Constraint (y is up; in-plane DOFs are ux=0, uz=2, θy=4):
+ *   ux_slave = ux_m − (z_s−z_m)·θy_m
+ *   uz_slave = uz_m + (x_s−x_m)·θy_m
+ *   θy_slave = θy_m
+ *
+ * Returns null if no constraints could be applied (e.g., master DOFs are constrained).
+ */
+function buildDiaphragmT(
+  nodes: F3Node[], idx: Map<string, number>, freeIdx: Map<number, number>,
+  diaphragms: F3DiaphragmGroup[], nf: number,
+): { Trow: TEntry[][]; ni: number } | null {
+  const isSlave = new Uint8Array(nf)
+  // slaveRow[k] = expression in terms of master fpos values (will be remapped to ind below)
+  const slaveExpr: ({ masterFpos: number; coeff: number }[] | null)[] = new Array(nf).fill(null)
+
+  for (const dia of diaphragms) {
+    const mi = idx.get(dia.masterNode)
+    if (mi === undefined) continue
+    const mn = nodes[mi]
+    const fp_ux_m = freeIdx.get(6 * mi + 0)
+    const fp_uz_m = freeIdx.get(6 * mi + 2)
+    const fp_θy_m = freeIdx.get(6 * mi + 4)
+    // If master's lateral DOFs are constrained, skip this floor
+    if (fp_ux_m === undefined || fp_uz_m === undefined || fp_θy_m === undefined) continue
+
+    for (const slaveId of dia.slaveNodes) {
+      const si = idx.get(slaveId)
+      if (si === undefined || si === mi) continue
+      const sn = nodes[si]
+      const dx = sn.x - mn.x, dz = sn.z - mn.z
+
+      const fp_ux_s = freeIdx.get(6 * si + 0)
+      if (fp_ux_s !== undefined && !isSlave[fp_ux_s]) {
+        isSlave[fp_ux_s] = 1
+        slaveExpr[fp_ux_s] = [
+          { masterFpos: fp_ux_m, coeff: 1 },
+          ...(Math.abs(dz) > 1e-9 ? [{ masterFpos: fp_θy_m, coeff: -dz }] : []),
+        ]
+      }
+      const fp_uz_s = freeIdx.get(6 * si + 2)
+      if (fp_uz_s !== undefined && !isSlave[fp_uz_s]) {
+        isSlave[fp_uz_s] = 1
+        slaveExpr[fp_uz_s] = [
+          { masterFpos: fp_uz_m, coeff: 1 },
+          ...(Math.abs(dx) > 1e-9 ? [{ masterFpos: fp_θy_m, coeff: dx }] : []),
+        ]
+      }
+      const fp_θy_s = freeIdx.get(6 * si + 4)
+      if (fp_θy_s !== undefined && !isSlave[fp_θy_s]) {
+        isSlave[fp_θy_s] = 1
+        slaveExpr[fp_θy_s] = [{ masterFpos: fp_θy_m, coeff: 1 }]
+      }
+    }
+  }
+
+  if (!isSlave.some((v) => v)) return null
+
+  // Assign independent indices (in-order, skipping slaves)
+  const indOf = new Int32Array(nf).fill(-1)
+  let ni = 0
+  for (let k = 0; k < nf; k++) if (!isSlave[k]) indOf[k] = ni++
+
+  // Build final Trow with proper independent indices
+  const Trow: TEntry[][] = []
+  for (let k = 0; k < nf; k++) {
+    if (!isSlave[k]) {
+      Trow.push([{ ind: indOf[k], coeff: 1 }])
+    } else {
+      Trow.push(
+        (slaveExpr[k] ?? [])
+          .map(({ masterFpos, coeff }) => ({ ind: indOf[masterFpos], coeff }))
+          .filter((e) => e.ind >= 0),
+      )
+    }
+  }
+  return { Trow, ni }
+}
+
+/** Apply constraint transformation: K_ind[a,b] = Σ_{i,j} T[i,a]·Kff[i][j]·T[j,b] */
+function applyTtoK(Kff: number[][], Trow: TEntry[][], ni: number): number[][] {
+  const nf = Kff.length
+  const K = Array.from({ length: ni }, () => new Array(ni).fill(0))
+  for (let i = 0; i < nf; i++) {
+    for (const { ind: a, coeff: ca } of Trow[i]) {
+      for (let j = 0; j < nf; j++) {
+        const kij = Kff[i][j]
+        if (kij === 0) continue
+        for (const { ind: b, coeff: cb } of Trow[j]) K[a][b] += ca * kij * cb
+      }
+    }
+  }
+  return K
+}
+
+/** Transform load vector: Ff_ind[a] = Σ_i T^T[a,i]·Ff[i] = Σ_i T[i,a]·Ff[i] */
+function applyTtoLoad(Ff: number[], Trow: TEntry[][], ni: number): number[] {
+  const Ff_ind = new Array(ni).fill(0)
+  Ff.forEach((v, i) => { for (const { ind, coeff } of Trow[i]) Ff_ind[ind] += coeff * v })
+  return Ff_ind
+}
+
+/** Recover free DOF displacements: d_f[i] = Σ_a T[i,a]·d_ind[a] */
+function applyTrecover(d_ind: number[], Trow: TEntry[][]): number[] {
+  return Trow.map((row) => row.reduce((s, { ind, coeff }) => s + coeff * d_ind[ind], 0))
+}
+
 /** Assemble K from member geometry, find free DOFs, LU-factor Kff.
  *  Call once per geometry/support change; reuse for every load case. */
 export function precomputeFrame(
   nodes: F3Node[], members: F3Member[], supports: F3Support[],
+  diaphragms?: F3DiaphragmGroup[],
 ): FramePrecomp {
   const nm = new Map(nodes.map((n) => [n.id, n]))
   const idx = new Map(nodes.map((n, i) => [n.id, i]))
@@ -417,6 +545,15 @@ export function precomputeFrame(
     })
   }
 
+  if (diaphragms && diaphragms.length > 0) {
+    const dia = buildDiaphragmT(nodes, idx, freeIdx, diaphragms, nf)
+    if (dia) {
+      const K_ind = applyTtoK(Kff_raw, dia.Trow, dia.ni)
+      const Kff_ind = luFactor(K_ind)
+      return { nm, idx, nodes, members, supports, geoms, ndof, free, freeIdx,
+               Kff: Kff_ind, Kff_raw, diaT: dia.Trow, diaNi: dia.ni }
+    }
+  }
   const Kff = luFactor(Kff_raw)   // null if singular; {n:0} if nf===0
   return { nm, idx, nodes, members, supports, geoms, ndof, free, freeIdx, Kff, Kff_raw }
 }
@@ -432,6 +569,8 @@ export interface FramePrecompSerial {
   freeIdxEntries: [number, number][]
   Kff: LUFactor | null
   Kff_raw: number[][]
+  diaT?: { ind: number; coeff: number }[][]
+  diaNi?: number
 }
 
 export function serializePrecomp(p: FramePrecomp): FramePrecompSerial {
@@ -440,6 +579,7 @@ export function serializePrecomp(p: FramePrecomp): FramePrecompSerial {
     geoms: p.geoms, ndof: p.ndof, free: p.free,
     freeIdxEntries: [...p.freeIdx],
     Kff: p.Kff, Kff_raw: p.Kff_raw,
+    ...(p.diaT ? { diaT: p.diaT, diaNi: p.diaNi } : {}),
   }
 }
 
@@ -451,6 +591,7 @@ export function deserializePrecomp(s: FramePrecompSerial): FramePrecomp {
     geoms: s.geoms, ndof: s.ndof, free: s.free,
     freeIdx: new Map(s.freeIdxEntries),
     Kff: s.Kff, Kff_raw: s.Kff_raw,
+    ...(s.diaT ? { diaT: s.diaT, diaNi: s.diaNi } : {}),
   }
 }
 
@@ -530,7 +671,7 @@ function postprocessMember(m: F3Member, g: MemberGeom, ml: MemberLoads, d: numbe
 export function solveWithGeometry(
   precomp: FramePrecomp, loads: F3Load[], opts?: PDeltaOpts,
 ): F3Result | null {
-  const { idx, members, geoms, ndof, free, freeIdx, Kff, Kff_raw, supports } = precomp
+  const { idx, members, geoms, ndof, free, freeIdx, Kff, Kff_raw, supports, diaT, diaNi } = precomp
 
   const mloads = members.map((m, i) => computeMemberLoads(geoms[i], m, loads))
 
@@ -552,41 +693,86 @@ export function solveWithGeometry(
   if (free.length > 0) {
     if (!Kff) return null   // singular stiffness
     const Ff = free.map((dof) => F[dof])
-    const d0 = luSolve(Kff, Ff)
-    free.forEach((dof, k) => (d[dof] = d0[k]))
 
-    // P-Δ: iterate K + Kg(N); Kg depends on load-case axial forces so Kff_raw
-    // is the elastic baseline and we re-factor Ktff each iteration.
-    if (opts?.pDelta) {
-      const maxIter = opts.maxIter ?? 20
-      const tol = opts.tol ?? 1e-5
-      const nf = free.length
-      for (let it = 0; it < maxIter; it++) {
-        const Ktff: number[][] = Array.from({ length: nf }, (_, i) => [...Kff_raw[i]])
-        for (let mi = 0; mi < geoms.length; mi++) {
-          const g = geoms[mi], ml = mloads[mi]
-          const de = g.dofs.map((dof) => d[dof])
-          const dl = matVec(g.T, de)
-          const f = matVec(g.kl, dl).map((v, k) => v - ml.feq[k])
-          const N = (f[6] - f[0]) / 2                     // representative axial, tension +
-          const kgg = mul(mul(transpose(g.T), kgLocal(N, g.L)), g.T)
-          for (let a = 0; a < 12; a++) {
-            const ia = freeIdx.get(g.dofs[a])
-            if (ia === undefined) continue
-            for (let b = 0; b < 12; b++) {
-              const ib = freeIdx.get(g.dofs[b])
-              if (ib === undefined) continue
-              Ktff[ia][ib] += kgg[a][b]
+    if (diaT && diaNi !== undefined) {
+      // Constrained solve: transform load to independent DOFs, solve, recover full d_f
+      const Ff_ind = applyTtoLoad(Ff, diaT, diaNi)
+      const d_ind = luSolve(Kff, Ff_ind)   // Kff is already K_ind = T^T K T
+      const d0 = applyTrecover(d_ind, diaT)
+      free.forEach((dof, k) => (d[dof] = d0[k]))
+
+      // P-Δ with diaphragm: transform tangent K to independent space each iteration
+      if (opts?.pDelta) {
+        const maxIter = opts.maxIter ?? 20
+        const tol = opts.tol ?? 1e-5
+        const nf = free.length
+        for (let it = 0; it < maxIter; it++) {
+          const Ktff: number[][] = Array.from({ length: nf }, (_, i) => [...Kff_raw[i]])
+          for (let mi = 0; mi < geoms.length; mi++) {
+            const g = geoms[mi], ml = mloads[mi]
+            const de = g.dofs.map((dof) => d[dof])
+            const dl = matVec(g.T, de)
+            const f = matVec(g.kl, dl).map((v, k) => v - ml.feq[k])
+            const N = (f[6] - f[0]) / 2
+            const kgg = mul(mul(transpose(g.T), kgLocal(N, g.L)), g.T)
+            for (let a = 0; a < 12; a++) {
+              const ia = freeIdx.get(g.dofs[a])
+              if (ia === undefined) continue
+              for (let b = 0; b < 12; b++) {
+                const ib = freeIdx.get(g.dofs[b])
+                if (ib === undefined) continue
+                Ktff[ia][ib] += kgg[a][b]
+              }
             }
           }
+          const Kt_ind = applyTtoK(Ktff, diaT, diaNi)
+          const Ktff_fac = luFactor(Kt_ind)
+          if (!Ktff_fac) break
+          const dn_ind = luSolve(Ktff_fac, Ff_ind)
+          const dn = applyTrecover(dn_ind, diaT)
+          let num = 0, den = 0
+          free.forEach((dof, k) => { num += (dn[k] - d[dof]) ** 2; den += dn[k] ** 2 })
+          free.forEach((dof, k) => (d[dof] = dn[k]))
+          if (den === 0 || Math.sqrt(num / den) < tol) break
         }
-        const Ktff_fac = luFactor(Ktff)
-        if (!Ktff_fac) break                               // elastic instability — retain last d
-        const dn = luSolve(Ktff_fac, Ff)
-        let num = 0, den = 0
-        free.forEach((dof, k) => { num += (dn[k] - d[dof]) ** 2; den += dn[k] ** 2 })
-        free.forEach((dof, k) => (d[dof] = dn[k]))
-        if (den === 0 || Math.sqrt(num / den) < tol) break
+      }
+    } else {
+      const d0 = luSolve(Kff, Ff)
+      free.forEach((dof, k) => (d[dof] = d0[k]))
+
+      // P-Δ: iterate K + Kg(N); Kg depends on load-case axial forces so Kff_raw
+      // is the elastic baseline and we re-factor Ktff each iteration.
+      if (opts?.pDelta) {
+        const maxIter = opts.maxIter ?? 20
+        const tol = opts.tol ?? 1e-5
+        const nf = free.length
+        for (let it = 0; it < maxIter; it++) {
+          const Ktff: number[][] = Array.from({ length: nf }, (_, i) => [...Kff_raw[i]])
+          for (let mi = 0; mi < geoms.length; mi++) {
+            const g = geoms[mi], ml = mloads[mi]
+            const de = g.dofs.map((dof) => d[dof])
+            const dl = matVec(g.T, de)
+            const f = matVec(g.kl, dl).map((v, k) => v - ml.feq[k])
+            const N = (f[6] - f[0]) / 2                     // representative axial, tension +
+            const kgg = mul(mul(transpose(g.T), kgLocal(N, g.L)), g.T)
+            for (let a = 0; a < 12; a++) {
+              const ia = freeIdx.get(g.dofs[a])
+              if (ia === undefined) continue
+              for (let b = 0; b < 12; b++) {
+                const ib = freeIdx.get(g.dofs[b])
+                if (ib === undefined) continue
+                Ktff[ia][ib] += kgg[a][b]
+              }
+            }
+          }
+          const Ktff_fac = luFactor(Ktff)
+          if (!Ktff_fac) break                               // elastic instability — retain last d
+          const dn = luSolve(Ktff_fac, Ff)
+          let num = 0, den = 0
+          free.forEach((dof, k) => { num += (dn[k] - d[dof]) ** 2; den += dn[k] ** 2 })
+          free.forEach((dof, k) => (d[dof] = dn[k]))
+          if (den === 0 || Math.sqrt(num / den) < tol) break
+        }
       }
     }
   }
@@ -655,11 +841,12 @@ export interface F3AnalyzeOpts extends PDeltaOpts {
 export function analyzeFrame3D(
   nodes: F3Node[], members: F3Member[], supports: F3Support[], loads: F3Load[],
   opts?: F3AnalyzeOpts, onProgress?: ProgressFn,
+  diaphragms?: F3DiaphragmGroup[],
 ): F3Analysis | null {
   const perCombo: F3ComboRun[] = []
   let govIdx = -1, govM = -1
   const combos = nscpCombos(opts?.f1 ?? 1.0)
-  const precomp = precomputeFrame(nodes, members, supports)   // factor K once
+  const precomp = precomputeFrame(nodes, members, supports, diaphragms)   // factor K once
   combos.forEach((combo, i) => {
     onProgress?.({ phase: 'Analyzing load cases', current: i + 1, total: combos.length, detail: combo.name })
     const factored = applyF3Combo(loads, combo.f)

--- a/webapp/src/engine/model.ts
+++ b/webapp/src/engine/model.ts
@@ -95,6 +95,8 @@ export interface StructuralModel {
   supports: NodeSupport[]
   loads: ModelLoad[]
   storeys: Storey[]
+  /** Treat each storey as a rigid floor diaphragm (ties in-plane lateral DOFs). */
+  diaphragm?: boolean
 }
 
 export function emptyModel(name = 'Untitled'): StructuralModel {

--- a/webapp/src/engine/modelBridge.ts
+++ b/webapp/src/engine/modelBridge.ts
@@ -5,8 +5,9 @@
 // preserved) — the load path, automated.
 // ─────────────────────────────────────────────────────────────────────────
 import type { StructuralModel, RectSection, MemberReleases } from './model'
-import type { F3Node, F3Member, F3Support, F3Load } from './frame3d'
+import type { F3Node, F3Member, F3Support, F3Load, F3DiaphragmGroup } from './frame3d'
 import { rectJ } from './frame3d'
+import { buildDiaphragmGroups } from './diaphragm'
 import { distributePanel, type AreaLoad } from './tributary'
 import type { BeamLoad } from './beamAnalysis'
 import { shapeByName } from './aiscSections'
@@ -19,6 +20,8 @@ export interface BridgeResult {
   loads: F3Load[]
   /** Edges whose loads could not be attached (no matching member). */
   orphanEdges: string[]
+  /** Rigid floor diaphragm groups (one per storey); empty when diaphragm disabled. */
+  diaphragmGroups: F3DiaphragmGroup[]
 }
 
 function sectionProps(s: RectSection) {
@@ -205,5 +208,6 @@ export function modelToFrame3D(model: StructuralModel): BridgeResult {
     }
   }
 
-  return { nodes, members, supports, loads, orphanEdges }
+  const diaphragmGroups = model.diaphragm ? buildDiaphragmGroups(model) : []
+  return { nodes, members, supports, loads, orphanEdges, diaphragmGroups }
 }

--- a/webapp/src/engine/solverWorker.ts
+++ b/webapp/src/engine/solverWorker.ts
@@ -30,7 +30,7 @@ ctx.onmessage = async (e: MessageEvent<SolverRequest>) => {
   try {
     if (msg.kind === 'analyze') {
       const br = modelToFrame3D(msg.model)
-      const analysis = analyzeFrame3D(br.nodes, br.members, br.supports, br.loads, msg.opts, onProgress)
+      const analysis = analyzeFrame3D(br.nodes, br.members, br.supports, br.loads, msg.opts, onProgress, br.diaphragmGroups)
       let drift = null
       if (msg.drift.hasSeis) {
         onProgress({ phase: 'Storey-drift check' })

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -2065,6 +2065,11 @@ export default function ModelSpace() {
                   <span>P-Δ second-order analysis</span>
                 </label>
                 <label className="col-span-full flex items-center gap-2 text-sm">
+                  <input type="checkbox" disabled={!model} checked={model?.diaphragm ?? false}
+                    onChange={(e) => model && save({ ...model, diaphragm: e.target.checked })} />
+                  <span>Rigid floor diaphragm (ties in-plane lateral DOFs per storey)</span>
+                </label>
+                <label className="col-span-full flex items-center gap-2 text-sm">
                   <input type="checkbox" checked={tryBars} onChange={(e) => setTryBars(e.target.checked)} />
                   <span>Try alternative bar sizes (Design / Optimize pick ⌀16–⌀32 beams, ⌀20–⌀32 columns)</span>
                 </label>


### PR DESCRIPTION
## Summary

- **Constraint elimination (T-matrix)**: Each storey's floor nodes have their in-plane lateral DOFs `{ux, uz, θy}` tied to a master node via full rigid-body kinematics. The arm effect is exact: `ux_s = ux_m − dz·θy_m`, `uz_s = uz_m + dx·θy_m`, `θy_s = θy_m`.
- **Sparse T transformation**: `K_ind = T^T K T` reduces the system DOFs instead of adding penalty terms (no ill-conditioning). The LU-factored reduced system is stored in `FramePrecomp`; P-Δ iterations also transform the tangent stiffness.
- **`diaphragm?: boolean` on `StructuralModel`**: stored with the model; toggled by a new "Rigid floor diaphragm" checkbox in the Analysis tab.
- **`diaphragm.ts`**: `buildDiaphragmGroups()` groups nodes by storey elevation (tolerance 0.1 mm); storeys with fewer than 2 nodes are skipped.
- 3 new tests: equal-Ux enforcement across a two-column floor, arm-effect constraint verification (`ux_s = ux_m − dz·θy_m` to 6 decimal places), and confirmation that columns are independent without the diaphragm.

## Files changed

| File | Change |
|---|---|
| `engine/model.ts` | `diaphragm?: boolean` on `StructuralModel` |
| `engine/diaphragm.ts` | *(new)* `buildDiaphragmGroups()` |
| `engine/frame3d.ts` | `buildDiaphragmT`, `applyTtoK/Load/recover`, `precomputeFrame` diaphragm path, `solveWithGeometry` constrained solve + P-Δ, `analyzeFrame3D` signature, serial/deserial |
| `engine/modelBridge.ts` | `BridgeResult.diaphragmGroups`; calls `buildDiaphragmGroups` when enabled |
| `engine/solverWorker.ts` | Passes `diaphragmGroups` to `analyzeFrame3D` |
| `pages/ModelSpace.tsx` | "Rigid floor diaphragm" checkbox in Analysis tab |
| `engine/frame3d.test.ts` | 3 new diaphragm tests |

## Test plan

- [x] `npm test` — 601/601 passing (3 new tests added)
- [x] `npx tsc -b` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_