### PR TITLE
feat(D11): integrate shell FE into slab design via Wood-Armer

### DIFF
--- a/webapp/src/engine/shellModel.test.ts
+++ b/webapp/src/engine/shellModel.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { solveModelShells, designModelSlabsFE, meshModelShells } from './shellModel'
+import type { StructuralModel } from './model'
+
+// A single 6×5 m slab panel, clamped at its four corners, under area D + L.
+function panel(thickness = 150): StructuralModel {
+  return {
+    version: 1, name: 'panel',
+    nodes: [
+      { id: 'n0', x: 0, y: 0, z: 0 }, { id: 'n1', x: 6, y: 0, z: 0 },
+      { id: 'n2', x: 6, y: 0, z: 5 }, { id: 'n3', x: 0, y: 0, z: 5 },
+    ],
+    sections: [], members: [],
+    plates: [{ id: 's0', corners: ['n0', 'n1', 'n2', 'n3'], role: 'slab', thickness }],
+    walls: [],
+    supports: [
+      { node: 'n0', fixity: 'fixed' }, { node: 'n1', fixity: 'fixed' },
+      { node: 'n2', fixity: 'fixed' }, { node: 'n3', fixity: 'fixed' },
+    ],
+    loads: [
+      { kind: 'area', plate: 's0', q: 6, cat: 'D' },
+      { kind: 'area', plate: 's0', q: 4, cat: 'L' },
+    ],
+    storeys: [],
+    shellElements: true,
+  }
+}
+
+describe('meshModelShells', () => {
+  it('reuses the model corner node ids and meshes n×n cells', () => {
+    const { nodes, elems } = meshModelShells(panel(), 4)
+    // 4×4 grid ⇒ 25 nodes, 2·16 = 32 triangles
+    expect(nodes).toHaveLength(25)
+    expect(elems).toHaveLength(32)
+    for (const id of ['n0', 'n1', 'n2', 'n3']) expect(nodes.some((n) => n.id === id)).toBe(true)
+    // every element id is prefixed by its plate id
+    expect(elems.every((e) => e.id.startsWith('s0_'))).toBe(true)
+  })
+})
+
+describe('solveModelShells', () => {
+  it('returns null when the model has no plates', () => {
+    expect(solveModelShells({ ...panel(), plates: [] })).toBeNull()
+  })
+
+  it('recovers a non-trivial bending field under area load', () => {
+    const r = solveModelShells(panel(), { subdiv: 4 })!
+    expect(r).toBeTruthy()
+    expect(r.stresses).toHaveLength(32)
+    const peakM = Math.max(...r.stresses.map((s) => Math.max(Math.abs(s.Mx), Math.abs(s.My))))
+    expect(peakM).toBeGreaterThan(0)
+  })
+
+  it('factored field scales linearly with the load factors', () => {
+    const svc = solveModelShells(panel(), { subdiv: 3, dFactor: 1, lFactor: 1 })!
+    const fac = solveModelShells(panel(), { subdiv: 3, dFactor: 2, lFactor: 2 })!
+    const peak = (r: typeof svc) => Math.max(...r.stresses.map((s) => Math.abs(s.Mx)))
+    expect(peak(fac)).toBeCloseTo(2 * peak(svc), 6)
+  })
+})
+
+describe('designModelSlabsFE — Wood-Armer reinforcement from the FE field', () => {
+  it('designs one row per slab with positive reinforcement', () => {
+    const out = designModelSlabsFE(panel(), { subdiv: 4 })!
+    expect(out.rows).toHaveLength(1)
+    const row = out.rows[0]
+    expect(row.plate).toBe('s0')
+    expect(row.thickness).toBe(150)
+    // at least one face/direction needs flexural steel beyond the minimum
+    const strips = [row.design.bottomX, row.design.bottomY, row.design.topX, row.design.topY]
+    expect(strips.every((s) => s.As > 0 && s.spacing > 0)).toBe(true)
+    expect(strips.some((s) => !s.usedMin)).toBe(true)
+    // governing elements belong to this plate
+    expect(row.design.govBottom.startsWith('s0_')).toBe(true)
+    expect(row.design.govTop.startsWith('s0_')).toBe(true)
+  })
+
+  it('uses the NSCP 1.2D + 1.6L factored field by default (heavier than service)', () => {
+    const factored = designModelSlabsFE(panel(), { subdiv: 4 })!
+    const service = designModelSlabsFE(panel(), { subdiv: 4, dFactor: 1, lFactor: 1 })!
+    const env = (o: typeof factored) => o.rows[0].design.moments.mxBottom + o.rows[0].design.moments.myBottom
+    expect(env(factored)).toBeGreaterThan(env(service))
+  })
+
+  it('factored design never needs less steel than the service field', () => {
+    const factored = designModelSlabsFE(panel(), { subdiv: 4 })!.rows[0]
+    const service = designModelSlabsFE(panel(), { subdiv: 4, dFactor: 1, lFactor: 1 })!.rows[0]
+    expect(factored.design.bottomX.As).toBeGreaterThanOrEqual(service.design.bottomX.As - 1e-6)
+    expect(factored.design.topY.As).toBeGreaterThanOrEqual(service.design.topY.As - 1e-6)
+  })
+
+  it('skips wall panels', () => {
+    const m = panel()
+    m.plates[0].role = 'wall'
+    const out = designModelSlabsFE(m, { subdiv: 3 })!
+    expect(out.rows).toHaveLength(0)
+  })
+})

