### PR TITLE
feat(D10): shell quad subdivision / auto-meshing

### DIFF
--- a/webapp/src/engine/shell.test.ts
+++ b/webapp/src/engine/shell.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import {
   triFrame, cstMembrane, dktBending, dktBmat, triShell, solveShell, rectPlateMesh,
-  recoverShellStress, shellNodalContour,
-  type ShellNode, type ShellElem, type ShellSupport,
+  recoverShellStress, shellNodalContour, bilinearQuad, subdivideQuadPlates,
+  type ShellNode, type ShellElem, type ShellSupport, type V3, type QuadPlateSpec,
 } from './shell'
 
 const E = 25000, nu = 0.3   // MPa, concrete-ish; ν=0.3 matches Timoshenko tables
@@ -272,5 +272,89 @@ describe('shellNodalContour', () => {
       expect(isFinite(v)).toBe(true)
       expect(v).toBeGreaterThanOrEqual(0)
     }
+  })
+})
+
+// ── Quad subdivision / auto-meshing (D10) ────────────────────────────────────
+describe('bilinearQuad', () => {
+  const c: [V3, V3, V3, V3] = [[0, 0, 0], [2, 0, 0], [2, 3, 0], [0, 3, 0]]
+  it('reproduces the four corners at the parametric corners', () => {
+    expect(bilinearQuad(c, 0, 0)).toEqual([0, 0, 0])
+    expect(bilinearQuad(c, 1, 0)).toEqual([2, 0, 0])
+    expect(bilinearQuad(c, 1, 1)).toEqual([2, 3, 0])
+    expect(bilinearQuad(c, 0, 1)).toEqual([0, 3, 0])
+  })
+  it('gives the centroid at (½,½) and edge midpoints', () => {
+    expect(bilinearQuad(c, 0.5, 0.5)).toEqual([1, 1.5, 0])
+    expect(bilinearQuad(c, 0.5, 0)).toEqual([1, 0, 0])
+  })
+})
+
+describe('subdivideQuadPlates', () => {
+  const sq: QuadPlateSpec = {
+    id: 'P', corners: [[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]], E: 25000, nu: 0.3, t: 200,
+  }
+
+  it('n = 1 reproduces the 2-triangle, 4-node quad', () => {
+    const m = subdivideQuadPlates([sq], 1)
+    expect(m.nodes.length).toBe(4)
+    expect(m.elems.length).toBe(2)
+  })
+
+  it('n = 4 yields (n+1)² nodes and 2n² triangles', () => {
+    const m = subdivideQuadPlates([sq], 4)
+    expect(m.nodes.length).toBe(25)
+    expect(m.elems.length).toBe(32)
+  })
+
+  it('adjacent plates share the common-edge nodes (conforming mesh)', () => {
+    const q2: QuadPlateSpec = {
+      id: 'Q', corners: [[1, 0, 0], [2, 0, 0], [2, 1, 0], [1, 1, 0]], E: 25000, nu: 0.3, t: 200,
+    }
+    const n = 2
+    const m = subdivideQuadPlates([sq, q2], n)
+    // 2·(n+1)² − (n+1) shared edge nodes
+    expect(m.nodes.length).toBe(2 * (n + 1) ** 2 - (n + 1))
+    expect(m.elems.length).toBe(2 * (2 * n ** 2))
+  })
+
+  it('cornerId reuses existing model node ids at coincident positions', () => {
+    const named: [V3, string][] = [
+      [[0, 0, 0], 'A'], [[1, 0, 0], 'B'], [[1, 1, 0], 'C'], [[0, 1, 0], 'D'],
+    ]
+    // exact-coordinate match only (edge/interior points return undefined → synthetic)
+    const cornerId = (p: V3) =>
+      named.find(([q]) => Math.hypot(p[0] - q[0], p[1] - q[1], p[2] - q[2]) < 1e-6)?.[1]
+    const m = subdivideQuadPlates([sq], 2, cornerId)
+    const byId = new Map(m.nodes.map((nd) => [nd.id, nd]))
+    expect(byId.has('A')).toBe(true)
+    expect(byId.has('C')).toBe(true)
+    expect(byId.get('C')).toMatchObject({ x: 1, y: 1, z: 0 })
+    // interior + edge midside nodes are synthetic
+    expect(m.nodes.some((nd) => nd.id.startsWith('sv'))).toBe(true)
+  })
+
+  it('refining the subdivision converges a simply-supported plate toward Timoshenko', () => {
+    const L = 5, t = 200, q = 10, Es = E * 1e3, tm = t / 1000
+    const D = (Es * tm ** 3) / (12 * (1 - nu * nu))
+    const exact = 0.00406 * q * L ** 4 / D
+    const plate: QuadPlateSpec = {
+      id: 'S', corners: [[0, 0, 0], [L, 0, 0], [L, L, 0], [0, L, 0]], E, nu, t,
+    }
+    const central = (nsub: number) => {
+      const { nodes, elems } = subdivideQuadPlates([plate], nsub)
+      const edge = (v: number) => Math.abs(v) < 1e-6 || Math.abs(v - L) < 1e-6
+      const supports: ShellSupport[] = nodes
+        .filter((nd) => edge(nd.x) || edge(nd.y))
+        .map((nd) => ({ node: nd.id, uz: true, ux: true, uy: true, rz: true }))
+      const r = solveShell(nodes, elems, supports, [], elems.map((e) => ({ elem: e.id, q })))!
+      const mid = nodes.find((nd) => Math.abs(nd.x - L / 2) < 1e-6 && Math.abs(nd.y - L / 2) < 1e-6)!
+      return Math.abs(r.disp.get(mid.id)![2])
+    }
+    const e2 = Math.abs(central(2) / exact - 1)
+    const e8 = Math.abs(central(8) / exact - 1)
+    expect(e8).toBeLessThan(e2)            // finer mesh is closer
+    expect(central(8) / exact).toBeGreaterThan(0.9)
+    expect(central(8) / exact).toBeLessThan(1.1)
   })
 })

