### PR TITLE
feat: rigid-zone refinements — per-member override, clear-span column, steel

### DIFF
--- a/webapp/src/engine/model.ts
+++ b/webapp/src/engine/model.ts
@@ -50,6 +50,9 @@ export interface Member {
   section: string               // RectSection id
   releases?: MemberReleases
   offsets?: MemberOffsets
+  /** Per-member rigid-zone factor override (0–1); falls back to the model factor.
+   *  0 excludes this member from automatic rigid end zones. */
+  rigidZoneFactor?: number
 }
 
 export type PlateRole = 'slab' | 'wall'

--- a/webapp/src/engine/rigidEndZones.test.ts
+++ b/webapp/src/engine/rigidEndZones.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { autoRigidOffsets } from './rigidEndZones'
+import { shapeByName } from './aiscSections'
 import { emptyModel, type StructuralModel, type RectSection } from './model'
 
 const col: RectSection = { id: 'C', name: 'col', b: 400, h: 600, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
@@ -53,6 +54,40 @@ describe('autoRigidOffsets', () => {
     const full = autoRigidOffsets(portal(), 1).get('bm')!.offI![0]
     const half = autoRigidOffsets(portal(), 0.5).get('bm')!.offI![0]
     expect(half).toBeCloseTo(full / 2, 9)
+  })
+
+  it('per-member rigidZoneFactor overrides the model factor (0 excludes the member)', () => {
+    const model = portal()
+    model.members[1].rigidZoneFactor = 0   // exclude the beam
+    const m = autoRigidOffsets(model, 1)
+    expect(m.get('bm')).toBeUndefined()    // beam excluded
+    expect(m.get('cL')).toBeTruthy()       // column still gets its zone
+
+    const model2 = portal()
+    model2.members[1].rigidZoneFactor = 0.5
+    expect(autoRigidOffsets(model2, 1).get('bm')!.offI![0]).toBeCloseTo(0.1, 6)  // 0.5 × 0.2
+  })
+
+  it('resolves steel AISC shape dimensions, not the bounding-box b/h', () => {
+    const shp = shapeByName('W310x97')!
+    const colSteel: RectSection = {
+      id: 'CS', name: 'W310x97', b: 1, h: 1,           // bogus bounding box
+      fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40,
+      material: 'steel', shape: 'W310x97', steelFy: 345,
+    }
+    const model: StructuralModel = {
+      ...emptyModel('t'),
+      nodes: [{ id: 'bl', x: 0, y: 0, z: 0 }, { id: 'tl', x: 0, y: 4, z: 0 }, { id: 'tr', x: 6, y: 4, z: 0 }],
+      sections: [colSteel, beam],
+      members: [
+        { id: 'cL', i: 'bl', j: 'tl', role: 'column', section: 'CS' },
+        { id: 'bm', i: 'tl', j: 'tr', role: 'beam', section: 'B' },
+      ],
+      supports: [{ node: 'bl', fixity: 'fixed' }],
+    }
+    // beam i-end zone uses the steel column's width (bf) along X, not h/b = 1 mm.
+    const bm = autoRigidOffsets(model, 1).get('bm')!
+    expect(bm.offI![0]).toBeCloseTo((shp.bf! / 1000) / 2, 6)
   })
 
   it('caps the total offset so the clear span stays positive', () => {

--- a/webapp/src/engine/rigidEndZones.ts
+++ b/webapp/src/engine/rigidEndZones.ts
@@ -11,24 +11,39 @@
 //
 // Units: section b/h in mm → m; offsets in m (global).
 // ─────────────────────────────────────────────────────────────────────────
-import type { StructuralModel } from './model'
+import type { StructuralModel, RectSection } from './model'
 import { localAxes, type V3 } from './frame3d'
+import { shapeByName } from './aiscSections'
 
 const sub = (a: V3, b: V3): V3 => [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
 const dot = (a: V3, b: V3): number => a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
 
-interface MG { id: string; i: string; j: string; e: V3; L: number; yp: V3; zp: V3; b: number; h: number }
+/** Cross-section depth (along local y′) and width (along local z′) in metres.
+ *  Steel resolves the AISC shape (d × bf / h × b / D); concrete uses h × b. */
+function depthWidth(sec: RectSection | undefined): { depth: number; width: number } {
+  if (sec?.material === 'steel') {
+    const shp = sec.shape ? shapeByName(sec.shape) : undefined
+    if (shp) {
+      const depth = shp.d ?? shp.h ?? shp.D ?? sec.h
+      const width = shp.bf ?? shp.b ?? shp.D ?? sec.b
+      return { depth: depth / 1000, width: width / 1000 }
+    }
+  }
+  return { depth: (sec?.h ?? 0) / 1000, width: (sec?.b ?? 0) / 1000 }
+}
+
+interface MG { id: string; i: string; j: string; e: V3; L: number; yp: V3; zp: V3; depth: number; width: number; factor: number }
 
 /**
  * Auto end-offset vectors per member from joint connectivity + member depths.
- * `factor` (0–1) scales the rigid-zone length (ETABS rigid-zone factor). Returns
- * an empty map when factor ≤ 0. offI points i→j, offJ points j→i (inward).
+ * `factor` (0–1) is the default rigid-zone scale (ETABS rigid-zone factor); a
+ * member's own `rigidZoneFactor` overrides it (0 excludes that member). offI
+ * points i→j, offJ points j→i (inward). Works for concrete and steel sections.
  */
 export function autoRigidOffsets(
   model: StructuralModel, factor: number,
 ): Map<string, { offI?: V3; offJ?: V3 }> {
   const out = new Map<string, { offI?: V3; offJ?: V3 }>()
-  if (!(factor > 0)) return out
 
   const nm = new Map(model.nodes.map((n) => [n.id, [n.x, n.y, n.z] as V3]))
   const secById = new Map(model.sections.map((s) => [s.id, s]))
@@ -41,8 +56,8 @@ export function autoRigidOffsets(
     const L = Math.hypot(...dir)
     if (L <= 1e-9) continue
     const [xp, yp, zp] = localAxes(dir)
-    const sec = secById.get(m.section)
-    mgs.push({ id: m.id, i: m.i, j: m.j, e: xp, L, yp, zp, b: (sec?.b ?? 0) / 1000, h: (sec?.h ?? 0) / 1000 })
+    const { depth, width } = depthWidth(secById.get(m.section))
+    mgs.push({ id: m.id, i: m.i, j: m.j, e: xp, L, yp, zp, depth, width, factor: m.rigidZoneFactor ?? factor })
   }
 
   const byNode = new Map<string, MG[]>()
@@ -53,13 +68,14 @@ export function autoRigidOffsets(
   }
 
   // half-extent of member n's cross-section projected on direction e (m)
-  const halfExtent = (n: MG, e: V3) => (n.h / 2) * Math.abs(dot(e, n.yp)) + (n.b / 2) * Math.abs(dot(e, n.zp))
+  const halfExtent = (n: MG, e: V3) => (n.depth / 2) * Math.abs(dot(e, n.yp)) + (n.width / 2) * Math.abs(dot(e, n.zp))
 
   for (const mg of mgs) {
+    if (!(mg.factor > 0)) continue   // member excluded from rigid zones
     const zone = (nd: string) => {
       let d = 0
       for (const o of byNode.get(nd) ?? []) if (o.id !== mg.id) d = Math.max(d, halfExtent(o, mg.e))
-      return factor * d
+      return mg.factor * d
     }
     let li = zone(mg.i), lj = zone(mg.j)
     // keep a positive clear span

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -1602,12 +1602,19 @@ export default function ModelSpace() {
                           <th className="py-1 pr-1 font-semibold">h</th>
                           <th className="py-1 pr-1 font-semibold">i</th>
                           <th className="py-1 pr-1 font-semibold">j</th>
+                          <th className="py-1 pr-1 font-semibold" title="clear span (centreline length minus rigid end zones)">Lc</th>
                           <th className="py-1" />
                         </tr>
                       </thead>
                       <tbody>
                         {model.members.map((m) => {
                           const ms = sectionFor(m.id)
+                          const pa = nodePos.get(m.i), pb = nodePos.get(m.j)
+                          const Lfull = pa && pb ? pa.distanceTo(pb) : 0
+                          const eI = m.offsets?.iEnd ?? autoOff?.get(m.id)?.offI
+                          const eJ = m.offsets?.jEnd ?? autoOff?.get(m.id)?.offJ
+                          const Lc = Math.max(Lfull - (eI ? Math.hypot(...eI) : 0) - (eJ ? Math.hypot(...eJ) : 0), 0)
+                          const trimmed = Lc < Lfull - 1e-6
                           return (
                             <tr key={m.id} className={`border-t border-slate-100 ${m.id === selected ? 'bg-amber-50' : ''}`}>
                               <td className="py-0.5 pr-2 font-medium cursor-pointer" onClick={() => setSelected(m.id)}>{m.id}</td>
@@ -1633,6 +1640,10 @@ export default function ModelSpace() {
                                   </select>
                                 </td>
                               ))}
+                              <td className={`py-0.5 pr-1 tabular-nums ${trimmed ? 'font-semibold text-violet-700' : 'text-slate-500'}`}
+                                title={trimmed ? `full ${Lfull.toFixed(2)} m` : 'no rigid end zone'}>
+                                {Lc.toFixed(2)}
+                              </td>
                               <td className="py-0.5 text-right">
                                 <button type="button" onClick={() => { save(removeElements(model, new Set([m.id]))); if (selected === m.id) setSelected(null) }}
                                   className="rounded px-1.5 text-red-500 hover:bg-red-50">✕</button>
@@ -1749,6 +1760,17 @@ export default function ModelSpace() {
                           </tbody>
                         </table>
                         <p className="mt-1 text-[10px] text-slate-400">Vector node→member-end (global m). The flexible member spans end→end; node↔end is a rigid arm (purple).</p>
+                        <label className="mt-2 flex items-center gap-2 border-t border-violet-200 pt-2 text-[11px] text-slate-700">
+                          <span>Auto rigid-zone factor override</span>
+                          <input type="number" min={0} max={1} step={0.1}
+                            value={sel.rigidZoneFactor ?? ''} placeholder="model"
+                            onChange={(e) => {
+                              const v = parseFloat(e.target.value)
+                              updMember(sel.id, { rigidZoneFactor: Number.isFinite(v) ? Math.max(0, Math.min(1, v)) : undefined })
+                            }}
+                            className="w-16 rounded border border-violet-200 px-1 py-0.5 text-right" />
+                          <span className="text-[10px] text-slate-400">blank = model factor · 0 = no zone for this member (needs Auto rigid end zones on)</span>
+                        </label>
                       </div>
                     )
                   })()}


### PR DESCRIPTION
## Summary

- **Per-member rigid-zone factor override** — `Member.rigidZoneFactor` (0–1) overrides the model-level factor; 0 excludes that member from auto zones entirely. Editable in the Geometry tab offsets panel.
- **Clear-span Lc column** — Beams & columns table now shows Lc = L − |offI| − |offJ|; cells are highlighted violet when the zone trims the member, with a tooltip showing the full length.
- **Steel AISC shape support** — `depthWidth()` resolves the actual W/HSS/pipe geometry via `shapeByName` (d × bf) instead of the bounding-box b × h, so rigid-zone sizes are correct for steel frames.
- 7 unit tests in `rigidEndZones.test.ts` (factor ≤ 0, beam/column offsets, linear scaling, per-member override, steel AISC lookup, cap for short spans); total suite 700 tests green.

## Test plan

- [ ] Enable Auto rigid end zones on a concrete portal → Lc column shows trimmed values (violet)
- [ ] Set per-member factor 0 on a member → its Lc un-trims
- [ ] Switch material to steel, regenerate → Lc uses AISC depths (narrower zone than concrete)
- [ ] Very short beam between two large columns → offsets capped at 90 % of L

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_