### PR TITLE
polish(steel connections): accurate connected elements + custom eccentric bolts

### DIFF
--- a/webapp/src/engine/steelConnections.test.ts
+++ b/webapp/src/engine/steelConnections.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import { generateGridModel, buildGravityLoads } from './modelBuilder'
 import { designStructure } from './pipeline'
-import { designSteelJoints } from './steelConnections'
+import { designSteelJoints, designBolts } from './steelConnections'
+import type { BoltPos } from './steelDesign'
 import type { RectSection } from './model'
 
 const steelSection: RectSection = {
@@ -42,11 +43,25 @@ describe('steel joint / connection design', () => {
     }
   })
 
-  it('bolt group: n × φRn ≥ Vu for each connection', () => {
+  it('bolt group: elastic eccentric method sizes each bolt within φRn', () => {
     for (const j of joints) {
       for (const c of j.connections) {
-        expect(c.bolts.n * c.bolts.phiRnKn).toBeGreaterThanOrEqual(c.Vu - 1e-6)
-        expect(c.bolts.dia).toBe(20)              // M20
+        expect(c.bolts.dia).toBe(20)                       // M20
+        expect(c.bolts.locations.length).toBe(c.bolts.n)   // one position per bolt
+        expect(c.bolts.Rmax).toBeLessThanOrEqual(c.bolts.phiRnKn + 1e-6)
+        expect(c.bolts.ok).toBe(true)
+        expect(c.bolts.ecc).toBeGreaterThan(0)             // real in-plane eccentricity
+        // the eccentric peak force is at least the direct share V/n
+        expect(c.bolts.Rmax).toBeGreaterThanOrEqual(c.Vu / c.bolts.n - 1e-6)
+      }
+    }
+  })
+
+  it('connected elements are reflected on both sides (column face → beam element)', () => {
+    for (const j of joints) {
+      for (const c of j.connections) {
+        expect(['flange', 'web']).toContain(c.faceType)
+        expect(c.beamElement).toBe(c.connType === 'moment-flange-weld' ? 'web+flanges' : 'web')
       }
     }
   })
@@ -83,5 +98,39 @@ describe('steel joint / connection design', () => {
     rcModel.loads = buildGravityLoads(rcModel, 4.8, 2.4)
     const rcDesign = designStructure(rcModel, soil)!
     expect(designSteelJoints(rcModel, rcDesign)).toHaveLength(0)
+  })
+})
+
+describe('designBolts — elastic eccentric bolt group', () => {
+  it('lays out one column, each bolt within φRn, ecc = centroid-to-weld distance', () => {
+    const g = designBolts(200)
+    expect(g.n).toBeGreaterThanOrEqual(2)
+    expect(g.locations).toHaveLength(g.n)
+    expect(g.ecc).toBeCloseTo(Math.abs(g.locations[0].x), 6)   // single column → Cx = bolt x
+    expect(g.Rmax).toBeLessThanOrEqual(g.phiRnKn + 1e-6)
+    expect(g.ok).toBe(true)
+  })
+
+  it('eccentricity raises the peak bolt force above the concentric share', () => {
+    const conc = designBolts(200, { aMm: 0 })    // no eccentricity ⇒ Rmax = V/n
+    const ecc = designBolts(200, { aMm: 120 })   // large eccentricity
+    expect(conc.Rmax).toBeCloseTo(200 / conc.n, 4)
+    expect(ecc.Rmax).toBeGreaterThan(200 / ecc.n)
+  })
+
+  it('accepts CUSTOM per-bolt locations and evaluates each', () => {
+    const locations: BoltPos[] = [
+      { id: 'B1', x: 50, y: 0 }, { id: 'B2', x: 50, y: 70 },
+      { id: 'B3', x: 50, y: 140 }, { id: 'B4', x: 110, y: 70 },   // an off-column bolt
+    ]
+    const g = designBolts(150, { locations })
+    expect(g.n).toBe(4)
+    expect(g.locations).toEqual(locations)
+    expect(g.Rmax).toBeGreaterThan(0)
+    expect(g.criticalId).toMatch(/^B[1-4]$/)
+  })
+
+  it('heavier shear needs more bolts', () => {
+    expect(designBolts(400).n).toBeGreaterThan(designBolts(150).n)
   })
 })

