### PR TITLE
feat(E12): NSCP 207E.4 Components &amp; Cladding wall wind pressures

### DIFF
--- a/webapp/src/engine/wind.test.ts
+++ b/webapp/src/engine/wind.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { computeWind, windKz, cpLeeward } from './wind'
+import { computeWind, windKz, cpLeeward, velocityPressure, gcpiMagnitude, wallGCp, computeCladding } from './wind'
 import { generateGridModel } from './modelBuilder'
 import { modelToFrame3D } from './modelBridge'
 import { solveFrame3D, applyF3Combo } from './frame3d'
@@ -88,5 +88,64 @@ describe('NSCP 207B.4 — MWFRS directional wind on a frame', () => {
     expect(r.B).toBeCloseTo(12, 9)   // across-wind now the x extent
     expect(r.L).toBeCloseTo(5, 9)
     expect(r.loads.every((l) => (l as { Fz?: number }).Fz !== undefined)).toBe(true)
+  })
+})
+
+describe('NSCP 207E.4 — Components & Cladding wall pressures', () => {
+  it('GCpi magnitudes per Table 207A.11-1', () => {
+    expect(gcpiMagnitude('enclosed')).toBe(0.18)
+    expect(gcpiMagnitude('partially')).toBe(0.55)
+    expect(gcpiMagnitude('open')).toBe(0)
+  })
+
+  it('wall GCp endpoints at A₁ = 0.93 m² and A₂ = 46.5 m² (Fig 207E.4-1)', () => {
+    expect(wallGCp(4, 0.93)).toEqual({ pos: 1.0, neg: -1.1 })
+    expect(wallGCp(5, 0.93)).toEqual({ pos: 1.0, neg: -1.4 })
+    const big4 = wallGCp(4, 46.5), big5 = wallGCp(5, 46.5)
+    expect(big4.pos).toBeCloseTo(0.7, 9); expect(big4.neg).toBeCloseTo(-0.8, 9)
+    expect(big5.pos).toBeCloseTo(0.7, 9); expect(big5.neg).toBeCloseTo(-0.8, 9)
+  })
+
+  it('clamps outside the area band and interpolates log-linearly within', () => {
+    // below A₁ and above A₂ are constant
+    expect(wallGCp(5, 0.1)).toEqual(wallGCp(5, 0.93))
+    expect(wallGCp(5, 500)).toEqual(wallGCp(5, 46.5))
+    // log-midpoint A = √(0.93·46.5) ⇒ GCp = mean of the endpoints
+    const aMid = Math.sqrt(0.93 * 46.5)
+    expect(wallGCp(4, aMid).neg).toBeCloseTo((-1.1 + -0.8) / 2, 9)
+    expect(wallGCp(4, aMid).pos).toBeCloseTo((1.0 + 0.7) / 2, 9)
+  })
+
+  it('corner zone 5 always carries the larger suction', () => {
+    for (const a of [0.93, 5, 20, 46.5])
+      expect(wallGCp(5, a).neg).toBeLessThanOrEqual(wallGCp(4, a).neg + 1e-12)
+  })
+
+  it('computeCladding: p = qh·[(GCp) − (GCpi)] at the mean roof height', () => {
+    const m = generateGridModel({ baysX: [6, 6], baysZ: [5], storeyH: [3.5, 3], section })
+    const r = computeCladding(m, { V: 50, exposure: 'C', dir: 'x', area: 1.0, enclosure: 'enclosed' })!
+    expect(r.h).toBeCloseTo(6.5, 9)
+    const qh = velocityPressure(6.5, 50, 'C')
+    expect(r.qh).toBeCloseTo(qh, 9)
+    expect(r.GCpi).toBe(0.18)
+    const g5 = wallGCp(5, 1.0)
+    expect(r.zone5.pPos).toBeCloseTo(qh * (g5.pos + 0.18), 9)
+    expect(r.zone5.pNeg).toBeCloseTo(qh * (g5.neg - 0.18), 9)
+    // suction (negative) is the controlling magnitude on a corner
+    expect(r.zone5.pNeg).toBeLessThan(r.zone4.pNeg)
+  })
+
+  it('partially enclosed raises the internal-pressure swing; open removes it', () => {
+    const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })
+    const enc = computeCladding(m, { V: 45, exposure: 'B', dir: 'x', area: 2, enclosure: 'enclosed' })!
+    const par = computeCladding(m, { V: 45, exposure: 'B', dir: 'x', area: 2, enclosure: 'partially' })!
+    expect(par.zone4.pNeg).toBeLessThan(enc.zone4.pNeg)    // bigger suction
+    expect(par.zone4.pPos).toBeGreaterThan(enc.zone4.pPos) // bigger inward
+  })
+
+  it('returns null for a model with no height', () => {
+    const flat = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })
+    flat.nodes = flat.nodes.map((n) => ({ ...n, y: 0 }))
+    expect(computeCladding(flat, { V: 50, exposure: 'C', dir: 'x', area: 1, enclosure: 'enclosed' })).toBeNull()
   })
 })

