### PR TITLE
feat: micropile axial design (FHWA) — roadmap Phase 3 geotech

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -25,6 +25,7 @@ import RetainingWall from './pages/RetainingWall'
 import Geotech from './pages/Geotech'
 import SoilNail from './pages/SoilNail'
 import StairDesign from './pages/StairDesign'
+import Micropile from './pages/Micropile'
 import SlabEstimate from './pages/SlabEstimate'
 import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
@@ -69,6 +70,7 @@ export default function App() {
         <Route path="/geotech" element={<Geotech />} />
         <Route path="/soil-nail" element={<SoilNail />} />
         <Route path="/stair" element={<StairDesign />} />
+        <Route path="/micropile" element={<Micropile />} />
         <Route path="/estimate/slab" element={<SlabEstimate />} />
         <Route path="/estimate/beam" element={<BeamEstimate />} />
         <Route path="/estimate/column" element={<ColumnEstimate />} />

--- a/webapp/src/engine/micropile.test.ts
+++ b/webapp/src/engine/micropile.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import {
+  micropileAreas, micropileStructural, micropileBond, requiredBondLength, designMicropile,
+  type MicropileSection,
+} from './micropile'
+
+const area = (d: number) => (Math.PI / 4) * d * d
+const sec: MicropileSection = { barDia: 32, fyBar: 520, groutDia: 150, fcGrout: 28 }
+const cased: MicropileSection = { ...sec, casingOD: 140, casingID: 125, fyCasing: 552 }
+
+describe('micropileAreas', () => {
+  it('bar, casing ring and net grout areas', () => {
+    const a = micropileAreas(cased)
+    expect(a.Abar).toBeCloseTo(area(32), 6)
+    expect(a.Acasing).toBeCloseTo(area(140) - area(125), 6)
+    expect(a.Agrout).toBeCloseTo(area(150) - a.Abar - a.Acasing, 6)
+  })
+  it('no casing ⇒ Acasing = 0', () => {
+    expect(micropileAreas(sec).Acasing).toBe(0)
+  })
+})
+
+describe('micropileStructural (FHWA ASD)', () => {
+  it('compression = 0.40·f′c·Agrout + 0.47·Fy·As', () => {
+    const a = micropileAreas(sec)
+    const expected = (0.40 * 28 * a.Agrout + 0.47 * 520 * a.Abar) / 1000
+    expect(micropileStructural(sec, 'compression')).toBeCloseTo(expected, 6)
+  })
+  it('tension = 0.55·Fy·As (grout carries none)', () => {
+    const a = micropileAreas(sec)
+    expect(micropileStructural(sec, 'tension')).toBeCloseTo((0.55 * 520 * a.Abar) / 1000, 6)
+  })
+  it('compression exceeds tension; a casing adds capacity', () => {
+    expect(micropileStructural(sec, 'compression')).toBeGreaterThan(micropileStructural(sec, 'tension'))
+    expect(micropileStructural(cased, 'compression')).toBeGreaterThan(micropileStructural(sec, 'compression'))
+  })
+})
+
+describe('micropileBond', () => {
+  it('Qult = π·Dbond·Lbond·αbond; Qall = Qult/FS', () => {
+    const r = micropileBond({ bondDia: 0.15, bondLength: 8, alphaBond: 150, FS: 2 })
+    expect(r.Qult).toBeCloseTo(Math.PI * 0.15 * 8 * 150, 6)
+    expect(r.Qall).toBeCloseTo(r.Qult / 2, 9)
+  })
+  it('requiredBondLength round-trips to the demand at the FS', () => {
+    const Le = requiredBondLength({ P: 300, bondDia: 0.15, alphaBond: 150, FS: 2 })
+    const r = micropileBond({ bondDia: 0.15, bondLength: Le, alphaBond: 150, FS: 2 })
+    expect(r.Qall).toBeCloseTo(300, 6)
+  })
+})
+
+describe('designMicropile', () => {
+  const base = {
+    section: sec, mode: 'compression' as const,
+    bondDia: 0.15, bondLength: 8, alphaBond: 150, FS: 2, P: 400,
+  }
+  it('governing allowable is the smaller of structural and bond', () => {
+    const r = designMicropile(base)
+    expect(r.allowable).toBeCloseTo(Math.min(r.structural, r.Qbond), 9)
+    expect(r.governs).toBe(r.structural <= r.Qbond ? 'structural' : 'bond')
+  })
+  it('FS = allowable/demand and OK flag', () => {
+    const r = designMicropile(base)
+    expect(r.fs).toBeCloseTo(r.allowable / 400, 9)
+    expect(r.ok).toBe(r.allowable >= 400)
+  })
+  it('a short bond zone makes bond govern; lengthening it relieves it', () => {
+    const short = designMicropile({ ...base, bondLength: 2 })
+    const long = designMicropile({ ...base, bondLength: 12 })
+    expect(short.Qbond).toBeLessThan(long.Qbond)
+    expect(short.governs).toBe('bond')
+  })
+})

--- a/webapp/src/engine/micropile.ts
+++ b/webapp/src/engine/micropile.ts
@@ -1,0 +1,81 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Micropile — structural & geotechnical axial capacity (FHWA-NHI-05-039).
+// A small-diameter drilled, grouted, reinforced pile. Allowable-stress design:
+//   Structural compression  Pc,allow = 0.40·f′c·Agrout + 0.47·(Fy,bar·Abar + Fy,cas·Acas)
+//   Structural tension       Pt,allow = 0.55·(Fy,bar·Abar + Fy,cas·Acas)   (grout: no tension)
+//   Geotechnical bond        Qg = π·Dbond·Lbond·αbond ,  allow = Qg / FS
+// where αbond = grout-to-ground ultimate bond strength (kPa), Dbond the bond-zone
+// (drill) diameter, Lbond the bonded length. Governing axial allowable is the
+// smaller of the structural and geotechnical values.
+// Units: Ø/areas mm·mm²; f′c/Fy MPa; αbond kPa; lengths m; capacity kN.
+// ─────────────────────────────────────────────────────────────────────────
+
+const area = (dia: number) => (Math.PI / 4) * dia * dia      // mm²
+
+export interface MicropileSection {
+  barDia: number; fyBar: number               // reinforcing bar
+  groutDia: number; fcGrout: number           // grout column (drill ID), MPa
+  casingOD?: number; casingID?: number; fyCasing?: number   // optional steel casing
+}
+
+export interface MicropileAreas { Abar: number; Acasing: number; Agrout: number }
+
+/** Component areas (mm²): bar, casing (OD²−ID² ring), and net grout. */
+export function micropileAreas(s: MicropileSection): MicropileAreas {
+  const Abar = area(s.barDia)
+  const Acasing = s.casingOD && s.casingID ? area(s.casingOD) - area(s.casingID) : 0
+  const Agrout = Math.max(area(s.groutDia) - Abar - Acasing, 0)
+  return { Abar, Acasing, Agrout }
+}
+
+/** Allowable structural axial capacity (kN), compression or tension (FHWA ASD). */
+export function micropileStructural(s: MicropileSection, mode: 'compression' | 'tension'): number {
+  const { Abar, Acasing, Agrout } = micropileAreas(s)
+  const fyCas = s.fyCasing ?? 248
+  const steel = s.fyBar * Abar + fyCas * Acasing
+  const P = mode === 'compression'
+    ? 0.40 * s.fcGrout * Agrout + 0.47 * steel
+    : 0.55 * steel                                  // grout carries no tension
+  return P / 1000                                   // N → kN
+}
+
+/** Geotechnical grout-ground bond capacity: ultimate and allowable (kN). */
+export function micropileBond(p: { bondDia: number; bondLength: number; alphaBond: number; FS?: number }): { Qult: number; Qall: number } {
+  const Qult = Math.PI * p.bondDia * p.bondLength * p.alphaBond    // kN (m·m·kPa)
+  return { Qult, Qall: Qult / (p.FS ?? 2.0) }
+}
+
+/** Bonded length (m) needed so the allowable bond carries the demand P. */
+export function requiredBondLength(p: { P: number; bondDia: number; alphaBond: number; FS?: number }): number {
+  const denom = Math.PI * p.bondDia * p.alphaBond
+  return denom > 0 ? (p.P * (p.FS ?? 2.0)) / denom : Infinity
+}
+
+export interface MicropileResult {
+  areas: MicropileAreas
+  structural: number          // allowable structural, kN
+  Qult: number; Qbond: number // bond ultimate & allowable, kN
+  allowable: number           // governing min(structural, bond), kN
+  governs: 'structural' | 'bond'
+  fs: number                  // governing allowable / demand
+  bondLengthReq: number       // m, for the bond FS at demand
+  ok: boolean
+}
+
+/** Design a micropile: governing allowable vs the axial demand P (kN). */
+export function designMicropile(p: {
+  section: MicropileSection; mode: 'compression' | 'tension';
+  bondDia: number; bondLength: number; alphaBond: number; FS?: number; P: number;
+}): MicropileResult {
+  const structural = micropileStructural(p.section, p.mode)
+  const { Qult, Qall } = micropileBond({ bondDia: p.bondDia, bondLength: p.bondLength, alphaBond: p.alphaBond, FS: p.FS })
+  const allowable = Math.min(structural, Qall)
+  const governs = structural <= Qall ? 'structural' : 'bond'
+  return {
+    areas: micropileAreas(p.section),
+    structural, Qult, Qbond: Qall, allowable, governs,
+    fs: p.P > 0 ? allowable / p.P : Infinity,
+    bondLengthReq: requiredBondLength({ P: p.P, bondDia: p.bondDia, alphaBond: p.alphaBond, FS: p.FS }),
+    ok: allowable >= p.P,
+  }
+}

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -34,6 +34,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/retaining-wall',   name: 'Retaining Wall',   sub: 'Cantilever · Rankine'     },
       { to: '/geotech',          name: 'Geotechnical',     sub: 'Bearing · earth · slope'  },
       { to: '/soil-nail',        name: 'Soil-Nail Wall',   sub: 'FHWA · tensile · pullout' },
+      { to: '/micropile',        name: 'Micropile',        sub: 'FHWA · structural · bond' },
       { to: '/load-combinations', name: 'Load Combinations', sub: 'NSCP 2015 §203.3 LRFD'   },
     ],
   },

