### PR TITLE
feat: RC stair flight (waist slab) design — roadmap Phase 3 structural

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -24,6 +24,7 @@ import PunchingShear from './pages/PunchingShear'
 import RetainingWall from './pages/RetainingWall'
 import Geotech from './pages/Geotech'
 import SoilNail from './pages/SoilNail'
+import StairDesign from './pages/StairDesign'
 import SlabEstimate from './pages/SlabEstimate'
 import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
@@ -67,6 +68,7 @@ export default function App() {
         <Route path="/retaining-wall" element={<RetainingWall />} />
         <Route path="/geotech" element={<Geotech />} />
         <Route path="/soil-nail" element={<SoilNail />} />
+        <Route path="/stair" element={<StairDesign />} />
         <Route path="/estimate/slab" element={<SlabEstimate />} />
         <Route path="/estimate/beam" element={<BeamEstimate />} />
         <Route path="/estimate/column" element={<ColumnEstimate />} />

--- a/webapp/src/engine/stair.test.ts
+++ b/webapp/src/engine/stair.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { stairGeometry, stairLoads, designStair } from './stair'
+import { flexuralSteel, rhoMin } from './flexure'
+
+describe('stairGeometry', () => {
+  it('θ = atan(R/G); cosθ = G/√(G²+R²)', () => {
+    const g = stairGeometry(150, 300)
+    expect(g.thetaDeg).toBeCloseTo((Math.atan2(150, 300) * 180) / Math.PI, 6)
+    expect(g.cosTheta).toBeCloseTo(300 / Math.hypot(150, 300), 9)
+    expect(g.slopeFactor).toBeCloseTo(1 / g.cosTheta, 9)
+  })
+  it('a steeper flight has a smaller cosθ (more incline)', () => {
+    expect(stairGeometry(200, 250).cosTheta).toBeLessThan(stairGeometry(150, 300).cosTheta)
+  })
+})
+
+describe('stairLoads', () => {
+  const base = { t: 150, R: 150, G: 300, finishes: 1.5, live: 4.8 }
+  it('dead = waist/cosθ + steps(R/2) + finishes; wu = 1.2D + 1.6L', () => {
+    const L = stairLoads(base)
+    const cos = 300 / Math.hypot(150, 300)
+    expect(L.waist).toBeCloseTo((24 * 0.15) / cos, 6)
+    expect(L.steps).toBeCloseTo((24 * 0.15) / 2, 6)
+    expect(L.dead).toBeCloseTo(L.waist + L.steps + 1.5, 9)
+    expect(L.wu).toBeCloseTo(1.2 * L.dead + 1.6 * 4.8, 9)
+  })
+  it('a thicker waist and bigger riser increase the dead load', () => {
+    expect(stairLoads({ ...base, t: 200 }).dead).toBeGreaterThan(stairLoads(base).dead)
+    expect(stairLoads({ ...base, R: 200 }).steps).toBeGreaterThan(stairLoads(base).steps)
+  })
+})
+
+describe('designStair', () => {
+  const base = {
+    span: 3.5, t: 150, R: 150, G: 300, fc: 28, fy: 415,
+    barDia: 12, cover: 20, finishes: 1.5, live: 4.8,
+  }
+  it('Mu = wu·L²/8 (simple) and As matches flexuralSteel per metre', () => {
+    const r = designStair(base)
+    expect(r.Mu).toBeCloseTo((r.loads.wu * 3.5 ** 2) / 8, 6)
+    const d = 150 - 20 - 6
+    const flex = flexuralSteel({ Mu: r.Mu, b: 1000, d, fc: 28, fy: 415 })
+    expect(r.AsMain).toBeCloseTo(Math.max(flex.As, rhoMin(28, 415) * 1000 * d), 4)
+  })
+  it('distribution steel = 0.0018·b·t (§424.4.3.2)', () => {
+    const r = designStair(base)
+    expect(r.AsDist).toBeCloseTo(0.0018 * 1000 * 150, 6)
+  })
+  it('support condition changes the moment coefficient', () => {
+    const simple = designStair(base)
+    const cont = designStair({ ...base, support: 'both-ends' })
+    expect(cont.Mu).toBeLessThan(simple.Mu)       // wu·L²/11 < wu·L²/8
+  })
+  it('flags an under-thick waist (Table 409.3.1.1, ℓ/20 simple)', () => {
+    expect(designStair({ ...base, t: 150 }).tMin).toBeCloseTo(3500 / 20, 6)   // 175 mm
+    expect(designStair({ ...base, t: 150 }).tMinOK).toBe(false)               // 150 < 175
+    expect(designStair({ ...base, t: 200 }).tMinOK).toBe(true)
+  })
+  it('main bar spacing is capped at min(3t, 450) and positive', () => {
+    const r = designStair(base)
+    expect(r.mainSpacing).toBeGreaterThan(0)
+    expect(r.mainSpacing).toBeLessThanOrEqual(Math.min(3 * 150, 450))
+  })
+})

--- a/webapp/src/engine/stair.ts
+++ b/webapp/src/engine/stair.ts
@@ -1,0 +1,99 @@
+// ─────────────────────────────────────────────────────────────────────────
+// RC stair flight (waist-slab type) — NSCP 2015 / ACI 318-14.
+// A waist slab spans the flight; treads sit on top as triangular concrete.
+//   Loads per m² of HORIZONTAL projection:
+//     waist self-wt   = γc·t / cosθ          (t ⊥ slope → per plan area)
+//     steps self-wt   = γc·R / 2             (triangular, average R/2)
+//     + finishes + live (NSCP 205: 4.8 kPa for stairs/exits)
+//   θ = atan(R/G),  cosθ = G/√(G²+R²)
+//   Design as a one-way slab per metre width: Mu = wu·Ln²/k (k by support),
+//   main bars along the span + distribution (shrinkage/temperature) steel.
+// Units: spans m; t/R/G/cover/db mm; loads kPa; moments kN·m/m; As mm²/m.
+// ─────────────────────────────────────────────────────────────────────────
+import { flexuralSteel, rhoMin } from './flexure'
+
+const GAMMA_C = 24            // kN/m³, reinforced concrete
+
+export type StairSupport = 'simple' | 'one-end' | 'both-ends'
+
+/** Flight geometry from riser R and going G (mm). */
+export function stairGeometry(R: number, G: number): { thetaDeg: number; cosTheta: number; slopeFactor: number } {
+  const hyp = Math.hypot(R, G)
+  const cosTheta = G / hyp
+  return { thetaDeg: (Math.atan2(R, G) * 180) / Math.PI, cosTheta, slopeFactor: 1 / cosTheta }
+}
+
+export interface StairLoads {
+  waist: number; steps: number; finishes: number   // kPa (dead components)
+  dead: number; live: number; wu: number           // kPa (wu = 1.2D + 1.6L)
+}
+
+/** Service + factored gravity load on a stair flight, kPa of plan area. */
+export function stairLoads(p: {
+  t: number; R: number; G: number; finishes: number; live: number; gammaC?: number
+}): StairLoads {
+  const gc = p.gammaC ?? GAMMA_C
+  const { cosTheta } = stairGeometry(p.R, p.G)
+  const waist = (gc * (p.t / 1000)) / cosTheta            // kPa, waist ⊥ slope → per plan area
+  const steps = (gc * (p.R / 1000)) / 2                   // triangular treads, average R/2
+  const dead = waist + steps + p.finishes
+  const wu = 1.2 * dead + 1.6 * p.live
+  return { waist, steps, finishes: p.finishes, dead, live: p.live, wu }
+}
+
+/** Span coefficient k in Mu = wu·Ln²/k. */
+const momentDenom = (s: StairSupport): number => (s === 'simple' ? 8 : s === 'one-end' ? 9 : 11)
+/** Minimum one-way slab thickness denominator (Table 409.3.1.1). */
+const thicknessDenom = (s: StairSupport): number => (s === 'simple' ? 20 : s === 'one-end' ? 24 : 28)
+
+export interface StairDesign {
+  geom: { thetaDeg: number; cosTheta: number }
+  loads: StairLoads
+  Mu: number                  // kN·m per metre width
+  d: number                   // effective depth, mm
+  AsMain: number              // main steel, mm²/m
+  mainSpacing: number         // bar spacing, mm
+  AsDist: number              // distribution steel, mm²/m
+  distSpacing: number
+  tMin: number; tMinOK: boolean   // min waist thickness, mm
+  ok: boolean
+}
+
+/**
+ * Design a waist-slab stair flight per metre width. `span` is the clear flight
+ * span (m) along the slope's horizontal projection.
+ */
+export function designStair(p: {
+  span: number; t: number; R: number; G: number;
+  fc: number; fy: number; barDia: number; distBarDia?: number; cover: number;
+  finishes: number; live: number; support?: StairSupport; gammaC?: number;
+}): StairDesign {
+  const support = p.support ?? 'simple'
+  const geom = stairGeometry(p.R, p.G)
+  const loads = stairLoads({ t: p.t, R: p.R, G: p.G, finishes: p.finishes, live: p.live, gammaC: p.gammaC })
+
+  const Mu = (loads.wu * p.span ** 2) / momentDenom(support)        // kN·m/m
+  const d = Math.max(p.t - p.cover - p.barDia / 2, 0.5 * p.t)
+  const flex = flexuralSteel({ Mu, b: 1000, d, fc: p.fc, fy: p.fy })
+  const AsMain = Math.max(flex.As, rhoMin(p.fc, p.fy) * 1000 * d)
+
+  // distribution steel: 0.0018·Ag (Grade-420 shrinkage/temperature, §424.4.3.2)
+  const AsDist = 0.0018 * 1000 * p.t
+  const distDia = p.distBarDia ?? 10
+
+  const sMax = Math.min(3 * p.t, 450)
+  const spacing = (dia: number, As: number) => {
+    const Ab = (Math.PI / 4) * dia ** 2
+    return As > 0 ? Math.max(50, Math.min(sMax, Math.floor((1000 * Ab) / As / 5) * 5)) : sMax
+  }
+
+  const tMin = (p.span * 1000) / thicknessDenom(support)
+  return {
+    geom: { thetaDeg: geom.thetaDeg, cosTheta: geom.cosTheta },
+    loads, Mu, d,
+    AsMain, mainSpacing: spacing(p.barDia, AsMain),
+    AsDist, distSpacing: spacing(distDia, AsDist),
+    tMin, tMinOK: p.t >= tMin - 1e-9,
+    ok: flex.As > 0 && d > 0,
+  }
+}

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -27,6 +27,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/truss',         name: 'Truss Space',        sub: 'Plane truss solver'    },
       { to: '/steel',         name: 'Steel Design',       sub: 'AISC 360-16 LRFD'      },
       { to: '/slab-design',   name: 'Slab Design',        sub: 'Two-way DDM · ACI 318'  },
+      { to: '/stair',         name: 'Stair Design',       sub: 'RC waist slab · NSCP'   },
       { to: '/torsion',       name: 'Torsion Design',     sub: 'RC torsion · ACI 318-14' },
       { to: '/dev-length',    name: 'Dev & Splice',       sub: 'ACI 318-14 §25.4–25.5'   },
       { to: '/punching-shear', name: 'Punching Shear',   sub: 'Two-way §22.6 · ACI 318' },

--- a/webapp/src/pages/StairDesign.tsx
+++ b/webapp/src/pages/StairDesign.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react'
+import { designStair, type StairSupport } from '../engine/stair'
+
+function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
+const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
+const f0 = (n: number) => (Number.isFinite(n) ? Math.round(n).toString() : '—')
+
+function Field({ label, value, onChange, unit, step = 'any' }: {
+  label: string; value: number; onChange: (v: number) => void; unit?: string; step?: string
+}) {
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="mb-1 font-medium text-slate-600">{label}{unit ? ` (${unit})` : ''}</span>
+      <input type="number" step={step} value={value} onChange={(e) => onChange(num(e.target.value))}
+        className="rounded-md border border-slate-300 px-2.5 py-1.5" />
+    </label>
+  )
+}
+
+function Out({ label, value, ok }: { label: string; value: string; ok?: boolean }) {
+  return (
+    <div className="flex items-baseline justify-between border-t border-slate-100 py-1 text-sm">
+      <span className="text-slate-500">{label}</span>
+      <span className={`font-mono font-medium ${ok === undefined ? 'text-slate-800' : ok ? 'text-emerald-600' : 'text-red-600'}`}>{value}</span>
+    </div>
+  )
+}
+
+export default function StairDesign() {
+  const [span, setSpan] = useState(3.5)
+  const [t, setT] = useState(150)
+  const [R, setR] = useState(150)
+  const [G, setG] = useState(300)
+  const [fc, setFc] = useState(28)
+  const [fy, setFy] = useState(415)
+  const [barDia, setBarDia] = useState(12)
+  const [cover, setCover] = useState(20)
+  const [finishes, setFinishes] = useState(1.5)
+  const [live, setLive] = useState(4.8)
+  const [support, setSupport] = useState<StairSupport>('simple')
+
+  const r = designStair({ span, t, R, G, fc, fy, barDia, cover, finishes, live, support })
+
+  return (
+    <main className="mx-auto max-w-3xl px-5 py-10">
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">Structural</p>
+      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">RC stair flight — waist slab</h1>
+      <p className="mt-2 text-sm text-slate-600">
+        One-way waist-slab stair to NSCP 2015 / ACI 318-14. Self-weight of the inclined waist plus
+        triangular treads, finishes, and the NSCP 205 stair live load (4.8 kPa), designed per metre width.
+      </p>
+
+      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Geometry &amp; loads</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Field label="Flight span" unit="m" value={span} onChange={setSpan} />
+          <Field label="Waist t" unit="mm" value={t} onChange={setT} />
+          <Field label="Riser R" unit="mm" value={R} onChange={setR} />
+          <Field label="Going G" unit="mm" value={G} onChange={setG} />
+          <Field label="Finishes" unit="kPa" value={finishes} onChange={setFinishes} />
+          <Field label="Live load" unit="kPa" value={live} onChange={setLive} />
+          <label className="flex flex-col text-sm">
+            <span className="mb-1 font-medium text-slate-600">Support</span>
+            <select value={support} onChange={(e) => setSupport(e.target.value as StairSupport)}
+              className="rounded-md border border-slate-300 px-2.5 py-1.5">
+              <option value="simple">Simply supported</option>
+              <option value="one-end">One end continuous</option>
+              <option value="both-ends">Both ends continuous</option>
+            </select>
+          </label>
+        </div>
+        <h2 className="mb-3 mt-5 text-[1.05rem] font-bold text-[#0056b3]">Materials</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Field label="f′c" unit="MPa" value={fc} onChange={setFc} />
+          <Field label="fy" unit="MPa" value={fy} onChange={setFy} />
+          <Field label="Main bar Ø" unit="mm" value={barDia} onChange={setBarDia} />
+          <Field label="Cover" unit="mm" value={cover} onChange={setCover} />
+        </div>
+      </section>
+
+      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Results</h2>
+        <Out label="Slope θ" value={`${f2(r.geom.thetaDeg)}°`} />
+        <Out label="Dead / Live" value={`${f2(r.loads.dead)} / ${f2(r.loads.live)} kPa`} />
+        <Out label="Factored wu" value={`${f2(r.loads.wu)} kPa`} />
+        <Out label="Design Mu" value={`${f2(r.Mu)} kN·m/m`} />
+        <Out label="Effective depth d" value={`${f0(r.d)} mm`} />
+        <Out label="Main steel As" value={`${f0(r.AsMain)} mm²/m`} />
+        <Out label="Main bars" value={`⌀${barDia} @ ${f0(r.mainSpacing)} mm`} />
+        <Out label="Distribution steel" value={`${f0(r.AsDist)} mm²/m — ⌀10 @ ${f0(r.distSpacing)} mm`} />
+        <Out label="Min. waist (ℓ/20…ℓ/28)" value={`${f0(r.tMin)} mm`} ok={r.tMinOK} />
+        <p className="mt-2 text-[10px] text-slate-400">
+          Mu = wu·ℓ²/k (k = 8/9/11 by support). Distribution steel 0.0018·b·t (§424.4.3.2); spacing capped
+          at min(3t, 450). Verify the landing and support detailing separately.
+        </p>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

Adds the **stair design** the roadmap lists under Phase 3 (Structural). One-way waist-slab flight to NSCP 2015 / ACI 318-14, designed per metre width.

## Engine (`stair.ts`)
- `stairGeometry` — slope θ, cosθ, slope factor from riser/going.
- `stairLoads` — waist self-weight `γc·t/cosθ` + triangular treads `γc·R/2` + finishes + the NSCP 205 stair live load (4.8 kPa); `wu = 1.2D + 1.6L`.
- `designStair` — `Mu = wu·ℓ²/k` (k = 8/9/11 by support); main steel via `flexuralSteel` with a ρ_min floor; `0.0018·b·t` distribution steel (§424.4.3.2); `ℓ/20…ℓ/28` minimum-thickness check; spacing capped at `min(3t, 450)`.

## Tests (+9)
Geometry identities, load composition & sensitivity, `Mu`/`As` match, support-coefficient effect, min-thickness flag, spacing cap.

## UI
`pages/StairDesign.tsx` + `/stair` route + a Structural nav entry — geometry/loads/materials inputs with live results (slope, loads, Mu, steel, spacing, min thickness).

Verified: `npm test` (888 passing), `npx tsc -b`, `npm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_