### PR TITLE
feat: eccentric bolted-connection solver (elastic vector method)

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -30,6 +30,7 @@ import RockAnchor from './pages/RockAnchor'
 import SeismicWizard from './pages/SeismicWizard'
 import WaterTank from './pages/WaterTank'
 import ShotcreteFacing from './pages/ShotcreteFacing'
+import BoltedConnection from './pages/BoltedConnection'
 import SlabEstimate from './pages/SlabEstimate'
 import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
@@ -79,6 +80,7 @@ export default function App() {
         <Route path="/seismic-wizard" element={<SeismicWizard />} />
         <Route path="/water-tank" element={<WaterTank />} />
         <Route path="/shotcrete-facing" element={<ShotcreteFacing />} />
+        <Route path="/bolted-connection" element={<BoltedConnection />} />
         <Route path="/estimate/slab" element={<SlabEstimate />} />
         <Route path="/estimate/beam" element={<BeamEstimate />} />
         <Route path="/estimate/column" element={<ColumnEstimate />} />

--- a/webapp/src/engine/boltedConnection.test.ts
+++ b/webapp/src/engine/boltedConnection.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { solveBoltedConnection } from './boltedConnection'
+import type { BoltPos } from './steelDesign'
+
+const square: BoltPos[] = [
+  { id: 'B1', x: 0, y: 0 }, { id: 'B2', x: 100, y: 0 },
+  { id: 'B3', x: 0, y: 100 }, { id: 'B4', x: 100, y: 100 },
+]
+
+describe('solveBoltedConnection — concentric load', () => {
+  it('no eccentricity ⇒ every bolt carries the equal direct share P/N', () => {
+    // vertical load through the centroid (50,50)
+    const r = solveBoltedConnection({
+      bolts: square, dia: 20, allowableStress: 150,
+      load: { P: 40, angleDeg: -90, px: 50, py: 50 },
+    })
+    expect(r.ex).toBeCloseTo(0, 9); expect(r.ey).toBeCloseTo(0, 9)
+    expect(r.T).toBeCloseTo(0, 9)
+    for (const b of r.bolts) expect(b.R).toBeCloseTo(40 / 4, 6)   // 10 kN each
+    expect(r.Rmax).toBeCloseTo(10, 6)
+  })
+})
+
+describe('solveBoltedConnection — in-plane eccentricity (hand check)', () => {
+  // 4 bolts at a 100×100 square; centroid (50,50); J = Σ(x²+y²) = 4·(50²+50²) = 20000.
+  // Vertical load P = 100 kN at (150,50) ⇒ ex = 100, ey = 0, T = −100P.
+  // Corner bolts at x = +50 govern: R = √(0.25² + 0.5²)·P = 0.559·P.
+  const r = solveBoltedConnection({
+    bolts: square, dia: 22, allowableStress: 150,
+    load: { P: 100, angleDeg: -90, px: 150, py: 50 },
+  })
+
+  it('polar inertia J = Σ(x² + y²) about the centroid', () => {
+    expect(r.J).toBeCloseTo(20000, 6)
+    expect(r.ex).toBeCloseTo(100, 6)
+    expect(r.T).toBeCloseTo(-100 * 100, 6)   // Py·ex, Py = −100 kN
+  })
+
+  it('most-loaded bolt R ≈ 0.559·P; least-loaded ≈ 0.25·P', () => {
+    expect(r.Rmax).toBeCloseTo(55.9, 1)
+    expect(r.Rmin).toBeCloseTo(25, 1)
+    // the two right-hand bolts (x = 100) are critical
+    expect(['B2', 'B4']).toContain(r.criticalId)
+    expect(['B1', 'B3']).toContain(r.leastId)
+  })
+
+  it('max shear stress = Rmax/Ab and drives the allowable-P back-calc', () => {
+    const Ab = (Math.PI / 4) * 22 * 22
+    expect(r.tauMax).toBeCloseTo((r.Rmax * 1000) / Ab, 4)
+    // maxP scales linearly: maxP = P · (τallow·Ab) / Rmax
+    const cap = (150 * Ab) / 1000
+    expect(r.maxP).toBeCloseTo((100 * cap) / r.Rmax, 4)
+  })
+
+  it('the load at an inclined angle splits into Px, Py components', () => {
+    const inc = solveBoltedConnection({
+      bolts: square, dia: 22, allowableStress: 150,
+      load: { P: 80, angleDeg: -40, px: 200, py: 50 },
+    })
+    expect(inc.Px).toBeCloseTo(80 * Math.cos((-40 * Math.PI) / 180), 6)
+    expect(inc.Py).toBeCloseTo(80 * Math.sin((-40 * Math.PI) / 180), 6)
+    expect(inc.Rmax).toBeGreaterThan(inc.Rmin)
+  })
+})
+
+describe('solveBoltedConnection — custom bolt pattern', () => {
+  it('accepts an arbitrary (non-grid) bolt layout and finds the critical bolt', () => {
+    const custom: BoltPos[] = [
+      { id: 'A', x: 0, y: 0 }, { id: 'B', x: 60, y: 20 },
+      { id: 'C', x: 30, y: 90 }, { id: 'D', x: 120, y: 60 },
+    ]
+    const r = solveBoltedConnection({
+      bolts: custom, dia: 20, allowableStress: 150,
+      load: { P: 50, angleDeg: -90, px: 200, py: 40 },
+    })
+    expect(r.bolts).toHaveLength(4)
+    expect(r.Rmax).toBeGreaterThan(0)
+    expect(r.criticalId).toMatch(/^[ABCD]$/)
+    expect(r.maxP).toBeGreaterThan(0)
+  })
+})

--- a/webapp/src/engine/boltedConnection.ts
+++ b/webapp/src/engine/boltedConnection.ts
@@ -1,0 +1,77 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Eccentrically-loaded bolt group — elastic (vector) method.
+// AISC / classic mechanics (as in the worked examples): a load P applied at an
+// eccentricity (ex, ey) from the bolt-group centroid is split into
+//   Direct shear   Rdx = Px/N ,  Rdy = Py/N
+//   Torsional shear (about the centroid, T = Py·ex − Px·ey):
+//                   RTx = T·yc/J ,  RTy = T·xc/J ,  J = Σ(xc² + yc²)
+// The resultant on each bolt is R = √((Rdx ± RTx)² + (Rdy ∓ RTy)²); the most-
+// loaded bolt governs the shear stress, and the maximum applied load P follows
+// from the allowable bolt shear (R scales linearly with P).
+// Bolts can be placed at ANY location in the plane (custom pattern).
+// Units: positions/eccentricity mm; P kN; stress MPa; forces kN.
+// ─────────────────────────────────────────────────────────────────────────
+import { boltGeomFromPositions, eccentricBoltGroup, type BoltPos, type BoltForce, type BoltGroupGeom } from './steelDesign'
+
+export interface BoltConnLoad {
+  /** Magnitude of the applied load, kN. */
+  P: number
+  /** Direction, degrees measured from +X (horizontal), positive CCW. */
+  angleDeg: number
+  /** Load application point in plate coordinates (bottom-left origin), mm. */
+  px: number; py: number
+}
+
+export interface BoltConnResult {
+  geom: BoltGroupGeom
+  Px: number; Py: number       // load components, kN
+  ex: number; ey: number       // eccentricity of the load from the centroid, mm
+  T: number                    // torsional moment about the centroid, kN·mm
+  J: number                    // polar moment Σ(x²+y²), mm²
+  bolts: BoltForce[]           // per-bolt forces (direct + torsional resultant)
+  Rmax: number; criticalId: string
+  Rmin: number; leastId: string
+  tauMax: number               // max bolt shear stress, MPa
+  maxP: number                 // maximum applied load for the allowable stress, kN
+  ok: boolean
+}
+
+/**
+ * Solve an eccentrically-loaded bolt group by the elastic method. `bolts` are
+ * absolute plate-coordinate positions (any custom pattern). The load `P` acts at
+ * `angleDeg` through the point (px, py); `allowableStress` is the permissible
+ * bolt shear stress; `nShear` is the number of shear planes (1 single, 2 double).
+ */
+export function solveBoltedConnection(p: {
+  bolts: BoltPos[]; dia: number; load: BoltConnLoad; allowableStress: number; nShear?: number;
+}): BoltConnResult {
+  const geom = boltGeomFromPositions(p.bolts)
+  const nShear = p.nShear ?? 1
+  const Ab = (Math.PI / 4) * p.dia * p.dia
+  const rad = (p.load.angleDeg * Math.PI) / 180
+  const Px = p.load.P * Math.cos(rad)
+  const Py = p.load.P * Math.sin(rad)
+  const ex = p.load.px - geom.Cx
+  const ey = p.load.py - geom.Cy
+
+  // Elastic vector method: Pu = vertical (+Y), Hu = horizontal (+X), load at (ex, ey).
+  const phiPlaceholder = 1   // strength unused here; we report stress & max-P instead
+  const res = eccentricBoltGroup(geom, Py, Px, ex, ey, phiPlaceholder, p.dia, 10)
+  const T = Py * ex - Px * ey
+
+  const forces = res.bolts
+  const ci = forces.reduce((mi, _, i) => (forces[i].R > forces[mi].R ? i : mi), 0)
+  const li = forces.reduce((mi, _, i) => (forces[i].R < forces[mi].R ? i : mi), 0)
+  const Rmax = forces[ci].R, Rmin = forces[li].R
+
+  const capacityPerBolt = (p.allowableStress * Ab * nShear) / 1000   // kN
+  const tauMax = (Rmax * 1000) / (Ab * nShear)                        // MPa
+  // R scales linearly with P ⇒ maxP = P · capacity / Rmax.
+  const maxP = Rmax > 1e-9 ? (p.load.P * capacityPerBolt) / Rmax : Infinity
+
+  return {
+    geom, Px, Py, ex, ey, T, J: geom.Ip, bolts: forces,
+    Rmax, criticalId: forces[ci].id, Rmin, leastId: forces[li].id,
+    tauMax, maxP, ok: tauMax <= p.allowableStress + 1e-6,
+  }
+}

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -26,6 +26,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/model',         name: '3D Model Space',     sub: 'BIM-lite viewer'       },
       { to: '/truss',         name: 'Truss Space',        sub: 'Plane truss solver'    },
       { to: '/steel',         name: 'Steel Design',       sub: 'AISC 360-16 LRFD'      },
+      { to: '/bolted-connection', name: 'Bolted Connection', sub: 'Eccentric bolt group' },
       { to: '/slab-design',   name: 'Slab Design',        sub: 'Two-way DDM · ACI 318'  },
       { to: '/stair',         name: 'Stair Design',       sub: 'RC waist slab · NSCP'   },
       { to: '/water-tank',    name: 'Water Tank',         sub: 'Circular · IS 3370/ACI 350' },

--- a/webapp/src/pages/BoltedConnection.tsx
+++ b/webapp/src/pages/BoltedConnection.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react'
+import { solveBoltedConnection } from '../engine/boltedConnection'
+import { ConnectionDrawing } from '../components/ConnectionDrawing'
+import type { BoltPos } from '../engine/steelDesign'
+
+function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
+const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
+
+const DEFAULT_BOLTS: BoltPos[] = [
+  { id: 'B1', x: 40, y: 180 }, { id: 'B2', x: 110, y: 180 },
+  { id: 'B3', x: 40, y: 110 }, { id: 'B4', x: 110, y: 110 },
+  { id: 'B5', x: 40, y: 40 }, { id: 'B6', x: 110, y: 40 },
+]
+
+export default function BoltedConnection() {
+  const [bolts, setBolts] = useState<BoltPos[]>(DEFAULT_BOLTS)
+  const [dia, setDia] = useState(22)
+  const [P, setP] = useState(80)
+  const [angle, setAngle] = useState(-40)
+  const [px, setPx] = useState(280)
+  const [py, setPy] = useState(180)
+  const [allow, setAllow] = useState(150)
+  const [nShear, setNShear] = useState(1)
+
+  const r = solveBoltedConnection({ bolts, dia, allowableStress: allow, nShear, load: { P, angleDeg: angle, px, py } })
+
+  const setBolt = (i: number, k: 'x' | 'y', v: number) =>
+    setBolts((bs) => bs.map((b, j) => (j === i ? { ...b, [k]: v } : b)))
+  const addBolt = () => setBolts((bs) => [...bs, { id: `B${bs.length + 1}`, x: 40, y: 40 }])
+  const delBolt = (i: number) => setBolts((bs) => bs.filter((_, j) => j !== i).map((b, k) => ({ ...b, id: `B${k + 1}` })))
+
+  return (
+    <main className="mx-auto max-w-5xl px-5 py-10">
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">Structural · Steel</p>
+      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Eccentric bolted connection</h1>
+      <p className="mt-2 max-w-3xl text-sm text-slate-600">
+        Elastic (vector) method for an eccentrically-loaded bolt group. Each bolt carries the direct
+        share P/N plus a torsional share T·ρ/J (T = Pᵧ·eₓ − Pₓ·e_y, J = Σ(x²+y²)). Place bolts anywhere —
+        the solver finds the most/least-loaded bolt, the peak shear stress, and the maximum load P.
+      </p>
+
+      <div className="mt-6 grid gap-5 lg:grid-cols-[1.1fr_1fr]">
+        <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-[1.05rem] font-bold text-[#0056b3]">Bolt pattern (mm)</h2>
+            <button type="button" onClick={addBolt} className="rounded-md border border-slate-300 px-2.5 py-1 text-xs font-semibold text-[#0056b3] hover:bg-blue-50">+ Add bolt</button>
+          </div>
+          <div className="max-h-60 overflow-auto">
+            <table className="w-full text-xs">
+              <thead className="text-slate-500"><tr className="text-left"><th className="pr-2 py-1">Bolt</th><th className="pr-2">x</th><th className="pr-2">y</th><th className="pr-2 text-right">R (kN)</th><th /></tr></thead>
+              <tbody>
+                {bolts.map((b, i) => {
+                  const force = r.bolts.find((f) => f.id === b.id)
+                  const crit = b.id === r.criticalId, least = b.id === r.leastId
+                  return (
+                    <tr key={b.id} className={`border-t border-slate-100 ${crit ? 'bg-red-50' : least ? 'bg-emerald-50' : ''}`}>
+                      <td className="pr-2 py-1 font-medium">{b.id}{crit ? ' ▲' : least ? ' ▽' : ''}</td>
+                      <td className="pr-2"><input type="number" value={b.x} onChange={(e) => setBolt(i, 'x', num(e.target.value))} className="w-16 rounded border border-slate-200 px-1 py-0.5" /></td>
+                      <td className="pr-2"><input type="number" value={b.y} onChange={(e) => setBolt(i, 'y', num(e.target.value))} className="w-16 rounded border border-slate-200 px-1 py-0.5" /></td>
+                      <td className="pr-2 text-right font-mono">{force ? f2(force.R) : '—'}</td>
+                      <td className="text-right"><button type="button" onClick={() => delBolt(i)} className="text-slate-400 hover:text-red-600">✕</button></td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          <h2 className="mb-2 mt-4 text-[1.05rem] font-bold text-[#0056b3]">Load &amp; bolts</h2>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+            {([['Load P (kN)', P, setP], ['Angle (° from +X)', angle, setAngle], ['Bolt Ø (mm)', dia, setDia],
+              ['Load at x (mm)', px, setPx], ['Load at y (mm)', py, setPy], ['Allow. τ (MPa)', allow, setAllow]] as const).map(([lbl, val, set]) => (
+              <label key={lbl} className="flex flex-col text-sm">
+                <span className="mb-1 text-slate-600">{lbl}</span>
+                <input type="number" value={val} onChange={(e) => set(num(e.target.value))} className="rounded-md border border-slate-300 px-2.5 py-1.5" />
+              </label>
+            ))}
+            <label className="flex flex-col text-sm">
+              <span className="mb-1 text-slate-600">Shear planes</span>
+              <select value={nShear} onChange={(e) => setNShear(parseInt(e.target.value))} className="rounded-md border border-slate-300 px-2.5 py-1.5">
+                <option value={1}>Single (1)</option><option value={2}>Double (2)</option>
+              </select>
+            </label>
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+            <ConnectionDrawing geom={r.geom} db={dia} boltForces={r.bolts} critical={r.criticalId}
+              Vu={r.Py} Hu={r.Px} ex_load={r.ex} ey_load={r.ey} />
+          </div>
+          <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm text-sm">
+            <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Results</h2>
+            {[['Load components Pₓ / Pᵧ', `${f2(r.Px)} / ${f2(r.Py)} kN`],
+              ['Eccentricity eₓ / e_y', `${f2(r.ex)} / ${f2(r.ey)} mm`],
+              ['Torsion T = Pᵧ·eₓ − Pₓ·e_y', `${f2(r.T / 1000)} kN·m`],
+              ['Polar inertia J = Σ(x²+y²)', `${f2(r.J / 1e6)} ×10⁶ mm²`],
+              ['Most-loaded bolt', `${r.criticalId} — ${f2(r.Rmax)} kN`],
+              ['Least-loaded bolt', `${r.leastId} — ${f2(r.Rmin)} kN`]].map(([k, v]) => (
+              <div key={k} className="flex justify-between border-t border-slate-100 py-1"><span className="text-slate-500">{k}</span><span className="font-mono">{v}</span></div>
+            ))}
+            <div className="flex justify-between border-t border-slate-100 py-1">
+              <span className="text-slate-500">Max shear stress τ (≤ {f2(allow)})</span>
+              <span className={`font-mono font-semibold ${r.ok ? 'text-emerald-600' : 'text-red-600'}`}>{f2(r.tauMax)} MPa {r.ok ? '✓' : '✗'}</span>
+            </div>
+            <div className="mt-2 flex items-baseline justify-between rounded-lg bg-blue-50 p-2">
+              <span className="text-sm font-semibold text-[#0056b3]">Max allowable load P</span>
+              <span className="font-mono text-lg font-bold text-[#0056b3]">{f2(r.maxP)} kN</span>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

**Part A** of the connection work you requested — a general solver that reproduces the classic worked-example analysis of an eccentrically-loaded bolt group (the elastic/vector method in the reference PDFs).

## Engine (`boltedConnection.ts`)
`solveBoltedConnection` — a load `P` at any **angle**, applied at a point `(px, py)`, is split into:
- **direct shear** `Rd = P/N`
- **torsional shear** `RT = T·ρ/J`, with `T = Py·ex − Px·ey` and `J = Σ(x²+y²)`

…giving each bolt's resultant `R = √((Rdx±RTx)² + (Rdy∓RTy)²)`, the **most/least-loaded bolt**, the **peak shear stress**, and the **maximum allowable load P** (R scales linearly with P). Bolts can be at **any custom locations**. Reuses `boltGeomFromPositions` + `eccentricBoltGroup`.

## Tests (+6)
Concentric = `P/N`; a **hand-checked** 4-bolt 100×100 square (`J=20000`, `Rmax=0.559P`, `Rmin=0.25P`); stress & max-P back-calc; inclined-load components; arbitrary non-grid pattern.

## UI
`pages/BoltedConnection.tsx` + `/bolted-connection` route + a Steel nav entry — **editable per-bolt coordinates** (add / remove / move each bolt), load at angle & application point, live per-bolt forces, most/least-loaded highlight, `τmax`, **max P**, and the `ConnectionDrawing` force-vector plot.

Verified: `npm test` (951 passing), `npx tsc -b`, `npm run build` all clean.

---

**Part B** (next PR): connection **type → member end release / force behaviour** — a *simple/shear* connection pins the beam end (releases Mz, the "schematic hinge" in the reference) while a *moment* connection stays rigid, so the analysis reflects the actual connection choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_