### PR TITLE
feat: geotechnical toolkit — earth pressure, bearing capacity, slope stability

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -22,6 +22,7 @@ import TorsionDesign from './pages/TorsionDesign'
 import DevLength from './pages/DevLength'
 import PunchingShear from './pages/PunchingShear'
 import RetainingWall from './pages/RetainingWall'
+import Geotech from './pages/Geotech'
 import SlabEstimate from './pages/SlabEstimate'
 import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
@@ -63,6 +64,7 @@ export default function App() {
         <Route path="/dev-length" element={<DevLength />} />
         <Route path="/punching-shear" element={<PunchingShear />} />
         <Route path="/retaining-wall" element={<RetainingWall />} />
+        <Route path="/geotech" element={<Geotech />} />
         <Route path="/estimate/slab" element={<SlabEstimate />} />
         <Route path="/estimate/beam" element={<BeamEstimate />} />
         <Route path="/estimate/column" element={<ColumnEstimate />} />

--- a/webapp/src/engine/geotech.test.ts
+++ b/webapp/src/engine/geotech.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import {
+  rankineKa, rankineKp, activeThrust, passiveThrust,
+  bearingFactors, bearingCapacity, infiniteSlopeFS,
+} from './geotech'
+
+describe('Rankine earth-pressure coefficients', () => {
+  it('Ka = (1−sinφ)/(1+sinφ); Kp is its reciprocal', () => {
+    expect(rankineKa(30)).toBeCloseTo(1 / 3, 6)          // textbook 0.333
+    expect(rankineKp(30)).toBeCloseTo(3, 6)
+    expect(rankineKa(30) * rankineKp(30)).toBeCloseTo(1, 9)
+  })
+  it('φ = 0 gives K = 1 (hydrostatic-like)', () => {
+    expect(rankineKa(0)).toBeCloseTo(1, 9)
+    expect(rankineKp(0)).toBeCloseTo(1, 9)
+  })
+})
+
+describe('active / passive thrust', () => {
+  const wall = { gamma: 18, H: 5, phiDeg: 30 }
+  it('active thrust Pa = ½·Ka·γ·H² acting at H/3', () => {
+    const r = activeThrust(wall)
+    expect(r.P).toBeCloseTo(0.5 * (1 / 3) * 18 * 25, 4)   // 75 kN/m
+    expect(r.lineOfAction).toBeCloseTo(5 / 3, 6)
+    expect(r.basePressure).toBeCloseTo((1 / 3) * 18 * 5, 6)
+  })
+  it('a surcharge raises the thrust and the line of action', () => {
+    const bare = activeThrust(wall)
+    const sur = activeThrust({ ...wall, surcharge: 20 })
+    expect(sur.P).toBeGreaterThan(bare.P)
+    expect(sur.lineOfAction).toBeGreaterThan(bare.lineOfAction)   // rectangular block at H/2
+    expect(sur.P).toBeCloseTo(bare.P + (1 / 3) * 20 * 5, 6)        // + Ka·q·H
+  })
+  it('passive thrust is far larger than active (Kp ≫ Ka)', () => {
+    expect(passiveThrust(wall).P).toBeGreaterThan(activeThrust(wall).P * 8)
+  })
+})
+
+describe('bearing-capacity factors (Vesić Nγ)', () => {
+  it('match published values at φ = 30°', () => {
+    const f = bearingFactors(30)
+    expect(f.Nq).toBeCloseTo(18.40, 1)
+    expect(f.Nc).toBeCloseTo(30.14, 1)
+    expect(f.Ngamma).toBeCloseTo(22.40, 1)
+  })
+  it('φ = 0: Nc = 5.14, Nq = 1, Nγ = 0', () => {
+    expect(bearingFactors(0)).toEqual({ Nc: 5.14, Nq: 1, Ngamma: 0 })
+  })
+  it('factors increase with φ', () => {
+    expect(bearingFactors(35).Nq).toBeGreaterThan(bearingFactors(30).Nq)
+  })
+})
+
+describe('Terzaghi/Meyerhof bearing capacity', () => {
+  it('strip footing qult = c·Nc + q·Nq + ½·γ·B·Nγ', () => {
+    const r = bearingCapacity({ c: 20, phiDeg: 30, gamma: 18, B: 2, Df: 1.5, shape: 'strip' })
+    const q = 18 * 1.5
+    const expected = 20 * r.Nc + q * r.Nq + 0.5 * 18 * 2 * r.Ngamma
+    expect(r.qult).toBeCloseTo(expected, 4)
+    expect(r.qnet).toBeCloseTo(r.qult - q, 6)
+    expect(r.qallow).toBeCloseTo(r.qult / 3, 6)
+  })
+  it('square footing applies Meyerhof shape factors (higher cohesion term, lower γ term)', () => {
+    const strip = bearingCapacity({ c: 20, phiDeg: 30, gamma: 18, B: 2, Df: 1.5, shape: 'strip' })
+    const square = bearingCapacity({ c: 20, phiDeg: 30, gamma: 18, B: 2, Df: 1.5, shape: 'square' })
+    // sc = 1 + 0.2·Kp > 1 and sγ = 0.6 < 1; cohesion dominates here ⇒ square is larger
+    expect(square.qult).toBeGreaterThan(strip.qult)
+  })
+  it('custom FS scales the allowable', () => {
+    const a = bearingCapacity({ c: 10, phiDeg: 25, gamma: 17, B: 1.5, Df: 1, FS: 2.5 })
+    expect(a.qallow).toBeCloseTo(a.qult / 2.5, 6)
+  })
+})
+
+describe('infinite-slope factor of safety', () => {
+  it('cohesionless dry slope: FS = tanφ / tanβ', () => {
+    const fs = infiniteSlopeFS({ c: 0, phiDeg: 30, gamma: 18, z: 3, betaDeg: 20 })
+    expect(fs).toBeCloseTo(Math.tan(30 * Math.PI / 180) / Math.tan(20 * Math.PI / 180), 6)
+  })
+  it('cohesion raises FS; a steeper slope lowers it', () => {
+    const base = infiniteSlopeFS({ c: 5, phiDeg: 30, gamma: 18, z: 3, betaDeg: 20 })
+    const noC = infiniteSlopeFS({ c: 0, phiDeg: 30, gamma: 18, z: 3, betaDeg: 20 })
+    const steep = infiniteSlopeFS({ c: 5, phiDeg: 30, gamma: 18, z: 3, betaDeg: 30 })
+    expect(base).toBeGreaterThan(noC)
+    expect(steep).toBeLessThan(base)
+  })
+  it('seepage parallel to the slope reduces FS (buoyant normal stress)', () => {
+    const dry = infiniteSlopeFS({ c: 0, phiDeg: 32, gamma: 20, z: 4, betaDeg: 18 })
+    const wet = infiniteSlopeFS({ c: 0, phiDeg: 32, gamma: 20, z: 4, betaDeg: 18, seepage: true, gammaSat: 20, gammaW: 9.81 })
+    expect(wet).toBeLessThan(dry)
+    // cohesionless with full seepage: FS ≈ (γ′/γsat)·tanφ/tanβ
+    const expected = ((20 - 9.81) / 20) * Math.tan(32 * Math.PI / 180) / Math.tan(18 * Math.PI / 180)
+    expect(wet).toBeCloseTo(expected, 6)
+  })
+})

--- a/webapp/src/engine/geotech.ts
+++ b/webapp/src/engine/geotech.ts
@@ -1,0 +1,130 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Geotechnical engineering — lateral earth pressure, bearing capacity and
+// slope stability. Classic closed-form soil mechanics, used by retaining-wall,
+// foundation and slope checks.
+//   Lateral pressure : Rankine active/passive coefficients & thrust.
+//   Bearing capacity : Terzaghi/Meyerhof equation with Vesić N-factors.
+//   Slope stability  : infinite-slope factor of safety (dry / seepage).
+// Angles are passed in DEGREES; γ in kN/m³, lengths m, cohesion kPa,
+// pressures kPa, thrust kN per metre run.
+// ─────────────────────────────────────────────────────────────────────────
+
+const rad = (deg: number) => (deg * Math.PI) / 180
+
+// ── Rankine lateral earth pressure ──────────────────────────────────────────
+/** Active earth-pressure coefficient Ka = tan²(45 − φ/2) (level backfill). */
+export function rankineKa(phiDeg: number): number {
+  return Math.tan(rad(45 - phiDeg / 2)) ** 2
+}
+/** Passive earth-pressure coefficient Kp = tan²(45 + φ/2) (level backfill). */
+export function rankineKp(phiDeg: number): number {
+  return Math.tan(rad(45 + phiDeg / 2)) ** 2
+}
+
+export interface EarthThrust {
+  K: number
+  /** Total horizontal thrust per metre run, kN/m. */
+  P: number
+  /** Height of the resultant above the base, m. */
+  lineOfAction: number
+  /** Pressure at the base of the wall, kPa. */
+  basePressure: number
+}
+
+/**
+ * Rankine ACTIVE thrust on a wall of height H retaining cohesionless soil
+ * (γ, φ) with an optional uniform surcharge q (kPa). The triangular soil part
+ * acts at H/3; the rectangular surcharge part at H/2 — the resultant line of
+ * action is the weighted average.
+ */
+export function activeThrust(p: { gamma: number; H: number; phiDeg: number; surcharge?: number }): EarthThrust {
+  const Ka = rankineKa(p.phiDeg)
+  const q = p.surcharge ?? 0
+  const Psoil = 0.5 * Ka * p.gamma * p.H ** 2          // triangular, acts at H/3
+  const Pq = Ka * q * p.H                              // rectangular, acts at H/2
+  const P = Psoil + Pq
+  const lineOfAction = P > 0 ? (Psoil * (p.H / 3) + Pq * (p.H / 2)) / P : p.H / 3
+  return { K: Ka, P, lineOfAction, basePressure: Ka * (p.gamma * p.H + q) }
+}
+
+/** Rankine PASSIVE thrust on a wall of height H (cohesionless soil). */
+export function passiveThrust(p: { gamma: number; H: number; phiDeg: number }): EarthThrust {
+  const Kp = rankineKp(p.phiDeg)
+  const P = 0.5 * Kp * p.gamma * p.H ** 2
+  return { K: Kp, P, lineOfAction: p.H / 3, basePressure: Kp * p.gamma * p.H }
+}
+
+// ── Bearing capacity ────────────────────────────────────────────────────────
+export interface BearingFactors { Nc: number; Nq: number; Ngamma: number }
+
+/**
+ * Bearing-capacity factors. Nq and Nc follow Prandtl/Reissner (used by Meyerhof,
+ * Hansen and Vesić); Nγ is the Vesić form Nγ = 2(Nq + 1)·tanφ.
+ *   Nq = e^(π·tanφ)·tan²(45 + φ/2),  Nc = (Nq − 1)·cotφ  (Nc = 5.14 at φ = 0).
+ */
+export function bearingFactors(phiDeg: number): BearingFactors {
+  const phi = rad(phiDeg)
+  if (phiDeg <= 0) return { Nc: 5.14, Nq: 1, Ngamma: 0 }
+  const Nq = Math.exp(Math.PI * Math.tan(phi)) * Math.tan(rad(45 + phiDeg / 2)) ** 2
+  const Nc = (Nq - 1) / Math.tan(phi)
+  const Ngamma = 2 * (Nq + 1) * Math.tan(phi)
+  return { Nc, Nq, Ngamma }
+}
+
+export type FootingShape = 'strip' | 'square' | 'circular'
+
+export interface BearingResult extends BearingFactors {
+  /** Ultimate gross bearing capacity, kPa. */
+  qult: number
+  /** Net ultimate (qult − surcharge), kPa. */
+  qnet: number
+  /** Allowable gross bearing capacity = qult / FS, kPa. */
+  qallow: number
+}
+
+/**
+ * Terzaghi/Meyerhof bearing capacity  qult = c·Nc·sc + q·Nq + ½·γ·B·Nγ·sγ,
+ * with Meyerhof shape factors for square/circular footings (strip → 1.0).
+ *   q = γ·Df is the surcharge from the embedment Df.
+ */
+export function bearingCapacity(p: {
+  c: number; phiDeg: number; gamma: number; B: number; Df: number;
+  shape?: FootingShape; FS?: number;
+}): BearingResult {
+  const f = bearingFactors(p.phiDeg)
+  const q = p.gamma * p.Df
+  const shape = p.shape ?? 'strip'
+  // Meyerhof shape factors for B/L = 1 (square/circular); strip = 1.0
+  const Kp = rankineKp(p.phiDeg)
+  const sc = shape === 'strip' ? 1 : 1 + 0.2 * Kp        // 1 + 0.2·Kp·(B/L)
+  const sg = shape === 'strip' ? 1 : 0.6                 // 1 − 0.4·(B/L)
+  const qult = p.c * f.Nc * sc + q * f.Nq + 0.5 * p.gamma * p.B * f.Ngamma * sg
+  const FS = p.FS ?? 3
+  return { ...f, qult, qnet: qult - q, qallow: qult / FS }
+}
+
+// ── Infinite-slope stability ────────────────────────────────────────────────
+/**
+ * Factor of safety of an infinite slope at depth z, inclination β.
+ *   dry:      FS = (c + γ·z·cos²β·tanφ) / (γ·z·sinβ·cosβ)
+ *   seepage parallel to the slope (water table at surface): the effective
+ *   normal uses the buoyant unit weight γ′ = γsat − γw, while the driving
+ *   shear still uses γsat:
+ *             FS = (c + (γsat − γw)·z·cos²β·tanφ) / (γsat·z·sinβ·cosβ)
+ * For a cohesionless dry slope this reduces to FS = tanφ / tanβ.
+ */
+export function infiniteSlopeFS(p: {
+  c: number; phiDeg: number; gamma: number; z: number; betaDeg: number;
+  seepage?: boolean; gammaSat?: number; gammaW?: number;
+}): number {
+  const beta = rad(p.betaDeg), phi = rad(p.phiDeg)
+  const cosB = Math.cos(beta), sinB = Math.sin(beta)
+  const gSat = p.gammaSat ?? p.gamma
+  const gW = p.gammaW ?? 9.81
+  const drivingGamma = p.seepage ? gSat : p.gamma
+  const normalGamma = p.seepage ? gSat - gW : p.gamma
+  const driving = drivingGamma * p.z * sinB * cosB
+  if (driving <= 0) return Infinity
+  const resisting = p.c + normalGamma * p.z * cosB * cosB * Math.tan(phi)
+  return resisting / driving
+}

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -31,6 +31,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/dev-length',    name: 'Dev & Splice',       sub: 'ACI 318-14 §25.4–25.5'   },
       { to: '/punching-shear', name: 'Punching Shear',   sub: 'Two-way §22.6 · ACI 318' },
       { to: '/retaining-wall',   name: 'Retaining Wall',   sub: 'Cantilever · Rankine'     },
+      { to: '/geotech',          name: 'Geotechnical',     sub: 'Bearing · earth · slope'  },
       { to: '/load-combinations', name: 'Load Combinations', sub: 'NSCP 2015 §203.3 LRFD'   },
     ],
   },

