### PR TITLE
feat(C8): elastic response spectrum from CSV vs NSCP 208 design spectrum

### DIFF
--- a/webapp/src/components/RecordedSpectrumPanel.tsx
+++ b/webapp/src/components/RecordedSpectrumPanel.tsx
@@ -1,0 +1,86 @@
+import { ResultCard, Row } from './qty'
+import type { AccelSpectrum, DesignSpectrumPoint } from '../engine/accelSpectrum'
+
+interface Props {
+  /** Elastic response spectrum computed from the uploaded record. */
+  spec: AccelSpectrum
+  /** NSCP 208 design spectrum sampled at the same periods. */
+  design: DesignSpectrumPoint[]
+  /** Name of the source record, for the caption. */
+  recordName?: string
+}
+
+/**
+ * Elastic response spectrum (PSA vs period) computed from an uploaded
+ * accelerogram, overlaid on the NSCP 208 design spectrum (Tier 4 C8).
+ */
+export function RecordedSpectrumPanel({ spec, design, recordName }: Props) {
+  const W = 480, H = 300, padL = 52, padR = 14, padT = 16, padB = 40
+  const x0 = padL, x1 = W - padR, y0 = H - padB, y1 = padT
+
+  const Tmax = Math.max(...spec.points.map((p) => p.T), 1e-6)
+  const saMax = Math.max(
+    spec.peakPSA,
+    ...design.map((d) => d.Sa),
+    1e-6,
+  )
+  const sx = (T: number) => x0 + (T / Tmax) * (x1 - x0)
+  const sy = (sa: number) => y0 - (sa / saMax) * (y0 - y1)
+
+  const line = (pts: [number, number][]) =>
+    pts.map(([T, sa]) => `${sx(T).toFixed(1)},${sy(sa).toFixed(1)}`).join(' ')
+
+  const recPts = line(spec.points.map((p) => [p.T, p.PSA]))
+  const dsgPts = line(design.map((d) => [d.T, d.Sa]))
+
+  // axis ticks
+  const xTicks = Array.from({ length: 5 }, (_, i) => (Tmax * i) / 4)
+  const yTicks = Array.from({ length: 5 }, (_, i) => (saMax * i) / 4)
+
+  return (
+    <ResultCard title="Response spectrum vs NSCP 208 design spectrum">
+      <div className="col-span-full mb-2 overflow-hidden rounded-lg border border-slate-200 bg-white">
+        <svg viewBox={`0 0 ${W} ${H}`} xmlns="http://www.w3.org/2000/svg"
+          preserveAspectRatio="xMidYMid meet" style={{ width: '100%', height: 'auto' }}>
+          {/* grid + ticks */}
+          {yTicks.map((sa, i) => (
+            <g key={`y${i}`}>
+              <line x1={x0} y1={sy(sa)} x2={x1} y2={sy(sa)} stroke="#eef2f7" strokeWidth={1} />
+              <text x={x0 - 5} y={sy(sa) + 3} fontSize={8} fill="#64748b" textAnchor="end">{sa.toFixed(1)}</text>
+            </g>
+          ))}
+          {xTicks.map((T, i) => (
+            <text key={`x${i}`} x={sx(T)} y={y0 + 12} fontSize={8} fill="#64748b" textAnchor="middle">{T.toFixed(1)}</text>
+          ))}
+          {/* axes */}
+          <line x1={x0} y1={y0} x2={x1} y2={y0} stroke="#94a3b8" strokeWidth={1} />
+          <line x1={x0} y1={y0} x2={x0} y2={y1} stroke="#94a3b8" strokeWidth={1} />
+          <text x={(x0 + x1) / 2} y={H - 6} fontSize={9} fill="#475569" textAnchor="middle">Period T (s)</text>
+          <text x={12} y={(y0 + y1) / 2} fontSize={9} fill="#475569" textAnchor="middle"
+            transform={`rotate(-90 12 ${(y0 + y1) / 2})`}>PSA (m/s²)</text>
+
+          {/* design spectrum (red dashed) */}
+          <polyline points={dsgPts} fill="none" stroke="#dc2626" strokeWidth={1.6} strokeDasharray="5 3" />
+          {/* recorded spectrum (blue solid) */}
+          <polyline points={recPts} fill="none" stroke="#0056b3" strokeWidth={1.8} />
+          {/* peak marker */}
+          <circle cx={sx(spec.peakPSAT)} cy={sy(spec.peakPSA)} r={2.6} fill="#0056b3" />
+
+          {/* legend */}
+          <g transform={`translate(${x1 - 150}, ${y1 + 4})`}>
+            <line x1={0} y1={4} x2={18} y2={4} stroke="#0056b3" strokeWidth={1.8} />
+            <text x={22} y={7} fontSize={8} fill="#334155">Record ({(spec.zeta * 100).toFixed(0)}% damping)</text>
+            <line x1={0} y1={16} x2={18} y2={16} stroke="#dc2626" strokeWidth={1.6} strokeDasharray="5 3" />
+            <text x={22} y={19} fontSize={8} fill="#334155">NSCP 208 design</text>
+          </g>
+        </svg>
+      </div>
+
+      <Row label="Peak ground accel (PGA)" value={`${spec.pga.toFixed(3)} m/s²`} sub={`${(spec.pga / 9.81).toFixed(3)} g`} />
+      <Row label="Peak spectral accel (PSA)" value={`${spec.peakPSA.toFixed(3)} m/s²`} sub={`at T = ${spec.peakPSAT.toFixed(2)} s`} />
+      <Row label="Amplification PSA/PGA" value={spec.pga > 0 ? `${(spec.peakPSA / spec.pga).toFixed(2)}×` : '—'} />
+      <Row label="Damping ζ" value={`${(spec.zeta * 100).toFixed(0)} %`}
+        sub={recordName ? `record: ${recordName}` : undefined} />
+    </ResultCard>
+  )
+}

