### PR TITLE
feat: rock/ground anchor design (PTI/FHWA) — roadmap Phase 3 geotech

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -26,6 +26,7 @@ import Geotech from './pages/Geotech'
 import SoilNail from './pages/SoilNail'
 import StairDesign from './pages/StairDesign'
 import Micropile from './pages/Micropile'
+import RockAnchor from './pages/RockAnchor'
 import SlabEstimate from './pages/SlabEstimate'
 import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
@@ -71,6 +72,7 @@ export default function App() {
         <Route path="/soil-nail" element={<SoilNail />} />
         <Route path="/stair" element={<StairDesign />} />
         <Route path="/micropile" element={<Micropile />} />
+        <Route path="/rock-anchor" element={<RockAnchor />} />
         <Route path="/estimate/slab" element={<SlabEstimate />} />
         <Route path="/estimate/beam" element={<BeamEstimate />} />
         <Route path="/estimate/column" element={<ColumnEstimate />} />

--- a/webapp/src/engine/rockAnchor.test.ts
+++ b/webapp/src/engine/rockAnchor.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { tendonCapacity, groundBondCapacity, requiredBondLength, designRockAnchor } from './rockAnchor'
+
+describe('tendonCapacity', () => {
+  it('GUTS = fpu·Aps; Td = 0.60·GUTS', () => {
+    const r = tendonCapacity({ fpu: 1860, Aps: 1000 })
+    expect(r.GUTS).toBeCloseTo((1860 * 1000) / 1000, 6)     // 1860 kN
+    expect(r.Td).toBeCloseTo(0.6 * r.GUTS, 9)
+  })
+  it('a custom design factor scales the design load', () => {
+    expect(tendonCapacity({ fpu: 1860, Aps: 1000, designFactor: 0.5 }).Td).toBeCloseTo(0.5 * 1860, 6)
+  })
+})
+
+describe('groundBondCapacity', () => {
+  it('Qult = π·Dhole·Lbond·τult; Qall = Qult/FS', () => {
+    const r = groundBondCapacity({ holeDia: 0.115, bondLength: 6, tauUlt: 700, FS: 2 })
+    expect(r.Qult).toBeCloseTo(Math.PI * 0.115 * 6 * 700, 6)
+    expect(r.Qall).toBeCloseTo(r.Qult / 2, 9)
+  })
+  it('requiredBondLength round-trips to the demand at the FS', () => {
+    const Le = requiredBondLength({ T: 500, holeDia: 0.115, tauUlt: 700, FS: 2 })
+    const r = groundBondCapacity({ holeDia: 0.115, bondLength: Le, tauUlt: 700, FS: 2 })
+    expect(r.Qall).toBeCloseTo(500, 6)
+  })
+})
+
+describe('designRockAnchor', () => {
+  const base = { fpu: 1860, Aps: 1000, holeDia: 0.115, bondLength: 6, tauUlt: 700, FS: 2, T: 600 }
+  it('governing allowable is the smaller of tendon design load and ground bond', () => {
+    const r = designRockAnchor(base)
+    expect(r.allowable).toBeCloseTo(Math.min(r.Td, r.Qall), 9)
+    expect(r.governs).toBe(r.Td <= r.Qall ? 'tendon' : 'bond')
+  })
+  it('proof/test load = min(1.33·T, 0.80·GUTS)', () => {
+    const r = designRockAnchor(base)
+    expect(r.testLoad).toBeCloseTo(Math.min(1.33 * 600, 0.8 * r.GUTS), 6)
+  })
+  it('FS = allowable/demand, with mode OK flags', () => {
+    const r = designRockAnchor(base)
+    expect(r.fs).toBeCloseTo(r.allowable / 600, 9)
+    expect(r.tendonOK).toBe(r.Td >= 600)
+    expect(r.bondOK).toBe(r.Qall >= 600)
+    expect(r.ok).toBe(r.allowable >= 600)
+  })
+  it('a short bond zone makes bond govern; lengthening it relieves it', () => {
+    const short = designRockAnchor({ ...base, bondLength: 1.5 })
+    const long = designRockAnchor({ ...base, bondLength: 10 })
+    expect(short.Qall).toBeLessThan(long.Qall)
+    expect(short.governs).toBe('bond')
+  })
+})

--- a/webapp/src/engine/rockAnchor.ts
+++ b/webapp/src/engine/rockAnchor.ts
@@ -1,0 +1,59 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Rock / ground anchor — tendon & grout-ground bond capacity.
+// PTI DC35.1 / FHWA-IF-99-015 (Ground Anchors and Anchored Systems).
+//   GUTS  = fpu · Aps                              (guaranteed ultimate strength)
+//   Tendon design  Td = 0.60·GUTS                  (max design load, permanent)
+//   Proof/test     Tt = min(1.33·T, 0.80·GUTS)     (field acceptance)
+//   Ground bond    Qult = π·Dhole·Lbond·τult ,  allow = Qult / FS  (FS ≥ 2 perm.)
+// Anchor is adequate when the applied design tension T ≤ the tendon design load
+// AND ≤ the allowable ground-bond capacity. Governing = the smaller capacity.
+// Units: fpu MPa; Aps mm²; Ø/lengths m; τult kPa; forces kN.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Guaranteed ultimate tensile strength (kN) and the 0.60·GUTS design load. */
+export function tendonCapacity(p: { fpu: number; Aps: number; designFactor?: number }): { GUTS: number; Td: number } {
+  const GUTS = (p.fpu * p.Aps) / 1000          // kN
+  return { GUTS, Td: (p.designFactor ?? 0.60) * GUTS }
+}
+
+/** Grout-ground (rock socket) bond: ultimate and allowable capacity (kN). */
+export function groundBondCapacity(p: { holeDia: number; bondLength: number; tauUlt: number; FS?: number }): { Qult: number; Qall: number } {
+  const Qult = Math.PI * p.holeDia * p.bondLength * p.tauUlt    // kN (m·m·kPa)
+  return { Qult, Qall: Qult / (p.FS ?? 2.0) }
+}
+
+/** Bond length (m) needed so the allowable ground bond carries the demand T. */
+export function requiredBondLength(p: { T: number; holeDia: number; tauUlt: number; FS?: number }): number {
+  const denom = Math.PI * p.holeDia * p.tauUlt
+  return denom > 0 ? (p.T * (p.FS ?? 2.0)) / denom : Infinity
+}
+
+export interface RockAnchorResult {
+  GUTS: number; Td: number          // tendon strength & design load, kN
+  testLoad: number                  // proof/acceptance load, kN
+  Qult: number; Qall: number        // ground bond, kN
+  allowable: number                 // governing min(Td, Qall), kN
+  governs: 'tendon' | 'bond'
+  fs: number                        // governing allowable / demand
+  bondLengthReq: number             // m, for the bond FS at demand
+  tendonOK: boolean; bondOK: boolean; ok: boolean
+}
+
+/** Design a rock anchor: demand T (kN) vs tendon design load and ground bond. */
+export function designRockAnchor(p: {
+  fpu: number; Aps: number;
+  holeDia: number; bondLength: number; tauUlt: number; FS?: number;
+  T: number; designFactor?: number;
+}): RockAnchorResult {
+  const { GUTS, Td } = tendonCapacity({ fpu: p.fpu, Aps: p.Aps, designFactor: p.designFactor })
+  const { Qult, Qall } = groundBondCapacity({ holeDia: p.holeDia, bondLength: p.bondLength, tauUlt: p.tauUlt, FS: p.FS })
+  const allowable = Math.min(Td, Qall)
+  const governs = Td <= Qall ? 'tendon' : 'bond'
+  const testLoad = Math.min(1.33 * p.T, 0.80 * GUTS)
+  return {
+    GUTS, Td, testLoad, Qult, Qall, allowable, governs,
+    fs: p.T > 0 ? allowable / p.T : Infinity,
+    bondLengthReq: requiredBondLength({ T: p.T, holeDia: p.holeDia, tauUlt: p.tauUlt, FS: p.FS }),
+    tendonOK: Td >= p.T, bondOK: Qall >= p.T, ok: allowable >= p.T,
+  }
+}

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -35,6 +35,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/geotech',          name: 'Geotechnical',     sub: 'Bearing · earth · slope'  },
       { to: '/soil-nail',        name: 'Soil-Nail Wall',   sub: 'FHWA · tensile · pullout' },
       { to: '/micropile',        name: 'Micropile',        sub: 'FHWA · structural · bond' },
+      { to: '/rock-anchor',      name: 'Rock Anchor',      sub: 'PTI · tendon · bond'      },
       { to: '/load-combinations', name: 'Load Combinations', sub: 'NSCP 2015 §203.3 LRFD'   },
     ],
   },

