### PR TITLE
feat(D9): shell stress recovery + SVG contour overlay

### DIFF
--- a/webapp/src/components/ShellContourPanel.tsx
+++ b/webapp/src/components/ShellContourPanel.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react'
+import { ResultCard, Row } from './qty'
+import type { ShellNode, ShellElem, ElementStress } from '../engine/shell'
+import { shellNodalContour } from '../engine/shell'
+
+type StressKey = 'vonMises' | 'sigmaX' | 'sigmaY' | 'tauXY' | 'sigma1' | 'sigma2' | 'Mx' | 'My' | 'Mxy'
+const KEYS: [StressKey, string][] = [
+  ['vonMises', 'Von Mises σvm (kN/m²)'],
+  ['sigmaX',  'σx (kN/m²)'],
+  ['sigmaY',  'σy (kN/m²)'],
+  ['tauXY',   'τxy (kN/m²)'],
+  ['sigma1',  'σ₁ principal (kN/m²)'],
+  ['sigma2',  'σ₂ principal (kN/m²)'],
+  ['Mx',      'Mx (kN·m/m)'],
+  ['My',      'My (kN·m/m)'],
+  ['Mxy',     'Mxy (kN·m/m)'],
+]
+
+// ── Colour map: blue (low) → cyan → green → yellow → red (high) ──────────────
+function heatColor(t: number): string {
+  const c = Math.max(0, Math.min(1, t))
+  const r = Math.round(255 * Math.min(1, 2 * c))
+  const g = Math.round(255 * Math.min(1, 2 * (1 - Math.abs(c - 0.5))))
+  const b = Math.round(255 * Math.max(0, 1 - 2 * c))
+  return `rgb(${r},${g},${b})`
+}
+
+interface Props {
+  nodes: ShellNode[]
+  elems: ShellElem[]
+  stresses: ElementStress[]
+}
+
+export function ShellContourPanel({ nodes, elems, stresses }: Props) {
+  const [key, setKey] = useState<StressKey>('vonMises')
+  const nodal = shellNodalContour(nodes, elems, stresses, key)
+
+  // ── Build projected 2D geometry (use global x,z as the 2D plane if mostly horizontal,
+  //    or x,y otherwise — pick the two axes with the most spread). ───────────────────
+  const W = 460, H = 300, padL = 10, padR = 10, padT = 10, padB = 10
+  const xs = nodes.map((n) => n.x), ys = nodes.map((n) => n.y), zs = nodes.map((n) => n.z)
+  const spanX = Math.max(...xs) - Math.min(...xs)
+  const spanY = Math.max(...ys) - Math.min(...ys)
+  const spanZ = Math.max(...zs) - Math.min(...zs)
+  // Pick the two axes with largest span
+  const axes = (['x', 'y', 'z'] as const).map((a, i) => ({ a, s: [spanX, spanY, spanZ][i] }))
+    .sort((a, b) => b.s - a.s)
+  const ax0 = axes[0].a, ax1 = axes[1].a
+  const coord = (n: ShellNode): [number, number] => [n[ax0], n[ax1]]
+
+  const px = nodes.map((n) => coord(n)[0]), py = nodes.map((n) => coord(n)[1])
+  const [pxMin, pxMax] = [Math.min(...px), Math.max(...px)]
+  const [pyMin, pyMax] = [Math.min(...py), Math.max(...py)]
+  const rangeX = pxMax - pxMin || 1, rangeY = pyMax - pyMin || 1
+  const scale = Math.min((W - padL - padR) / rangeX, (H - padT - padB) / rangeY)
+  const offX = padL + ((W - padL - padR) - rangeX * scale) / 2
+  const offY = padT + ((H - padT - padB) - rangeY * scale) / 2
+  const sx = (v: number) => offX + (v - pxMin) * scale
+  const sy = (v: number) => offY + (rangeY - (v - pyMin)) * scale   // flip Y
+
+  const nodeXY = new Map(nodes.map((n) => [n.id, [sx(coord(n)[0]), sy(coord(n)[1])] as [number, number]]))
+
+  // Min/max of nodal contour (for scaling colours)
+  const vals = [...nodal.values()]
+  const vMin = Math.min(...vals), vMax = Math.max(...vals)
+  const vRange = vMax - vMin || 1
+  const norm = (v: number) => (v - vMin) / vRange
+
+  const maxAbs = Math.max(Math.abs(vMax), Math.abs(vMin))
+  const peakElem = stresses.reduce((a, b) => {
+    const av = Math.abs(a[key] as number), bv = Math.abs(b[key] as number)
+    return bv > av ? b : a
+  }, stresses[0])
+
+  const keyLabel = KEYS.find(([k]) => k === key)?.[1] ?? key
+
+  return (
+    <ResultCard title="Shell stress contour">
+      {/* Quantity selector */}
+      <div className="col-span-full mb-2">
+        <select value={key} onChange={(e) => setKey(e.target.value as StressKey)}
+          className="rounded border border-slate-300 bg-white px-2 py-1 text-sm text-slate-700">
+          {KEYS.map(([k, label]) => <option key={k} value={k}>{label}</option>)}
+        </select>
+      </div>
+
+      {/* SVG contour */}
+      <div className="col-span-full mb-3 overflow-hidden rounded-lg border border-slate-200 bg-slate-50">
+        <svg viewBox={`0 0 ${W} ${H}`} xmlns="http://www.w3.org/2000/svg"
+          preserveAspectRatio="xMidYMid meet" style={{ width: '100%', height: 'auto' }}>
+          {elems.map((e) => {
+            const pts = e.nodes.map((id) => {
+              const [x, y] = nodeXY.get(id)!
+              return `${x.toFixed(1)},${y.toFixed(1)}`
+            }).join(' ')
+            // Colour by element centroid value (average of its 3 node values)
+            const cv = e.nodes.reduce((s, id) => s + (nodal.get(id) ?? 0), 0) / 3
+            return (
+              <polygon key={e.id} points={pts}
+                fill={heatColor(norm(cv))} stroke="#94a3b8" strokeWidth={0.4} opacity={0.92} />
+            )
+          })}
+          {/* Colour bar */}
+          {Array.from({ length: 20 }, (_, i) => {
+            const t = i / 19
+            const bx = W - 28, bw = 14, bh = (H - padT - padB) / 20
+            return (
+              <rect key={i} x={bx} y={H - padB - (i + 1) * bh} width={bw} height={bh + 0.5}
+                fill={heatColor(t)} />
+            )
+          })}
+          <text x={W - 14} y={padT + 4} fontSize={8} fill="#334155" textAnchor="middle">{vMax.toFixed(0)}</text>
+          <text x={W - 14} y={H - padB - 2} fontSize={8} fill="#334155" textAnchor="middle">{vMin.toFixed(0)}</text>
+        </svg>
+      </div>
+
+      {/* Summary rows */}
+      <Row label={`Max |${key}|`} value={`${maxAbs.toFixed(1)} ${key.startsWith('M') ? 'kN·m/m' : 'kN/m²'}`}
+        sub={`element ${peakElem?.id ?? '—'}`} />
+      <Row label="Max von Mises" value={`${Math.max(...stresses.map((s) => s.vonMises)).toFixed(1)} kN/m²`} />
+      <Row label="Max Mx bending" value={`${Math.max(...stresses.map((s) => Math.abs(s.Mx))).toFixed(3)} kN·m/m`} />
+      <Row label="Elements / nodes" value={`${elems.length} / ${nodes.length}`}
+        sub={`contour: ${keyLabel}`} />
+    </ResultCard>
+  )
+}