--- a/webapp/src/engine/wind.ts
+++ b/webapp/src/engine/wind.ts
@@ -12,7 +12,10 @@
 // storey force uses only the external windward + leeward wall pressures. The
 // forces are emitted as NODE loads (category 'W') split across each level's
 // nodes — the existing NSCP combinations (1.2D+1.0W+…, 0.9D+1.0W) pick them up.
-// (Roof uplift, side-wall and components-&-cladding pressures are out of scope.)
+//
+// Components & Cladding (§207E.4, low-rise walls) is provided separately below
+// (`computeCladding`) for local cladding/curtain-wall pressures. Roof uplift and
+// MWFRS side-wall pressures remain out of scope.
 // ─────────────────────────────────────────────────────────────────────────
 import type { StructuralModel, ModelLoad } from './model'
 
@@ -55,6 +58,13 @@ export function windKz(z: number, exposure: 'B' | 'C' | 'D'): number {
   return 2.01 * (zz / zg) ** (2 / a)
 }
 
+/** Velocity pressure qz = 0.613·Kz·Kzt·Kd·V² (207B.3-1), returned in kN/m². */
+export function velocityPressure(
+  z: number, V: number, exposure: 'B' | 'C' | 'D', Kzt = 1.0, Kd = 0.85,
+): number {
+  return (0.613 * windKz(z, exposure) * Kzt * Kd * V * V) / 1000
+}
+
 /** Leeward-wall external pressure coefficient Cp (Figure 207B.4-1), a function
  *  of the along-wind/across-wind ratio L/B: −0.5 (≤1), −0.3 (=2), −0.2 (≥4). */
 export function cpLeeward(LB: number): number {
@@ -81,7 +91,7 @@ export function computeWind(model: StructuralModel, p: WindParams): WindResult |
   const LB = L > 0 ? L / B : 1
 
   const Kd = p.Kd ?? 0.85, Kzt = p.Kzt ?? 1.0, G = p.G ?? 0.85
-  const q = (z: number) => (0.613 * windKz(z, p.exposure) * Kzt * Kd * p.V ** 2) / 1000 // kN/m²
+  const q = (z: number) => velocityPressure(z, p.V, p.exposure, Kzt, Kd) // kN/m²
   const qh = q(h)
   const CpLee = cpLeeward(LB)
   const pLee = qh * G * Math.abs(CpLee)              // leeward suction → adds to along-wind force
@@ -115,4 +125,84 @@ export function computeWind(model: StructuralModel, p: WindParams): WindResult |
     }
   }
   return { V: p.V, h, B, L, LB, Kd, G, qh, CpLee, levels, baseShear, loads }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// NSCP 2015 §207E — Components & Cladding (C&C), low-rise walls (h ≤ 18.3 m).
