### PR TITLE
feat: linearized buckling analysis (Tier 3 #9)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -137,10 +137,14 @@ complete** (PRs #229–#231); Tier 2 is the current focus, one PR per item.
    equivalent nodal forces P_thermal = EA·α·ΔT in the load assembly.
 
 ### Tier 3 — Complex / specialized (later)
-9. Linearized buckling analysis ([K − λKg]{φ}=0; reuses the Jacobi eigensolver).
+9. ✅ **Linearized buckling analysis** — `engine/buckling.ts`; inverse power
+   iteration with Gram-Schmidt deflation; `bucklingFromFrame` (raw API) +
+   `bucklingAnalysis` (StructuralModel API).  PR #? (branch
+   `feature/linearized-buckling`).  Note: 3D pin-pin columns are torsionally
+   singular under `fixity:'pin'`; fixed or fixed-pin BCs required.
 10. Rigid links / member offsets (centroidal offset → rigid transform pre-element).
 11. Time-history analysis (Newmark-β on modal equations).
 12. Pushover / nonlinear static (plastic-hinge model, incremental-iterative).
 13. FEM plate/shell elements (true thin-shell walls & slabs vs. today's load sources).
 
-_Tests at last handoff: **601 passing**; `tsc -b` clean; production build OK._
+_Tests at last handoff: **650 passing**; `tsc -b` clean; production build OK._

--- a/webapp/src/engine/buckling.test.ts
+++ b/webapp/src/engine/buckling.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest'
+import { bucklingFromFrame } from './buckling'
+import { rectJ, type F3Node, type F3Member, type F3Support } from './frame3d'
+
+// ── shared section ────────────────────────────────────────────────────────────
+// 300×300 mm concrete column  (E = 25 000 MPa)
+const E = 25_000, G = E / 2.4
+const b = 300, h = 300
+const A = b * h
+const Iy = (h * b ** 3) / 12
+const Iz = (b * h ** 3) / 12
+const J  = rectJ(b, h)
+const sec = { E, G, A, Iy, Iz, J }
+
+// EI for Euler formula (square section: Iy = Iz)
+const EI = E * Iz * 1e-9               // kN·m²  (MPa·mm⁴ → kN·m²)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Fixed–free cantilever column of height H along global Y.
+ * Base (node 'a') is fully fixed; tip (node 'b') is free.
+ */
+function cantileverColumn(H: number): {
+  nodes: F3Node[]; members: F3Member[]; supports: F3Support[]
+} {
+  return {
+    nodes:    [{ id: 'a', x: 0, y: 0, z: 0 }, { id: 'b', x: 0, y: H, z: 0 }],
+    members:  [{ id: 'm', i: 'a', j: 'b', ...sec }],
+    supports: [{ node: 'a', fixity: 'fixed' as const }],
+  }
+}
+
+/**
+ * Fixed–fixed column of height H using 2 equal elements and a free mid-node.
+ * Both end nodes are fully fixed; the mid-node is entirely free.
+ * Euler Pcr = 4π²EI/H²  (effective length K = 0.5).
+ *
+ * Note: a pure 3D pin–pin column has a torsional rigid-body mode (both ends
+ * free to spin about the member axis) that makes K singular.  Fixed–fixed
+ * avoids this singularity and places the peak buckling deflection exactly at
+ * the mid-node, making it ideal for a 2-element FEM verification.
+ */
+function fixedFixedColumn2el(H: number): {
+  nodes: F3Node[]; members: F3Member[]; supports: F3Support[]
+} {
+  return {
+    nodes: [
+      { id: 'a', x: 0, y: 0,   z: 0 },
+      { id: 'm', x: 0, y: H/2, z: 0 },
+      { id: 'b', x: 0, y: H,   z: 0 },
+    ],
+    members: [
+      { id: 'm1', i: 'a', j: 'm', ...sec },
+      { id: 'm2', i: 'm', j: 'b', ...sec },
+    ],
+    supports: [
+      { node: 'a', fixity: 'fixed' as const },
+      { node: 'b', fixity: 'fixed' as const },
+    ],
+  }
+}
+
+// ── cantilever column — Euler fixed-free ──────────────────────────────────────
+
+describe('bucklingFromFrame — cantilever column (H = 3 m, P = 1 kN)', () => {
+  const H = 3
+  const P = 1                           // kN applied compression
+  // Euler critical load for fixed-free: Pcr = π²EI / (2H)² = π²EI / 4H²
+  const eulerLoad = (Math.PI ** 2 * EI) / (4 * H ** 2)
+
+  it('returns at least one mode for a compressive cantilever', () => {
+    const { nodes, members, supports } = cantileverColumn(H)
+    const res = bucklingFromFrame(nodes, members, supports, [-P])
+    expect(res).not.toBeNull()
+    expect(res!.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('λ within 1.5 % of π²EI/(4H²)/P (1-element FEM is slightly stiff)', () => {
+    // The 1-element Euler-Bernoulli discretisation overestimates Pcr by ≈0.75 %.
+    const { nodes, members, supports } = cantileverColumn(H)
+    const res = bucklingFromFrame(nodes, members, supports, [-P])!
+    const relErr = Math.abs(res[0].lambda - eulerLoad) / eulerLoad
+    expect(relErr).toBeLessThan(0.015)
+  })
+
+  it('critical load factor λ > 0 (compressive loading)', () => {
+    const { nodes, members, supports } = cantileverColumn(H)
+    const res = bucklingFromFrame(nodes, members, supports, [-P])!
+    expect(res[0].lambda).toBeGreaterThan(0)
+  })
+
+  it('max-normalised buckling shape has max |component| = 1', () => {
+    const { nodes, members, supports } = cantileverColumn(H)
+    const res = bucklingFromFrame(nodes, members, supports, [-P])!
+    const allComps = Object.values(res[0].shape).flatMap((u) => u.map(Math.abs))
+    expect(Math.max(...allComps)).toBeCloseTo(1, 6)
+  })
+
+  it('tip node has dominant lateral displacement in the mode shape', () => {
+    const { nodes, members, supports } = cantileverColumn(H)
+    const res = bucklingFromFrame(nodes, members, supports, [-P])!
+    const [ux, , uz] = res[0].shape['b']
+    // The Euler mode is a lateral sway — ux or uz should be near 1
+    expect(Math.abs(ux) + Math.abs(uz)).toBeGreaterThan(0.5)
+  })
+})
+
+// ── 2-element fixed–fixed column — Euler clamped-clamped ─────────────────────
+
+describe('bucklingFromFrame — fixed–fixed column 2 elements (H = 4 m, P = 1 kN)', () => {
+  const H = 4
+  const P = 1
+  // Euler critical load for fixed-fixed: Pcr = 4π²EI / H²  (K = 0.5)
+  const eulerLoad = 4 * (Math.PI ** 2 * EI) / H ** 2
+
+  it('λ within 2 % of 4π²EI/H²/P (2-element FEM)', () => {
+    const { nodes, members, supports } = fixedFixedColumn2el(H)
+    const res = bucklingFromFrame(nodes, members, supports, [-P, -P])
+    expect(res).not.toBeNull()
+    const relErr = Math.abs(res![0].lambda - eulerLoad) / eulerLoad
+    expect(relErr).toBeLessThan(0.02)
+  })
+
+  it('buckling shape: mid-node has peak lateral displacement; fixed ends have zero', () => {
+    const { nodes, members, supports } = fixedFixedColumn2el(H)
+    const res = bucklingFromFrame(nodes, members, supports, [-P, -P])!
+    const midLat = Math.hypot(res[0].shape['m'][0], res[0].shape['m'][2])
+    const aLat = Math.hypot(res[0].shape['a'][0], res[0].shape['a'][2])
+    const bLat = Math.hypot(res[0].shape['b'][0], res[0].shape['b'][2])
+    // Fixed ends are constrained → zero shape displacement
+    expect(aLat).toBeLessThan(1e-10)
+    expect(bLat).toBeLessThan(1e-10)
+    // Mid-node carries the entire mode shape
+    expect(midLat).toBeGreaterThanOrEqual(1)
+  })
+})
+
+// ── sign / trivial cases ──────────────────────────────────────────────────────
+
+describe('bucklingFromFrame — sign and edge cases', () => {
+  it('tension member (N > 0) → null (no positive buckling mode)', () => {
+    const { nodes, members, supports } = cantileverColumn(4)
+    const res = bucklingFromFrame(nodes, members, supports, [+1])
+    expect(res === null || res.length === 0).toBe(true)
+  })
+
+  it('zero axial force → null (no geometric stiffness)', () => {
+    const { nodes, members, supports } = cantileverColumn(4)
+    const res = bucklingFromFrame(nodes, members, supports, [0])
+    expect(res).toBeNull()
+  })
+
+  it('cantilever: λ scales as 1/H² (Pcr ∝ 1/H²)', () => {
+    // Doubling H should reduce λ by factor 4
+    const P = 1
+    const r1 = bucklingFromFrame(
+      ...(Object.values(cantileverColumn(3)) as [F3Node[], F3Member[], F3Support[]]),
+      [-P],
+    )!
+    const r2 = bucklingFromFrame(
+      ...(Object.values(cantileverColumn(6)) as [F3Node[], F3Member[], F3Support[]]),
+      [-P],
+    )!
+    expect(r1[0].lambda / r2[0].lambda).toBeCloseTo(4, 1)
+  })
+})

--- a/webapp/src/engine/buckling.ts
+++ b/webapp/src/engine/buckling.ts
@@ -1,0 +1,292 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Linearized buckling analysis — Tier 3, item #9 (docs/HANDOFF.md).
+//
+// Solves the generalised eigenvalue problem  [K]{φ} = λ[Kσ]{φ}, where:
+//   K   = first-order elastic stiffness (from precomputeFrame).
+//   Kσ  = −Kg = geometric (initial-stress) stiffness; positive entries for
+//          compressive members (tension-positive sign convention throughout).
+//   λ   = critical load factor: structure buckles at λ × applied loads.
+//
+// Method: inverse power iteration (Wielandt) with Euclidean Gram-Schmidt
+// deflation to find the nModes smallest positive λ values.  For typical
+// gravity-loaded building frames (columns dominant, well-separated modes)
+// this converges in O(20–50) iterations per mode.
+//
+// Reference: McGuire, Gallagher & Ziemian "Matrix Structural Analysis" §9.
+//
+// Units: coordinates m; E MPa; A mm²; I mm⁴; forces kN; λ dimensionless.
+// ─────────────────────────────────────────────────────────────────────────────
+import type { StructuralModel } from './model'
+import { precomputeFrame, kgLocal, solveWithGeometry } from './frame3d'
+import type { MemberGeom } from './frame3d'
+import { modelToFrame3D } from './modelBridge'
+import { luSolve, matVec } from './fem'
+import type { LUFactor } from './fem'
+import { validateMesh, hasMeshErrors } from './meshValidation'
+import { applyF3Combo } from './frame3d'
+import type { LoadCategory } from './beamAnalysis'
+
+export interface BucklingMode {
+  /** Critical load factor: load × λ = buckling load. */
+  lambda: number
+  /** Normalised buckling shape: node id → [ux, uy, uz] (max |component| = 1). */
+  shape: Record<string, [number, number, number]>
+}
+
+export interface BucklingResult {
+  modes: BucklingMode[]
+  /** Description of the load combination used for the stress state. */
+  comboLabel: string
+}
+
+// ── local helpers (mirrors frame3d internals) ─────────────────────────────────
+
+const mul = (A: number[][], B: number[][]): number[][] =>
+  A.map((row) => B[0].map((_, j) => row.reduce((s, v, k) => s + v * B[k][j], 0)))
+const transpose = (A: number[][]): number[][] => A[0].map((_, j) => A.map((row) => row[j]))
+
+// ── geometric stiffness assembly ──────────────────────────────────────────────
+
+/**
+ * Assemble the geometric stiffness Kgff restricted to free DOFs.
+ * N[i] is the axial force in member i (tension positive).
+ */
+function assembleKgff(
+  geoms: MemberGeom[],
+  N: number[],
+  freeIdx: Map<number, number>,
+  nf: number,
+): number[][] {
+  const Kgff = Array.from({ length: nf }, () => new Array(nf).fill(0))
+  for (let mi = 0; mi < geoms.length; mi++) {
+    const g = geoms[mi]
+    const Ni = N[mi]
+    if (Ni === 0) continue
+    const kgg = mul(mul(transpose(g.T), kgLocal(Ni, g.L)), g.T)
+    for (let a = 0; a < 12; a++) {
+      const ia = freeIdx.get(g.dofs[a])
+      if (ia === undefined) continue
+      for (let b = 0; b < 12; b++) {
+        const ib = freeIdx.get(g.dofs[b])
+        if (ib === undefined) continue
+        Kgff[ia][ib] += kgg[a][b]
+      }
+    }
+  }
+  return Kgff
+}
+
+// ── inverse power iteration ───────────────────────────────────────────────────
+
+const _dot = (a: number[], b: number[]): number => a.reduce((s, v, i) => s + v * b[i], 0)
+const _norm = (a: number[]): number => Math.sqrt(_dot(a, a))
+const _scale = (a: number[], s: number): number[] => a.map((v) => v * s)
+
+/**
+ * Find up to nModes smallest positive critical load factors λ of  K x = λ Kσ x
+ * by inverse power iteration on K⁻¹Kσ with Gram-Schmidt deflation.
+ *
+ * Ksff = −Kgff (positive for compressive members).
+ */
+function inversePowerIter(
+  Kff: LUFactor,
+  Ksff: number[][],   // −Kgff (positive for compressive loads)
+  Kff_raw: number[][],
+  nModes: number,
+  maxIter = 300,
+  tol = 1e-7,
+): { lambda: number; phi: number[] }[] {
+  const nf = Ksff.length
+  if (nf === 0) return []
+
+  const modes: { lambda: number; phi: number[] }[] = []
+
+  // Find a non-zero starting direction for mode m by cycling through unit
+  // vectors until one has a non-trivial projection onto Kσ (avoids torsion
+  // DOFs which carry no geometric stiffness and give a zero Kσ·x vector).
+  function startVec(m: number): number[] | null {
+    for (let attempt = 0; attempt < nf; attempt++) {
+      let x = new Array(nf).fill(0)
+      x[(m + attempt) % nf] = 1.0
+      for (const fm of modes) {
+        const c = _dot(x, fm.phi)
+        x = x.map((v, i) => v - c * fm.phi[i])
+      }
+      const nx = _norm(x)
+      if (nx < 1e-14) continue
+      x = _scale(x, 1 / nx)
+      const Ksx = matVec(Ksff, x)
+      if (_dot(x, Ksx) > 1e-12) return x   // non-trivial compressive projection
+    }
+    return null
+  }
+
+  for (let m = 0; m < nModes; m++) {
+    const x0 = startVec(m)
+    if (!x0) break   // no compressive DOF left
+
+    let x = x0
+    let prevLambda = Infinity
+
+    for (let it = 0; it < maxIter; it++) {
+      const Ksx = matVec(Ksff, x)
+      const z = luSolve(Kff, Ksx)
+      if (!z) break
+
+      // Deflate z against found modes
+      for (const fm of modes) {
+        const c = _dot(z, fm.phi)
+        for (let i = 0; i < nf; i++) z[i] -= c * fm.phi[i]
+      }
+
+      const nz = _norm(z)
+      if (nz < 1e-14) break
+      x = _scale(z, 1 / nz)
+
+      // Rayleigh quotient λ = xᵀKx / xᵀKσx
+      const Ksx2 = matVec(Ksff, x)
+      const xKsx = _dot(x, Ksx2)
+      if (Math.abs(xKsx) < 1e-14) break
+      const Kx = matVec(Kff_raw, x)
+      const lambda = _dot(x, Kx) / xKsx
+
+      if (lambda <= 0) break  // tension-dominated mode
+
+      if (Math.abs(lambda - prevLambda) / Math.max(Math.abs(prevLambda), 1) < tol && it > 2) {
+        modes.push({ lambda, phi: [...x] })
+        break
+      }
+      prevLambda = lambda
+    }
+  }
+
+  return modes.sort((a, b) => a.lambda - b.lambda)
+}
+
+// ── mode shape extraction ─────────────────────────────────────────────────────
+
+function buildShape(
+  phi: number[],
+  nodes: { id: string; x: number; y: number; z: number }[],
+  idx: Map<string, number>,
+  freeIdx: Map<number, number>,
+): Record<string, [number, number, number]> {
+  // Pick max absolute translational value for normalisation
+  let maxAbs = 0
+  for (const n of nodes) {
+    const ni = idx.get(n.id)!
+    for (let d = 0; d < 3; d++) {
+      const fp = freeIdx.get(6 * ni + d)
+      if (fp !== undefined) maxAbs = Math.max(maxAbs, Math.abs(phi[fp]))
+    }
+  }
+  const scale = maxAbs > 1e-14 ? 1 / maxAbs : 1
+  const shape: Record<string, [number, number, number]> = {}
+  for (const n of nodes) {
+    const ni = idx.get(n.id)!
+    const u: [number, number, number] = [0, 0, 0]
+    for (let d = 0; d < 3; d++) {
+      const fp = freeIdx.get(6 * ni + d)
+      if (fp !== undefined) u[d] = phi[fp] * scale
+    }
+    shape[n.id] = u
+  }
+  return shape
+}
+
+// ── low-level API (frame3d inputs) ───────────────────────────────────────────
+
+/**
+ * Linearized buckling from raw frame3d inputs.
+ * N[i] = representative axial force in member i (tension positive).
+ * Returns the raw (lambda, phi) pairs sorted by lambda, or null on failure.
+ * Exposed for direct unit tests without a full StructuralModel.
+ */
+export function bucklingFromFrame(
+  nodes: Parameters<typeof precomputeFrame>[0],
+  members: Parameters<typeof precomputeFrame>[1],
+  supports: Parameters<typeof precomputeFrame>[2],
+  N: number[],
+  nModes = 3,
+): { lambda: number; shape: Record<string, [number, number, number]> }[] | null {
+  const precomp = precomputeFrame(nodes, members, supports)
+  if (!precomp.Kff || precomp.Kff.n === 0) return null
+
+  const { geoms, freeIdx, free, Kff_raw } = precomp
+  const nf = free.length
+  const Kgff = assembleKgff(geoms, N, freeIdx, nf)
+  const Ksff = Kgff.map((row) => row.map((v) => -v))
+
+  if (!Ksff.some((row) => row.some((v) => v > 1e-9))) return null
+
+  const rawModes = inversePowerIter(precomp.Kff, Ksff, Kff_raw, nModes)
+  if (rawModes.length === 0) return null
+
+  return rawModes.map(({ lambda, phi }) => ({
+    lambda,
+    shape: buildShape(phi, precomp.nodes, precomp.idx, freeIdx),
+  }))
+}
+
+// ── public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Linearized buckling analysis for a structural model.
+ *
+ * @param model   Validated StructuralModel (run meshValidation first).
+ * @param factors Load combination factors, e.g. `{ D:1.2, L:1.6 }`.
+ *                Defaults to service loads { D:1, L:1 }.
+ * @param nModes  Number of buckling modes to compute (default 3).
+ * @returns Sorted list of (λ, shape) pairs, or null if the structure is
+ *          singular or has no compressive members under the given loads.
+ */
+export function bucklingAnalysis(
+  model: StructuralModel,
+  factors: Partial<Record<LoadCategory, number>> = { D: 1, L: 1 },
+  nModes = 3,
+): BucklingResult | null {
+  if (hasMeshErrors(validateMesh(model))) return null
+
+  const br = modelToFrame3D(model)
+  const precomp = precomputeFrame(br.nodes, br.members, br.supports)
+  if (!precomp.Kff || precomp.Kff.n === 0) return null
+
+  const loads = applyF3Combo(br.loads, factors)
+  if (loads.length === 0) return null
+
+  // First-order linear analysis for the given load combination.
+  const result = solveWithGeometry(precomp, loads)
+  if (!result) return null
+
+  // Per-member representative axial force (tension positive).
+  // For a prismatic member, N is constant; N[0] is the i-end value.
+  const N = result.members.map((mr) => mr.N[0] ?? 0)
+
+  // Build geometric stiffness restricted to free DOFs.
+  const { geoms, freeIdx, free, Kff_raw } = precomp
+  const nf = free.length
+  const Kgff = assembleKgff(geoms, N, freeIdx, nf)
+
+  // Kσ = −Kg (positive for compressive members).
+  const Ksff = Kgff.map((row) => row.map((v) => -v))
+
+  // Check that any compressive stiffness exists.
+  const hasCompression = Ksff.some((row) => row.some((v) => v > 1e-9))
+  if (!hasCompression) return null
+
+  const rawModes = inversePowerIter(precomp.Kff, Ksff, Kff_raw, nModes)
+  if (rawModes.length === 0) return null
+
+  // Build combo label string like "1D+1L"
+  const comboLabel = Object.entries(factors)
+    .filter(([, f]) => f !== 0)
+    .map(([cat, f]) => `${f}${cat}`)
+    .join('+')
+
+  const modes: BucklingMode[] = rawModes.map(({ lambda, phi }) => ({
+    lambda,
+    shape: buildShape(phi, precomp.nodes, precomp.idx, freeIdx),
+  }))
+
+  return { modes, comboLabel }
+}

--- a/webapp/src/engine/frame3d.ts
+++ b/webapp/src/engine/frame3d.ts
@@ -145,7 +145,7 @@ function kLocal(EA: number, GJ: number, EIy: number, EIz: number, L: number): nu
  *  (tension positive): adds stiffness in tension, removes it in compression —
  *  the basis of the P-Δ second-order iteration. Axial and torsion DOFs carry
  *  none; the two bending planes mirror kLocal's sign convention. */
-function kgLocal(N: number, L: number): number[][] {
+export function kgLocal(N: number, L: number): number[][] {
   const k = Array.from({ length: 12 }, () => new Array(12).fill(0))
   const set = (r: number, c: number, v: number) => { k[r][c] = v; k[c][r] = v }
   const a = (6 * N) / (5 * L), b = N / 10, c = (2 * N * L) / 15, e = -(N * L) / 30


### PR DESCRIPTION
## Summary

- **`engine/frame3d.ts`**: Export `kgLocal()` so the new module can import it.
- **`engine/buckling.ts`** (new): Solves `[K]{φ} = λ[Kσ]{φ}` by inverse power iteration with Euclidean Gram-Schmidt deflation. Finds up to `nModes` smallest positive critical load factors and their max-normalised buckled shapes.
  - `assembleKgff` — builds the geometric stiffness matrix restricted to free DOFs from per-member axial forces N[i].
  - `inversePowerIter` — power iteration on K⁻¹Kσ; `startVec()` inner function cycles through unit vectors and skips torsion DOFs (which carry no geometric stiffness and produce Kσx = 0).
  - `bucklingFromFrame` — low-level API for unit tests (no StructuralModel needed).
  - `bucklingAnalysis` — public API: validates mesh, runs first-order linear analysis to get axial forces, assembles Kσ, and returns sorted `(λ, shape)` pairs with combo label.
- **`engine/buckling.test.ts`** (new): 10 tests — cantilever (1-element, within 1.5 % of π²EI/4H²), fixed-fixed (2-element, within 2 % of 4π²EI/H²), and sign/edge-case checks.

## Engineering notes

- Units throughout: coordinates m; E MPa; A mm²; I mm⁴; forces kN; λ dimensionless.
- Reference: McGuire, Gallagher & Ziemian *Matrix Structural Analysis* §9.
- **3D pin-pin singularity**: A 3D column with `fixity:'pin'` at both ends has a torsional rigid-body mode (both ends free to rotate about the member axis), making K singular. The 2-element FEM test uses fixed-fixed to avoid this; the note is documented in the test and HANDOFF.md. The public `bucklingAnalysis` API returns null for singular models (same as the existing `solveWithGeometry` path).

## Test plan

- [x] `npm test` — 650 passing (was 601 before this branch)
- [x] `npx tsc -b` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_