--- a/webapp/src/engine/shellModel.ts
+++ b/webapp/src/engine/shellModel.ts
@@ -1,0 +1,121 @@
+// ─────────────────────────────────────────────────────────────────────────
+// StructuralModel → shell FE bridge (Tier 4 #11).
+//
+// Meshes the model's quad plates into a conforming triangular flat-shell mesh
+// (D10 `subdivideQuadPlates`), solves the membrane+bending FE problem under a
+// chosen load factor, and recovers the per-element stress/moment field. The
+// recovered slab bending moments then drive Wood-Armer reinforcement design,
+// integrating the shell results into the NSCP design pipeline (previously the FE
+// field was visualised only; slabs were sized by the empirical DDM).
+//
+// Units: coordinates m; pressures kPa (kN/m²); moments kN·m/m.
+// ─────────────────────────────────────────────────────────────────────────
+import type { StructuralModel } from './model'
+import {
+  subdivideQuadPlates, solveShell, recoverShellStress,
+  type V3, type QuadPlateSpec, type ShellNode, type ShellElem, type ShellSupport, type ElementStress,
+} from './shell'
+import { designSlabFE, type SlabFEDesign, type ShellMomentSample } from './woodArmer'
+
+/** Default concrete shell material (E MPa, ν). */
+const SHELL_E = 25000
+const SHELL_NU = 0.2
+
+export interface ShellModelMesh {
+  nodes: ShellNode[]
+  elems: ShellElem[]
+}
+
+export interface ShellModelStress extends ShellModelMesh {
+  stresses: ElementStress[]
+}
+
+/** Mesh every quad plate into an n×n conforming triangular shell mesh. Model
+ *  node ids are reused at coincident corners so supports/loads still attach. */
+export function meshModelShells(model: StructuralModel, subdiv = 4): ShellModelMesh {
+  const posById = new Map(model.nodes.map((n) => [n.id, [n.x, n.y, n.z] as V3]))
+  const cornerId = (p: V3): string | undefined => {
+    for (const n of model.nodes)
+      if (Math.hypot(p[0] - n.x, p[1] - n.y, p[2] - n.z) < 1e-4) return n.id
+    return undefined
+  }
+  const specs: QuadPlateSpec[] = model.plates.flatMap((p) => {
+    const cs = p.corners.map((id) => posById.get(id))
+    if (cs.some((c) => !c)) return []
+    return [{ id: p.id, corners: cs as [V3, V3, V3, V3], E: SHELL_E, nu: SHELL_NU, t: p.thickness }]
+  })
+  return subdivideQuadPlates(specs, Math.max(1, Math.round(subdiv)), cornerId)
+}
+
+/** Fully restrain every supported model node in the shell mesh (all 6 DOFs). */
+function shellSupports(model: StructuralModel): ShellSupport[] {
+  return model.supports.map((s) => ({
+    node: s.node, ux: true, uy: true, uz: true, rx: true, ry: true, rz: true,
+  }))
+}
+
+/**
+ * Solve the model's shell mesh under a factored area-load combination and recover
+ * the element stress/moment field. `dFactor`/`lFactor` scale the dead/live area
+ * loads (default 1.0/1.0 → service field for display; pass 1.2/1.6 for design).
+ * Returns null if the model has no plates or the solve is singular.
+ */
+export function solveModelShells(
+  model: StructuralModel, opts: { subdiv?: number; dFactor?: number; lFactor?: number } = {},
+): ShellModelStress | null {
+  if (!model.plates.length) return null
+  const { nodes, elems } = meshModelShells(model, opts.subdiv ?? 4)
+  if (!nodes.length || !elems.length) return null
+  const dF = opts.dFactor ?? 1, lF = opts.lFactor ?? 1
+  const pressures = model.loads.flatMap((l) => {
+    if (l.kind !== 'area') return []
+    const factor = l.cat === 'D' ? dF : l.cat === 'L' ? lF : 1
+    if (factor === 0) return []
+    return elems.filter((e) => e.id.startsWith(`${l.plate}_`)).map((e) => ({ elem: e.id, q: l.q * factor }))
+  })
+  const result = solveShell(nodes, elems, shellSupports(model), [], pressures)
+  if (!result) return null
+  return { nodes, elems, stresses: recoverShellStress(nodes, elems, result) }
+}
+
+/** Wood-Armer reinforcement design for one model plate. */
+export interface SlabFEScheduleRow {
+  plate: string
+  thickness: number          // mm
+  design: SlabFEDesign
+}
+
+export interface ShellDesignOpts {
+  subdiv?: number
+  /** Factored load factors (default NSCP 1.2D + 1.6L). */
+  dFactor?: number; lFactor?: number
+  /** Slab reinforcement parameters (default cover 20 mm, ⌀12, fc 28, fy 415). */
+  cover?: number; barDia?: number; fc?: number; fy?: number
+}
+
+/**
+ * Design slab reinforcement for every plate from the shell FE moment field via
+ * Wood-Armer. Solves the mesh once under the factored combination, groups the
+ * element moments per plate (by the `{plateId}_…` element-id prefix), and sizes
+ * the four reinforcement strips. Returns null when there are no plates.
+ */
+export function designModelSlabsFE(
+  model: StructuralModel, opts: ShellDesignOpts = {},
+): { mesh: ShellModelStress; rows: SlabFEScheduleRow[] } | null {
+  const solved = solveModelShells(model, {
+    subdiv: opts.subdiv, dFactor: opts.dFactor ?? 1.2, lFactor: opts.lFactor ?? 1.6,
+  })
+  if (!solved) return null
+  const sByElem = new Map(solved.stresses.map((s) => [s.id, s]))
+  const sec = { cover: opts.cover ?? 20, barDia: opts.barDia ?? 12, fc: opts.fc ?? 28, fy: opts.fy ?? 415 }
+  const rows: SlabFEScheduleRow[] = []
+  for (const p of model.plates) {
+    if (p.role === 'wall') continue
+    const samples: ShellMomentSample[] = solved.elems
+      .filter((e) => e.id.startsWith(`${p.id}_`))
+      .map((e) => { const s = sByElem.get(e.id)!; return { id: e.id, Mx: s.Mx, My: s.My, Mxy: s.Mxy } })
+    const design = designSlabFE(samples, { t: p.thickness, ...sec })
+    if (design) rows.push({ plate: p.id, thickness: p.thickness, design })
+  }
+  return { mesh: solved, rows }
+}

