### PR TITLE
feat: rigid links / member offsets — Tier 3 #10

### DIFF
--- a/webapp/src/engine/frame3d.test.ts
+++ b/webapp/src/engine/frame3d.test.ts
@@ -442,3 +442,68 @@ describe('rigid floor diaphragm — precomputeFrame + solveWithGeometry', () => 
     expect(r.d[6 * tR + 4]).toBeCloseTo(θy_m, 9)
   })
 })
+
+describe('rigid links / member offsets — Teff = T·H', () => {
+  const L = 3
+
+  it('zero offset is identical to no offset (cantilever closed form)', () => {
+    const P = 20
+    const base = cant([{ kind: 'member-point', member: 'm', a: L, P, cat: 'D' }])
+    const off = solveFrame3D(
+      [{ id: 'a', x: 0, y: 0, z: 0 }, { id: 'b', x: 3, y: 0, z: 0 }],
+      [{ id: 'm', i: 'a', j: 'b', ...sec, offI: [0, 0, 0], offJ: [0, 0, 0] }],
+      [{ node: 'a', fixity: 'fixed' }],
+      [{ kind: 'member-point', member: 'm', a: L, P, cat: 'D' }],
+    )!
+    expect(off.d[6 + 1]).toBeCloseTo(base.d[6 + 1], 12)
+    expect(off.members[0].Mz[0]).toBeCloseTo(base.members[0].Mz[0], 9)
+  })
+
+  it('rigid offset arm matches an explicit near-rigid stub member', () => {
+    // Flexible beam A→(L,0,0); a rigid arm of (0,h,0) lifts the loaded node to (L,h,0).
+    // A horizontal load Fx at the lifted node bends the beam via the lever moment Fx·h.
+    const hArm = 1.2, Fx = 8
+
+    // Offset model: node B at (L,h,0); member end j pulled back to (L,0,0) by offJ=(0,-h,0).
+    const offModel = solveFrame3D(
+      [{ id: 'a', x: 0, y: 0, z: 0 }, { id: 'b', x: L, y: hArm, z: 0 }],
+      [{ id: 'm', i: 'a', j: 'b', ...sec, offJ: [0, -hArm, 0] }],
+      [{ node: 'a', fixity: 'fixed' }],
+      [{ kind: 'node', node: 'b', Fx, cat: 'D' }],
+    )!
+
+    // Explicit model: real flexible beam A→P2(L,0,0) + a stiff stub P2→B(L,h,0).
+    const stiff = { E: E * 1e6, G: G * 1e6, A, Iy, Iz, J }
+    const explicit = solveFrame3D(
+      [{ id: 'a', x: 0, y: 0, z: 0 }, { id: 'p2', x: L, y: 0, z: 0 }, { id: 'b', x: L, y: hArm, z: 0 }],
+      [
+        { id: 'm', i: 'a', j: 'p2', ...sec },
+        { id: 'stub', i: 'p2', j: 'b', ...stiff },
+      ],
+      [{ node: 'a', fixity: 'fixed' }],
+      [{ kind: 'node', node: 'b', Fx, cat: 'D' }],
+    )!
+
+    // Displacements at the loaded node must agree (offset arm = perfectly rigid stub).
+    // offModel: node b is index 1 (DOFs at 6); explicit: node b is index 2 (DOFs at 12).
+    expect(offModel.d[6 + 0]).toBeCloseTo(explicit.d[12 + 0], 4)  // ux
+    expect(offModel.d[6 + 1]).toBeCloseTo(explicit.d[12 + 1], 4)  // uy
+    expect(offModel.d[6 + 5]).toBeCloseTo(explicit.d[12 + 5], 4)  // θz
+    // The flexible member sees the lever moment at its base: |Mz,base| ≈ Fx·h.
+    expect(Math.abs(offModel.members[0].Mz[0])).toBeCloseTo(Fx * hArm, 2)
+  })
+
+  it('global equilibrium holds with an offset (ΣReactions + ΣApplied = 0)', () => {
+    const Fx = 8, hArm = 1.2
+    const r = solveFrame3D(
+      [{ id: 'a', x: 0, y: 0, z: 0 }, { id: 'b', x: L, y: hArm, z: 0 }],
+      [{ id: 'm', i: 'a', j: 'b', ...sec, offJ: [0, -hArm, 0] }],
+      [{ node: 'a', fixity: 'fixed' }],
+      [{ kind: 'node', node: 'b', Fx, cat: 'D' }],
+    )!
+    // Single fixed base reacts the whole applied horizontal load.
+    expect(r.reactions[0].F[0]).toBeCloseTo(-Fx, 4)
+    // Base moment about Z balances Fx acting at height hArm above the base node.
+    expect(r.reactions[0].M[2]).toBeCloseTo(Fx * hArm, 2)
+  })
+})

