### PR TITLE
docs+feat: Validation Manual ch.1 (frame) + 2 dashboard benchmarks

### DIFF
--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -1,0 +1,31 @@
+# Validation Manual
+
+This directory is the documented validation manual for the analysis and design
+engines. Each chapter states a benchmark as:
+
+> **Problem → Reference solution → Software output → Error % → PASS/FAIL**
+
+The "Software output" column is produced by the same engines the app's design
+pages use. Every benchmark here is also encoded in the automated test suite
+(`webapp/src/engine/validation.ts` + `validation.test.ts`) and surfaced live on
+the in-app **[/validation](../../webapp/src/pages/Validation.tsx)** dashboard with
+per-module pass counts, so the manual cannot silently drift from the code.
+
+## Chapters
+
+| Chapter | Scope | Status |
+| --- | --- | --- |
+| [Frame analysis](./frame.md) | Beam/frame solver vs closed-form elasticity | ✅ |
+| RC design | Beam Mn, column φPn, footing area | in `/validation` (dashboard) |
+| Steel design | φMp, φVn | in `/validation` (dashboard) |
+| Geotechnical | Bearing factors, earth pressure, slope FS | in `/validation` (dashboard) |
+| Modal / response spectrum | Periods, base shear vs ETABS | _planned_ |
+| NSCP seismic | 208 static base shear + distribution | _planned_ |
+
+## Levels of validation
+
+1. **Closed-form** (textbook / code clause) — exact analytical results. Used for
+   beams, columns, footings, single elements, and the frame benchmarks here.
+2. **External tools** (ETABS / STAAD / SAP2000) — for multi-element systems where
+   hand solutions are impractical (space frames, modal, response spectrum). These
+   cross-checks are the planned next step.

--- a/docs/validation/frame.md
+++ b/docs/validation/frame.md
@@ -1,0 +1,55 @@
+# Chapter 1 — Frame analysis
+
+The 3D space-frame solver (`engine/frame3d.ts`) is validated against closed-form
+elasticity for prismatic members. The element is a 12-DOF space-frame element
+(axial + St-Venant torsion + biaxial Hermite bending), so for these load cases it
+reproduces the exact Euler–Bernoulli results to machine precision.
+
+## Common section
+
+| Property | Value |
+| --- | --- |
+| E | 25 000 MPa |
+| Section | 300 × 500 mm (rectangular) |
+| Iz | b·h³/12 = 3.125 × 10⁹ mm⁴ |
+| **EIz** | **78 125 kN·m²** |
+
+## Benchmarks
+
+All "Software" values are produced by `solveFrame3D` and are enforced by
+`webapp/src/engine/validation.ts` / `validation.test.ts` (tolerance shown).
+
+| # | Problem | Reference solution | Formula | Hand value | Software | Error | Result |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Cantilever, tip point load P = 10 kN, L = 3 m — tip deflection | Euler–Bernoulli | δ = P·L³ / (3·E·I) | 1.1520 mm | 1.1520 mm | < 0.01 % | ✅ PASS |
+| 2 | Same — tip rotation | Euler–Bernoulli | θ = P·L² / (2·E·I) | 5.760 × 10⁻⁴ rad | 5.760 × 10⁻⁴ rad | < 0.01 % | ✅ PASS |
+| 3 | Same — fixed-end moment | Statics | M = P·L | 30.00 kN·m | 30.00 kN·m | < 0.01 % | ✅ PASS |
+| 4 | Fixed–fixed beam, central load P = 20 kN, L = 4 m — midspan deflection | Matrix analysis / Roark | δ = P·L³ / (192·E·I) | 0.08533 mm | 0.08533 mm | < 0.1 % | ✅ PASS |
+
+### Worked check — Benchmark 1
+
+```
+δ = P·L³ / (3·E·I)
+  = (10 kN)(3 m)³ / (3 · 78 125 kN·m²)
+  = 270 / 234 375
+  = 1.1520 × 10⁻³ m  = 1.152 mm
+```
+
+The solver returns 1.152 mm (the Hermite cubic is exact for a tip point load), an
+error below 0.01 %.
+
+## Cross-checks already in the test suite
+
+Beyond the dashboard cases above, `frame3d.test.ts` independently verifies:
+
+- a planar portal frame against the 2-D solver (`frame2d`),
+- the second-order P-Δ amplifier against `1 / (1 − P/Pe)`,
+- global statics self-checks (ΣF, ΣM ≈ 0) on assembled models,
+- rigid-floor-diaphragm and rigid-link (member-offset) kinematics.
+
+## Planned (external-tool) cross-checks
+
+For multi-bay, multi-storey **space frames** where hand solutions are
+impractical, the next step is a side-by-side comparison against ETABS / STAAD on
+a documented reference model (member forces, drifts), reported in the same
+Problem → Reference → Software → Error % format.

