### PR TITLE
feat: soil-nail shotcrete facing design (FHWA GEC-7) — roadmap Phase 3 geotech

### DIFF
--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -68,7 +68,7 @@ Geotechnical:
 - [x] Geotechnical toolkit (`/geotech`: bearing capacity, earth pressure, slope)
 - [x] Soil Nailing (`/soil-nail`, FHWA GEC-7)
 - [x] Micropile Design (`/micropile`, FHWA-NHI-05-039)
-- [ ] Shotcrete Design (facing design — partly covered by soil-nail facing checks)
+- [x] Shotcrete Design (`/shotcrete-facing`; FHWA GEC-7 facing flexure + punching)
 - [ ] Rock Anchors
 - [ ] Pressure Grouting
 

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -29,6 +29,7 @@ import Micropile from './pages/Micropile'
 import RockAnchor from './pages/RockAnchor'
 import SeismicWizard from './pages/SeismicWizard'
 import WaterTank from './pages/WaterTank'
+import ShotcreteFacing from './pages/ShotcreteFacing'
 import SlabEstimate from './pages/SlabEstimate'
 import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
@@ -77,6 +78,7 @@ export default function App() {
         <Route path="/rock-anchor" element={<RockAnchor />} />
         <Route path="/seismic-wizard" element={<SeismicWizard />} />
         <Route path="/water-tank" element={<WaterTank />} />
+        <Route path="/shotcrete-facing" element={<ShotcreteFacing />} />
         <Route path="/estimate/slab" element={<SlabEstimate />} />
         <Route path="/estimate/beam" element={<BeamEstimate />} />
         <Route path="/estimate/column" element={<ColumnEstimate />} />

--- a/webapp/src/engine/shotcreteFacing.test.ts
+++ b/webapp/src/engine/shotcreteFacing.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { facingMoment, facingFlexuralStrength, facingPunchingStrength, designFacing } from './shotcreteFacing'
+import { concreteBeamMn } from './scwb'
+
+describe('facingMoment', () => {
+  it('m = As·fy·(d − a/2) per metre width (matches concreteBeamMn at b = 1000)', () => {
+    expect(facingMoment(500, 90, 21, 415)).toBeCloseTo(concreteBeamMn(1000, 90, 500, 21, 415), 9)
+  })
+})
+
+describe('facingFlexuralStrength — FHWA GEC-7', () => {
+  it('R_FF = C_F·(m_neg + m_pos)·8·S_perp/S_span', () => {
+    const r = facingFlexuralStrength({ CF: 2, mNeg: 10, mPos: 10, Sspan: 1.5, Sperp: 1.5 })
+    expect(r).toBeCloseTo((2 * 20 * 8 * 1.5) / 1.5, 6)   // 320 kN
+  })
+  it('closer spacing (smaller S_span) raises the strength', () => {
+    const wide = facingFlexuralStrength({ CF: 2, mNeg: 10, mPos: 10, Sspan: 2.0, Sperp: 1.5 })
+    const tight = facingFlexuralStrength({ CF: 2, mNeg: 10, mPos: 10, Sspan: 1.0, Sperp: 1.5 })
+    expect(tight).toBeGreaterThan(wide)
+  })
+})
+
+describe('facingPunchingStrength — ACI two-way', () => {
+  it('φ·0.33·√f′c·bo·d around the bearing plate', () => {
+    const d = 100 - 30
+    const bo = Math.PI * (0.2 * 1000 + d)
+    const expected = (0.75 * 0.33 * Math.sqrt(21) * bo * d) / 1000
+    expect(facingPunchingStrength({ fc: 21, bearingPlate: 0.2, hc: 100, cover: 30 })).toBeCloseTo(expected, 6)
+  })
+  it('a thicker facing punches harder to fail', () => {
+    expect(facingPunchingStrength({ fc: 21, bearingPlate: 0.2, hc: 150, cover: 30 }))
+      .toBeGreaterThan(facingPunchingStrength({ fc: 21, bearingPlate: 0.2, hc: 100, cover: 30 }))
+  })
+})
+
+describe('designFacing', () => {
+  const base = {
+    SH: 1.5, SV: 1.5, hc: 100, cover: 30, AsVert: 400, AsHoriz: 400,
+    fc: 21, fy: 415, bearingPlate: 0.2, CF: 2.0, nailHeadForce: 60,
+  }
+  it('governing strength = min(flexure, punching); FoS = strength/demand', () => {
+    const r = designFacing(base)
+    expect(r.strength).toBeCloseTo(Math.min(r.Rff, r.Rfp), 9)
+    expect(r.governs).toBe(r.Rff <= r.Rfp ? 'flexure' : 'punching')
+    expect(r.fs).toBeCloseTo(r.strength / 60, 9)
+    expect(r.ok).toBe(r.strength >= 60)
+  })
+  it('equal spacing & steel ⇒ the two flexure directions match', () => {
+    const r = designFacing(base)
+    expect(r.RffVert).toBeCloseTo(r.RffHoriz, 6)
+  })
+  it('more facing reinforcement raises the flexural strength', () => {
+    const light = designFacing({ ...base, AsVert: 300, AsHoriz: 300 })
+    const heavy = designFacing({ ...base, AsVert: 700, AsHoriz: 700 })
+    expect(heavy.Rff).toBeGreaterThan(light.Rff)
+  })
+  it('a heavy nail-head force fails a thin, lightly-meshed facing', () => {
+    const r = designFacing({ ...base, nailHeadForce: 500 })
+    expect(r.ok).toBe(false)
+    expect(r.fs).toBeLessThan(1)
+  })
+})

--- a/webapp/src/engine/shotcreteFacing.ts
+++ b/webapp/src/engine/shotcreteFacing.ts
@@ -1,0 +1,89 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Soil-nail shotcrete facing — flexure & punching (FHWA GEC-7, Soil Nail Walls).
+//
+// WHY the facing is designed for FLEXURE:
+//   The shotcrete facing is not a retaining wall — it is a thin panel that spans
+//   BETWEEN the discrete nail heads. Earth pressure pushes on the panel and is
+//   reacted only at the nails, so the facing bends like a continuous two-way slab
+//   supported on a grid of point supports (spacing S_H × S_V): it hogs (negative
+//   moment) over each nail head and sags (positive moment) at midspan. If it
+//   can't carry that bending it cracks/yields between nails and the wall loses the
+//   ability to transfer soil load into the nails — a facing failure, distinct from
+//   nail tensile/pullout failure. Hence FHWA GEC-7 checks the facing flexural
+//   nail-head strength R_FF, the punching-shear strength R_FP (the head punching
+//   through the panel), and, for permanent facing, headed-stud tension.
+//
+//   R_FF (per direction) = C_F · (m_neg + m_pos) · 8 · S_perp / S_span
+//     from the plastic mechanism of a fixed-ended strip: w_c·S_span² / 8 =
+//     m_neg + m_pos, and the nail-head force R = w_c · (S_H·S_V). C_F (Table 6-x)
+//     scales for the real, non-uniform (arching) pressure vs. a uniform one.
+//   m = A_s·f_y·(d − a/2) per metre width (the panel's flexural resistance).
+//   R_FP = 0.33·√f′c · b_o · d  (ACI two-way shear around the bearing plate).
+// The facing is adequate when the nail-head force ≤ min(R_FF, R_FP).
+// Units: spacings/plate m; h_c/d/cover mm; A_s mm²/m; f MPa; forces kN.
+// ─────────────────────────────────────────────────────────────────────────
+import { concreteBeamMn } from './scwb'
+
+/** Panel flexural resistance per metre width, m = As·fy·(d − a/2), kN·m/m. */
+export function facingMoment(As: number, d: number, fc: number, fy: number): number {
+  return concreteBeamMn(1000, d, As, fc, fy)
+}
+
+/**
+ * Facing flexural nail-head strength in one bending direction (FHWA GEC-7):
+ * R_FF = C_F·(m_neg + m_pos)·8·S_perp/S_span. `Sspan` is the nail spacing the
+ * reinforcement spans; `Sperp` the tributary spacing perpendicular to it.
+ */
+export function facingFlexuralStrength(p: { CF: number; mNeg: number; mPos: number; Sspan: number; Sperp: number }): number {
+  return (p.CF * (p.mNeg + p.mPos) * 8 * p.Sperp) / p.Sspan
+}
+
+/** Facing punching-shear strength around the bearing plate (ACI two-way), kN. */
+export function facingPunchingStrength(p: { fc: number; bearingPlate: number; hc: number; cover: number; phi?: number }): number {
+  const d = Math.max(p.hc - p.cover, 0.5 * p.hc)          // mm
+  const bo = Math.PI * (p.bearingPlate * 1000 + d)        // mm (plate m→mm + d)
+  const Vc = 0.33 * Math.sqrt(Math.max(p.fc, 1)) * bo * d // N
+  return ((p.phi ?? 0.75) * Vc) / 1000                    // kN
+}
+
+export interface FacingResult {
+  d: number
+  mVert: number; mHoriz: number          // panel moments per width, kN·m/m
+  RffVert: number; RffHoriz: number      // flexural strength each direction, kN
+  Rff: number; Rfp: number               // governing flexure & punching, kN
+  strength: number                       // governing facing nail-head strength, kN
+  governs: 'flexure' | 'punching'
+  fs: number
+  ok: boolean
+}
+
+/**
+ * Design a soil-nail shotcrete facing panel. Assumes equal reinforcement on both
+ * faces (m_neg = m_pos) — typical for a symmetric welded-wire/waler mesh.
+ */
+export function designFacing(p: {
+  SH: number; SV: number;              // nail spacings, m
+  hc: number; cover: number;            // facing thickness & cover, mm
+  AsVert: number; AsHoriz: number;      // reinforcement each direction, mm²/m
+  fc: number; fy: number;
+  bearingPlate: number;                 // bearing-plate width, m
+  CF?: number;                          // facing pressure factor (Table 6-x, ~2 thin → 1 thick)
+  nailHeadForce: number;                // demand, kN
+}): FacingResult {
+  const d = Math.max(p.hc - p.cover, 0.5 * p.hc)
+  const CF = p.CF ?? 2.0
+  const mVert = facingMoment(p.AsVert, d, p.fc, p.fy)
+  const mHoriz = facingMoment(p.AsHoriz, d, p.fc, p.fy)
+  // vertical reinforcement spans S_V (between rows), tributary width S_H
+  const RffVert = facingFlexuralStrength({ CF, mNeg: mVert, mPos: mVert, Sspan: p.SV, Sperp: p.SH })
+  const RffHoriz = facingFlexuralStrength({ CF, mNeg: mHoriz, mPos: mHoriz, Sspan: p.SH, Sperp: p.SV })
+  const Rff = Math.min(RffVert, RffHoriz)
+  const Rfp = facingPunchingStrength({ fc: p.fc, bearingPlate: p.bearingPlate, hc: p.hc, cover: p.cover })
+  const strength = Math.min(Rff, Rfp)
+  return {
+    d, mVert, mHoriz, RffVert, RffHoriz, Rff, Rfp, strength,
+    governs: Rff <= Rfp ? 'flexure' : 'punching',
+    fs: p.nailHeadForce > 0 ? strength / p.nailHeadForce : Infinity,
+    ok: strength >= p.nailHeadForce,
+  }
+}

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -37,6 +37,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/soil-nail',        name: 'Soil-Nail Wall',   sub: 'FHWA · tensile · pullout' },
       { to: '/micropile',        name: 'Micropile',        sub: 'FHWA · structural · bond' },
       { to: '/rock-anchor',      name: 'Rock Anchor',      sub: 'PTI · tendon · bond'      },
+      { to: '/shotcrete-facing', name: 'Shotcrete Facing',  sub: 'FHWA · flexure · punching' },
       { to: '/seismic-wizard',   name: 'Seismic Wizard',   sub: 'NSCP 208 Ca/Cv/I/R'       },
       { to: '/load-combinations', name: 'Load Combinations', sub: 'NSCP 2015 §203.3 LRFD'   },
     ],

