### PR TITLE
feat: per-module pass counts on /validation + more benchmarks

### DIFF
--- a/webapp/src/engine/validation.ts
+++ b/webapp/src/engine/validation.ts
@@ -11,8 +11,10 @@
 import { concreteBeamMn } from './scwb'
 import { velocityPressure, windKz } from './wind'
 import { requiredArea } from './bearing'
-import { beamFlexure, deriveWSection } from './steelDesign'
+import { beamFlexure, beamShear, deriveWSection } from './steelDesign'
 import { shapeByName } from './aiscSections'
+import { designAxialColumn } from './columnDesign'
+import { activeThrust, rankineKa, bearingFactors, infiniteSlopeFS } from './geotech'
 import { solveFrame3D, rectJ, type F3Node, type F3Member, type F3Support } from './frame3d'
 
 export interface ValidationCase {
@@ -75,6 +77,39 @@ const footing = (() => {
   return { manual: P / qNet, software: requiredArea(P, qNet) }
 })()
 
+// ── 6. Tied column — max axial φPn,max = φ·α·[0.85f′c(Ag−Ast)+fy·Ast] ─────────
+const columnAxial = (() => {
+  const b = 400, h = 400, fc = 28, fy = 415, barDia = 25, numBars = 8
+  const Ast = numBars * (Math.PI / 4) * barDia ** 2, Ag = b * h
+  const Po = (0.85 * fc * (Ag - Ast) + fy * Ast) / 1000
+  const r = designAxialColumn({ shape: 'tied', b, h, cover: 40, barDia, tieDia: 10, fc, fy, Pu: 1000, numBars })
+  return { manual: 0.65 * 0.80 * Po, software: r.phiPnMax }    // φ 0.65 tied, α 0.80
+})()
+
+// ── 7. Steel beam shear — φVn = 1.0·0.6·Fy·Aw·Cv1 (stocky web) ────────────────
+const steelVn = (() => {
+  const shape = shapeByName('W310x79')!, Fy = 345
+  const r = beamShear(shape, deriveWSection(shape), Fy)
+  const Aw = shape.d! * shape.tw!                              // §G2.1b for I-shapes
+  return { manual: (1.0 * 0.6 * Fy * Aw * r.Cv1) / 1000, software: r.phiVn }
+})()
+
+// ── 8. Rankine active thrust  Pa = ½·Ka·γ·H² ─────────────────────────────────
+const earthThrust = (() => {
+  const gamma = 18, H = 5, phiDeg = 30
+  return { manual: 0.5 * rankineKa(phiDeg) * gamma * H ** 2, software: activeThrust({ gamma, H, phiDeg }).P }
+})()
+
+// ── 9. Bearing factor Nq at φ = 30° (Prandtl/Reissner) ───────────────────────
+const bearingNq = (() => ({ manual: 18.401, software: bearingFactors(30).Nq }))()
+
+// ── 10. Infinite-slope FS (cohesionless dry) = tanφ/tanβ ─────────────────────
+const slopeFS = (() => {
+  const phiDeg = 32, betaDeg = 18
+  const tan = (d: number) => Math.tan((d * Math.PI) / 180)
+  return { manual: tan(phiDeg) / tan(betaDeg), software: infiniteSlopeFS({ c: 0, phiDeg, gamma: 18, z: 3, betaDeg }) }
+})()
+
 export const VALIDATION_CASES: ValidationCase[] = [
   {
     id: 'rc-beam-mn', category: 'RC', title: 'Singly-reinforced beam — nominal moment',
@@ -105,5 +140,30 @@ export const VALIDATION_CASES: ValidationCase[] = [
     id: 'footing-area', category: 'Geotech', title: 'Spread footing required bearing area',
     reference: 'NSCP 305 / ACI 318-14 §13', formula: 'A = P / q_net',
     manual: footing.manual, software: footing.software, unit: 'm²', tol: 1e-9,
+  },
+  {
+    id: 'column-phipn', category: 'RC', title: 'Tied column — max axial capacity',
+    reference: 'NSCP 422.4 / ACI 318-14 §22.4', formula: 'φPn,max = 0.65·0.80·[0.85·f′c·(Ag−Ast) + fy·Ast]',
+    manual: columnAxial.manual, software: columnAxial.software, unit: 'kN', tol: 1e-6,
+  },
+  {
+    id: 'steel-phivn', category: 'Steel', title: 'I-section web shear strength',
+    reference: 'AISC 360 §G2.1', formula: 'φVn = 1.0·0.6·Fy·Aw·Cv1',
+    manual: steelVn.manual, software: steelVn.software, unit: 'kN', tol: 1e-6,
+  },
+  {
+    id: 'earth-thrust', category: 'Geotech', title: 'Rankine active thrust',
+    reference: 'Rankine (1857)', formula: 'Pa = ½·Ka·γ·H²',
+    manual: earthThrust.manual, software: earthThrust.software, unit: 'kN/m', tol: 1e-9,
+  },
+  {
+    id: 'bearing-nq', category: 'Geotech', title: 'Bearing factor Nq (φ = 30°)',
+    reference: 'Prandtl/Reissner', formula: 'Nq = e^(π·tanφ)·tan²(45+φ/2)',
+    manual: bearingNq.manual, software: bearingNq.software, unit: '—', tol: 1e-3,
+  },
+  {
+    id: 'slope-fs', category: 'Geotech', title: 'Infinite-slope FS (cohesionless, dry)',
+    reference: 'Soil mechanics', formula: 'FS = tanφ / tanβ',
+    manual: slopeFS.manual, software: slopeFS.software, unit: '—', tol: 1e-9,
   },
 ]

--- a/webapp/src/pages/Validation.tsx
+++ b/webapp/src/pages/Validation.tsx
@@ -28,8 +28,17 @@ function Row({ c }: { c: ValidationCase }) {
   )
 }
 
+const passes = (c: ValidationCase) => pctDiff(c) <= c.tol * 100 + 1e-9 || pctDiff(c) < 0.01
+
 export default function Validation() {
-  const allOK = VALIDATION_CASES.every((c) => pctDiff(c) < 0.01)
+  const total = VALIDATION_CASES.length
+  const passing = VALIDATION_CASES.filter(passes).length
+  const allOK = passing === total
+  const perCat = CATS.map((cat) => {
+    const cases = VALIDATION_CASES.filter((c) => c.category === cat)
+    return { cat, n: cases.length, ok: cases.filter(passes).length }
+  }).filter((g) => g.n > 0)
+
   return (
     <main className="mx-auto max-w-5xl px-5 py-10">
       <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">Reference</p>
@@ -37,10 +46,27 @@ export default function Validation() {
       <p className="mt-2 max-w-3xl text-sm text-slate-600">
         Each calculation engine is checked against an independent closed-form hand calculation from a
         textbook or the governing code clause. The <b>Software</b> column is produced by the same engine
-        the design pages use; the <b>Manual</b> column is the analytical result. These cases are also
-        enforced by the automated test suite ({VALIDATION_CASES.length} cases, {' '}
-        <span className={allOK ? 'text-emerald-600' : 'text-red-600'}>{allOK ? 'all passing' : 'see failures'}</span>).
+        the design pages use; the <b>Manual</b> column is the analytical result. Every case below is also
+        enforced by the automated test suite.
       </p>
+
+      {/* Per-module pass-count summary */}
+      <div className="mt-5 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className={`rounded-md px-3 py-1.5 text-sm font-bold ${allOK ? 'bg-emerald-50 text-emerald-700' : 'bg-red-50 text-red-700'}`}>
+            {allOK ? '✓' : '✗'} {passing}/{total} benchmarks passing
+          </span>
+          {perCat.map((g) => (
+            <span key={g.cat} className={`rounded-md px-2.5 py-1.5 text-xs font-medium ${g.ok === g.n ? 'bg-emerald-50 text-emerald-700' : 'bg-red-50 text-red-700'}`}>
+              {g.cat} {g.ok}/{g.n}
+            </span>
+          ))}
+        </div>
+        <p className="mt-2 text-[11px] text-slate-400">
+          A benchmark passes when the engine result is within tolerance of the hand calculation
+          (typically &lt; 0.01 %). Counts are evaluated live from the same engines the design pages use.
+        </p>
+      </div>
 
       {CATS.map((cat) => {
         const cases = VALIDATION_CASES.filter((c) => c.category === cat)


### PR DESCRIPTION
## Summary

Adds the per-module **pass-count summary** the review asked for to `/validation`, and broadens the benchmark set.

- **Summary band** — live badges: `11/11 benchmarks passing` plus per-module counts (`RC 2/2`, `Steel 2/2`, `Analysis 2/2`, `Wind 1/1`, `Geotech 4/4`). Evaluated at runtime from the same engines the design pages use.
- **5 new benchmarks** in `engine/validation.ts` (6 → 11):
  - **RC** — tied-column max axial `φPn,max = φ·α·[0.85f′c(Ag−Ast)+fy·Ast]`
  - **Steel** — I-section web shear `φVn = 1.0·0.6·Fy·Aw·Cv1`
  - **Geotech** — Rankine active thrust `½·Ka·γ·H²`, bearing factor `Nq(30°)=18.40`, infinite-slope `FS = tanφ/tanβ`

Verified: `npm test` (863 passing), `npx tsc -b`, `npm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_