### PR TITLE
docs+feat: Validation Manual ch.3 (modal &amp; response spectrum)

### DIFF
--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -17,10 +17,10 @@ per-module pass counts, so the manual cannot silently drift from the code.
 | --- | --- | --- |
 | [Frame analysis](./frame.md) | Beam/frame solver vs closed-form elasticity | ✅ |
 | [NSCP seismic](./seismic.md) | 208 static period & base shear + governing logic | ✅ |
+| [Modal & response spectrum](./dynamics.md) | Eigen-solver, SDOF period, pseudo relations | ✅ |
 | RC design | Beam Mn, column φPn, footing area | in `/validation` (dashboard) |
 | Steel design | φMp, φVn | in `/validation` (dashboard) |
 | Geotechnical | Bearing factors, earth pressure, slope FS | in `/validation` (dashboard) |
-| Modal / response spectrum | Periods, base shear vs ETABS | _planned_ |
 
 ## Levels of validation
 

--- a/docs/validation/dynamics.md
+++ b/docs/validation/dynamics.md
@@ -1,0 +1,49 @@
+# Chapter 3 — Modal & response spectrum
+
+The dynamics engines are the eigen-solver and modal analysis (`engine/modal.ts`)
+and the elastic response spectrum from a recorded accelerogram
+(`engine/accelSpectrum.ts`). They are validated against linear-algebra closed
+forms, single-degree-of-freedom (SDOF) theory, and the pseudo-spectral
+identities.
+
+## Benchmarks (dashboard-enforced)
+
+| # | Quantity | Reference | Formula | Result |
+| --- | --- | --- | --- | --- |
+| 1 | Jacobi eigenvalue of `[[2,1],[1,2]]` | Linear algebra | λ = 2 ± 1 → λmax = 3 | ✅ PASS |
+| 2 | Response spectrum T → 0 anchor | Chopra | Sa(0) = PGA | ✅ PASS |
+| 3 | Pseudo-acceleration relation | Chopra | PSA = ω²·Sd | ✅ PASS |
+
+### Notes
+
+- **Eigenvalues** — the symmetric Jacobi solver reproduces the exact eigenpairs
+  of a hand-solvable matrix; this is the kernel under modal analysis.
+- **T = 0 anchor** — a rigid oscillator follows the ground, so the spectral
+  acceleration at zero period equals the peak ground acceleration.
+- **Pseudo relation** — the engine forms `PSV = ω·Sd` and `PSA = ω²·Sd`; the
+  benchmark confirms the identity holds at an arbitrary period of the computed
+  spectrum.
+
+## Cross-checks already in the test suite
+
+`modal.test.ts`:
+
+- **SDOF fundamental period** of a lumped-mass column matches `T = 2π·√(m/k)`,
+  with `k` taken from a static unit-load analysis and `m` from the lumped
+  seismic mass — to 4 decimal places.
+- eigenpairs satisfy `A·v = λ·v`; eigenvectors are unit length; mass assembly
+  totals the member + slab masses; effective-mass ratios sum to ~1.
+
+`accelSpectrum.test.ts`:
+
+- **Newmark-β SDOF** integration of `ü + 2ζω·u̇ + ω²u = −ag` reproduces the
+  steady-state response of a harmonic base motion and shows resonance near the
+  natural frequency.
+- the `PSA / PSV / Sd` relations hold across the period grid; increasing damping
+  ζ lowers the ordinates; empty/zero/`dt ≤ 0` inputs are guarded.
+
+## Planned cross-checks
+
+A multi-storey shear-building modal comparison (periods, mode shapes,
+participation factors) and a base-shear comparison against **ETABS** response
+spectrum analysis on a documented reference model.

--- a/webapp/src/engine/validation.ts
+++ b/webapp/src/engine/validation.ts
@@ -16,13 +16,15 @@ import { shapeByName } from './aiscSections'
 import { designAxialColumn } from './columnDesign'
 import { activeThrust, rankineKa, bearingFactors, infiniteSlopeFS } from './geotech'
 import { computeSeismic } from './seismic'