--- a/webapp/src/engine/validation.ts
+++ b/webapp/src/engine/validation.ts
@@ -54,7 +54,24 @@ const cantilever = (() => {
   return {
     defl: { manual: (P * L ** 3) / (3 * EIz) * 1000, software: Math.abs(res.d[6 + 1]) * 1000 },  // mm
     moment: { manual: P * L, software: Math.abs(res.members[0].Mz[0]) },                          // kN·m
+    slope: { manual: (P * L ** 2) / (2 * EIz), software: Math.abs(res.d[6 + 5]) },                // rad (θz at tip)
   }
+})()
+
+// ── Fixed–fixed beam, central point load — deflection P·L³/192EI ──────────────
+const fixedFixed = (() => {
+  const E = 25000, G = E / 2.4, b = 300, h = 500, L = 4, P = 20
+  const Iz = (b * h ** 3) / 12, Iy = (h * b ** 3) / 12, A = b * h, J = rectJ(b, h)
+  const EIz = (E * Iz) / 1e9
+  const nodes: F3Node[] = [
+    { id: 'a', x: 0, y: 0, z: 0 }, { id: 'c', x: L / 2, y: 0, z: 0 }, { id: 'b', x: L, y: 0, z: 0 },
+  ]
+  const members: F3Member[] = [
+    { id: 'ac', i: 'a', j: 'c', E, G, A, Iy, Iz, J }, { id: 'cb', i: 'c', j: 'b', E, G, A, Iy, Iz, J },
+  ]
+  const supports: F3Support[] = [{ node: 'a', fixity: 'fixed' }, { node: 'b', fixity: 'fixed' }]
+  const res = solveFrame3D(nodes, members, supports, [{ kind: 'node', node: 'c', Fy: -P, cat: 'D' }])!
+  return { manual: (P * L ** 3) / (192 * EIz) * 1000, software: Math.abs(res.d[6 + 1]) * 1000 }  // mm at mid
 })()
 
 // ── 3. Compact steel beam — plastic moment φMp = 0.9·Fy·Zx ───────────────────
@@ -125,6 +142,16 @@ export const VALIDATION_CASES: ValidationCase[] = [
     id: 'cantilever-moment', category: 'Analysis', title: 'Cantilever fixed-end moment',
     reference: 'Statics', formula: 'M = P·L',
     manual: cantilever.moment.manual, software: cantilever.moment.software, unit: 'kN·m', tol: 1e-4,
+  },
+  {
+    id: 'cantilever-slope', category: 'Analysis', title: 'Cantilever tip rotation',
+    reference: 'Hibbeler, Structural Analysis', formula: 'θ = P·L² / (2·E·I)',
+    manual: cantilever.slope.manual, software: cantilever.slope.software, unit: 'rad', tol: 1e-4,
+  },
+  {
+    id: 'fixed-fixed-defl', category: 'Analysis', title: 'Fixed–fixed beam, central load',
+    reference: 'Roark / matrix analysis', formula: 'δ = P·L³ / (192·E·I)',
+    manual: fixedFixed.manual, software: fixedFixed.software, unit: 'mm', tol: 1e-3,
   },
   {
     id: 'steel-phimp', category: 'Steel', title: 'Compact W-beam plastic moment (short Lb)',


### PR DESCRIPTION
## Summary

Starts the **documented validation manual** (roadmap Phase 2 — the review's top priority) and grows the `/validation` dashboard.

## Docs
- **`docs/validation/README.md`** — manual index + a "levels of validation" note (closed-form vs external-tool); ties every chapter to the live `/validation` dashboard and the automated test suite so the manual can't drift from the code.
- **`docs/validation/frame.md`** — **Chapter 1: Frame analysis**. The 3D solver vs closed-form elasticity (cantilever δ/θ/M, fixed-fixed central deflection) in **Problem → Reference → Software → Error % → PASS** format, with a worked check and the existing `frame3d.test.ts` cross-checks (portal vs `frame2d`, P-Δ amplifier, statics, diaphragm/rigid-link). Planned ETABS/STAAD space-frame cross-checks noted.

## Engine
- `engine/validation.ts` — two new benchmarks: cantilever **tip rotation** `θ = P·L²/2EI` and **fixed-fixed** central deflection `δ = P·L³/192EI`. Both computed by `solveFrame3D`, shown on the dashboard and enforced by `validation.test.ts`.

Verified: `npm test` (906 passing), `npx tsc -b`, `npm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_