### PR TITLE
feat: floor vibration check (AISC DG11) — Tier 2 #7

### DIFF
--- a/webapp/src/components/qty.tsx
+++ b/webapp/src/components/qty.tsx
@@ -4,8 +4,8 @@ import type { ConcreteClass } from '../engine/quantities'
 import { ReportControls } from './ReportControls'
 
 /** Numeric input. */
-export function Num({ label, unit, value, onChange, step = 'any' }: {
-  label: ReactNode; unit?: string; value: number; onChange: (v: number) => void; step?: string
+export function Num({ label, unit, value, onChange, step = 'any', hint }: {
+  label: ReactNode; unit?: string; value: number; onChange: (v: number) => void; step?: string; hint?: string
 }) {
   return (
     <label className="flex flex-col text-sm">
@@ -15,6 +15,7 @@ export function Num({ label, unit, value, onChange, step = 'any' }: {
       <input type="number" inputMode="decimal" step={step} value={Number.isFinite(value) ? value : ''}
         onChange={(e) => onChange(parseFloat(e.target.value))}
         className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none focus:ring-1 focus:ring-[#0056b3]" />
+      {hint ? <span className="mt-0.5 text-[10px] text-slate-400">{hint}</span> : null}
     </label>
   )
 }

--- a/webapp/src/engine/floorVibration.test.ts
+++ b/webapp/src/engine/floorVibration.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { freqFromDeflection, dg11Walking, DG11_OCCUPANCY } from './floorVibration'
+import { GRAVITY } from './modal'
+
+describe('freqFromDeflection — DG11 Eq. 3.3', () => {
+  it('fn = 0.18·√(g/Δ)', () => {
+    const defl = 0.005   // 5 mm
+    expect(freqFromDeflection(defl)).toBeCloseTo(0.18 * Math.sqrt(GRAVITY / defl), 9)
+    expect(freqFromDeflection(0.005)).toBeCloseTo(7.97, 1)   // ~8 Hz
+  })
+
+  it('stiffer floor (smaller Δ) ⇒ higher frequency', () => {
+    expect(freqFromDeflection(0.002)).toBeGreaterThan(freqFromDeflection(0.010))
+  })
+
+  it('zero/negative deflection ⇒ infinite frequency (degenerate)', () => {
+    expect(freqFromDeflection(0)).toBe(Infinity)
+    expect(freqFromDeflection(-1)).toBe(Infinity)
+  })
+})
+
+describe('dg11Walking — peak acceleration vs tolerance (Eq. 4.1)', () => {
+  it('ap/g = Po·exp(−0.35·fn)/(β·W)', () => {
+    const r = dg11Walking({ fn: 5, W: 500, beta: 0.03, Po: 0.29, aoLimit: 0.005 })
+    const expected = (0.29 * Math.exp(-0.35 * 5)) / (0.03 * 500)
+    expect(r.apOverG).toBeCloseTo(expected, 12)
+    expect(r.apOverG).toBeCloseTo(0.00336, 4)
+    expect(r.ok).toBe(true)            // 0.336% < 0.5%
+    expect(r.ratio).toBeCloseTo(r.apOverG / 0.005, 9)
+  })
+
+  it('flags a lively floor that exceeds the office limit', () => {
+    // light, lightly-damped floor → large ap/g
+    const r = dg11Walking({ fn: 4, W: 150, beta: 0.02, Po: 0.29, aoLimit: 0.005 })
+    expect(r.apOverG).toBeGreaterThan(0.005)
+    expect(r.ok).toBe(false)
+    expect(r.ratio).toBeGreaterThan(1)
+  })
+
+  it('higher frequency and more damping both reduce ap/g', () => {
+    const base = dg11Walking({ fn: 4, W: 300, beta: 0.03, Po: 0.29, aoLimit: 0.005 })
+    const stiffer = dg11Walking({ fn: 7, W: 300, beta: 0.03, Po: 0.29, aoLimit: 0.005 })
+    const damped = dg11Walking({ fn: 4, W: 300, beta: 0.05, Po: 0.29, aoLimit: 0.005 })
+    expect(stiffer.apOverG).toBeLessThan(base.apOverG)
+    expect(damped.apOverG).toBeLessThan(base.apOverG)
+  })
+
+  it('degenerate W or β ⇒ infinite acceleration (fails)', () => {
+    expect(dg11Walking({ fn: 5, W: 0, beta: 0.03, Po: 0.29, aoLimit: 0.005 }).ok).toBe(false)
+    expect(dg11Walking({ fn: 5, W: 500, beta: 0, Po: 0.29, aoLimit: 0.005 }).ok).toBe(false)
+  })
+})
+
+describe('DG11_OCCUPANCY presets', () => {
+  it('offices use 0.5%g, malls 1.5%g, outdoor footbridges 5%g', () => {
+    const by = (id: string) => DG11_OCCUPANCY.find((o) => o.id === id)!
+    expect(by('office').aoLimit).toBeCloseTo(0.005, 9)
+    expect(by('mall').aoLimit).toBeCloseTo(0.015, 9)
+    expect(by('footbridge-out').aoLimit).toBeCloseTo(0.050, 9)
+    expect(by('footbridge-in').Po).toBeCloseTo(0.41, 9)
+    expect(by('office').Po).toBeCloseTo(0.29, 9)
+  })
+})

--- a/webapp/src/engine/floorVibration.ts
+++ b/webapp/src/engine/floorVibration.ts
@@ -1,0 +1,70 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Floor vibration serviceability — AISC Design Guide 11 (Vibrations of Steel-
+// Framed Structural Systems Due to Human Activity), walking excitation of a
+// low-frequency floor (fn ≲ 9 Hz). Post-processes the frame analysis: the floor
+// framing deflection Δ under the supported load gives the fundamental frequency
+//   fn = 0.18·√(g/Δ)                                   (DG11 Eq. 3.3)
+// and the predicted peak acceleration ratio from a walker is
+//   ap/g = Po·exp(−0.35·fn) / (β·W)                    (DG11 Eq. 4.1)
+// checked against the occupancy tolerance ao/g (DG11 Table 4.1). All forces in
+// kN, deflections in m, g in m/s².
+// ─────────────────────────────────────────────────────────────────────────
+import { GRAVITY } from './modal'
+
+/** Fundamental frequency (Hz) of a floor system from its deflection Δ (m) under
+ *  the supported weight. DG11 Eq. 3.3: fn = 0.18·√(g/Δ). */
+export function freqFromDeflection(defl: number): number {
+  if (defl <= 0) return Infinity
+  return 0.18 * Math.sqrt(GRAVITY / defl)
+}
+
+export interface DG11Input {
+  /** Fundamental frequency, Hz. */
+  fn: number
+  /** Effective weight supported by the panel, kN. */
+  W: number
+  /** Modal damping ratio β (e.g. 0.03 for a furnished office floor). */
+  beta: number
+  /** Constant walking force Po, kN (≈0.29 buildings, 0.41 footbridges). */
+  Po: number
+  /** Acceleration tolerance ao/g (fraction of g, e.g. 0.005 for offices). */
+  aoLimit: number
+}
+
+export interface DG11Result {
+  fn: number
+  /** Predicted peak acceleration ratio ap/g (fraction of g). */
+  apOverG: number
+  /** Acceptance limit ao/g (fraction of g). */
+  aoLimit: number
+  /** apOverG / aoLimit — ≤ 1 passes. */
+  ratio: number
+  ok: boolean
+}
+
+/** DG11 walking-excitation check (Eq. 4.1) for a low-frequency floor. */
+export function dg11Walking(i: DG11Input): DG11Result {
+  const apOverG = i.W > 0 && i.beta > 0
+    ? (i.Po * Math.exp(-0.35 * i.fn)) / (i.beta * i.W)
+    : Infinity
+  const ratio = apOverG / i.aoLimit
+  return { fn: i.fn, apOverG, aoLimit: i.aoLimit, ratio, ok: ratio <= 1 }
+}
+
+export interface OccupancyPreset {
+  id: string
+  label: string
+  Po: number        // kN
+  beta: number      // recommended modal damping ratio
+  aoLimit: number   // ao/g
+}
+
+/** DG11 Table 4.1 recommended Po, β and acceleration limits by occupancy. */
+export const DG11_OCCUPANCY: OccupancyPreset[] = [
+  { id: 'office',      label: 'Office / residence / church', Po: 0.29, beta: 0.03, aoLimit: 0.005 },
+  { id: 'office-bare', label: 'Office — bare floor (β=0.02)', Po: 0.29, beta: 0.02, aoLimit: 0.005 },
+  { id: 'office-part', label: 'Office — full-height partitions (β=0.05)', Po: 0.29, beta: 0.05, aoLimit: 0.005 },
+  { id: 'mall',        label: 'Shopping mall', Po: 0.29, beta: 0.02, aoLimit: 0.015 },
+  { id: 'footbridge-in',  label: 'Indoor footbridge', Po: 0.41, beta: 0.01, aoLimit: 0.015 },
+  { id: 'footbridge-out', label: 'Outdoor footbridge', Po: 0.41, beta: 0.01, aoLimit: 0.050 },
+]

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -22,6 +22,8 @@ import { TABLE_205_1, TABLE_206 } from '../engine/liveLoads'
 import type { ConcreteClass } from '../engine/quantities'
 import { computeSeismic, type SeismicResult, type DriftRow } from '../engine/seismic'
 import { columnKFactors, type ColumnK } from '../engine/effectiveLength'
+import { freqFromDeflection, dg11Walking, DG11_OCCUPANCY } from '../engine/floorVibration'
+import { buildSeismicMass, GRAVITY } from '../engine/modal'
 import { computeWind, type WindResult } from '../engine/wind'
 import { ReportControls } from '../components/ReportControls'
 import { WorkedSolution } from '../components/WorkedSolution'
@@ -687,6 +689,10 @@ export default function ModelSpace() {
   const [modeAmp, setModeAmp] = useState(1.5)
   const [forceDiag, setForceDiag] = useState<DiagramComp | null>(null)   // inline 3D BMD/SFD overlay
   const [forceDiagScale, setForceDiagScale] = useState(1)                // user offset multiplier
+  // AISC DG11 floor-vibration check (0 = use the value auto-suggested from analysis)
+  const [dg11OccId, setDg11OccId] = useState('office')
+  const [dg11DeflMm, setDg11DeflMm] = useState(0)
+  const [dg11W, setDg11W] = useState(0)
   const [rsa, setRsa] = useState<ResponseSpectrumResult | null>(null)
   const [nModes, setNModes] = useState(12)
   const [design, setDesign] = useState<StructureDesign | null>(null)
@@ -1121,6 +1127,24 @@ export default function ModelSpace() {
     if (!model) return new Map<string, ColumnK>()
     return new Map(columnKFactors(model).map((k) => [k.memberId, k]))
   }, [model])
+
+  // DG11 auto-suggestions from the analysis: the worst floor vertical deflection
+  // (Δ for fn) and the dead weight supported by that floor's storey (W).
+  const dg11Suggest = useMemo(() => {
+    if (!model || !govRes) return null
+    const supports = new Set(model.supports.map((s) => s.node))
+    let worst = 0, worstY = 0
+    model.nodes.forEach((n, k) => {
+      if (supports.has(n.id) || n.y <= 1e-6) return       // skip bases & ground
+      const uy = Math.abs(govRes.d[6 * k + 1])            // vertical deflection, m
+      if (uy > worst) { worst = uy; worstY = n.y }
+    })
+    if (worst <= 0) return null
+    const mass = buildSeismicMass(model)                  // tonnes per node (dead)
+    let storeyT = 0
+    for (const n of model.nodes) if (Math.abs(n.y - worstY) < 1e-3) storeyT += mass.get(n.id) ?? 0
+    return { deflMm: worst * 1000, W: storeyT * GRAVITY } // mm, kN
+  }, [model, govRes])
 
   // immediate grid-neighbour base supports (share an x- or z-line and are the
   // nearest column either side, nothing between) — the only sensible partners
@@ -2333,6 +2357,40 @@ export default function ModelSpace() {
                 </ResultCard>
               )}
               {rsa && <ResponseSpectrumPanel result={rsa} seismicT={seis?.T} />}
+
+              {(() => {
+                const occ = DG11_OCCUPANCY.find((o) => o.id === dg11OccId) ?? DG11_OCCUPANCY[0]
+                const deflMm = dg11DeflMm > 0 ? dg11DeflMm : (dg11Suggest?.deflMm ?? 0)
+                const W = dg11W > 0 ? dg11W : (dg11Suggest?.W ?? 0)
+                const fn = freqFromDeflection(deflMm / 1000)
+                const res = dg11Walking({ fn, W, beta: occ.beta, Po: occ.Po, aoLimit: occ.aoLimit })
+                const has = deflMm > 0 && W > 0
+                return (
+                  <Card title="Floor vibration — AISC Design Guide 11 (walking)">
+                    <Pick label="Occupancy" value={dg11OccId} onChange={setDg11OccId}
+                      options={DG11_OCCUPANCY.map((o) => [o.id, o.label])} />
+                    <Num label="Floor deflection Δ" unit="mm" value={dg11DeflMm} onChange={setDg11DeflMm} step="0.1"
+                      hint={dg11Suggest ? `analysis suggests ${dg11Suggest.deflMm.toFixed(1)} (0 = use it)` : 'run Analyze to auto-suggest'} />
+                    <Num label="Supported weight W" unit="kN" value={dg11W} onChange={setDg11W} step="10"
+                      hint={dg11Suggest ? `storey dead ≈ ${dg11Suggest.W.toFixed(0)} (0 = use it)` : 'effective panel weight'} />
+                    <p className="col-span-full text-[11px] text-slate-500">
+                      fn = 0.18·√(g/Δ); aₚ/g = Po·e^(−0.35 fn)/(β·W) ≤ aₒ/g. Po = {occ.Po} kN, β = {occ.beta}, aₒ/g = {(occ.aoLimit * 100).toFixed(1)}% (DG11 Table 4.1).
+                    </p>
+                    {has ? (
+                      <div className="col-span-full mt-1 space-y-1">
+                        <Row label="Fundamental frequency fₙ" value={`${fn.toFixed(2)} Hz`}
+                          sub={fn > 9 ? 'high-frequency floor — Eq. 4.1 is conservative' : 'low-frequency floor'} />
+                        <Row label="Peak acceleration aₚ/g" value={`${(res.apOverG * 100).toFixed(2)}%`}
+                          sub={`limit aₒ/g = ${(res.aoLimit * 100).toFixed(1)}%`} />
+                        <Row alert={!res.ok} label={res.ok ? '✓ Satisfactory' : '✗ Exceeds tolerance'}
+                          value={`ratio ${res.ratio.toFixed(2)}`} sub={res.ok ? 'aₚ ≤ aₒ' : 'stiffen framing, add damping/mass, or relax occupancy'} />
+                      </div>
+                    ) : (
+                      <p className="col-span-full text-[11px] text-amber-600">Enter Δ and W (or run Analyze for auto-suggestions) to evaluate.</p>
+                    )}
+                  </Card>
+                )
+              })()}
             </div>
           )}
 


### PR DESCRIPTION
Fourth phase of Tier 2. Post-processes the analysis to evaluate walking-induced floor vibration per **AISC Design Guide 11** (low-frequency floors).

## Engine — `engine/floorVibration.ts` (pure, +8 tests)
- **`freqFromDeflection(Δ)`** → `fn = 0.18·√(g/Δ)` (DG11 Eq. 3.3) — fundamental frequency from the floor framing deflection.
- **`dg11Walking({fn, W, β, Po, aoLimit})`** → `aₚ/g = Po·e^(−0.35·fn) / (β·W)` (DG11 Eq. 4.1), checked against the tolerance `aₒ/g`.
- **`DG11_OCCUPANCY`** presets — Po, β and acceleration limits by occupancy (Table 4.1: office/residence 0.5%g, mall 1.5%g, indoor/outdoor footbridges 1.5%/5%g).

## UI — Modal tab
A "Floor vibration (AISC DG11)" card with an **occupancy preset** and **Δ / W** inputs:
- **Δ** is auto-suggested from the worst floor vertical deflection in the current analysis;
- **W** from that storey's dead weight (`buildSeismicMass`);
- both editable (0 = use the suggestion).
- Shows `fn`, `aₚ/g` vs `aₒ/g`, and a pass/fail verdict (flags high-frequency floors where Eq. 4.1 is conservative).

`qty.tsx`: `Num` gained an optional `hint` line (used for the auto-suggest hints).

## Verification
- [x] `npm test` **631/631** (+8: Eq. 3.3 frequency, Eq. 4.1 acceleration arithmetic, monotonicity in fn/β, degenerate guards, preset limits)
- [x] `npx tsc -b` clean · `vite build` clean

## Notes
- Δ from the frame analysis is the beam/girder framing deflection — which is exactly what DG11's deflection method uses. W defaults to the storey dead weight as a starting estimate; the engineer refines it to the effective panel weight (standard DG11 judgement).

## Tier 2 remaining
#8 Temperature / thermal loads — the last item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_