### PR TITLE
docs(HANDOFF): record rigid-zone refinements (PR #254) — 700 tests

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -173,9 +173,13 @@ complete**; Tier 3 items #10–13 are the remaining backlog.
   connectivity (factor × ½·connecting-member depth, projected on the member axis);
   applied in the bridge (manual offsets win per end), so every solve honours them.
   Analysis-tab toggle + rigid-zone factor; 3D renders zones as muted member segments.
+- ✅ **Rigid-zone refinements** — PR #254. `Member.rigidZoneFactor` per-member override
+  (0 = exclude); clear-span **Lc column** in the Beams & columns table (violet when
+  trimmed, tooltip shows full L); `depthWidth()` resolves AISC shape d×bf for steel
+  so zones are correct for W/C/HSS sections, not the bounding-box b×h.
 
 ### UI follow-ups still open
 - Pushover: P–M interaction surface, axial/shear hinges, optional P-Δ in the push.
 - Time-history: upload a real accelerogram (CSV) in addition to synthetic samples.
 
-_Tests at last handoff: **698 passing**; `tsc -b` clean; production build OK._
+_Tests at last handoff: **700 passing**; `tsc -b` clean; production build OK._


### PR DESCRIPTION
Updates HANDOFF.md to record PR #254 (rigid-zone refinements) and corrects the test count to 700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_