+//
+//   Design pressure  p = qh·[(GCp) − (GCpi)]   (kN/m²)        (207E.4-1)
+//   qh = velocity pressure at mean roof height h
+//   (GCp): external pressure coefficient by wall zone & effective wind area
+//          (Figure 207E.4-1); (GCpi): internal pressure coefficient
+//          (Table 207A.11-1: ±0.18 enclosed, ±0.55 partially enclosed, 0 open).
+//
+// Wall (GCp), all roof angles, h ≤ 18.3 m — log-linear in the effective wind
+// area A between A₁ = 0.93 m² and A₂ = 46.5 m² (constant outside that band):
+//   Zone 4 (interior):  + 1.0 → +0.7 ,  − 1.1 → −0.8
+//   Zone 5 (corner)  :  + 1.0 → +0.7 ,  − 1.4 → −0.8
+// The controlling pressures combine the worst internal pressure with each
+// external sign: p⁺ = qh·(GCp⁺ + |GCpi|),  p⁻ = qh·(GCp⁻ − |GCpi|).
+// (Roof C&C zones 1/2/3 and h > 18.3 m §207E.5 remain out of scope.)
+// ─────────────────────────────────────────────────────────────────────────
+export type WindEnclosure = 'enclosed' | 'partially' | 'open'
+
+/** Internal pressure coefficient magnitude |GCpi| (Table 207A.11-1). */
+export function gcpiMagnitude(e: WindEnclosure): number {
+  return e === 'enclosed' ? 0.18 : e === 'partially' ? 0.55 : 0
+}
+
+/** Effective-wind-area breakpoints for the wall C&C curves, m² (10 / 500 ft²). */
+const CC_A1 = 0.93
+const CC_A2 = 46.5
+
+/** Log-linear interpolation of a GCp value over the effective wind area A. */
+function ccInterp(v1: number, v2: number, area: number): number {
+  const a = Math.min(Math.max(area, CC_A1), CC_A2)
+  const t = (Math.log10(a) - Math.log10(CC_A1)) / (Math.log10(CC_A2) - Math.log10(CC_A1))
+  return v1 + (v2 - v1) * t
+}
+
+/** External wall (GCp) for C&C zone 4 (interior) or 5 (corner), by area (Fig 207E.4-1). */
+export function wallGCp(zone: 4 | 5, area: number): { pos: number; neg: number } {
+  const pos = ccInterp(1.0, 0.7, area)                       // both zones share +GCp
+  const neg = zone === 5 ? ccInterp(-1.4, -0.8, area) : ccInterp(-1.1, -0.8, area)
+  return { pos, neg }
+}
+
+/** C&C design pressures (kN/m²) for one wall zone at a given effective area. */
+export interface CladdingZonePressure {
+  zone: 4 | 5
+  GCpPos: number; GCpNeg: number
+  /** Positive (inward) and negative (suction, ≤ 0) design pressures, kN/m². */
+  pPos: number; pNeg: number
+}
+
+export interface CladdingParams extends WindParams {
+  /** Effective wind area of the component, m² (§207A.3); clamps to the curve band. */
+  area: number
+  enclosure: WindEnclosure
+}
+
+export interface CladdingResult {
+  h: number; qh: number; GCpi: number; area: number; enclosure: WindEnclosure
+  zone4: CladdingZonePressure; zone5: CladdingZonePressure
+}
+
+/**
+ * Components & Cladding wall pressures (NSCP §207E.4) for an enclosed/partially
+ * enclosed low-rise building. Returns null when the building height is non-positive.
+ * `dir` is irrelevant for C&C wall pressures (qh uses the mean roof height h).
+ */
+export function computeCladding(model: StructuralModel, p: CladdingParams): CladdingResult | null {
+  if (model.nodes.length === 0) return null
+  const h = Math.max(...model.nodes.map((n) => n.y))
+  if (!(h > 0)) return null
+  const Kd = p.Kd ?? 0.85, Kzt = p.Kzt ?? 1.0
+  const qh = velocityPressure(h, p.V, p.exposure, Kzt, Kd)
+  const gi = gcpiMagnitude(p.enclosure)
+  const zone = (z: 4 | 5): CladdingZonePressure => {
+    const g = wallGCp(z, p.area)
+    return { zone: z, GCpPos: g.pos, GCpNeg: g.neg, pPos: qh * (g.pos + gi), pNeg: qh * (g.neg - gi) }
+  }
+  return { h, qh, GCpi: gi, area: p.area, enclosure: p.enclosure, zone4: zone(4), zone5: zone(5) }
 }

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -27,7 +27,7 @@ import { columnKFactors, type ColumnK } from '../engine/effectiveLength'
 import { freqFromDeflection, dg11Walking, DG11_OCCUPANCY } from '../engine/floorVibration'
 import { buildSeismicMass, GRAVITY } from '../engine/modal'
 import { autoRigidOffsets } from '../engine/rigidEndZones'
