### PR TITLE
feat: thermal/temperature loads — Tier 2 #8

### DIFF
--- a/webapp/src/engine/frame3d.ts
+++ b/webapp/src/engine/frame3d.ts
@@ -52,6 +52,9 @@ export type F3Load =
   | { kind: 'member-udl'; member: string; w: number; cat: LoadCategory }                       // kN/m, global −Y
   | { kind: 'member-vdl'; member: string; x1: number; x2: number; w1: number; w2: number; cat: LoadCategory } // global −Y
   | { kind: 'member-point'; member: string; a: number; P: number; cat: LoadCategory }          // kN, global −Y at a from i
+  /** Thermal axial prestress PT = EA·α·ΔT (kN). Positive ΔT = heating = member wants to elongate.
+   *  Fixed-end forces in local x′: −PT at i-node, +PT at j-node (self-equilibrating pair). */
+  | { kind: 'member-thermal'; member: string; PT: number; cat: LoadCategory }
 
 export interface F3MemberResult {
   id: string; L: number
@@ -78,6 +81,7 @@ function scaleF3(ld: F3Load, f: number): F3Load {
   if (ld.kind === 'node') return { ...ld, Fx: (ld.Fx ?? 0) * f, Fy: (ld.Fy ?? 0) * f, Fz: (ld.Fz ?? 0) * f, Mx: (ld.Mx ?? 0) * f, My: (ld.My ?? 0) * f, Mz: (ld.Mz ?? 0) * f }
   if (ld.kind === 'member-udl') return { ...ld, w: ld.w * f }
   if (ld.kind === 'member-vdl') return { ...ld, w1: ld.w1 * f, w2: ld.w2 * f }
+  if (ld.kind === 'member-thermal') return { ...ld, PT: ld.PT * f }
   return { ...ld, P: ld.P * f }
 }
 
@@ -88,6 +92,7 @@ export function applyF3Combo(loads: F3Load[], factors: Partial<Record<LoadCatego
       if (ld.kind === 'node') return [ld.Fx, ld.Fy, ld.Fz, ld.Mx, ld.My, ld.Mz].some((v) => Math.abs(v ?? 0) > 1e-9)
       if (ld.kind === 'member-udl') return Math.abs(ld.w) > 1e-9
       if (ld.kind === 'member-vdl') return Math.abs(ld.w1) + Math.abs(ld.w2) > 1e-9
+      if (ld.kind === 'member-thermal') return Math.abs(ld.PT) > 1e-9
       return Math.abs(ld.P) > 1e-9
     })
 }
@@ -108,6 +113,8 @@ export function appliedResultant(loads: F3Load[], memberLen: (id: string) => num
       const L = memberLen(ld.member)
       const x1 = Math.max(0, ld.x1), x2 = Math.min(L, ld.x2)
       if (x2 > x1) fy -= 0.5 * (ld.w1 + ld.w2) * (x2 - x1)
+    } else if (ld.kind === 'member-thermal') {
+      // self-equilibrating — zero net global force
     } else { fy -= ld.P }
   }
   return [fx, fy, fz]
@@ -329,6 +336,11 @@ function computeMemberLoads(geom: MemberGeom, m: F3Member, loads: F3Load[]): Mem
       feq[7] += ld.P * gl[1] * N[2]; feq[11] += ld.P * gl[1] * N[3]
       feq[2] += ld.P * gl[2] * N[0]; feq[4] -= ld.P * gl[2] * N[1]
       feq[8] += ld.P * gl[2] * N[2]; feq[10] -= ld.P * gl[2] * N[3]
