### PR TITLE
docs+feat: Validation Manual ch.2 (NSCP seismic) + dashboard benchmarks

### DIFF
--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -16,11 +16,11 @@ per-module pass counts, so the manual cannot silently drift from the code.
 | Chapter | Scope | Status |
 | --- | --- | --- |
 | [Frame analysis](./frame.md) | Beam/frame solver vs closed-form elasticity | ✅ |
+| [NSCP seismic](./seismic.md) | 208 static period & base shear + governing logic | ✅ |
 | RC design | Beam Mn, column φPn, footing area | in `/validation` (dashboard) |
 | Steel design | φMp, φVn | in `/validation` (dashboard) |
 | Geotechnical | Bearing factors, earth pressure, slope FS | in `/validation` (dashboard) |
 | Modal / response spectrum | Periods, base shear vs ETABS | _planned_ |
-| NSCP seismic | 208 static base shear + distribution | _planned_ |
 
 ## Levels of validation
 

--- a/docs/validation/seismic.md
+++ b/docs/validation/seismic.md
@@ -1,0 +1,54 @@
+# Chapter 2 — NSCP 208 static seismic
+
+The equivalent-lateral-force engine (`engine/seismic.ts`) implements the NSCP
+2015 §208.5.2 static procedure. Native NSCP support is the platform's core
+differentiator, so this chapter checks the period and base-shear equations and
+documents the governing-case logic.
+
+## Equations (NSCP §208.5.2)
+
+```
+T    = Ct · hn^(3/4)                         (208.5.2.2, Method A; Ct = 0.0731 RC MRF, m)
+V    = Cv·I·W / (R·T)                         (208-8, basic)
+       2.5·Ca·I·W / R   ≥  V  ≥  0.11·Ca·I·W  (208-9 upper, 208-10 lower)
+Zone-4 floor:  V ≥ 0.8·Z·Nv·I·W / R          (208-11)
+```
+
+## Benchmarks (dashboard-enforced)
+
+Reference model: a 6 m × 5 m single-bay frame, two 3 m storeys (hn = 6 m),
+400 × 400 concrete sections; Ca = 0.44, Cv = 0.64, I = 1, R = 8.5. Values come
+from `computeSeismic` and are enforced by `validation.ts` / `validation.test.ts`.
+
+| # | Quantity | Reference | Formula | Result |
+| --- | --- | --- | --- | --- |
+| 1 | Fundamental period T | NSCP 208.5.2.2 | T = 0.0731 · hn^(3/4) | ✅ PASS (< 0.0001 %) |
+| 2 | Basic base shear Vraw | NSCP 208-8 | V = Cv·I·W / (R·T) | ✅ PASS (< 0.0001 %) |
+
+### Worked check — period
+
+```
+hn = 6 m  (two 3 m storeys)
+T  = 0.0731 · 6^(3/4) = 0.0731 · 3.834 = 0.2803 s
+```
+
+The engine returns the same T from the model height, then forms
+`Vraw = Cv·I·W/(R·T)` with the seismic weight W lumped from member/slab masses
+(`buildSeismicMass`).
+
+## Governing-case logic (verified in `seismic.test.ts`)
+
+The design base shear is `V = max(Vmin, Vsrc, min(Vraw, Vmax))`:
+
+- **Vmax** caps `Vraw` for short, stiff buildings (208-9).
+- **Vmin** floors it (208-10).
+- **Vsrc** is the Zone-4 near-source floor (208-11), active only when `Z ≥ 0.4`.
+
+`seismic.test.ts` exercises each branch (cap-governs, floor-governs, Zone-4
+floor) and the vertical force distribution `Fx = (V − Ft)·wx·hx / Σ(wi·hi)` with
+the whip force `Ft = 0.07·T·V` (≤ 0.25 V, zero when T ≤ 0.7 s).
+
+## Planned cross-checks
+
+A worked NSCP example (published textbook / DPWH design aid) and an ETABS model
+with the same parameters, compared on base shear and storey-force distribution.

--- a/webapp/src/engine/validation.ts
+++ b/webapp/src/engine/validation.ts
@@ -15,11 +15,14 @@ import { beamFlexure, beamShear, deriveWSection } from './steelDesign'
 import { shapeByName } from './aiscSections'
 import { designAxialColumn } from './columnDesign'
 import { activeThrust, rankineKa, bearingFactors, infiniteSlopeFS } from './geotech'