--- a/webapp/src/engine/woodArmer.test.ts
+++ b/webapp/src/engine/woodArmer.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest'
+import { woodArmer, designSlabStrip, designSlabFE, maxSlabSpacing, type ShellMomentSample } from './woodArmer'
+import { flexuralSteel, rhoMin } from './flexure'
+
+describe('woodArmer — design moments from (Mx, My, Mxy)', () => {
+  it('no twist: bottom = sagging moments, top = hogging magnitudes', () => {
+    const wa = woodArmer(40, 20, 0)
+    expect(wa.mxBottom).toBeCloseTo(40, 9)
+    expect(wa.myBottom).toBeCloseTo(20, 9)
+    expect(wa.mxTop).toBe(0)        // both positive ⇒ no hogging steel
+    expect(wa.myTop).toBe(0)
+  })
+
+  it('pure twist Mxy adds |Mxy| to both bottom and top faces', () => {
+    const wa = woodArmer(0, 0, 15)
+    expect(wa.mxBottom).toBeCloseTo(15, 9)
+    expect(wa.myBottom).toBeCloseTo(15, 9)
+    expect(wa.mxTop).toBeCloseTo(15, 9)
+    expect(wa.myTop).toBeCloseTo(15, 9)
+  })
+
+  it('default rule M*x = Mx + |Mxy| when it stays positive', () => {
+    const wa = woodArmer(30, 10, 8)
+    expect(wa.mxBottom).toBeCloseTo(38, 9)
+    expect(wa.myBottom).toBeCloseTo(18, 9)
+  })
+
+  it('sign of Mxy is immaterial (uses magnitude)', () => {
+    const a = woodArmer(30, 10, 8)
+    const b = woodArmer(30, 10, -8)
+    expect(b.mxBottom).toBeCloseTo(a.mxBottom, 12)
+    expect(b.myBottom).toBeCloseTo(a.myBottom, 12)
+  })
+
+  it('correction A: when Mx + |Mxy| < 0, M*x = 0 and M*y picks up |Mxy²/Mx|', () => {
+    // Mx = −5, Mxy = 3 → Mx + |Mxy| = −2 < 0
+    const wa = woodArmer(-5, 12, 3)
+    expect(wa.mxBottom).toBe(0)
+    expect(wa.myBottom).toBeCloseTo(12 + (3 * 3) / 5, 9)   // My + |Mxy²/Mx| = 12 + 1.8
+  })
+
+  it('top face: a hogging panel needs top steel, no bottom steel', () => {
+    const wa = woodArmer(-40, -25, 0)
+    expect(wa.mxBottom).toBe(0)
+    expect(wa.myBottom).toBe(0)
+    expect(wa.mxTop).toBeCloseTo(40, 9)
+    expect(wa.myTop).toBeCloseTo(25, 9)
+  })
+
+  it('top correction: Mx − |Mxy| > 0 ⇒ M*x_top = 0, M*y_top from |Mxy²/Mx|', () => {
+    // Mx = 5, My = −20, Mxy = 3 → top default M*x = 5 − 3 = 2 > 0
+    const wa = woodArmer(5, -20, 3)
+    expect(wa.mxTop).toBe(0)
+    expect(wa.myTop).toBeCloseTo(Math.abs(-20 - (3 * 3) / 5), 9)   // |−20 − 1.8| = 21.8
+  })
+
+  it('always returns non-negative magnitudes', () => {
+    for (const [mx, my, mxy] of [[-50, -50, 40], [12, -7, 20], [-3, 9, -11]] as const) {
+      const wa = woodArmer(mx, my, mxy)
+      for (const v of [wa.mxBottom, wa.myBottom, wa.mxTop, wa.myTop]) expect(v).toBeGreaterThanOrEqual(0)
+    }
+  })
+})
+
+describe('designSlabStrip — per-metre flexural reinforcement', () => {
+  const sec = { t: 150, cover: 20, barDia: 12, fc: 28, fy: 415 }
+
+  it('As matches flexuralSteel at d = t − cover − 1.5·db over a 1 m strip', () => {
+    const d = 150 - 20 - 1.5 * 12               // 112 mm
+    const flex = flexuralSteel({ Mu: 25, b: 1000, d, fc: 28, fy: 415 })
+    const AsMin = rhoMin(28, 415) * 1000 * d
+    const r = designSlabStrip({ Mu: 25, ...sec })
+    expect(r.As).toBeCloseTo(Math.max(flex.As, AsMin), 6)
+  })
+
+  it('zero moment still provides the shrinkage/temperature minimum', () => {
+    const d = 150 - 20 - 1.5 * 12
+    const r = designSlabStrip({ Mu: 0, ...sec })
+    expect(r.usedMin).toBe(true)
+    expect(r.As).toBeCloseTo(rhoMin(28, 415) * 1000 * d, 6)
+    expect(r.As).toBeGreaterThan(0)
+  })
+
+  it('spacing never exceeds the ACI maximum min(3h, 450)', () => {
+    const r = designSlabStrip({ Mu: 0.1, ...sec })
+    expect(r.spacing).toBeLessThanOrEqual(maxSlabSpacing(150))
+    expect(maxSlabSpacing(150)).toBe(450)
+  })
+
+  it('provided steel at the adopted spacing covers the requirement', () => {
+    const r = designSlabStrip({ Mu: 40, ...sec })
+    expect(r.AsProvided).toBeGreaterThanOrEqual(r.As * 0.999)   // spacing rounded down ⇒ ≥ required
+  })
+
+  it('a heavier moment needs more steel (tighter spacing)', () => {
+    const light = designSlabStrip({ Mu: 10, ...sec })
+    const heavy = designSlabStrip({ Mu: 45, ...sec })
+    expect(heavy.As).toBeGreaterThan(light.As)
+    expect(heavy.spacing).toBeLessThanOrEqual(light.spacing)
+  })
+})
+
+describe('designSlabFE — envelope over a panel', () => {
+  const sec = { t: 150, cover: 20, barDia: 12, fc: 28, fy: 415 }
+  const samples: ShellMomentSample[] = [
+    { id: 'p_0_0_0', Mx: 30, My: 10, Mxy: 5 },     // sagging mid-panel
+    { id: 'p_1_0_0', Mx: 12, My: 6, Mxy: 2 },
+    { id: 'p_0_1_0', Mx: -28, My: -18, Mxy: 4 },   // hogging near support
+  ]
+
+  it('returns null for an empty field', () => {
+    expect(designSlabFE([], sec)).toBeNull()
+  })
+
+  it('envelopes the worst Wood-Armer moment per direction/face', () => {
+    const r = designSlabFE(samples, sec)!
+    // bottom envelope = max sagging design moment across the elements
+    const each = samples.map((s) => woodArmer(s.Mx, s.My, s.Mxy))
+    expect(r.moments.mxBottom).toBeCloseTo(Math.max(...each.map((w) => w.mxBottom)), 9)
+    expect(r.moments.myTop).toBeCloseTo(Math.max(...each.map((w) => w.myTop)), 9)
+  })
+
+  it('attributes the governing sagging/hogging elements', () => {
+    const r = designSlabFE(samples, sec)!
+    expect(r.govBottom).toBe('p_0_0_0')   // largest +M element
+    expect(r.govTop).toBe('p_0_1_0')      // largest −M element
+  })
+
+  it('designs all four strips with positive steel', () => {
+    const r = designSlabFE(samples, sec)!
+    for (const strip of [r.bottomX, r.bottomY, r.topX, r.topY]) {
+      expect(strip.As).toBeGreaterThan(0)
+      expect(strip.spacing).toBeGreaterThan(0)
+    }
+  })
+})