--- a/webapp/src/engine/shell.ts
+++ b/webapp/src/engine/shell.ts
@@ -408,3 +408,59 @@ export function rectPlateMesh(
   }
   return { nodes, elems, id }
 }
+
+// ── Quad subdivision / auto-meshing (Tier 4 D10) ─────────────────────────────
+// Coarse 2-triangle plates systematically overestimate stiffness; splitting each
+// quad into n×n cells (2n² triangles) converges the slab response. Subdivision
+// nodes are keyed by snapped coordinate so coincident points on a shared edge of
+// adjacent plates collapse to ONE node — the assembled mesh stays conforming.
+
+/** Bilinear point in a quad p00→p10→p11→p01 at parametric (s, u) ∈ [0,1]². */
+export function bilinearQuad(c: [V3, V3, V3, V3], s: number, u: number): V3 {
+  const w = [(1 - s) * (1 - u), s * (1 - u), s * u, (1 - s) * u]
+  return [0, 1, 2].map((k) => w[0] * c[0][k] + w[1] * c[1][k] + w[2] * c[2][k] + w[3] * c[3][k]) as V3
+}
+
+export interface QuadPlateSpec { id: string; corners: [V3, V3, V3, V3]; E: number; nu: number; t: number }
+
+/**
+ * Subdivide a set of 3D quad plates into an n×n triangular mesh each, sharing
+ * nodes between plates that meet on a common edge (coordinate-hashed identity).
+ * `cornerId(pos)` may return an existing model node id for a coincident position
+ * (so supports/loads still attach); other vertices get synthetic `sv*` ids.
+ * n = 1 reproduces the original 2-triangle-per-quad mesh.
+ */
+export function subdivideQuadPlates(
+  plates: QuadPlateSpec[], n: number,
+  cornerId?: (pos: V3) => string | undefined, tol = 1e-4,
+): { nodes: ShellNode[]; elems: ShellElem[] } {
+  const m = Math.max(1, Math.floor(n))
+  const reg = new Map<string, string>()        // snapped-coord key → node id
+  const nodeMap = new Map<string, ShellNode>()
+  let ctr = 0
+  const key = (p: V3) => `${Math.round(p[0] / tol)}_${Math.round(p[1] / tol)}_${Math.round(p[2] / tol)}`
+  const vid = (p: V3): string => {
+    const k = key(p)
+    const ex = reg.get(k)
+    if (ex) return ex
+    const id = cornerId?.(p) ?? `sv${ctr++}`
+    reg.set(k, id)
+    if (!nodeMap.has(id)) nodeMap.set(id, { id, x: p[0], y: p[1], z: p[2] })
+    return id
+  }
+
+  const elems: ShellElem[] = []
+  for (const pl of plates) {
+    const gid: string[][] = []
+    for (let j = 0; j <= m; j++) {
+      gid[j] = []
+      for (let i = 0; i <= m; i++) gid[j][i] = vid(bilinearQuad(pl.corners, i / m, j / m))
+    }
+    for (let j = 0; j < m; j++) for (let i = 0; i < m; i++) {
+      const A = gid[j][i], B = gid[j][i + 1], C = gid[j + 1][i + 1], D = gid[j + 1][i]
+      elems.push({ id: `${pl.id}_${i}_${j}_0`, nodes: [A, B, C], E: pl.E, nu: pl.nu, t: pl.t })
+      elems.push({ id: `${pl.id}_${i}_${j}_1`, nodes: [A, C, D], E: pl.E, nu: pl.nu, t: pl.t })
+    }
+  }
+  return { nodes: [...nodeMap.values()], elems }
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -15,7 +15,7 @@ import { type StructureDesign, type FootingPlan, type OptimizeResult, type Later
 import type { SteelJoint } from '../engine/steelConnections'
 import { estimateTakeoff, costBill, type PriceList } from '../engine/takeoff'
 import { footingLayout } from '../engine/footingLayout'
-import { solveShell, recoverShellStress, type ShellNode, type ShellElem, type ShellSupport, type ElementStress } from '../engine/shell'
+import { solveShell, recoverShellStress, subdivideQuadPlates, type ShellNode, type ShellElem, type ShellSupport, type ElementStress, type QuadPlateSpec } from '../engine/shell'
 import { useSolver } from '../lib/useSolver'
 import type { SolveProgress } from '../engine/progress'
 import { TABLE_204_1, TABLE_204_2, sdlItemKPa, sdlTotal, type SdlItem } from '../engine/deadLoads'
@@ -800,6 +800,7 @@ export default function ModelSpace() {
   const [thZeta, setThZeta] = useState(5)        // %
   const [shellStress, setShellStress] = useState<{ nodes: ShellNode[]; elems: ShellElem[]; stresses: ElementStress[] } | null>(null)
   const [recSpec, setRecSpec] = useState<{ spec: AccelSpectrum; design: DesignSpectrumPoint[]; name: string } | null>(null)
+  const [shellSubdiv, setShellSubdiv] = useState(4)   // n×n triangulation per plate
   const [thCsv, setThCsv] = useState<{ text: string; name: string; npts: number } | null>(null)
   const [thCsvUnits, setThCsvUnits] = useState<'g' | 'ms2'>('g')
   const [thCsvDt, setThCsvDt] = useState(0.02)  // s, for one-column CSV
@@ -958,23 +959,31 @@ export default function ModelSpace() {
 
   const runShellStress = () => {
     if (!model || !model.shellElements || model.plates.length === 0) return
-    const shNodes: ShellNode[] = model.nodes.map((n) => ({ id: n.id, x: n.x, y: n.y, z: n.z }))
-    const shElems: ShellElem[] = []
-    // Default concrete material: E = 25000 MPa, ν = 0.2
-    for (const p of model.plates) {
-      const [a, b, c, d] = p.corners
-      shElems.push({ id: `${p.id}_t0`, nodes: [a, b, c], E: 25000, nu: 0.2, t: p.thickness })
-      shElems.push({ id: `${p.id}_t1`, nodes: [a, c, d], E: 25000, nu: 0.2, t: p.thickness })
+    // Subdivide each quad plate into an n×n triangular mesh (D10). Subdivision
+    // nodes are shared across plate edges by coordinate; original model nodes are
+    // reused at coincident corners so supports/loads still attach.
+    const posById = new Map(model.nodes.map((n) => [n.id, [n.x, n.y, n.z] as V3]))
+    const cornerId = (p: V3): string | undefined => {
+      for (const n of model.nodes)
+        if (Math.hypot(p[0] - n.x, p[1] - n.y, p[2] - n.z) < 1e-4) return n.id
+      return undefined
     }
+    // Default concrete material: E = 25000 MPa, ν = 0.2
+    const specs: QuadPlateSpec[] = model.plates.flatMap((p) => {
+      const cs = p.corners.map((id) => posById.get(id))
+      if (cs.some((c) => !c)) return []
+      return [{ id: p.id, corners: cs as [V3, V3, V3, V3], E: 25000, nu: 0.2, t: p.thickness }]
+    })
+    const { nodes: shNodes, elems: shElems } = subdivideQuadPlates(specs, shellSubdiv, cornerId)
     const shSupports: ShellSupport[] = model.supports.map((s) => ({
       node: s.node, ux: true, uy: true, uz: true, rx: true, ry: true, rz: true,
     }))
-    // Area loads → pressure on elements (kN/m²)
+    // Area loads → pressure on every sub-element of the plate (kN/m²)
     const pressures = model.loads
       .filter((l) => l.kind === 'area')
       .flatMap((l) => {
         const al = l as { kind: 'area'; plate: string; q: number }
-        return [`${al.plate}_t0`, `${al.plate}_t1`].map((id) => ({ elem: id, q: al.q }))
+        return shElems.filter((e) => e.id.startsWith(`${al.plate}_`)).map((e) => ({ elem: e.id, q: al.q }))
       })
     const r = solveShell(shNodes, shElems, shSupports, [], pressures)
     if (!r) return
@@ -2560,6 +2569,13 @@ export default function ModelSpace() {
                     Recovers per-element membrane stresses (σx, σy, τxy, von Mises) and bending
                     moments (Mx, My, Mxy) from the shell FEM. Uses E = 25 000 MPa, ν = 0.2 for
                     all plates. Area loads are applied as uniform pressure.
+                  </p>
+                  <Num label="Mesh subdivision n×n" value={shellSubdiv} step="1"
+                    onChange={(v) => setShellSubdiv(Math.max(1, Math.min(12, Math.round(v) || 1)))}
+                    hint="1–12 cells per side" />
+                  <p className="col-span-full text-[11px] text-slate-500">
+                    Each quad is split into {shellSubdiv}×{shellSubdiv} cells (2·{shellSubdiv}² triangles); finer meshes
+                    reduce the stiffness overestimate of coarse 2-triangle plates. Edges shared by adjacent plates stay conforming.
                   </p>
                   <div className="col-span-full">
                     <button type="button" onClick={runShellStress} disabled={!model || !!busy}


### PR DESCRIPTION
## Summary

Tier 4 item **D10** — *Subdivision / auto-meshing*. Each quad plate is split into an n×n triangular mesh (2n² triangles) before the shell solve, converging the slab response away from the systematic stiffness overestimate of coarse 2-triangle plates (critical near columns with high curvature gradients).

The key correctness requirement is a **conforming** assembled mesh: subdivision nodes are keyed by snapped coordinate, so coincident points on a shared edge of two adjacent plates collapse to a single node rather than splitting the structure along plate boundaries.

- **`shell.ts`**
  - `bilinearQuad(corners, s, u)` — bilinear point in a 3D quad.
  - `QuadPlateSpec` + `subdivideQuadPlates(plates, n, cornerId?, tol)` — coordinate-hashed node identity; `cornerId(pos)` reuses an existing model node id at coincident corners so supports/loads still attach; non-corner vertices get synthetic `sv*` ids. `n = 1` reproduces the original 2-triangle mesh.
- **`shell.test.ts`**: bilinear corners/midpoints; node & element counts at `n = 1` (4 nodes / 2 tris) and `n = 4` (25 / 32); conforming shared-edge dedup for two adjacent plates; `cornerId` id reuse; mesh refinement converges a simply-supported plate toward the Timoshenko value.
- **`ModelSpace.tsx`**: `runShellStress()` now builds `QuadPlateSpec[]` from the model plates, reuses model node ids at corners, and maps each area load as pressure on every sub-element of its plate; new **Mesh subdivision n×n** input (default 4, clamped 1–12).

## Verification
- `npm test` → **786 passed** (7 new)
- `npx tsc -b` clean · `npm run build` clean

## Remaining Tier 4 items
A3 → B6 → D11 → E12 → E13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_