### PR TITLE
feat: connection type drives member releases &amp; force behaviour

### DIFF
--- a/webapp/src/engine/model.ts
+++ b/webapp/src/engine/model.ts
@@ -43,12 +43,26 @@ export interface MemberOffsets {
   jEnd?: [number, number, number]
 }
 
+/** Physical connection idealisation at a member end, which drives BOTH the
+ *  analysis (releases) and the steel connection design:
+ *   'simple' — shear-only (shear tab / web plate / cleat): a PIN — releases the
+ *              bending moments My, Mz at that end (the "schematic hinge").
+ *   'moment' — rigid moment connection (end plate / flange weld): no release.
+ *   'fixed'  — fully continuous (default for a monolithic joint): no release. */
+export type ConnectionKind = 'simple' | 'moment' | 'fixed'
+
+/** Per-end connection type. Absent ⇒ continuous. */
+export interface MemberConnections { iEnd?: ConnectionKind; jEnd?: ConnectionKind }
+
 export interface Member {
   id: string
   i: string; j: string          // node ids
   role: MemberRole
   section: string               // RectSection id
   releases?: MemberReleases
+  /** Physical connection type per end — pins a 'simple' end (releases My, Mz) and
+   *  tags 'moment' ends for moment-connection design. Absent ⇒ continuous. */
+  connections?: MemberConnections
   offsets?: MemberOffsets
   /** Per-member rigid-zone factor override (0–1); falls back to the model factor.
    *  0 excludes this member from automatic rigid end zones. */

--- a/webapp/src/engine/modelBridge.test.ts
+++ b/webapp/src/engine/modelBridge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { modelToFrame3D } from './modelBridge'
+import { modelToFrame3D, effectiveReleases } from './modelBridge'
 import { emptyModel, type StructuralModel, type RectSection } from './model'
 
 const section: RectSection = {
@@ -120,5 +120,31 @@ describe('modelToFrame3D — shell elements', () => {
     const br = modelToFrame3D(model, { useShells: false })
     expect(br.shells).toEqual([])
     expect(br.loads.some((l) => l.kind === 'member-vdl')).toBe(true)
+  })
+})
+
+describe('connection type → member releases (force behaviour)', () => {
+  it("a 'simple' end releases the bending moments My, Mz (a pin)", () => {
+    const rel = effectiveReleases({ connections: { iEnd: 'simple' } })
+    expect(rel.iEnd).toMatchObject({ My: true, Mz: true })
+    expect(rel.iEnd?.Fx).toBeFalsy()      // shear/axial still transferred
+    expect(rel.jEnd).toBeUndefined()
+  })
+
+  it("'moment' and 'fixed' ends stay continuous (no release)", () => {
+    expect(effectiveReleases({ connections: { iEnd: 'moment', jEnd: 'fixed' } })).toEqual({})
+  })
+
+  it('explicit releases are unioned with connection-implied ones', () => {
+    const rel = effectiveReleases({ releases: { jEnd: { Fx: true } }, connections: { jEnd: 'simple' } })
+    expect(rel.jEnd).toMatchObject({ Fx: true, My: true, Mz: true })
+  })
+
+  it('the bridge pins a simple-ended beam in the assembled frame', () => {
+    const m = baseModel()
+    m.members[0].connections = { jEnd: 'simple' }
+    const br = modelToFrame3D(m)
+    expect(br.members[0].relJ?.[5]).toBe(true)   // Mz released at j
+    expect(br.members[0].relJ?.[4]).toBe(true)   // My released at j
   })
 })

--- a/webapp/src/engine/modelBridge.ts
+++ b/webapp/src/engine/modelBridge.ts
@@ -4,7 +4,7 @@
 // and land on the matching edge members as vdl/udl gravity loads (categories
 // preserved) — the load path, automated.
 // ─────────────────────────────────────────────────────────────────────────
-import type { StructuralModel, RectSection, MemberReleases, Plate } from './model'
+import type { StructuralModel, RectSection, MemberReleases, MemberConnections, ConnectionKind, Plate } from './model'
 import type { F3Node, F3Member, F3Support, F3Load, F3DiaphragmGroup, F3Shell } from './frame3d'
 import { rectJ } from './frame3d'
 import { buildDiaphragmGroups } from './diaphragm'
