### PR TITLE
feat: time-history UI — response plots in the Modal tab (Tier 3 #11 UI)

### DIFF
--- a/webapp/src/components/TimeHistoryPanel.tsx
+++ b/webapp/src/components/TimeHistoryPanel.tsx
@@ -1,0 +1,66 @@
+import { ResultCard, Row } from './qty'
+import type { TimeHistoryModelResult } from '../engine/timeHistoryModel'
+
+/** A signed time series on a shared time axis (zero line centred). */
+function TimeChart({ t, y, color, yLabel, yScale = 1 }: {
+  t: number[]; y: number[]; color: string; yLabel: string; yScale?: number
+}) {
+  const W = 460, H = 170, padL = 56, padR = 12, padT = 10, padB = 28
+  const x0 = padL, x1 = W - padR, yMid = (H - padB + padT) / 2
+  const tMax = Math.max(t[t.length - 1] ?? 1, 1e-9)
+  const yAbs = Math.max(...y.map((v) => Math.abs(v * yScale)), 1e-9)
+  const sx = (v: number) => x0 + (x1 - x0) * (v / tMax)
+  const sy = (v: number) => yMid - (H - padB - padT) / 2 * ((v * yScale) / yAbs)
+  const pts = y.map((v, i) => `${sx(t[i]).toFixed(1)},${sy(v).toFixed(1)}`).join(' ')
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet"
+      style={{ width: '100%', height: 'auto', fontFamily: 'Arial, sans-serif' }}>
+      {/* zero line + frame */}
+      <line x1={x0} y1={yMid} x2={x1} y2={yMid} stroke="#cbd5e1" strokeWidth={1} />
+      <line x1={x0} y1={padT} x2={x0} y2={H - padB} stroke="#475569" strokeWidth={1} />
+      <line x1={x0} y1={H - padB} x2={x1} y2={H - padB} stroke="#475569" strokeWidth={1} />
+      {/* y extremes */}
+      <text x={x0 - 5} y={padT + 8} fontSize={9} fill="#64748b" textAnchor="end">{(yAbs).toFixed(yAbs < 10 ? 1 : 0)}</text>
+      <text x={x0 - 5} y={H - padB} fontSize={9} fill="#64748b" textAnchor="end">{(-yAbs).toFixed(yAbs < 10 ? 1 : 0)}</text>
+      {/* time ticks */}
+      {[0, 0.5, 1].map((f) => (
+        <text key={f} x={sx(tMax * f)} y={H - padB + 12} fontSize={9} fill="#64748b" textAnchor="middle">{(tMax * f).toFixed(1)}s</text>
+      ))}
+      <polyline points={pts} fill="none" stroke={color} strokeWidth={1.4} />
+      <text x={12} y={yMid} fontSize={9} fill="#334155" textAnchor="middle" fontWeight={700}
+        transform={`rotate(-90 12 ${yMid})`}>{yLabel}</text>
+    </svg>
+  )
+}
+
+export function TimeHistoryPanel({ res, dirLabel }: { res: TimeHistoryModelResult; dirLabel: string }) {
+  const r = res.result
+  const t = r.t
+  const roof = r.nodeHistory ? r.nodeHistory.u.map((u) => u[r.dir]) : []
+  const T1 = r.modal[0]?.period ?? 0
+
+  return (
+    <ResultCard title={`Time-history — ground motion ${dirLabel}`}>
+      <div className="mb-1 text-[11px] font-semibold text-slate-500">Base shear V(t)</div>
+      <div className="mb-3 rounded-lg border border-slate-200 bg-slate-50 p-2">
+        <TimeChart t={t} y={r.baseShear} color="#0056b3" yLabel="V (kN)" />
+      </div>
+      {roof.length > 0 && (
+        <>
+          <div className="mb-1 text-[11px] font-semibold text-slate-500">Roof displacement Δ(t) — node {res.controlNode}</div>
+          <div className="mb-3 rounded-lg border border-slate-200 bg-slate-50 p-2">
+            <TimeChart t={t} y={roof} color="#ea580c" yLabel="Δ (mm)" yScale={1000} />
+          </div>
+        </>
+      )}
+      <Row label="Peak base shear" value={`${r.peakBaseShear.toFixed(1)} kN`} />
+      <Row label="Peak roof displacement" value={`${(Math.abs(res.peakRoof) * 1000).toFixed(1)} mm`}
+        sub={`node ${res.controlNode}`} />
+      <Row label="Fundamental period T₁" value={`${T1.toFixed(3)} s`}
+        sub={`${r.modal.length} modes, PGA ${(res.pga / 9.81).toFixed(2)} g`} />
+      <Row label="Peak total displacement" value={`${(r.peakNodeDisp * 1000).toFixed(1)} mm`}
+        sub={r.peakNode ? `at ${r.peakNode}` : ''} />
+    </ResultCard>
+  )
+}

