### PR TITLE
fix(frame3d): spring reaction sign — report restoring force (−k·d)

### DIFF
--- a/webapp/src/engine/frame3d.test.ts
+++ b/webapp/src/engine/frame3d.test.ts
@@ -307,7 +307,7 @@ describe('frame3d — spring supports', () => {
     expect(r.d[6 + 1]).toBeCloseTo(-10 / (kBeam + ky), 6)
   })
 
-  it('spring reaction = k × displacement (identity check)', () => {
+  it('spring reaction opposes displacement (restoring force sign)', () => {
     const ky = 200
     const r = solveFrame3D(
       [{ id: 'a', x: 0, y: 0, z: 0 }, { id: 'b', x: L, y: 0, z: 0 }],
@@ -316,7 +316,11 @@ describe('frame3d — spring supports', () => {
       [{ kind: 'node', node: 'b', Fy: -40, cat: 'D' }],
     )!
     const springReac = r.reactions.find((rx) => rx.fixity === 'spring')!
-    expect(springReac.F[1]).toBeCloseTo(ky * r.d[6 + 1], 6)
+    // Spring settles downward (d[6+1] < 0); reaction must be upward (positive) = −k·d
+    expect(springReac.F[1]).toBeCloseTo(-ky * r.d[6 + 1], 6)
+    // Fixed base + spring together balance the 40 kN downward load
+    const totalRy = r.reactions.reduce((s, rx) => s + rx.F[1], 0)
+    expect(totalRy).toBeCloseTo(40, 4)
   })
 
   it('spring carries only a share of the load (beam stiffness >> spring stiffness here)', () => {

--- a/webapp/src/engine/frame3d.ts
+++ b/webapp/src/engine/frame3d.ts
@@ -803,13 +803,14 @@ export function solveWithGeometry(
     .map((s) => {
       const i = idx.get(s.node)!
       if (s.fixity === 'spring') {
-        // Spring reaction = spring stiffness × displacement
+        // Spring reaction = restoring force = −k·d (opposes displacement, consistent with
+        // pin/roller/fixed sign: positive = force the support exerts ON the structure in +axis).
         return {
           node: s.node, fixity: s.fixity,
           F: [
-            (s.kx ?? 0) * d[6 * i + 0],
-            (s.ky ?? 0) * d[6 * i + 1],
-            (s.kz ?? 0) * d[6 * i + 2],
+            -(s.kx ?? 0) * d[6 * i + 0],
+            -(s.ky ?? 0) * d[6 * i + 1],
+            -(s.kz ?? 0) * d[6 * i + 2],
           ] as [number, number, number],
           M: [0, 0, 0] as [number, number, number],
         }


### PR DESCRIPTION
## Summary

- **Bug**: reported spring support reactions had the wrong sign (`+k·d`, same direction as displacement) instead of the correct restoring force (`−k·d`, opposing displacement)
- **Structural solution unaffected** — the stiffness `k` is correctly placed on the free-DOF diagonal of K, so all computed displacements and member forces are correct. This was a display-only error in the post-processing reaction recovery.
- **Fix**: negate the spring reaction components in `frame3d.ts` so the sign is consistent with pin/roller/fixed reactions (positive = force the support exerts ON the structure in the +axis direction)
- **Test updated**: old test checked `F[1] ≈ k·d` (the buggy identity); new test checks `F[1] ≈ −k·d` and also verifies global equilibrium (`ΣFy = applied load`)

## Sign convention note
For a spring support settling downward (`d < 0`), the spring pushes upward on the structure:
- Correct: `F_reaction = −k·d > 0` (upward, positive)
- Wrong: `F_reaction = +k·d < 0` (downward — same direction as displacement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_