--- a/webapp/src/pages/RockAnchor.tsx
+++ b/webapp/src/pages/RockAnchor.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react'
+import { designRockAnchor } from '../engine/rockAnchor'
+
+function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
+const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
+const f0 = (n: number) => (Number.isFinite(n) ? Math.round(n).toString() : '—')
+
+function Field({ label, value, onChange, unit, step = 'any' }: {
+  label: string; value: number; onChange: (v: number) => void; unit?: string; step?: string
+}) {
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="mb-1 font-medium text-slate-600">{label}{unit ? ` (${unit})` : ''}</span>
+      <input type="number" step={step} value={value} onChange={(e) => onChange(num(e.target.value))}
+        className="rounded-md border border-slate-300 px-2.5 py-1.5" />
+    </label>
+  )
+}
+
+function Out({ label, value, ok }: { label: string; value: string; ok?: boolean }) {
+  return (
+    <div className="flex items-baseline justify-between border-t border-slate-100 py-1 text-sm">
+      <span className="text-slate-500">{label}</span>
+      <span className={`font-mono font-medium ${ok === undefined ? 'text-slate-800' : ok ? 'text-emerald-600' : 'text-red-600'}`}>{value}</span>
+    </div>
+  )
+}
+
+export default function RockAnchor() {
+  const [fpu, setFpu] = useState(1860)
+  const [Aps, setAps] = useState(1000)
+  const [holeDia, setHoleDia] = useState(0.115)
+  const [bondLength, setBondLength] = useState(6)
+  const [tauUlt, setTauUlt] = useState(700)
+  const [T, setT] = useState(600)
+
+  const r = designRockAnchor({ fpu, Aps, holeDia, bondLength, tauUlt, FS: 2, T })
+
+  return (
+    <main className="mx-auto max-w-3xl px-5 py-10">
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">Geotechnical</p>
+      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Rock / ground anchor</h1>
+      <p className="mt-2 text-sm text-slate-600">
+        PTI DC35.1 / FHWA-IF-99-015 check: prestressing-tendon design load (0.60·GUTS) and grout-ground
+        (rock socket) bond capacity vs the applied anchor tension. Governing allowable = the smaller.
+      </p>
+
+      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Tendon &amp; bond zone</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          <Field label="fpu" unit="MPa" value={fpu} onChange={setFpu} />
+          <Field label="Tendon area Aps" unit="mm²" value={Aps} onChange={setAps} />
+          <Field label="Axial demand T" unit="kN" value={T} onChange={setT} />
+          <Field label="Hole Ø" unit="m" value={holeDia} onChange={setHoleDia} step="0.005" />
+          <Field label="Bond length" unit="m" value={bondLength} onChange={setBondLength} />
+          <Field label="Bond τult" unit="kPa" value={tauUlt} onChange={setTauUlt} />
+        </div>
+      </section>
+
+      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Results</h2>
+        <Out label="GUTS = fpu·Aps" value={`${f0(r.GUTS)} kN`} />
+        <Out label="Tendon design load (0.60·GUTS)" value={`${f0(r.Td)} kN`} ok={r.tendonOK} />
+        <Out label="Bond Qult / allowable (FS 2)" value={`${f0(r.Qult)} / ${f0(r.Qall)} kN`} ok={r.bondOK} />
+        <Out label={`Governing allowable (${r.governs})`} value={`${f0(r.allowable)} kN`} ok={r.ok} />
+        <Out label="FS (allowable / demand)" value={f2(r.fs)} ok={r.ok} />
+        <Out label="Proof/test load" value={`${f0(r.testLoad)} kN`} />
+        <Out label="Bond length for FS = 2" value={`${f2(r.bondLengthReq)} m`} ok={bondLength >= r.bondLengthReq} />
+        <p className="mt-2 text-[10px] text-slate-400">
+          Td = 0.60·GUTS (PTI permanent max). Bond Qult = π·Dhole·Lbond·τult / FS. Proof load
+          min(1.33·T, 0.80·GUTS). Provide the unbonded (free) length and corrosion protection separately.
+        </p>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

Adds the **rock/ground anchor** module from roadmap Phase 3 (Geotechnical), following the soil-nail/micropile pattern.

## Engine (`rockAnchor.ts`)
- `tendonCapacity` — `GUTS = fpu·Aps`, design load `Td = 0.60·GUTS` (PTI permanent max).
- `groundBondCapacity` — rock-socket `Qult = π·Dhole·Lbond·τult`, allowable `Qult/FS`.
- `requiredBondLength`; `designRockAnchor` — governing allowable = `min(Td, bond)` vs the applied tension, proof/test load `min(1.33·T, 0.80·GUTS)`, FoS and mode OK flags.

## Tests (+8)
`GUTS`/`Td`, bond scaling, `requiredBondLength` round-trip, governing logic, proof load, FoS.

## UI
`pages/RockAnchor.tsx` + `/rock-anchor` route + a Structural nav entry — tendon & bond-zone inputs with live capacities, proof load, and required bond length.

Verified: `npm test` (906 passing), `npx tsc -b`, `npm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_