### PR TITLE
feat: non-W steel sections in the 3D model — Tier 2 #6

### DIFF
--- a/webapp/src/engine/aiscSections.test.ts
+++ b/webapp/src/engine/aiscSections.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { AISC_SHAPES, shapesOf, shapeByName, effectiveSection, doubleAngle, W_SORTED, nextHeavierW, nextLighterW } from './aiscSections'
+import { AISC_SHAPES, shapesOf, shapeByName, effectiveSection, doubleAngle, W_SORTED, nextHeavierW, nextLighterW, sectionBoundingBox, FAMILIES } from './aiscSections'
 
 describe('AISC section library', () => {
   it('every shape has area + radii and a unique name', () => {
@@ -95,5 +95,30 @@ describe('W-shape optimizer helpers', () => {
     const heavier = nextHeavierW(name)!
     const back = nextLighterW(heavier.name)!
     expect(back.name).toBe(name)
+  })
+
+  describe('sectionBoundingBox — positive box for every family', () => {
+    it('returns a finite positive b×h for one shape of every family', () => {
+      for (const { id } of FAMILIES) {
+        const s = shapesOf(id)[0]
+        expect(s, `no shapes for family ${id}`).toBeTruthy()
+        const box = sectionBoundingBox(s)
+        expect(box.b).toBeGreaterThan(0)
+        expect(box.h).toBeGreaterThan(0)
+        expect(Number.isFinite(box.b) && Number.isFinite(box.h)).toBe(true)
+      }
+    })
+
+    it('uses bf×d for W, b×h for HSS, D×D for pipe, legs for angles', () => {
+      const w = shapeByName('W310x79')!
+      expect(sectionBoundingBox(w)).toEqual({ b: w.bf!, h: w.d! })
+      const hss = shapesOf('HSS')[0]
+      expect(sectionBoundingBox(hss)).toEqual({ b: hss.b!, h: hss.h! })
+      const pipe = shapesOf('PIPE')[0]
+      expect(sectionBoundingBox(pipe)).toEqual({ b: pipe.D!, h: pipe.D! })
+      const ang = shapesOf('L')[0]
+      const box = sectionBoundingBox(ang)
+      expect(box.h).toBeGreaterThanOrEqual(box.b)   // longer leg is the depth
+    })
   })
 })

--- a/webapp/src/engine/aiscSections.ts
+++ b/webapp/src/engine/aiscSections.ts
@@ -495,6 +495,20 @@ export const FAMILIES: { id: SectionFamily; label: string }[] = [
 export const shapesOf   = (family: SectionFamily) => AISC_SHAPES.filter((s) => s.family === family)
 export const shapeByName = (name: string) => AISC_SHAPES.find((s) => s.name === name)
 
+/** Overall cross-section bounding box {b (width), h (depth)} in mm, per family.
+ *  Used as the RectSection b×h carried alongside a steel member (self-weight uses
+ *  the true area, but the box drives fallbacks, quantities and labelling). */
+export function sectionBoundingBox(s: AiscShape): { b: number; h: number } {
+  if (s.family === 'HSS') return { b: s.b ?? 100, h: s.h ?? 100 }
+  if (s.family === 'PIPE') return { b: s.D ?? 100, h: s.D ?? 100 }
+  if (s.family === 'L') {
+    const legV = Math.max(s.leg1 ?? 50, s.leg2 ?? 50), legH = Math.min(s.leg1 ?? 50, s.leg2 ?? 50)
+    return { b: legH, h: legV }
+  }
+  // W / WT / C
+  return { b: s.bf ?? 100, h: s.d ?? 100 }
+}
+
 /** Effective section used by a member: single shape or back-to-back DOUBLE ANGLE (2L) with a gusset gap. */
 export interface EffectiveSection {
   label: string

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -40,15 +40,14 @@ import { DimBelow, DimSide } from '../components/dims'
 import { HintButton, SeismicHint, WindHint } from '../components/LoadHints'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { FitView } from '../components/FitView'
-import { shapeByName, shapesOf, effectiveSection } from '../engine/aiscSections'
+import { shapeByName, shapesOf, effectiveSection, sectionBoundingBox, FAMILIES, type SectionFamily } from '../engine/aiscSections'
 import { buildSectionShapes } from '../lib/sectionShapes3d'
+import { SectionShape } from '../components/SectionShape'
 import { f1, f2 } from '../lib/format'
 
 const AUTOSAVE_KEY = 'model-space-autosave'
 const INPUTS_KEY = 'model-space-inputs'
 
-// AISC W-shape picker options for the steel material path.
-const W_SHAPE_OPTS: [string, string][] = shapesOf('W').map((s) => [s.name, s.name])
 
 /** The design inputs persisted alongside the autosaved model so a reload keeps
  *  the Geometry/Properties/Loading/etc. fields consistent with the 3D model
@@ -642,6 +641,9 @@ export default function ModelSpace() {
   const [gammaC, setGammaC] = useState(n('gammaC', 24))            // concrete unit weight, kN/m³
   // Material: 'concrete' (RC) or 'steel' (AISC W-shapes) for the frame members.
   const [material, setMaterial] = useState<'concrete' | 'steel'>((si.material as 'concrete' | 'steel') ?? 'concrete')
+  const [colFam, setColFam] = useState<SectionFamily>((s('colFam', 'W')) as SectionFamily)
+  const [girFam, setGirFam] = useState<SectionFamily>((s('girFam', 'W')) as SectionFamily)
+  const [beaFam, setBeaFam] = useState<SectionFamily>((s('beaFam', 'W')) as SectionFamily)
   const [colShape, setColShape] = useState(s('colShape', 'W310x79'))
   const [girShape, setGirShape] = useState(s('girShape', 'W360x51'))
   const [beaShape, setBeaShape] = useState(s('beaShape', 'W310x38.7'))
@@ -738,7 +740,7 @@ export default function ModelSpace() {
         qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs,
         Vw, expo, Kzt, wDirs, assembly, pDelta, tryBars,
         concreteClass, prices, planSel,
-        material, colShape, girShape, beaShape, steelFy, steelFu,
+        material, colFam, girFam, beaFam, colShape, girShape, beaShape, steelFy, steelFu,
       }))
     } catch { /* quota — ignore */ }
   }, [baysX, baysZ, storeyH, colB, colH, girB, girH, beaB, beaH,
@@ -746,7 +748,7 @@ export default function ModelSpace() {
     qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs,
     Vw, expo, Kzt, wDirs, assembly, pDelta, tryBars,
     concreteClass, prices, planSel,
-    material, colShape, girShape, beaShape, steelFy, steelFu])
+    material, colFam, girFam, beaFam, colShape, girShape, beaShape, steelFy, steelFu])
 
   const save = (m: StructuralModel | null) => {
     setModel(m)
@@ -1065,8 +1067,8 @@ export default function ModelSpace() {
     // material/shape so the bridge, design pipeline and 3D extrusion pick it up.
     const steelRole = (shapeName: string, id: string): RectSection => {
       const sh = shapeByName(shapeName)
-      const bf = sh?.bf ?? sh?.b ?? sh?.D ?? 200, d = sh?.d ?? sh?.h ?? sh?.D ?? 300
-      return { id, name: shapeName, b: bf, h: d, ...mat, material: 'steel', shape: shapeName, steelFy, steelFu }
+      const { b, h } = sh ? sectionBoundingBox(sh) : { b: 200, h: 300 }
+      return { id, name: shapeName, b, h, ...mat, material: 'steel', shape: shapeName, steelFy, steelFu }
     }
     const steel = (matOverride ?? material) === 'steel'
     const m = generateGridModel({
@@ -1694,19 +1696,26 @@ export default function ModelSpace() {
                 </p>
               </Card>
               {material === 'steel' ? (
-                <Card title="Steel sections (AISC W)">
-                  <Pick label="Column" value={colShape} onChange={setColShape}
-                    options={W_SHAPE_OPTS} />
-                  <Pick label="Girder" value={girShape} onChange={setGirShape}
-                    options={W_SHAPE_OPTS} />
-                  <Pick label="Beam" value={beaShape} onChange={setBeaShape}
-                    options={W_SHAPE_OPTS} />
+                <Card title="Steel sections (AISC)">
+                  <Pick label="Column family" value={colFam} onChange={(v) => { const f = v as SectionFamily; setColFam(f); setColShape(shapesOf(f)[0].name) }}
+                    options={FAMILIES.map((f) => [f.id, f.label])} />
+                  <Pick label="Column shape" value={colShape} onChange={setColShape}
+                    options={shapesOf(colFam).map((sh) => [sh.name, sh.name])} />
+                  <Pick label="Girder family" value={girFam} onChange={(v) => { const f = v as SectionFamily; setGirFam(f); setGirShape(shapesOf(f)[0].name) }}
+                    options={FAMILIES.map((f) => [f.id, f.label])} />
+                  <Pick label="Girder shape" value={girShape} onChange={setGirShape}
+                    options={shapesOf(girFam).map((sh) => [sh.name, sh.name])} />
+                  <Pick label="Beam family" value={beaFam} onChange={(v) => { const f = v as SectionFamily; setBeaFam(f); setBeaShape(shapesOf(f)[0].name) }}
+                    options={FAMILIES.map((f) => [f.id, f.label])} />
+                  <Pick label="Beam shape" value={beaShape} onChange={setBeaShape}
+                    options={shapesOf(beaFam).map((sh) => [sh.name, sh.name])} />
                   <Num label="Steel Fy" unit="MPa" value={steelFy} onChange={setSteelFy} step="5" />
                   <Num label="Steel Fu" unit="MPa" value={steelFu} onChange={setSteelFu} step="5" />
                   <Num label="Slab thickness" unit="mm" value={slabThk} onChange={setSlabThk} />
                   <p className="col-span-full text-[11px] text-slate-400">
-                    Applied on the next “Generate model”. The 3D view extrudes each member's true
-                    cross-section. Concrete f′c below is still used for the base-plate bearing check.
+                    All AISC families (W/C/L/HSS/Pipe/WT) — analysis & 3D extrusion use the true section.
+                    HSS/angles suit braces. Auto-design covers W/WT flexure + axial for any family; detailed
+                    HSS/angle/channel flexure checks are not yet automated. Concrete f′c is still used for base-plate bearing.
                   </p>
                 </Card>
               ) : (
@@ -2984,9 +2993,13 @@ export default function ModelSpace() {
                       <tr key={`${c.id}-sol`}>
                         <td colSpan={9} className="bg-slate-50 px-4 py-3">
                           <div className="flex flex-wrap gap-6">
-                            {/* W-shape cross-section drawing */}
+                            {/* cross-section drawing — W/WT as flanged section, others via the universal drawer */}
                             <div className="shrink-0">
-                              <WShapeSection shape={c.shape} d={c.d} bf={c.bf} tf={c.tf} tw={c.tw} />
+                              {(() => {
+                                const sh = shapeByName(c.shape)
+                                if (sh && sh.family !== 'W' && sh.family !== 'WT') return <SectionShape sec={effectiveSection(sh, false)} />
+                                return <WShapeSection shape={c.shape} d={c.d} bf={c.bf} tf={c.tf} tw={c.tw} />
+                              })()}
                             </div>
                             {/* Section properties */}
                             <div className="min-w-[160px]">


### PR DESCRIPTION
Third phase of Tier 2. The 3D model space could only build **W-shapes**; real buildings brace with **HSS and angles**, so the steel path now offers every AISC family.

## What already worked (verified, not rebuilt)
- **FEM analysis** of non-W members — the bridge's `steelSectionProps` already has a generic `I = A·r²`, `J = Iz+Iy` branch.
- **3D extrusion** — `buildSectionShapes` already draws W/WT/C/L/HSS/Pipe.
- **Column axial design** — `columnAxial` is family-agnostic (uses A, rx, ry).

## Gaps this PR closes
- **Section picker** — replaced the W-only list with per-role **Family + Shape** pickers (W/C/L/HSS/Pipe/WT). Changing family resets the shape to the first of that family. New `colFam/girFam/beaFam` state, persisted to session.
- **Bounding box** — new pure `sectionBoundingBox(shape)` (`engine/aiscSections.ts`) returns correct `b×h` per family (W/WT/C → bf×d, HSS → b×h, Pipe → D×D, angle → legs). `steelRole` used it via `shape.bf` which is `undefined` for HSS/angle/pipe → previously a wrong 200×300 box.
- **Schedule drawing** — non-W columns (which already produce axial design rows) now render through the universal `SectionShape` instead of the W-only `WShapeSection`.

## Honest limitations (noted in the UI)
- Detailed **HSS/angle/channel flexure** design (AISC F7/F8/F10) is **not** automated — non-W **beams** are skipped by the designer, and the optimizer's W-shape ladder leaves non-W members unchanged. Both are handled gracefully (no crash); non-W members are fully modeled, analyzed, drawn, and (for columns) axial-checked.

## Verification
- [x] `npm test` **623/623** (+2 bounding-box tests across all families)
- [x] `npx tsc -b` clean · `vite build` clean
- Optimizer/design confirmed graceful on non-W members (`nextHeavierW` returns `undefined` → left unchanged).

## Tier 2 remaining
#7 DG11 floor vibration · #8 thermal loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_