-import { computeWind, type WindResult } from '../engine/wind'
+import { computeWind, computeCladding, type WindResult, type WindEnclosure, type CladdingResult } from '../engine/wind'
 import { ReportControls } from '../components/ReportControls'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { beamSectionSolution, columnRowSolution, footingRowSolution, combinedRowSolution } from '../lib/modelSpaceSolutions'
@@ -750,6 +750,9 @@ export default function ModelSpace() {
   const [Kzt, setKzt] = useState(n('Kzt', 1.0))
   const [wDirs, setWDirs] = useState<string[]>((si.wDirs as string[]) ?? ['+X', '-X', '+Z', '-Z'])  // directional W cases
   const [wind, setWind] = useState<WindResult | null>(null)
+  const [ccArea, setCcArea] = useState(1.0)   // C&C effective wind area, m²
+  const [ccEncl, setCcEncl] = useState<WindEnclosure>('enclosed')
+  const [cladding, setCladding] = useState<CladdingResult | null>(null)
   const [eCases, setECases] = useState<LateralCase[]>([])
   const [wCases, setWCases] = useState<LateralCase[]>([])
   // Analysis options: f₁ live-load factor (§203.3.1) and P-Δ second order
@@ -1018,6 +1021,11 @@ export default function ModelSpace() {
     }))
     const primary = dirCase(primaryRes.loads, 'W', wDirs[0] ?? '+X')
     save({ ...model, loads: [...model.loads.filter((l) => !(l.cat === 'W' && l.kind === 'node')), ...primary.loads] })
+  }
+
+  const runCladding = () => {
+    if (!model) return
+    setCladding(computeCladding(model, { V: Vw, exposure: expo, Kzt, dir: 'x', area: ccArea, enclosure: ccEncl }))
   }
 
   const soil = { qAllow: qa, gammaSoil, gammaConc: gammaC, H: Hf }