+    } else if (ld.kind === 'member-thermal' && ld.member === m.id) {
+      // Equivalent axial end forces in local x′: {f_T}^e = EA·α·ΔT · {-1, +1}
+      // derived from ∫[B]^T · E·α·ΔT · A · dx (standard FEM thermal load vector).
+      feq[0] -= ld.PT   // i-end: compressive push (−x′)
+      feq[6] += ld.PT   // j-end: compressive push (+x′)
     }
   }
   for (const dd of dists) {

--- a/webapp/src/engine/model.ts
+++ b/webapp/src/engine/model.ts
@@ -81,6 +81,10 @@ export type ModelLoad =
   | { kind: 'member-point'; member: string; t: number /* 0–1 along i→j */; P: number; cat: LoadCategory }
   | { kind: 'member-udl'; member: string; w: number; cat: LoadCategory }
   | { kind: 'area'; plate: string; q: number /* kPa */; cat: LoadCategory }
+  /** Uniform temperature change ΔT (°C, + = rise) with linear expansion α (/°C).
+   *  Equivalent axial force P_T = EA·α·ΔT is applied as self-equilibrating end forces
+   *  in the solver (AISC 360 Commentary §C2; ACI 318-14 §6.6.3.1). */
+  | { kind: 'member-thermal'; member: string; deltaT: number; alpha: number; cat: LoadCategory }
 
 export interface Storey { id: string; name: string; elevation: number /* m */ }
 

--- a/webapp/src/engine/modelBridge.ts
+++ b/webapp/src/engine/modelBridge.ts
@@ -164,6 +164,14 @@ export function modelToFrame3D(model: StructuralModel): BridgeResult {
       const a = nm.get(m.i)!, b = nm.get(m.j)!
       const L = Math.hypot(b.x - a.x, b.y - a.y, b.z - a.z)
       loads.push({ kind: 'member-point', member: ld.member, a: ld.t * L, P: ld.P, cat: ld.cat })
+    } else if (ld.kind === 'member-thermal') {
+      const m = model.members.find((q) => q.id === ld.member)
+      if (!m) continue
+      const sec = model.sections.find((s) => s.id === m.section)
+      if (!sec) continue
+      const { E, A } = sectionProps(sec)   // E in kN/mm², A in mm²
+      const PT = E * A * ld.alpha * ld.deltaT   // kN
+      loads.push({ kind: 'member-thermal', member: ld.member, PT, cat: ld.cat })
     }
   }
 