--- a/webapp/src/engine/frame3d.ts
+++ b/webapp/src/engine/frame3d.ts
@@ -28,6 +28,12 @@ export interface F3Member {
   relI?: [boolean, boolean, boolean, boolean, boolean, boolean]
   /** Released local DOFs at end j: [ux, uy, uz, θx, θy, θz]. */
   relJ?: [boolean, boolean, boolean, boolean, boolean, boolean]
+  /** Rigid end offset (member offset / rigid link) at end i: vector from node i to the
+   *  member end in GLOBAL coords [m]. The span between the offset ends carries the flexible
+   *  element; node↔end is a rigid arm. Used to model centroidal/eccentric connections. */
+  offI?: [number, number, number]
+  /** Rigid end offset at end j: vector from node j to the member end in global coords [m]. */
+  offJ?: [number, number, number]
 }
 export type F3Fixity = 'pin' | 'fixed' | 'spring'
 export interface F3Support {
@@ -190,6 +196,28 @@ const mul = (A: number[][], B: number[][]): number[][] =>
   A.map((row) => B[0].map((_, j) => row.reduce((s, v, k) => s + v * B[k][j], 0)))
 const transpose = (A: number[][]): number[][] => A[0].map((_, j) => A.map((row) => row[j]))
 
+/**
+ * Rigid-link (member offset) transformation H mapping NODE DOFs → member-END DOFs, in
+ * global coordinates. For a rigid arm r (node→end vector), the end displacement follows
+ * rigid-body kinematics:  u_end = u_node + θ_node × r,  θ_end = θ_node. In matrix form the
+ * per-end 6×6 block is [[I, M(r)],[0, I]] with M(r)·θ = θ × r, i.e.
+ *   M(r) = [[0, rz, -ry], [-rz, 0, rx], [ry, -rx, 0]].
+ * Composing with the rotation T (Teff = T·H) carries the offset through every Galerkin form
+ * (Tᵀ k T, T·d, Tᵀ·f), so stiffness, loads, force recovery and Kg all stay consistent.
+ */
+function rigidLinkH(rI: V3, rJ: V3): number[][] {
+  const H = Array.from({ length: 12 }, (_, i) => { const row = new Array(12).fill(0); row[i] = 1; return row })
+  const block = (base: number, r: V3) => {
+    const [rx, ry, rz] = r
+    H[base + 0][base + 4] = rz;  H[base + 0][base + 5] = -ry
+    H[base + 1][base + 3] = -rz; H[base + 1][base + 5] = rx
+    H[base + 2][base + 3] = ry;  H[base + 2][base + 4] = -rx
+  }
+  block(0, rI)
+  block(6, rJ)
+  return H
+}
+
 // ── Geometry-only member data (load-independent) ──────────────────────────
 export interface MemberGeom {
   L: number; R: [V3, V3, V3]
@@ -287,7 +315,11 @@ function condenseLocal(kl: number[][], relIdx: number[]): {
 
 function prepMemberGeom(m: F3Member, nm: Map<string, F3Node>, idx: Map<string, number>): MemberGeom {
   const ni = nm.get(m.i)!, nj = nm.get(m.j)!
-  const dir: V3 = sub([nj.x, nj.y, nj.z], [ni.x, ni.y, ni.z])
+  // Member ends shift by the rigid offsets; the flexible element spans end→end.
+  const offI = m.offI ?? [0, 0, 0], offJ = m.offJ ?? [0, 0, 0]
+  const pi: V3 = [ni.x + offI[0], ni.y + offI[1], ni.z + offI[2]]
+  const pj: V3 = [nj.x + offJ[0], nj.y + offJ[1], nj.z + offJ[2]]
+  const dir: V3 = sub(pj, pi)
   const L = Math.hypot(...dir)
   const R = localAxes(dir)
   const EA = (m.E * m.A) / 1000
@@ -309,7 +341,10 @@ function prepMemberGeom(m: F3Member, nm: Map<string, F3Node>, idx: Map<string, n
     releaseData = { relIdx, retIdx: cond.retIdx, kff_inv: cond.kff_inv, kfr: cond.kfr }
   }
 
-  const T = tMatrix(R)
+  // Effective transform node→local: rotation T composed with the rigid-link H when offsets
+  // are present (Teff = T·H). With no offsets H = I, so this is exactly the rotation.
+  const hasOffset = (m.offI && m.offI.some((v) => v !== 0)) || (m.offJ && m.offJ.some((v) => v !== 0))
+  const T = hasOffset ? mul(tMatrix(R), rigidLinkH(offI, offJ)) : tMatrix(R)
   const kg = mul(mul(transpose(T), klEff), T)   // uses condensed stiffness when releases exist
   const ii = idx.get(m.i)!, jj = idx.get(m.j)!
   const dofs = [...Array.from({ length: 6 }, (_, k) => 6 * ii + k), ...Array.from({ length: 6 }, (_, k) => 6 * jj + k)]


### PR DESCRIPTION
## Summary

Implements **Tier 3 #10 — Rigid links / member offsets** from the STAAD-parity roadmap. Each member end can now carry a rigid arm so the flexible element connects at a point offset from its node (eccentric/centroidal connections, beam-to-column joint offsets, rigid stubs).

## What changed
- New optional fields on `F3Member`: `offI?` / `offJ?` — the node→member-end vector in **global** coords [m]. The flexible 12-DOF element spans end→end; node↔end is a rigid arm.
- New `rigidLinkH(rI, rJ)` builds the rigid-link transform **H** mapping node DOFs → member-end DOFs from rigid-body kinematics:
  - `u_end = u_node + θ_node × r`, `θ_end = θ_node`
  - per-end 6×6 block `[[I, M(r)], [0, I]]` with `M(r)·θ = θ × r`
- The element transform becomes `Teff = T·H` (with `H = I` when there are no offsets, so existing models are byte-for-byte unchanged). Because every consumer uses the transform only in Galerkin forms (`Tᵀ k T`, `T·d`, `Tᵀ·f`), this single change carries the offset consistently through:
  - global stiffness assembly
  - equivalent nodal loads (incl. the moment from the arm)
  - member force recovery
  - geometric stiffness / P-Δ **and** linearized buckling (`buckling.ts` reuses `g.T`/`g.L` unchanged)

## Verification
- **Zero-offset identity**: a member with `offI=offJ=[0,0,0]` reproduces the cantilever closed form exactly.
- **Rigid arm vs. explicit stub**: a lifted load node modeled with an offset matches an explicit near-rigid stub member (ux/uy/θz agree; flexible base sees the lever moment `Fx·h`). Confirmed the explicit stub converges to the offset result as stub stiffness → ∞.
- **Global equilibrium** with an offset: `ΣReactions + ΣApplied = 0` (base force `−Fx`, base moment `Fx·h`).
- Full suite **653 passing** (650 + 3 new); `tsc -b` clean.

## Follow-up (next phase)
- UI wiring in ModelSpace (per-member offset inputs) + 3D rendering of the rigid arm — engine is ready and consumed via `F3Member.offI/offJ`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_