### PR TITLE
feat(A3): per-member Lb bracing override for §F2 LTB (AISC 360)

### DIFF
--- a/webapp/src/engine/model.ts
+++ b/webapp/src/engine/model.ts
@@ -53,6 +53,10 @@ export interface Member {
   /** Per-member rigid-zone factor override (0–1); falls back to the model factor.
    *  0 excludes this member from automatic rigid end zones. */
   rigidZoneFactor?: number
+  /** Unbraced length for §F2 lateral-torsional buckling, m (steel beams/girders).
+   *  Absent ⇒ the full member length is used (conservative). Set to the real
+   *  brace spacing (e.g. purlin/joist pitch) to relieve LTB. */
+  Lb?: number
 }
 
 export type PlateRole = 'slab' | 'wall'

--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -179,6 +179,47 @@ describe('steel design pipeline (AISC routing + base plates)', () => {
   })
 })
 
+describe('Lb bracing override per member (A3)', () => {
+  // W310x79, Fy=345: Lp ≈ 1.76·ry·√(E/Fy) = 1.76×49×√(200000/345) ≈ 2076 mm ≈ 2.08 m
+  // Full 6 m beam → Lb=6000 > Lp → inelastic/elastic zone.
+  // Setting Lb: 1.0 m on the member → Lb=1000 < Lp → plastic zone.
+  function steelModelLb(lbMetres?: number) {
+    const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })
+    m.loads = m.plates.flatMap((p) => [
+      { kind: 'area' as const, plate: p.id, q: 4.8, cat: 'D' as const },
+      { kind: 'area' as const, plate: p.id, q: 2.4, cat: 'L' as const },
+    ])
+    m.sections = m.sections.map((s) => ({ ...s, material: 'steel' as const, shape: 'W310x79', steelFy: 345, steelFu: 448 }))
+    if (lbMetres !== undefined)
+      m.members = m.members.map((mb) => mb.role === 'beam' ? { ...mb, Lb: lbMetres } : mb)
+    return m
+  }
+
+  it('Lb field in schedule row reflects the override in mm', () => {
+    const r = designStructure(steelModelLb(1.0), soil)!
+    const beam = r.steelBeams.find((b) => b.role === 'beam')!
+    expect(beam).toBeDefined()
+    expect(beam.Lb).toBeCloseTo(1000, 1)          // 1.0 m → 1000 mm
+  })
+
+  it('short Lb (< Lp) forces plastic zone; long Lb gives inelastic/elastic', () => {
+    const rShort = designStructure(steelModelLb(1.0), soil)!
+    const rFull  = designStructure(steelModelLb(), soil)!
+    const beamShort = rShort.steelBeams.find((b) => b.role === 'beam')!
+    const beamFull  = rFull.steelBeams.find((b) => b.role === 'beam')!
+    expect(beamShort.ltbZone).toBe('plastic')
+    expect(['inelastic', 'elastic']).toContain(beamFull.ltbZone)
+  })
+
+  it('short Lb gives higher or equal φMn than full-length Lb', () => {
+    const rShort = designStructure(steelModelLb(1.0), soil)!
+    const rFull  = designStructure(steelModelLb(), soil)!
+    const beamShort = rShort.steelBeams.find((b) => b.role === 'beam')!
+    const beamFull  = rFull.steelBeams.find((b) => b.role === 'beam')!
+    expect(beamShort.phiMn).toBeGreaterThanOrEqual(beamFull.phiMn - 1e-6)
+  })
+})
+
 describe('beam critical sections — interior is the sagging peak', () => {
   it('a continuous multi-bay frame still sags at mid-span (not all hogging)', () => {
     const m = generateGridModel({ baysX: [6, 6], baysZ: [5], storeyH: [3.5, 3], section })

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -178,15 +178,18 @@ export function designOK(d: StructureDesign): boolean {
 }
 
 // ── Steel member design (reuses steelDesign engine) ──────────────────────────
-/** Design a steel beam/girder from a member result. Lb = full length
- *  (conservative; the slab braces the top flange for sagging but support
- *  hogging puts the bottom flange in compression). */
-function designSteelBeamRow(mr: F3MemberResult, role: string, sec: RectSection): SteelBeamScheduleRow | null {
+/** Design a steel beam/girder from a member result. Lb defaults to the full
+ *  member length (conservative; the slab braces the top flange for sagging but
+ *  support hogging puts the bottom flange in compression). Pass `lbOverride`
+ *  (m) to use the real brace spacing for §F2 lateral-torsional buckling. */
+function designSteelBeamRow(
+  mr: F3MemberResult, role: string, sec: RectSection, lbOverride?: number,
+): SteelBeamScheduleRow | null {
   const shape = sec.shape ? shapeByName(sec.shape) : undefined
   if (!shape || (shape.family !== 'W' && shape.family !== 'WT')) return null
   const Fy = sec.steelFy ?? 248
   const p = deriveWSection(shape)
-  const Lb = mr.L * 1000
+  const Lb = (lbOverride && lbOverride > 0 ? lbOverride : mr.L) * 1000
   const flex = beamFlexure(shape, p, Fy, Lb, 1.0)
   const shear = beamShear(shape, p, Fy)
   const Mu = mr.Mmax, Vu = mr.Vmax
@@ -444,7 +447,7 @@ function designFromRuns(
         let best: SteelBeamScheduleRow | null = null, bestSev = -1, gov = ''
         for (const run of runs) {
           const mr = memberOf(run, m.id); if (!mr) continue
-          const row = designSteelBeamRow(mr, role, sec); if (!row) continue
+          const row = designSteelBeamRow(mr, role, sec, m.Lb); if (!row) continue
           const sev = (row.ok ? 0 : 1e9) + row.Mu
           if (sev > bestSev) { bestSev = sev; best = row; gov = run.name }
         }

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -1862,6 +1862,19 @@ export default function ModelSpace() {
                             className="w-16 rounded border border-violet-200 px-1 py-0.5 text-right" />
                           <span className="text-[10px] text-slate-400">blank = model factor · 0 = no zone for this member (needs Auto rigid end zones on)</span>
                         </label>
+                        {(sel.role === 'beam' || sel.role === 'girder') && (
+                          <label className="mt-2 flex items-center gap-2 border-t border-violet-200 pt-2 text-[11px] text-slate-700">
+                            <span>Lb unbraced length (m)</span>
+                            <input type="number" min={0} step={0.1}
+                              value={sel.Lb ?? ''} placeholder="full span"
+                              onChange={(e) => {
+                                const v = parseFloat(e.target.value)
+                                updMember(sel.id, { Lb: Number.isFinite(v) && v > 0 ? v : undefined })
+                              }}
+                              className="w-16 rounded border border-violet-200 px-1 py-0.5 text-right" />
+                            <span className="text-[10px] text-slate-400">§F2 LTB brace spacing — blank = full member length (conservative)</span>
+                          </label>
+                        )}
                       </div>
                     )
                   })()}
@@ -3503,7 +3516,7 @@ export default function ModelSpace() {
                               </table>
                             </div>
                           </div>
-                          <p className="mt-2 text-[10px] text-slate-400">Lb = full member length (conservative unbraced). Cb = 1.0. φ = 0.9 (flexure), 1.0 (shear, doubly-symmetric I). δ est. = 5Mu·L²/(48·E·Ix), SS bound vs L/240.</p>
+                          <p className="mt-2 text-[10px] text-slate-400">Lb = member brace spacing (set per-member in Geometry → Properties; blank = full length, conservative). Cb = 1.0. φ = 0.9 (flexure), 1.0 (shear, doubly-symmetric I). δ est. = 5Mu·L²/(48·E·Ix), SS bound vs L/240.</p>
                         </td>
                       </tr>
                     )


### PR DESCRIPTION
## Summary

- **`Member.Lb?: number` (m)** — optional unbraced length per beam/girder for §F2 lateral-torsional buckling; absent = full span (conservative)
- **`pipeline.ts`** — `designSteelBeamRow` takes `lbOverride?`; `row.Lb` reflects the resolved value (mm); call site passes `m.Lb`
- **`pipeline.test.ts`** — 3 new tests: Lb reflected in mm, short Lb (< Lp) → plastic zone, short Lb → higher φMn
- **`ModelSpace.tsx`** — Lb number input in Geometry → Properties panel (beam/girder only); footnote and steel beam table note updated

## Remaining Tier 4 phases
- **B6** — P-Δ inside the pushover loop
- **D11** — shell integration into NSCP design pipeline
- **E12** — wind load generation NSCP 207E.6
- **E13** — seismic detailing SMRF/OMRF flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_