### PR TITLE
feat: soil-nail wall design (FHWA GEC-7) — roadmap Phase 3 geotech

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -23,6 +23,7 @@ import DevLength from './pages/DevLength'
 import PunchingShear from './pages/PunchingShear'
 import RetainingWall from './pages/RetainingWall'
 import Geotech from './pages/Geotech'
+import SoilNail from './pages/SoilNail'
 import SlabEstimate from './pages/SlabEstimate'
 import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
@@ -65,6 +66,7 @@ export default function App() {
         <Route path="/punching-shear" element={<PunchingShear />} />
         <Route path="/retaining-wall" element={<RetainingWall />} />
         <Route path="/geotech" element={<Geotech />} />
+        <Route path="/soil-nail" element={<SoilNail />} />
         <Route path="/estimate/slab" element={<SlabEstimate />} />
         <Route path="/estimate/beam" element={<BeamEstimate />} />
         <Route path="/estimate/column" element={<ColumnEstimate />} />

--- a/webapp/src/engine/soilNail.test.ts
+++ b/webapp/src/engine/soilNail.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { nailTensileCapacity, nailPulloutCapacity, requiredBondLength, designSoilNail } from './soilNail'
+import { rankineKa } from './geotech'
+
+describe('nailTensileCapacity', () => {
+  it('Tn = Ab·fy; allowable = Tn/FS', () => {
+    const Ab = (Math.PI / 4) * 25 ** 2
+    const r = nailTensileCapacity({ barDia: 25, fy: 415, FS: 1.8 })
+    expect(r.Tn).toBeCloseTo((415 * Ab) / 1000, 6)
+    expect(r.Tall).toBeCloseTo(r.Tn / 1.8, 9)
+  })
+  it('a larger bar carries more', () => {
+    expect(nailTensileCapacity({ barDia: 32, fy: 415 }).Tn).toBeGreaterThan(nailTensileCapacity({ barDia: 25, fy: 415 }).Tn)
+  })
+})
+
+describe('nailPulloutCapacity', () => {
+  it('Qult = π·DDH·Le·qu and Qall = Qult/FS', () => {
+    const r = nailPulloutCapacity({ drillDia: 0.15, bondLength: 6, qu: 150, FS: 2 })
+    expect(r.Qult).toBeCloseTo(Math.PI * 0.15 * 6 * 150, 6)
+    expect(r.Qall).toBeCloseTo(r.Qult / 2, 9)
+  })
+  it('longer bond length ⇒ more pullout capacity', () => {
+    const a = nailPulloutCapacity({ drillDia: 0.15, bondLength: 4, qu: 150 })
+    const b = nailPulloutCapacity({ drillDia: 0.15, bondLength: 8, qu: 150 })
+    expect(b.Qult).toBeCloseTo(2 * a.Qult, 6)
+  })
+})
+
+describe('requiredBondLength', () => {
+  it('inverts the pullout equation: Le = T·FS/(π·DDH·qu)', () => {
+    const Le = requiredBondLength({ T: 100, drillDia: 0.15, qu: 150, FS: 2 })
+    expect(Le).toBeCloseTo((100 * 2) / (Math.PI * 0.15 * 150), 6)
+    // the recovered Le gives exactly Qall = T at that FS
+    const q = nailPulloutCapacity({ drillDia: 0.15, bondLength: Le, qu: 150, FS: 2 })
+    expect(q.Qall).toBeCloseTo(100, 6)
+  })
+})
+
+describe('designSoilNail — per-nail demand vs capacity', () => {
+  const base = {
+    z: 6, Sh: 1.5, Sv: 1.5, gamma: 18, phiDeg: 30, surcharge: 10,
+    barDia: 25, fy: 415, drillDia: 0.15, bondLength: 6, qu: 150, FSpullout: 2,
+  }
+  it('demand Tmax = Ka·(γ·z + q)·Sh·Sv', () => {
+    const r = designSoilNail(base)
+    expect(r.Ka).toBeCloseTo(rankineKa(30), 9)
+    expect(r.Tmax).toBeCloseTo(rankineKa(30) * (18 * 6 + 10) * 1.5 * 1.5, 6)
+  })
+  it('factors of safety are ultimate/demand and drive the OK flags', () => {
+    const r = designSoilNail(base)
+    expect(r.fsTensile).toBeCloseTo(r.Tn / r.Tmax, 9)
+    expect(r.fsPullout).toBeCloseTo(r.Qult / r.Tmax, 9)
+    expect(r.tensileOK).toBe(r.fsTensile >= 1.8)
+    expect(r.pulloutOK).toBe(r.fsPullout >= 2.0)
+  })
+  it('deeper nails and wider spacing raise the demand', () => {
+    expect(designSoilNail({ ...base, z: 9 }).Tmax).toBeGreaterThan(designSoilNail(base).Tmax)
+    expect(designSoilNail({ ...base, Sh: 2 }).Tmax).toBeGreaterThan(designSoilNail(base).Tmax)
+  })
+  it('the reported required bond length achieves the pullout FS', () => {
+    const r = designSoilNail(base)
+    const checked = designSoilNail({ ...base, bondLength: r.bondLengthReq })
+    expect(checked.fsPullout).toBeCloseTo(base.FSpullout, 4)
+  })
+})

--- a/webapp/src/engine/soilNail.ts
+++ b/webapp/src/engine/soilNail.ts
@@ -1,0 +1,73 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Soil-nail wall — local design checks (FHWA GEC-7, Soil Nail Walls).
+// A soil-nail wall stabilises a cut with grouted steel bars in tension. This
+// module covers the per-nail capacity/demand checks (preliminary design):
+//   Demand   Tmax = Ka·(γ·z + q)·Sh·Sv          (tributary active load)
+//   Tensile  Tn   = Ab·fy ,  φTn = φ·Tn          (bar yield, §FHWA 5.4)
+//   Pullout  Qult = π·DDH·Le·qu ,  Qall = Qult/FS (grout-ground bond, §FHWA 5.3)
+// where Sh,Sv = horizontal/vertical nail spacing, z = nail depth, DDH = drill-
+// hole diameter, Le = bond (resisting) length beyond the slip surface, qu =
+// ultimate bond strength. Global (slip-surface) stability is out of scope —
+// use the slope-stability tools and a limit-equilibrium search for that.
+// Units: lengths m; bar Ø mm; γ kN/m³; q,qu kPa; fy MPa; forces kN.
+// ─────────────────────────────────────────────────────────────────────────
+import { rankineKa } from './geotech'
+
+/** Nominal bar tensile capacity Tn = Ab·fy (kN) and the allowable Tn/FS. */
+export function nailTensileCapacity(p: { barDia: number; fy: number; FS?: number }): { Tn: number; Tall: number } {
+  const Ab = (Math.PI / 4) * p.barDia ** 2          // mm²
+  const Tn = (p.fy * Ab) / 1000                      // kN
+  return { Tn, Tall: Tn / (p.FS ?? 1.8) }
+}
+
+/** Grout-ground pullout: ultimate Qult = π·DDH·Le·qu and allowable Qult/FS (kN). */
+export function nailPulloutCapacity(p: { drillDia: number; bondLength: number; qu: number; FS?: number }): { Qult: number; Qall: number } {
+  const Qult = Math.PI * p.drillDia * p.bondLength * p.qu     // kN
+  return { Qult, Qall: Qult / (p.FS ?? 2.0) }
+}
+
+/** Bond length Le (m) needed so the allowable pullout carries the nail force T. */
+export function requiredBondLength(p: { T: number; drillDia: number; qu: number; FS?: number }): number {
+  const denom = Math.PI * p.drillDia * p.qu
+  return denom > 0 ? (p.T * (p.FS ?? 2.0)) / denom : Infinity
+}
+
+export interface SoilNailResult {
+  Ka: number
+  /** Tributary nail force demand, kN. */
+  Tmax: number
+  Tn: number; Tall: number
+  Qult: number; Qall: number
+  /** Factor of safety in each mode = ultimate capacity / demand. */
+  fsTensile: number; fsPullout: number
+  /** Bond length required to reach the target pullout FS at this demand, m. */
+  bondLengthReq: number
+  tensileOK: boolean; pulloutOK: boolean
+}
+
+/**
+ * Per-nail check at depth z: tributary active demand vs bar-tensile and
+ * grout-ground pullout capacities. `bondLength` is the resisting length Le
+ * beyond the assumed slip surface.
+ */
+export function designSoilNail(p: {
+  z: number; Sh: number; Sv: number;
+  gamma: number; phiDeg: number; surcharge?: number;
+  barDia: number; fy: number;
+  drillDia: number; bondLength: number; qu: number;
+  FSpullout?: number; FStensile?: number;
+}): SoilNailResult {
+  const Ka = rankineKa(p.phiDeg)
+  const q = p.surcharge ?? 0
+  const FSp = p.FSpullout ?? 2.0, FSt = p.FStensile ?? 1.8
+  const Tmax = Ka * (p.gamma * p.z + q) * p.Sh * p.Sv          // kN
+  const { Tn, Tall } = nailTensileCapacity({ barDia: p.barDia, fy: p.fy, FS: FSt })
+  const { Qult, Qall } = nailPulloutCapacity({ drillDia: p.drillDia, bondLength: p.bondLength, qu: p.qu, FS: FSp })
+  const fsTensile = Tmax > 0 ? Tn / Tmax : Infinity           // ultimate / demand
+  const fsPullout = Tmax > 0 ? Qult / Tmax : Infinity
+  const bondLengthReq = requiredBondLength({ T: Tmax, drillDia: p.drillDia, qu: p.qu, FS: FSp })
+  return {
+    Ka, Tmax, Tn, Tall, Qult, Qall, fsTensile, fsPullout, bondLengthReq,
+    tensileOK: fsTensile >= FSt, pulloutOK: fsPullout >= FSp,
+  }
+}

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -32,6 +32,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/punching-shear', name: 'Punching Shear',   sub: 'Two-way §22.6 · ACI 318' },
       { to: '/retaining-wall',   name: 'Retaining Wall',   sub: 'Cantilever · Rankine'     },
       { to: '/geotech',          name: 'Geotechnical',     sub: 'Bearing · earth · slope'  },
+      { to: '/soil-nail',        name: 'Soil-Nail Wall',   sub: 'FHWA · tensile · pullout' },
       { to: '/load-combinations', name: 'Load Combinations', sub: 'NSCP 2015 §203.3 LRFD'   },
     ],
   },

