### PR TITLE
feat: NSCP 208 Seismic Wizard — roadmap Phase 3 structural

### DIFF
--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -60,7 +60,7 @@ Target: v2.0
 Structural:
 - [x] Retaining Wall Design (`/retaining-wall`, cantilever · Rankine)
 - [x] Wind Load Generator (NSCP §207B MWFRS + §207E.4 C&C, in 3D model space)
-- [ ] NSCP Seismic Wizard (engine exists in `engine/seismic.ts`; needs a guided UI)
+- [x] NSCP Seismic Wizard (`/seismic-wizard`; §208 Ca/Cv/I/R/Na/Nv tables + Cs)
 - [x] Stair Design (`/stair`, RC waist slab)
 - [ ] Water Tank Design
 

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -27,6 +27,7 @@ import SoilNail from './pages/SoilNail'
 import StairDesign from './pages/StairDesign'
 import Micropile from './pages/Micropile'
 import RockAnchor from './pages/RockAnchor'
+import SeismicWizard from './pages/SeismicWizard'
 import SlabEstimate from './pages/SlabEstimate'
 import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
@@ -73,6 +74,7 @@ export default function App() {
         <Route path="/stair" element={<StairDesign />} />
         <Route path="/micropile" element={<Micropile />} />
         <Route path="/rock-anchor" element={<RockAnchor />} />
+        <Route path="/seismic-wizard" element={<SeismicWizard />} />
         <Route path="/estimate/slab" element={<SlabEstimate />} />
         <Route path="/estimate/beam" element={<BeamEstimate />} />
         <Route path="/estimate/column" element={<ColumnEstimate />} />

--- a/webapp/src/engine/nscpSeismic.test.ts
+++ b/webapp/src/engine/nscpSeismic.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import {
+  nearSourceFactors, seismicCoefficients, importanceFactor, nscpSeismicParams,
+  baseShearCoeff, STRUCTURAL_SYSTEMS,
+} from './nscpSeismic'
+
+describe('nearSourceFactors — Tables 208-4 / 208-5', () => {
+  it('source A endpoints: Na 1.5→1.0 (2→10 km), Nv 2.0→1.0 (2→15 km)', () => {
+    expect(nearSourceFactors('A', 2)).toEqual({ Na: 1.5, Nv: 2.0 })
+    expect(nearSourceFactors('A', 5)).toEqual({ Na: 1.2, Nv: 1.6 })
+    expect(nearSourceFactors('A', 10).Na).toBeCloseTo(1.0, 9)
+    expect(nearSourceFactors('A', 15).Nv).toBeCloseTo(1.0, 9)
+  })
+  it('clamps below 2 km and above the last knot', () => {
+    expect(nearSourceFactors('A', 1)).toEqual({ Na: 1.5, Nv: 2.0 })
+    expect(nearSourceFactors('A', 50)).toEqual({ Na: 1.0, Nv: 1.0 })
+  })
+  it('interpolates linearly (A at 3.5 km is midway 2→5)', () => {
+    expect(nearSourceFactors('A', 3.5).Na).toBeCloseTo((1.5 + 1.2) / 2, 9)
+    expect(nearSourceFactors('A', 3.5).Nv).toBeCloseTo((2.0 + 1.6) / 2, 9)
+  })
+  it('source C is always unity', () => {
+    expect(nearSourceFactors('C', 2)).toEqual({ Na: 1.0, Nv: 1.0 })
+  })
+})
+
+describe('seismicCoefficients — Tables 208-7 / 208-8', () => {
+  it('Zone 2 SD: Ca 0.28, Cv 0.40 (no near-source)', () => {
+    expect(seismicCoefficients(2, 'SD')).toEqual({ Ca: 0.28, Cv: 0.40 })
+  })
+  it('Zone 4 SD source C: Ca 0.44, Cv 0.64', () => {
+    const { Na, Nv } = nearSourceFactors('C', 10)
+    expect(seismicCoefficients(4, 'SD', Na, Nv)).toEqual({ Ca: 0.44, Cv: 0.64 })
+  })
+  it('Zone 4 SD source A at 2 km applies Na/Nv', () => {
+    const c = seismicCoefficients(4, 'SD', 1.5, 2.0)
+    expect(c.Ca).toBeCloseTo(0.44 * 1.5, 9)
+    expect(c.Cv).toBeCloseTo(0.64 * 2.0, 9)
+  })
+  it('Zone 2 ignores near-source factors', () => {
+    expect(seismicCoefficients(2, 'SC', 1.5, 2.0)).toEqual({ Ca: 0.24, Cv: 0.32 })
+  })
+})
+
+describe('importanceFactor — Table 208-1', () => {
+  it('essential/hazardous 1.5, special 1.25, standard 1.0', () => {
+    expect(importanceFactor('essential')).toBe(1.5)
+    expect(importanceFactor('hazardous')).toBe(1.5)
+    expect(importanceFactor('special')).toBe(1.25)
+    expect(importanceFactor('standard')).toBe(1.0)
+  })
+})
+
+describe('STRUCTURAL_SYSTEMS', () => {
+  it('includes SMRF concrete R = 8.5 and OMRF concrete R = 3.5', () => {
+    expect(STRUCTURAL_SYSTEMS.find((s) => s.id === 'smrf-concrete')!.R).toBe(8.5)
+    expect(STRUCTURAL_SYSTEMS.find((s) => s.id === 'omrf-concrete')!.R).toBe(3.5)
+  })
+})
+
+describe('nscpSeismicParams — resolve all', () => {
+  it('Zone 4 essential SMRF on SD near a type-A source', () => {
+    const r = nscpSeismicParams({ zone: 4, soil: 'SD', occupancy: 'essential', R: 8.5, source: 'A', distanceKm: 2 })
+    expect(r.Z).toBe(0.4)
+    expect(r.Na).toBe(1.5); expect(r.Nv).toBe(2.0)
+    expect(r.Ca).toBeCloseTo(0.44 * 1.5, 9)
+    expect(r.Cv).toBeCloseTo(0.64 * 2.0, 9)
+    expect(r.I).toBe(1.5); expect(r.R).toBe(8.5)
+  })
+  it('Zone 2 standard ignores source (Na = Nv = 1)', () => {
+    const r = nscpSeismicParams({ zone: 2, soil: 'SC', occupancy: 'standard', R: 5.5 })
+    expect(r.Z).toBe(0.2); expect(r.Na).toBe(1); expect(r.Nv).toBe(1)
+    expect(r.Ca).toBe(0.24); expect(r.Cv).toBe(0.32); expect(r.I).toBe(1)
+  })
+})
+
+describe('baseShearCoeff — Cs governing logic (§208.5.2.1)', () => {
+  const p = { Ca: 0.44, Cv: 0.64, I: 1, R: 8.5, Z: 0.4, Nv: 1 }
+  it('basic Cs = Cv·I/(R·T) when within bounds', () => {
+    const r = baseShearCoeff({ ...p, T: 0.6 })
+    expect(r.Csraw).toBeCloseTo((0.64 * 1) / (8.5 * 0.6), 9)
+    expect(['basic', 'max-cap']).toContain(r.governs)
+  })
+  it('upper cap 2.5·Ca·I/R governs at very short period', () => {
+    const r = baseShearCoeff({ ...p, T: 0.1 })
+    expect(r.Cs).toBeCloseTo((2.5 * 0.44 * 1) / 8.5, 9)
+    expect(r.governs).toBe('max-cap')
+  })
+  it('lower / Zone-4 floor governs at long period', () => {
+    const r = baseShearCoeff({ ...p, T: 5, Nv: 1.2 })
+    expect(r.Cs).toBeGreaterThanOrEqual(0.11 * 0.44 * 1)
+    expect(['min-floor', 'zone4-floor']).toContain(r.governs)
+  })
+})

--- a/webapp/src/engine/nscpSeismic.ts
+++ b/webapp/src/engine/nscpSeismic.ts
@@ -1,0 +1,106 @@
+// ─────────────────────────────────────────────────────────────────────────
+// NSCP 2015 §208 seismic-parameter lookup — the tables an engineer reads off by
+// hand to feed the static base-shear procedure. Drives the Seismic Wizard.
+//   Zone Z          : Zone 2 → 0.20, Zone 4 → 0.40           (§208.4.4.1)
+//   Near-source Na,Nv: Tables 208-4 / 208-5 (Zone 4 only)
+//   Seismic coeff Ca : Table 208-7,  Cv : Table 208-8 (× Na/Nv in Zone 4)
+//   Importance I     : Table 208-1
+//   System R         : Table 208-11
+//   Base shear coeff : Cs = V/W = Cv·I/(R·T), 2.5Ca·I/R ≥ Cs ≥ 0.11Ca·I,
+//                      Zone-4 floor 0.8·Z·Nv·I/R              (208-8…208-11)
+// ─────────────────────────────────────────────────────────────────────────
+
+export type SoilProfile = 'SA' | 'SB' | 'SC' | 'SD' | 'SE'
+export type SeismicSource = 'A' | 'B' | 'C'
+export type SeismicZone = 2 | 4
+export type Occupancy = 'essential' | 'hazardous' | 'special' | 'standard'
+
+/** Piecewise-linear interpolation of v at x over ascending knots xs→vs (clamped). */
+function interp(x: number, xs: number[], vs: number[]): number {
+  if (x <= xs[0]) return vs[0]
+  if (x >= xs[xs.length - 1]) return vs[vs.length - 1]
+  for (let i = 1; i < xs.length; i++)
+    if (x <= xs[i]) return vs[i - 1] + ((vs[i] - vs[i - 1]) * (x - xs[i - 1])) / (xs[i] - xs[i - 1])
+  return vs[vs.length - 1]
+}
+
+// Table 208-4 (Na) and 208-5 (Nv): knots at the listed closest-distance values.
+const NA_DIST = [2, 5, 10]
+const NA: Record<SeismicSource, number[]> = { A: [1.5, 1.2, 1.0], B: [1.3, 1.0, 1.0], C: [1.0, 1.0, 1.0] }
+const NV_DIST = [2, 5, 10, 15]
+const NV: Record<SeismicSource, number[]> = { A: [2.0, 1.6, 1.2, 1.0], B: [1.6, 1.2, 1.0, 1.0], C: [1.0, 1.0, 1.0, 1.0] }
+
+/** Near-source factors Na, Nv (Zone 4) for a source type and closest distance (km). */
+export function nearSourceFactors(source: SeismicSource, distanceKm: number): { Na: number; Nv: number } {
+  return { Na: interp(distanceKm, NA_DIST, NA[source]), Nv: interp(distanceKm, NV_DIST, NV[source]) }
+}
+
+// Table 208-7 (Ca) / 208-8 (Cv) base values by soil & zone (pre near-source factor).
+const CA: Record<SoilProfile, Record<SeismicZone, number>> = {
+  SA: { 2: 0.16, 4: 0.32 }, SB: { 2: 0.20, 4: 0.40 }, SC: { 2: 0.24, 4: 0.40 },
+  SD: { 2: 0.28, 4: 0.44 }, SE: { 2: 0.34, 4: 0.36 },
+}
+const CV: Record<SoilProfile, Record<SeismicZone, number>> = {
+  SA: { 2: 0.16, 4: 0.32 }, SB: { 2: 0.20, 4: 0.40 }, SC: { 2: 0.32, 4: 0.56 },
+  SD: { 2: 0.40, 4: 0.64 }, SE: { 2: 0.64, 4: 0.96 },
+}
+
+/** Seismic coefficients Ca, Cv (× Na/Nv in Zone 4). */
+export function seismicCoefficients(zone: SeismicZone, soil: SoilProfile, Na = 1, Nv = 1): { Ca: number; Cv: number } {
+  const f = zone === 4 ? { na: Na, nv: Nv } : { na: 1, nv: 1 }
+  return { Ca: CA[soil][zone] * f.na, Cv: CV[soil][zone] * f.nv }
+}
+
+/** Importance factor I, Table 208-1. */
+export function importanceFactor(o: Occupancy): number {
+  return o === 'essential' || o === 'hazardous' ? 1.5 : o === 'special' ? 1.25 : 1.0
+}
+
+/** Common lateral-force-resisting systems and their R (Table 208-11). */
+export interface StructuralSystem { id: string; name: string; R: number; omega0: number }
+export const STRUCTURAL_SYSTEMS: StructuralSystem[] = [
+  { id: 'smrf-concrete', name: 'Special RC moment frame (SMRF)', R: 8.5, omega0: 2.8 },
+  { id: 'smf-steel', name: 'Special steel moment frame (SMF)', R: 8.0, omega0: 3.0 },
+  { id: 'imrf-concrete', name: 'Intermediate RC moment frame (IMRF)', R: 5.5, omega0: 2.8 },
+  { id: 'omrf-concrete', name: 'Ordinary RC moment frame (OMRF)', R: 3.5, omega0: 2.8 },
+  { id: 'omf-steel', name: 'Ordinary steel moment frame (OMF)', R: 4.5, omega0: 3.0 },
+  { id: 'dual-smrf-wall', name: 'Dual: SMRF + special RC shear walls', R: 8.5, omega0: 2.8 },
+  { id: 'bf-special-wall', name: 'Building frame: special RC shear walls', R: 5.5, omega0: 2.8 },
+  { id: 'bearing-special-wall', name: 'Bearing wall: special RC shear walls', R: 4.5, omega0: 2.8 },
+  { id: 'bearing-ordinary-wall', name: 'Bearing wall: ordinary RC shear walls', R: 4.5, omega0: 2.8 },
+  { id: 'braced-steel', name: 'Building frame: special steel braced frame', R: 6.0, omega0: 2.2 },
+]
+
+export interface NscpSeismicParams {
+  Z: number; Na: number; Nv: number; Ca: number; Cv: number; I: number; R: number
+}
+
+/** Resolve all NSCP 208 parameters from the wizard selections. */
+export function nscpSeismicParams(p: {
+  zone: SeismicZone; soil: SoilProfile; occupancy: Occupancy; R: number;
+  source?: SeismicSource; distanceKm?: number;
+}): NscpSeismicParams {
+  const Z = p.zone === 4 ? 0.4 : 0.2
+  const { Na, Nv } = p.zone === 4 ? nearSourceFactors(p.source ?? 'C', p.distanceKm ?? 10) : { Na: 1, Nv: 1 }
+  const { Ca, Cv } = seismicCoefficients(p.zone, p.soil, Na, Nv)
+  return { Z, Na, Nv, Ca, Cv, I: importanceFactor(p.occupancy), R: p.R }
+}
+
+export interface BaseShearCoeff {
+  Csraw: number; Csmax: number; Csmin: number; Cszone4: number
+  Cs: number; governs: 'basic' | 'max-cap' | 'min-floor' | 'zone4-floor'
+}
+
+/** Design base-shear coefficient Cs = V/W for a fundamental period T (§208.5.2.1). */
+export function baseShearCoeff(p: { Ca: number; Cv: number; I: number; R: number; T: number; Z: number; Nv: number }): BaseShearCoeff {
+  const Csraw = (p.Cv * p.I) / (p.R * p.T)
+  const Csmax = (2.5 * p.Ca * p.I) / p.R
+  const Csmin = 0.11 * p.Ca * p.I
+  const Cszone4 = p.Z >= 0.4 ? (0.8 * p.Z * p.Nv * p.I) / p.R : 0
+  const capped = Math.min(Csraw, Csmax)
+  const Cs = Math.max(Csmin, Cszone4, capped)
+  const governs = Cs === Cszone4 && Cszone4 > 0 ? 'zone4-floor'
+    : Cs === Csmin ? 'min-floor'
+      : capped === Csmax ? 'max-cap' : 'basic'
+  return { Csraw, Csmax, Csmin, Cszone4, Cs, governs }
+}

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -36,6 +36,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/soil-nail',        name: 'Soil-Nail Wall',   sub: 'FHWA · tensile · pullout' },
       { to: '/micropile',        name: 'Micropile',        sub: 'FHWA · structural · bond' },
       { to: '/rock-anchor',      name: 'Rock Anchor',      sub: 'PTI · tendon · bond'      },
+      { to: '/seismic-wizard',   name: 'Seismic Wizard',   sub: 'NSCP 208 Ca/Cv/I/R'       },
       { to: '/load-combinations', name: 'Load Combinations', sub: 'NSCP 2015 §203.3 LRFD'   },
     ],
   },