--- a/webapp/src/engine/steelConnections.ts
+++ b/webapp/src/engine/steelConnections.ts
@@ -11,12 +11,11 @@
  */
 import type { StructuralModel, Node as ModelNode } from './model'
 import type { StructureDesign, SteelBeamScheduleRow } from './pipeline'
+import { boltGeomFromPositions, eccentricBoltGroup, type BoltPos } from './steelDesign'
 
 // ── Material constants ──────────────────────────────────────────────────────
 const PHI_SHEAR_BOLT = 0.75           // AISC §J3.6
 const FNV_A325 = 495                  // MPa  (threads excluded from shear plane)
-const A_M20   = Math.PI / 4 * 20 * 20  // 314.16 mm² — M20 bolt
-const PHI_RN_BOLT_KN = PHI_SHEAR_BOLT * FNV_A325 * A_M20 / 1000  // ≈ 116.5 kN/bolt
 
 const PHI_PLATE_YIELD = 1.0           // AISC §J4.2 shear yielding
 const FY_PLATE = 248                  // MPa  A36
@@ -38,6 +37,9 @@ function adoptPlate(t: number): number {
 
 // ── Types ────────────────────────────────────────────────────────────────────
 export type ConnFaceType = 'flange' | 'web'
+/** Which beam element(s) the connection engages: shear-tab bolts the beam WEB;
+ *  a moment connection welds the beam FLANGES and shear-tabs the web. */
+export type BeamAttachment = 'web' | 'web+flanges'
 export type ConnType     = 'shear-tab' | 'moment-flange-weld'
 export type SpanDir      = 'x' | 'z' | 'other'
 
@@ -46,7 +48,17 @@ export interface BoltGroup {
   dia: number       // bolt diameter mm (20 = M20)
   pitchMm: number   // bolt pitch mm
   edgeMm: number    // edge distance mm
-  phiRnKn: number   // design strength per bolt, kN
+  phiRnKn: number   // design shear strength per bolt, kN
+  /** In-plane eccentricity of the reaction from the bolt-group centroid, mm
+   *  (the weld/support line is x = 0). Drives the elastic bolt-force method. */
+  ecc: number
+  /** Per-bolt positions in the connection plane (absolute plate mm). These can be
+   *  laid out automatically OR supplied CUSTOM per bolt via `designBolts`. */
+  locations: BoltPos[]
+  /** Maximum bolt resultant from the elastic (vector) eccentric method, kN. */
+  Rmax: number
+  criticalId: string   // id of the most-loaded bolt
+  ok: boolean          // Rmax ≤ φRn
 }
 
 export interface ShearTab {
@@ -69,7 +81,8 @@ export interface BeamConnection {
   beamId: string
   role: string
   spanDir: SpanDir
-  faceType: ConnFaceType  // which column face the beam frames into
+  faceType: ConnFaceType       // which column element the beam frames into (flange/web)
+  beamElement: BeamAttachment  // which beam element(s) the connection engages
   connType: ConnType
   Vu: number              // design shear kN
   Mu: number              // design moment kN·m
@@ -92,14 +105,63 @@ export interface SteelJoint {
 
 // ── Core design functions ─────────────────────────────────────────────────────
 
-/** Design a single-plate shear tab for the given end shear Vu (kN). */
-function designShearTab(Vu: number): ShearTab {
-  const pitchMm = 75, edgeMm = 40
+// Conventional single-plate weld-to-bolt distance (bolt line offset from the
+// column face / weld line), mm — the in-plane eccentricity source.
+const A_WELD_TO_BOLT = 60
 
-  // bolt group (single shear)
-  const nBolts = Math.max(2, Math.ceil(Vu / PHI_RN_BOLT_KN))
+/** Per-bolt design shear strength (single shear plane), kN. */
+function phiBoltShear(dia: number): number {
+  const Ab = (Math.PI / 4) * dia * dia
+  return (PHI_SHEAR_BOLT * FNV_A325 * Ab) / 1000
+}
+
+/** Single-column bolt layout: n bolts at `pitch`, first `edge` from the top,
+ *  column at horizontal offset `a` from the weld line. Absolute plate mm. */
+function boltColumn(n: number, pitchMm: number, edgeMm: number, aMm: number): BoltPos[] {
+  return Array.from({ length: n }, (_, i) => ({ id: `B${i + 1}`, x: aMm, y: edgeMm + i * pitchMm }))
+}
+
+/**
+ * Design the connection bolt group for a vertical reaction Vu (kN) by the
+ * elastic (vector) eccentric method — each bolt carries direct shear V/n plus a
+ * torsional component from the reaction acting at eccentricity `ecc` from the
+ * group centroid. Auto-lays a single column and grows it until the most-loaded
+ * bolt is within φRn; alternatively pass CUSTOM `locations` to place each bolt
+ * anywhere in the plane (the weld/support line is x = 0).
+ */
+export function designBolts(Vu: number, opts: {
+  dia?: number; pitchMm?: number; edgeMm?: number; aMm?: number; locations?: BoltPos[];
+} = {}): BoltGroup {
+  const dia = opts.dia ?? 20
+  const pitchMm = opts.pitchMm ?? 75, edgeMm = opts.edgeMm ?? 40, aMm = opts.aMm ?? A_WELD_TO_BOLT
+  const phiRn = phiBoltShear(dia)
+
+  let locations: BoltPos[]
+  if (opts.locations && opts.locations.length > 0) {
+    locations = opts.locations
+  } else {
+    let n = Math.max(2, Math.ceil(Vu / phiRn))
+    for (let it = 0; it < 30; it++) {
+      const g = boltGeomFromPositions(boltColumn(n, pitchMm, edgeMm, aMm))
+      if (eccentricBoltGroup(g, Vu, 0, aMm, 0, phiRn, dia, 10).Rmax <= phiRn + 1e-6 || n >= 24) break
+      n++
+    }
+    locations = boltColumn(n, pitchMm, edgeMm, aMm)
+  }
+
+  const geom = boltGeomFromPositions(locations)
+  const ecc = Math.abs(geom.Cx)   // centroid-to-weld-line (x = 0) distance
+  const res = eccentricBoltGroup(geom, Vu, 0, ecc, 0, phiRn, dia, 10)
+  return {
+    n: locations.length, dia, pitchMm, edgeMm, phiRnKn: phiRn,
+    ecc, locations, Rmax: res.Rmax, criticalId: res.critical, ok: res.Rmax <= phiRn + 1e-6,
+  }
+}
+
+/** Design a single-plate shear tab sized to a bolt column of `nBolts`. */
+function designShearTab(Vu: number, nBolts: number, pitchMm = 75, edgeMm = 40): ShearTab {
   const hMm = (nBolts - 1) * pitchMm + 2 * edgeMm      // plate height
-  const wMm = 80                                          // plate width (horiz.)
+  const wMm = A_WELD_TO_BOLT + 2 * edgeMm               // plate width (weld line → bolt + edge)
 
   // plate thickness from shear yielding (governs over rupture for typical cases)
   const tReq = Vu * 1000 / (PHI_PLATE_YIELD * 0.6 * FY_PLATE * hMm)
@@ -213,18 +275,19 @@ export function designSteelJoints(
         // Connection type: use moment connection when moment demand is significant
         const useMoment = phiMn > 1e-9 && (Mu / phiMn) > MOMENT_CONN_THRESHOLD
 
-        const tab = designShearTab(Vu)
-        const bolts: BoltGroup = {
-          n: Math.max(2, Math.ceil(Vu / PHI_RN_BOLT_KN)),
-          dia: 20, pitchMm: 75, edgeMm: 40, phiRnKn: PHI_RN_BOLT_KN,
-        }
+        // Elastic eccentric bolt group (each bolt placed & checked individually).
+        const bolts = designBolts(Vu, { dia: 20 })
+        const tab = designShearTab(Vu, bolts.n)
 
         let flangeConn: FlangeMomentConn | undefined
         if (useMoment && row) {
           flangeConn = designFlangeConn(Mu, row.d, row.tf, row.bf)
         }
 
-        const boltOk = bolts.n * PHI_RN_BOLT_KN >= Vu - 1e-6
+        // Which beam element(s) the connection engages: web only for a shear tab;
+        // web (shear) + both flanges (CJP welds) for a moment connection.
+        const beamElement: BeamAttachment = useMoment ? 'web+flanges' : 'web'
+
         const tabOk  = tab.phiVn >= Vu - 1e-6 && tab.phiWeldVn >= Vu - 1e-6
         const flangeOk = !flangeConn || flangeConn.ok
 
@@ -233,12 +296,13 @@ export function designSteelJoints(
           role: mem.role,
           spanDir: sDir,
           faceType,
+          beamElement,
           connType: useMoment ? 'moment-flange-weld' : 'shear-tab',
           Vu, Mu,
           bolts,
           tab,
           flange: flangeConn,
-          ok: boltOk && tabOk && flangeOk,
+          ok: bolts.ok && tabOk && flangeOk,
         })
       }
 

--- a/webapp/src/engine/steelDesign.ts
+++ b/webapp/src/engine/steelDesign.ts
@@ -291,6 +291,20 @@ export function boltGroupGeom(
   return { bolts, n, Cx, Cy, Ip, plateW: 2 * ex + (nCols - 1) * sx, plateH: 2 * ey + (nRows - 1) * sy }
 }
 
+/** Bolt-group geometry (centroid + polar inertia Ip) from ARBITRARY bolt
+ *  positions — lets a connection be designed with each bolt placed anywhere in
+ *  the plane, not just a regular grid. Positions are absolute (plate) mm. */
+export function boltGeomFromPositions(abs: BoltPos[]): BoltGroupGeom {
+  const n = abs.length
+  if (n === 0) return { bolts: [], n: 0, Cx: 0, Cy: 0, Ip: 0, plateW: 0, plateH: 0 }
+  const Cx = abs.reduce((s, b) => s + b.x, 0) / n
+  const Cy = abs.reduce((s, b) => s + b.y, 0) / n
+  const bolts = abs.map((b) => ({ id: b.id, x: b.x - Cx, y: b.y - Cy }))
+  const Ip = bolts.reduce((s, b) => s + b.x ** 2 + b.y ** 2, 0)
+  const xs = abs.map((b) => b.x), ys = abs.map((b) => b.y)
+  return { bolts, n, Cx, Cy, Ip, plateW: Math.max(...xs) - Math.min(...xs), plateH: Math.max(...ys) - Math.min(...ys) }
+}
+
 // ─── In-plane eccentric bolt group — elastic (vector) method ─────────────
 // Forces Pu (+Y = up) and Hu (+X = right) applied at offset (ex_load, ey_load)
 // from the bolt centroid. Positive ex_load → load is to the RIGHT of centroid.

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -3834,7 +3834,7 @@ export default function ModelSpace() {
                     <th className="py-1 pr-2 font-semibold">Col. shape</th>
                     <th className="py-1 pr-2 font-semibold">Beam</th>
                     <th className="py-1 pr-2 font-semibold">Dir</th>
-                    <th className="py-1 pr-2 font-semibold">Face</th>
+                    <th className="py-1 pr-2 font-semibold">Connects (col → beam)</th>
                     <th className="py-1 pr-2 font-semibold">Type</th>
                     <th className="py-1 pr-2 text-right font-semibold">Vu (kN)</th>
                     <th className="py-1 pr-2 text-right font-semibold">Mu (kN·m)</th>
@@ -3860,15 +3860,19 @@ export default function ModelSpace() {
                         )}
                         <td className="py-1 pr-2 font-medium">{c.beamId}</td>
                         <td className="py-1 pr-2 uppercase">{c.spanDir}</td>
-                        <td className={`py-1 pr-2 font-semibold ${c.faceType === 'flange' ? 'text-blue-700' : 'text-slate-600'}`}>
-                          {c.faceType}
+                        <td className="py-1 pr-2 text-[11px]">
+                          <span className={c.faceType === 'flange' ? 'font-semibold text-blue-700' : 'text-slate-600'}>col {c.faceType}</span>
+                          <span className="text-slate-400"> → beam {c.beamElement}</span>
                         </td>
                         <td className="py-1 pr-2 text-[11px]">
                           {c.connType === 'moment-flange-weld' ? 'Moment (CJP flange)' : 'Shear tab'}
                         </td>
                         <td className="py-1 pr-2 text-right">{f1(c.Vu)}</td>
                         <td className="py-1 pr-2 text-right">{f1(c.Mu)}</td>
-                        <td className="py-1 pr-2 text-[11px]">{c.bolts.n} × M{c.bolts.dia} A325</td>
+                        <td className="py-1 pr-2 text-[11px]">
+                          {c.bolts.n} × M{c.bolts.dia} A325
+                          <div className="text-[10px] text-slate-400">R={f1(c.bolts.Rmax)}/{f1(c.bolts.phiRnKn)} kN · e={Math.round(c.bolts.ecc)}mm</div>
+                        </td>
                         <td className="py-1 pr-2 text-[11px]">{c.tab.t}×{Math.round(c.tab.hMm)} mm</td>
                         <td className="py-1 pr-2 text-[11px]">
                           {c.tab.weldSizeMm}mm E70


### PR DESCRIPTION
## Summary

Polishes the beam-to-column connection designer (`steelConnections.ts`) on the two points requested.

### 1. Connected elements reflected on **both** sides
Each connection now records the **column element** it frames into (`faceType`: flange/web) **and the beam element** it engages (`beamElement`): `'web'` for a shear tab (beam web bolted to the tab), `'web+flanges'` for a moment connection (flanges CJP-welded + web shear tab). The ModelSpace connection schedule now shows **"col ⟨face⟩ → beam ⟨element⟩"**.

### 2. Bolts designed with custom per-bolt locations (elastic eccentric method)
The old designer used a naïve concentric `n·φRn ≥ Vu` uniform column. It now uses the **elastic (vector) eccentric method** with explicit per-bolt positions:

- **`steelDesign.ts`** — new `boltGeomFromPositions(bolts)` builds the group geometry (centroid + polar inertia `Ip`) from **arbitrary** positions, feeding the existing `eccentricBoltGroup` elastic method.
- **`steelConnections.ts`** — new `designBolts(Vu, { dia, pitch, edge, aMm, locations })`: auto-lays a single column and grows it until the **most-loaded bolt** (direct `V/n` + torsional `M·r/Ip`) is within `φRn`, **or accepts custom `locations`** to place each bolt anywhere in the plane (weld/support line at `x=0`). `BoltGroup` now carries `locations[]`, `ecc`, `Rmax`, `criticalId`; the shear tab is sized to the resulting bolt count.

This replaces the concentric approximation with the stricter, position-aware per-bolt check.

## Tests (+5)
Elastic sizing within `φRn`; both-sides element reflection; eccentricity raising the peak force above the concentric share; **custom per-bolt locations** evaluated individually; bolt-count monotonicity.

Verified: `npm test` (945 passing), `npx tsc -b`, `npm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_