### PR TITLE
feat(E13): strong-column/weak-beam joint check (NSCP §418.7.3.2)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -189,10 +189,22 @@ complete**; Tier 3 items #10–13 are the remaining backlog.
   trimmed, tooltip shows full L); `depthWidth()` resolves AISC shape d×bf for steel
   so zones are correct for W/C/HSS sections, not the bounding-box b×h.
 
-## Tier 4 — Next phase (post STAAD-parity)
+## Tier 4 — ✅ COMPLETE (post STAAD-parity)
 
-The STAAD-parity roadmap is complete. This tier adds polish, completeness, and new
-capability across the four main engineering domains.
+The STAAD-parity roadmap is complete. This tier added polish, completeness, and new
+capability across the four main engineering domains. **All thirteen items (A1–E13)
+are now shipped and merged** (PRs through #273):
+
+- **A** — steel auto-optimizer, per-shape costed BOM, per-member `Lb` LTB bracing.
+- **B** — pushover P–M interaction surfaces, axial/shear hinges, second-order P-Δ
+  (gravity geometric stiffness; partial-step-to-target stop).
+- **C** — CSV accelerogram upload + Newmark response spectrum vs NSCP 208.
+- **D** — shell stress recovery + contour, n×n auto-meshing, and Wood-Armer slab
+  reinforcement from the shell FE moment field (`woodArmer.ts`, `shellModel.ts`).
+- **E** — NSCP §207E.4 Components & Cladding wall pressures; §418.7.3.2
+  strong-column/weak-beam joint check (`scwb.ts`) for Special Moment Frames.
+
+(The original per-item notes are retained below for reference / future extension.)
 
 ### Group A — Steel (optimizer + BOM + connections)
 1. **Steel section auto-optimizer** *(highest priority)*
@@ -262,4 +274,4 @@ capability across the four main engineering domains.
 
 **Order of implementation**: A1 → B4 → C7 → D9 → A2 → B5 → C8 → D10 → A3 → B6 → D11 → E12 → E13.
 
-_Tests at last handoff: **718 passing**; `tsc -b` clean; production build OK._
+_Tests after Tier 4 (E13): **845 passing**; `tsc -b` clean; production build OK._

--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -429,6 +429,19 @@ describe('strong column–weak beam hierarchy', () => {
     expect(anyCol.b).toBeGreaterThanOrEqual(350)
     expect(anyCol.h).toBeGreaterThanOrEqual(anyCol.b)
   })
+
+  it('SCWB joint check (§418.7.3.2) is populated only for a Special Moment Frame', () => {
+    const m = makeModel()
+    expect(designStructure(m, soil)!.scwb).toHaveLength(0)                       // default gravity
+    expect(designStructure(m, soil, {}, { seismicSystem: 'imf' })!.scwb).toHaveLength(0)
+    const smf = designStructure(m, soil, {}, { seismicSystem: 'smf' })!
+    expect(smf.scwb.length).toBeGreaterThan(0)
+    for (const j of smf.scwb) {
+      expect(j.nCols).toBeGreaterThan(0); expect(j.nBeams).toBeGreaterThan(0)
+      expect(j.ok).toBe(j.ratio >= 1.2 - 1e-9)
+      expect(j.ratio).toBeCloseTo(j.sumMnc / j.sumMnb, 9)
+    }
+  })
 })
 
 describe('model editing helpers', () => {

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -21,6 +21,7 @@ import { designSquareFooting, type SquareFootingResult } from './isolatedFooting
 import { designCombinedFooting, type CombinedFootingResult } from './combinedFooting'
 import { designSlabDDM, type SlabDesignResult } from './slabDDM'
 import { designShearWall, type ShearWallResult } from './shearWallDesign'
+import { checkModelSCWB, type SCWBJointRow } from './scwb'
 import { shapeByName, nextHeavierW, nextLighterW, type AiscShape } from './aiscSections'
 import { deriveWSection, beamFlexure, beamShear, columnAxial, combinedLoading } from './steelDesign'
 import { designBasePlate, adoptPlateThickness, type BasePlateResult } from './baseplate'
@@ -166,6 +167,9 @@ export interface StructureDesign {
   walls: WallScheduleRow[]
   footings: FootingScheduleRow[]
   combined: CombinedScheduleRow[]
+  /** Strong-column/weak-beam joint checks (NSCP §418.7.3.2); only populated for
+   *  a Special Moment Frame (`seismicSystem: 'smf'`), empty otherwise. */
+  scwb: SCWBJointRow[]
   totals: { concreteMembers: number; concreteSlabs: number; concrete: number; steelKg: number }
   orphanEdges: number
 }
@@ -653,10 +657,14 @@ function designFromRuns(
     beams, columns, steelBeams, steelColumns, basePlates,
     joints: [] as SteelJoint[],
     slabs, walls, footings, combined,
+    scwb: [] as SCWBJointRow[],
     totals: { concreteMembers, concreteSlabs, concrete: concreteMembers + concreteSlabs, steelKg },
     orphanEdges: br.orphanEdges.length,
   }
   partialDesign.joints = designSteelJoints(model, partialDesign)
+  // Strong-column/weak-beam is a Special-Moment-Frame requirement (§418.7.3.2).
+  if ((opts.seismicSystem ?? 'gravity') === 'smf')
+    partialDesign.scwb = checkModelSCWB(model, partialDesign)
   return partialDesign
 }
 

--- a/webapp/src/engine/scwb.test.ts
+++ b/webapp/src/engine/scwb.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest'
+import {
+  concreteBeamMn, concreteColumnMn, scwbRatio, checkModelSCWB, SCWB_FACTOR,
+} from './scwb'
+import { beta1 } from './loads'
+import type { StructuralModel, RectSection } from './model'
+import type { StructureDesign } from './pipeline'
+
+describe('concreteBeamMn — singly-reinforced rectangular', () => {
+  it('Mn = As·fy·(d − a/2), a = As·fy/(0.85·fc·b)', () => {
+    const b = 300, d = 440, As = 1200, fc = 28, fy = 415
+    const a = (As * fy) / (0.85 * fc * b)
+    expect(concreteBeamMn(b, d, As, fc, fy)).toBeCloseTo((As * fy * (d - a / 2)) / 1e6, 9)
+  })
+  it('zero/!positive steel ⇒ zero capacity', () => {
+    expect(concreteBeamMn(300, 440, 0, 28, 415)).toBe(0)
+    expect(concreteBeamMn(0, 440, 1200, 28, 415)).toBe(0)
+  })
+  it('more steel ⇒ more moment', () => {
+    expect(concreteBeamMn(300, 440, 1800, 28, 415)).toBeGreaterThan(concreteBeamMn(300, 440, 1000, 28, 415))
+  })
+})
+
+describe('concreteColumnMn — P–M strain-compatibility', () => {
+  const b = 400, h = 400, Ast = 2500, fc = 28, fy = 415, cover = 40, db = 20
+
+  it('positive capacity in pure bending (P = 0)', () => {
+    expect(concreteColumnMn(b, h, Ast, fc, fy, 0, cover, db)).toBeGreaterThan(0)
+  })
+
+  it('axial below balanced increases the moment; high axial reduces it', () => {
+    const m0 = concreteColumnMn(b, h, Ast, fc, fy, 0, cover, db)
+    const mRise = concreteColumnMn(b, h, Ast, fc, fy, 1200, cover, db)
+    const mFall = concreteColumnMn(b, h, Ast, fc, fy, 3800, cover, db)
+    expect(mRise).toBeGreaterThan(m0)        // compression-controlled rising branch
+    expect(mFall).toBeLessThan(mRise)        // past balanced, capacity drops
+  })
+
+  it('more longitudinal steel ⇒ more moment at the same axial', () => {
+    const a = concreteColumnMn(b, h, 2000, fc, fy, 800, cover, db)
+    const c = concreteColumnMn(b, h, 4000, fc, fy, 800, cover, db)
+    expect(c).toBeGreaterThan(a)
+  })
+
+  it('recovers the rectangular-stress-block β1 dependence (smoke)', () => {
+    // higher f′c (lower β1 above 28) still yields a finite, positive moment
+    expect(beta1(45)).toBeLessThan(beta1(28))
+    expect(concreteColumnMn(b, h, Ast, 45, fy, 1000, cover, db)).toBeGreaterThan(0)
+  })
+})
+
+describe('scwbRatio — NSCP §418.7.3.2 (6/5)', () => {
+  it('factor is 6/5', () => expect(SCWB_FACTOR).toBeCloseTo(1.2, 9))
+  it('passes at exactly 6/5 and above', () => {
+    expect(scwbRatio(120, 100).ok).toBe(true)       // 1.2
+    expect(scwbRatio(150, 100).ok).toBe(true)
+    expect(scwbRatio(119, 100).ok).toBe(false)
+  })
+  it('no beams framing in ⇒ infinite ratio, trivially satisfied', () => {
+    const r = scwbRatio(100, 0)
+    expect(r.ratio).toBe(Infinity); expect(r.ok).toBe(true)
+  })
+})
+
+describe('checkModelSCWB — joint walk over a concrete frame', () => {
+  const colSec: RectSection = { id: 'C', name: 'col', b: 500, h: 500, fc: 28, fy: 415, barDia: 25, tieDia: 10, cover: 40, material: 'concrete' }
+  const beamSec: RectSection = { id: 'B', name: 'beam', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40, material: 'concrete' }
+
+  // interior joint 'j' with a column below (cA) + above (cB) and two beams (bL,bR)
+  function model(): StructuralModel {
+    return {
+      version: 1, name: 'm',
+      nodes: [
+        { id: 'j', x: 0, y: 3, z: 0 }, { id: 'g', x: 0, y: 0, z: 0 }, { id: 'r', x: 0, y: 6, z: 0 },
+        { id: 'l', x: -5, y: 3, z: 0 }, { id: 'rr', x: 5, y: 3, z: 0 },
+      ],
+      sections: [colSec, beamSec], members: [
+        { id: 'cA', i: 'g', j: 'j', role: 'column', section: 'C' },
+        { id: 'cB', i: 'j', j: 'r', role: 'column', section: 'C' },
+        { id: 'bL', i: 'l', j: 'j', role: 'beam', section: 'B' },
+        { id: 'bR', i: 'j', j: 'rr', role: 'beam', section: 'B' },
+      ],
+      plates: [], walls: [], supports: [], loads: [], storeys: [],
+    }
+  }
+  // minimal design with only the fields checkModelSCWB reads
+  function design(colBars: number, beamAs: number): StructureDesign {
+    const col = (id: string) => ({ id, bars: colBars, Pu: 900 })
+    const beam = (id: string) => ({ id, sections: [{ design: { As: beamAs, d: 450 } }] })
+    return {
+      columns: [col('cA'), col('cB')], beams: [beam('bL'), beam('bR')],
+      steelBeams: [], steelColumns: [], basePlates: [], joints: [], slabs: [], walls: [],
+      footings: [], combined: [], govName: '', cases: [], orphanEdges: 0,
+      totals: { concreteMembers: 0, concreteSlabs: 0, concrete: 0, steelKg: 0 },
+    } as unknown as StructureDesign
+  }
+
+  it('reports one row at the beam-column joint with ΣMnc/ΣMnb', () => {
+    const rows = checkModelSCWB(model(), design(8, 1500))
+    expect(rows).toHaveLength(1)
+    const r = rows[0]
+    expect(r.node).toBe('j')
+    expect(r.nCols).toBe(2); expect(r.nBeams).toBe(2)
+    expect(r.ratio).toBeCloseTo(r.sumMnc / r.sumMnb, 9)
+  })
+
+  it('a strong column / light beam satisfies 6/5; a weak column / heavy beam fails', () => {
+    const strong = checkModelSCWB(model(), design(12, 900))[0]
+    const weak = checkModelSCWB(model(), design(4, 3000))[0]
+    expect(strong.ratio).toBeGreaterThan(weak.ratio)
+    expect(strong.ok).toBe(strong.ratio >= SCWB_FACTOR - 1e-9)
+    expect(weak.ok).toBe(false)
+  })
+
+  it('ignores nodes that are not beam-column joints (a base with no beam)', () => {
+    const rows = checkModelSCWB(model(), design(8, 1500))
+    expect(rows.some((r) => r.node === 'g')).toBe(false)   // column base, no beams
+    expect(rows.some((r) => r.node === 'l')).toBe(false)   // beam end, no column
+  })
+})

--- a/webapp/src/engine/scwb.ts
+++ b/webapp/src/engine/scwb.ts
@@ -1,0 +1,141 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Strong-column / weak-beam (SCWB) check — NSCP 2015 §418.7.3.2.
+//
+// At each beam-column joint of a Special Moment Frame the columns must be
+// stronger in flexure than the beams, so plastic hinges form in the beams (a
+// ductile mechanism) rather than the columns (a soft storey):
+//
+//   ΣMnc ≥ (6/5)·ΣMnb                                        (418.7.3.2-1)
+//
+//   ΣMnc — sum of the nominal flexural strengths of the columns framing into
+//          the joint, evaluated at the factored axial force giving the LOWEST
+//          flexural strength (taken here at the column's design axial Pu).
+//   ΣMnb — sum of the nominal flexural strengths of the beams framing in.
+//
+// Beam Mn — singly-reinforced rectangular section, Mn = As·fy·(d − a/2).
+// Column Mn — rectangular tied section with symmetric reinforcement, recovered
+// by a neutral-axis (strain-compatibility) solve at the given axial: the
+// rectangular stress block (εcu = 0.003, β1 per f′c) plus two steel layers.
+// Units: geometry mm; fc/fy MPa; As mm²; axial kN; moments kN·m.
+// ─────────────────────────────────────────────────────────────────────────
+import type { StructuralModel, RectSection } from './model'
+import { beta1 } from './loads'
+import type { StructureDesign } from './pipeline'
+
+/** SCWB strength ratio required by NSCP §418.7.3.2 (= ACI 318-14 §18.7.3.2). */
+export const SCWB_FACTOR = 6 / 5
+
+const ES = 200000   // steel modulus, MPa
+const ECU = 0.003   // ultimate concrete strain
+
+/** Nominal flexural strength of a singly-reinforced rectangular beam, kN·m. */
+export function concreteBeamMn(b: number, d: number, As: number, fc: number, fy: number): number {
+  if (As <= 0 || b <= 0 || d <= 0) return 0
+  const a = (As * fy) / (0.85 * fc * b)
+  return (As * fy * (d - a / 2)) / 1e6
+}
+
+/**
+ * Nominal flexural strength of a rectangular tied column at a given axial load,
+ * kN·m, by a strain-compatibility neutral-axis solve. Reinforcement is taken
+ * symmetric: Ast/2 at each face (centroid `cover + barDia/2` from the face).
+ * Compression is positive; the moment is taken about the geometric centroid.
+ */
+export function concreteColumnMn(
+  b: number, h: number, Ast: number, fc: number, fy: number, P: number,
+  cover: number, barDia: number,
+): number {
+  if (b <= 0 || h <= 0) return 0
+  const b1 = beta1(fc)
+  const dp = cover + barDia / 2     // compression-layer depth from compression face
+  const d = h - dp                  // tension-layer depth
+  const Asf = Math.max(Ast, 0) / 2
+  const Pn = P * 1e3                 // kN → N
+  const fsAt = (c: number, di: number) => Math.max(-fy, Math.min(fy, (ES * ECU * (c - di)) / c))
+  const axialAt = (c: number) => {
+    const a = Math.min(b1 * c, h)
+    return 0.85 * fc * b * a + Asf * fsAt(c, dp) + Asf * fsAt(c, d)   // N (compression +)
+  }
+  // axialAt is monotonic increasing in c; bisect for the c giving the target Pn.
+  let lo = 1e-3 * h, hi = 5 * h
+  if (Pn >= axialAt(hi)) { /* over-squashed: use the capped section */ }
+  else for (let i = 0; i < 80; i++) {
+    const c = (lo + hi) / 2
+    if (axialAt(c) < Pn) lo = c; else hi = c
+  }
+  const c = (lo + hi) / 2
+  const a = Math.min(b1 * c, h)
+  const Cc = 0.85 * fc * b * a
+  const Fs1 = Asf * fsAt(c, dp), Fs2 = Asf * fsAt(c, d)
+  // moment of the internal forces about the section centroid (N·mm)
+  const Mn = Cc * (h / 2 - a / 2) + Fs1 * (h / 2 - dp) + Fs2 * (h / 2 - d)
+  return Math.abs(Mn) / 1e6
+}
+
+/** SCWB ratio ΣMnc/ΣMnb and its pass/fail against the 6/5 requirement. */
+export function scwbRatio(sumMnc: number, sumMnb: number): { ratio: number; ok: boolean } {
+  const ratio = sumMnb > 1e-9 ? sumMnc / sumMnb : Infinity
+  return { ratio, ok: ratio >= SCWB_FACTOR - 1e-9 }
+}
+
+export interface SCWBJointRow {
+  node: string
+  sumMnc: number; sumMnb: number     // kN·m
+  ratio: number
+  ok: boolean
+  nCols: number; nBeams: number
+}
+
+/** Bar area for a single ⌀db bar, mm². */
+const barArea = (db: number) => (Math.PI / 4) * db * db
+
+/**
+ * Strong-column/weak-beam check at every beam-column joint of a concrete frame,
+ * from a completed design. Concrete columns use their designed bar count and
+ * design axial Pu; concrete beams use the heaviest designed tension steel of the
+ * member (the support/negative-moment section governs the hinge). Steel members
+ * are skipped (steel SCWB uses different probable-strength provisions). Returns
+ * one row per joint that has at least one column and one beam.
+ */
+export function checkModelSCWB(model: StructuralModel, design: StructureDesign): SCWBJointRow[] {
+  const secById = new Map(model.sections.map((s) => [s.id, s]))
+  const colRow = new Map(design.columns.map((c) => [c.id, c]))
+  const beamRow = new Map(design.beams.map((b) => [b.id, b]))
+  const isConcrete = (s: RectSection | undefined) => !!s && s.material !== 'steel'
+
+  // column nominal moment at its design axial
+  const columnMn = (memberId: string): number | null => {
+    const row = colRow.get(memberId); if (!row) return null
+    const m = model.members.find((x) => x.id === memberId); if (!m) return null
+    const s = secById.get(m.section); if (!isConcrete(s)) return null
+    const Ast = row.bars * barArea(s!.barDia)
+    return concreteColumnMn(s!.b, s!.h, Ast, s!.fc, s!.fy, row.Pu, s!.cover, s!.barDia)
+  }
+  // beam nominal moment from the heaviest designed section
+  const beamMn = (memberId: string): number | null => {
+    const row = beamRow.get(memberId); if (!row || row.sections.length === 0) return null
+    const m = model.members.find((x) => x.id === memberId); if (!m) return null
+    const s = secById.get(m.section); if (!isConcrete(s)) return null
+    const gov = row.sections.reduce((a, b) => (b.design.As > a.design.As ? b : a))
+    return concreteBeamMn(s!.b, gov.design.d, gov.design.As, s!.fc, s!.fy)
+  }
+
+  const rows: SCWBJointRow[] = []
+  for (const node of model.nodes) {
+    const incident = model.members.filter((m) => m.i === node.id || m.j === node.id)
+    let sumMnc = 0, nCols = 0, sumMnb = 0, nBeams = 0
+    for (const m of incident) {
+      if (m.role === 'column') {
+        const mn = columnMn(m.id); if (mn === null) continue
+        sumMnc += mn; nCols++
+      } else if (m.role === 'beam' || m.role === 'girder') {
+        const mn = beamMn(m.id); if (mn === null) continue
+        sumMnb += mn; nBeams++
+      }
+    }
+    if (nCols === 0 || nBeams === 0) continue
+    const { ratio, ok } = scwbRatio(sumMnc, sumMnb)
+    rows.push({ node: node.id, sumMnc, sumMnb, ratio, ok, nCols, nBeams })
+  }
+  return rows
+}

--- a/webapp/src/engine/takeoff.test.ts
+++ b/webapp/src/engine/takeoff.test.ts
@@ -115,7 +115,7 @@ describe('structural steel — per-shape unit weight + costed BOM line items (A2
   const STEEL_DENSITY = 7850
   const emptyDesign: StructureDesign = {
     govName: '', cases: [], beams: [], columns: [], steelBeams: [], steelColumns: [],
-    basePlates: [], joints: [], slabs: [], walls: [], footings: [], combined: [],
+    basePlates: [], joints: [], slabs: [], walls: [], footings: [], combined: [], scwb: [],
     totals: { concreteMembers: 0, concreteSlabs: 0, concrete: 0, steelKg: 0 }, orphanEdges: 0,
   }
   // Two steel members: one 6 m W200x46.1 beam, two 4 m W250x49.1 columns.

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -3320,6 +3320,42 @@ export default function ModelSpace() {
             </table>
           </div>}
 
+          {/* Strong-column/weak-beam joint check — NSCP §418.7.3.2 (SMF only) */}
+          {design.scwb.length > 0 && report !== 'draw-only' && (
+            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Strong-column / weak-beam — NSCP §418.7.3.2</h3>
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
+                    <th className="py-1 pr-2 font-semibold">Joint</th>
+                    <th className="py-1 pr-2 text-right font-semibold">ΣMnc (kN·m)</th>
+                    <th className="py-1 pr-2 text-right font-semibold">ΣMnb (kN·m)</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Ratio</th>
+                    <th className="py-1 pr-2 text-right font-semibold">≥ 6/5</th>
+                    <th className="py-1 font-semibold">Cols / Beams</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {design.scwb.map((j) => (
+                    <tr key={j.node} className="border-t border-slate-100">
+                      <td className="py-1 pr-2 font-medium">{j.node}</td>
+                      <td className="py-1 pr-2 text-right font-mono">{f1(j.sumMnc)}</td>
+                      <td className="py-1 pr-2 text-right font-mono">{f1(j.sumMnb)}</td>
+                      <td className="py-1 pr-2 text-right font-mono">{Number.isFinite(j.ratio) ? j.ratio.toFixed(2) : '∞'}</td>
+                      <td className={`py-1 pr-2 text-right font-semibold ${j.ok ? 'text-emerald-600' : 'text-red-600'}`}>{j.ok ? '✓' : '✗'}</td>
+                      <td className="py-1 text-slate-400">{j.nCols} / {j.nBeams}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <p className="mt-2 text-[10px] text-slate-400">
+                ΣMnc ≥ (6/5)·ΣMnb at each beam-column joint (§418.7.3.2). Column Mnc is taken at the design axial Pu;
+                beam Mnb from the heaviest designed tension steel. Failing joints need larger columns or lighter beams.
+                {design.scwb.every((j) => j.ok) ? ' All joints satisfy the requirement.' : ' ✗ One or more joints fail.'}
+              </p>
+            </div>
+          )}
+
           {/* Slab schedule (full width) — two-way DDM */}
           {design.slabs.length > 0 && report !== 'draw-only' && (
             <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">


### PR DESCRIPTION
## Summary

SMF/IMF tie **confinement** detailing (ℓo zone, spacing limits) already existed. The missing seismic-detailing piece was the **column-to-beam flexural-strength ratio** — the strong-column/weak-beam (SCWB) check required for Special Moment Frames so plastic hinges form in the beams, not the columns:

> **ΣMnc ≥ (6/5)·ΣMnb** at each beam-column joint (NSCP §418.7.3.2 = ACI 318-14 §18.7.3.2)

## Engine (`scwb.ts`)
- **`concreteBeamMn`** — singly-reinforced `Mn = As·fy·(d − a/2)`.
- **`concreteColumnMn`** — column nominal moment at a given axial via a **strain-compatibility neutral-axis solve** (rectangular stress block, εcu = 0.003, β1 per f′c, symmetric two-layer steel). Captures the rising/falling P–M branches.
- **`scwbRatio` / `SCWB_FACTOR` (6/5)**; **`checkModelSCWB`** — walks each joint, sums column Mnc (at design axial Pu) and beam Mnb (heaviest designed section), reports ratio + pass/fail.

## Pipeline + UI
- `StructureDesign` gains `scwb`, populated only when `seismicSystem === 'smf'`.
- ModelSpace design output gains an **SCWB joint-check table** (ΣMnc, ΣMnb, ratio, ≥6/5 pass/fail, cols/beams).

## Tests (+14, 845 total green)
Beam/column Mn (P–M rising & falling branches, steel & β1 sensitivity); the 6/5 clause incl. the no-beam ∞ case; joint-walk over a concrete frame (strong vs weak column); and the pipeline integration (SMF-only population, ratio identity).

Verified: `npm test` (845 passing), `npx tsc -b`, and `npm run build` all clean.

## 🎉 Tier 4 complete
This is the final phase — **all thirteen Tier 4 items (A1–E13) are now shipped**. HANDOFF.md updated to reflect completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_