### PR TITLE
feat: effective length factor K from alignment chart — Tier 2 #5

### DIFF
--- a/webapp/src/engine/effectiveLength.test.ts
+++ b/webapp/src/engine/effectiveLength.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import { effectiveLengthK, columnKFactors, G_FIXED, G_PINNED } from './effectiveLength'
+import { emptyModel, type RectSection, type StructuralModel } from './model'
+
+describe('effectiveLengthK — Dumonteil fit to the AISC alignment chart', () => {
+  it('braced K stays in [0.5, 1.0]', () => {
+    for (const ga of [0, 1, 3, 10]) for (const gb of [0, 1, 3, 10]) {
+      const k = effectiveLengthK(ga, gb, 'braced')
+      expect(k).toBeGreaterThanOrEqual(0.5)
+      expect(k).toBeLessThanOrEqual(1.0)
+    }
+  })
+
+  it('sway K is ≥ 1.0 and grows with G', () => {
+    expect(effectiveLengthK(0, 0, 'sway')).toBeGreaterThanOrEqual(1.0)
+    expect(effectiveLengthK(10, 10, 'sway')).toBeGreaterThan(effectiveLengthK(1, 1, 'sway'))
+  })
+
+  // textbook anchor points (G = 1 ≈ fixed, G = 10 ≈ pinned per AISC)
+  it('matches known chart values', () => {
+    expect(effectiveLengthK(1, 1, 'braced')).toBeCloseTo(0.776, 2)   // fixed-fixed braced
+    expect(effectiveLengthK(1, 1, 'sway')).toBeCloseTo(1.342, 2)     // fixed-fixed sway
+    expect(effectiveLengthK(10, 10, 'sway')).toBeCloseTo(3.0, 2)     // pinned-pinned sway (G=10 cap)
+    expect(effectiveLengthK(0, 0, 'braced')).toBeCloseTo(0.5, 2)     // theoretical fixed-fixed
+  })
+
+  it('is symmetric in GA, GB', () => {
+    expect(effectiveLengthK(2, 7, 'sway')).toBeCloseTo(effectiveLengthK(7, 2, 'sway'), 12)
+    expect(effectiveLengthK(2, 7, 'braced')).toBeCloseTo(effectiveLengthK(7, 2, 'braced'), 12)
+  })
+})
+
+// single-bay single-storey portal in the X direction, fixed bases
+const colSec: RectSection = { id: 'C', name: '400×400', b: 400, h: 400, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
+const beamSec: RectSection = { id: 'B', name: '300×500', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
+const portal: StructuralModel = {
+  ...emptyModel('portal'),
+  nodes: [
+    { id: 'b1', x: 0, y: 0, z: 0 }, { id: 't1', x: 0, y: 3, z: 0 },
+    { id: 'b2', x: 6, y: 0, z: 0 }, { id: 't2', x: 6, y: 3, z: 0 },
+  ],
+  sections: [colSec, beamSec],
+  members: [
+    { id: 'c1', i: 'b1', j: 't1', role: 'column', section: 'C' },
+    { id: 'c2', i: 'b2', j: 't2', role: 'column', section: 'C' },
+    { id: 'bm', i: 't1', j: 't2', role: 'beam', section: 'B' },
+  ],
+  supports: [{ node: 'b1', fixity: 'fixed' }, { node: 'b2', fixity: 'fixed' }],
+}
+
+describe('columnKFactors — portal frame', () => {
+  it('returns one entry per column (beams excluded)', () => {
+    const ks = columnKFactors(portal)
+    expect(ks.map((k) => k.memberId).sort()).toEqual(['c1', 'c2'])
+  })
+
+  it('fixed base end takes G = 1.0', () => {
+    const c1 = columnKFactors(portal).find((k) => k.memberId === 'c1')!
+    // end i is the base (b1) → fixed
+    expect(c1.Gi.x).toBeCloseTo(G_FIXED, 9)
+    expect(c1.Gi.z).toBeCloseTo(G_FIXED, 9)
+  })
+
+  it('top-joint X-sway G = Σ(EI/L)col / Σ(EI/L)beam (hand value 1.365)', () => {
+    const c1 = columnKFactors(portal).find((k) => k.memberId === 'c1')!
+    // col Iy = 400⁴/12 over L=3; beam Iz = 300·500³/12 over L=6; E cancels
+    expect(c1.Gj.x).toBeCloseTo(1.3653, 3)
+  })
+
+  it('top joint has no beam in Z ⇒ G = 10 (pinned) for Z-sway', () => {
+    const c1 = columnKFactors(portal).find((k) => k.memberId === 'c1')!
+    expect(c1.Gj.z).toBeCloseTo(G_PINNED, 9)
+  })
+
+  it('computes K from the end G-factors (hand values)', () => {
+    const c1 = columnKFactors(portal).find((k) => k.memberId === 'c1')!
+    expect(c1.Kx.sway).toBeCloseTo(1.393, 2)
+    expect(c1.Kx.braced).toBeCloseTo(0.796, 2)
+    expect(c1.Kz.sway).toBeCloseTo(1.910, 2)
+    expect(c1.Kz.braced).toBeCloseTo(0.864, 2)
+  })
+})

--- a/webapp/src/engine/effectiveLength.ts
+++ b/webapp/src/engine/effectiveLength.ts
@@ -1,0 +1,125 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Effective length factor K from the AISC alignment chart (Commentary C-C2 /
+// NSCP 2015 §503). Each column end has a stiffness ratio
+//   G = Σ(E·I/L) of columns / Σ(E·I/L) of beams  rigidly framing into the joint,
+// and K is read from the braced (sidesway-inhibited) or sway (sidesway-
+// uninhibited) chart. We use Dumonteil's closed-form fits to those charts
+// (P. Dumonteil, "Simple Equations for Effective Length Factors", AISC
+// Engineering Journal, 1992) — accurate to within chart-reading precision and
+// free of the transcendental singularities of the exact equations.
+//
+// Recommended end G for idealised supports (AISC Commentary):
+//   fixed base  G ≈ 1.0   (theoretical 0, but no base is perfectly rigid)
+//   pinned base G ≈ 10    (theoretical ∞)
+// Stiffness ratios are dimensionless, so E·I/L may be carried in any consistent
+// units (here MPa·mm⁴·m⁻¹); the units cancel in G.
+// ─────────────────────────────────────────────────────────────────────────
+import type { StructuralModel } from './model'
+import { modelToFrame3D } from './modelBridge'
+
+export type SwayCase = 'braced' | 'sway'
+
+/** AISC practical end-restraint G for a column end sitting on a support. */
+export const G_FIXED = 1.0
+export const G_PINNED = 10.0
+
+/**
+ * Effective length factor K for a column with end stiffness ratios GA, GB.
+ * Dumonteil's closed-form fit to the alignment chart:
+ *   braced: K = (3·GA·GB + 1.4(GA+GB) + 0.64) / (3·GA·GB + 2(GA+GB) + 1.28)
+ *   sway:   K = √[ (1.6·GA·GB + 4(GA+GB) + 7.5) / (GA+GB + 7.5) ]
+ */
+export function effectiveLengthK(GA: number, GB: number, sway: SwayCase): number {
+  const a = Math.min(Math.max(GA, 0), G_PINNED)
+  const b = Math.min(Math.max(GB, 0), G_PINNED)
+  const sum = a + b, prod = a * b
+  if (sway === 'braced') {
+    return (3 * prod + 1.4 * sum + 0.64) / (3 * prod + 2 * sum + 1.28)
+  }
+  return Math.sqrt((1.6 * prod + 4 * sum + 7.5) / (sum + 7.5))
+}
+
+interface KMember { id: string; i: string; j: string; ix: number; iy: number; iz: number; jx: number; jy: number; jz: number; E: number; Iy: number; Iz: number; L: number }
+type Dir = 'col' | 'xbeam' | 'zbeam' | 'other'
+
+/** Classify a member by its dominant geometric direction. */
+function classify(m: KMember): Dir {
+  const dx = Math.abs(m.jx - m.ix), dy = Math.abs(m.jy - m.iy), dz = Math.abs(m.jz - m.iz)
+  if (dy >= dx && dy >= dz) return 'col'
+  if (dx >= dz) return 'xbeam'
+  return 'zbeam'
+}
+
+export interface ColumnK {
+  memberId: string
+  /** G at end i / end j, for X-sway and Z-sway respectively. */
+  Gi: { x: number; z: number }
+  Gj: { x: number; z: number }
+  /** K resisting sway in the global-X direction (column bends about Iy). */
+  Kx: { braced: number; sway: number }
+  /** K resisting sway in the global-Z direction (column bends about Iz). */
+  Kz: { braced: number; sway: number }
+}
+
+/**
+ * Compute the alignment-chart G-factors and effective length factors K for every
+ * column in the model, for both horizontal sway directions.
+ *
+ * For X-sway the column resists with Iy and the restraining beams run in X
+ * (their gravity-plane stiffness Iz); for Z-sway the column uses Iz and the
+ * beams run in Z. A column end landing on a support takes the recommended
+ * support G (fixed → 1, pinned/roller/spring → 10, since translational springs
+ * give no rotational restraint). A joint with no restraining beams in a
+ * direction is treated as pinned (G = 10) for that direction.
+ */
+export function columnKFactors(model: StructuralModel): ColumnK[] {
+  const br = modelToFrame3D(model)
+  const pos = new Map(model.nodes.map((n) => [n.id, n]))
+  const realIds = new Set(model.members.map((m) => m.id))
+  const f3ById = new Map(br.members.map((m) => [m.id, m]))
+
+  const mems: (KMember & { dir: Dir })[] = []
+  for (const m of model.members) {
+    const f3 = f3ById.get(m.id), a = pos.get(m.i), b = pos.get(m.j)
+    if (!f3 || !a || !b) continue
+    const L = Math.hypot(b.x - a.x, b.y - a.y, b.z - a.z) || 1
+    const km: KMember = { id: m.id, i: m.i, j: m.j, ix: a.x, iy: a.y, iz: a.z, jx: b.x, jy: b.y, jz: b.z, E: f3.E, Iy: f3.Iy, Iz: f3.Iz, L }
+    mems.push({ ...km, dir: classify(km) })
+  }
+
+  // members framing into each node
+  const atNode = new Map<string, (KMember & { dir: Dir })[]>()
+  const push = (id: string, m: KMember & { dir: Dir }) => {
+    const arr = atNode.get(id); if (arr) arr.push(m); else atNode.set(id, [m])
+  }
+  for (const m of mems) { push(m.i, m); push(m.j, m) }
+
+  const supG = new Map<string, number>()
+  for (const s of model.supports) supG.set(s.node, s.fixity === 'fixed' ? G_FIXED : G_PINNED)
+
+  /** G at a joint for the given sway direction. */
+  const gAt = (nodeId: string, dir: 'x' | 'z'): number => {
+    if (supG.has(nodeId)) return supG.get(nodeId)!
+    const arr = atNode.get(nodeId) ?? []
+    let col = 0, beam = 0
+    for (const m of arr) {
+      if (m.dir === 'col') col += (m.E * (dir === 'x' ? m.Iy : m.Iz)) / m.L
+      else if (dir === 'x' && m.dir === 'xbeam') beam += (m.E * m.Iz) / m.L
+      else if (dir === 'z' && m.dir === 'zbeam') beam += (m.E * m.Iz) / m.L
+    }
+    return beam > 1e-12 ? col / beam : G_PINNED
+  }
+
+  const out: ColumnK[] = []
+  for (const m of mems) {
+    if (m.dir !== 'col' || !realIds.has(m.id)) continue
+    const Gi = { x: gAt(m.i, 'x'), z: gAt(m.i, 'z') }
+    const Gj = { x: gAt(m.j, 'x'), z: gAt(m.j, 'z') }
+    out.push({
+      memberId: m.id, Gi, Gj,
+      Kx: { braced: effectiveLengthK(Gi.x, Gj.x, 'braced'), sway: effectiveLengthK(Gi.x, Gj.x, 'sway') },
+      Kz: { braced: effectiveLengthK(Gi.z, Gj.z, 'braced'), sway: effectiveLengthK(Gi.z, Gj.z, 'sway') },
+    })
+  }
+  return out
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -21,6 +21,7 @@ import { TABLE_204_1, TABLE_204_2, sdlItemKPa, sdlTotal, type SdlItem } from '..
 import { TABLE_205_1, TABLE_206 } from '../engine/liveLoads'
 import type { ConcreteClass } from '../engine/quantities'
 import { computeSeismic, type SeismicResult, type DriftRow } from '../engine/seismic'
+import { columnKFactors, type ColumnK } from '../engine/effectiveLength'
 import { computeWind, type WindResult } from '../engine/wind'
 import { ReportControls } from '../components/ReportControls'
 import { WorkedSolution } from '../components/WorkedSolution'
@@ -1112,6 +1113,12 @@ export default function ModelSpace() {
 
   const selMember: Member | undefined = model?.members.find((m) => m.id === selected)
   const selPlate: Plate | undefined = model?.plates.find((p) => p.id === selected)
+
+  // Alignment-chart K-factors per column (AISC Commentary C-C2), keyed by member.
+  const columnKs = useMemo(() => {
+    if (!model) return new Map<string, ColumnK>()
+    return new Map(columnKFactors(model).map((k) => [k.memberId, k]))
+  }, [model])
 
   // immediate grid-neighbour base supports (share an x- or z-line and are the
   // nearest column either side, nothing between) — the only sensible partners
@@ -2221,6 +2228,21 @@ export default function ModelSpace() {
                         <Diagram xs={mr.xs} ys={mr.Vz} title="Vz — shear (x′-z′)" unit="kN" color="#0e7490" decimals={1} />
                         <Diagram xs={mr.xs} ys={mr.N} title="N — axial (+tension)" unit="kN" color="#7c3aed" decimals={1} />
                         <Diagram xs={mr.xs} ys={mr.T} title="T — torsion" unit="kN·m" color="#b45309" decimals={1} />
+                      </div>
+                    )
+                  })()}
+                  {selMember.role === 'column' && columnKs.get(selMember.id) && (() => {
+                    const k = columnKs.get(selMember.id)!
+                    return (
+                      <div className="mt-3 rounded-lg border border-slate-200 bg-slate-50 p-2">
+                        <p className="mb-1 text-[11px] font-semibold text-[#0056b3]">Effective length K — AISC alignment chart (C-C2)</p>
+                        <Row label="K — X-sway" value={`sway ${f2(k.Kx.sway)} · braced ${f2(k.Kx.braced)}`}
+                          sub={`G: ${f2(k.Gi.x)} (i) · ${f2(k.Gj.x)} (j)`} />
+                        <Row label="K — Z-sway" value={`sway ${f2(k.Kz.sway)} · braced ${f2(k.Kz.braced)}`}
+                          sub={`G: ${f2(k.Gi.z)} (i) · ${f2(k.Gj.z)} (j)`} />
+                        <p className="mt-1 text-[10px] text-slate-400">
+                          G = Σ(EI/L)<sub>col</sub> / Σ(EI/L)<sub>beam</sub> at each joint; fixed base G = 1.0, pinned/no-beam G = 10.
+                        </p>
                       </div>
                     )
                   })()}


### PR DESCRIPTION
Second phase of Tier 2. Column slenderness previously took the effective length factor **K as an assumed input** (`SlendernessInput.k`); this computes it from the **AISC alignment chart** (Commentary C-C2 / NSCP §503) using stiffness ratios already implied by the model geometry and sections.

## Engine — `engine/effectiveLength.ts` (pure, +9 tests)
- **`effectiveLengthK(GA, GB, sway)`** — Dumonteil's closed-form fit to the braced and sway alignment charts:
  - braced: `K = (3·GA·GB + 1.4(GA+GB) + 0.64) / (3·GA·GB + 2(GA+GB) + 1.28)`
  - sway: `K = √[(1.6·GA·GB + 4(GA+GB) + 7.5) / (GA+GB + 7.5)]`
  - Accurate to chart-reading precision and free of the transcendental singularities of the exact equations.
- **`columnKFactors(model)`** — for each column, the **G-factor at each end** and **K for both horizontal sway directions**:
  - `G = Σ(EI/L)col / Σ(EI/L)beam` at the joint;
  - column **Iy** resists X-sway, **Iz** resists Z-sway; restraining beams use their gravity-plane stiffness;
  - fixed base → G = 1.0; pinned/roller/spring or a joint with no restraining beam → G = 10 (translational springs give no rotational restraint).

## UI
A selected **column** in the Model Space inspector now shows **K (sway & braced) for both directions** with the underlying end G-factors. It's geometry-based, so it displays without needing an analysis run.

## Verification
- [x] Hand-computed **portal frame** in the suite: top-joint X-sway `G = 1.365`, `Kx,sway = 1.393`, `Kx,braced = 0.796`, `Kz,sway = 1.910` (no beam in Z → G = 10).
- [x] Chart anchor points: fixed-fixed braced `0.776`, fixed-fixed sway `1.342`, pinned-pinned sway `3.0`.
- [x] `npm test` **621/621** · `npx tsc -b` clean · `vite build` clean.

## Notes / future
- Far-end beam stiffness modifiers (AISC Commentary refinements for pinned/fixed far ends) are not applied — standard textbook G. Could be a later refinement.
- K is now *computed and surfaced*; feeding it into the column **design** slenderness (moment magnification) is a natural follow-on but out of scope here.

## Tier 2 remaining
#6 non-W steel sections in the 3D model · #7 DG11 floor vibration · #8 thermal loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_