### PR TITLE
feat: wire flat-shell elements into solver & bridge (Tier 3 #13 phase 2)

### DIFF
--- a/webapp/src/engine/buckling.ts
+++ b/webapp/src/engine/buckling.ts
@@ -247,7 +247,7 @@ export function bucklingAnalysis(
 ): BucklingResult | null {
   if (hasMeshErrors(validateMesh(model))) return null
 
-  const br = modelToFrame3D(model)
+  const br = modelToFrame3D(model, { useShells: false })
   const precomp = precomputeFrame(br.nodes, br.members, br.supports)
   if (!precomp.Kff || precomp.Kff.n === 0) return null
 

--- a/webapp/src/engine/effectiveLength.ts
+++ b/webapp/src/engine/effectiveLength.ts
@@ -73,7 +73,7 @@ export interface ColumnK {
  * direction is treated as pinned (G = 10) for that direction.
  */
 export function columnKFactors(model: StructuralModel): ColumnK[] {
-  const br = modelToFrame3D(model)
+  const br = modelToFrame3D(model, { useShells: false })
   const pos = new Map(model.nodes.map((n) => [n.id, n]))
   const realIds = new Set(model.members.map((m) => m.id))
   const f3ById = new Map(br.members.map((m) => [m.id, m]))

--- a/webapp/src/engine/frame3d.ts
+++ b/webapp/src/engine/frame3d.ts
@@ -13,6 +13,7 @@ import { luFactor, luSolve, matVec, hermite, gauss5Vec } from './fem'
 import type { LUFactor } from './fem'
 import { nscpCombos, type Combo, type LoadCategory } from './beamAnalysis'
 import type { ProgressFn } from './progress'
+import { triShell } from './shell'
 
 /** Second-order (P-Δ) options for the frame solve. */
 export interface PDeltaOpts { pDelta?: boolean; maxIter?: number; tol?: number }
@@ -35,6 +36,11 @@ export interface F3Member {
   /** Rigid end offset at end j: vector from node j to the member end in global coords [m]. */
   offJ?: [number, number, number]
 }
+/** Flat triangular shell element (CST membrane + DKT plate bending) framing into
+ *  three nodes of the model. Carries in-plane (wall) and out-of-plane (slab)
+ *  stiffness in the same global solve as the frame members. E in MPa, t in mm. */
+export interface F3Shell { id: string; nodes: [string, string, string]; E: number; nu: number; t: number }
+
 export type F3Fixity = 'pin' | 'fixed' | 'spring'
 export interface F3Support {
   node: string
@@ -232,6 +238,26 @@ export interface MemberGeom {
   kfr?: number[][]      // k_fr sub-matrix (nf × nr), used in force recovery
 }
 
+// ── Shell element geometry (load-independent) ──────────────────────────────
+export interface ShellGeom {
+  id: string
+  Ke: number[][]     // 18×18 global stiffness, DOF order [u,v,w,θx,θy,θz]×3 nodes
+  dofs: number[]     // 18 global DOF indices
+  A: number          // area (m²)
+  normal: V3         // element +normal (global), for pressure loads
+  nodeIds: [string, string, string]
+}
+
+function prepShellGeom(sh: F3Shell, nm: Map<string, F3Node>, idx: Map<string, number>): ShellGeom {
+  const [na, nb, nc] = sh.nodes.map((id) => nm.get(id)!)
+  const { Ke, A, f } = triShell(
+    [na.x, na.y, na.z], [nb.x, nb.y, nb.z], [nc.x, nc.y, nc.z], sh.E, sh.nu, sh.t,
+  )
+  const dofs: number[] = []
+  for (const id of sh.nodes) { const ni = idx.get(id)!; for (let k = 0; k < 6; k++) dofs.push(6 * ni + k) }
+  return { id: sh.id, Ke, dofs, A, normal: f.R[2], nodeIds: sh.nodes }
+}
+
 // ── Load-dependent member data ─────────────────────────────────────────────
 interface MemberLoads {
   feq: number[]         // original fixed-end forces (for postprocessMember)
@@ -252,6 +278,7 @@ export interface FramePrecomp {
   members: F3Member[]
   supports: F3Support[]
   geoms: MemberGeom[]
+  shellGeoms: ShellGeom[]        // flat-shell elements (empty when none)
   ndof: number
   free: number[]
   freeIdx: Map<number, number>   // global DOF → position in free[]
@@ -546,13 +573,16 @@ function applyTrecover(d_ind: number[], Trow: TEntry[][]): number[] {
  *  Call once per geometry/support change; reuse for every load case. */
 export function precomputeFrame(
   nodes: F3Node[], members: F3Member[], supports: F3Support[],
-  diaphragms?: F3DiaphragmGroup[],
+  diaphragms?: F3DiaphragmGroup[], shells?: F3Shell[],
 ): FramePrecomp {
   const nm = new Map(nodes.map((n) => [n.id, n]))
   const idx = new Map(nodes.map((n, i) => [n.id, i]))
   const ndof = 6 * nodes.length
 
   const geoms = members.map((m) => prepMemberGeom(m, nm, idx))
+  const shellGeoms = (shells ?? [])
+    .filter((sh) => sh.nodes.every((id) => nm.has(id)))
+    .map((sh) => prepShellGeom(sh, nm, idx))
 
   const constrained = new Set<number>()
   for (const s of supports) {
@@ -578,6 +608,18 @@ export function precomputeFrame(
       }
     }
   }
+  // Flat-shell elements: add their 18×18 global stiffness to the free block.
+  for (const sg of shellGeoms) {
+    for (let a = 0; a < 18; a++) {
+      const ia = freeIdx.get(sg.dofs[a])
+      if (ia === undefined) continue
+      for (let b = 0; b < 18; b++) {
+        const ib = freeIdx.get(sg.dofs[b])
+        if (ib === undefined) continue
+        Kff_raw[ia][ib] += sg.Ke[a][b]
+      }
+    }
+  }
 
   // Spring supports: add translational spring stiffness to Kff diagonal
   for (const s of supports) {
@@ -597,12 +639,12 @@ export function precomputeFrame(
     if (dia) {
       const K_ind = applyTtoK(Kff_raw, dia.Trow, dia.ni)
       const Kff_ind = luFactor(K_ind)
-      return { nm, idx, nodes, members, supports, geoms, ndof, free, freeIdx,
+      return { nm, idx, nodes, members, supports, geoms, shellGeoms, ndof, free, freeIdx,
                Kff: Kff_ind, Kff_raw, diaT: dia.Trow, diaNi: dia.ni }
     }
   }
   const Kff = luFactor(Kff_raw)   // null if singular; {n:0} if nf===0
-  return { nm, idx, nodes, members, supports, geoms, ndof, free, freeIdx, Kff, Kff_raw }
+  return { nm, idx, nodes, members, supports, geoms, shellGeoms, ndof, free, freeIdx, Kff, Kff_raw }
 }
 
 /** Plain-JSON-serializable form of FramePrecomp — Maps become entry arrays for postMessage. */
@@ -611,6 +653,7 @@ export interface FramePrecompSerial {
   members: F3Member[]
   supports: F3Support[]
   geoms: MemberGeom[]
+  shellGeoms: ShellGeom[]
   ndof: number
   free: number[]
   freeIdxEntries: [number, number][]
@@ -623,7 +666,7 @@ export interface FramePrecompSerial {
 export function serializePrecomp(p: FramePrecomp): FramePrecompSerial {
   return {
     nodes: p.nodes, members: p.members, supports: p.supports,
-    geoms: p.geoms, ndof: p.ndof, free: p.free,
+    geoms: p.geoms, shellGeoms: p.shellGeoms, ndof: p.ndof, free: p.free,
     freeIdxEntries: [...p.freeIdx],
     Kff: p.Kff, Kff_raw: p.Kff_raw,
     ...(p.diaT ? { diaT: p.diaT, diaNi: p.diaNi } : {}),
@@ -635,7 +678,7 @@ export function deserializePrecomp(s: FramePrecompSerial): FramePrecomp {
     nm: new Map(s.nodes.map((n) => [n.id, n])),
     idx: new Map(s.nodes.map((n, i) => [n.id, i])),
     nodes: s.nodes, members: s.members, supports: s.supports,
-    geoms: s.geoms, ndof: s.ndof, free: s.free,
+    geoms: s.geoms, shellGeoms: s.shellGeoms ?? [], ndof: s.ndof, free: s.free,
     freeIdx: new Map(s.freeIdxEntries),
     Kff: s.Kff, Kff_raw: s.Kff_raw,
     ...(s.diaT ? { diaT: s.diaT, diaNi: s.diaNi } : {}),
@@ -718,7 +761,7 @@ function postprocessMember(m: F3Member, g: MemberGeom, ml: MemberLoads, d: numbe
 export function solveWithGeometry(
   precomp: FramePrecomp, loads: F3Load[], opts?: PDeltaOpts,
 ): F3Result | null {
-  const { idx, members, geoms, ndof, free, freeIdx, Kff, Kff_raw, supports, diaT, diaNi } = precomp
+  const { idx, members, geoms, shellGeoms, ndof, free, freeIdx, Kff, Kff_raw, supports, diaT, diaNi } = precomp
 
   const mloads = members.map((m, i) => computeMemberLoads(geoms[i], m, loads))
 
@@ -831,6 +874,11 @@ export function solveWithGeometry(
     const gde = matVec(g.kg, de)
     for (let a = 0; a < 12; a++) Kd[g.dofs[a]] += gde[a]
   }
+  for (const sg of shellGeoms) {
+    const de = sg.dofs.map((dof) => d[dof])
+    const gde = matVec(sg.Ke, de)
+    for (let a = 0; a < 18; a++) Kd[sg.dofs[a]] += gde[a]
+  }
   const Rv = Kd.map((v, i) => v - F[i])
 
   const reactions: F3Reaction[] = supports
@@ -871,9 +919,9 @@ export function solveWithGeometry(
 /** Backward-compatible single-solve entry point. */
 export function solveFrame3D(
   nodes: F3Node[], members: F3Member[], supports: F3Support[], loads: F3Load[],
-  opts?: PDeltaOpts,
+  opts?: PDeltaOpts, shells?: F3Shell[],
 ): F3Result | null {
-  return solveWithGeometry(precomputeFrame(nodes, members, supports), loads, opts)
+  return solveWithGeometry(precomputeFrame(nodes, members, supports, undefined, shells), loads, opts)
 }
 
 // ── NSCP combination orchestration ────────────────────────────────────────
@@ -889,12 +937,12 @@ export interface F3AnalyzeOpts extends PDeltaOpts {
 export function analyzeFrame3D(
   nodes: F3Node[], members: F3Member[], supports: F3Support[], loads: F3Load[],
   opts?: F3AnalyzeOpts, onProgress?: ProgressFn,
-  diaphragms?: F3DiaphragmGroup[],
+  diaphragms?: F3DiaphragmGroup[], shells?: F3Shell[],
 ): F3Analysis | null {
   const perCombo: F3ComboRun[] = []
   let govIdx = -1, govM = -1
   const combos = nscpCombos(opts?.f1 ?? 1.0)
-  const precomp = precomputeFrame(nodes, members, supports, diaphragms)   // factor K once
+  const precomp = precomputeFrame(nodes, members, supports, diaphragms, shells)   // factor K once
   combos.forEach((combo, i) => {
     onProgress?.({ phase: 'Analyzing load cases', current: i + 1, total: combos.length, detail: combo.name })
     const factored = applyF3Combo(loads, combo.f)

--- a/webapp/src/engine/frame3dShell.test.ts
+++ b/webapp/src/engine/frame3dShell.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import {
+  precomputeFrame, solveWithGeometry, solveFrame3D, serializePrecomp, deserializePrecomp,
+  type F3Node, type F3Member, type F3Support, type F3Load, type F3Shell,
+} from './frame3d'
+import { solveShell, type ShellNode, type ShellElem, type ShellSupport, type ShellNodeLoad } from './shell'
+
+const E = 25000, nu = 0.3, t = 200
+
+// 2×1 m plate (X-Y plane) as two triangles; left edge (x=0) fixed, tip loaded −z.
+const nodes: F3Node[] = [
+  { id: 'a', x: 0, y: 0, z: 0 }, { id: 'b', x: 2, y: 0, z: 0 },
+  { id: 'c', x: 2, y: 1, z: 0 }, { id: 'd', x: 0, y: 1, z: 0 },
+]
+const shells: F3Shell[] = [
+  { id: 's0', nodes: ['a', 'b', 'c'], E, nu, t },
+  { id: 's1', nodes: ['a', 'c', 'd'], E, nu, t },
+]
+const supports: F3Support[] = [
+  { node: 'a', fixity: 'fixed' }, { node: 'd', fixity: 'fixed' },
+]
+const loads: F3Load[] = [
+  { kind: 'node', node: 'b', Fz: -3, cat: 'D' }, { kind: 'node', node: 'c', Fz: -3, cat: 'D' },
+]
+
+describe('frame3d shell integration', () => {
+  it('matches the standalone solveShell displacements (same elements & loads)', () => {
+    const r = solveFrame3D(nodes, [], supports, loads, undefined, shells)!
+    expect(r).toBeTruthy()
+
+    const sn: ShellNode[] = nodes.map((n) => ({ id: n.id, x: n.x, y: n.y, z: n.z }))
+    const se: ShellElem[] = shells.map((s) => ({ id: s.id, nodes: s.nodes, E, nu, t }))
+    const ss: ShellSupport[] = [
+      { node: 'a', ux: true, uy: true, uz: true, rx: true, ry: true, rz: true },
+      { node: 'd', ux: true, uy: true, uz: true, rx: true, ry: true, rz: true },
+    ]
+    const sl: ShellNodeLoad[] = [{ node: 'b', Fz: -3 }, { node: 'c', Fz: -3 }]
+    const rs = solveShell(sn, se, ss, sl)!
+
+    const i = (id: string) => nodes.findIndex((n) => n.id === id)
+    for (const id of ['b', 'c']) {
+      expect(r.d[6 * i(id) + 2]).toBeCloseTo(rs.disp.get(id)![2], 9)   // w
+      expect(r.d[6 * i(id) + 0]).toBeCloseTo(rs.disp.get(id)![0], 9)   // u
+    }
+  })
+
+  it('reactions balance the applied load (ΣFz = +6 kN up)', () => {
+    const r = solveFrame3D(nodes, [], supports, loads, undefined, shells)!
+    const sumFz = r.reactions.reduce((s, rx) => s + rx.F[2], 0)
+    expect(sumFz).toBeCloseTo(6, 6)   // resists the two −3 kN tip loads
+  })
+
+  it('a shell stiffens a frame model — combined tip deflection < bare beam', () => {
+    // beam a→b with a,c,d fixed and b loaded; adding the shell panel (which also
+    // ties b to the fixed corners a,c) must reduce b's deflection.
+    const beam: F3Member = { id: 'm', i: 'a', j: 'b', E, G: E / 2.4, A: 90000, Iy: 6.75e8, Iz: 6.75e8, J: 1e9 }
+    const sup: F3Support[] = [
+      { node: 'a', fixity: 'fixed' }, { node: 'c', fixity: 'fixed' }, { node: 'd', fixity: 'fixed' },
+    ]
+    const ld: F3Load[] = [{ kind: 'node', node: 'b', Fz: -5, cat: 'D' }]
+    const bare = solveFrame3D(nodes, [beam], sup, ld)!
+    const withShell = solveFrame3D(nodes, [beam], sup, ld, undefined, shells)!
+    const bi = nodes.findIndex((n) => n.id === 'b')
+    expect(Math.abs(withShell.d[6 * bi + 2])).toBeLessThan(Math.abs(bare.d[6 * bi + 2]))
+  })
+
+  it('no shells → identical result to the pre-shell solver (backward compatible)', () => {
+    const ab: F3Node[] = [{ id: 'a', x: 0, y: 0, z: 0 }, { id: 'b', x: 2, y: 0, z: 0 }]
+    const beam: F3Member = { id: 'm', i: 'a', j: 'b', E, G: E / 2.4, A: 90000, Iy: 6.75e8, Iz: 6.75e8, J: 1e9 }
+    const sup: F3Support[] = [{ node: 'a', fixity: 'fixed' }]
+    const ld: F3Load[] = [{ kind: 'node', node: 'b', Fz: -5, cat: 'D' }]
+    const r1 = solveFrame3D(ab, [beam], sup, ld)!
+    const r2 = solveFrame3D(ab, [beam], sup, ld, undefined, [])!
+    expect(r2.d).toEqual(r1.d)
+  })
+
+  it('serializes shell geometry across the worker boundary', () => {
+    const p = precomputeFrame(nodes, [], supports, undefined, shells)
+    const q = deserializePrecomp(serializePrecomp(p))
+    expect(q.shellGeoms.length).toBe(2)
+    const r1 = solveWithGeometry(p, loads)!
+    const r2 = solveWithGeometry(q, loads)!
+    expect(r2.d).toEqual(r1.d)
+  })
+})

--- a/webapp/src/engine/modal.ts
+++ b/webapp/src/engine/modal.ts
@@ -179,7 +179,7 @@ export function modalAnalysis(model: StructuralModel, nModes = 12): ModalResult 
   // A mesh with errors (e.g. no supports → rigid-body modes) makes K singular
   // in ways luFactor's pivot tolerance may not catch; gate on validation.
   if (hasMeshErrors(validateMesh(model))) return null
-  const br = modelToFrame3D(model)
+  const br = modelToFrame3D(model, { useShells: false })
   const precomp = precomputeFrame(br.nodes, br.members, br.supports)
   if (!precomp.Kff || precomp.Kff.n === 0) return null
 

--- a/webapp/src/engine/model.ts
+++ b/webapp/src/engine/model.ts
@@ -117,6 +117,10 @@ export interface StructuralModel {
   rigidEndZones?: boolean
   /** Rigid-zone factor (0–1) scaling the auto end-offset length (default 0.5). */
   rigidZoneFactor?: number
+  /** Model slab/wall panels as flat-shell finite elements (CST membrane + DKT
+   *  bending) assembled into the solve, instead of tributary edge load sources.
+   *  Each panel meshes to two triangles on its four corner nodes. */
+  shellElements?: boolean
 }
 
 export function emptyModel(name = 'Untitled'): StructuralModel {

--- a/webapp/src/engine/modelBridge.test.ts
+++ b/webapp/src/engine/modelBridge.test.ts
@@ -64,3 +64,61 @@ describe('modelToFrame3D — rigid offsets', () => {
     expect(m.offI).toEqual([0, 0.9, 0])    // manual wins
   })
 })
+
+// 4×3 m slab panel in the X-Z plane (y=4) carried by 4 corner nodes.
+function slabModel(): StructuralModel {
+  return {
+    ...emptyModel('t'),
+    nodes: [
+      { id: 'n0', x: 0, y: 4, z: 0 }, { id: 'n1', x: 4, y: 4, z: 0 },
+      { id: 'n2', x: 4, y: 4, z: 3 }, { id: 'n3', x: 0, y: 4, z: 3 },
+    ],
+    sections: [section],
+    members: [
+      { id: 'e0', i: 'n0', j: 'n1', role: 'beam', section: 'S' },
+      { id: 'e1', i: 'n1', j: 'n2', role: 'beam', section: 'S' },
+      { id: 'e2', i: 'n2', j: 'n3', role: 'beam', section: 'S' },
+      { id: 'e3', i: 'n3', j: 'n0', role: 'beam', section: 'S' },
+    ],
+    plates: [{ id: 'p', corners: ['n0', 'n1', 'n2', 'n3'], role: 'slab', thickness: 150 }],
+    supports: [{ node: 'n0', fixity: 'fixed' }, { node: 'n1', fixity: 'fixed' }, { node: 'n2', fixity: 'fixed' }, { node: 'n3', fixity: 'fixed' }],
+    loads: [{ kind: 'area', plate: 'p', q: 5, cat: 'D' }],
+  }
+}
+
+describe('modelToFrame3D — shell elements', () => {
+  it('meshes each panel into two triangular shells when shellElements is on', () => {
+    const model = { ...slabModel(), shellElements: true }
+    const br = modelToFrame3D(model)
+    expect(br.shells.length).toBe(2)
+    expect(br.shells[0].nodes).toEqual(['n0', 'n1', 'n2'])
+    expect(br.shells[1].nodes).toEqual(['n0', 'n2', 'n3'])
+    expect(br.shells[0].t).toBe(150)
+    expect(br.shells[0].E).toBeCloseTo(4700 * Math.sqrt(28), 3)
+  })
+
+  it('produces no shells (classic tributary path) when the flag is off', () => {
+    const br = modelToFrame3D(slabModel())
+    expect(br.shells).toEqual([])
+    // tributary edge loads land on the beams as member-vdl
+    expect(br.loads.some((l) => l.kind === 'member-vdl')).toBe(true)
+  })
+
+  it('routes the panel area load to corner nodes (−Y) and skips tributary — no double count', () => {
+    const model = { ...slabModel(), shellElements: true }
+    const br = modelToFrame3D(model)
+    // no tributary edge loads for the shell panel
+    expect(br.loads.some((l) => l.kind === 'member-vdl' || l.kind === 'member-udl')).toBe(false)
+    const nodeLoads = br.loads.filter((l) => l.kind === 'node') as Extract<typeof br.loads[number], { kind: 'node' }>[]
+    const sumFy = nodeLoads.reduce((s, l) => s + (l.Fy ?? 0), 0)
+    // total lumped load = −q·area = −5·(4·3) = −60 kN
+    expect(sumFy).toBeCloseTo(-60, 6)
+  })
+
+  it('useShells:false overrides the model flag (keeps tributary for design)', () => {
+    const model = { ...slabModel(), shellElements: true }
+    const br = modelToFrame3D(model, { useShells: false })
+    expect(br.shells).toEqual([])
+    expect(br.loads.some((l) => l.kind === 'member-vdl')).toBe(true)
+  })
+})

--- a/webapp/src/engine/modelBridge.ts
+++ b/webapp/src/engine/modelBridge.ts
@@ -4,8 +4,8 @@
 // and land on the matching edge members as vdl/udl gravity loads (categories
 // preserved) — the load path, automated.
 // ─────────────────────────────────────────────────────────────────────────
-import type { StructuralModel, RectSection, MemberReleases } from './model'
-import type { F3Node, F3Member, F3Support, F3Load, F3DiaphragmGroup } from './frame3d'
+import type { StructuralModel, RectSection, MemberReleases, Plate } from './model'
+import type { F3Node, F3Member, F3Support, F3Load, F3DiaphragmGroup, F3Shell } from './frame3d'
 import { rectJ } from './frame3d'
 import { buildDiaphragmGroups } from './diaphragm'
 import { autoRigidOffsets } from './rigidEndZones'
@@ -19,10 +19,37 @@ export interface BridgeResult {
   members: F3Member[]
   supports: F3Support[]
   loads: F3Load[]
+  /** Flat-shell elements meshed from slab/wall panels (empty unless shellElements on). */
+  shells: F3Shell[]
   /** Edges whose loads could not be attached (no matching member). */
   orphanEdges: string[]
   /** Rigid floor diaphragm groups (one per storey); empty when diaphragm disabled. */
   diaphragmGroups: F3DiaphragmGroup[]
+}
+
+/** Concrete shell material for slab/wall panels: E = 4700√fc (NSCP/ACI), ν = 0.2.
+ *  fc taken from the model's first concrete section (fallback 28 MPa). */
+function plateMaterial(model: StructuralModel): { E: number; nu: number } {
+  const fc = model.sections.find((s) => s.material !== 'steel')?.fc ?? 28
+  return { E: 4700 * Math.sqrt(Math.max(fc, 1)), nu: 0.2 }
+}
+
+/** Triangle area (m²) from three model node ids. */
+function triArea(p: [F3Node, F3Node, F3Node]): number {
+  const [a, b, c] = p
+  const ux = b.x - a.x, uy = b.y - a.y, uz = b.z - a.z
+  const vx = c.x - a.x, vy = c.y - a.y, vz = c.z - a.z
+  const cx = uy * vz - uz * vy, cy = uz * vx - ux * vz, cz = ux * vy - uy * vx
+  return 0.5 * Math.hypot(cx, cy, cz)
+}
+
+/** Mesh one quad panel into two triangular shells across the c0–c2 diagonal. */
+function plateShells(plate: Plate, mat: { E: number; nu: number }): F3Shell[] {
+  const [c0, c1, c2, c3] = plate.corners
+  return [
+    { id: `${plate.id}#0`, nodes: [c0, c1, c2], E: mat.E, nu: mat.nu, t: plate.thickness },
+    { id: `${plate.id}#1`, nodes: [c0, c2, c3], E: mat.E, nu: mat.nu, t: plate.thickness },
+  ]
 }
 
 function sectionProps(s: RectSection) {
@@ -129,7 +156,13 @@ function releaseFlags(rel: MemberReleases | undefined): Pick<F3Member, 'relI' | 
   return { ...(relI ? { relI } : {}), ...(relJ ? { relJ } : {}) }
 }
 
-export function modelToFrame3D(model: StructuralModel): BridgeResult {
+/** Bridge options. `useShells` defaults to the model's `shellElements` flag; the
+ *  design / modal / buckling paths pass `false` to keep the classic tributary
+ *  edge-load model (shells are an analysis-path feature in this phase). */
+export interface BridgeOpts { useShells?: boolean }
+
+export function modelToFrame3D(model: StructuralModel, opts?: BridgeOpts): BridgeResult {
+  const useShells = opts?.useShells ?? !!model.shellElements
   const nodes: F3Node[] = model.nodes.map((n) => ({ id: n.id, x: n.x, y: n.y, z: n.z }))
   const nm = new Map(nodes.map((n) => [n.id, n]))
   const secById = new Map(model.sections.map((s) => [s.id, sectionProps(s)]))
@@ -161,6 +194,23 @@ export function modelToFrame3D(model: StructuralModel): BridgeResult {
     if (s.fixity === 'spring') return { node: s.node, fixity: 'spring', kx: s.kx, ky: s.ky, kz: s.kz }
     return { node: s.node, fixity: s.fixity === 'fixed' ? 'fixed' : 'pin' }
   })
+
+  // Optional: mesh slab/wall panels into flat-shell elements (two triangles per
+  // panel on its corner nodes). Panels handled as shells carry their area loads
+  // through the shell — the tributary edge-load path is skipped for them below.
+  const shells: F3Shell[] = []
+  const shellPlateIds = new Set<string>()
+  if (useShells) {
+    const mat = plateMaterial(model)
+    for (const plate of model.plates) {
+      const c = plate.corners.map((id) => nm.get(id))
+      if (c.some((q) => !q)) continue
+      const [c0, c1, c2, c3] = c as F3Node[]
+      if (triArea([c0, c1, c2]) + triArea([c0, c2, c3]) < 1e-9) continue   // degenerate
+      shells.push(...plateShells(plate, mat))
+      shellPlateIds.add(plate.id)
+    }
+  }
 
   const loads: F3Load[] = []
   const orphanEdges: string[] = []
@@ -196,6 +246,21 @@ export function modelToFrame3D(model: StructuralModel): BridgeResult {
     const c = plate.corners.map((id) => nm.get(id))
     if (c.some((q) => !q)) continue
     const [c0, c1, c2, c3] = c as F3Node[]
+
+    // Shell panel: lump each gravity area load to the corner nodes (−Y), split
+    // per triangle (q·A_tri/3 to each of its three nodes). Avoids double-count
+    // with the shell stiffness (no tributary edge loads for this panel).
+    if (shellPlateIds.has(plate.id)) {
+      const A0 = triArea([c0, c1, c2]), A1 = triArea([c0, c2, c3])
+      for (const al of areaLoads) {
+        const f0 = (al.q * A0) / 3, f1 = (al.q * A1) / 3
+        const add = (id: string, f: number) => loads.push({ kind: 'node', node: id, Fy: -f, cat: al.cat })
+        add(c0.id, f0); add(c1.id, f0); add(c2.id, f0)
+        add(c0.id, f1); add(c2.id, f1); add(c3.id, f1)
+      }
+      continue
+    }
+
     const lxSpan = Math.hypot(c1.x - c0.x, c1.y - c0.y, c1.z - c0.z)   // edge c0→c1 (and c3→c2)
     const lzSpan = Math.hypot(c3.x - c0.x, c3.y - c0.y, c3.z - c0.z)   // edge c0→c3 (and c1→c2)
     const trib = distributePanel(lxSpan, lzSpan, areaLoads)
@@ -228,5 +293,5 @@ export function modelToFrame3D(model: StructuralModel): BridgeResult {
   }
 
   const diaphragmGroups = model.diaphragm ? buildDiaphragmGroups(model) : []
-  return { nodes, members, supports, loads, orphanEdges, diaphragmGroups }
+  return { nodes, members, supports, loads, shells, orphanEdges, diaphragmGroups }
 }

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -337,7 +337,7 @@ function buildRuns(model: StructuralModel, opts: AnalyzeOptions, onProgress?: Pr
   // slab tributary line loads and member self-weight; lateral cases are pure
   // node loads applied on top per direction.
   const gravityModel = { ...model, loads: model.loads.filter((l) => l.cat !== 'E' && l.cat !== 'W') }
-  const br = modelToFrame3D(gravityModel)
+  const br = modelToFrame3D(gravityModel, { useShells: false })
 
   let lateral = opts.lateral ?? []
   if (lateral.length === 0) {
@@ -666,7 +666,7 @@ async function buildRunsParallel(
   model: StructuralModel, opts: AnalyzeOptions, pool: FramePool, onProgress?: ProgressFn,
 ): Promise<{ br: BridgeResult; runs: FrameRun[] }> {
   const gravityModel = { ...model, loads: model.loads.filter((l) => l.cat !== 'E' && l.cat !== 'W') }
-  const br = modelToFrame3D(gravityModel)
+  const br = modelToFrame3D(gravityModel, { useShells: false })
 
   let lateral = opts.lateral ?? []
   if (lateral.length === 0) {

--- a/webapp/src/engine/pushoverModel.ts
+++ b/webapp/src/engine/pushoverModel.ts
@@ -74,7 +74,7 @@ export interface PushoverModelResult {
  * reported base shear equals the load factor λ at each event.
  */
 export function runPushoverModel(model: StructuralModel, opts: PushoverModelOpts = {}): PushoverModelResult | null {
-  const br = modelToFrame3D(model)
+  const br = modelToFrame3D(model, { useShells: false })
   if (br.nodes.length === 0) return null
   const dir = opts.dir ?? 0
 

--- a/webapp/src/engine/solverWorker.ts
+++ b/webapp/src/engine/solverWorker.ts
@@ -34,12 +34,12 @@ ctx.onmessage = async (e: MessageEvent<SolverRequest>) => {
   try {
     if (msg.kind === 'analyze') {
       const br = modelToFrame3D(msg.model)
-      const analysis = analyzeFrame3D(br.nodes, br.members, br.supports, br.loads, msg.opts, onProgress, br.diaphragmGroups)
+      const analysis = analyzeFrame3D(br.nodes, br.members, br.supports, br.loads, msg.opts, onProgress, br.diaphragmGroups, br.shells)
       let drift = null
       if (msg.drift.hasSeis) {
         onProgress({ phase: 'Storey-drift check' })
         const eOnly = applyF3Combo(br.loads, { E: 1 })
-        const sol = eOnly.length ? solveFrame3D(br.nodes, br.members, br.supports, eOnly, { pDelta: msg.drift.pDelta }) : null
+        const sol = eOnly.length ? solveFrame3D(br.nodes, br.members, br.supports, eOnly, { pDelta: msg.drift.pDelta }, br.shells) : null
         drift = sol ? driftCheck(msg.model, br.nodes, sol.d, msg.drift.R, msg.drift.T, msg.drift.axis) : null
       }
       ctx.postMessage({ id: msg.id, ok: true, result: { analysis, orphans: br.orphanEdges.length, drift } })


### PR DESCRIPTION
## Summary

Tier 3 #13 (FEM plate/shell elements) — **Phase 2: solver + bridge wiring**. Builds on the shell engine (#256) so slab/wall panels participate in the global analysis instead of only sourcing tributary loads.

### `frame3d` core (additive, fully backward-compatible)
- New `F3Shell` input and `ShellGeom`; `precomputeFrame` assembles each shell's 18×18 global stiffness into the free block, and reactions now include the shell `K·d` contribution.
- Shells threaded through `analyzeFrame3D` / `solveFrame3D` and serialized across the worker boundary (so the design pool path round-trips them).
- No-shell calls are byte-identical to before.

### Model bridge
- `StructuralModel.shellElements` toggle. Each `Plate` meshes to two triangular shells on its four corner nodes (concrete `E=4700√fc`, `ν=0.2`, `t=thickness`).
- Area loads on shell panels lump to the corner nodes (−Y, per-triangle `q·A/3`); the tributary edge-load path is **skipped** for those panels → no double-counting.
- `BridgeOpts.useShells` lets the design / modal / buckling / pushover paths keep the classic tributary model. **Shells are an analysis-path feature this phase** — the NSCP design pipeline is unchanged.

## Tests (+9, **718** total)
- Integrated solver matches the standalone `solveShell` to 9 digits (same elements & loads)
- Reactions balance the applied load; a shell stiffens a frame (tip deflection ↓)
- No-shell path produces identical results; precomp serialization round-trips shells
- Bridge: panel → 2 shells, area load → corner nodes summing to −q·A, tributary skipped, `useShells:false` override

`tsc -b` clean.

## Remaining phase
- Phase 3 — ModelSpace UI: a toggle to enable shells + 3D rendering of the shell panels / deflected mesh (and optionally element-stress recovery + contours).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_