--- a/webapp/src/engine/accelSpectrum.test.ts
+++ b/webapp/src/engine/accelSpectrum.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { elasticResponseSpectrum, nscp208DesignCurve } from './accelSpectrum'
+import { nscp208Spectrum } from './responseSpectrum'
+import { GRAVITY } from './modal'
+
+/** Sampled harmonic ground acceleration a_g(t) = A·sin(2πf t), m/s². */
+function harmonic(A: number, f: number, dur: number, dt: number): number[] {
+  const n = Math.round(dur / dt) + 1
+  return Array.from({ length: n }, (_, i) => A * Math.sin(2 * Math.PI * f * i * dt))
+}
+
+describe('elasticResponseSpectrum — pseudo-spectral relationships', () => {
+  const ag = harmonic(1, 2, 20, 0.005)   // 1 m/s², 2 Hz (T = 0.5 s), 20 s
+  const spec = elasticResponseSpectrum(ag, 0.005)!
+
+  it('returns a spectrum anchored at T = 0 with S_a(0) = PGA', () => {
+    expect(spec.points[0].T).toBe(0)
+    expect(spec.points[0].PSA).toBeCloseTo(spec.pga, 9)
+    expect(spec.pga).toBeCloseTo(1, 2)
+  })
+
+  it('PSV = ω·Sd and PSA = ω²·Sd hold exactly at every finite period', () => {
+    for (const p of spec.points) {
+      if (p.T === 0) continue
+      const w = (2 * Math.PI) / p.T
+      expect(p.PSV).toBeCloseTo(w * p.Sd, 9)
+      expect(p.PSA).toBeCloseTo(w * w * p.Sd, 9)
+      expect(p.PSAg).toBeCloseTo(p.PSA / GRAVITY, 9)
+      expect(p.PSA).toBeGreaterThanOrEqual(0)
+    }
+  })
+
+  it('points are sorted ascending in period', () => {
+    for (let i = 1; i < spec.points.length; i++)
+      expect(spec.points[i].T).toBeGreaterThan(spec.points[i - 1].T)
+  })
+})
+
+describe('elasticResponseSpectrum — resonance amplification', () => {
+  it('a 2 Hz harmonic peaks near T = 0.5 s, amplified well above PGA', () => {
+    const ag = harmonic(1, 2, 25, 0.005)
+    const spec = elasticResponseSpectrum(ag, 0.005, { zeta: 0.05, Tmin: 0.1, Tmax: 2, nT: 80 })!
+    // resonance near the input period; ζ = 5 % gives ~1/(2ζ) = 10× amplification
+    expect(spec.peakPSAT).toBeGreaterThan(0.4)
+    expect(spec.peakPSAT).toBeLessThan(0.6)
+    expect(spec.peakPSA).toBeGreaterThan(3 * spec.pga)   // strongly amplified
+    expect(spec.peakPSA).toBeLessThan(15 * spec.pga)     // sanity bound
+  })
+
+  it('higher damping reduces the resonant peak', () => {
+    const ag = harmonic(1, 2, 25, 0.005)
+    const lo = elasticResponseSpectrum(ag, 0.005, { zeta: 0.02, Tmin: 0.1, Tmax: 2, nT: 80 })!
+    const hi = elasticResponseSpectrum(ag, 0.005, { zeta: 0.10, Tmin: 0.1, Tmax: 2, nT: 80 })!
+    expect(hi.peakPSA).toBeLessThan(lo.peakPSA)
+  })
+})
+
+describe('elasticResponseSpectrum — guards', () => {
+  it('empty record or non-positive dt → null', () => {
+    expect(elasticResponseSpectrum([], 0.01)).toBeNull()
+    expect(elasticResponseSpectrum([0, 1, 0], 0)).toBeNull()
+  })
+
+  it('zero ground motion → flat zero spectrum (PGA = 0)', () => {
+    const spec = elasticResponseSpectrum(new Array(500).fill(0), 0.01)!
+    expect(spec.pga).toBe(0)
+    expect(spec.peakPSA).toBe(0)
+    expect(spec.points.every((p) => p.PSA === 0 && p.Sd === 0)).toBe(true)
+  })
+})
+
+describe('nscp208DesignCurve — overlay sampling', () => {
+  it('matches nscp208Spectrum at each period and exposes Sa/g', () => {
+    const Ts = [0, 0.2, 0.5, 1, 2]
+    const curve = nscp208DesignCurve(Ts, 0.44, 0.64, 1, 8.5)
+    curve.forEach((pt, i) => {
+      expect(pt.T).toBe(Ts[i])
+      expect(pt.Sa).toBeCloseTo(nscp208Spectrum(Ts[i], 0.44, 0.64, 1, 8.5), 9)
+      expect(pt.SaG).toBeCloseTo(pt.Sa / GRAVITY, 9)
+    })
+    // plateau (short T) ≥ velocity branch (long T)
+    expect(curve[1].Sa).toBeGreaterThanOrEqual(curve[4].Sa)
+  })
+})

