### PR TITLE
feat: rigid offsets UI — per-member end offsets + 3D arm (Tier 3 #10 UI)

### DIFF
--- a/webapp/src/engine/model.ts
+++ b/webapp/src/engine/model.ts
@@ -35,12 +35,21 @@ export interface MemberReleases {
   jEnd?: { Fx?: boolean; Fy?: boolean; Fz?: boolean; Mx?: boolean; My?: boolean; Mz?: boolean }
 }
 
+/** Rigid end offsets (member offset / rigid link): vector from the node to the
+ *  member end, in GLOBAL coordinates [m]. The flexible element spans end→end;
+ *  node↔end is a rigid arm. Models eccentric/centroidal connections. */
+export interface MemberOffsets {
+  iEnd?: [number, number, number]
+  jEnd?: [number, number, number]
+}
+
 export interface Member {
   id: string
   i: string; j: string          // node ids
   role: MemberRole
   section: string               // RectSection id
   releases?: MemberReleases
+  offsets?: MemberOffsets
 }
 
 export type PlateRole = 'slab' | 'wall'

--- a/webapp/src/engine/modelBridge.test.ts
+++ b/webapp/src/engine/modelBridge.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { modelToFrame3D } from './modelBridge'
+import { emptyModel, type StructuralModel, type RectSection } from './model'
+
+const section: RectSection = {
+  id: 'S', name: '300×500', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40,
+}
+
+function baseModel(): StructuralModel {
+  return {
+    ...emptyModel('t'),
+    nodes: [{ id: 'a', x: 0, y: 0, z: 0 }, { id: 'b', x: 4, y: 0, z: 0 }],
+    sections: [section],
+    members: [{ id: 'm', i: 'a', j: 'b', role: 'beam', section: 'S' }],
+    supports: [{ node: 'a', fixity: 'fixed' }],
+  }
+}
+
+describe('modelToFrame3D — rigid offsets', () => {
+  it('maps member offsets to F3Member offI / offJ', () => {
+    const model = baseModel()
+    model.members[0].offsets = { iEnd: [0, 0.3, 0], jEnd: [0, -0.2, 0] }
+    const br = modelToFrame3D(model)
+    const m = br.members.find((x) => x.id === 'm')!
+    expect(m.offI).toEqual([0, 0.3, 0])
+    expect(m.offJ).toEqual([0, -0.2, 0])
+  })
+
+  it('omits offI / offJ when no offsets are set', () => {
+    const br = modelToFrame3D(baseModel())
+    const m = br.members.find((x) => x.id === 'm')!
+    expect(m.offI).toBeUndefined()
+    expect(m.offJ).toBeUndefined()
+  })
+})

--- a/webapp/src/engine/modelBridge.ts
+++ b/webapp/src/engine/modelBridge.ts
@@ -137,6 +137,8 @@ export function modelToFrame3D(model: StructuralModel): BridgeResult {
   const members: F3Member[] = model.members.map((m) => ({
     id: m.id, i: m.i, j: m.j, ...(secById.get(m.section) ?? fallback),
     ...releaseFlags(m.releases),
+    ...(m.offsets?.iEnd ? { offI: m.offsets.iEnd } : {}),
+    ...(m.offsets?.jEnd ? { offJ: m.offsets.jEnd } : {}),
   }))
   // shear walls → equivalent diagonal struts (lateral stiffness only)
   members.push(...wallStruts(model, nm))

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -117,6 +117,24 @@ function Member3D({ a, b, role, selected, tint = 0, sec, onPick }: {
   )
 }
 
+/** Rigid end-offset arm: a thin purple stub from a node to its (offset) member end. */
+function RigidArm3D({ a, b }: { a: THREE.Vector3; b: THREE.Vector3 }) {
+  const { mid, quat, len } = useMemo(() => {
+    const dir = new THREE.Vector3().subVectors(b, a)
+    const len = dir.length()
+    const quat = new THREE.Quaternion().setFromUnitVectors(
+      new THREE.Vector3(1, 0, 0), len > 1e-9 ? dir.clone().normalize() : new THREE.Vector3(1, 0, 0))
+    return { mid: new THREE.Vector3().addVectors(a, b).multiplyScalar(0.5), quat, len }
+  }, [a, b])
+  if (len < 1e-6) return null
+  return (
+    <mesh position={mid} quaternion={quat}>
+      <boxGeometry args={[len, 0.06, 0.06]} />
+      <meshStandardMaterial color="#9333ea" />
+    </mesh>
+  )
+}
+
 /** Steel member drawn as its true AISC cross-section, extruded along the member
  *  axis (i→j). The profile is built in the local XY plane then oriented so its
  *  extrude (+Z) runs along the member and its strong axis (depth d) stays
@@ -1313,12 +1331,23 @@ export default function ModelSpace() {
                   const tint = govRes && govRes.Mmax > 1e-9
                     ? (memForce.get(m.id)?.Mmax ?? 0) / govRes.Mmax : 0
                   const sec = sectionFor(m.id)
-                  if (sec?.material === 'steel' && sec.shape) {
-                    return <MemberSteel3D key={m.id} a={a} b={bb} role={m.role} shapeName={sec.shape}
-                      tint={tint * 0.85} selected={m.id === selected} onPick={() => setSelected(m.id)} />
-                  }
-                  return <Member3D key={m.id} a={a} b={bb} role={m.role} tint={tint * 0.85}
-                    sec={sec} selected={m.id === selected} onPick={() => setSelected(m.id)} />
+                  // rigid end offsets shift the flexible member endpoints; node↔end is a rigid arm
+                  const oI = m.offsets?.iEnd, oJ = m.offsets?.jEnd
+                  const aEff = oI ? a.clone().add(new THREE.Vector3(oI[0], oI[1], oI[2])) : a
+                  const bEff = oJ ? bb.clone().add(new THREE.Vector3(oJ[0], oJ[1], oJ[2])) : bb
+                  const memberEl = sec?.material === 'steel' && sec.shape
+                    ? <MemberSteel3D a={aEff} b={bEff} role={m.role} shapeName={sec.shape}
+                        tint={tint * 0.85} selected={m.id === selected} onPick={() => setSelected(m.id)} />
+                    : <Member3D a={aEff} b={bEff} role={m.role} tint={tint * 0.85}
+                        sec={sec} selected={m.id === selected} onPick={() => setSelected(m.id)} />
+                  if (!oI && !oJ) return <group key={m.id}>{memberEl}</group>
+                  return (
+                    <group key={m.id}>
+                      {memberEl}
+                      {oI && <RigidArm3D a={a} b={aEff} />}
+                      {oJ && <RigidArm3D a={bb} b={bEff} />}
+                    </group>
+                  )
                 })}
                 {model.plates.map((p) => {
                   const cs = p.corners.map((c) => nodePos.get(c))
@@ -1644,6 +1673,50 @@ export default function ModelSpace() {
                           </tbody>
                         </table>
                         <p className="mt-1 text-[10px] text-slate-400">Check to release (zero force/moment). Mz = in-plane bending; My = out-of-plane. Click a member row to select.</p>
+                      </div>
+                    )
+                  })()}
+                  {/* Rigid end offsets — shown when a member is selected */}
+                  {(() => {
+                    const sel = model.members.find((m) => m.id === selected)
+                    if (!sel) return null
+                    const off = sel.offsets ?? {}
+                    const axes = ['x', 'y', 'z'] as const
+                    const updOff = (end: 'iEnd' | 'jEnd', ax: 0 | 1 | 2, v: number) => {
+                      const cur: [number, number, number] = [...(off[end] ?? [0, 0, 0])] as [number, number, number]
+                      cur[ax] = Number.isFinite(v) ? v : 0
+                      const next = { ...off, [end]: cur }
+                      // drop a zero vector so it doesn't linger in the model
+                      if (next.iEnd && next.iEnd.every((c) => c === 0)) delete next.iEnd
+                      if (next.jEnd && next.jEnd.every((c) => c === 0)) delete next.jEnd
+                      updMember(sel.id, { offsets: Object.keys(next).length ? next : undefined })
+                    }
+                    return (
+                      <div className="mt-2 rounded-lg border border-violet-200 bg-violet-50 p-2 text-xs">
+                        <p className="mb-1.5 font-semibold text-violet-800">Rigid end offsets (m) — {sel.id}</p>
+                        <table className="w-full border-collapse">
+                          <thead>
+                            <tr className="text-left text-[10px] uppercase tracking-wide text-slate-500">
+                              <th className="pr-2">End</th>
+                              {axes.map((a) => <th key={a} className="pr-1 text-center">{a}</th>)}
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {(['iEnd', 'jEnd'] as const).map((end) => (
+                              <tr key={end}>
+                                <td className="pr-2 font-medium text-slate-700">{end === 'iEnd' ? 'i' : 'j'}</td>
+                                {axes.map((_, ax) => (
+                                  <td key={ax} className="pr-1">
+                                    <input type="number" step="0.05" value={(off[end] ?? [0, 0, 0])[ax]}
+                                      onChange={(e) => updOff(end, ax as 0 | 1 | 2, parseFloat(e.target.value))}
+                                      className="w-14 rounded border border-violet-200 px-1 py-0.5 text-right" />
+                                  </td>
+                                ))}
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                        <p className="mt-1 text-[10px] text-slate-400">Vector node→member-end (global m). The flexible member spans end→end; node↔end is a rigid arm (purple).</p>
                       </div>
                     )
                   })()}


### PR DESCRIPTION
## Summary

UI phase for **Tier 3 #10 — Rigid links / member offsets**. Lets you set per-member rigid end offsets in the 3D Model Space and see the rigid arm; the offsets flow through to the analysis (engine: PR #242).

## What changed
- **`model.ts`**: `Member.offsets { iEnd?, jEnd? }` — node→member-end vector in global coordinates [m].
- **`modelBridge.ts`**: maps `offsets` → `F3Member.offI/offJ` (so every solve — static, P-Δ, modal, buckling, pushover, time-history — honours the arm). Tested.
- **`ModelSpace` Geometry tab**: a "Rigid end offsets (m)" editor on the selected member (i/j × x/y/z); a zeroed vector is dropped so it doesn't linger in the model.
- **3D**: the flexible member's endpoints shift by the offsets and a purple `RigidArm3D` stub is drawn from each node to its offset member end.

## Verification
- 2 new bridge tests (offsets map to `offI/offJ`; omitted when unset). Full suite **691 passing**; `tsc -b` + `vite build` clean.
- **In-browser (Playwright headless)**: generate model → select column `c0.0.0` → set iEnd y → the value reads back and **persists to the model as `offsets {iEnd:[0,0.8,0]}`**; canvas renders the frame with the offset applied; no runtime errors. Screenshot of the Geometry tab with the editor + 3D view captured.

## Wrap-up
This completes the UI phases for the recent Tier 3 engine work: **#12 pushover** (PR #248), **#11 time-history** (PR #249), and **#10 rigid offsets** (this PR). Remaining roadmap item: Tier 3 #13 (FEM plate/shell elements).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_