### PR TITLE
feat: member force diagrams (BMD/SFD) — Tier 2 #4

### DIFF
--- a/webapp/src/engine/frame3d.ts
+++ b/webapp/src/engine/frame3d.ts
@@ -162,7 +162,7 @@ const dot = (a: V3, b: V3): number => a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
 const norm = (a: V3): V3 => { const l = Math.hypot(...a); return [a[0] / l, a[1] / l, a[2] / l] }
 
 /** Rotation matrix rows = local axes (x′, y′, z′) in global components. */
-function localAxes(dir: V3): [V3, V3, V3] {
+export function localAxes(dir: V3): [V3, V3, V3] {
   const xp = norm(dir)
   const up: V3 = Math.abs(dot(xp, [0, 1, 0])) > 0.999 ? [0, 0, 1] : [0, 1, 0]
   const proj = dot(up, xp)

--- a/webapp/src/engine/memberDiagram3d.test.ts
+++ b/webapp/src/engine/memberDiagram3d.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { memberDiagramRibbon, diagramScale } from './memberDiagram3d'
+import type { V3 } from './frame3d'
+
+const dot = (a: V3, b: V3) => a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+const sub = (a: V3, b: V3): V3 => [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+
+describe('memberDiagramRibbon — 3D internal-force diagram geometry', () => {
+  // horizontal member along +x, L = 4
+  const a: V3 = [0, 0, 0], b: V3 = [4, 0, 0]
+  const xs = [0, 1, 2, 3, 4]
+  const ys = [0, 5, 8, 5, 0]   // a sagging-like ordinate
+
+  it('returns one curve/base point per station', () => {
+    const r = memberDiagramRibbon(a, b, xs, ys, 'Mz', 0.1)
+    expect(r.curve).toHaveLength(xs.length)
+    expect(r.base).toHaveLength(xs.length)
+  })
+
+  it('baseline points lie on the member axis (a→b)', () => {
+    const { base } = memberDiagramRibbon(a, b, xs, ys, 'Mz', 0.1)
+    base.forEach((p, i) => {
+      expect(p[0]).toBeCloseTo(xs[i], 9)  // x advances with station
+      expect(p[1]).toBeCloseTo(0, 9)
+      expect(p[2]).toBeCloseTo(0, 9)
+    })
+  })
+
+  it('offset is perpendicular to the member axis', () => {
+    const dir = sub(b, a)
+    const { base, curve } = memberDiagramRibbon(a, b, xs, ys, 'Mz', 0.2)
+    curve.forEach((c, i) => expect(dot(sub(c, base[i]), dir)).toBeCloseTo(0, 9))
+  })
+
+  it('zero ordinate ⇒ curve coincides with the baseline', () => {
+    const { base, curve } = memberDiagramRibbon(a, b, xs, [0, 0, 0, 0, 0], 'Vy', 0.5)
+    curve.forEach((c, i) => expect(sub(c, base[i])).toEqual([0, 0, 0]))
+  })
+
+  it('offset magnitude is linear in scale and ordinate', () => {
+    const r1 = memberDiagramRibbon(a, b, xs, ys, 'Mz', 0.1)
+    const r2 = memberDiagramRibbon(a, b, xs, ys, 'Mz', 0.2)
+    const mag = (r: { base: V3[]; curve: V3[] }, i: number) => Math.hypot(...sub(r.curve[i], r.base[i]))
+    // peak at i=2 (ys=8): scale 0.2 gives exactly twice the offset of scale 0.1
+    expect(mag(r2, 2)).toBeCloseTo(2 * mag(r1, 2), 9)
+    // and equals |ys·scale|
+    expect(mag(r1, 2)).toBeCloseTo(8 * 0.1, 9)
+  })
+
+  it('Mz (x′-y′ plane) and My (x′-z′ plane) offset along different axes', () => {
+    const mz = memberDiagramRibbon(a, b, xs, ys, 'Mz', 0.1)
+    const my = memberDiagramRibbon(a, b, xs, ys, 'My', 0.1)
+    // for a member along +x: y′ = global +y, z′ = global +z
+    expect(sub(mz.curve[2], mz.base[2])[1]).not.toBeCloseTo(0, 6)  // Mz moves in y
+    expect(sub(my.curve[2], my.base[2])[2]).not.toBeCloseTo(0, 6)  // My moves in z
+    expect(sub(mz.curve[2], mz.base[2])[2]).toBeCloseTo(0, 9)
+    expect(sub(my.curve[2], my.base[2])[1]).toBeCloseTo(0, 9)
+  })
+
+  it('fill has two triangles (18 floats) per segment', () => {
+    const { fill } = memberDiagramRibbon(a, b, xs, ys, 'Mz', 0.1)
+    expect(fill).toHaveLength((xs.length - 1) * 18)
+  })
+
+  it('works for a vertical column (offset stays perpendicular)', () => {
+    const c: V3 = [2, 0, 1], d: V3 = [2, 3, 1]
+    const cs = [0, 1.5, 3], cy = [10, 0, -10]
+    const dir = sub(d, c)
+    const { base, curve } = memberDiagramRibbon(c, d, cs, cy, 'Mz', 0.05)
+    curve.forEach((p, i) => expect(dot(sub(p, base[i]), dir)).toBeCloseTo(0, 9))
+  })
+})
+
+describe('diagramScale', () => {
+  it('maps the largest |ordinate| to the target offset', () => {
+    expect(diagramScale(40, 1.2)).toBeCloseTo(1.2 / 40, 12)
+  })
+  it('returns 0 when there is nothing to draw', () => {
+    expect(diagramScale(0, 1.2)).toBe(0)
+    expect(diagramScale(1e-12, 1.2)).toBe(0)
+  })
+
+  it('applied scale puts the peak at the target offset', () => {
+    const a: V3 = [0, 0, 0], b: V3 = [5, 0, 0]
+    const xs = [0, 2.5, 5], ys = [0, -40, 0]
+    const s = diagramScale(40, 1.2)
+    const { base, curve } = memberDiagramRibbon(a, b, xs, ys, 'Vy', s)
+    expect(Math.hypot(...[0, 1, 2].map((k) => curve[1][k] - base[1][k]))).toBeCloseTo(1.2, 9)
+  })
+})

--- a/webapp/src/engine/memberDiagram3d.ts
+++ b/webapp/src/engine/memberDiagram3d.ts
@@ -1,0 +1,69 @@
+// ─────────────────────────────────────────────────────────────────────────
+// 3D internal-force diagram ribbons (BMD / SFD / axial / torsion). Turns a
+// member's sampled internal-force arrays (from F3MemberResult) into geometry
+// that can be drawn directly on the member in the 3D view — STAAD's inline
+// force-diagram overlay. Pure + tested; the page only feeds it the member
+// endpoints, the chosen component's ordinates, and a scale.
+//
+// Offset convention (local axes from frame3d.localAxes = [x′, y′, z′]):
+//   Mz / Vy act in the x′-y′ plane → drawn offset along local y′,
+//   My / Vz act in the x′-z′ plane → drawn offset along local z′,
+//   N (axial) along y′ and T (torsion) along z′ (no natural plane).
+// For a horizontal member y′ is global-up, so the gravity BMD reads vertically;
+// for a column both transverse axes are horizontal (lateral diagrams).
+// ─────────────────────────────────────────────────────────────────────────
+import { localAxes, type V3 } from './frame3d'
+
+export type DiagramComp = 'N' | 'Vy' | 'Vz' | 'T' | 'My' | 'Mz'
+
+/** Which local transverse axis (index into [x′, y′, z′]) each component offsets along. */
+const OFFSET_AXIS: Record<DiagramComp, 1 | 2> = {
+  Mz: 1, Vy: 1, N: 1,   // local y′
+  My: 2, Vz: 2, T: 2,   // local z′
+}
+
+export interface DiagramRibbon {
+  /** Ordinate polyline: member axis + offset·value·scale at each station. */
+  curve: V3[]
+  /** Member-axis baseline at the same stations (the zero line). */
+  base: V3[]
+  /** Triangulated strip positions (flat number[], two triangles per segment). */
+  fill: number[]
+}
+
+/**
+ * Build the 3D ribbon for one force component along a member a→b. `xs` are the
+ * stations in metres (0…L) and `ys` the ordinates (kN or kN·m). `scale` is the
+ * transverse offset in metres per force unit.
+ */
+export function memberDiagramRibbon(
+  a: V3, b: V3, xs: number[], ys: number[], comp: DiagramComp, scale: number,
+): DiagramRibbon {
+  const dir: V3 = [b[0] - a[0], b[1] - a[1], b[2] - a[2]]
+  const L = Math.hypot(...dir) || 1
+  const off = localAxes(dir)[OFFSET_AXIS[comp]]   // unit transverse axis, global coords
+
+  const base: V3[] = []
+  const curve: V3[] = []
+  for (let i = 0; i < xs.length; i++) {
+    const t = xs[i] / L                            // station fraction 0…1
+    const p: V3 = [a[0] + dir[0] * t, a[1] + dir[1] * t, a[2] + dir[2] * t]
+    base.push(p)
+    const d = (ys[i] ?? 0) * scale
+    curve.push([p[0] + off[0] * d, p[1] + off[1] * d, p[2] + off[2] * d])
+  }
+
+  // Triangulate the strip: (base[i], base[i+1], curve[i+1]) + (base[i], curve[i+1], curve[i]).
+  const fill: number[] = []
+  for (let i = 0; i < xs.length - 1; i++) {
+    const b0 = base[i], b1 = base[i + 1], c0 = curve[i], c1 = curve[i + 1]
+    fill.push(...b0, ...b1, ...c1, ...b0, ...c1, ...c0)
+  }
+  return { base, curve, fill }
+}
+
+/** Symmetric scale mapping the largest |ordinate| to ~`target` metres of offset.
+ *  Returns 0 when everything is ~0 (nothing to draw). */
+export function diagramScale(maxAbs: number, target: number): number {
+  return maxAbs > 1e-9 ? target / maxAbs : 0
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -6,7 +6,8 @@ import * as THREE from 'three'
 import { generateGridModel, removeElements, removeNode, buildGravityLoads, splitSharedSections } from '../engine/modelBuilder'
 import type { StructuralModel, Member, Plate, RectSection, ModelLoad, MemberRole, MemberReleases, NodeSupport, SupportFixity } from '../engine/model'
 import { distributePanel } from '../engine/tributary'
-import { type F3Analysis } from '../engine/frame3d'
+import { type F3Analysis, type F3MemberResult, type V3 } from '../engine/frame3d'
+import { memberDiagramRibbon, diagramScale, type DiagramComp } from '../engine/memberDiagram3d'
 import { validateMesh, hasMeshErrors } from '../engine/meshValidation'
 import { type ModalResult } from '../engine/modal'
 import { computeResponseSpectrum, type ResponseSpectrumResult } from '../engine/responseSpectrum'
@@ -305,6 +306,37 @@ function ModeShapePlayer({ shape, nodePos, members, amp }: {
   })
 
   return <primitive object={group} />
+}
+
+// ── Member force diagrams (BMD / SFD / axial / torsion) ─────────────────────
+const DIAG_COLOR: Record<DiagramComp, string> = {
+  Mz: '#d62728', My: '#ea580c', Vy: '#1f77b4', Vz: '#0e7490', N: '#7c3aed', T: '#b45309',
+}
+const DIAG_LABEL: Record<DiagramComp, string> = {
+  Mz: 'Mz', My: 'My', Vy: 'Vy', Vz: 'Vz', N: 'N', T: 'T',
+}
+
+/** Inline 3D internal-force diagram drawn directly on one member. */
+function MemberForceDiagram3D({ a, b, xs, ys, comp, scale }: {
+  a: V3; b: V3; xs: number[]; ys: number[]; comp: DiagramComp; scale: number
+}) {
+  const { fillGeo, curveGeo } = useMemo(() => {
+    const r = memberDiagramRibbon(a, b, xs, ys, comp, scale)
+    const fillGeo = new THREE.BufferGeometry()
+    fillGeo.setAttribute('position', new THREE.Float32BufferAttribute(r.fill, 3))
+    const curveGeo = new THREE.BufferGeometry().setFromPoints(
+      r.curve.map((p) => new THREE.Vector3(p[0], p[1], p[2])))
+    return { fillGeo, curveGeo }
+  }, [a, b, xs, ys, comp, scale])
+  const color = DIAG_COLOR[comp]
+  return (
+    <group>
+      <mesh geometry={fillGeo}>
+        <meshBasicMaterial color={color} transparent opacity={0.25} side={THREE.DoubleSide} depthWrite={false} />
+      </mesh>
+      <primitive object={new THREE.Line(curveGeo, new THREE.LineBasicMaterial({ color }))} />
+    </group>
+  )
 }
 
 // ── Load glyphs ─────────────────────────────────────────────────────────────
@@ -650,6 +682,8 @@ export default function ModelSpace() {
   const [modal, setModal] = useState<ModalResult | null>(null)
   const [modeShapeIdx, setModeShapeIdx] = useState<number | null>(null)
   const [modeAmp, setModeAmp] = useState(1.5)
+  const [forceDiag, setForceDiag] = useState<DiagramComp | null>(null)   // inline 3D BMD/SFD overlay
+  const [forceDiagScale, setForceDiagScale] = useState(1)                // user offset multiplier
   const [rsa, setRsa] = useState<ResponseSpectrumResult | null>(null)
   const [nModes, setNModes] = useState(12)
   const [design, setDesign] = useState<StructureDesign | null>(null)
@@ -1064,6 +1098,18 @@ export default function ModelSpace() {
     return { min: [Math.min(...xs), Math.min(...ys), Math.min(...zs)] as [number, number, number], max: [Math.max(...xs), Math.max(...ys), Math.max(...zs)] as [number, number, number] }
   }, [model])
 
+  // Auto-scale for the inline 3D force diagram: the model-wide peak |ordinate| of
+  // the chosen component maps to ~10% of the model's largest dimension (× user mult).
+  const forceDiagInfo = useMemo(() => {
+    if (!forceDiag || !govRes || !modelBox) return null
+    const byId = new Map<string, F3MemberResult>(govRes.members.map((m) => [m.id, m]))
+    let maxAbs = 0
+    for (const m of govRes.members) for (const v of m[forceDiag]) maxAbs = Math.max(maxAbs, Math.abs(v))
+    const span = Math.max(modelBox.max[0] - modelBox.min[0], modelBox.max[1] - modelBox.min[1], modelBox.max[2] - modelBox.min[2], 1)
+    const scale = diagramScale(maxAbs, span * 0.1 * forceDiagScale)
+    return { byId, scale, maxAbs }
+  }, [forceDiag, forceDiagScale, govRes, modelBox])
+
   const selMember: Member | undefined = model?.members.find((m) => m.id === selected)
   const selPlate: Plate | undefined = model?.plates.find((p) => p.id === selected)
 
@@ -1232,6 +1278,14 @@ export default function ModelSpace() {
                   return <Wall3D key={w.id} tA={tA} tB={tB} bA={bA} bB={bB} shear={w.shearWall} />
                 })}
                 {showLoads && <Loads3D model={model} nodePos={nodePos} />}
+                {forceDiag && forceDiagInfo && forceDiagInfo.scale > 0 && model.members.map((m) => {
+                  const mr = forceDiagInfo.byId.get(m.id)
+                  const a = nodePos.get(m.i), bb = nodePos.get(m.j)
+                  if (!mr || !a || !bb) return null
+                  return <MemberForceDiagram3D key={`fd-${m.id}`}
+                    a={[a.x, a.y, a.z]} b={[bb.x, bb.y, bb.z]}
+                    xs={mr.xs} ys={mr[forceDiag]} comp={forceDiag} scale={forceDiagInfo.scale} />
+                })}
                 {modal && modeShapeIdx !== null && modal.modes[modeShapeIdx] && (
                   <ModeShapePlayer
                     shape={modal.modes[modeShapeIdx].shape}
@@ -1281,6 +1335,30 @@ export default function ModelSpace() {
               </span>
             )}
           </label>
+          {govRes && (
+            <div className="no-print mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-slate-600">
+              <span className="font-medium">Force diagram:</span>
+              <button type="button" onClick={() => setForceDiag(null)}
+                className={`rounded px-1.5 py-0.5 font-semibold ${forceDiag === null ? 'bg-slate-200 text-slate-700' : 'text-slate-400 hover:text-slate-600'}`}>off</button>
+              {(['N', 'Vy', 'Vz', 'My', 'Mz', 'T'] as DiagramComp[]).map((c) => (
+                <button key={c} type="button" onClick={() => setForceDiag(c)}
+                  title={`Draw ${c} on every member (governing combo)`}
+                  className="rounded px-1.5 py-0.5 font-semibold transition"
+                  style={forceDiag === c
+                    ? { background: DIAG_COLOR[c], color: '#fff' }
+                    : { color: DIAG_COLOR[c] }}>
+                  {DIAG_LABEL[c]}
+                </button>
+              ))}
+              {forceDiag && (
+                <label className="ml-1 inline-flex items-center gap-1">
+                  <span className="text-slate-400">scale</span>
+                  <input type="range" min={0.3} max={3} step={0.1} value={forceDiagScale}
+                    onChange={(e) => setForceDiagScale(Number(e.target.value))} className="h-1 w-20" />
+                </label>
+              )}
+            </div>
+          )}
         </div>
 
         {/* RIGHT — tabbed controls */}
@@ -2136,10 +2214,13 @@ export default function ModelSpace() {
                     return (
                       <div className="mt-2 space-y-2">
                         <Row label="Forces (governing)" value={`M ${f1(mr.Mmax)} kN·m`}
-                          sub={`V ${f1(mr.Vmax)} · N ${f1(mr.Nmax)} kN`} />
-                        <Diagram xs={mr.xs} ys={mr.Mz} title="Mz" unit="kN·m" color="#d62728" decimals={1} />
-                        <Diagram xs={mr.xs} ys={mr.Vy} title="Vy" unit="kN" color="#1f77b4" decimals={1} />
-                        <Diagram xs={mr.xs} ys={mr.N} title="N (+tension)" unit="kN" color="#7c3aed" decimals={1} />
+                          sub={`V ${f1(mr.Vmax)} · N ${f1(mr.Nmax)} · T ${f1(mr.Tmax)} kN`} />
+                        <Diagram xs={mr.xs} ys={mr.Mz} title="Mz — strong-axis moment" unit="kN·m" color="#d62728" decimals={1} />
+                        <Diagram xs={mr.xs} ys={mr.My} title="My — weak-axis moment" unit="kN·m" color="#ea580c" decimals={1} />
+                        <Diagram xs={mr.xs} ys={mr.Vy} title="Vy — shear (x′-y′)" unit="kN" color="#1f77b4" decimals={1} />
+                        <Diagram xs={mr.xs} ys={mr.Vz} title="Vz — shear (x′-z′)" unit="kN" color="#0e7490" decimals={1} />
+                        <Diagram xs={mr.xs} ys={mr.N} title="N — axial (+tension)" unit="kN" color="#7c3aed" decimals={1} />
+                        <Diagram xs={mr.xs} ys={mr.T} title="T — torsion" unit="kN·m" color="#b45309" decimals={1} />
                       </div>
                     )
                   })()}