--- a/webapp/src/engine/solverWorker.ts
+++ b/webapp/src/engine/solverWorker.ts
@@ -11,6 +11,7 @@ import { modelToFrame3D } from './modelBridge'
 import { analyzeFrame3D, solveFrame3D, applyF3Combo, type F3AnalyzeOpts } from './frame3d'
 import { modalAnalysis } from './modal'
 import { runPushoverModel, type PushoverModelOpts } from './pushoverModel'
+import { runTimeHistoryModel, type TimeHistoryModelOpts } from './timeHistoryModel'
 import { driftCheck } from './seismic'
 import { designStructureAsync, optimizeStructureAsync, selectBarDiameters, type SoilOptions, type FootingPlan, type AnalyzeOptions } from './pipeline'
 import type { SolveProgress } from './progress'
@@ -22,6 +23,7 @@ export type SolverRequest =
   | { id: number; kind: 'optimize'; model: StructuralModel; soil: SoilOptions; plan: FootingPlan; opts: AnalyzeOptions; tryBars: boolean; maxIter: number }
   | { id: number; kind: 'modal'; model: StructuralModel; nModes: number }
   | { id: number; kind: 'pushover'; model: StructuralModel; opts: PushoverModelOpts }
+  | { id: number; kind: 'timeHistory'; model: StructuralModel; opts: TimeHistoryModelOpts }
 
 const ctx = self as unknown as Worker
 
@@ -49,6 +51,10 @@ ctx.onmessage = async (e: MessageEvent<SolverRequest>) => {
       onProgress({ phase: 'Pushover (event-to-event)' })
       const pushover = runPushoverModel(msg.model, msg.opts)
       ctx.postMessage({ id: msg.id, ok: true, result: { pushover } })
+    } else if (msg.kind === 'timeHistory') {
+      onProgress({ phase: 'Time-history (modal Newmark-β)' })
+      const timeHistory = runTimeHistoryModel(msg.model, msg.opts)
+      ctx.postMessage({ id: msg.id, ok: true, result: { timeHistory } })
     } else if (msg.kind === 'design') {
       let m = msg.model
       if (msg.tryBars) {

--- a/webapp/src/engine/timeHistory.test.ts
+++ b/webapp/src/engine/timeHistory.test.ts
@@ -142,4 +142,17 @@ describe('modalTimeHistory', () => {
     expect(r2.peakBaseShear).toBeCloseTo(3 * r1.peakBaseShear, 6)
     expect(r2.peakNodeDisp).toBeCloseTo(3 * r1.peakNodeDisp, 6)
   })
+
+  it('historyNode returns the full node displacement history; its max = peakDisp', () => {
+    const r = modalTimeHistory(model, gm, { zeta: 0.05, nModes: 6, historyNode: 'n_0_0_0' })!
+    // pick whatever the engine reports as peak node instead (n_0_0_0 may be a base)
+    const target = r.peakNode!
+    const r2 = modalTimeHistory(model, gm, { zeta: 0.05, nModes: 6, historyNode: target })!
+    expect(r2.nodeHistory).toBeTruthy()
+    expect(r2.nodeHistory!.node).toBe(target)
+    expect(r2.nodeHistory!.u.length).toBe(N)
+    // max over the captured X-history equals the reported peakDisp[X]
+    const mx = Math.max(...r2.nodeHistory!.u.map((v) => Math.abs(v[0])))
+    expect(mx).toBeCloseTo(r2.peakDisp[target][0], 9)
+  })
 })