+import { jacobiEigen } from './modal'
+import { elasticResponseSpectrum } from './accelSpectrum'
 import { generateGridModel } from './modelBuilder'
 import { solveFrame3D, rectJ, type F3Node, type F3Member, type F3Support } from './frame3d'
 import type { RectSection } from './model'
 
 export interface ValidationCase {
   id: string
-  category: 'RC' | 'Steel' | 'Analysis' | 'Wind' | 'Geotech' | 'Seismic'
+  category: 'RC' | 'Steel' | 'Analysis' | 'Seismic' | 'Dynamics' | 'Wind' | 'Geotech'
   title: string
   reference: string
   formula: string
@@ -130,6 +132,20 @@ const slopeFS = (() => {
   return { manual: tan(phiDeg) / tan(betaDeg), software: infiniteSlopeFS({ c: 0, phiDeg, gamma: 18, z: 3, betaDeg }) }
 })()
 
+// ── Dynamics — eigen-solver & response spectrum ──────────────────────────────
+const dynamics = (() => {
+  const vals = jacobiEigen([[2, 1], [1, 2]]).values             // closed form: 1, 3
+  const ag = [0, 0.4, 1.0, -0.7, 0.5, -1.0, 0.2]                // m/s², PGA = 1.0
+  const spec = elasticResponseSpectrum(ag, 0.02, { Tmin: 0.1, Tmax: 2, nT: 20 })!
+  const p = spec.points[Math.floor(spec.points.length / 2)]
+  const omega = (2 * Math.PI) / p.T
+  return {
+    eig: { manual: 3, software: Math.max(...vals) },
+    anchor: { manual: spec.pga, software: spec.points[0].PSA },
+    pseudo: { manual: omega * omega * p.Sd, software: p.PSA },
+  }
+})()
+
 // ── 11. NSCP 208 seismic static — period & base shear ────────────────────────
 const seismic = (() => {
   const section: RectSection = { id: 'S', name: 's', b: 400, h: 400, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
@@ -216,5 +232,20 @@ export const VALIDATION_CASES: ValidationCase[] = [
     id: 'seismic-base-shear', category: 'Seismic', title: 'NSCP 208 static base shear',
     reference: 'NSCP 208.5.2.1', formula: 'V = Cv·I·W / (R·T)',
     manual: seismic.baseShear.manual, software: seismic.baseShear.software, unit: 'kN', tol: 1e-6,
+  },
+  {
+    id: 'eigen-jacobi', category: 'Dynamics', title: 'Jacobi eigenvalue of [[2,1],[1,2]]',
+    reference: 'Linear algebra', formula: 'λ = 2 ± 1  →  λmax = 3',
+    manual: dynamics.eig.manual, software: dynamics.eig.software, unit: '—', tol: 1e-6,
+  },
+  {
+    id: 'spectrum-anchor', category: 'Dynamics', title: 'Response spectrum T = 0 anchor',
+    reference: 'Chopra, Dynamics of Structures', formula: 'Sa(T→0) = PGA',
+    manual: dynamics.anchor.manual, software: dynamics.anchor.software, unit: 'm/s²', tol: 1e-9,
+  },
+  {
+    id: 'spectrum-pseudo', category: 'Dynamics', title: 'Pseudo-acceleration relation',
+    reference: 'Chopra, Dynamics of Structures', formula: 'PSA = ω²·Sd',
+    manual: dynamics.pseudo.manual, software: dynamics.pseudo.software, unit: 'm/s²', tol: 1e-9,
   },
 ]

--- a/webapp/src/pages/Validation.tsx
+++ b/webapp/src/pages/Validation.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom'
 import { VALIDATION_CASES, pctDiff, type ValidationCase } from '../engine/validation'
 
-const CATS = ['RC', 'Steel', 'Analysis', 'Seismic', 'Wind', 'Geotech'] as const
+const CATS = ['RC', 'Steel', 'Analysis', 'Seismic', 'Dynamics', 'Wind', 'Geotech'] as const
 
 function fmt(v: number): string {
   if (!Number.isFinite(v)) return '—'


### PR DESCRIPTION
## Summary

Adds **Chapter 3 — Modal & response spectrum** to the validation manual (the second item you asked for), with matching dashboard benchmarks.

## Docs
- **`docs/validation/dynamics.md`** — eigen-solver, response-spectrum T→0 anchor and pseudo-acceleration identity as benchmarks, plus the existing cross-checks in `modal.test.ts` (SDOF period `2π√(m/k)`, eigenpairs, mass/effective-mass) and `accelSpectrum.test.ts` (Newmark-β SDOF, resonance, PSA/PSV/Sd relations, damping). Planned multi-storey + ETABS comparison noted.
- `README.md` index updated (dynamics chapter ✅).

## Engine / UI
- `engine/validation.ts` — new **`Dynamics`** category with three benchmarks:
  - Jacobi eigenvalue of `[[2,1],[1,2]]` → `λmax = 3` (linear-algebra closed form)
  - response spectrum **T = 0 anchor** → `Sa = PGA`
  - **pseudo-acceleration** identity `PSA = ω²·Sd`
- `pages/Validation.tsx` — `Dynamics` added to the dashboard categories.

Verified: `npm test` (931 passing), `npx tsc -b`, `npm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_