+import { computeSeismic } from './seismic'
+import { generateGridModel } from './modelBuilder'
 import { solveFrame3D, rectJ, type F3Node, type F3Member, type F3Support } from './frame3d'
+import type { RectSection } from './model'
 
 export interface ValidationCase {
   id: string
-  category: 'RC' | 'Steel' | 'Analysis' | 'Wind' | 'Geotech'
+  category: 'RC' | 'Steel' | 'Analysis' | 'Wind' | 'Geotech' | 'Seismic'
   title: string
   reference: string
   formula: string
@@ -127,6 +130,17 @@ const slopeFS = (() => {
   return { manual: tan(phiDeg) / tan(betaDeg), software: infiniteSlopeFS({ c: 0, phiDeg, gamma: 18, z: 3, betaDeg }) }
 })()
 
+// ── 11. NSCP 208 seismic static — period & base shear ────────────────────────
+const seismic = (() => {
+  const section: RectSection = { id: 'S', name: 's', b: 400, h: 400, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
+  const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3, 3], section })
+  const r = computeSeismic(m, { Ca: 0.44, Cv: 0.64, I: 1, R: 8.5, dir: 'x' })!
+  return {
+    period: { manual: 0.0731 * r.hn ** 0.75, software: r.T },                 // T = Ct·hn^¾
+    baseShear: { manual: (0.64 * 1 * r.W) / (8.5 * r.T), software: r.Vraw },  // V = Cv·I·W/(R·T)
+  }
+})()
+
 export const VALIDATION_CASES: ValidationCase[] = [
   {
     id: 'rc-beam-mn', category: 'RC', title: 'Singly-reinforced beam — nominal moment',
@@ -192,5 +206,15 @@ export const VALIDATION_CASES: ValidationCase[] = [
     id: 'slope-fs', category: 'Geotech', title: 'Infinite-slope FS (cohesionless, dry)',
     reference: 'Soil mechanics', formula: 'FS = tanφ / tanβ',
     manual: slopeFS.manual, software: slopeFS.software, unit: '—', tol: 1e-9,
+  },
+  {
+    id: 'seismic-period', category: 'Seismic', title: 'NSCP 208 fundamental period (Method A)',
+    reference: 'NSCP 208.5.2.2', formula: 'T = Ct·hn^¾ (Ct = 0.0731)',
+    manual: seismic.period.manual, software: seismic.period.software, unit: 's', tol: 1e-6,
+  },
+  {
+    id: 'seismic-base-shear', category: 'Seismic', title: 'NSCP 208 static base shear',
+    reference: 'NSCP 208.5.2.1', formula: 'V = Cv·I·W / (R·T)',
+    manual: seismic.baseShear.manual, software: seismic.baseShear.software, unit: 'kN', tol: 1e-6,
   },
 ]

--- a/webapp/src/pages/Validation.tsx
+++ b/webapp/src/pages/Validation.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom'
 import { VALIDATION_CASES, pctDiff, type ValidationCase } from '../engine/validation'
 
-const CATS = ['RC', 'Steel', 'Analysis', 'Wind', 'Geotech'] as const
+const CATS = ['RC', 'Steel', 'Analysis', 'Seismic', 'Wind', 'Geotech'] as const
 
 function fmt(v: number): string {
   if (!Number.isFinite(v)) return '—'


### PR DESCRIPTION
## Summary

Adds **Chapter 2 — NSCP 208 static seismic** to the validation manual (native NSCP support is the platform's core differentiator), with matching dashboard benchmarks.

## Docs
- **`docs/validation/seismic.md`** — period `T = Ct·hn^¾` and base shear `V = Cv·I·W/(R·T)` benchmarks; a worked period check; and the governing-case logic `V = max(Vmin, Vsrc, min(Vraw, Vmax))` (Vmax cap / Vmin floor / Zone-4 Vsrc), cross-referenced to the branches `seismic.test.ts` exercises, plus the `Fx` distribution and `Ft` whip force.
- `README.md` index updated (seismic chapter ✅).

## Engine / UI
- `engine/validation.ts` — new **`Seismic`** category with two benchmarks (period, basic base shear) from `computeSeismic` on a 2-storey reference model.
- `pages/Validation.tsx` — `Seismic` added to the dashboard's category list.

Verified: `npm test` (906 passing), `npx tsc -b`, `npm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_