--- a/webapp/src/engine/timeHistory.ts
+++ b/webapp/src/engine/timeHistory.ts
@@ -75,6 +75,8 @@ export interface TimeHistoryOpts extends NewmarkOpts {
   zeta?: number
   /** Number of modes to include (default 12, capped by available modes). */
   nModes?: number
+  /** When set, the full displacement history of this node is returned (nodeHistory). */
+  historyNode?: string
 }
 
 /** Per-mode time-history contribution. */
@@ -107,6 +109,8 @@ export interface TimeHistoryResult {
   peakNode: string | null
   /** Largest peak total displacement magnitude (over all nodes), m. */
   peakNodeDisp: number
+  /** Full displacement history [ux,uy,uz] (m) at opts.historyNode, when requested. */
+  nodeHistory?: { node: string; u: [number, number, number][] }
 }
 
 /**
@@ -168,22 +172,27 @@ export function modalTimeHistory(
   for (const mode of modal.modes) for (const id of Object.keys(mode.shape)) nodeIds.add(id)
   const peakDisp: Record<string, [number, number, number]> = {}
   let peakNode: string | null = null, peakNodeDisp = 0
+  let nodeHistory: TimeHistoryResult['nodeHistory']
   for (const id of nodeIds) {
     const peak: [number, number, number] = [0, 0, 0]
+    const keepHist = id === opts?.historyNode
+    const hist: [number, number, number][] | null = keepHist ? Array.from({ length: n }, () => [0, 0, 0]) : null
     for (let d = 0; d < 3; d++) {
       // coefficient per mode: φ_r·Γ_r  → response is Σ_r coeff·D_r(t)
       const coeff = modal.modes.map((mode, r) => (mode.shape[id]?.[d] ?? 0) * gammas[r])
       for (let i = 0; i < n; i++) {
         let s = 0
         for (let r = 0; r < coeff.length; r++) s += coeff[r] * Ds[r][i]
+        if (hist) hist[i][d] = s
         const abs = Math.abs(s)
         if (abs > peak[d]) peak[d] = abs
       }
     }
     peakDisp[id] = peak
+    if (hist) nodeHistory = { node: id, u: hist }
     const mag = Math.hypot(peak[0], peak[1], peak[2])
     if (mag > peakNodeDisp) { peakNodeDisp = mag; peakNode = id }
   }
 
-  return { t, dir: gm.dir, modal: modal_out, baseShear, peakBaseShear, peakDisp, peakNode, peakNodeDisp }
+  return { t, dir: gm.dir, modal: modal_out, baseShear, peakBaseShear, peakDisp, peakNode, peakNodeDisp, ...(nodeHistory ? { nodeHistory } : {}) }
 }

--- a/webapp/src/engine/timeHistoryModel.test.ts
+++ b/webapp/src/engine/timeHistoryModel.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { makeGroundMotion, runTimeHistoryModel } from './timeHistoryModel'
+import { generateGridModel } from './modelBuilder'
+import type { RectSection } from './model'
+
+describe('makeGroundMotion', () => {
+  it('harmonic: a_g = PGA·sin(2πf t), correct length and peak', () => {
+    const gm = makeGroundMotion({ kind: 'harmonic', dt: 0.01, duration: 2, pga: 3, freq: 1, dir: 0 })
+    expect(gm.ag.length).toBe(201)
+    expect(gm.dt).toBe(0.01)
+    expect(Math.max(...gm.ag.map(Math.abs))).toBeCloseTo(3, 3)
+    expect(gm.ag[0]).toBeCloseTo(0, 9)
+    expect(gm.ag[25]).toBeCloseTo(3 * Math.sin(2 * Math.PI * 1 * 0.25), 6)  // quarter period → peak
+  })
+
+  it('pulse: zero after one period', () => {
+    const f = 2
+    const gm = makeGroundMotion({ kind: 'pulse', dt: 0.01, duration: 2, pga: 5, freq: f, dir: 0 })
+    const tQuiet = Math.round((1 / f + 0.2) / 0.01)
+    expect(gm.ag[tQuiet]).toBe(0)
+    expect(Math.max(...gm.ag.map(Math.abs))).toBeGreaterThan(0)
+  })
+
+  it('rampedSine: starts near zero and decays toward the end', () => {
+    const gm = makeGroundMotion({ kind: 'rampedSine', dt: 0.01, duration: 6, pga: 4, freq: 1.5, dir: 0 })
+    const earlyPeak = Math.max(...gm.ag.slice(0, 100).map(Math.abs))
+    const latePeak = Math.max(...gm.ag.slice(-100).map(Math.abs))
+    expect(latePeak).toBeLessThan(earlyPeak)   // envelope decays
+  })
+})
+
+describe('runTimeHistoryModel', () => {
+  const section: RectSection = {
+    id: 'S1', name: '400×400', b: 400, h: 400, fc: 28, fy: 415,
+    barDia: 20, tieDia: 10, cover: 40, material: 'concrete',
+  }
+  const model = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3.5, 3], section })
+
+  it('runs and returns base-shear + roof histories at the roof control node', () => {
+    const r = runTimeHistoryModel(model, {
+      spec: { kind: 'rampedSine', dt: 0.02, duration: 6, pga: 3, freq: 2, dir: 0 },
+      zeta: 0.05, nModes: 8,
+    })!
+    expect(r).toBeTruthy()
+    // control node is a roof node
+    const yMax = Math.max(...model.nodes.map((nd) => nd.y))
+    expect(model.nodes.find((nd) => nd.id === r.controlNode)!.y).toBeCloseTo(yMax, 6)
+    // histories present and consistent in length
+    expect(r.result.baseShear.length).toBe(r.result.t.length)
+    expect(r.result.nodeHistory!.node).toBe(r.controlNode)
+    expect(r.result.nodeHistory!.u.length).toBe(r.result.t.length)
+    expect(r.result.peakBaseShear).toBeGreaterThan(0)
+    expect(Math.abs(r.peakRoof)).toBeGreaterThan(0)
+  })
+
+  it('returns null for an empty model', () => {
+    expect(runTimeHistoryModel({ ...model, nodes: [], members: [] }, {
+      spec: { kind: 'harmonic', dt: 0.02, duration: 2, pga: 1, freq: 1, dir: 0 },
+    })).toBeNull()
+  })
+})

--- a/webapp/src/engine/timeHistoryModel.ts
+++ b/webapp/src/engine/timeHistoryModel.ts
@@ -1,0 +1,82 @@
+// ─────────────────────────────────────────────────────────────────────────
+// StructuralModel → time-history bridge (Tier 3 #11, UI phase).
+//
+// Synthesises a uniform ground-acceleration record and runs modalTimeHistory,
+// returning the base-shear and roof-displacement histories for plotting. Keeps
+// the page thin — record synthesis + control-node choice live here, tested.
+//
+// Sample records (scaled to a target PGA, m/s²):
+//   harmonic    : steady sine  a_g = PGA·sin(2πf t)
+//   pulse       : one-cycle sine pulse over 1/f s, then quiet
+//   rampedSine  : sine under a ramp-up / exponential-decay envelope (transient)
+// ─────────────────────────────────────────────────────────────────────────
+import type { StructuralModel } from './model'
+import { modalTimeHistory, type GroundMotion, type TimeHistoryResult } from './timeHistory'
+
+export type GroundMotionKind = 'harmonic' | 'pulse' | 'rampedSine'
+
+export interface GroundMotionSpec {
+  kind: GroundMotionKind
+  dt: number          // s
+  duration: number    // s
+  pga: number         // peak ground acceleration, m/s² (g·9.81)
+  freq: number        // excitation frequency, Hz
+  dir: 0 | 1 | 2
+}
+
+/** Build a ground-acceleration record from a spec (see file header). */
+export function makeGroundMotion(spec: GroundMotionSpec): GroundMotion {
+  const n = Math.max(1, Math.round(spec.duration / spec.dt) + 1)
+  const w = 2 * Math.PI * spec.freq
+  const ag = new Array(n)
+  for (let i = 0; i < n; i++) {
+    const t = i * spec.dt
+    let a = spec.pga * Math.sin(w * t)
+    if (spec.kind === 'pulse') {
+      a = t <= 1 / spec.freq ? a : 0
+    } else if (spec.kind === 'rampedSine') {
+      // 0.5 s linear ramp-up, then exponential decay (τ = duration/3)
+      const ramp = Math.min(1, t / 0.5)
+      const decay = Math.exp(-t / Math.max(spec.duration / 3, 1e-6))
+      a *= ramp * decay
+    }
+    ag[i] = a
+  }
+  return { dt: spec.dt, ag, dir: spec.dir }
+}
+
+export interface TimeHistoryModelOpts {
+  spec: GroundMotionSpec
+  zeta?: number
+  nModes?: number
+  controlNode?: string
+}
+
+export interface TimeHistoryModelResult {
+  result: TimeHistoryResult
+  controlNode: string
+  pga: number
+  /** Peak displacement at the control node in the excitation direction, m. */
+  peakRoof: number
+}
+
+/**
+ * Build the record, pick the roof control node and run modal time-history.
+ * Returns null when modal analysis fails (singular K / no mass).
+ */
+export function runTimeHistoryModel(
+  model: StructuralModel, opts: TimeHistoryModelOpts,
+): TimeHistoryModelResult | null {
+  if (model.nodes.length === 0) return null
+  const yMax = Math.max(...model.nodes.map((nd) => nd.y))
+  const controlNode = opts.controlNode ?? (model.nodes.find((nd) => nd.y === yMax)?.id ?? model.nodes[0].id)
+
+  const gm = makeGroundMotion(opts.spec)
+  const result = modalTimeHistory(model, gm, {
+    zeta: opts.zeta, nModes: opts.nModes, historyNode: controlNode,
+  })
+  if (!result) return null
+
+  const peakRoof = result.peakDisp[controlNode]?.[opts.spec.dir] ?? 0
+  return { result, controlNode, pga: opts.spec.pga, peakRoof }
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -37,6 +37,8 @@ import { ModalPanel } from '../components/ModalPanel'
 import { ResponseSpectrumPanel } from '../components/ResponseSpectrumPanel'
 import { PushoverPanel } from '../components/PushoverPanel'
 import type { PushoverModelResult } from '../engine/pushoverModel'
+import { TimeHistoryPanel } from '../components/TimeHistoryPanel'
+import type { TimeHistoryModelResult, GroundMotionKind } from '../engine/timeHistoryModel'
 import { BeamSchematic } from '../components/BeamSchematic'
 import { ColumnSchematic } from '../components/ColumnSchematic'
 import { FootingSchematic } from '../components/FootingSchematic'
@@ -710,6 +712,14 @@ export default function ModelSpace() {
   const [poRho, setPoRho] = useState(1.5)        // concrete tension-steel ratio, %
   const [poMpScale, setPoMpScale] = useState(1)
   const [po, setPo] = useState<PushoverModelResult | null>(null)
+  // Time-history (modal Newmark-β) inputs + result
+  const [thKind, setThKind] = useState<GroundMotionKind>('rampedSine')
+  const [thDir, setThDir] = useState<'x' | 'z'>('x')
+  const [thPga, setThPga] = useState(0.3)        // g
+  const [thFreq, setThFreq] = useState(2)        // Hz
+  const [thDur, setThDur] = useState(10)         // s
+  const [thZeta, setThZeta] = useState(5)        // %
+  const [th, setTh] = useState<TimeHistoryModelResult | null>(null)
   const [design, setDesign] = useState<StructureDesign | null>(null)
   const [opt, setOpt] = useState<OptimizeResult | null>(null)
   const [expanded, setExpanded] = useState<string | null>(null)   // open schedule-row solution
@@ -833,6 +843,18 @@ export default function ModelSpace() {
       opts: { dir: poDir === 'x' ? 0 : 2, pattern: poPattern, rho: poRho / 100, mpScale: poMpScale },
     }).then((r) => setPo((r as { pushover: PushoverModelResult | null }).pushover))
       .catch((e) => console.error('pushover failed', e))
+  }
+
+  const runTimeHistory = () => {
+    if (!model || busy || meshErrors) return
+    run('timeHistory', {
+      model,
+      opts: {
+        spec: { kind: thKind, dt: 0.02, duration: thDur, pga: thPga * GRAVITY, freq: thFreq, dir: thDir === 'x' ? 0 : 2 },
+        zeta: thZeta / 100, nModes,
+      },
+    }).then((r) => setTh((r as { timeHistory: TimeHistoryModelResult | null }).timeHistory))
+      .catch((e) => console.error('time-history failed', e))
   }
 
   // Re-sign / re-axis a base node-load set into a directional case.