@@ -146,6 +146,27 @@ function edgeLoadToMember(ld: BeamLoad, memberId: string, sameDir: boolean, L: n
   return null
 }
 
+/** A 'simple' (shear-only) connection pins the end: release the bending moments. */
+function connEnd(kind?: ConnectionKind): MemberReleases['iEnd'] {
+  return kind === 'simple' ? { My: true, Mz: true } : undefined
+}
+
+/** Combine explicit releases with the connection-type-implied releases (union:
+ *  either source releasing a DOF releases it). A 'simple' connection therefore
+ *  turns the member end into a pin, matching the connection's real behaviour. */
+export function effectiveReleases(m: { releases?: MemberReleases; connections?: MemberConnections }): MemberReleases {
+  const merge = (a?: MemberReleases['iEnd'], b?: MemberReleases['iEnd']): MemberReleases['iEnd'] | undefined => {
+    if (!a && !b) return undefined
+    return {
+      Fx: a?.Fx || b?.Fx, Fy: a?.Fy || b?.Fy, Fz: a?.Fz || b?.Fz,
+      Mx: a?.Mx || b?.Mx, My: a?.My || b?.My, Mz: a?.Mz || b?.Mz,
+    }
+  }
+  const iEnd = merge(m.releases?.iEnd, connEnd(m.connections?.iEnd))
+  const jEnd = merge(m.releases?.jEnd, connEnd(m.connections?.jEnd))
+  return { ...(iEnd ? { iEnd } : {}), ...(jEnd ? { jEnd } : {}) }
+}
+
 /** Map MemberReleases flags to F3Member relI / relJ arrays. */
 function releaseFlags(rel: MemberReleases | undefined): Pick<F3Member, 'relI' | 'relJ'> {
   if (!rel) return {}
@@ -177,7 +198,7 @@ export function modelToFrame3D(model: StructuralModel, opts?: BridgeOpts): Bridg
     const offJ = m.offsets?.jEnd ?? a?.offJ
     return {
       id: m.id, i: m.i, j: m.j, ...(secById.get(m.section) ?? fallback),
-      ...releaseFlags(m.releases),
+      ...releaseFlags(effectiveReleases(m)),
       ...(offI ? { offI } : {}),
       ...(offJ ? { offJ } : {}),
     }

--- a/webapp/src/engine/steelConnections.ts
+++ b/webapp/src/engine/steelConnections.ts
@@ -84,6 +84,9 @@ export interface BeamConnection {
   faceType: ConnFaceType       // which column element the beam frames into (flange/web)
   beamElement: BeamAttachment  // which beam element(s) the connection engages
   connType: ConnType
+  /** True when the connection releases beam-end bending (a shear/simple pin) —
+   *  the analysis idealisation the joint implies. False for a rigid moment conn. */
+  pinned: boolean
   Vu: number              // design shear kN
   Mu: number              // design moment kN·m
   bolts: BoltGroup
@@ -272,8 +275,13 @@ export function designSteelJoints(
         const Mu = row?.Mu ?? 0
         const phiMn = row?.phiMn ?? 1
 
-        // Connection type: use moment connection when moment demand is significant
-        const useMoment = phiMn > 1e-9 && (Mu / phiMn) > MOMENT_CONN_THRESHOLD
+        // The user's explicit connection type at the end framing into THIS node
+        // governs; otherwise infer from the moment demand. A 'simple' end is a
+        // pin (shear tab); 'moment' forces a moment connection.
+        const end = mem.i === nodeId ? 'iEnd' : 'jEnd'
+        const connKind = mem.connections?.[end]
+        const useMoment = connKind === 'moment'
+          || (connKind !== 'simple' && phiMn > 1e-9 && (Mu / phiMn) > MOMENT_CONN_THRESHOLD)
 
         // Elastic eccentric bolt group (each bolt placed & checked individually).
         const bolts = designBolts(Vu, { dia: 20 })
@@ -298,6 +306,7 @@ export function designSteelJoints(
           faceType,
           beamElement,
           connType: useMoment ? 'moment-flange-weld' : 'shear-tab',
+          pinned: !useMoment,
           Vu, Mu,
           bolts,
           tab,

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -1869,6 +1869,28 @@ export default function ModelSpace() {
                             <span className="text-[10px] text-slate-400">§F2 LTB brace spacing — blank = full member length (conservative)</span>
                           </label>
                         )}
+                        <div className="mt-2 border-t border-violet-200 pt-2">
+                          <p className="mb-1 text-[11px] font-semibold text-violet-800">End connections — {sel.id}</p>
+                          <div className="flex flex-wrap gap-3">
+                            {(['iEnd', 'jEnd'] as const).map((end) => (
+                              <label key={end} className="flex items-center gap-1.5 text-[11px] text-slate-700">
+                                <span>{end === 'iEnd' ? 'i' : 'j'}-end</span>
+                                <select value={sel.connections?.[end] ?? 'fixed'}
+                                  onChange={(e) => {
+                                    const k = e.target.value as 'simple' | 'moment' | 'fixed'
+                                    const next = { ...(sel.connections ?? {}), [end]: k }
+                                    updMember(sel.id, { connections: next })
+                                  }}
+                                  className="rounded border border-violet-200 px-1 py-0.5">
+                                  <option value="fixed">Continuous</option>
+                                  <option value="simple">Simple (pin)</option>
+                                  <option value="moment">Moment (rigid)</option>
+                                </select>
+                              </label>
+                            ))}
+                          </div>
+                          <span className="mt-1 block text-[10px] text-slate-400">Simple = shear-only pin (releases My, Mz — the connection hinge); Moment = rigid; drives both analysis and steel connection design.</span>
+                        </div>
                       </div>
                     )
                   })()}