--- a/webapp/src/engine/woodArmer.ts
+++ b/webapp/src/engine/woodArmer.ts
@@ -1,0 +1,155 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Wood-Armer slab design — shell FE moment field → orthogonal reinforcement.
+//
+// A flat-shell (DKT) analysis returns the plate bending field per element as the
+// moment triad (Mx, My, Mxy) per unit width. Reinforcement, however, runs in two
+// orthogonal directions and cannot carry the twisting moment Mxy directly. The
+// Wood & Armer (1968) rules convert (Mx, My, Mxy) into equivalent NORMAL design
+// moments that the x- and y-bars must resist, separately for the bottom face
+// (sagging, +M) and the top face (hogging, −M):
+//
+//   bottom:  M*x = Mx + |Mxy|,           M*y = My + |Mxy|
+//            if M*x < 0 → M*x = 0, M*y = My + |Mxy²/Mx|   (and clamp ≥ 0)
+//            if M*y < 0 → M*y = 0, M*x = Mx + |Mxy²/My|
+//   top:     M*x = Mx − |Mxy|,           M*y = My − |Mxy|
+//            if M*x > 0 → M*x = 0, M*y = My − |Mxy²/Mx|   (and clamp ≤ 0)
+//            if M*y > 0 → M*y = 0, M*x = Mx − |Mxy²/My|
+//
+// Each design moment is then sized for flexure to NSCP 2015 / ACI 318-14
+// (φ = 0.90), per metre width, with the slab effective depth.
+// Units: moments kN·m/m; thickness/cover/bar mm; fc/fy MPa; As mm²/m; spacing mm.
+// ─────────────────────────────────────────────────────────────────────────
+import { flexuralSteel, rhoMin } from './flexure'
+
+/** Wood-Armer normal design moments (kN·m/m). Bottom values are sagging
+ *  magnitudes (≥ 0); top values are hogging magnitudes (≥ 0, sign removed). */
+export interface WoodArmerMoments {
+  mxBottom: number; myBottom: number
+  mxTop: number; myTop: number
+}
+
+/**
+ * Wood-Armer design moments from a shell moment triad (per unit width).
+ * `Mx`, `My`, `Mxy` follow the DKT sign convention (sagging +). The returned
+ * bottom/top moments are non-negative magnitudes ready for flexural design.
+ */
+export function woodArmer(Mx: number, My: number, Mxy: number): WoodArmerMoments {
+  const a = Math.abs(Mxy)
+
+  // ── Bottom face (sagging) ──────────────────────────────────────────────
+  let mxb = Mx + a
+  let myb = My + a
+  if (mxb < 0) {
+    mxb = 0
+    myb = My + (a * a) / Math.abs(Mx)
+  } else if (myb < 0) {
+    myb = 0
+    mxb = Mx + (a * a) / Math.abs(My)
+  }
+  mxb = Math.max(0, mxb); myb = Math.max(0, myb)
+
+  // ── Top face (hogging) ─────────────────────────────────────────────────
+  let mxt = Mx - a
+  let myt = My - a
+  if (mxt > 0) {
+    mxt = 0
+    myt = My - (a * a) / Math.abs(Mx)
+  } else if (myt > 0) {
+    myt = 0
+    mxt = Mx - (a * a) / Math.abs(My)
+  }
+  mxt = Math.min(0, mxt); myt = Math.min(0, myt)
+
+  return { mxBottom: mxb, myBottom: myb, mxTop: Math.abs(mxt), myTop: Math.abs(myt) }
+}
+
+/** Reinforcement for one slab strip (one direction, one face), per metre width. */
+export interface SlabStripDesign {
+  /** Design moment carried by this strip, kN·m/m. */
+  Mu: number
+  /** Required steel area per metre width, mm²/m (≥ ρ_min·1000·d). */
+  As: number
+  /** Bar spacing for the chosen bar diameter, mm (capped at min(3t, 450)). */
+  spacing: number
+  /** Steel actually provided at the adopted spacing, mm²/m. */
+  AsProvided: number
+  /** True when ρ_min (shrinkage/temperature or flexural minimum) governed. */
+  usedMin: boolean
+}
+
+/** ACI 318-14 §7.7.2.3 / §8.7.2.2 maximum slab bar spacing: min(3h, 450 mm). */
+export function maxSlabSpacing(t: number): number {
+  return Math.min(3 * t, 450)
+}
+
+/**
+ * Size one slab strip for a Wood-Armer design moment. Designs per metre width
+ * (b = 1000 mm) at the mat effective depth d = t − cover − 1.5·db (the inner of
+ * the two orthogonal layers, conservative for both directions). The bar spacing
+ * is rounded down to a 5 mm module and capped at the ACI maximum.
+ */
+export function designSlabStrip(params: {
+  Mu: number; t: number; cover: number; barDia: number; fc: number; fy: number
+}): SlabStripDesign {
+  const { Mu, t, cover, barDia, fc, fy } = params
+  const d = Math.max(t - cover - 1.5 * barDia, 0.5 * t)        // mm
+  const flex = flexuralSteel({ Mu, b: 1000, d, fc, fy })
+  // shrinkage/temperature floor still applies even where flexure needs nothing
+  const AsMin = rhoMin(fc, fy) * 1000 * d
+  const As = Math.max(flex.As, AsMin)
+  const Ab = (Math.PI / 4) * barDia * barDia                  // mm² per bar
+  const sMax = maxSlabSpacing(t)
+  const sRaw = As > 0 ? (1000 * Ab) / As : sMax               // mm c/c for As over 1 m
+  const spacing = Math.max(50, Math.min(sMax, Math.floor(sRaw / 5) * 5))
+  const AsProvided = (1000 * Ab) / spacing
+  return { Mu, As, spacing, AsProvided, usedMin: flex.usedMin || flex.As <= AsMin }
+}
+
+/** Full Wood-Armer reinforcement design for a slab panel (both faces, both dirs). */
+export interface SlabFEDesign {
+  /** Governing (envelope) Wood-Armer design moments over the panel, kN·m/m. */
+  moments: WoodArmerMoments
+  bottomX: SlabStripDesign; bottomY: SlabStripDesign
+  topX: SlabStripDesign; topY: SlabStripDesign
+  /** Element id where the peak bottom (sagging) moment occurs, for traceability. */
+  govBottom: string
+  /** Element id where the peak top (hogging) moment occurs. */
+  govTop: string
+}
+
+/** A shell moment sample: element id + the local moment triad (kN·m/m). */
+export interface ShellMomentSample { id: string; Mx: number; My: number; Mxy: number }
+
+/**
+ * Design a slab panel from its shell FE moment field. Takes the ENVELOPE of the
+ * Wood-Armer moments across every sub-element (worst sagging and worst hogging
+ * per direction) and sizes the four reinforcement strips. Returns null if the
+ * sample set is empty.
+ */
+export function designSlabFE(
+  samples: ShellMomentSample[],
+  sec: { t: number; cover: number; barDia: number; fc: number; fy: number },
+): SlabFEDesign | null {
+  if (samples.length === 0) return null
+  const env: WoodArmerMoments = { mxBottom: 0, myBottom: 0, mxTop: 0, myTop: 0 }
+  let govBottom = samples[0].id, govTop = samples[0].id
+  let peakBottom = -Infinity, peakTop = -Infinity
+  for (const s of samples) {
+    const wa = woodArmer(s.Mx, s.My, s.Mxy)
+    env.mxBottom = Math.max(env.mxBottom, wa.mxBottom)
+    env.myBottom = Math.max(env.myBottom, wa.myBottom)
+    env.mxTop = Math.max(env.mxTop, wa.mxTop)
+    env.myTop = Math.max(env.myTop, wa.myTop)
+    const b = Math.max(wa.mxBottom, wa.myBottom)
+    if (b > peakBottom) { peakBottom = b; govBottom = s.id }
+    const tp = Math.max(wa.mxTop, wa.myTop)
+    if (tp > peakTop) { peakTop = tp; govTop = s.id }
+  }
+  const strip = (Mu: number) => designSlabStrip({ Mu, ...sec })
+  return {
+    moments: env,
+    bottomX: strip(env.mxBottom), bottomY: strip(env.myBottom),
+    topX: strip(env.mxTop), topY: strip(env.myTop),
+    govBottom, govTop,
+  }
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -15,7 +15,8 @@ import { type StructureDesign, type FootingPlan, type OptimizeResult, type Later
 import type { SteelJoint } from '../engine/steelConnections'
 import { estimateTakeoff, costBill, type PriceList } from '../engine/takeoff'
 import { footingLayout } from '../engine/footingLayout'
-import { solveShell, recoverShellStress, subdivideQuadPlates, type ShellNode, type ShellElem, type ShellSupport, type ElementStress, type QuadPlateSpec } from '../engine/shell'
+import { type ShellNode, type ShellElem, type ElementStress } from '../engine/shell'
+import { solveModelShells, designModelSlabsFE, type SlabFEScheduleRow } from '../engine/shellModel'
 import { useSolver } from '../lib/useSolver'
 import type { SolveProgress } from '../engine/progress'
 import { TABLE_204_1, TABLE_204_2, sdlItemKPa, sdlTotal, type SdlItem } from '../engine/deadLoads'
@@ -800,6 +801,7 @@ export default function ModelSpace() {
   const [thDur, setThDur] = useState(10)         // s
   const [thZeta, setThZeta] = useState(5)        // %
   const [shellStress, setShellStress] = useState<{ nodes: ShellNode[]; elems: ShellElem[]; stresses: ElementStress[] } | null>(null)
+  const [slabFE, setSlabFE] = useState<SlabFEScheduleRow[] | null>(null)
   const [recSpec, setRecSpec] = useState<{ spec: AccelSpectrum; design: DesignSpectrumPoint[]; name: string } | null>(null)
   const [shellSubdiv, setShellSubdiv] = useState(4)   // n×n triangulation per plate
   const [thCsv, setThCsv] = useState<{ text: string; name: string; npts: number } | null>(null)
@@ -960,36 +962,19 @@ export default function ModelSpace() {
 
   const runShellStress = () => {
     if (!model || !model.shellElements || model.plates.length === 0) return
-    // Subdivide each quad plate into an n×n triangular mesh (D10). Subdivision
-    // nodes are shared across plate edges by coordinate; original model nodes are
-    // reused at coincident corners so supports/loads still attach.
-    const posById = new Map(model.nodes.map((n) => [n.id, [n.x, n.y, n.z] as V3]))
-    const cornerId = (p: V3): string | undefined => {
-      for (const n of model.nodes)
-        if (Math.hypot(p[0] - n.x, p[1] - n.y, p[2] - n.z) < 1e-4) return n.id
-      return undefined
-    }
-    // Default concrete material: E = 25000 MPa, ν = 0.2
-    const specs: QuadPlateSpec[] = model.plates.flatMap((p) => {
-      const cs = p.corners.map((id) => posById.get(id))
-      if (cs.some((c) => !c)) return []
-      return [{ id: p.id, corners: cs as [V3, V3, V3, V3], E: 25000, nu: 0.2, t: p.thickness }]
-    })
-    const { nodes: shNodes, elems: shElems } = subdivideQuadPlates(specs, shellSubdiv, cornerId)
-    const shSupports: ShellSupport[] = model.supports.map((s) => ({
-      node: s.node, ux: true, uy: true, uz: true, rx: true, ry: true, rz: true,
-    }))
-    // Area loads → pressure on every sub-element of the plate (kN/m²)
-    const pressures = model.loads
-      .filter((l) => l.kind === 'area')
-      .flatMap((l) => {
-        const al = l as { kind: 'area'; plate: string; q: number }
-        return shElems.filter((e) => e.id.startsWith(`${al.plate}_`)).map((e) => ({ elem: e.id, q: al.q }))
-      })
-    const r = solveShell(shNodes, shElems, shSupports, [], pressures)
-    if (!r) return
-    const st = recoverShellStress(shNodes, shElems, r)
-    setShellStress({ nodes: shNodes, elems: shElems, stresses: st })
+    // Mesh + solve the model's shell plates under the SERVICE area-load field for
+    // display (subdivision, conforming edges and corner-id reuse handled by the
+    // shared shellModel bridge). Pass nothing for D/L factors → unfactored stress.
+    const solved = solveModelShells(model, { subdiv: shellSubdiv })
+    if (!solved) { setShellStress(null); return }
+    setShellStress({ nodes: solved.nodes, elems: solved.elems, stresses: solved.stresses })
+  }
+
+  const runSlabFE = () => {
+    if (!model || !model.shellElements || model.plates.length === 0) return
+    // Factored (1.2D + 1.6L) shell moment field → Wood-Armer slab reinforcement.
+    const out = designModelSlabsFE(model, { subdiv: shellSubdiv })
+    setSlabFE(out ? out.rows : null)
   }
 
   // Re-sign / re-axis a base node-load set into a directional case.
@@ -2591,16 +2576,65 @@ export default function ModelSpace() {
                     Each quad is split into {shellSubdiv}×{shellSubdiv} cells (2·{shellSubdiv}² triangles); finer meshes
                     reduce the stiffness overestimate of coarse 2-triangle plates. Edges shared by adjacent plates stay conforming.
                   </p>
-                  <div className="col-span-full">
+                  <div className="col-span-full flex flex-wrap gap-2">
                     <button type="button" onClick={runShellStress} disabled={!model || !!busy}
                       className={btn('from-[#0d9488] to-[#0f766e]')}>
                       ⬡ Recover shell stresses
                     </button>
+                    <button type="button" onClick={runSlabFE} disabled={!model || !!busy}
+                      className={btn('from-[#0d9488] to-[#0f766e]')}>
+                      ▦ Design slab steel (Wood-Armer)
+                    </button>
                   </div>
+                  <p className="col-span-full text-[11px] text-slate-500">
+                    Wood-Armer (1968) converts the factored (1.2D + 1.6L) shell moment field (Mx, My, Mxy) into
+                    orthogonal design moments for the bottom (sagging) and top (hogging) faces, then sizes the x/y
+                    reinforcement per metre to NSCP 2015 / ACI 318-14 (φ = 0.90, ⌀12 @ 20 mm cover, fc 28, fy 415).
+                  </p>
                 </Card>
               )}
               {shellStress && (
                 <ShellContourPanel nodes={shellStress.nodes} elems={shellStress.elems} stresses={shellStress.stresses} />
+              )}
+              {slabFE && slabFE.length > 0 && (
+                <ResultCard title="Slab reinforcement — Wood-Armer (shell FE, factored)">
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-left text-xs">
+                      <thead className="text-slate-500">
+                        <tr className="border-b border-slate-200">
+                          <th className="py-1 pr-2">Slab</th><th className="py-1 pr-2">t (mm)</th>
+                          <th className="py-1 pr-2">Face / dir</th><th className="py-1 pr-2">M* (kN·m/m)</th>
+                          <th className="py-1 pr-2">As (mm²/m)</th><th className="py-1 pr-2">Bars ⌀12</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {slabFE.flatMap((r) => {
+                          const d = r.design
+                          const rows: [string, number, typeof d.bottomX][] = [
+                            ['Bottom · x', d.moments.mxBottom, d.bottomX],
+                            ['Bottom · y', d.moments.myBottom, d.bottomY],
+                            ['Top · x', d.moments.mxTop, d.topX],
+                            ['Top · y', d.moments.myTop, d.topY],
+                          ]
+                          return rows.map(([lbl, m, s], i) => (
+                            <tr key={`${r.plate}-${lbl}`} className="border-b border-slate-100">
+                              {i === 0 && <td className="py-1 pr-2 font-medium align-top" rowSpan={4}>{r.plate}</td>}
+                              {i === 0 && <td className="py-1 pr-2 align-top" rowSpan={4}>{r.thickness}</td>}
+                              <td className="py-1 pr-2">{lbl}</td>
+                              <td className="py-1 pr-2 font-mono">{m.toFixed(1)}</td>
+                              <td className="py-1 pr-2 font-mono">{s.As.toFixed(0)}{s.usedMin ? ' (min)' : ''}</td>
+                              <td className="py-1 pr-2 font-mono">⌀12 @ {s.spacing.toFixed(0)} mm</td>
+                            </tr>
+                          ))
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                  <p className="mt-2 text-[10px] text-slate-400">
+                    Envelope of the per-element Wood-Armer design moments over each panel. As includes the
+                    shrinkage/temperature minimum (ρ_min); spacing capped at min(3t, 450) mm. d = t − cover − 1.5⌀.
+                  </p>
+                </ResultCard>
               )}
 
               {drift && seis && (


### PR DESCRIPTION
## Summary

The flat-shell (CST membrane + DKT bending) results were **visualised only** — slabs were sized by the empirical Direct Design Method, and the recovered FE moment field never drove design. This phase wires the shell field into reinforcement design via **Wood & Armer (1968)**.

## Engine
- **`woodArmer.ts`** — `woodArmer(Mx, My, Mxy)` returns orthogonal design moments for the **bottom** (sagging) and **top** (hogging) faces, including the `M*<0` corrections that shed the twisting moment `Mxy`. `designSlabStrip` sizes one strip per metre (NSCP 2015 / ACI 318-14, φ=0.90) with a ρ_min floor and the ACI max spacing `min(3t, 450)`. `designSlabFE` envelopes the four strips over a panel and attributes the governing sagging/hogging elements.
- **`shellModel.ts`** — model→shell bridge: `meshModelShells` (D10 conforming subdivision, model-node reuse at corners), `solveModelShells` under a factored area-load combination, and `designModelSlabsFE` (defaults to **1.2D + 1.6L**) producing a Wood-Armer slab schedule per plate.

## UI
- **`ModelSpace.tsx`** — `runShellStress` refactored onto the shared `solveModelShells`; new **"Design slab steel (Wood-Armer)"** action and a reinforcement table (M\*, As, ⌀12 spacing per face/direction).

## Tests (+25, 824 total green)
- Wood-Armer rules incl. both `M*<0` corrections and `Mxy` sign-invariance; per-strip flexure / ρ_min / spacing cap; panel envelope + governing-element attribution.
- Model bridge: conforming mesh & corner-id reuse, factored-field linearity, factored ≥ service, wall-panel skip.

Verified: `npm test` (824 passing), `npx tsc -b`, and `npm run build` all clean. The new slab table is a pure render of unit-tested data (no preview tool available in this environment).

## Remaining Tier 4 phases
- **E12** — wind load generation NSCP 207E.6
- **E13** — seismic detailing SMRF/OMRF flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_