@@ -2426,6 +2448,27 @@ export default function ModelSpace() {
                 </ResultCard>
               )}
               {rsa && <ResponseSpectrumPanel result={rsa} seismicT={seis?.T} />}
+
+              <Card title="Time-history — modal Newmark-β (linear)">
+                <Pick label="Ground motion" value={thKind} onChange={setThKind}
+                  options={[['rampedSine', 'Ramped sine (transient)'], ['pulse', 'Single pulse'], ['harmonic', 'Steady harmonic']]} />
+                <Pick label="Direction" value={thDir} onChange={setThDir} options={[['x', '+X'], ['z', '+Z']]} />
+                <Num label="Peak ground accel" unit="g" value={thPga} onChange={setThPga} step="0.05" />
+                <Num label="Frequency" unit="Hz" value={thFreq} onChange={setThFreq} step="0.5" />
+                <Num label="Duration" unit="s" value={thDur} onChange={setThDur} step="1" />
+                <Num label="Damping ζ" unit="%" value={thZeta} onChange={setThZeta} step="1" />
+                <p className="col-span-full text-[11px] text-slate-500">
+                  Modal superposition: each mode is an SDOF integrated by Newmark-β (β=¼, γ=½) under the
+                  ground record. Uses the modal count above (run modal first for periods). Δt = 0.02 s.
+                </p>
+                <div className="col-span-full">
+                  <button type="button" onClick={runTimeHistory} disabled={!model || !!busy || meshErrors} className={btn('from-[#0d9488] to-[#0f766e]')}>
+                    {busy === 'timeHistory' ? '⏳ Integrating…' : '∿ Run time-history'}
+                  </button>
+                </div>
+                {busy === 'timeHistory' && <SolverProgress p={progress} />}
+              </Card>
+              {th && <TimeHistoryPanel res={th} dirLabel={thDir === 'x' ? '+X' : '+Z'} />}
 
               {(() => {
                 const occ = DG11_OCCUPANCY.find((o) => o.id === dg11OccId) ?? DG11_OCCUPANCY[0]


### PR DESCRIPTION
## Summary

UI phase for **Tier 3 #11 — Time-history**. Surfaces the modal Newmark-β engine (PR #244) in the 3D Model Space's **Modal tab** (it's a modal-superposition method, so it lives with the other dynamic results — no new top-level tab).

## What changed
- **`timeHistory.ts`** (additive): optional `historyNode` in `TimeHistoryOpts` → returns the full `[ux,uy,uz]` displacement history at that node (`nodeHistory`), needed for the roof-displacement plot. Tested (max of the captured history equals the reported peak).
- **`engine/timeHistoryModel.ts`** (tested) — the model→time-history bridge:
  - `makeGroundMotion(spec)`: synthesises a uniform ground-acceleration record scaled to a target PGA — **harmonic**, single **pulse**, or **ramped sine** (ramp-up + exponential-decay envelope, a realistic transient).
  - `runTimeHistoryModel(model, opts)`: picks the roof control node and runs `modalTimeHistory`, returning base-shear + roof histories.
- **Worker**: new `'timeHistory'` request kind (off the main thread).
- **`components/TimeHistoryPanel.tsx`**: base-shear `V(t)` and roof-displacement `Δ(t)` time-series charts (zero-centred) + summary (peak base shear, peak roof, T₁, peak total displacement).
- **`ModelSpace`**: a Time-history card in the Modal tab — ground-motion kind, direction (±X/±Z), PGA (g), frequency, duration, damping ζ — running via `useSolver`.

## Verification
- 6 new engine tests (ground-motion shapes; bridge histories/length/peak; empty-model guard). Full suite **689 passing**; `tsc -b` + `vite build` clean.
- **In-browser (Playwright headless)**: generate model → Modal → Run time-history plots the ramped-sine transient (build-up then decay) for both `V(t)` and `Δ(t)`; **peak base shear 368 kN, peak roof 13.4 mm, T₁ = 0.302 s** at PGA 0.30 g. Full-panel screenshot captured.

## Notes / follow-up
- Ground motions are synthetic samples; uploading a real accelerogram (CSV) is a natural future addition.
- Remaining UI phase (separate PR): rigid offsets (#10) per-member inputs + 3D arm rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_