--- a/webapp/src/engine/shell.test.ts
+++ b/webapp/src/engine/shell.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
-  triFrame, cstMembrane, dktBending, triShell, solveShell, rectPlateMesh,
+  triFrame, cstMembrane, dktBending, dktBmat, triShell, solveShell, rectPlateMesh,
+  recoverShellStress, shellNodalContour,
   type ShellNode, type ShellElem, type ShellSupport,
 } from './shell'
 
@@ -149,5 +150,127 @@ describe('orientation independence', () => {
     const wXY = Math.abs(rXY.disp.get(mXY.id(c, c))![2])   // out-of-plane = z
     const wXZ = Math.abs(rXZ.disp.get(mXY.id(c, c))![1])   // out-of-plane = y
     expect(wXZ).toBeCloseTo(wXY, 6)
+  })
+})
+
+// ── dktBmat: consistency with dktBending ────────────────────────────────────
+describe('dktBmat', () => {
+  it('integrating Bᵀ D B over the 3 mid-edge Gauss points reproduces dktBending K', () => {
+    const f = triFrame([0, 0, 0], [3, 0, 0], [0, 4, 0])
+    const t = 150, nu = 0.3, Es = E * 1e3, tm = t / 1000
+    const cb = Es / (1 - nu * nu)
+    const Db = [[cb, cb * nu, 0], [cb * nu, cb, 0], [0, 0, cb * (1 - nu) / 2]].map((r) => r.map((v) => v * (tm ** 3 / 12)))
+    const gps: [number, number][] = [[0.5, 0], [0, 0.5], [0.5, 0.5]]
+    const mul = (A: number[][], B: number[][]): number[][] =>
+      A.map((row) => B[0].map((_, j) => row.reduce((s, v, k) => s + v * B[k][j], 0)))
+    const transpose = (A: number[][]): number[][] => A[0].map((_, j) => A.map((r) => r[j]))
+    const zeros9 = () => Array.from({ length: 9 }, () => new Array(9).fill(0))
+    let K = zeros9()
+    for (const [xi, eta] of gps) {
+      const B = dktBmat(f, xi, eta)
+      const k = mul(transpose(B), mul(Db, B))
+      K = K.map((row, i) => row.map((v, j) => v + (f.A / 3) * k[i][j]))
+    }
+    const Kref = dktBending(f, E, nu, t)
+    for (let i = 0; i < 9; i++) for (let j = 0; j < 9; j++) expect(K[i][j]).toBeCloseTo(Kref[i][j], 6)
+  })
+})
+
+// ── Stress recovery ──────────────────────────────────────────────────────────
+describe('recoverShellStress', () => {
+  // Reuse the 1×1 m uniaxial-tension setup from the CST membrane test.
+  const t = 100
+  const nodes: ShellNode[] = [
+    { id: 'bl', x: 0, y: 0, z: 0 }, { id: 'br', x: 1, y: 0, z: 0 },
+    { id: 'tr', x: 1, y: 1, z: 0 }, { id: 'tl', x: 0, y: 1, z: 0 },
+  ]
+  const elems: ShellElem[] = [
+    { id: 'e0', nodes: ['bl', 'br', 'tr'], E, nu, t },
+    { id: 'e1', nodes: ['bl', 'tr', 'tl'], E, nu, t },
+  ]
+  const sigma = 5   // MPa applied as traction
+  const P = (sigma * t * 1000) / 1e3
+  const supports: ShellSupport[] = [
+    { node: 'bl', ux: true, uy: true, uz: true, rx: true, ry: true, rz: true },
+    { node: 'tl', ux: true, uz: true, rx: true, ry: true, rz: true },
+    { node: 'br', uz: true, rx: true, ry: true, rz: true },
+    { node: 'tr', uz: true, rx: true, ry: true, rz: true },
+  ]
+
+  it('recovers σx ≈ σ_applied on the axis-aligned element (e0 local frame = global)', () => {
+    const r = solveShell(nodes, elems, supports, [{ node: 'br', Fx: P / 2 }, { node: 'tr', Fx: P / 2 }])!
+    const st = recoverShellStress(nodes, elems, r)
+    // e0 (bl→br→tr) has x̂ aligned with global X → local σx = global σx = 5 MPa = 5000 kN/m²
+    const s0 = st.find((s) => s.id === 'e0')!
+    expect(s0.sigmaX).toBeCloseTo(sigma * 1e3, 1)
+    // e1 (bl→tr→tl) is rotated 45°: local σx = σy_global·sin²45° + σx·cos²45° = 2500 kN/m²
+    const s1 = st.find((s) => s.id === 'e1')!
+    expect(s1.sigmaX).toBeCloseTo(sigma * 1e3 / 2, 1)
+  })
+
+  it('σ1 ≥ σ2 and vonMises ≥ 0 for all elements', () => {
+    const r = solveShell(nodes, elems, supports, [{ node: 'br', Fx: P / 2 }, { node: 'tr', Fx: P / 2 }])!
+    const st = recoverShellStress(nodes, elems, r)
+    for (const s of st) {
+      expect(s.sigma1).toBeGreaterThanOrEqual(s.sigma2 - 1e-9)
+      expect(s.vonMises).toBeGreaterThanOrEqual(0)
+    }
+  })
+
+  it('bending moments ≈ 0 for a pure in-plane load', () => {
+    const r = solveShell(nodes, elems, supports, [{ node: 'br', Fx: P / 2 }, { node: 'tr', Fx: P / 2 }])!
+    const st = recoverShellStress(nodes, elems, r)
+    for (const s of st) {
+      expect(Math.abs(s.Mx)).toBeLessThan(1e-6)
+      expect(Math.abs(s.My)).toBeLessThan(1e-6)
+      expect(Math.abs(s.Mxy)).toBeLessThan(1e-6)
+    }
+  })
+
+  it('bending moments non-zero under out-of-plane pressure (coarser mesh with interior node)', () => {
+    // 2×2 mesh gives a free interior node that deflects under pressure → non-zero M
+    const { nodes: mn, elems: me, id } = rectPlateMesh(1, 1, 2, 2, E, nu, t)
+    const n = 2
+    const onEdge = (i: number, j: number) => i === 0 || j === 0 || i === n || j === n
+    const sup: ShellSupport[] = []
+    for (let j = 0; j <= n; j++) for (let i = 0; i <= n; i++) if (onEdge(i, j))
+      sup.push({ node: id(i, j), uz: true, ux: true, uy: true, rz: true })
+    const pr = me.map((e) => ({ elem: e.id, q: 10 }))
+    const r = solveShell(mn, me, sup, [], pr)!
+    const st = recoverShellStress(mn, me, r)
+    const maxMx = Math.max(...st.map((s) => Math.abs(s.Mx)))
+    expect(maxMx).toBeGreaterThan(0)
+  })
+})
+
+describe('shellNodalContour', () => {
+  const t = 100
+  const nodes: ShellNode[] = [
+    { id: 'a', x: 0, y: 0, z: 0 }, { id: 'b', x: 1, y: 0, z: 0 },
+    { id: 'c', x: 0.5, y: 1, z: 0 },
+  ]
+  const elems: ShellElem[] = [{ id: 'e0', nodes: ['a', 'b', 'c'], E, nu, t }]
+  const supports: ShellSupport[] = [
+    { node: 'a', ux: true, uy: true, uz: true, rx: true, ry: true, rz: true },
+    { node: 'b', ux: true, uy: true, uz: true, rx: true, ry: true, rz: true },
+    { node: 'c', ux: true, uy: true, uz: true, rx: true, ry: true, rz: true },
+  ]
+
+  it('returns a value for every node', () => {
+    const r = solveShell(nodes, elems, supports)!
+    const st = recoverShellStress(nodes, elems, r)
+    const contour = shellNodalContour(nodes, elems, st, 'vonMises')
+    expect(contour.size).toBe(3)
+    for (const n of nodes) expect(contour.has(n.id)).toBe(true)
+  })
+
+  it('all values finite and non-negative for vonMises', () => {
+    const r = solveShell(nodes, elems, supports, [{ node: 'c', Fx: 1 }])!
+    const st = recoverShellStress(nodes, elems, r)
+    const contour = shellNodalContour(nodes, elems, st, 'vonMises')
+    for (const v of contour.values()) {
+      expect(isFinite(v)).toBe(true)
+      expect(v).toBeGreaterThanOrEqual(0)
+    }
   })
 })

