### PR TITLE
feat(B6): second-order P-Δ inside the pushover loop

### DIFF
--- a/webapp/src/components/PushoverPanel.tsx
+++ b/webapp/src/components/PushoverPanel.tsx
@@ -68,7 +68,7 @@ export function PushoverPanel({ res, dirLabel }: { res: PushoverModelResult; dir
         <CapacityCurve res={res} />
       </div>
       <Row label="Peak base shear" value={`${peakV.toFixed(1)} kN`}
-        sub={res.result.mechanism ? 'collapse mechanism' : 'target reached'} />
+        sub={`${res.result.mechanism ? 'collapse mechanism' : 'target reached'}${res.pDelta ? ' · P-Δ on' : ''}`} />
       <Row label="Peak roof displacement" value={`${(peakD * 1000).toFixed(1)} mm`}
         sub={`drift ${(drift * 100).toFixed(2)}% of H`} />
       <Row label="Plastic hinges formed" value={`${nHinges}`}

--- a/webapp/src/engine/frame3d.test.ts
+++ b/webapp/src/engine/frame3d.test.ts
@@ -176,6 +176,29 @@ describe('frame3d — P-Δ second order (vertical cantilever, L = 4)', () => {
     // second-order base moment = H·L + P·Δ > first-order H·L
     expect(Math.abs(r.members[0].My[0])).toBeGreaterThan(H * L)
   })
+
+  it('fixedAxial builds a CONSTANT geometric tangent (lateral-only solve, linear in load)', () => {
+    const P = 0.25 * Pe
+    // lateral-only load, geometric stiffness frozen at compression P (member axial
+    // tension +, so −P). Matches the self-consistent amplifier 1/(1−P/Pe).
+    const r = solveFrame3D(colNodes, colMem, sup, lat, { pDelta: true, fixedAxial: [-P] })!
+    const d2 = Math.abs(r.d[6 + 0])
+    expect(d2 / d1).toBeCloseTo(1 / (1 - 0.25), 1)
+    // constant tangent ⇒ drift scales linearly with lateral load (double H → double Δ)
+    const r2 = solveFrame3D(colNodes, colMem, sup,
+      [{ kind: 'node', node: 'top', Fx: 2 * H, cat: 'D' }], { pDelta: true, fixedAxial: [-P] })!
+    expect(Math.abs(r2.d[6 + 0]) / d2).toBeCloseTo(2, 6)
+  })
+
+  it('fixedAxial tension stiffens; amplification grows without bound toward Pcr', () => {
+    const rt = solveFrame3D(colNodes, colMem, sup, lat, { pDelta: true, fixedAxial: [+0.25 * Pe] })!
+    expect(Math.abs(rt.d[6 + 0])).toBeLessThan(d1)               // tension below first order
+    // compression marching toward the buckling load → drift amplifier blows up
+    const a25 = Math.abs(solveFrame3D(colNodes, colMem, sup, lat, { pDelta: true, fixedAxial: [-0.25 * Pe] })!.d[6 + 0]) / d1
+    const a90 = Math.abs(solveFrame3D(colNodes, colMem, sup, lat, { pDelta: true, fixedAxial: [-0.90 * Pe] })!.d[6 + 0]) / d1
+    expect(a90).toBeGreaterThan(a25)
+    expect(a90).toBeGreaterThan(5)                               // ~1/(1−0.9) order of magnitude
+  })
 })
 
 describe('serializePrecomp / deserializePrecomp — postMessage roundtrip', () => {

--- a/webapp/src/engine/frame3d.ts
+++ b/webapp/src/engine/frame3d.ts
@@ -16,7 +16,16 @@ import type { ProgressFn } from './progress'
 import { triShell } from './shell'
 
 /** Second-order (P-Δ) options for the frame solve. */
-export interface PDeltaOpts { pDelta?: boolean; maxIter?: number; tol?: number }
+export interface PDeltaOpts {
+  pDelta?: boolean; maxIter?: number; tol?: number
+  /** Constant geometric-stiffness axial state, per member (tension +), kN. When
+   *  set together with `pDelta`, Kg is built ONCE from these forces (no
+   *  self-consistent iteration) so the tangent Kt = Ke + Kg is constant — the
+   *  ETABS-style "P-Δ from gravity loads" used by the pushover, where the axial
+   *  pattern is frozen at a gravity preload while the lateral load is scaled.
+   *  Length must equal the member count; a singular tangent returns null. */
+  fixedAxial?: number[]
+}
 
 export interface F3Node { id: string; x: number; y: number; z: number }
 export interface F3Member {
@@ -783,8 +792,54 @@ export function solveWithGeometry(
   if (free.length > 0) {
     if (!Kff) return null   // singular stiffness
     const Ff = free.map((dof) => F[dof])
+    const nf = free.length
 
-    if (diaT && diaNi !== undefined) {
+    // Free-block tangent Kt = Ke + Σ Kg(N): geometric stiffness assembled from a
+    // per-member axial force (tension +). Shared by the self-consistent P-Δ
+    // iteration and the fixed-axial (constant geometric tangent) pushover path.
+    const assembleKtff = (axialOf: (mi: number) => number): number[][] => {
+      const Ktff: number[][] = Array.from({ length: nf }, (_, i) => [...Kff_raw[i]])
+      for (let mi = 0; mi < geoms.length; mi++) {
+        const g = geoms[mi]
+        const kgg = mul(mul(transpose(g.T), kgLocal(axialOf(mi), g.L)), g.T)
+        for (let a = 0; a < 12; a++) {
+          const ia = freeIdx.get(g.dofs[a])
+          if (ia === undefined) continue
+          for (let b = 0; b < 12; b++) {
+            const ib = freeIdx.get(g.dofs[b])
+            if (ib === undefined) continue
+            Ktff[ia][ib] += kgg[a][b]
+          }
+        }
+      }
+      return Ktff
+    }
+    // Representative member axial (tension +) recovered from the current state d.
+    const axialFromState = (mi: number): number => {
+      const g = geoms[mi], ml = mloads[mi]
+      const dl = matVec(g.T, g.dofs.map((dof) => d[dof]))
+      const f = matVec(g.kl, dl).map((v, k) => v - ml.feq[k])
+      return (f[6] - f[0]) / 2
+    }
+
+    if (opts?.pDelta && opts.fixedAxial) {
+      // Constant geometric tangent from a prescribed axial state (ETABS-style
+      // "P-Δ from gravity"): one solve, no self-consistent iteration. A singular
+      // tangent (elastic instability under the preload) returns null.
+      const fixed = opts.fixedAxial
+      const Ktff = assembleKtff((mi) => fixed[mi] ?? 0)
+      if (diaT && diaNi !== undefined) {
+        const fac = luFactor(applyTtoK(Ktff, diaT, diaNi))
+        if (!fac) return null
+        const dn = applyTrecover(luSolve(fac, applyTtoLoad(Ff, diaT, diaNi)), diaT)
+        free.forEach((dof, k) => (d[dof] = dn[k]))
+      } else {
+        const fac = luFactor(Ktff)
+        if (!fac) return null
+        const dn = luSolve(fac, Ff)
+        free.forEach((dof, k) => (d[dof] = dn[k]))
+      }
+    } else if (diaT && diaNi !== undefined) {
       // Constrained solve: transform load to independent DOFs, solve, recover full d_f
       const Ff_ind = applyTtoLoad(Ff, diaT, diaNi)
       const d_ind = luSolve(Kff, Ff_ind)   // Kff is already K_ind = T^T K T
@@ -795,31 +850,11 @@ export function solveWithGeometry(
       if (opts?.pDelta) {
         const maxIter = opts.maxIter ?? 20
         const tol = opts.tol ?? 1e-5
-        const nf = free.length
         for (let it = 0; it < maxIter; it++) {
-          const Ktff: number[][] = Array.from({ length: nf }, (_, i) => [...Kff_raw[i]])
-          for (let mi = 0; mi < geoms.length; mi++) {
-            const g = geoms[mi], ml = mloads[mi]
-            const de = g.dofs.map((dof) => d[dof])
-            const dl = matVec(g.T, de)
-            const f = matVec(g.kl, dl).map((v, k) => v - ml.feq[k])
-            const N = (f[6] - f[0]) / 2
-            const kgg = mul(mul(transpose(g.T), kgLocal(N, g.L)), g.T)
-            for (let a = 0; a < 12; a++) {
-              const ia = freeIdx.get(g.dofs[a])
-              if (ia === undefined) continue
-              for (let b = 0; b < 12; b++) {
-                const ib = freeIdx.get(g.dofs[b])
-                if (ib === undefined) continue
-                Ktff[ia][ib] += kgg[a][b]
-              }
-            }
-          }
-          const Kt_ind = applyTtoK(Ktff, diaT, diaNi)
+          const Kt_ind = applyTtoK(assembleKtff(axialFromState), diaT, diaNi)
           const Ktff_fac = luFactor(Kt_ind)
           if (!Ktff_fac) break
-          const dn_ind = luSolve(Ktff_fac, Ff_ind)
-          const dn = applyTrecover(dn_ind, diaT)
+          const dn = applyTrecover(luSolve(Ktff_fac, Ff_ind), diaT)
           let num = 0, den = 0
           free.forEach((dof, k) => { num += (dn[k] - d[dof]) ** 2; den += dn[k] ** 2 })
           free.forEach((dof, k) => (d[dof] = dn[k]))
@@ -835,27 +870,8 @@ export function solveWithGeometry(
       if (opts?.pDelta) {
         const maxIter = opts.maxIter ?? 20
         const tol = opts.tol ?? 1e-5
-        const nf = free.length
         for (let it = 0; it < maxIter; it++) {
-          const Ktff: number[][] = Array.from({ length: nf }, (_, i) => [...Kff_raw[i]])
-          for (let mi = 0; mi < geoms.length; mi++) {
-            const g = geoms[mi], ml = mloads[mi]
-            const de = g.dofs.map((dof) => d[dof])
-            const dl = matVec(g.T, de)
-            const f = matVec(g.kl, dl).map((v, k) => v - ml.feq[k])
-            const N = (f[6] - f[0]) / 2                     // representative axial, tension +
-            const kgg = mul(mul(transpose(g.T), kgLocal(N, g.L)), g.T)
-            for (let a = 0; a < 12; a++) {
-              const ia = freeIdx.get(g.dofs[a])
-              if (ia === undefined) continue
-              for (let b = 0; b < 12; b++) {
-                const ib = freeIdx.get(g.dofs[b])
-                if (ib === undefined) continue
-                Ktff[ia][ib] += kgg[a][b]
-              }
-            }
-          }
-          const Ktff_fac = luFactor(Ktff)
+          const Ktff_fac = luFactor(assembleKtff(axialFromState))
           if (!Ktff_fac) break                               // elastic instability — retain last d
           const dn = luSolve(Ktff_fac, Ff)
           let num = 0, den = 0

--- a/webapp/src/engine/pushover.test.ts
+++ b/webapp/src/engine/pushover.test.ts
@@ -136,6 +136,66 @@ describe('pushover — fixed-base portal frame', () => {
   })
 })
 
+describe('pushover — P-Δ second order (gravity softens the capacity curve)', () => {
+  // horizontal cantilever (member along X, fixed at i): lateral tip load in −Y
+  // bends about Mz with the base hinge at end i. A tip axial −X load is the
+  // gravity preload that compresses the member and softens that bending plane.
+  const L = 3, Mp = 60
+  const nodes: F3Node[] = [{ id: 'a', x: 0, y: 0, z: 0 }, { id: 'b', x: L, y: 0, z: 0 }]
+  const members: F3Member[] = [{ id: 'm', i: 'a', j: 'b', ...sec }]
+  const supports: F3Support[] = [{ node: 'a', fixity: 'fixed' }]
+  const base: PushoverInput = {
+    nodes, members, supports, Mp: { m: Mp }, pattern: { b: -1 }, dir: 1, controlNode: 'b',
+  }
+  // effective Euler load of the Mz plane from a first-order unit lateral solve
+  const lin = solveFrame3D(nodes, members, supports, [{ kind: 'node', node: 'b', Fy: -1, cat: 'E' }])!
+  const EIeff = L ** 3 / (3 * Math.abs(lin.d[6 + 1]))
+  const Pe = (Math.PI ** 2 * EIeff) / (4 * L ** 2)
+
+  const fy = pushoverAnalysis(base).curve[1]
+
+  it('first-order capacity = Mp / L with no gravity', () => {
+    expect(Math.abs(fy.baseShear)).toBeCloseTo(Mp / L, 4)
+  })
+
+  it('base moment = lateral V·L plus the P·Δ second-order term (≈ Mp at yield)', () => {
+    const P = 0.3 * Pe
+    const y = pushoverAnalysis({ ...base, pDelta: true, gravity: [{ node: 'b', Fx: -P }] }).curve[1]
+    // first-order would reach Mp on V·L alone; with P-Δ the lateral moment is well
+    // short of Mp and the axial-through-drift term P·Δ makes up the balance. The
+    // consistent (cubic) Kg distributes that term, so the tip-string sum V·L + P·Δ
+    // recovers Mp only approximately (within ~7%).
+    expect(Math.abs(y.baseShear) * L).toBeLessThan(Mp * 0.9)
+    const stringTotal = Math.abs(y.baseShear) * L + P * Math.abs(y.roofDisp)
+    expect(stringTotal).toBeGreaterThan(Mp * 0.9)
+    expect(stringTotal).toBeLessThanOrEqual(Mp + 1e-6)
+  })
+
+  it('P-Δ lowers the collapse base shear and amplifies roof drift', () => {
+    const P = 0.3 * Pe
+    const y = pushoverAnalysis({ ...base, pDelta: true, gravity: [{ node: 'b', Fx: -P }] }).curve[1]
+    expect(Math.abs(y.baseShear)).toBeLessThan(Math.abs(fy.baseShear) * 0.95)
+    expect(Math.abs(y.roofDisp)).toBeGreaterThan(Math.abs(fy.roofDisp))
+  })
+
+  it('heavier gravity ⇒ lower collapse base shear (monotone softening)', () => {
+    const light = pushoverAnalysis({ ...base, pDelta: true, gravity: [{ node: 'b', Fx: -0.2 * Pe }] })
+    const heavy = pushoverAnalysis({ ...base, pDelta: true, gravity: [{ node: 'b', Fx: -0.5 * Pe }] })
+    expect(Math.abs(heavy.curve[1].baseShear)).toBeLessThan(Math.abs(light.curve[1].baseShear))
+  })
+
+  it('pDelta on but no gravity ⇒ identical to first order', () => {
+    const r = pushoverAnalysis({ ...base, pDelta: true })
+    expect(Math.abs(r.curve[1].baseShear)).toBeCloseTo(Math.abs(fy.baseShear), 8)
+    expect(Math.abs(r.curve[1].roofDisp)).toBeCloseTo(Math.abs(fy.roofDisp), 8)
+  })
+
+  it('gravity given but pDelta off ⇒ gravity ignored (first order)', () => {
+    const r = pushoverAnalysis({ ...base, gravity: [{ node: 'b', Fx: -0.5 * Pe }] })
+    expect(Math.abs(r.curve[1].baseShear)).toBeCloseTo(Math.abs(fy.baseShear), 8)
+  })
+})
+
 describe('pushover — guards', () => {
   const nodes: F3Node[] = [{ id: 'a', x: 0, y: 0, z: 0 }, { id: 'b', x: 3, y: 0, z: 0 }]
   const members: F3Member[] = [{ id: 'm', i: 'a', j: 'b', ...sec }]

--- a/webapp/src/engine/pushover.ts
+++ b/webapp/src/engine/pushover.ts
@@ -16,6 +16,13 @@
 //   4. Repeat until a mechanism forms (singular tangent / no positive event) or
 //      a target roof displacement is reached.
 //
+// Second-order P-Δ (optional, `pDelta`): the geometric stiffness Kg is built once
+// from a constant gravity-preload axial state and added to the elastic tangent at
+// every event (ETABS-style "P-Δ from gravity loads"). This keeps each event's
+// solve linear in λ — so the event-to-event scheme is unchanged — while softening
+// the lateral stiffness: drift is amplified, hinges form at lower λ, and the
+// collapse base shear drops (the post-yield branch can turn negative).
+//
 // The result is the capacity (pushover) curve: base shear V vs. control-node
 // displacement Δ, piecewise-linear with a break at each hinge event. With
 // geometry linear this matches rigid-plastic limit analysis (collapse load).
@@ -65,6 +72,17 @@ export interface PushoverInput {
   targetDisp?: number
   /** Maximum number of hinge events before stopping (default 100). */
   maxEvents?: number
+  /** Include second-order P-Δ effects in the pushover tangent. The geometric
+   *  stiffness is built once from the `gravity` preload axial state and held
+   *  constant while the lateral pattern is scaled (ETABS-style "P-Δ from gravity
+   *  loads"). Softens lateral stiffness, amplifies drift, and lowers the collapse
+   *  load — the post-yield branch can turn negative. Default false (first-order). */
+  pDelta?: boolean
+  /** Constant gravity loads (kN) that generate the P-Δ axial state. Used only when
+   *  `pDelta` is on; absent/empty ⇒ no geometric softening. Typically downward
+   *  vertical node loads (Fy < 0). Not added to the lateral load vector — they only
+   *  set the axial forces for the geometric stiffness. */
+  gravity?: { node: string; Fx?: number; Fy?: number; Fz?: number }[]
 }
 
 /** Hinge mode: plastic moment, axial yield, or shear yield. */
@@ -182,6 +200,19 @@ export function pushoverAnalysis(input: PushoverInput): PushoverResult {
 
   const ctrlIdx = input.nodes.findIndex((n) => n.id === input.controlNode)
 
+  // P-Δ: representative member axial (tension +) from a gravity preload, solved
+  // once on the un-hinged elastic frame and held constant. Feeds the geometric
+  // stiffness so the lateral tangent softens as gravity grows (ETABS linearization).
+  let fixedAxial: number[] | undefined
+  if (input.pDelta && input.gravity && input.gravity.length > 0) {
+    const gLoads: F3Load[] = input.gravity.map((g) => ({
+      kind: 'node', node: g.node, Fx: g.Fx ?? 0, Fy: g.Fy ?? 0, Fz: g.Fz ?? 0, cat: 'D',
+    }))
+    const resG = solveWithGeometry(precomputeFrame(input.nodes, input.members, input.supports), gLoads)
+    if (resG) fixedAxial = resG.members.map((mr) => mr.N.reduce((s, v) => s + v, 0) / mr.N.length)
+  }
+  const solveOpts = fixedAxial ? { pDelta: true, fixedAxial } : undefined
+
   let lambda = 0, roofDisp = 0
   let mechanism = false
   let dmax0 = 0   // elastic peak |displacement| baseline, for mechanism detection
@@ -200,7 +231,7 @@ export function pushoverAnalysis(input: PushoverInput): PushoverResult {
     }
 
     const precomp = precomputeFrame(input.nodes, members, input.supports)
-    const res = solveWithGeometry(precomp, refLoads)
+    const res = solveWithGeometry(precomp, refLoads, solveOpts)
     if (!res) { mechanism = true; break }   // singular tangent → mechanism
 
     // Mechanism guard: luFactor's pivot tolerance can let a near-singular
@@ -250,6 +281,24 @@ export function pushoverAnalysis(input: PushoverInput): PushoverResult {
       if (dl > TOL && dl < dLam) { dLam = dl; crit = s }
     }
     if (!crit || !isFinite(dLam)) { mechanism = true; break }   // no further events → mechanism
+
+    // If the next hinge would overshoot the target drift, take a PARTIAL step to
+    // the target (no new hinge) and stop. This is standard pushover practice and
+    // also discards a spurious large-Δλ increment when the tangent has nearly
+    // collapsed to a mechanism (e.g. under P-Δ softening) — the overshoot point
+    // would otherwise pollute the capacity curve with a meaningless base shear.
+    if (input.targetDisp !== undefined && Math.abs(dRoof) > TOL) {
+      const dLamToTarget = (Math.abs(input.targetDisp) - Math.abs(roofDisp)) / Math.abs(dRoof)
+      if (dLamToTarget >= 0 && dLamToTarget < dLam) {
+        lambda += dLamToTarget
+        roofDisp += dRoof * dLamToTarget
+        curve.push({
+          event, lambda, baseShear: lambda * Vref, roofDisp,
+          newHinge: null, numHinges: slots.filter((s) => s.hinged).length,
+        })
+        break
+      }
+    }
 
     // advance cumulative state by Δλ
     lambda += dLam

--- a/webapp/src/engine/pushoverModel.test.ts
+++ b/webapp/src/engine/pushoverModel.test.ts
@@ -86,6 +86,24 @@ describe('runPushoverModel', () => {
     const on = runPushoverModel(model, { dir: 0, pmInteraction: true })!
     expect(peak(on)).toBeLessThanOrEqual(peak(off) + 1e-6)
   })
+
+  it('pDelta defaults off; flag is reported in the result', () => {
+    expect(runPushoverModel(model, { dir: 0 })!.pDelta).toBe(false)
+    expect(runPushoverModel(model, { dir: 0, pDelta: true })!.pDelta).toBe(true)
+  })
+
+  it('P-Δ lowers (or matches) the first-yield base shear from gravity softening', () => {
+    // compare at the first yield event, where both analyses share the same (elastic)
+    // hinge state — P-Δ amplifies the demand so yield arrives at a lower load factor.
+    // (Peak-over-curve isn't a clean invariant: the two runs can terminate on
+    // different events — a mechanism vs a drift-target partial step.)
+    const firstYield = (r: NonNullable<ReturnType<typeof runPushoverModel>>) =>
+      Math.abs(r.result.curve[1].baseShear)
+    const off = runPushoverModel(model, { dir: 0, pDelta: false })!
+    const on = runPushoverModel(model, { dir: 0, pDelta: true })!
+    expect(firstYield(on)).toBeLessThanOrEqual(firstYield(off) + 1e-6)
+    expect(firstYield(on)).toBeGreaterThan(firstYield(off) * 0.9)   // small gravity ⇒ close
+  })
 })
 
 describe('axialCapacity', () => {

--- a/webapp/src/engine/pushoverModel.ts
+++ b/webapp/src/engine/pushoverModel.ts
@@ -14,7 +14,7 @@ import type { StructuralModel, RectSection } from './model'
 import { shapeByName } from './aiscSections'
 import { deriveWSection } from './steelDesign'
 import { modelToFrame3D } from './modelBridge'
-import { buildSeismicMass } from './modal'
+import { buildSeismicMass, GRAVITY } from './modal'
 import { pushoverAnalysis, type PushoverResult } from './pushover'
 
 /** Axial capacity for the P–M interaction surface, kN:
@@ -72,6 +72,10 @@ export interface PushoverModelOpts {
   targetDispRatio?: number
   /** Max hinge events (default 100). */
   maxEvents?: number
+  /** Include second-order P-Δ in the pushover tangent. The geometric stiffness is
+   *  built from the gravity weight (seismic mass × g, applied downward) and held
+   *  constant while the lateral pattern is scaled. Default false. */
+  pDelta?: boolean
 }
 
 export interface PushoverModelResult {
@@ -84,6 +88,8 @@ export interface PushoverModelResult {
   nHingeable: number
   /** Whether P–M interaction was applied (reduced plastic moment at hinges). */
   pmInteraction: boolean
+  /** Whether second-order P-Δ (gravity geometric stiffness) was included. */
+  pDelta: boolean
 }
 
 /**
@@ -132,10 +138,17 @@ export function runPushoverModel(model: StructuralModel, opts: PushoverModelOpts
 
   const targetDisp = totalHeight > 0 ? totalHeight * (opts.targetDispRatio ?? 0.04) : undefined
 
+  // P-Δ gravity preload: lumped seismic weight (mass[t]×g) applied downward (−Y).
+  const usePDelta = opts.pDelta ?? false
+  const gravity = usePDelta
+    ? [...mass].filter(([, mt]) => mt > 0).map(([node, mt]) => ({ node, Fy: -mt * GRAVITY }))
+    : undefined
+
   const result = pushoverAnalysis({
     nodes: br.nodes, members: br.members, supports: br.supports,
     Mp, pattern, dir, controlNode, targetDisp, maxEvents: opts.maxEvents ?? 100,
     ...(usePM ? { pm } : {}),
+    ...(usePDelta && gravity && gravity.length ? { pDelta: true, gravity } : {}),
   })
-  return { result, controlNode, totalHeight, nHingeable: Object.keys(Mp).length, pmInteraction: usePM }
+  return { result, controlNode, totalHeight, nHingeable: Object.keys(Mp).length, pmInteraction: usePM, pDelta: usePDelta }
 }

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -790,6 +790,7 @@ export default function ModelSpace() {
   const [poRho, setPoRho] = useState(1.5)        // concrete tension-steel ratio, %
   const [poMpScale, setPoMpScale] = useState(1)
   const [poPM, setPoPM] = useState(false)        // apply P–M interaction at hinges
+  const [poPDelta, setPoPDelta] = useState(false) // include second-order P-Δ (gravity)
   const [po, setPo] = useState<PushoverModelResult | null>(null)
   // Time-history (modal Newmark-β) inputs + result
   const [thKind, setThKind] = useState<GroundMotionKind>('rampedSine')
@@ -925,7 +926,7 @@ export default function ModelSpace() {
     if (!model || busy || meshErrors) return
     run('pushover', {
       model,
-      opts: { dir: poDir === 'x' ? 0 : 2, pattern: poPattern, rho: poRho / 100, mpScale: poMpScale, pmInteraction: poPM },
+      opts: { dir: poDir === 'x' ? 0 : 2, pattern: poPattern, rho: poRho / 100, mpScale: poMpScale, pmInteraction: poPM, pDelta: poPDelta },
     }).then((r) => setPo((r as { pushover: PushoverModelResult | null }).pushover))
       .catch((e) => console.error('pushover failed', e))
   }
@@ -2865,12 +2866,19 @@ export default function ModelSpace() {
                     onChange={(e) => setPoPM(e.target.checked)} />
                   <span>P–M interaction (reduce plastic moment Mpc(P) at each hinge)</span>
                 </label>
+                <label className="col-span-full flex items-center gap-2 text-sm">
+                  <input type="checkbox" disabled={!model} checked={poPDelta}
+                    onChange={(e) => setPoPDelta(e.target.checked)} />
+                  <span>P-Δ second order (gravity geometric stiffness softens the capacity curve)</span>
+                </label>
                 <p className="col-span-full text-[11px] text-slate-500">
                   Event-to-event concentrated plastic hinges (a hinge = a member-end moment release).
                   Capacity curve = base shear vs roof displacement; pushes to a 4% drift target or a collapse
                   mechanism. Mp: steel Fy·Zx; concrete ρ·b·d²·fy·(1−0.59ρfy/f′c).
                   {' '}P–M interaction (opt-in): hinges yield at the reduced Mpc(P) — steel AISC App. 1
                   (1.18Mp(1−P/Py) major, 1.19Mp(1−(P/Py)²) minor); concrete ACI §22.4 linear chord Mp(1−P/Pn0).
+                  {' '}P-Δ (opt-in): a constant geometric stiffness from the gravity weight (mass×g) softens the
+                  lateral tangent — drift is amplified, hinges form earlier, and the collapse base shear drops.
                 </p>
                 <div className="col-span-full">
                   <button type="button" onClick={runPushover} disabled={!model || !!busy || meshErrors} className={btn('from-[#ea580c] to-[#c2410c]')}>


### PR DESCRIPTION
## Summary

Adds an opt-in **P-Δ** mode to the nonlinear-static (pushover) analysis. The geometric stiffness is built once from a constant gravity preload and held fixed while the lateral pattern is scaled (ETABS-style *"P-Δ from gravity loads"*), so each event's solve stays linear in λ and the event-to-event scheme is unchanged — while the lateral tangent softens: drift amplifies, hinges form at lower λ, and the collapse base shear drops.

## Engine
- **`frame3d.ts`** — new `PDeltaOpts.fixedAxial`: builds Kg **once** from a prescribed per-member axial state (constant tangent, single solve; singular tangent ⇒ `null`). Duplicated `Ktff` assembly refactored into a shared `assembleKtff` helper (no behaviour change to the existing self-consistent P-Δ iteration).
- **`pushover.ts`** — `pDelta` + `gravity` inputs. Solves the gravity preload once on the un-hinged frame for the representative member axial, then passes `fixedAxial` to every event solve. Adds a **partial-step-to-target** stop that discards a spurious large-Δλ overshoot when the tangent nears a mechanism.
- **`pushoverModel.ts`** — `pDelta` option/flag; gravity weight = seismic mass × g applied downward; reported in the result.

## UI
- **`ModelSpace.tsx`** — "P-Δ second order" checkbox on the Pushover tab + help text.
- **`PushoverPanel.tsx`** — "P-Δ on" annotation on the peak-base-shear row.

## Tests (+10, 799 total green)
- **frame3d**: `fixedAxial` constant tangent (drift linear in load), tension stiffens, amplifier grows toward Pcr.
- **pushover**: base moment = `V·L + P·Δ` second-order split, lower collapse base shear, monotone softening with heavier gravity, no-gravity / pDelta-off regressions.
- **pushoverModel**: `pDelta` flag reported; first-yield base shear ≤ first order.

Verified: `npm test` (799 passing), `npx tsc -b`, and `npm run build` all clean.

## Remaining Tier 4 phases
- **D11** — shell integration into NSCP design pipeline
- **E12** — wind load generation NSCP 207E.6
- **E13** — seismic detailing SMRF/OMRF flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_