### PR TITLE
docs(HANDOFF): mark Tier 3 #10 (rigid offsets) done

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -152,13 +152,13 @@ complete**; Tier 3 items #10–13 are the remaining backlog.
    iteration with Gram-Schmidt deflation; `bucklingFromFrame` (raw API) +
    `bucklingAnalysis` (StructuralModel API). Note: 3D pin-pin columns are torsionally
    singular under `fixity:'pin'`; fixed or fixed-pin BCs required.
-10. Rigid links / member offsets (centroidal offset → rigid transform pre-element).
+10. ✅ **Rigid links / member offsets** — PR #242. `offI`/`offJ` (node→member-end
+    vector, global m) on `F3Member`; rigid-link transform H folded into the element
+    transform (`Teff = T·H`) so stiffness, loads, force recovery, P-Δ and buckling
+    all carry the arm with no other code changes. **Next phase**: UI inputs +
+    3D rendering of the rigid arm in ModelSpace (engine ready).
 11. Time-history analysis (Newmark-β on modal equations).
 12. Pushover / nonlinear static (plastic-hinge model, incremental-iterative).
 13. FEM plate/shell elements (true thin-shell walls & slabs vs. today's load sources).
 
-### Pending fix
-- **Spring reaction sign** (branch `claude/next-phase-jsoxhl`): display-only sign
-  error in reported spring reactions — fix is committed, needs a PR to main.
-
-_Tests at last handoff: **650 passing**; `tsc -b` clean; production build OK._
+_Tests at last handoff: **653 passing**; `tsc -b` clean; production build OK._


### PR DESCRIPTION
## Summary

- Marks Tier 3 #10 (rigid links / member offsets) ✅ DONE with PR #242 and a next-phase note (UI + 3D rendering)
- Drops the "Pending fix" note for the spring reaction sign — merged in PR #241
- Test count updated to 653

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_