--- a/webapp/src/engine/shell.ts
+++ b/webapp/src/engine/shell.ts
@@ -88,22 +88,21 @@ export function cstMembrane(f: TriFrame, E: number, nu: number, t: number): numb
 // ── DKT plate bending (3×3 = 9 DOF: w,θx,θy per node) ──────────────────────
 // θx = ∂w/∂y, θy = −∂w/∂x (Kirchhoff). Batoz/Bathe/Ho (1980) shape-function
 // derivative arrays HX,HY (w.r.t. area coords ξ,η) → curvature matrix B (3×9).
-export function dktBending(f: TriFrame, E: number, nu: number, t: number): number[][] {
-  const Es = E * 1e3, tm = t / 1000
+
+/** DKT curvature-displacement matrix B (3×9) evaluated at area coords (ξ,η). */
+export function dktBmat(f: TriFrame, xi: number, eta: number): number[][] {
   const [x1, x2, x3] = f.x, [y1, y2, y3] = f.y
   const x21 = x2 - x1, x31 = x3 - x1, y21 = y2 - y1, y31 = y3 - y1
-  const det2A = x21 * y31 - x31 * y21   // = 2A (oriented +)
+  const det2A = x21 * y31 - x31 * y21
 
-  // side differences k = 4(23), 5(31), 6(12)
   const sd = (xi: number, xj: number, yi: number, yj: number) => {
     const dx = xi - xj, dy = yi - yj, l2 = dx * dx + dy * dy
     return { P: -6 * dx / l2, t: -6 * dy / l2, q: 3 * dx * dy / l2, r: 3 * dy * dy / l2 }
   }
   const s4 = sd(x2, x3, y2, y3), s5 = sd(x3, x1, y3, y1), s6 = sd(x1, x2, y1, y2)
-  const P4 = s4.P, P5 = s5.P, P6 = s6.P
-  const t4 = s4.t, t5 = s5.t, t6 = s6.t
-  const q4 = s4.q, q5 = s5.q, q6 = s6.q
-  const r4 = s4.r, r5 = s5.r, r6 = s6.r
+  const { P: P4, t: t4, q: q4, r: r4 } = s4
+  const { P: P5, t: t5, q: q5, r: r5 } = s5
+  const { P: P6, t: t6, q: q6, r: r6 } = s6
 
   const HXxi = (xi: number, eta: number): number[] => [
     P6 * (1 - 2 * xi) + (P5 - P6) * eta,
@@ -112,9 +111,7 @@ export function dktBending(f: TriFrame, E: number, nu: number, t: number): numbe
     -P6 * (1 - 2 * xi) + eta * (P4 + P6),
     q6 * (1 - 2 * xi) + eta * (q4 - q6),
     -2 + 6 * xi + r6 * (1 - 2 * xi) + eta * (r4 - r6),
-    -eta * (P4 + P5),
-    eta * (q4 - q5),
-    -eta * (r5 - r4),
+    -eta * (P4 + P5), eta * (q4 - q5), -eta * (r5 - r4),
   ]
   const HYxi = (xi: number, eta: number): number[] => [
     t6 * (1 - 2 * xi) + (t5 - t6) * eta,
@@ -123,17 +120,13 @@ export function dktBending(f: TriFrame, E: number, nu: number, t: number): numbe
     -t6 * (1 - 2 * xi) + eta * (t4 + t6),
     -1 + r6 * (1 - 2 * xi) + eta * (r4 - r6),
     -q6 * (1 - 2 * xi) - eta * (q4 - q6),
-    -eta * (t4 + t5),
-    eta * (r4 - r5),
-    -eta * (q4 - q5),
+    -eta * (t4 + t5), eta * (r4 - r5), -eta * (q4 - q5),
   ]
   const HXeta = (xi: number, eta: number): number[] => [
     -P5 * (1 - 2 * eta) - (P6 - P5) * xi,
     q5 * (1 - 2 * eta) - (q5 + q6) * xi,
     -4 + 6 * (xi + eta) + r5 * (1 - 2 * eta) - xi * (r5 + r6),
-    xi * (P4 + P6),
-    xi * (q4 - q6),
-    -xi * (r6 - r4),
+    xi * (P4 + P6), xi * (q4 - q6), -xi * (r6 - r4),
     P5 * (1 - 2 * eta) - xi * (P4 + P5),
     q5 * (1 - 2 * eta) + xi * (q4 - q5),
     -2 + 6 * eta + r5 * (1 - 2 * eta) + xi * (r4 - r5),
@@ -142,30 +135,29 @@ export function dktBending(f: TriFrame, E: number, nu: number, t: number): numbe
     -t5 * (1 - 2 * eta) - (t6 - t5) * xi,
     1 + r5 * (1 - 2 * eta) - (r5 + r6) * xi,
     -q5 * (1 - 2 * eta) + xi * (q5 + q6),
-    xi * (t4 + t6),
-    xi * (r4 - r6),
-    -xi * (q4 - q6),
+    xi * (t4 + t6), xi * (r4 - r6), -xi * (q4 - q6),
     t5 * (1 - 2 * eta) - xi * (t4 + t5),
     -1 + r5 * (1 - 2 * eta) + xi * (r4 - r5),
     -q5 * (1 - 2 * eta) - xi * (q4 - q5),
   ]
 
-  const D = planeStress(Es, nu).map((row) => row.map((v) => v * (tm * tm * tm / 12)))  // = Db (×t³/12 vs membrane ×t)
   const inv = 1 / det2A
-  const Bof = (xi: number, eta: number): number[][] => {
-    const hxx = HXxi(xi, eta), hxe = HXeta(xi, eta), hyx = HYxi(xi, eta), hye = HYeta(xi, eta)
-    const row1 = hxx.map((_, i) => inv * (y31 * hxx[i] - y21 * hxe[i]))
-    const row2 = hxx.map((_, i) => inv * (-x31 * hyx[i] + x21 * hye[i]))
-    const row3 = hxx.map((_, i) => inv * (-x31 * hxx[i] + x21 * hxe[i] + y31 * hyx[i] - y21 * hye[i]))
-    return [row1, row2, row3]
-  }
+  const hxx = HXxi(xi, eta), hxe = HXeta(xi, eta), hyx = HYxi(xi, eta), hye = HYeta(xi, eta)
+  return [
+    hxx.map((_, i) => inv * (y31 * hxx[i] - y21 * hxe[i])),
+    hxx.map((_, i) => inv * (-x31 * hyx[i] + x21 * hye[i])),
+    hxx.map((_, i) => inv * (-x31 * hxx[i] + x21 * hxe[i] + y31 * hyx[i] - y21 * hye[i])),
+  ]
+}
 
-  // 3-point mid-edge integration (exact for the linear DKT curvature), weight A/3
+export function dktBending(f: TriFrame, E: number, nu: number, t: number): number[][] {
+  const Es = E * 1e3, tm = t / 1000
+  const D = planeStress(Es, nu).map((row) => row.map((v) => v * (tm * tm * tm / 12)))  // = Db (×t³/12)
   const gps: [number, number][] = [[0.5, 0], [0, 0.5], [0.5, 0.5]]
-  const A = det2A / 2
+  const A = f.A
   let K = zeros(9, 9)
   for (const [xi, eta] of gps) {
-    const B = Bof(xi, eta)
+    const B = dktBmat(f, xi, eta)
     const DB = mul(D, B)
     const k = mul(transpose(B), DB)
     K = K.map((row, i) => row.map((v, j) => v + (A / 3) * k[i][j]))
@@ -288,6 +280,114 @@ export function solveShell(
     rot.set(n.id, [d[6 * i + 3], d[6 * i + 4], d[6 * i + 5]])
   })
   return { d, disp, rot }
+}
+
+// ── Shell stress recovery ─────────────────────────────────────────────────────
+/** Per-element stress state recovered from the global DOF vector. */
+export interface ElementStress {
+  id: string
+  /** Membrane stresses in element-local x–y, kN/m² (= kPa). */
+  sigmaX: number; sigmaY: number; tauXY: number
+  /** Principal membrane stresses, kN/m². */
+  sigma1: number; sigma2: number
+  /** Von Mises membrane stress, kN/m² (plane-stress formula). */
+  vonMises: number
+  /** Bending moments per unit width in element-local x–y, kN·m/m. */
+  Mx: number; My: number; Mxy: number
+}
+
+/**
+ * Recover element stresses from a `ShellResult`. Uses:
+ *   membrane: CST constant strain (σ = D_m · B_m · u_local, constant per element)
+ *   bending : DKT curvature at the centroid (ξ=η=1/3) → M = D_b · B_b · u_local
+ * All stresses are in element-local coordinates.
+ */
+export function recoverShellStress(
+  nodes: ShellNode[], elems: ShellElem[], result: ShellResult,
+): ElementStress[] {
+  const idx = new Map(nodes.map((n, i) => [n.id, i]))
+  return elems.map((e) => {
+    const ni = e.nodes.map((id) => idx.get(id)!)
+    const ns = e.nodes.map((id) => nodes[idx.get(id)!])
+    const p1: V3 = [ns[0].x, ns[0].y, ns[0].z]
+    const p2: V3 = [ns[1].x, ns[1].y, ns[1].z]
+    const p3: V3 = [ns[2].x, ns[2].y, ns[2].z]
+    const f = triFrame(p1, p2, p3)
+    const R = f.R   // rows: [x̂, ŷ, ẑ] (global→local rotation)
+
+    // Extract local translations & rotations per node
+    const uLoc: number[] = []   // [u1,v1, u2,v2, u3,v3] in-plane
+    const bLoc: number[] = []   // [w1,θx1,θy1, w2,θx2,θy2, w3,θx3,θy3] bending
+    for (const i of ni) {
+      const b = 6 * i
+      const ug: V3 = [result.d[b], result.d[b + 1], result.d[b + 2]]
+      const thg: V3 = [result.d[b + 3], result.d[b + 4], result.d[b + 5]]
+      uLoc.push(dot(R[0], ug), dot(R[1], ug))         // in-plane local u, v
+      bLoc.push(dot(R[2], ug), dot(R[0], thg), dot(R[1], thg)) // w, θx, θy
+    }
+
+    // ── Membrane stress (CST constant per element) ──────────────────────────
+    const [x1, x2, x3] = f.x, [y1, y2, y3] = f.y
+    const b_c = [y2 - y3, y3 - y1, y1 - y2]
+    const c_c = [x3 - x2, x1 - x3, x2 - x1]
+    const inv = 1 / (2 * f.A)
+    const epsX = b_c.reduce((s, b, i) => s + b * inv * uLoc[2 * i], 0)
+    const epsY = c_c.reduce((s, c, i) => s + c * inv * uLoc[2 * i + 1], 0)
+    const gamXY = c_c.reduce((s, c, i) => s + c * inv * uLoc[2 * i], 0)
+             + b_c.reduce((s, b, i) => s + b * inv * uLoc[2 * i + 1], 0)
+    const Es = e.E * 1e3, nu = e.nu   // MPa → kN/m²
+    const cm = Es / (1 - nu * nu)
+    const sigmaX = cm * (epsX + nu * epsY)
+    const sigmaY = cm * (nu * epsX + epsY)
+    const tauXY = cm * (1 - nu) / 2 * gamXY
+
+    // Principal stresses & von Mises
+    const avg = (sigmaX + sigmaY) / 2
+    const rad = Math.sqrt(((sigmaX - sigmaY) / 2) ** 2 + tauXY ** 2)
+    const sigma1 = avg + rad, sigma2 = avg - rad
+    const vonMises = Math.sqrt(sigmaX ** 2 + sigmaY ** 2 - sigmaX * sigmaY + 3 * tauXY ** 2)
+
+    // ── Bending moments at element centroid (ξ=η=1/3) ───────────────────────
+    const Bb = dktBmat(f, 1 / 3, 1 / 3)          // 3×9
+    const tm = e.t / 1000
+    const cb = (Es * tm * tm * tm) / (12 * (1 - nu * nu))  // plate rigidity kN·m
+    const kap = Bb.map((row) => row.reduce((s, v, i) => s + v * bLoc[i], 0))  // [κx,κy,2κxy]
+    const Mx = cb * (kap[0] + nu * kap[1])
+    const My = cb * (nu * kap[0] + kap[1])
+    const Mxy = cb * (1 - nu) / 2 * kap[2]
+
+    return { id: e.id, sigmaX, sigmaY, tauXY, sigma1, sigma2, vonMises, Mx, My, Mxy }
+  })
+}
+
+/**
+ * Build a per-node averaged contour from element stresses (for smooth colour maps).
+ * `key` selects which ElementStress field to average.
+ */
+export function shellNodalContour(
+  nodes: ShellNode[],
+  elems: ShellElem[],
+  stresses: ElementStress[],
+  key: keyof Omit<ElementStress, 'id'>,
+): Map<string, number> {
+  const sum = new Map<string, number>()
+  const cnt = new Map<string, number>()
+  const stressById = new Map(stresses.map((s) => [s.id, s]))
+  for (const e of elems) {
+    const s = stressById.get(e.id)
+    if (!s) continue
+    const v = s[key] as number
+    for (const id of e.nodes) {
+      sum.set(id, (sum.get(id) ?? 0) + v)
+      cnt.set(id, (cnt.get(id) ?? 0) + 1)
+    }
+  }
+  const out = new Map<string, number>()
+  for (const n of nodes) {
+    const c = cnt.get(n.id) ?? 0
+    out.set(n.id, c > 0 ? sum.get(n.id)! / c : 0)
+  }
+  return out
 }
 
 // ── Test/utility mesher: rectangular plate in the X-Y plane (normal +z) ─────

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -15,6 +15,7 @@ import { type StructureDesign, type FootingPlan, type OptimizeResult, type Later
 import type { SteelJoint } from '../engine/steelConnections'
 import { estimateTakeoff, costBill, type PriceList } from '../engine/takeoff'
 import { footingLayout } from '../engine/footingLayout'
+import { solveShell, recoverShellStress, type ShellNode, type ShellElem, type ShellSupport, type ElementStress } from '../engine/shell'
 import { useSolver } from '../lib/useSolver'
 import type { SolveProgress } from '../engine/progress'
 import { TABLE_204_1, TABLE_204_2, sdlItemKPa, sdlTotal, type SdlItem } from '../engine/deadLoads'
@@ -39,6 +40,7 @@ import { ResponseSpectrumPanel } from '../components/ResponseSpectrumPanel'
 import { PushoverPanel } from '../components/PushoverPanel'
 import type { PushoverModelResult } from '../engine/pushoverModel'
 import { TimeHistoryPanel } from '../components/TimeHistoryPanel'
+import { ShellContourPanel } from '../components/ShellContourPanel'
 import type { TimeHistoryModelResult, GroundMotionKind, CsvAccelerogramOpts } from '../engine/timeHistoryModel'
 import { BeamSchematic } from '../components/BeamSchematic'
 import { ColumnSchematic } from '../components/ColumnSchematic'
@@ -793,6 +795,7 @@ export default function ModelSpace() {
   const [thFreq, setThFreq] = useState(2)        // Hz
   const [thDur, setThDur] = useState(10)         // s
   const [thZeta, setThZeta] = useState(5)        // %
+  const [shellStress, setShellStress] = useState<{ nodes: ShellNode[]; elems: ShellElem[]; stresses: ElementStress[] } | null>(null)
   const [thCsv, setThCsv] = useState<{ text: string; name: string; npts: number } | null>(null)
   const [thCsvUnits, setThCsvUnits] = useState<'g' | 'ms2'>('g')
   const [thCsvDt, setThCsvDt] = useState(0.02)  // s, for one-column CSV
@@ -935,6 +938,32 @@ export default function ModelSpace() {
         : { spec: { kind: thKind, dt: 0.02, duration: thDur, pga: thPga * GRAVITY, freq: thFreq, dir }, zeta: thZeta / 100, nModes },
     }).then((r) => setTh((r as { timeHistory: TimeHistoryModelResult | null }).timeHistory))
       .catch((e) => console.error('time-history failed', e))
+  }
+
+  const runShellStress = () => {
+    if (!model || !model.shellElements || model.plates.length === 0) return
+    const shNodes: ShellNode[] = model.nodes.map((n) => ({ id: n.id, x: n.x, y: n.y, z: n.z }))
+    const shElems: ShellElem[] = []
+    // Default concrete material: E = 25000 MPa, ν = 0.2
+    for (const p of model.plates) {
+      const [a, b, c, d] = p.corners
+      shElems.push({ id: `${p.id}_t0`, nodes: [a, b, c], E: 25000, nu: 0.2, t: p.thickness })
+      shElems.push({ id: `${p.id}_t1`, nodes: [a, c, d], E: 25000, nu: 0.2, t: p.thickness })
+    }
+    const shSupports: ShellSupport[] = model.supports.map((s) => ({
+      node: s.node, ux: true, uy: true, uz: true, rx: true, ry: true, rz: true,
+    }))
+    // Area loads → pressure on elements (kN/m²)
+    const pressures = model.loads
+      .filter((l) => l.kind === 'area')
+      .flatMap((l) => {
+        const al = l as { kind: 'area'; plate: string; q: number }
+        return [`${al.plate}_t0`, `${al.plate}_t1`].map((id) => ({ elem: id, q: al.q }))
+      })
+    const r = solveShell(shNodes, shElems, shSupports, [], pressures)
+    if (!r) return
+    const st = recoverShellStress(shNodes, shElems, r)
+    setShellStress({ nodes: shNodes, elems: shElems, stresses: st })
   }
 
   // Re-sign / re-axis a base node-load set into a directional case.
@@ -2507,6 +2536,25 @@ export default function ModelSpace() {
 
               {analysis && model && (
                 <DisplacementTable analysis={analysis} nodes={model.nodes} />
+              )}
+
+              {model?.shellElements && model.plates.length > 0 && (
+                <Card title="Shell plate stress (CST membrane + DKT bending)">
+                  <p className="col-span-full text-[11px] text-slate-500">
+                    Recovers per-element membrane stresses (σx, σy, τxy, von Mises) and bending
+                    moments (Mx, My, Mxy) from the shell FEM. Uses E = 25 000 MPa, ν = 0.2 for
+                    all plates. Area loads are applied as uniform pressure.
+                  </p>
+                  <div className="col-span-full">
+                    <button type="button" onClick={runShellStress} disabled={!model || !!busy}
+                      className={btn('from-[#0d9488] to-[#0f766e]')}>
+                      ⬡ Recover shell stresses
+                    </button>
+                  </div>
+                </Card>
+              )}
+              {shellStress && (
+                <ShellContourPanel nodes={shellStress.nodes} elems={shellStress.elems} stresses={shellStress.stresses} />
               )}
 
               {drift && seis && (


### PR DESCRIPTION
## Summary

- **`shell.ts`**: Extract `dktBmat(f, ξ, η)` as an exported function (DKT curvature-displacement matrix at any point); `recoverShellStress(nodes, elems, result)` computes per-element σx/σy/τxy/σ₁/σ₂/σvm (kN/m²) and Mx/My/Mxy (kN·m/m) in local element frame; `shellNodalContour` averages element values onto nodes for smooth display
- **`ShellContourPanel.tsx`**: New component with 9-quantity dropdown, SVG heat-map contour (blue→cyan→green→yellow→red), colour bar with min/max labels, and summary rows (peak element, max von Mises, max Mx, mesh size)
- **`ModelSpace.tsx`**: `runShellStress()` wires plate geometry → `solveShell` → `recoverShellStress` → `ShellContourPanel`; shell contour appears below time-history panel when plate members are defined
- **`shell.test.ts`**: Tests for `dktBmat` (verifies vs existing `dktBending` integral), `recoverShellStress` (axis-aligned and 45°-rotated elements, zero bending under in-plane load, non-zero Mx under pressure using 2×2 mesh with free interior node), and `shellNodalContour`
- All 763 tests pass; `tsc -b` clean

## Remaining Tier 4 items
A2 → B5 → C8 → D10 → A3 → B6 → D11 → E12 → E13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_