@@ -3866,6 +3888,7 @@ export default function ModelSpace() {
                         </td>
                         <td className="py-1 pr-2 text-[11px]">
                           {c.connType === 'moment-flange-weld' ? 'Moment (CJP flange)' : 'Shear tab'}
+                          <div className="text-[10px] text-slate-400">{c.pinned ? 'pin — releases Mz' : 'rigid'}</div>
                         </td>
                         <td className="py-1 pr-2 text-right">{f1(c.Vu)}</td>
                         <td className="py-1 pr-2 text-right">{f1(c.Mu)}</td>


### PR DESCRIPTION
## Summary

**Part B** — let the user customize the connection at each member end so it reflects the **actual analysis implication (release)** and drives the steel connection design. This is the "schematic location of hinge" from the reference: a shear/simple connection is a **pin**, a moment connection is **rigid**.

## Changes
- **`model.ts`** — `ConnectionKind` (`'simple' | 'moment' | 'fixed'`) + `Member.connections` (per end).
- **`modelBridge.ts`** — `effectiveReleases()` **unions** a member's explicit releases with the connection-implied ones: a `'simple'` end releases **My & Mz** (a pin), so the assembled frame's force behaviour matches the connection choice; shear/axial still transfer.
- **`steelConnections.ts`** — the joint designer now **honors the explicit connection kind** (`'moment'` → moment connection, `'simple'` → shear tab) instead of only inferring from the moment demand; each connection reports **`pinned`** (the release it implies).
- **`ModelSpace`** — per-end **connection-type picker** in the member Properties panel (Continuous / Simple pin / Moment) with the release note; the connection schedule shows *"pin — releases Mz"* vs *"rigid"*.

## Tests (+4)
`effectiveReleases`: simple = pin (My,Mz), moment/fixed = continuous, union with explicit releases, and the **bridge pinning a simple-ended beam** in the assembled frame (`relJ` My/Mz true).

Verified: `npm test` (955 passing), `npx tsc -b`, `npm run build` all clean.

Together with #294 (the eccentric bolted-connection solver), this delivers both: the engine solves connections like the worked examples, **and** connection customization now reflects real releases / force behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_