--- a/webapp/src/pages/SoilNail.tsx
+++ b/webapp/src/pages/SoilNail.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react'
+import { designSoilNail } from '../engine/soilNail'
+
+function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
+const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
+
+function Field({ label, value, onChange, unit, step = 'any' }: {
+  label: string; value: number; onChange: (v: number) => void; unit?: string; step?: string
+}) {
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="mb-1 font-medium text-slate-600">{label}{unit ? ` (${unit})` : ''}</span>
+      <input type="number" step={step} value={value} onChange={(e) => onChange(num(e.target.value))}
+        className="rounded-md border border-slate-300 px-2.5 py-1.5" />
+    </label>
+  )
+}
+
+function Out({ label, value, ok }: { label: string; value: string; ok?: boolean }) {
+  return (
+    <div className="flex items-baseline justify-between border-t border-slate-100 py-1 text-sm">
+      <span className="text-slate-500">{label}</span>
+      <span className={`font-mono font-medium ${ok === undefined ? 'text-slate-800' : ok ? 'text-emerald-600' : 'text-red-600'}`}>{value}</span>
+    </div>
+  )
+}
+
+export default function SoilNail() {
+  const [z, setZ] = useState(6)
+  const [Sh, setSh] = useState(1.5)
+  const [Sv, setSv] = useState(1.5)
+  const [gamma, setGamma] = useState(18)
+  const [phi, setPhi] = useState(30)
+  const [q, setQ] = useState(10)
+  const [barDia, setBarDia] = useState(25)
+  const [fy, setFy] = useState(415)
+  const [drillDia, setDrillDia] = useState(0.15)
+  const [bondLength, setBondLength] = useState(6)
+  const [qu, setQu] = useState(150)
+
+  const r = designSoilNail({
+    z, Sh, Sv, gamma, phiDeg: phi, surcharge: q, barDia, fy,
+    drillDia, bondLength, qu, FSpullout: 2.0, FStensile: 1.8,
+  })
+
+  return (
+    <main className="mx-auto max-w-3xl px-5 py-10">
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">Geotechnical</p>
+      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Soil-nail wall — per-nail check</h1>
+      <p className="mt-2 text-sm text-slate-600">
+        Preliminary FHWA GEC-7 checks for a single nail: tributary active demand vs bar-tensile and
+        grout-ground pullout capacities. Global (slip-surface) stability is separate — use the{' '}
+        <a href="/geotech" className="text-[#0056b3] underline">slope-stability tool</a>.
+      </p>
+
+      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Geometry &amp; soil</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Field label="Nail depth z" unit="m" value={z} onChange={setZ} />
+          <Field label="Horiz. spacing Sh" unit="m" value={Sh} onChange={setSh} />
+          <Field label="Vert. spacing Sv" unit="m" value={Sv} onChange={setSv} />
+          <Field label="γ" unit="kN/m³" value={gamma} onChange={setGamma} />
+          <Field label="φ" unit="°" value={phi} onChange={setPhi} />
+          <Field label="Surcharge q" unit="kPa" value={q} onChange={setQ} />
+        </div>
+        <h2 className="mb-3 mt-5 text-[1.05rem] font-bold text-[#0056b3]">Nail &amp; grout</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Field label="Bar Ø" unit="mm" value={barDia} onChange={setBarDia} />
+          <Field label="fy" unit="MPa" value={fy} onChange={setFy} />
+          <Field label="Drill hole DDH" unit="m" value={drillDia} onChange={setDrillDia} step="0.01" />
+          <Field label="Bond length Le" unit="m" value={bondLength} onChange={setBondLength} />
+          <Field label="Bond strength qu" unit="kPa" value={qu} onChange={setQu} />
+        </div>
+      </section>
+
+      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Results</h2>
+        <Out label="Ka (Rankine)" value={f2(r.Ka)} />
+        <Out label="Demand Tmax = Ka·(γz+q)·Sh·Sv" value={`${f2(r.Tmax)} kN`} />
+        <Out label="Bar tensile Tn = Ab·fy" value={`${f2(r.Tn)} kN`} />
+        <Out label="FS tensile (Tn / Tmax ≥ 1.8)" value={f2(r.fsTensile)} ok={r.tensileOK} />
+        <Out label="Pullout Qult = π·DDH·Le·qu" value={`${f2(r.Qult)} kN`} />
+        <Out label="FS pullout (Qult / Tmax ≥ 2.0)" value={f2(r.fsPullout)} ok={r.pulloutOK} />
+        <Out label="Bond length for FS = 2.0" value={`${f2(r.bondLengthReq)} m`} ok={bondLength >= r.bondLengthReq} />
+        <p className="mt-2 text-[10px] text-slate-400">
+          FHWA GEC-7. Tmax is the tributary active load on one nail at depth z. Allowable bar load Tn/1.8,
+          allowable pullout Qult/2.0. Provide Le ≥ the required bond length beyond the slip surface.
+          This is a preliminary component check — verify global stability separately.
+        </p>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

Adds the **soil-nailing** module the roadmap lists under Phase 3 (Geotechnical) and the review called a *signature feature*. Per-nail preliminary design checks (FHWA GEC-7); global slip-surface stability stays with the slope-stability tool.

## Engine (`soilNail.ts`)
- `nailTensileCapacity` — `Tn = Ab·fy`, allowable `Tn/FS`.
- `nailPulloutCapacity` — grout-ground `Qult = π·DDH·Le·qu`, allowable `Qult/FS`.
- `requiredBondLength` — inverts pullout for a target FS.
- `designSoilNail` — tributary demand `Tmax = Ka·(γz+q)·Sh·Sv` vs tensile & pullout; FoS = **ultimate/demand** with OK flags (FS 1.8 tensile, 2.0 pullout). Reuses Rankine `Ka` from `geotech.ts`.

## Tests (+9)
`Tn`/`Tall`, `Qult` scaling, `requiredBondLength` round-trip (gives exactly the target FS), demand formula, FoS identities, depth/spacing monotonicity.

## UI
`pages/SoilNail.tsx` + `/soil-nail` route + a Structural nav entry — geometry/soil and nail/grout inputs with live FoS and required bond length.

Verified: `npm test` (879 passing), `npx tsc -b`, `npm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_