--- a/webapp/src/engine/thermalLoad.test.ts
+++ b/webapp/src/engine/thermalLoad.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import { solveFrame3D, rectJ, type F3Node, type F3Member, type F3Support, type F3Load } from './frame3d'
+
+// Section: 300×500 mm concrete (MPa → kN/mm²; A mm²; EA = E·A kN)
+const E = 25000, G = E / 2.4
+const b = 300, h = 500
+const A = b * h, Iz = (b * h ** 3) / 12, Iy = (h * b ** 3) / 12, J = rectJ(b, h)
+const sec = { E, G, A, Iy, Iz, J }
+const EA = (E * A) / 1000   // kN (A in mm², E in kN/mm²; /1000 = unit conversion m→mm in frame3d)
+// Note: frame3d uses L in metres; EA/L gives kN/m stiffness, consistent with kN forces.
+
+const alpha = 10e-6   // /°C — typical concrete
+const deltaT = 30     // °C rise
+
+/** Two-node member fully fixed at both ends along global X. */
+const bothFixed = (loads: F3Load[]) => solveFrame3D(
+  [{ id: 'a', x: 0, y: 0, z: 0 }, { id: 'b', x: 4, y: 0, z: 0 }] as F3Node[],
+  [{ id: 'm', i: 'a', j: 'b', ...sec }] as F3Member[],
+  [{ node: 'a', fixity: 'fixed' }, { node: 'b', fixity: 'fixed' }] as F3Support[],
+  loads,
+)!
+
+/** Cantilever: fixed at a, free at b. */
+const cantilever = (loads: F3Load[]) => solveFrame3D(
+  [{ id: 'a', x: 0, y: 0, z: 0 }, { id: 'b', x: 3, y: 0, z: 0 }] as F3Node[],
+  [{ id: 'm', i: 'a', j: 'b', ...sec }] as F3Member[],
+  [{ node: 'a', fixity: 'fixed' }] as F3Support[],
+  loads,
+)!
+
+describe('member-thermal — both ends fixed (L = 4 m, ΔT = +30 °C, α = 10e-6)', () => {
+  const PT = EA * alpha * deltaT   // expected axial thermal force, kN
+
+  it('axial force = −EA·α·ΔT (compression) throughout the restrained member', () => {
+    const ld: F3Load = { kind: 'member-thermal', member: 'm', PT, cat: 'D' }
+    const r = bothFixed([ld])
+    // N should be negative (compression) and constant along the member
+    for (const N of r.members[0].N) {
+      expect(N).toBeCloseTo(-PT, 4)
+    }
+  })
+
+  it('no transverse force or moment for uniform thermal load', () => {
+    const ld: F3Load = { kind: 'member-thermal', member: 'm', PT, cat: 'D' }
+    const r = bothFixed([ld])
+    const m = r.members[0]
+    for (const v of [...m.Vy, ...m.Vz, ...m.My, ...m.Mz, ...m.T]) {
+      expect(Math.abs(v)).toBeLessThan(1e-6)
+    }
+  })
+
+  it('both nodes have zero displacement (fully constrained)', () => {
+    const ld: F3Load = { kind: 'member-thermal', member: 'm', PT, cat: 'D' }
+    const r = bothFixed([ld])
+    for (const d of r.d) expect(Math.abs(d)).toBeLessThan(1e-12)
+  })
+
+  it('reactions at fixed ends: equal and opposite axial (compression pair)', () => {
+    const ld: F3Load = { kind: 'member-thermal', member: 'm', PT, cat: 'D' }
+    const r = bothFixed([ld])
+    // Support at a pushes +X (opposes outward expansion at i-end); b pushes −X
+    const Ra = r.reactions.find((rx) => rx.node === 'a')!
+    const Rb = r.reactions.find((rx) => rx.node === 'b')!
+    expect(Ra.F[0]).toBeCloseTo(+PT, 3)
+    expect(Rb.F[0]).toBeCloseTo(-PT, 3)
+    // Net reaction = 0 (self-equilibrating)
+    expect(Ra.F[0] + Rb.F[0]).toBeCloseTo(0, 10)
+  })
+})
+
+describe('member-thermal — cantilever (fixed at a, free at b)', () => {
+  const PT = EA * alpha * deltaT
+
+  it('free end can expand → zero internal axial force', () => {
+    const ld: F3Load = { kind: 'member-thermal', member: 'm', PT, cat: 'D' }
+    const r = cantilever([ld])
+    for (const N of r.members[0].N) {
+      expect(Math.abs(N)).toBeLessThan(1e-6)
+    }
+  })
+
+  it('free end displaces by α·ΔT·L (free thermal elongation)', () => {
+    const L = 3
+    const ld: F3Load = { kind: 'member-thermal', member: 'm', PT, cat: 'D' }
+    const r = cantilever([ld])
+    // node b is DOF index 1, DOF 0 is u_x of node b
+    expect(r.d[6]).toBeCloseTo(alpha * deltaT * L, 7)
+  })
+
+  it('no reaction at fixed end for cantilever (no restraint of free expansion)', () => {
+    const ld: F3Load = { kind: 'member-thermal', member: 'm', PT, cat: 'D' }
+    const r = cantilever([ld])
+    const Ra = r.reactions.find((rx) => rx.node === 'a')!
+    expect(Math.abs(Ra.F[0])).toBeLessThan(1e-6)
+  })
+})
+
+describe('member-thermal — scaling via combo factor', () => {
+  it('zero load factor → no thermal effect', () => {
+    // A thermal load with factor 0 should be filtered out by applyF3Combo
+    // Test indirectly: PT=0 → same as no load → no axial force in cantilever
+    const ld: F3Load = { kind: 'member-thermal', member: 'm', PT: 0, cat: 'D' }
+    const r = cantilever([ld])
+    for (const N of r.members[0].N) expect(Math.abs(N)).toBeLessThan(1e-9)
+  })
+
+  it('cooling (negative ΔT) gives tension in restrained member', () => {
+    const PT = EA * alpha * 20   // cooling → member wants to contract → tension
+    const ld: F3Load = { kind: 'member-thermal', member: 'm', PT: -PT, cat: 'D' }
+    const r = bothFixed([ld])
+    // Negative PT means contraction; internal force = +PT (tension)
+    for (const N of r.members[0].N) expect(N).toBeCloseTo(PT, 4)
+  })
+})

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -689,6 +689,12 @@ export default function ModelSpace() {
   const [modeAmp, setModeAmp] = useState(1.5)
   const [forceDiag, setForceDiag] = useState<DiagramComp | null>(null)   // inline 3D BMD/SFD overlay
   const [forceDiagScale, setForceDiagScale] = useState(1)                // user offset multiplier
+  // Thermal load inputs
+  const [thMember, setThMember] = useState('')
+  const [thDeltaT, setThDeltaT] = useState(30)
+  const [thAlphaKey, setThAlphaKey] = useState<'steel' | 'concrete' | 'custom'>('steel')
+  const [thAlphaCustom, setThAlphaCustom] = useState(12e-6)
+  const thAlpha = thAlphaKey === 'steel' ? 11.7e-6 : thAlphaKey === 'concrete' ? 10e-6 : thAlphaCustom
   // AISC DG11 floor-vibration check (0 = use the value auto-suggested from analysis)
   const [dg11OccId, setDg11OccId] = useState('office')
   const [dg11DeflMm, setDg11DeflMm] = useState(0)
@@ -1036,6 +1042,7 @@ export default function ModelSpace() {
         if (l.kind === 'area') return { ...l, q: v }
         if (l.kind === 'member-udl') return { ...l, w: v }
         if (l.kind === 'member-point') return { ...l, P: v }
+        if (l.kind === 'member-thermal') return { ...l, deltaT: v }
         return l
       }),
     })