@@ -2471,6 +2479,55 @@ export default function ModelSpace() {
                       qh = {f2(wind.qh)} kPa · B×L = {f1(wind.B)}×{f1(wind.L)} m (L/B {f2(wind.LB)}) ·
                       Cp,lee {f2(wind.CpLee)} · base shear V = {f1(wind.baseShear)} kN — {wCases.length} cat-W
                       case{wCases.length === 1 ? '' : 's'} ({wDirs.join(', ') || 'none'}). Windward Cp = 0.8, G = {wind.G}, Kd = {wind.Kd}.
+                    </p>
+                  )}
+                </div>
+              </Card>
+
+              <Card title="Wind — NSCP 207E.4 Components & Cladding (walls)">
+                <p className="col-span-full text-[11px] text-slate-500">
+                  Local wall cladding/curtain-wall pressures p = qh·[(GCp) − (GCpi)] at the mean roof
+                  height. GCp by zone &amp; effective wind area (Fig 207E.4-1); GCpi from the enclosure
+                  (±0.18 enclosed, ±0.55 partially enclosed). Uses the V, Kzt &amp; exposure above.
+                </p>
+                <Num label="Effective wind area" unit="m²" value={ccArea} step="0.5"
+                  onChange={(v) => setCcArea(Math.max(0.1, v))} hint="0.93–46.5 m² band" />
+                <label className="flex flex-col text-sm">
+                  <span className="mb-1 font-medium text-slate-600">Enclosure</span>
+                  <select value={ccEncl} onChange={(e) => setCcEncl(e.target.value as WindEnclosure)}
+                    className="rounded-md border border-slate-300 px-2.5 py-1.5">
+                    <option value="enclosed">Enclosed (±0.18)</option>
+                    <option value="partially">Partially enclosed (±0.55)</option>
+                    <option value="open">Open (0)</option>
+                  </select>
+                </label>
+                <div className="col-span-full">
+                  <button type="button" onClick={runCladding} disabled={!model}
+                    className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50 disabled:opacity-40">▦ Compute C&amp;C wall pressures</button>
+                  {cladding && (
+                    <table className="mt-2 w-full text-left text-xs">
+                      <thead className="text-slate-500">
+                        <tr className="border-b border-slate-200">
+                          <th className="py-1 pr-2">Zone</th><th className="py-1 pr-2">GCp (+ / −)</th>
+                          <th className="py-1 pr-2">p⁺ (inward)</th><th className="py-1 pr-2">p⁻ (suction)</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {([['4 — interior', cladding.zone4], ['5 — corner', cladding.zone5]] as [string, CladdingResult['zone4']][]).map(([lbl, zone]) => (
+                          <tr key={zone.zone} className="border-b border-slate-100">
+                            <td className="py-1 pr-2 font-medium">Zone {lbl}</td>
+                            <td className="py-1 pr-2 font-mono">{f2(zone.GCpPos)} / {f2(zone.GCpNeg)}</td>
+                            <td className="py-1 pr-2 font-mono">{f2(zone.pPos)} kPa</td>
+                            <td className="py-1 pr-2 font-mono text-red-600">{f2(zone.pNeg)} kPa</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  )}
+                  {cladding && (
+                    <p className="mt-1 text-[10px] text-slate-400">
+                      qh = {f2(cladding.qh)} kPa at h = {f1(cladding.h)} m · |GCpi| = {cladding.GCpi} · A = {f1(cladding.area)} m².
+                      Corner zone 5 governs cladding suction. Roof C&amp;C and h &gt; 18.3 m (§207E.5) out of scope.
                     </p>
                   )}
                 </div>


### PR DESCRIPTION
## Summary

The §207B MWFRS storey-wind generator (`computeWind`) already automates lateral wind forces from geometry + terrain category. Its companion **Components & Cladding** pressures (NSCP §207E) were explicitly *out of scope*. This phase adds C&C **wall** pressures for enclosed / partially-enclosed low-rise buildings (h ≤ 18.3 m).

## Engine (`wind.ts`)
- **`velocityPressure(z, …)`** — exported `qz = 0.613·Kz·Kzt·Kd·V²` helper (207B.3-1); `computeWind` refactored onto it (no behaviour change).
- **`gcpiMagnitude(enclosure)`** — internal pressure |GCpi| ±0.18 / ±0.55 / 0 (Table 207A.11-1).
- **`wallGCp(zone, area)`** — external (GCp) for wall **zone 4** (interior) and **zone 5** (corner), log-linear in the effective wind area between 0.93 and 46.5 m² (Fig 207E.4-1).
- **`computeCladding(model, params)`** — `p = qh·[(GCp) − (GCpi)]` at the mean roof height; returns inward (p⁺) and suction (p⁻) pressures per zone.

## UI
- **`ModelSpace.tsx`** — new *"207E.4 Components & Cladding"* card on the Loading tab: effective-area + enclosure inputs and a per-zone pressure table (corner zone 5 governs suction).

## Tests (+7, 831 total green)
GCpi table; wall GCp endpoints / clamp / log-midpoint; corner-governs-suction; `computeCladding` pressure identity; enclosure swing; null-height guard.

Verified: `npm test` (831 passing), `npx tsc -b`, and `npm run build` all clean.

## Remaining Tier 4 phase
- **E13** — seismic detailing SMRF/OMRF flags (NSCP 408). *Note: column-tie detailing already keys off an `smf/imf/omf` system flag in the UI; E13 will formalize the beam-column ratio (§406.3.2) and transverse-spacing limits.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_