--- a/webapp/src/pages/Micropile.tsx
+++ b/webapp/src/pages/Micropile.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react'
+import { designMicropile } from '../engine/micropile'
+
+function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
+const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
+const f0 = (n: number) => (Number.isFinite(n) ? Math.round(n).toString() : '—')
+
+function Field({ label, value, onChange, unit, step = 'any' }: {
+  label: string; value: number; onChange: (v: number) => void; unit?: string; step?: string
+}) {
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="mb-1 font-medium text-slate-600">{label}{unit ? ` (${unit})` : ''}</span>
+      <input type="number" step={step} value={value} onChange={(e) => onChange(num(e.target.value))}
+        className="rounded-md border border-slate-300 px-2.5 py-1.5" />
+    </label>
+  )
+}
+
+function Out({ label, value, ok }: { label: string; value: string; ok?: boolean }) {
+  return (
+    <div className="flex items-baseline justify-between border-t border-slate-100 py-1 text-sm">
+      <span className="text-slate-500">{label}</span>
+      <span className={`font-mono font-medium ${ok === undefined ? 'text-slate-800' : ok ? 'text-emerald-600' : 'text-red-600'}`}>{value}</span>
+    </div>
+  )
+}
+
+export default function Micropile() {
+  const [barDia, setBarDia] = useState(32)
+  const [fyBar, setFyBar] = useState(520)
+  const [groutDia, setGroutDia] = useState(150)
+  const [fcGrout, setFcGrout] = useState(28)
+  const [casing, setCasing] = useState(false)
+  const [casingOD, setCasingOD] = useState(140)
+  const [casingID, setCasingID] = useState(125)
+  const [fyCasing, setFyCasing] = useState(552)
+  const [mode, setMode] = useState<'compression' | 'tension'>('compression')
+  const [bondDia, setBondDia] = useState(0.15)
+  const [bondLength, setBondLength] = useState(8)
+  const [alphaBond, setAlphaBond] = useState(150)
+  const [P, setP] = useState(400)
+
+  const r = designMicropile({
+    section: { barDia, fyBar, groutDia, fcGrout, ...(casing ? { casingOD, casingID, fyCasing } : {}) },
+    mode, bondDia, bondLength, alphaBond, FS: 2, P,
+  })
+
+  return (
+    <main className="mx-auto max-w-3xl px-5 py-10">
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">Geotechnical</p>
+      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Micropile — axial capacity</h1>
+      <p className="mt-2 text-sm text-slate-600">
+        FHWA-NHI-05-039 allowable-stress check: structural capacity of the bar/casing/grout vs the
+        grout-ground bond capacity of the bonded zone. Governing allowable = the smaller of the two.
+      </p>
+
+      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Section</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Field label="Bar Ø" unit="mm" value={barDia} onChange={setBarDia} />
+          <Field label="Fy bar" unit="MPa" value={fyBar} onChange={setFyBar} />
+          <Field label="Grout Ø (drill)" unit="mm" value={groutDia} onChange={setGroutDia} />
+          <Field label="f′c grout" unit="MPa" value={fcGrout} onChange={setFcGrout} />
+        </div>
+        <label className="mt-3 flex items-center gap-2 text-sm">
+          <input type="checkbox" checked={casing} onChange={(e) => setCasing(e.target.checked)} />
+          <span>Permanent steel casing</span>
+        </label>
+        {casing && (
+          <div className="mt-2 grid grid-cols-2 gap-3 sm:grid-cols-3">
+            <Field label="Casing OD" unit="mm" value={casingOD} onChange={setCasingOD} />
+            <Field label="Casing ID" unit="mm" value={casingID} onChange={setCasingID} />
+            <Field label="Fy casing" unit="MPa" value={fyCasing} onChange={setFyCasing} />
+          </div>
+        )}
+        <h2 className="mb-3 mt-5 text-[1.05rem] font-bold text-[#0056b3]">Bond zone &amp; demand</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <label className="flex flex-col text-sm">
+            <span className="mb-1 font-medium text-slate-600">Load mode</span>
+            <select value={mode} onChange={(e) => setMode(e.target.value as 'compression' | 'tension')}
+              className="rounded-md border border-slate-300 px-2.5 py-1.5">
+              <option value="compression">Compression</option>
+              <option value="tension">Tension</option>
+            </select>
+          </label>
+          <Field label="Bond Ø" unit="m" value={bondDia} onChange={setBondDia} step="0.01" />
+          <Field label="Bond length" unit="m" value={bondLength} onChange={setBondLength} />
+          <Field label="αbond" unit="kPa" value={alphaBond} onChange={setAlphaBond} />
+          <Field label="Axial demand P" unit="kN" value={P} onChange={setP} />
+        </div>
+      </section>
+
+      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Results</h2>
+        <Out label="Structural allowable" value={`${f0(r.structural)} kN`} />
+        <Out label="Bond Qult / allowable (FS 2)" value={`${f0(r.Qult)} / ${f0(r.Qbond)} kN`} />
+        <Out label={`Governing allowable (${r.governs})`} value={`${f0(r.allowable)} kN`} />
+        <Out label="FS (allowable / demand)" value={f2(r.fs)} ok={r.ok} />
+        <Out label="Bond length for FS = 2" value={`${f2(r.bondLengthReq)} m`} ok={bondLength >= r.bondLengthReq} />
+        <p className="mt-2 text-[10px] text-slate-400">
+          Structural: 0.40·f′c·Agrout + 0.47·Fy·As (compression), 0.55·Fy·As (tension). Bond:
+          π·Dbond·Lbond·αbond / FS. Verify buckling in very soft soils and group/settlement effects separately.
+        </p>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

Adds the **micropile** module from roadmap Phase 3 (Geotechnical) — FHWA-NHI-05-039 allowable-stress axial design, complementing the soil-nail tool.

## Engine (`micropile.ts`)
- `micropileAreas` — bar, casing ring (`OD²−ID²`), and net grout areas.
- `micropileStructural` — compression `0.40·f′c·Agrout + 0.47·Fy·As`; tension `0.55·Fy·As` (grout carries none); optional permanent steel casing adds to both.
- `micropileBond` — grout-ground `Qult = π·Dbond·Lbond·αbond`, allowable `Qult/FS`.
- `requiredBondLength`; `designMicropile` — governing allowable = `min(structural, bond)` vs the axial demand, with FoS, governing-mode and OK flag.

## Tests (+10)
Areas, structural compression/tension & casing contribution, bond scaling, `requiredBondLength` round-trip, governing logic, FoS.

## UI
`pages/Micropile.tsx` + `/micropile` route + a Structural nav entry — section (bar/casing/grout), bond zone and demand inputs with live capacities and required bond length.

Verified: `npm test` (898 passing), `npx tsc -b`, `npm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_