@@ -2050,18 +2057,19 @@ export default function ModelSpace() {
                       <tbody>
                         {model.loads.map((l: ModelLoad, idx) => {
                           const target = l.kind === 'node' ? l.node : l.kind === 'area' ? l.plate : l.member
-                          const val = l.kind === 'area' ? l.q : l.kind === 'member-udl' ? l.w : l.kind === 'member-point' ? l.P : null
-                          const unit = l.kind === 'area' ? 'kPa' : l.kind === 'member-udl' ? 'kN/m' : 'kN'
+                          const val = l.kind === 'area' ? l.q : l.kind === 'member-udl' ? l.w : l.kind === 'member-point' ? l.P : l.kind === 'member-thermal' ? l.deltaT : null
+                          const unit = l.kind === 'area' ? 'kPa' : l.kind === 'member-udl' ? 'kN/m' : l.kind === 'member-thermal' ? '°C' : 'kN'
                           return (
                             <tr key={idx} className="border-t border-slate-100">
                               <td className={`py-0.5 pr-2 font-semibold ${l.cat === 'D' ? 'text-slate-600' : l.cat === 'L' ? 'text-emerald-700' : 'text-purple-700'}`}>{l.cat}</td>
-                              <td className="py-0.5 pr-2">{l.kind === 'node' ? '·' : l.kind === 'area' ? '▦' : '—'} {target}</td>
+                              <td className="py-0.5 pr-2">{l.kind === 'node' ? '·' : l.kind === 'area' ? '▦' : l.kind === 'member-thermal' ? '🌡' : '—'} {target}</td>
                               <td className="py-0.5 pr-1 whitespace-nowrap">
                                 {val !== null ? (
                                   <>
                                     <input type="number" step="0.1" value={val}
                                       onChange={(e) => updLoad(idx, parseFloat(e.target.value))}
                                       className="w-16 rounded border border-slate-200 px-1 py-0.5" /> {unit}
+                                    {l.kind === 'member-thermal' && <span className="ml-1 text-slate-400">(α = {(l.alpha * 1e6).toFixed(1)}×10⁻⁶)</span>}
                                   </>
                                 ) : (
                                   <span className="text-slate-500">
@@ -2085,6 +2093,49 @@ export default function ModelSpace() {
                     input. “Rebuild” regenerates both after you edit the frame.
                   </p>
                 </div>
+              )}
+
+              {model && (
+                <Card title="Thermal / temperature loads">
+                  <label className="flex flex-col text-sm">
+                    <span className="mb-1 font-medium text-slate-600">Member</span>
+                    <select value={thMember} onChange={(e) => setThMember(e.target.value)}
+                      className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none">
+                      <option value="">— select member —</option>
+                      {model.members.map((m) => <option key={m.id} value={m.id}>{m.id}</option>)}
+                    </select>
+                  </label>
+                  <Num label="Temperature change ΔT" unit="°C" value={thDeltaT} onChange={setThDeltaT} step="5"
+                    hint="+ve = heating (expansion); −ve = cooling (contraction)" />
+                  <label className="flex flex-col text-sm">
+                    <span className="mb-1 font-medium text-slate-600">Expansion coeff. α</span>
+                    <select value={thAlphaKey} onChange={(e) => setThAlphaKey(e.target.value as 'steel' | 'concrete' | 'custom')}
+                      className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none">
+                      <option value="steel">Steel — 11.7×10⁻⁶ /°C (AISC)</option>
+                      <option value="concrete">Concrete — 10×10⁻⁶ /°C (ACI 318)</option>
+                      <option value="custom">Custom</option>
+                    </select>
+                    {thAlphaKey === 'custom' && (
+                      <input type="number" step="1e-7" value={thAlphaCustom}
+                        onChange={(e) => setThAlphaCustom(parseFloat(e.target.value))}
+                        className="mt-1 rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none focus:ring-1 focus:ring-[#0056b3]" />
+                    )}
+                  </label>
+                  <div className="col-span-full">
+                    <button type="button"
+                      disabled={!thMember || !Number.isFinite(thDeltaT) || !Number.isFinite(thAlpha) || thAlpha <= 0}
+                      onClick={() => {
+                        if (!model || !thMember) return
+                        save({ ...model, loads: [...model.loads, { kind: 'member-thermal', member: thMember, deltaT: thDeltaT, alpha: thAlpha, cat: 'D' }] })
+                      }}
+                      className="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50 disabled:opacity-40">
+                      + Add thermal load
+                    </button>
+                  </div>
+                  <p className="col-span-full text-[10px] text-slate-400">
+                    Equivalent axial force P_T = EA·α·ΔT applied as self-equilibrating end forces (AISC 360-16 Commentary §C2). Treated as dead load (D) in NSCP 2015 combinations. Thermal effects appear in the member N diagram after Analyze.
+                  </p>
+                </Card>
               )}
 
               <Card title="Seismic — NSCP 208 static force">


### PR DESCRIPTION
## Summary

- **Engine**: New `member-thermal` load type — uniform temperature change ΔT (°C) with coefficient α (/°C) produces self-equilibrating axial end forces `P_T = EA·α·ΔT` via the standard FEM thermal load vector (`{−PT, +PT}` at local axial DOFs i/j). Ref: AISC 360-16 Commentary §C2; ACI 318-14 §6.6.3.1.
- **Tests** (`thermalLoad.test.ts`, 9 tests): restrained member develops compression `N = −EA·α·ΔT`; cantilever has zero internal force and free elongation `α·ΔT·L`; cooling → tension; self-equilibrating reactions sum to zero.
- **UI** (Loading tab → new "Thermal / temperature loads" card): member picker, ΔT input (°C), α preset (Steel 11.7×10⁻⁶, Concrete 10×10⁻⁶, Custom). Loads table shows ΔT with α annotation; inline ΔT editing works. Treated as dead load (D) in NSCP 2015 combinations.

## Changed files

| File | Change |
|------|--------|
| `src/engine/model.ts` | Add `member-thermal` to `ModelLoad` |
| `src/engine/frame3d.ts` | Add `member-thermal` to `F3Load`; update `scaleF3`, `applyF3Combo`, `appliedResultant`, `computeMemberLoads` |
| `src/engine/modelBridge.ts` | Convert `member-thermal` model load → F3Load with `PT = EA·α·ΔT` |
| `src/engine/thermalLoad.test.ts` | 9 new tests (all pass) |
| `src/pages/ModelSpace.tsx` | Thermal loads card + table display |

## Test plan

- [x] `npm test` — 640/640 pass (was 631; +9 thermal tests)
- [x] `npx tsc -b` — clean

## Notes

This completes **Tier 2** of the STAAD-parity roadmap. All 8 Tier 2 items are now merged:

| # | Feature | PR |
|---|---------|-----|
| 4 | Member force diagrams (3D BMD/SFD) | #232 |
| 5 | Effective length factor K (AISC alignment chart) | #233 |
| 6 | Non-W steel sections (all AISC families) | #235 |
| 7 | Floor vibration check (AISC DG11) | #236 |
| 8 | Thermal/temperature loads | **this PR** |

Tier 3 items (linearized buckling, rigid links, time-history, pushover, FEM plate/shell) are available on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_