### PR DESCRIPTION
First phase of Tier 2 (STAAD-parity). Completes member internal-force visualization in the 3D Model Space.

## What was missing
- The member inspector showed only **3 of 6** internal-force components (Mz, Vy, N) — no weak-axis moment, out-of-plane shear, or torsion, which matter for columns under biaxial bending.
- There was **no inline 3D force-diagram overlay** (STAAD's signature "diagrams drawn on each member" visual), even though the per-member `xs[]`/`My[]`/`Mz[]`/`Vy[]`/`Vz[]`/`N[]`/`T[]` arrays already existed on `F3MemberResult`.

## Changes
**Inspector — all six components.** Added `My`, `Vz`, `T` diagrams next to `Mz`, `Vy`, `N`, with clearer titles (strong/weak-axis moment, shear plane, axial, torsion). The forces summary row now also reports `Tmax`.

**Inline 3D overlay (the killer visual).**
- New **pure, tested** geometry engine `engine/memberDiagram3d.ts`:
  - `memberDiagramRibbon(a, b, xs, ys, comp, scale)` builds the ribbon (baseline + ordinate polyline + triangulated fill) offset along the correct local transverse axis — `Mz/Vy → y′`, `My/Vz → z′`, `N/T` paired — reusing `frame3d.localAxes` (now exported) as the single source of truth.
  - `diagramScale(maxAbs, target)` for symmetric auto-scaling.
- `MemberForceDiagram3D` canvas component renders fill mesh + curve line per member.
- A component picker (`N / Vy / Vz / My / Mz / T`) + scale slider sit under the canvas; the chosen component is drawn on **every** member for the governing combo, auto-scaled so the model-wide peak maps to ~10% of the model size.

## Verification
- [x] `npm test` — **612/612** (11 new tests for the diagram geometry: perpendicularity to the member axis, linear scaling, correct plane per component, fill triangulation, vertical-column case)
- [x] `npx tsc -b` — clean
- [x] `vite build` — clean

_3D-canvas pixels aren't a reliable check (per `CLAUDE.md`'s WebGL caveat), so the diagram math is verified through the pure unit-tested module rather than screenshots._

## Tier 2 remaining
#5 K-factor · #6 non-W steel sections in the 3D model · #7 DG11 floor vibration · #8 thermal loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_