### PR TITLE
feat: circular RC water tank wall design — roadmap Phase 3 structural

### DIFF
--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -62,7 +62,7 @@ Structural:
 - [x] Wind Load Generator (NSCP §207B MWFRS + §207E.4 C&C, in 3D model space)
 - [x] NSCP Seismic Wizard (`/seismic-wizard`; §208 Ca/Cv/I/R/Na/Nv tables + Cs)
 - [x] Stair Design (`/stair`, RC waist slab)
-- [ ] Water Tank Design
+- [x] Water Tank Design (`/water-tank`; circular wall — IS 3370 / ACI 350 working stress)
 
 Geotechnical:
 - [x] Geotechnical toolkit (`/geotech`: bearing capacity, earth pressure, slope)

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -28,6 +28,7 @@ import StairDesign from './pages/StairDesign'
 import Micropile from './pages/Micropile'
 import RockAnchor from './pages/RockAnchor'
 import SeismicWizard from './pages/SeismicWizard'
+import WaterTank from './pages/WaterTank'
 import SlabEstimate from './pages/SlabEstimate'
 import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
@@ -75,6 +76,7 @@ export default function App() {
         <Route path="/micropile" element={<Micropile />} />
         <Route path="/rock-anchor" element={<RockAnchor />} />
         <Route path="/seismic-wizard" element={<SeismicWizard />} />
+        <Route path="/water-tank" element={<WaterTank />} />
         <Route path="/estimate/slab" element={<SlabEstimate />} />
         <Route path="/estimate/beam" element={<BeamEstimate />} />
         <Route path="/estimate/column" element={<ColumnEstimate />} />

--- a/webapp/src/engine/waterTank.test.ts
+++ b/webapp/src/engine/waterTank.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { hoopTension, wallCantileverMoment, designCircularTank } from './waterTank'
+
+describe('hoopTension', () => {
+  it('T(z) = γw·z·D/2, max at the base', () => {
+    expect(hoopTension(4, 10)).toBeCloseTo((9.81 * 4 * 10) / 2, 6)      // 196.2 kN/m
+    expect(hoopTension(4, 10, 2)).toBeCloseTo((9.81 * 2 * 10) / 2, 6)   // 98.1 at mid-height
+  })
+  it('scales with diameter and head', () => {
+    expect(hoopTension(4, 12)).toBeGreaterThan(hoopTension(4, 10))
+    expect(hoopTension(6, 10)).toBeGreaterThan(hoopTension(4, 10))
+  })
+})
+
+describe('wallCantileverMoment', () => {
+  it('M = γw·H³/6 (triangular hydrostatic on a vertical cantilever)', () => {
+    expect(wallCantileverMoment(4)).toBeCloseTo((9.81 * 4 ** 3) / 6, 6)   // 104.64 kN·m/m
+  })
+  it('grows with the cube of the depth', () => {
+    expect(wallCantileverMoment(6) / wallCantileverMoment(3)).toBeCloseTo(8, 6)
+  })
+})
+
+describe('designCircularTank', () => {
+  const base = { H: 4, D: 10, t: 250, fc: 28, cover: 40, barDia: 16 }
+
+  it('hoop steel As = T/σst at the permissible stress', () => {
+    const r = designCircularTank(base)
+    expect(r.T).toBeCloseTo(196.2, 1)
+    expect(r.hoopAs).toBeCloseTo((196.2 * 1000) / 130, 0)     // ~1509 mm²/m
+  })
+
+  it('vertical steel As = M/(σst·j·d)', () => {
+    const r = designCircularTank(base)
+    const d = 250 - 40 - 8
+    expect(r.vertAs).toBeCloseTo((r.M * 1e6) / (130 * 0.87 * d), 0)
+  })
+
+  it('concrete tensile stress check vs σct (thicker wall ⇒ lower fct)', () => {
+    const thin = designCircularTank({ ...base, t: 200 })
+    const thick = designCircularTank({ ...base, t: 400 })
+    expect(thick.fct).toBeLessThan(thin.fct)
+    expect(thick.thicknessOK).toBe(thick.fct <= 1.3)
+  })
+
+  it('a custom permissible steel stress changes the steel area', () => {
+    const a = designCircularTank({ ...base, sigmaSt: 130 })
+    const b = designCircularTank({ ...base, sigmaSt: 150 })
+    expect(b.hoopAs).toBeLessThan(a.hoopAs)                   // higher allowable ⇒ less steel
+  })
+
+  it('spacing is capped at min(3t, 300) for liquid-tightness', () => {
+    const r = designCircularTank(base)
+    expect(r.hoopSpacing).toBeLessThanOrEqual(Math.min(3 * 250, 300))
+    expect(r.hoopSpacing).toBeGreaterThan(0)
+  })
+
+  it('flags inadequate freeboard (< 300 mm)', () => {
+    expect(designCircularTank({ ...base, freeboard: 0.15 }).freeboardOK).toBe(false)
+    expect(designCircularTank({ ...base, freeboard: 0.30 }).freeboardOK).toBe(true)
+  })
+})

--- a/webapp/src/engine/waterTank.ts
+++ b/webapp/src/engine/waterTank.ts
@@ -1,0 +1,73 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Circular RC water tank — wall design (permissible-stress / working-stress).
+// Liquid-retaining crack-control philosophy of IS 3370 / ACI 350.
+//   Hydrostatic pressure at depth z:  p = γw·z
+//   Hoop (ring) tension per unit height (membrane):  T(z) = γw·z·D/2   → max at base
+//   Vertical cantilever moment (wall fixed at base):  M = γw·H³/6      per metre width
+//   Hoop steel:   As = T / σst         Vertical steel:  As = M / (σst·j·d)
+//   Wall thickness adequacy (no crack): fct = T / (Ac + (n−1)·As) ≤ σct
+// where σst = permissible steel tensile stress (≈130 MPa, crack control), σct =
+// permissible concrete direct tension, n = modular ratio, j ≈ 0.87.
+// Units: γw kN/m³; H,D,z m; t/d/cover/db mm; stresses MPa; T kN/m; M kN·m/m; As mm²/m.
+// ─────────────────────────────────────────────────────────────────────────
+
+const GAMMA_W = 9.81          // kN/m³, water
+const J = 0.87               // lever-arm factor (working stress)
+
+/** Hoop (ring) tension per unit height at depth z (default base z = H), kN/m. */
+export function hoopTension(H: number, D: number, z?: number, gammaW = GAMMA_W): number {
+  return (gammaW * (z ?? H) * D) / 2
+}
+
+/** Vertical cantilever moment at the wall base (triangular hydrostatic load), kN·m/m. */
+export function wallCantileverMoment(H: number, gammaW = GAMMA_W): number {
+  return (gammaW * H ** 3) / 6
+}
+
+export interface CircularTankResult {
+  T: number            // max hoop tension at base, kN/m
+  M: number            // base cantilever moment, kN·m/m
+  d: number            // effective depth, mm
+  hoopAs: number; hoopSpacing: number      // ring steel, mm²/m + spacing
+  vertAs: number; vertSpacing: number      // vertical steel, mm²/m + spacing
+  fct: number          // concrete tensile stress under hoop tension, MPa
+  thicknessOK: boolean
+  freeboardOK: boolean
+}
+
+/**
+ * Design a circular tank wall (per metre height/width). `sigmaSt` is the
+ * permissible steel tensile stress (crack control); `sigmaCt` the permissible
+ * concrete direct tension; `fc` sets the modular ratio.
+ */
+export function designCircularTank(p: {
+  H: number; D: number; t: number; freeboard?: number;
+  fc: number; sigmaSt?: number; sigmaCt?: number;
+  cover: number; barDia: number; gammaW?: number;
+}): CircularTankResult {
+  const gammaW = p.gammaW ?? GAMMA_W
+  const sigmaSt = p.sigmaSt ?? 130
+  const sigmaCt = p.sigmaCt ?? 1.3
+  const T = hoopTension(p.H, p.D, undefined, gammaW)        // kN/m
+  const M = wallCantileverMoment(p.H, gammaW)              // kN·m/m
+  const d = Math.max(p.t - p.cover - p.barDia / 2, 0.5 * p.t)
+
+  const hoopAs = (T * 1000) / sigmaSt                       // N / (N/mm²) = mm²/m
+  const vertAs = (M * 1e6) / (sigmaSt * J * d)              // N·mm / (N/mm² · mm) = mm²/m
+
+  const Ec = 4700 * Math.sqrt(Math.max(p.fc, 1))
+  const n = 200000 / Ec
+  const fct = (T * 1000) / (1000 * p.t + (n - 1) * hoopAs)  // MPa
+
+  const Ab = (Math.PI / 4) * p.barDia ** 2
+  const sMax = Math.min(3 * p.t, 300)                       // tighter cap for liquid tightness
+  const spacing = (As: number) => As > 0 ? Math.max(50, Math.min(sMax, Math.floor((1000 * Ab) / As / 5) * 5)) : sMax
+
+  return {
+    T, M, d,
+    hoopAs, hoopSpacing: spacing(hoopAs),
+    vertAs, vertSpacing: spacing(vertAs),
+    fct, thicknessOK: fct <= sigmaCt,
+    freeboardOK: (p.freeboard ?? 0.3) >= 0.3,
+  }
+}

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -28,6 +28,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/steel',         name: 'Steel Design',       sub: 'AISC 360-16 LRFD'      },
       { to: '/slab-design',   name: 'Slab Design',        sub: 'Two-way DDM · ACI 318'  },
       { to: '/stair',         name: 'Stair Design',       sub: 'RC waist slab · NSCP'   },
+      { to: '/water-tank',    name: 'Water Tank',         sub: 'Circular · IS 3370/ACI 350' },
       { to: '/torsion',       name: 'Torsion Design',     sub: 'RC torsion · ACI 318-14' },
       { to: '/dev-length',    name: 'Dev & Splice',       sub: 'ACI 318-14 §25.4–25.5'   },
       { to: '/punching-shear', name: 'Punching Shear',   sub: 'Two-way §22.6 · ACI 318' },

--- a/webapp/src/pages/WaterTank.tsx
+++ b/webapp/src/pages/WaterTank.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react'
+import { designCircularTank } from '../engine/waterTank'
+
+function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
+const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
+const f0 = (n: number) => (Number.isFinite(n) ? Math.round(n).toString() : '—')
+
+function Field({ label, value, onChange, unit, step = 'any' }: {
+  label: string; value: number; onChange: (v: number) => void; unit?: string; step?: string
+}) {
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="mb-1 font-medium text-slate-600">{label}{unit ? ` (${unit})` : ''}</span>
+      <input type="number" step={step} value={value} onChange={(e) => onChange(num(e.target.value))}
+        className="rounded-md border border-slate-300 px-2.5 py-1.5" />
+    </label>
+  )
+}
+
+function Out({ label, value, ok }: { label: string; value: string; ok?: boolean }) {
+  return (
+    <div className="flex items-baseline justify-between border-t border-slate-100 py-1 text-sm">
+      <span className="text-slate-500">{label}</span>
+      <span className={`font-mono font-medium ${ok === undefined ? 'text-slate-800' : ok ? 'text-emerald-600' : 'text-red-600'}`}>{value}</span>
+    </div>
+  )
+}
+
+export default function WaterTank() {
+  const [H, setH] = useState(4)
+  const [D, setD] = useState(10)
+  const [t, setT] = useState(250)
+  const [freeboard, setFreeboard] = useState(0.3)
+  const [fc, setFc] = useState(28)
+  const [sigmaSt, setSigmaSt] = useState(130)
+  const [sigmaCt, setSigmaCt] = useState(1.3)
+  const [cover, setCover] = useState(40)
+  const [barDia, setBarDia] = useState(16)
+
+  const r = designCircularTank({ H, D, t, freeboard, fc, sigmaSt, sigmaCt, cover, barDia })
+
+  return (
+    <main className="mx-auto max-w-3xl px-5 py-10">
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">Structural</p>
+      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Circular RC water tank — wall</h1>
+      <p className="mt-2 text-sm text-slate-600">
+        Permissible-stress (working-stress) wall design for a circular liquid-retaining tank, following the
+        crack-control philosophy of IS 3370 / ACI 350. Hoop (ring) tension governs the horizontal steel;
+        the base cantilever moment governs the vertical steel; the wall is checked against concrete cracking.
+      </p>
+
+      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Geometry</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Field label="Water depth H" unit="m" value={H} onChange={setH} />
+          <Field label="Diameter D" unit="m" value={D} onChange={setD} />
+          <Field label="Wall thickness t" unit="mm" value={t} onChange={setT} />
+          <Field label="Freeboard" unit="m" value={freeboard} onChange={setFreeboard} step="0.05" />
+        </div>
+        <h2 className="mb-3 mt-5 text-[1.05rem] font-bold text-[#0056b3]">Materials &amp; permissible stresses</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Field label="f′c" unit="MPa" value={fc} onChange={setFc} />
+          <Field label="σst (steel)" unit="MPa" value={sigmaSt} onChange={setSigmaSt} />
+          <Field label="σct (concrete)" unit="MPa" value={sigmaCt} onChange={setSigmaCt} step="0.1" />
+          <Field label="Bar Ø" unit="mm" value={barDia} onChange={setBarDia} />
+          <Field label="Cover" unit="mm" value={cover} onChange={setCover} />
+        </div>
+      </section>
+
+      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Results</h2>
+        <Out label="Max hoop tension T = γw·H·D/2" value={`${f2(r.T)} kN/m`} />
+        <Out label="Ring (hoop) steel As" value={`${f0(r.hoopAs)} mm²/m — ⌀${barDia} @ ${f0(r.hoopSpacing)} mm (each face)`} />
+        <Out label="Base cantilever moment M = γw·H³/6" value={`${f2(r.M)} kN·m/m`} />
+        <Out label="Vertical steel As" value={`${f0(r.vertAs)} mm²/m — ⌀${barDia} @ ${f0(r.vertSpacing)} mm`} />
+        <Out label={`Concrete tension fct (≤ ${f2(sigmaCt)})`} value={`${f2(r.fct)} MPa`} ok={r.thicknessOK} />
+        <Out label="Freeboard ≥ 300 mm" value={`${f2(freeboard)} m`} ok={r.freeboardOK} />
+        <p className="mt-2 text-[10px] text-slate-400">
+          Provide ring steel on both faces near the base where hoop tension peaks; reduce up the wall as
+          T = γw·z·D/2 falls. σst ≈ 115–150 MPa controls crack width (IS 3370 / ACI 350). Base slab, roof,
+          and the wall-base joint (fixed vs hinged) are designed separately.
+        </p>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

Adds **Water Tank design** (roadmap Phase 3, last remaining structural item).

**Scope decision:** circular liquid-retaining tank **wall**, designed by the **permissible-stress (working-stress) method** — the crack-control philosophy shared by **IS 3370 / ACI 350**. Circular gives the cleanest closed form (membrane hoop tension + cantilever moment) and working-stress keeps it transparent and testable.

## Engine (`waterTank.ts`)
- `hoopTension` — ring tension `T(z) = γw·z·D/2` per unit height (max at base).
- `wallCantileverMoment` — base moment `M = γw·H³/6` (triangular hydrostatic on a vertical cantilever wall).
- `designCircularTank` — hoop steel `T/σst`, vertical steel `M/(σst·j·d)`, concrete direct-tension crack check `fct ≤ σct`, spacing capped at `min(3t, 300)` for liquid-tightness, freeboard check.

## Tests (+10)
Hoop/moment formulas & scaling, steel areas, thickness/σct check, permissible-stress sensitivity, spacing cap, freeboard flag.

## UI
`pages/WaterTank.tsx` + `/water-tank` route + a Structural nav entry — geometry and permissible-stress inputs with live hoop tension, moment, ring/vertical steel, and the concrete-tension check.

Verified: `npm test` (931 passing), `npx tsc -b`, `npm run build` all clean.

> Note: scoped to the **wall**; base slab, roof and the wall-base joint (fixed vs hinged) are flagged as separate. Could extend to rectangular tanks (plate coefficients) and a base-slab module later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_