--- a/webapp/src/engine/accelSpectrum.ts
+++ b/webapp/src/engine/accelSpectrum.ts
@@ -1,0 +1,102 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Elastic response spectrum from a recorded ground-acceleration time history
+// (Tier 4 C8). For each trial period T a unit-mass SDOF oscillator
+//   ü + 2ζω u̇ + ω² u = −a_g(t)        (relative-displacement EOM, ω = 2π/T)
+// is integrated by Newmark-β (reusing `newmarkSDOF`); its peak relative
+// displacement is the spectral displacement Sd(T). The pseudo quantities are
+//   PSV = ω·Sd      PSA = ω²·Sd
+// PSA is the pseudo-spectral acceleration plotted against period and overlaid
+// on the NSCP 208 design spectrum (`nscp208DesignCurve`) for comparison.
+//
+// The T = 0 anchor is the rigid-oscillator limit S_a(0) = PGA (the mass follows
+// the ground; pseudo-accel → peak ground acceleration).
+// Units: a_g and PSA/PGA in m/s²; Sd in m; PSV in m/s; T in s.
+// ─────────────────────────────────────────────────────────────────────────
+import { newmarkSDOF } from './timeHistory'
+import { nscp208Spectrum } from './responseSpectrum'
+import { GRAVITY } from './modal'
+
+export interface SpectrumPoint {
+  T: number          // period, s
+  Sd: number         // spectral (relative) displacement, m
+  PSV: number        // pseudo-spectral velocity = ω·Sd, m/s
+  PSA: number        // pseudo-spectral acceleration = ω²·Sd, m/s²
+  PSAg: number       // PSA / g (dimensionless)
+}
+
+export interface AccelSpectrumOpts {
+  /** Viscous damping ratio (default 0.05). */
+  zeta?: number
+  /** Explicit period list (s). When omitted a log-spaced grid Tmin…Tmax is used. */
+  periods?: number[]
+  /** Period-grid bounds + count (defaults 0.05 s, 4.0 s, 60 points, log-spaced). */
+  Tmin?: number; Tmax?: number; nT?: number
+}
+
+export interface AccelSpectrum {
+  zeta: number
+  /** Spectrum ordinates, ascending in T. The first point is the T = 0 PGA anchor. */
+  points: SpectrumPoint[]
+  /** Peak ground acceleration |a_g|max, m/s². */
+  pga: number
+  /** Maximum PSA over the period range, m/s², and the period at which it occurs. */
+  peakPSA: number
+  peakPSAT: number
+}
+
+/** Log-spaced period grid (inclusive of both ends). */
+function logspace(a: number, b: number, n: number): number[] {
+  if (n <= 1) return [a]
+  const r = Math.pow(b / a, 1 / (n - 1))
+  return Array.from({ length: n }, (_, i) => a * Math.pow(r, i))
+}
+
+/**
+ * Elastic response spectrum of a ground-acceleration record. Returns null when
+ * the record is empty or dt ≤ 0. `ag` must be in m/s² (use parseAccelerogram to
+ * convert g → m/s² beforehand).
+ */
+export function elasticResponseSpectrum(
+  ag: number[], dt: number, opts: AccelSpectrumOpts = {},
+): AccelSpectrum | null {
+  if (ag.length === 0 || dt <= 0) return null
+  const zeta = opts.zeta ?? 0.05
+  const pga = ag.reduce((m, v) => Math.max(m, Math.abs(v)), 0)
+
+  const periods = (opts.periods ?? logspace(opts.Tmin ?? 0.05, opts.Tmax ?? 4.0, opts.nT ?? 60))
+    .filter((T) => T > 0).sort((p, q) => p - q)
+
+  // forcing p(t) = −a_g(t) for the unit-mass relative-displacement oscillator
+  const neg = ag.map((a) => -a)
+
+  // T = 0 anchor: rigid oscillator follows the ground ⇒ S_a = PGA.
+  const points: SpectrumPoint[] = [{ T: 0, Sd: 0, PSV: 0, PSA: pga, PSAg: pga / GRAVITY }]
+  let peakPSA = pga, peakPSAT = 0
+
+  for (const T of periods) {
+    const omega = (2 * Math.PI) / T
+    const { u } = newmarkSDOF(omega, zeta, neg, dt)
+    const Sd = u.reduce((m, v) => Math.max(m, Math.abs(v)), 0)
+    const PSV = omega * Sd
+    const PSA = omega * omega * Sd
+    points.push({ T, Sd, PSV, PSA, PSAg: PSA / GRAVITY })
+    if (PSA > peakPSA) { peakPSA = PSA; peakPSAT = T }
+  }
+
+  return { zeta, points, pga, peakPSA, peakPSAT }
+}
+
+export interface DesignSpectrumPoint { T: number; Sa: number; SaG: number }
+
+/**
+ * NSCP §208 elastic design spectrum sampled at the given periods (m/s²), for
+ * overlaying on a recorded response spectrum. Reuses `nscp208Spectrum`.
+ */
+export function nscp208DesignCurve(
+  periods: number[], Ca: number, Cv: number, I: number, R: number,
+): DesignSpectrumPoint[] {
+  return periods.map((T) => {
+    const Sa = nscp208Spectrum(T, Ca, Cv, I, R)
+    return { T, Sa, SaG: Sa / GRAVITY }
+  })
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -41,6 +41,9 @@ import { PushoverPanel } from '../components/PushoverPanel'
 import type { PushoverModelResult } from '../engine/pushoverModel'
 import { TimeHistoryPanel } from '../components/TimeHistoryPanel'
 import { ShellContourPanel } from '../components/ShellContourPanel'
+import { RecordedSpectrumPanel } from '../components/RecordedSpectrumPanel'
+import { elasticResponseSpectrum, nscp208DesignCurve, type AccelSpectrum, type DesignSpectrumPoint } from '../engine/accelSpectrum'
+import { parseAccelerogram } from '../engine/accelerogram'
 import type { TimeHistoryModelResult, GroundMotionKind, CsvAccelerogramOpts } from '../engine/timeHistoryModel'
 import { BeamSchematic } from '../components/BeamSchematic'
 import { ColumnSchematic } from '../components/ColumnSchematic'
@@ -796,6 +799,7 @@ export default function ModelSpace() {
   const [thDur, setThDur] = useState(10)         // s
   const [thZeta, setThZeta] = useState(5)        // %
   const [shellStress, setShellStress] = useState<{ nodes: ShellNode[]; elems: ShellElem[]; stresses: ElementStress[] } | null>(null)
+  const [recSpec, setRecSpec] = useState<{ spec: AccelSpectrum; design: DesignSpectrumPoint[]; name: string } | null>(null)
   const [thCsv, setThCsv] = useState<{ text: string; name: string; npts: number } | null>(null)
   const [thCsvUnits, setThCsvUnits] = useState<'g' | 'ms2'>('g')
   const [thCsvDt, setThCsvDt] = useState(0.02)  // s, for one-column CSV
@@ -938,6 +942,18 @@ export default function ModelSpace() {
         : { spec: { kind: thKind, dt: 0.02, duration: thDur, pga: thPga * GRAVITY, freq: thFreq, dir }, zeta: thZeta / 100, nModes },
     }).then((r) => setTh((r as { timeHistory: TimeHistoryModelResult | null }).timeHistory))
       .catch((e) => console.error('time-history failed', e))
+  }
+
+  // Elastic response spectrum from the uploaded accelerogram, overlaid on the
+  // NSCP 208 design spectrum (C8). Parses the same CSV used by the time-history.
+  const runResponseSpectrum = () => {
+    if (!thCsv) return
+    const parsed = parseAccelerogram(thCsv.text, { dt: thCsvDt, units: thCsvUnits })
+    if (!parsed) { setRecSpec(null); return }
+    const spec = elasticResponseSpectrum(parsed.ag, parsed.dt, { zeta: thZeta / 100 })
+    if (!spec) { setRecSpec(null); return }
+    const design = nscp208DesignCurve(spec.points.map((p) => p.T), Ca, Cv, Ie, Rw)
+    setRecSpec({ spec, design, name: thCsv.name })
   }
 
   const runShellStress = () => {
@@ -2746,14 +2762,26 @@ export default function ModelSpace() {
                   Modal superposition: each mode is an SDOF integrated by Newmark-β (β=¼, γ=½). Upload a real
                   record (two-column t/ag, one-column with Δt, or PEER AT2) or use the built-in synthetic motion.
                 </p>
-                <div className="col-span-full">
+                <div className="col-span-full flex flex-wrap gap-2">
                   <button type="button" onClick={runTimeHistory} disabled={!model || !!busy || meshErrors} className={btn('from-[#0d9488] to-[#0f766e]')}>
                     {busy === 'timeHistory' ? '⏳ Integrating…' : '∿ Run time-history'}
                   </button>
+                  {thCsv && (
+                    <button type="button" onClick={runResponseSpectrum} className={btn('from-[#0056b3] to-[#003d82]')}>
+                      ⌁ Response spectrum
+                    </button>
+                  )}
                 </div>
+                {thCsv && (
+                  <p className="col-span-full text-[11px] text-slate-500">
+                    The response spectrum integrates an SDOF oscillator per period (Newmark-β, ζ = {thZeta}%) over the
+                    uploaded record, then overlays it on the NSCP 208 design spectrum (Ca {Ca}, Cv {Cv}, I {Ie}, R {Rw}).
+                  </p>
+                )}
                 {busy === 'timeHistory' && <SolverProgress p={progress} />}
               </Card>
               {th && <TimeHistoryPanel res={th} dirLabel={thDir === 'x' ? '+X' : '+Z'} />}
+              {recSpec && <RecordedSpectrumPanel spec={recSpec.spec} design={recSpec.design} recordName={recSpec.name} />}
 
               {(() => {
                 const occ = DG11_OCCUPANCY.find((o) => o.id === dg11OccId) ?? DG11_OCCUPANCY[0]


### PR DESCRIPTION
## Summary

Tier 4 item **C8** — *Response-spectrum from CSV*. Computes the elastic (pseudo-acceleration) response spectrum from a user-supplied accelerogram and overlays it on the NSCP 208 design spectrum for comparison.

- **`accelSpectrum.ts`** (new)
  - `elasticResponseSpectrum(ag, dt, { zeta, periods, Tmin, Tmax, nT })` — for each trial period integrates a unit-mass SDOF via the existing `newmarkSDOF` on the relative-displacement EOM `ü + 2ζω u̇ + ω² u = −a_g(t)`, takes peak `Sd`, and returns `Sd`/`PSV = ω·Sd`/`PSA = ω²·Sd` per period (log-spaced grid 0.05–4 s by default) with a `T = 0` anchor at `S_a(0) = PGA`, plus the peak PSA and its period.
  - `nscp208DesignCurve(periods, Ca, Cv, I, R)` — samples the existing `nscp208Spectrum` at the same periods for the overlay.
- **`RecordedSpectrumPanel.tsx`** (new): SVG plot of the recorded spectrum (solid) vs the NSCP 208 design spectrum (dashed), with PGA / peak-PSA / amplification summary rows.
- **`ModelSpace.tsx`**: a **Response spectrum** button (shown when a CSV/AT2 record is loaded) parses the same record, computes the spectrum + design overlay at the current `Ca/Cv/I/R`, and renders the panel below the time-history results.

## Verification
- `npm test` → **779 passed** (8 new): pseudo relations `PSA = ω²Sd`/`PSV = ωSd`; `S_a(0) = PGA` anchor; resonance amplification near the input period (~1/2ζ); higher damping lowers the peak; empty/zero/`dt ≤ 0` guards; design-curve sampling.
- `npx tsc -b` clean · `npm run build` clean.

The SVG panel is a thin render of the unit-tested engine output (plain SVG, no WebGL).

## Remaining Tier 4 items
D10 → A3 → B6 → D11 → E12 → E13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_