--- a/webapp/src/pages/SeismicWizard.tsx
+++ b/webapp/src/pages/SeismicWizard.tsx
@@ -1,0 +1,184 @@
+import { useMemo, useState } from 'react'
+import {
+  nscpSeismicParams, baseShearCoeff, STRUCTURAL_SYSTEMS,
+  type SoilProfile, type SeismicSource, type SeismicZone, type Occupancy,
+} from '../engine/nscpSeismic'
+
+const f3 = (n: number) => (Number.isFinite(n) ? n.toFixed(3) : '—')
+
+function Choice<T extends string | number>({ value, set, options }: {
+  value: T; set: (v: T) => void; options: { v: T; label: string; sub?: string }[]
+}) {
+  return (
+    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+      {options.map((o) => (
+        <button key={String(o.v)} type="button" onClick={() => set(o.v)}
+          className={`rounded-lg border px-3 py-2 text-left text-sm transition ${value === o.v
+            ? 'border-[#0056b3] bg-blue-50 font-semibold text-[#0056b3]'
+            : 'border-slate-200 bg-white text-slate-700 hover:border-slate-300'}`}>
+          {o.label}{o.sub ? <span className="block text-[11px] font-normal text-slate-400">{o.sub}</span> : null}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export default function SeismicWizard() {
+  const [zone, setZone] = useState<SeismicZone>(4)
+  const [soil, setSoil] = useState<SoilProfile>('SD')
+  const [source, setSource] = useState<SeismicSource>('B')
+  const [distance, setDistance] = useState(10)
+  const [occupancy, setOccupancy] = useState<Occupancy>('standard')
+  const [systemId, setSystemId] = useState('smrf-concrete')
+  const [T, setT] = useState(0.5)
+  const [step, setStep] = useState(0)
+
+  const R = STRUCTURAL_SYSTEMS.find((s) => s.id === systemId)!.R
+  const params = useMemo(
+    () => nscpSeismicParams({ zone, soil, occupancy, R, source, distanceKm: distance }),
+    [zone, soil, occupancy, R, source, distance],
+  )
+  const cs = useMemo(
+    () => baseShearCoeff({ Ca: params.Ca, Cv: params.Cv, I: params.I, R: params.R, T, Z: params.Z, Nv: params.Nv }),
+    [params, T],
+  )
+
+  // Build the step list (near-source step only for Zone 4).
+  const steps = [
+    { key: 'zone', label: 'Seismic zone' },
+    { key: 'soil', label: 'Soil profile' },
+    ...(zone === 4 ? [{ key: 'source', label: 'Near-source' }] : []),
+    { key: 'occupancy', label: 'Occupancy' },
+    { key: 'system', label: 'Structural system' },
+    { key: 'result', label: 'Period & result' },
+  ]
+  const cur = steps[Math.min(step, steps.length - 1)]
+
+  return (
+    <main className="mx-auto max-w-3xl px-5 py-10">
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">Structural</p>
+      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">NSCP 208 Seismic Wizard</h1>
+      <p className="mt-2 text-sm text-slate-600">
+        Walk through the NSCP 2015 §208 static lateral-force tables — zone, soil, near-source, occupancy and
+        structural system — to get Ca, Cv, I, R and the design base-shear coefficient Cs = V/W.
+      </p>
+
+      {/* stepper */}
+      <div className="mt-5 flex flex-wrap gap-1.5">
+        {steps.map((s, i) => (
+          <button key={s.key} type="button" onClick={() => setStep(i)}
+            className={`rounded-full px-3 py-1 text-[11px] font-medium ${i === step
+              ? 'bg-[#0056b3] text-white' : i < step ? 'bg-blue-100 text-[#0056b3]' : 'bg-slate-100 text-slate-500'}`}>
+            {i + 1}. {s.label}
+          </button>
+        ))}
+      </div>
+
+      <section className="mt-4 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        {cur.key === 'zone' && (
+          <>
+            <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Seismic zone (§208.4.4.1)</h2>
+            <Choice<SeismicZone> value={zone} set={setZone} options={[
+              { v: 2, label: 'Zone 2', sub: 'Z = 0.20 — Palawan, Sulu, Tawi-Tawi' },
+              { v: 4, label: 'Zone 4', sub: 'Z = 0.40 — most of the Philippines' },
+            ]} />
+          </>
+        )}
+        {cur.key === 'soil' && (
+          <>
+            <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Soil profile type (Table 208-2)</h2>
+            <Choice<SoilProfile> value={soil} set={setSoil} options={[
+              { v: 'SA', label: 'SA — Hard rock' },
+              { v: 'SB', label: 'SB — Rock' },
+              { v: 'SC', label: 'SC — Very dense soil / soft rock' },
+              { v: 'SD', label: 'SD — Stiff soil (default)' },
+              { v: 'SE', label: 'SE — Soft soil' },
+            ]} />
+          </>
+        )}
+        {cur.key === 'source' && (
+          <>
+            <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Near-source (Tables 208-3…208-5)</h2>
+            <Choice<SeismicSource> value={source} set={setSource} options={[
+              { v: 'A', label: 'Type A', sub: 'M ≥ 7.0, high slip rate' },
+              { v: 'B', label: 'Type B', sub: 'most active faults' },
+              { v: 'C', label: 'Type C', sub: 'M < 6.5, low slip rate' },
+            ]} />
+            <label className="mt-3 flex flex-col text-sm">
+              <span className="mb-1 font-medium text-slate-600">Closest distance to the source (km)</span>
+              <input type="number" step="0.5" value={distance}
+                onChange={(e) => setDistance(parseFloat(e.target.value) || 0)}
+                className="w-40 rounded-md border border-slate-300 px-2.5 py-1.5" />
+            </label>
+            <p className="mt-2 text-[11px] text-slate-400">Na = {f3(params.Na)}, Nv = {f3(params.Nv)}</p>
+          </>
+        )}
+        {cur.key === 'occupancy' && (
+          <>
+            <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Occupancy category (Table 208-1)</h2>
+            <Choice<Occupancy> value={occupancy} set={setOccupancy} options={[
+              { v: 'essential', label: 'Essential facility', sub: 'I = 1.50 — hospitals, fire/police' },
+              { v: 'hazardous', label: 'Hazardous facility', sub: 'I = 1.50' },
+              { v: 'special', label: 'Special occupancy', sub: 'I = 1.25 — assembly > 300' },
+              { v: 'standard', label: 'Standard occupancy', sub: 'I = 1.00' },
+            ]} />
+          </>
+        )}
+        {cur.key === 'system' && (
+          <>
+            <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Structural system (Table 208-11)</h2>
+            <select value={systemId} onChange={(e) => setSystemId(e.target.value)}
+              className="w-full rounded-md border border-slate-300 px-2.5 py-2 text-sm">
+              {STRUCTURAL_SYSTEMS.map((s) => <option key={s.id} value={s.id}>{s.name} — R = {s.R}</option>)}
+            </select>
+          </>
+        )}
+        {cur.key === 'result' && (
+          <>
+            <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Fundamental period &amp; base shear</h2>
+            <label className="flex flex-col text-sm">
+              <span className="mb-1 font-medium text-slate-600">Fundamental period T (s) — Method A: Ct·hn^¾</span>
+              <input type="number" step="0.05" value={T}
+                onChange={(e) => setT(parseFloat(e.target.value) || 0.01)}
+                className="w-40 rounded-md border border-slate-300 px-2.5 py-1.5" />
+            </label>
+          </>
+        )}
+
+        <div className="mt-5 flex justify-between">
+          <button type="button" disabled={step === 0} onClick={() => setStep((s) => Math.max(0, s - 1))}
+            className="rounded-lg border border-slate-300 px-4 py-1.5 text-sm font-semibold text-slate-600 disabled:opacity-40">Back</button>
+          <button type="button" disabled={step >= steps.length - 1} onClick={() => setStep((s) => Math.min(steps.length - 1, s + 1))}
+            className="rounded-lg bg-[#0056b3] px-4 py-1.5 text-sm font-semibold text-white disabled:opacity-40">Next</button>
+        </div>
+      </section>
+
+      {/* live results summary */}
+      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-2 text-[1.05rem] font-bold text-[#0056b3]">Seismic parameters</h2>
+        <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-sm sm:grid-cols-4">
+          {[['Z', params.Z], ['Na', params.Na], ['Nv', params.Nv], ['Ca', params.Ca],
+            ['Cv', params.Cv], ['I', params.I], ['R', params.R], ['T (s)', T]].map(([k, v]) => (
+            <div key={k as string} className="flex justify-between border-b border-slate-100 py-1">
+              <span className="text-slate-500">{k}</span><span className="font-mono font-medium">{f3(v as number)}</span>
+            </div>
+          ))}
+        </div>
+        <div className="mt-3 rounded-lg bg-blue-50 p-3">
+          <div className="flex items-baseline justify-between">
+            <span className="text-sm font-semibold text-[#0056b3]">Design base-shear coefficient Cs = V/W</span>
+            <span className="font-mono text-lg font-bold text-[#0056b3]">{f3(cs.Cs)}</span>
+          </div>
+          <p className="mt-1 text-[11px] text-slate-500">
+            Governing: <b>{cs.governs}</b> · basic {f3(cs.Csraw)} · cap 2.5Ca·I/R {f3(cs.Csmax)} ·
+            floor 0.11Ca·I {f3(cs.Csmin)}{params.Z >= 0.4 ? ` · Zone-4 0.8Z·Nv·I/R ${f3(cs.Cszone4)}` : ''}
+          </p>
+        </div>
+        <p className="mt-2 text-[10px] text-slate-400">
+          V = Cs·W (§208.5.2.1). Feed Ca, Cv, I, R into the 3D model space seismic generator for the
+          full storey-force distribution. Verify the soil profile with a geotechnical investigation.
+        </p>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

Adds the **NSCP 208 Seismic Wizard** (roadmap Phase 3). The base-shear engine already existed; this guides the engineer through the tedious §208 **table lookups** and resolves Ca, Cv, I, R, Na, Nv and the design base-shear coefficient.

## Engine (`nscpSeismic.ts`)
- `nearSourceFactors` — Na/Nv (Tables 208-4 / 208-5) with linear interpolation by distance.
- `seismicCoefficients` — Ca/Cv (Tables 208-7 / 208-8), multiplied by Na/Nv in Zone 4.
- `importanceFactor` (Table 208-1); `STRUCTURAL_SYSTEMS` with R (Table 208-11).
- `nscpSeismicParams` — resolves Z/Na/Nv/Ca/Cv/I/R; `baseShearCoeff` — `Cs = V/W` with the cap (2.5Ca·I/R), floor (0.11Ca·I) and Zone-4 floor (0.8Z·Nv·I/R) governing logic (§208.5.2.1).

## Tests (+15)
Near-source endpoints/interpolation/clamp, Ca/Cv table values (Zone 2 & 4, with/without source), importance factors, system R, full resolve, and the Cs governing branches.

## UI
`pages/SeismicWizard.tsx` + `/seismic-wizard` route + a Structural nav entry — a **stepped wizard** (zone → soil → near-source [Zone 4 only] → occupancy → structural system → period) with a live parameter table and base-shear-coefficient summary that shows which equation governs. Feeds Ca/Cv/I/R into the 3D model space seismic generator.

Verified: `npm test` (921 passing), `npx tsc -b`, `npm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_