--- a/webapp/src/pages/Geotech.tsx
+++ b/webapp/src/pages/Geotech.tsx
@@ -1,0 +1,155 @@
+import { useState } from 'react'
+import { activeThrust, passiveThrust, bearingCapacity, infiniteSlopeFS, type FootingShape } from '../engine/geotech'
+
+function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
+
+function Field({ label, value, onChange, unit, step = 'any' }: {
+  label: string; value: number; onChange: (v: number) => void; unit?: string; step?: string
+}) {
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="mb-1 font-medium text-slate-600">{label}{unit ? ` (${unit})` : ''}</span>
+      <input type="number" step={step} value={value} onChange={(e) => onChange(num(e.target.value))}
+        className="rounded-md border border-slate-300 px-2.5 py-1.5" />
+    </label>
+  )
+}
+
+function Card({ title, sub, children }: { title: string; sub: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+      <h2 className="text-[1.05rem] font-bold text-[#0056b3]">{title}</h2>
+      <p className="mb-3 text-[11px] text-slate-400">{sub}</p>
+      {children}
+    </section>
+  )
+}
+
+function Out({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between border-t border-slate-100 py-1 text-sm">
+      <span className="text-slate-500">{label}</span>
+      <span className="font-mono font-medium text-slate-800">{value}</span>
+    </div>
+  )
+}
+
+const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
+
+function EarthPressure() {
+  const [gamma, setGamma] = useState(18)
+  const [H, setH] = useState(5)
+  const [phi, setPhi] = useState(30)
+  const [q, setQ] = useState(10)
+  const a = activeThrust({ gamma, H, phiDeg: phi, surcharge: q })
+  const p = passiveThrust({ gamma, H, phiDeg: phi })
+  return (
+    <Card title="Lateral earth pressure — Rankine" sub="Level cohesionless backfill, smooth vertical wall.">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Field label="γ" unit="kN/m³" value={gamma} onChange={setGamma} />
+        <Field label="Wall height H" unit="m" value={H} onChange={setH} />
+        <Field label="φ" unit="°" value={phi} onChange={setPhi} />
+        <Field label="Surcharge q" unit="kPa" value={q} onChange={setQ} />
+      </div>
+      <div className="mt-3">
+        <Out label="Ka" value={f2(a.K)} />
+        <Out label="Active thrust Pa" value={`${f2(a.P)} kN/m`} />
+        <Out label="Acts at (above base)" value={`${f2(a.lineOfAction)} m`} />
+        <Out label="Kp" value={f2(p.K)} />
+        <Out label="Passive thrust Pp" value={`${f2(p.P)} kN/m`} />
+      </div>
+    </Card>
+  )
+}
+
+function Bearing() {
+  const [c, setC] = useState(20)
+  const [phi, setPhi] = useState(30)
+  const [gamma, setGamma] = useState(18)
+  const [B, setB] = useState(2)
+  const [Df, setDf] = useState(1.5)
+  const [shape, setShape] = useState<FootingShape>('strip')
+  const [FS, setFS] = useState(3)
+  const r = bearingCapacity({ c, phiDeg: phi, gamma, B, Df, shape, FS })
+  return (
+    <Card title="Bearing capacity — Terzaghi/Meyerhof (Vesić Nγ)" sub="qult = c·Nc·sc + q·Nq + ½·γ·B·Nγ·sγ,  q = γ·Df.">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Field label="Cohesion c" unit="kPa" value={c} onChange={setC} />
+        <Field label="φ" unit="°" value={phi} onChange={setPhi} />
+        <Field label="γ" unit="kN/m³" value={gamma} onChange={setGamma} />
+        <Field label="Width B" unit="m" value={B} onChange={setB} />
+        <Field label="Depth Df" unit="m" value={Df} onChange={setDf} />
+        <label className="flex flex-col text-sm">
+          <span className="mb-1 font-medium text-slate-600">Shape</span>
+          <select value={shape} onChange={(e) => setShape(e.target.value as FootingShape)}
+            className="rounded-md border border-slate-300 px-2.5 py-1.5">
+            <option value="strip">Strip</option>
+            <option value="square">Square</option>
+            <option value="circular">Circular</option>
+          </select>
+        </label>
+        <Field label="FS" value={FS} onChange={setFS} />
+      </div>
+      <div className="mt-3">
+        <Out label="Nc / Nq / Nγ" value={`${f2(r.Nc)} / ${f2(r.Nq)} / ${f2(r.Ngamma)}`} />
+        <Out label="Ultimate qult" value={`${f2(r.qult)} kPa`} />
+        <Out label="Net ultimate qnet" value={`${f2(r.qnet)} kPa`} />
+        <Out label={`Allowable qallow (FS ${f2(FS)})`} value={`${f2(r.qallow)} kPa`} />
+      </div>
+    </Card>
+  )
+}
+
+function Slope() {
+  const [c, setC] = useState(5)
+  const [phi, setPhi] = useState(30)
+  const [gamma, setGamma] = useState(18)
+  const [z, setZ] = useState(3)
+  const [beta, setBeta] = useState(20)
+  const [seepage, setSeepage] = useState(false)
+  const [gammaSat, setGammaSat] = useState(20)
+  const fs = infiniteSlopeFS({ c, phiDeg: phi, gamma, z, betaDeg: beta, seepage, gammaSat })
+  return (
+    <Card title="Slope stability — infinite slope" sub="Planar failure at depth z; optional seepage parallel to the slope.">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Field label="Cohesion c" unit="kPa" value={c} onChange={setC} />
+        <Field label="φ" unit="°" value={phi} onChange={setPhi} />
+        <Field label="γ" unit="kN/m³" value={gamma} onChange={setGamma} />
+        <Field label="Depth z" unit="m" value={z} onChange={setZ} />
+        <Field label="Slope β" unit="°" value={beta} onChange={setBeta} />
+        {seepage && <Field label="γsat" unit="kN/m³" value={gammaSat} onChange={setGammaSat} />}
+      </div>
+      <label className="mt-3 flex items-center gap-2 text-sm">
+        <input type="checkbox" checked={seepage} onChange={(e) => setSeepage(e.target.checked)} />
+        <span>Seepage parallel to slope (water table at surface)</span>
+      </label>
+      <div className="mt-2">
+        <Out label="Factor of safety" value={f2(fs)} />
+        <Out label="Assessment" value={fs >= 1.5 ? '✓ Stable (FS ≥ 1.5)' : fs >= 1 ? '⚠ Marginal' : '✗ Unstable'} />
+      </div>
+    </Card>
+  )
+}
+
+export default function Geotech() {
+  return (
+    <main className="mx-auto max-w-5xl px-5 py-10">
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">Geotechnical</p>
+      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Geotechnical toolkit</h1>
+      <p className="mt-2 max-w-3xl text-sm text-slate-600">
+        Classic soil-mechanics checks — Rankine lateral earth pressure, shallow-foundation bearing
+        capacity, and infinite-slope stability. All formulas are closed-form and cross-checked against
+        the <a href="/validation" className="text-[#0056b3] underline">validation benchmarks</a>.
+      </p>
+      <div className="mt-6 space-y-5">
+        <EarthPressure />
+        <Bearing />
+        <Slope />
+      </div>
+      <p className="mt-6 text-[11px] text-slate-400">
+        Bearing factors: Nq, Nc per Prandtl/Reissner; Nγ per Vesić (2(Nq+1)tanφ). Shape factors per Meyerhof.
+        Use engineering judgement and site-specific investigation; these are preliminary checks.
+      </p>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

Adds a new **geotechnical engineering** domain — classic closed-form soil mechanics, cross-checked against published values. Complements the existing Retaining Wall page and leverages the geotechnical focus from the project review.

## Engine (`geotech.ts`)
- **Lateral earth pressure (Rankine)** — `Ka`/`Kp`, active & passive thrust with surcharge and resultant line of action.
- **Bearing capacity** — factors `Nq`, `Nc` (Prandtl/Reissner) and `Nγ` (Vesić, `2(Nq+1)tanφ`); Terzaghi/Meyerhof `qult = c·Nc·sc + q·Nq + ½·γ·B·Nγ·sγ` with Meyerhof shape factors; net & allowable (FS).
- **Slope stability** — infinite-slope factor of safety, dry and with seepage parallel to the slope (buoyant normal stress).

## Tests (+14)
Ka/Kp reciprocal identity; thrust & surcharge; **N-factors vs textbook** (φ=30° → Nq 18.4, Nc 30.14, Nγ 22.4); `qult` composition & shape factors; slope `FS = tanφ/tanβ` and the seepage reduction `FS ≈ (γ′/γsat)·tanφ/tanβ`.

## UI
`pages/Geotech.tsx` + `/geotech` route + a Structural nav entry — three interactive calculators (earth pressure, bearing capacity, slope stability) with live results.

Verified: `npm test` (863 passing), `npx tsc -b`, and `npm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_