### PR TITLE
feat: pushover UI — capacity curve in ModelSpace (Tier 3 #12 UI)

### DIFF
--- a/webapp/src/components/PushoverPanel.tsx
+++ b/webapp/src/components/PushoverPanel.tsx
@@ -1,0 +1,99 @@
+import { ResultCard, Row } from './qty'
+import type { PushoverModelResult } from '../engine/pushoverModel'
+
+/** Capacity (pushover) curve: base shear vs control-node displacement. */
+function CapacityCurve({ res }: { res: PushoverModelResult }) {
+  const curve = res.result.curve
+  const xs = curve.map((p) => Math.abs(p.roofDisp) * 1000)   // mm
+  const ys = curve.map((p) => Math.abs(p.baseShear))         // kN
+  const xMax = Math.max(...xs, 1e-9), yMax = Math.max(...ys, 1e-9)
+
+  const W = 460, H = 280, padL = 56, padR = 16, padT = 16, padB = 40
+  const x0 = padL, x1 = W - padR, y0 = H - padB, y1 = padT
+  const sx = (v: number) => x0 + (x1 - x0) * (v / xMax)
+  const sy = (v: number) => y0 - (y0 - y1) * (v / yMax)
+  const pts = curve.map((_, i) => `${sx(xs[i]).toFixed(1)},${sy(ys[i]).toFixed(1)}`).join(' ')
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet"
+      style={{ width: '100%', height: 'auto', fontFamily: 'Arial, sans-serif' }}>
+      {/* axes */}
+      <line x1={x0} y1={y0} x2={x1} y2={y0} stroke="#475569" strokeWidth={1.2} />
+      <line x1={x0} y1={y0} x2={x0} y2={y1} stroke="#475569" strokeWidth={1.2} />
+      {/* gridlines + tick labels (0, mid, max) */}
+      {[0, 0.5, 1].map((f) => (
+        <g key={`y${f}`}>
+          <line x1={x0} y1={sy(yMax * f)} x2={x1} y2={sy(yMax * f)} stroke="#e2e8f0" strokeWidth={0.8} />
+          <text x={x0 - 6} y={sy(yMax * f) + 3} fontSize={9} fill="#64748b" textAnchor="end">{(yMax * f).toFixed(0)}</text>
+        </g>
+      ))}
+      {[0, 0.5, 1].map((f) => (
+        <text key={`x${f}`} x={sx(xMax * f)} y={y0 + 14} fontSize={9} fill="#64748b" textAnchor="middle">{(xMax * f).toFixed(1)}</text>
+      ))}
+      {/* curve */}
+      <polyline points={pts} fill="none" stroke="#0056b3" strokeWidth={2} />
+      {curve.map((p, i) => (
+        <circle key={i} cx={sx(xs[i])} cy={sy(ys[i])} r={i === 0 ? 2.5 : 3}
+          fill={p.newHinge ? '#dc2626' : '#0056b3'} />
+      ))}
+      {/* axis titles */}
+      <text x={(x0 + x1) / 2} y={H - 4} fontSize={10} fill="#334155" textAnchor="middle" fontWeight={700}>
+        control-node displacement (mm)
+      </text>
+      <text x={12} y={(y0 + y1) / 2} fontSize={10} fill="#334155" textAnchor="middle" fontWeight={700}
+        transform={`rotate(-90 12 ${(y0 + y1) / 2})`}>base shear (kN)</text>
+    </svg>
+  )
+}
+
+export function PushoverPanel({ res, dirLabel }: { res: PushoverModelResult; dirLabel: string }) {
+  const curve = res.result.curve
+  const peakV = Math.max(...curve.map((p) => Math.abs(p.baseShear)))
+  const peakD = Math.max(...curve.map((p) => Math.abs(p.roofDisp)))
+  const drift = res.totalHeight > 0 ? peakD / res.totalHeight : 0
+  const nHinges = res.result.hinges.length
+
+  return (
+    <ResultCard title={`Pushover capacity — push ${dirLabel}`}>
+      <div className="mb-3 rounded-lg border border-slate-200 bg-slate-50 p-2">
+        <CapacityCurve res={res} />
+      </div>
+      <Row label="Peak base shear" value={`${peakV.toFixed(1)} kN`}
+        sub={res.result.mechanism ? 'collapse mechanism' : 'target reached'} />
+      <Row label="Peak roof displacement" value={`${(peakD * 1000).toFixed(1)} mm`}
+        sub={`drift ${(drift * 100).toFixed(2)}% of H`} />
+      <Row label="Plastic hinges formed" value={`${nHinges}`}
+        sub={`${res.nHingeable} members hingeable`} />
+      <Row alert={res.result.mechanism} label={res.result.mechanism ? '✗ Mechanism formed' : '✓ Stable to target'}
+        value={`${curve.length - 1} events`}
+        sub={res.result.mechanism ? 'a collapse mechanism developed' : 'no mechanism within target drift'} />
+
+      {nHinges > 0 && (
+        <div className="mt-3 overflow-x-auto">
+          <table className="w-full text-left text-xs">
+            <thead className="text-slate-500">
+              <tr className="border-b border-slate-200">
+                <th className="py-1 pr-2">Event</th>
+                <th className="py-1 pr-2">V (kN)</th>
+                <th className="py-1 pr-2">Δ (mm)</th>
+                <th className="py-1 pr-2">Hinge</th>
+              </tr>
+            </thead>
+            <tbody className="text-slate-700">
+              {curve.slice(1).map((p) => (
+                <tr key={p.event} className="border-b border-slate-100 last:border-0">
+                  <td className="py-1 pr-2">{p.event}</td>
+                  <td className="py-1 pr-2 font-semibold">{Math.abs(p.baseShear).toFixed(1)}</td>
+                  <td className="py-1 pr-2">{(Math.abs(p.roofDisp) * 1000).toFixed(1)}</td>
+                  <td className="py-1 pr-2 text-slate-500">
+                    {p.newHinge ? `${p.newHinge.member} @${p.newHinge.end} (M${p.newHinge.axis})` : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </ResultCard>
+  )
+}

--- a/webapp/src/engine/pushoverModel.test.ts
+++ b/webapp/src/engine/pushoverModel.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { plasticMoment, runPushoverModel } from './pushoverModel'
+import { shapeByName } from './aiscSections'
+import { deriveWSection } from './steelDesign'
+import { generateGridModel } from './modelBuilder'
+import type { RectSection } from './model'
+
+describe('plasticMoment', () => {
+  it('concrete: ρ·b·d²·fy·(1−0.59ρfy/fc)', () => {
+    const s: RectSection = {
+      id: 'S', name: '300×500', b: 300, h: 500, fc: 28, fy: 415,
+      barDia: 20, tieDia: 10, cover: 40, material: 'concrete',
+    }
+    const rho = 0.015
+    const d = 500 - 40 - 10 - 10           // 440
+    const expected = (rho * 300 * d * d * 415 * (1 - (0.59 * rho * 415) / 28)) / 1e6
+    expect(plasticMoment(s, rho)).toBeCloseTo(expected, 6)
+  })
+
+  it('steel W: Mp = Fy·Zx', () => {
+    const name = 'W310x79'
+    const shape = shapeByName(name)!
+    const s: RectSection = {
+      id: 'S', name, b: 305, h: 310, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40,
+      material: 'steel', shape: name, steelFy: 345,
+    }
+    expect(plasticMoment(s)).toBeCloseTo((345 * deriveWSection(shape).Zx) / 1e6, 6)
+  })
+
+  it('scales with the concrete ratio ρ (monotone increasing under-reinforced)', () => {
+    const s: RectSection = {
+      id: 'S', name: 'x', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40, material: 'concrete',
+    }
+    expect(plasticMoment(s, 0.02)).toBeGreaterThan(plasticMoment(s, 0.01))
+  })
+})
+
+describe('runPushoverModel', () => {
+  const section: RectSection = {
+    id: 'S1', name: '400×400', b: 400, h: 400, fc: 28, fy: 415,
+    barDia: 20, tieDia: 10, cover: 40, material: 'concrete',
+  }
+  const model = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3.5, 3], section })
+
+  it('runs and returns a capacity curve with a roof control node', () => {
+    const r = runPushoverModel(model, { dir: 0, pattern: 'triangular' })!
+    expect(r).toBeTruthy()
+    expect(r.nHingeable).toBeGreaterThan(0)
+    expect(r.totalHeight).toBeCloseTo(6.5, 6)
+    // control node is at the roof (max y)
+    const ctrl = model.nodes.find((n) => n.id === r.controlNode)!
+    const yMax = Math.max(...model.nodes.map((n) => n.y))
+    expect(ctrl.y).toBeCloseTo(yMax, 6)
+    // capacity curve starts at the origin and grows
+    expect(r.result.curve[0]).toMatchObject({ event: 0, baseShear: 0, roofDisp: 0 })
+    expect(r.result.curve.length).toBeGreaterThan(1)
+  })
+
+  it('curve is monotonic in displacement (event-to-event)', () => {
+    const r = runPushoverModel(model, { dir: 0 })!
+    const pts = r.result.curve
+    for (let k = 1; k < pts.length; k++)
+      expect(Math.abs(pts[k].roofDisp)).toBeGreaterThan(Math.abs(pts[k - 1].roofDisp) - 1e-12)
+  })
+
+  it('mpScale lifts the capacity proportionally at first yield', () => {
+    const a = runPushoverModel(model, { dir: 0, mpScale: 1 })!
+    const b = runPushoverModel(model, { dir: 0, mpScale: 2 })!
+    // first-yield base shear doubles when every Mp doubles
+    expect(Math.abs(b.result.curve[1].baseShear)).toBeCloseTo(2 * Math.abs(a.result.curve[1].baseShear), 4)
+  })
+
+  it('returns null for an empty model', () => {
+    expect(runPushoverModel({ ...model, nodes: [], members: [] })).toBeNull()
+  })
+})

--- a/webapp/src/engine/pushoverModel.ts
+++ b/webapp/src/engine/pushoverModel.ts
@@ -1,0 +1,117 @@
+// ─────────────────────────────────────────────────────────────────────────
+// StructuralModel → pushover bridge (Tier 3 #12, UI phase).
+//
+// Turns a model into a PushoverInput: derives a plastic-moment capacity per
+// member, builds a lateral load pattern from the lumped seismic mass, and picks
+// the roof control node. Keeps the page thin — all the policy lives here, tested.
+//
+// Plastic moment (kN·m):
+//   steel W/WT : Mp = Fy·Zx                       (exact plastic capacity)
+//   steel other: Mp ≈ 1.1·Fy·Sx, Sx = Ix/(d/2)    (shape factor on elastic)
+//   concrete   : Mn = ρ·b·d²·fy·(1 − 0.59·ρ·fy/f′c)   (assumed tension ratio ρ)
+// ─────────────────────────────────────────────────────────────────────────
+import type { StructuralModel, RectSection } from './model'
+import { shapeByName } from './aiscSections'
+import { deriveWSection } from './steelDesign'
+import { modelToFrame3D } from './modelBridge'
+import { buildSeismicMass } from './modal'
+import { pushoverAnalysis, type PushoverResult } from './pushover'
+
+/** Nominal plastic moment capacity of a section, kN·m (see file header). */
+export function plasticMoment(s: RectSection, rho = 0.015): number {
+  if (s.material === 'steel') {
+    const Fy = s.steelFy ?? 345
+    const shape = s.shape ? shapeByName(s.shape) : undefined
+    if (shape && (shape.family === 'W' || shape.family === 'WT')) {
+      return (Fy * deriveWSection(shape).Zx) / 1e6
+    }
+    if (shape) {
+      const depth = shape.d ?? shape.h ?? shape.D ?? s.h
+      const Sx = (shape.A * shape.rx ** 2) / (depth / 2)
+      return (1.1 * Fy * Sx) / 1e6
+    }
+    const Sx = (s.b * s.h ** 2) / 6     // rectangular bounding box
+    return (1.1 * Fy * Sx) / 1e6
+  }
+  // concrete — assumed tension steel ratio ρ
+  const d = Math.max(s.h - s.cover - s.tieDia - s.barDia / 2, 0.5 * s.h)
+  const Mn = rho * s.b * d * d * s.fy * (1 - (0.59 * rho * s.fy) / Math.max(s.fc, 1))
+  return Mn / 1e6
+}
+
+export type PushoverPattern = 'uniform' | 'triangular'
+
+export interface PushoverModelOpts {
+  /** Push direction: 0 = X (default), 2 = Z. */
+  dir?: 0 | 2
+  /** Lateral pattern: 'triangular' (mass×height, first-mode-like, default) or 'uniform' (mass). */
+  pattern?: PushoverPattern
+  /** Assumed concrete tension-steel ratio for Mp (default 0.015). */
+  rho?: number
+  /** Multiplier applied to every member Mp (default 1). */
+  mpScale?: number
+  /** Control node id; defaults to the highest node (roof). */
+  controlNode?: string
+  /** Stop at this fraction of the total height (default 0.04 = 4% drift). */
+  targetDispRatio?: number
+  /** Max hinge events (default 100). */
+  maxEvents?: number
+}
+
+export interface PushoverModelResult {
+  result: PushoverResult
+  /** Node used for the capacity-curve abscissa. */
+  controlNode: string
+  /** Total frame height (y span), m. */
+  totalHeight: number
+  /** Number of members assigned a plastic-moment capacity. */
+  nHingeable: number
+}
+
+/**
+ * Build and run a pushover analysis from a structural model. Returns null when
+ * the model has no nodes. The lateral pattern is normalised so Σ = 1, hence the
+ * reported base shear equals the load factor λ at each event.
+ */
+export function runPushoverModel(model: StructuralModel, opts: PushoverModelOpts = {}): PushoverModelResult | null {
+  const br = modelToFrame3D(model)
+  if (br.nodes.length === 0) return null
+  const dir = opts.dir ?? 0
+
+  // plastic moment per member
+  const secById = new Map(model.sections.map((s) => [s.id, s]))
+  const Mp: Record<string, number> = {}
+  for (const m of model.members) {
+    const s = secById.get(m.section)
+    if (!s) continue
+    const mp = plasticMoment(s, opts.rho) * (opts.mpScale ?? 1)
+    if (mp > 0) Mp[m.id] = mp
+  }
+
+  // control node = highest; total height from the y span
+  const ys = model.nodes.map((n) => n.y)
+  const yMax = Math.max(...ys), yMin = Math.min(...ys)
+  const totalHeight = yMax - yMin
+  const controlNode = opts.controlNode ?? (model.nodes.find((n) => n.y === yMax)?.id ?? model.nodes[0].id)
+
+  // lateral pattern from lumped mass (×height for triangular), normalised Σ=1
+  const mass = buildSeismicMass(model)
+  const pattern: Record<string, number> = {}
+  let sum = 0
+  const tri = (opts.pattern ?? 'triangular') === 'triangular'
+  for (const node of model.nodes) {
+    const m = mass.get(node.id) ?? 0
+    if (m <= 0) continue
+    const w = tri ? m * Math.max(node.y - yMin, 0) : m
+    if (w > 0) { pattern[node.id] = w; sum += w }
+  }
+  if (sum > 0) for (const k of Object.keys(pattern)) pattern[k] /= sum
+
+  const targetDisp = totalHeight > 0 ? totalHeight * (opts.targetDispRatio ?? 0.04) : undefined
+
+  const result = pushoverAnalysis({
+    nodes: br.nodes, members: br.members, supports: br.supports,
+    Mp, pattern, dir, controlNode, targetDisp, maxEvents: opts.maxEvents ?? 100,
+  })
+  return { result, controlNode, totalHeight, nHingeable: Object.keys(Mp).length }
+}

--- a/webapp/src/engine/solverWorker.ts
+++ b/webapp/src/engine/solverWorker.ts
@@ -10,6 +10,7 @@ import type { StructuralModel } from './model'
 import { modelToFrame3D } from './modelBridge'
 import { analyzeFrame3D, solveFrame3D, applyF3Combo, type F3AnalyzeOpts } from './frame3d'
 import { modalAnalysis } from './modal'
+import { runPushoverModel, type PushoverModelOpts } from './pushoverModel'
 import { driftCheck } from './seismic'
 import { designStructureAsync, optimizeStructureAsync, selectBarDiameters, type SoilOptions, type FootingPlan, type AnalyzeOptions } from './pipeline'
 import type { SolveProgress } from './progress'
@@ -20,6 +21,7 @@ export type SolverRequest =
   | { id: number; kind: 'design'; model: StructuralModel; soil: SoilOptions; plan: FootingPlan; opts: AnalyzeOptions; tryBars: boolean }
   | { id: number; kind: 'optimize'; model: StructuralModel; soil: SoilOptions; plan: FootingPlan; opts: AnalyzeOptions; tryBars: boolean; maxIter: number }
   | { id: number; kind: 'modal'; model: StructuralModel; nModes: number }
+  | { id: number; kind: 'pushover'; model: StructuralModel; opts: PushoverModelOpts }
 
 const ctx = self as unknown as Worker
 
@@ -43,6 +45,10 @@ ctx.onmessage = async (e: MessageEvent<SolverRequest>) => {
       onProgress({ phase: 'Modal analysis' })
       const modal = modalAnalysis(msg.model, msg.nModes)
       ctx.postMessage({ id: msg.id, ok: true, result: { modal } })
+    } else if (msg.kind === 'pushover') {
+      onProgress({ phase: 'Pushover (event-to-event)' })
+      const pushover = runPushoverModel(msg.model, msg.opts)
+      ctx.postMessage({ id: msg.id, ok: true, result: { pushover } })
     } else if (msg.kind === 'design') {
       let m = msg.model
       if (msg.tryBars) {

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -35,6 +35,8 @@ import { DisplacementTable } from '../components/DisplacementTable'
 import { ValidationPanel } from '../components/ValidationPanel'
 import { ModalPanel } from '../components/ModalPanel'
 import { ResponseSpectrumPanel } from '../components/ResponseSpectrumPanel'
+import { PushoverPanel } from '../components/PushoverPanel'
+import type { PushoverModelResult } from '../engine/pushoverModel'
 import { BeamSchematic } from '../components/BeamSchematic'
 import { ColumnSchematic } from '../components/ColumnSchematic'
 import { FootingSchematic } from '../components/FootingSchematic'
@@ -487,7 +489,7 @@ function DirPicker({ value, onChange }: { value: string[]; onChange: (v: string[
 }
 
 // ── Right-panel tabs ────────────────────────────────────────────────────────
-type Tab = 'geometry' | 'properties' | 'supports' | 'loading' | 'analysis' | 'modal' | 'design'
+type Tab = 'geometry' | 'properties' | 'supports' | 'loading' | 'analysis' | 'modal' | 'pushover' | 'design'
 const TABS: { id: Tab; label: string }[] = [
   { id: 'geometry', label: 'Geometry' },
   { id: 'properties', label: 'Properties' },
@@ -495,6 +497,7 @@ const TABS: { id: Tab; label: string }[] = [
   { id: 'loading', label: 'Loading' },
   { id: 'analysis', label: 'Analysis' },
   { id: 'modal', label: 'Modal' },
+  { id: 'pushover', label: 'Pushover' },
   { id: 'design', label: 'Design' },
 ]
 function TabBtn({ id, label, active, onClick }: { id: Tab; label: string; active: boolean; onClick: (t: Tab) => void }) {
@@ -701,6 +704,12 @@ export default function ModelSpace() {
   const [dg11W, setDg11W] = useState(0)
   const [rsa, setRsa] = useState<ResponseSpectrumResult | null>(null)
   const [nModes, setNModes] = useState(12)
+  // Pushover (nonlinear static) inputs + result
+  const [poDir, setPoDir] = useState<'x' | 'z'>('x')
+  const [poPattern, setPoPattern] = useState<'triangular' | 'uniform'>('triangular')
+  const [poRho, setPoRho] = useState(1.5)        // concrete tension-steel ratio, %
+  const [poMpScale, setPoMpScale] = useState(1)
+  const [po, setPo] = useState<PushoverModelResult | null>(null)
   const [design, setDesign] = useState<StructureDesign | null>(null)
   const [opt, setOpt] = useState<OptimizeResult | null>(null)
   const [expanded, setExpanded] = useState<string | null>(null)   // open schedule-row solution
@@ -815,6 +824,15 @@ export default function ModelSpace() {
         setRsa(null)
       }
     }).catch((e) => console.error('modal failed', e))
+  }
+
+  const runPushover = () => {
+    if (!model || busy || meshErrors) return
+    run('pushover', {
+      model,
+      opts: { dir: poDir === 'x' ? 0 : 2, pattern: poPattern, rho: poRho / 100, mpScale: poMpScale },
+    }).then((r) => setPo((r as { pushover: PushoverModelResult | null }).pushover))
+      .catch((e) => console.error('pushover failed', e))
   }
 
   // Re-sign / re-axis a base node-load set into a directional case.
@@ -2442,6 +2460,48 @@ export default function ModelSpace() {
                   </Card>
                 )
               })()}
+            </div>
+          )}
+
+          {/* ── PUSHOVER ── */}
+          {tab === 'pushover' && (
+            <div className="space-y-4">
+              <Card title="Pushover — nonlinear static (plastic hinges)">
+                <Pick label="Push direction" value={poDir} onChange={setPoDir}
+                  options={[['x', '+X'], ['z', '+Z']]} />
+                <Pick label="Lateral pattern" value={poPattern} onChange={setPoPattern}
+                  options={[['triangular', 'Inverted triangle (mass×h)'], ['uniform', 'Uniform (mass)']]} />
+                <Num label="Concrete ρ (tension)" unit="%" value={poRho} onChange={setPoRho} step="0.1"
+                  hint="assumed steel ratio for Mp (concrete only)" />
+                <Num label="Mp scale" value={poMpScale} onChange={setPoMpScale} step="0.1"
+                  hint="multiplier on every member capacity" />
+                <p className="col-span-full text-[11px] text-slate-500">
+                  Event-to-event concentrated plastic hinges (a hinge = a member-end moment release).
+                  Capacity curve = base shear vs roof displacement; pushes to a 4% drift target or a collapse
+                  mechanism. Mp: steel Fy·Zx; concrete ρ·b·d²·fy·(1−0.59ρfy/f′c). P–M interaction not yet modelled.
+                </p>
+                <div className="col-span-full">
+                  <button type="button" onClick={runPushover} disabled={!model || !!busy || meshErrors} className={btn('from-[#ea580c] to-[#c2410c]')}>
+                    {busy === 'pushover' ? '⏳ Pushing…' : '⤧ Run pushover'}
+                  </button>
+                  {meshErrors && <p className="mt-1 text-[11px] font-medium text-red-600">Resolve the mesh errors in the Analysis tab to enable pushover.</p>}
+                </div>
+                {busy === 'pushover' && <SolverProgress p={progress} />}
+              </Card>
+
+              {model && <ValidationPanel issues={meshIssues} />}
+
+              {po && po.result.curve.length > 1 && (
+                <PushoverPanel res={po} dirLabel={poDir === 'x' ? '+X' : '+Z'} />
+              )}
+              {po && po.result.curve.length <= 1 && (
+                <ResultCard title="Pushover">
+                  <p className="text-sm text-slate-600">
+                    No yield events — the model has no hingeable members or no lateral mass to push.
+                    Assign sections and ensure the frame carries self-weight.
+                  </p>
+                </ResultCard>
+              )}
             </div>
           )}
 


### PR DESCRIPTION
## Summary

UI phase for **Tier 3 #12 — Pushover**. Adds a **Pushover tab** to the 3D Model Space that runs the nonlinear-static engine (PR #246) and plots the capacity curve.

## What changed
- **`engine/pushoverModel.ts`** (tested) — the model→pushover bridge:
  - `plasticMoment(section, ρ)`: steel `Fy·Zx` (W/WT) or `1.1·Fy·Sx` (other families); concrete `ρ·b·d²·fy·(1 − 0.59ρfy/f′c)`.
  - `runPushoverModel(model, opts)`: derives `Mp` per member, builds the lateral pattern (inverted-triangle `mass×height` or uniform `mass`, normalised so base shear = λ), picks the roof control node, runs the event-to-event solver to a 4% drift target.
- **Worker**: new `'pushover'` request kind so it runs off the main thread (UI stays responsive).
- **`components/PushoverPanel.tsx`**: SVG capacity curve (base shear vs. control-node displacement, red hinge-event markers) + summary (peak base shear, peak roof drift, hinge count, mechanism flag) + per-event table.
- **`ModelSpace`**: Pushover tab with push direction (±X/±Z), lateral pattern, concrete ρ and an Mp scale factor; runs via `useSolver`.

## Verification
- 7 new engine tests (plastic moment closed forms, curve monotonicity, `mpScale` linearity, empty-model guard). Full suite **683 passing**; `tsc -b` + `vite build` clean.
- **In-browser (Playwright headless)**: generate model → Pushover → Run produces a rising capacity curve with hinge markers, **26 plastic hinges over 26 events, 732.8 kN peak base shear at 4.07% roof drift** ("Stable to target"). Screenshot of the full panel captured.

## Notes / follow-up
- Mp uses an assumed concrete tension ratio (user-editable) and no P–M interaction — consistent with the engine's documented first-cut scope.
- Remaining UI phases (separate PRs): time-history (#11) ground-motion input + response plots; rigid offsets (#10) per-member inputs + 3D arm rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_