--- a/webapp/src/pages/ShotcreteFacing.tsx
+++ b/webapp/src/pages/ShotcreteFacing.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react'
+import { designFacing } from '../engine/shotcreteFacing'
+
+function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
+const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
+const f0 = (n: number) => (Number.isFinite(n) ? Math.round(n).toString() : '—')
+
+function Field({ label, value, onChange, unit, step = 'any' }: {
+  label: string; value: number; onChange: (v: number) => void; unit?: string; step?: string
+}) {
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="mb-1 font-medium text-slate-600">{label}{unit ? ` (${unit})` : ''}</span>
+      <input type="number" step={step} value={value} onChange={(e) => onChange(num(e.target.value))}
+        className="rounded-md border border-slate-300 px-2.5 py-1.5" />
+    </label>
+  )
+}
+
+function Out({ label, value, ok }: { label: string; value: string; ok?: boolean }) {
+  return (
+    <div className="flex items-baseline justify-between border-t border-slate-100 py-1 text-sm">
+      <span className="text-slate-500">{label}</span>
+      <span className={`font-mono font-medium ${ok === undefined ? 'text-slate-800' : ok ? 'text-emerald-600' : 'text-red-600'}`}>{value}</span>
+    </div>
+  )
+}
+
+export default function ShotcreteFacing() {
+  const [SH, setSH] = useState(1.5)
+  const [SV, setSV] = useState(1.5)
+  const [hc, setHc] = useState(100)
+  const [cover, setCover] = useState(30)
+  const [AsVert, setAsVert] = useState(400)
+  const [AsHoriz, setAsHoriz] = useState(400)
+  const [fc, setFc] = useState(21)
+  const [fy, setFy] = useState(415)
+  const [bearingPlate, setBearingPlate] = useState(0.2)
+  const [CF, setCF] = useState(2.0)
+  const [nailHeadForce, setNailHeadForce] = useState(60)
+
+  const r = designFacing({ SH, SV, hc, cover, AsVert, AsHoriz, fc, fy, bearingPlate, CF, nailHeadForce })
+
+  return (
+    <main className="mx-auto max-w-3xl px-5 py-10">
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">Geotechnical</p>
+      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Soil-nail shotcrete facing</h1>
+      <p className="mt-2 text-sm text-slate-600">
+        FHWA GEC-7 facing check. The thin shotcrete panel spans <b>between</b> the nail heads, so earth
+        pressure bends it like a two-way slab on point supports — hogging over each nail, sagging at
+        midspan. This checks the facing flexural nail-head strength R<sub>FF</sub> and the punching-shear
+        strength R<sub>FP</sub> against the nail-head force.
+      </p>
+
+      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Layout &amp; facing</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Field label="Horiz. spacing SH" unit="m" value={SH} onChange={setSH} />
+          <Field label="Vert. spacing SV" unit="m" value={SV} onChange={setSV} />
+          <Field label="Facing thickness hc" unit="mm" value={hc} onChange={setHc} />
+          <Field label="Cover" unit="mm" value={cover} onChange={setCover} />
+          <Field label="Vert. steel As" unit="mm²/m" value={AsVert} onChange={setAsVert} />
+          <Field label="Horiz. steel As" unit="mm²/m" value={AsHoriz} onChange={setAsHoriz} />
+          <Field label="Bearing plate" unit="m" value={bearingPlate} onChange={setBearingPlate} step="0.05" />
+          <Field label="Pressure factor CF" value={CF} onChange={setCF} step="0.1" />
+        </div>
+        <h2 className="mb-3 mt-5 text-[1.05rem] font-bold text-[#0056b3]">Materials &amp; demand</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          <Field label="f′c" unit="MPa" value={fc} onChange={setFc} />
+          <Field label="fy" unit="MPa" value={fy} onChange={setFy} />
+          <Field label="Nail-head force" unit="kN" value={nailHeadForce} onChange={setNailHeadForce} />
+        </div>
+      </section>
+
+      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Results</h2>
+        <Out label="Panel moment m (vert / horiz)" value={`${f2(r.mVert)} / ${f2(r.mHoriz)} kN·m/m`} />
+        <Out label="Flexural R_FF (vert / horiz)" value={`${f0(r.RffVert)} / ${f0(r.RffHoriz)} kN`} />
+        <Out label="Punching R_FP" value={`${f0(r.Rfp)} kN`} />
+        <Out label={`Governing facing strength (${r.governs})`} value={`${f0(r.strength)} kN`} ok={r.ok} />
+        <Out label="FS (strength / nail-head force)" value={f2(r.fs)} ok={r.ok} />
+        <p className="mt-2 text-[10px] text-slate-400">
+          R_FF = C_F·(m_neg + m_pos)·8·S_perp/S_span (fixed-strip mechanism). R_FP = φ·0.33·√f′c·bo·d
+          around the bearing plate. C_F ≈ 2.0 thin → 1.0 thick facing (FHWA GEC-7 Table). Headed-stud
+          tension (permanent facing) and temporary-vs-final facing stages are checked separately.
+        </p>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

Adds the **shotcrete facing** check (roadmap "Shotcrete Design"), completing the soil-nail wall workflow, per **FHWA GEC-7**.

### Why facing *flexure* is the governing check
The shotcrete facing is **not** a retaining wall — it's a thin panel that spans **between** the discrete nail heads. Earth pressure pushes on it and is reacted only at the nails, so it bends like a **two-way slab on point supports** (spacing S_H × S_V): hogging (negative moment) over each nail head, sagging (positive moment) at midspan. If it can't carry that bending it cracks/yields between nails and can no longer transfer soil load into the nails — a **facing failure**, distinct from nail tensile/pullout failure. So GEC-7 checks the facing **flexural** nail-head strength `R_FF` and the **punching** strength `R_FP`.

## Engine (`shotcreteFacing.ts`)
- `facingMoment` — panel resistance `m = As·fy·(d−a/2)` per metre (reuses `concreteBeamMn`).
- `facingFlexuralStrength` — `R_FF = C_F·(m_neg+m_pos)·8·S_perp/S_span`, derived from the fixed-strip plastic mechanism (`w_c·S²/8 = m_neg+m_pos`, nail-head force `R = w_c·S_H·S_V`); `C_F` is the FHWA pressure factor (~2.0 thin → 1.0 thick).
- `facingPunchingStrength` — `φ·0.33·√f′c·bo·d` (ACI two-way shear) around the bearing plate.
- `designFacing` — governing `min(flexure both directions, punching)` vs the nail-head force, with FoS.

## Tests (+9)
Moment match, `R_FF` formula & spacing sensitivity, punching formula, governing/FoS logic, reinforcement sensitivity, overload failure.

## UI
`pages/ShotcreteFacing.tsx` + `/shotcrete-facing` route + a Structural nav entry, with the "why" explained inline.

Verified: `npm test` (940 passing), `npx tsc -b`, `npm run build` all clean.

> Scope: single (final) facing stage, symmetric mesh. Headed-stud tension (permanent facing) and temporary-vs-final staging are flagged as separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_