### PR TITLE
feat: eccentric weld group solver (elastic weld-line method)

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -31,6 +31,7 @@ import SeismicWizard from './pages/SeismicWizard'
 import WaterTank from './pages/WaterTank'
 import ShotcreteFacing from './pages/ShotcreteFacing'
 import BoltedConnection from './pages/BoltedConnection'
+import WeldedConnection from './pages/WeldedConnection'
 import SlabEstimate from './pages/SlabEstimate'
 import ChbEstimate from './pages/ChbEstimate'
 import ColumnEstimate from './pages/ColumnEstimate'
@@ -81,6 +82,7 @@ export default function App() {
         <Route path="/water-tank" element={<WaterTank />} />
         <Route path="/shotcrete-facing" element={<ShotcreteFacing />} />
         <Route path="/bolted-connection" element={<BoltedConnection />} />
+        <Route path="/welded-connection" element={<WeldedConnection />} />
         <Route path="/estimate/slab" element={<SlabEstimate />} />
         <Route path="/estimate/beam" element={<BeamEstimate />} />
         <Route path="/estimate/column" element={<ColumnEstimate />} />

--- a/webapp/src/engine/weldedConnection.test.ts
+++ b/webapp/src/engine/weldedConnection.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { solveWeldedConnection, type WeldSegment } from './weldedConnection'
+
+describe('solveWeldedConnection — elastic weld-line method', () => {
+  it('single vertical weld, eccentric vertical load (hand check)', () => {
+    // Weld (0,0)→(0,300); P = 100 kN vertical applied 100 mm to the side.
+    const segs: WeldSegment[] = [{ id: 'w', x1: 0, y1: 0, x2: 0, y2: 300 }]
+    const r = solveWeldedConnection({
+      segments: segs, size: 6,
+      load: { P: 100, angleDeg: 90, px: 100, py: 150 },
+    })
+    expect(r.Lw).toBe(300)
+    expect(r.Cx).toBeCloseTo(0, 6)
+    expect(r.Cy).toBeCloseTo(150, 6)
+    expect(r.Jt).toBeCloseTo(2.25e6, 0)          // 300³/12
+    expect(r.T).toBeCloseTo(10000, 6)            // Py·ex = 100·100 kN·mm
+    // direct fdy = 333.33, torsional ftx = 666.67 ⇒ fr = 745.36 N/mm
+    expect(r.fMax).toBeCloseTo(745.36, 1)
+  })
+
+  it('required weld size scales with the resultant and the throat', () => {
+    const segs: WeldSegment[] = [{ id: 'w', x1: 0, y1: 0, x2: 0, y2: 300 }]
+    const r = solveWeldedConnection({
+      segments: segs, size: 6, FEXX: 480, phi: 0.75,
+      load: { P: 100, angleDeg: 90, px: 100, py: 150 },
+    })
+    // capacity/len = 0.75·0.6·480·(0.707·6) = 916.6 N/mm
+    expect(r.capacityPerLen).toBeCloseTo(0.75 * 0.6 * 480 * 0.707 * 6, 3)
+    // reqSize = size·fMax/capacity  and  maxP = P·capacity/fMax are consistent
+    expect(r.reqSize).toBeCloseTo((6 * r.fMax) / r.capacityPerLen, 6)
+    expect(r.maxP).toBeCloseTo((100 * r.capacityPerLen) / r.fMax, 6)
+  })
+
+  it('concentric load produces pure direct shear (no torsion)', () => {
+    // Symmetric two-line group; load through the centroid ⇒ T = 0.
+    const segs: WeldSegment[] = [
+      { id: 'l', x1: 0, y1: 0, x2: 0, y2: 200 },
+      { id: 'r', x1: 100, y1: 0, x2: 100, y2: 200 },
+    ]
+    const r = solveWeldedConnection({
+      segments: segs, size: 6,
+      load: { P: 80, angleDeg: 90, px: 50, py: 100 },   // through centroid (50,100)
+    })
+    expect(r.Cx).toBeCloseTo(50, 6)
+    expect(r.Cy).toBeCloseTo(100, 6)
+    expect(r.T).toBeCloseTo(0, 6)
+    // pure direct: fdy = 80·1000 / 400 = 200 N/mm at every point
+    expect(r.fMax).toBeCloseTo(200, 6)
+  })
+
+  it('horizontal top-and-bottom fillet lines: J/t uses each line’s own L³/12', () => {
+    // Two horizontal welds 300 long, 200 apart — bracket connection.
+    const segs: WeldSegment[] = [
+      { id: 't', x1: 0, y1: 200, x2: 300, y2: 200 },
+      { id: 'b', x1: 0, y1: 0, x2: 300, y2: 0 },
+    ]
+    const r = solveWeldedConnection({
+      segments: segs, size: 8,
+      load: { P: 120, angleDeg: 90, px: 150 + 250, py: 100 },  // 250 mm eccentric
+    })
+    // centroid at (150,100); J/t = 2·[300³/12 + 300·100²] = 2·[2.25e6 + 3.0e6] = 1.05e7
+    expect(r.Cx).toBeCloseTo(150, 6)
+    expect(r.Cy).toBeCloseTo(100, 6)
+    expect(r.Jt).toBeCloseTo(1.05e7, 0)
+    expect(r.fMax).toBeGreaterThan(0)
+  })
+
+  it('flags overstress when the weld is too small', () => {
+    const segs: WeldSegment[] = [{ id: 'w', x1: 0, y1: 0, x2: 0, y2: 150 }]
+    const big = solveWeldedConnection({
+      segments: segs, size: 3,
+      load: { P: 200, angleDeg: 90, px: 200, py: 75 },
+    })
+    expect(big.ok).toBe(false)
+    expect(big.reqSize).toBeGreaterThan(3)
+  })
+})

--- a/webapp/src/engine/weldedConnection.ts
+++ b/webapp/src/engine/weldedConnection.ts
@@ -1,0 +1,128 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Eccentrically-loaded fillet weld group — elastic (weld-as-a-line) method.
+// A weld group made of straight segments carries an in-plane load P applied at
+// an eccentricity (ex, ey) from the group centroid. Treating the weld as a line
+// of unit throat, forces are per unit length (N/mm):
+//   Direct    fdx = Px/Lw ,  fdy = Py/Lw            (Lw = total weld length)
+//   Torsional (about the centroid, T = Py·ex − Px·ey):
+//             ftx = −T·yc/(J/t) ,  fty = T·xc/(J/t)
+//   with the unit-throat polar moment of the line
+//             J/t = Σ[ L³/12 + L·(xc² + yc²) ]      (general for any orientation,
+//                                                    since sin²θ + cos²θ = 1)
+// The resultant f = √(fx² + fy²) is evaluated at every segment endpoint; the
+// largest governs. The fillet throat is 0.707·w (NSCP 510.2.2 / AISC J2.2), so
+// the design strength per unit length is φ·0.60·FEXX·0.707·w. The required weld
+// size and the maximum applied load P follow (f scales linearly with P).
+// Units: coordinates mm; P kN; forces N/mm; FEXX MPa; weld size w mm.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** A straight fillet-weld segment given by its two endpoints (plate mm coords). */
+export interface WeldSegment { id: string; x1: number; y1: number; x2: number; y2: number }
+
+export interface WeldPoint { x: number; y: number; fx: number; fy: number; f: number }
+
+export interface WeldConnLoad {
+  /** Magnitude of the applied load, kN. */
+  P: number
+  /** Direction, degrees from +X (horizontal), positive CCW. */
+  angleDeg: number
+  /** Load application point in plate coordinates, mm. */
+  px: number; py: number
+}
+
+export interface WeldConnResult {
+  Lw: number                   // total weld length, mm
+  Cx: number; Cy: number       // weld-group centroid, mm
+  Jt: number                   // unit-throat polar moment J/t, mm³
+  Px: number; Py: number       // load components, kN
+  ex: number; ey: number       // eccentricity of the load from the centroid, mm
+  T: number                    // torsional moment about the centroid, kN·mm
+  points: WeldPoint[]          // resultant per-unit-length force at each endpoint, N/mm
+  fMax: number; criticalIndex: number   // governing endpoint
+  throat: number               // effective throat = 0.707·w, mm
+  capacityPerLen: number       // design strength per unit length φ·0.6·FEXX·throat, N/mm
+  reqSize: number              // required fillet leg for the applied P, mm
+  maxP: number                 // max applied P for the given weld size, kN
+  ok: boolean
+}
+
+/** Length of a weld segment (mm). */
+function segLen(s: WeldSegment): number {
+  return Math.hypot(s.x2 - s.x1, s.y2 - s.y1)
+}
+
+/**
+ * Solve an eccentrically-loaded fillet-weld group by the elastic line method.
+ * `size` is the fillet leg w (mm); `FEXX` is the electrode strength (MPa,
+ * default E70 ≈ 480); `phi` is the LRFD resistance factor (default 0.75).
+ */
+export function solveWeldedConnection(p: {
+  segments: WeldSegment[]; size: number; load: WeldConnLoad; FEXX?: number; phi?: number;
+}): WeldConnResult {
+  const FEXX = p.FEXX ?? 480
+  const phi = p.phi ?? 0.75
+  const segs = p.segments
+
+  // Total length and centroid of the weld line (sum of segment midpoints × length).
+  const Lw = segs.reduce((a, s) => a + segLen(s), 0)
+  let sx = 0, sy = 0
+  for (const s of segs) {
+    const L = segLen(s)
+    sx += L * (s.x1 + s.x2) / 2
+    sy += L * (s.y1 + s.y2) / 2
+  }
+  const Cx = Lw > 0 ? sx / Lw : 0
+  const Cy = Lw > 0 ? sy / Lw : 0
+
+  // Unit-throat polar moment about the centroid: Σ[L³/12 + L·(xc²+yc²)], where
+  // (xc,yc) is the segment midpoint relative to the centroid. L³/12 is the line's
+  // own second moment about its midpoint (valid for any segment orientation).
+  let Jt = 0
+  for (const s of segs) {
+    const L = segLen(s)
+    const mx = (s.x1 + s.x2) / 2 - Cx
+    const my = (s.y1 + s.y2) / 2 - Cy
+    Jt += (L * L * L) / 12 + L * (mx * mx + my * my)
+  }
+
+  const rad = (p.load.angleDeg * Math.PI) / 180
+  const Px = p.load.P * Math.cos(rad)
+  const Py = p.load.P * Math.sin(rad)
+  const ex = p.load.px - Cx
+  const ey = p.load.py - Cy
+  const T = Py * ex - Px * ey            // kN·mm, +CCW
+
+  // Direct force per unit length (N/mm): (kN → N) / mm.
+  const fdx = Lw > 0 ? (Px * 1000) / Lw : 0
+  const fdy = Lw > 0 ? (Py * 1000) / Lw : 0
+
+  // Evaluate the resultant at each segment endpoint; the extreme fibre governs.
+  const points: WeldPoint[] = []
+  for (const s of segs) {
+    for (const [x, y] of [[s.x1, s.y1], [s.x2, s.y2]] as const) {
+      const rx = x - Cx, ry = y - Cy
+      // Torsional force per unit length: fT = T·ρ/(J/t), ⟂ to ρ.
+      const ftx = Jt > 0 ? (-(T * 1000) * ry) / Jt : 0
+      const fty = Jt > 0 ? ((T * 1000) * rx) / Jt : 0
+      const fx = fdx + ftx
+      const fy = fdy + fty
+      points.push({ x, y, fx, fy, f: Math.hypot(fx, fy) })
+    }
+  }
+
+  const criticalIndex = points.reduce((mi, _, i) => (points[i].f > points[mi].f ? i : mi), 0)
+  const fMax = points.length ? points[criticalIndex].f : 0
+
+  const throat = 0.707 * p.size
+  const capacityPerLen = phi * 0.6 * FEXX * throat   // N/mm
+  // f scales linearly with the applied load and with the weld size:
+  //   reqSize = size · fMax / capacityPerLen ;  maxP = P · capacity / fMax.
+  const reqSize = capacityPerLen > 1e-9 ? (p.size * fMax) / capacityPerLen : Infinity
+  const maxP = fMax > 1e-9 ? (p.load.P * capacityPerLen) / fMax : Infinity
+
+  return {
+    Lw, Cx, Cy, Jt, Px, Py, ex, ey, T, points,
+    fMax, criticalIndex, throat, capacityPerLen, reqSize, maxP,
+    ok: fMax <= capacityPerLen + 1e-6,
+  }
+}

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -27,6 +27,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/truss',         name: 'Truss Space',        sub: 'Plane truss solver'    },
       { to: '/steel',         name: 'Steel Design',       sub: 'AISC 360-16 LRFD'      },
       { to: '/bolted-connection', name: 'Bolted Connection', sub: 'Eccentric bolt group' },
+      { to: '/welded-connection', name: 'Welded Connection', sub: 'Eccentric weld group' },
       { to: '/slab-design',   name: 'Slab Design',        sub: 'Two-way DDM · ACI 318'  },
       { to: '/stair',         name: 'Stair Design',       sub: 'RC waist slab · NSCP'   },
       { to: '/water-tank',    name: 'Water Tank',         sub: 'Circular · IS 3370/ACI 350' },

--- a/webapp/src/pages/WeldedConnection.tsx
+++ b/webapp/src/pages/WeldedConnection.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react'
+import { solveWeldedConnection, type WeldSegment } from '../engine/weldedConnection'
+
+function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
+const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
+
+// Bracket plate: two vertical fillet lines 200 apart, 250 mm tall.
+const DEFAULT_SEGS: WeldSegment[] = [
+  { id: 'L', x1: 0, y1: 0, x2: 0, y2: 250 },
+  { id: 'R', x1: 200, y1: 0, x2: 200, y2: 250 },
+]
+
+function WeldPlot({ r, segs, px, py }: { r: ReturnType<typeof solveWeldedConnection>; segs: WeldSegment[]; px: number; py: number }) {
+  const xs = segs.flatMap((s) => [s.x1, s.x2]).concat([r.Cx, px])
+  const ys = segs.flatMap((s) => [s.y1, s.y2]).concat([r.Cy, py])
+  const minX = Math.min(...xs), maxX = Math.max(...xs)
+  const minY = Math.min(...ys), maxY = Math.max(...ys)
+  const pad = 40, w = 380, h = 300
+  const sx = (maxX - minX) || 1, sy = (maxY - minY) || 1
+  const sc = Math.min((w - 2 * pad) / sx, (h - 2 * pad) / sy)
+  const X = (x: number) => pad + (x - minX) * sc
+  const Y = (y: number) => h - pad - (y - minY) * sc   // flip Y up
+  return (
+    <svg viewBox={`0 0 ${w} ${h}`} className="w-full">
+      {segs.map((s) => (
+        <line key={s.id} x1={X(s.x1)} y1={Y(s.y1)} x2={X(s.x2)} y2={Y(s.y2)} stroke="#0056b3" strokeWidth={4} strokeLinecap="round" />
+      ))}
+      {r.points.map((p, i) => (
+        <circle key={i} cx={X(p.x)} cy={Y(p.y)} r={i === r.criticalIndex ? 6 : 3}
+          fill={i === r.criticalIndex ? '#dc2626' : '#94a3b8'} />
+      ))}
+      {/* centroid */}
+      <circle cx={X(r.Cx)} cy={Y(r.Cy)} r={4} fill="none" stroke="#059669" strokeWidth={1.5} />
+      <line x1={X(r.Cx) - 8} y1={Y(r.Cy)} x2={X(r.Cx) + 8} y2={Y(r.Cy)} stroke="#059669" strokeWidth={1} />
+      <line x1={X(r.Cx)} y1={Y(r.Cy) - 8} x2={X(r.Cx)} y2={Y(r.Cy) + 8} stroke="#059669" strokeWidth={1} />
+      {/* load point + vector */}
+      <circle cx={X(px)} cy={Y(py)} r={4} fill="#f59e0b" />
+      <line x1={X(px)} y1={Y(py)} x2={X(r.Cx)} y2={Y(r.Cy)} stroke="#f59e0b" strokeDasharray="4 3" strokeWidth={1} />
+    </svg>
+  )
+}
+
+export default function WeldedConnection() {
+  const [segs, setSegs] = useState<WeldSegment[]>(DEFAULT_SEGS)
+  const [size, setSize] = useState(6)
+  const [P, setP] = useState(120)
+  const [angle, setAngle] = useState(90)
+  const [px, setPx] = useState(400)
+  const [py, setPy] = useState(125)
+  const [FEXX, setFEXX] = useState(480)
+  const [phi, setPhi] = useState(0.75)
+
+  const r = solveWeldedConnection({ segments: segs, size, FEXX, phi, load: { P, angleDeg: angle, px, py } })
+
+  const setSeg = (i: number, k: keyof Omit<WeldSegment, 'id'>, v: number) =>
+    setSegs((ss) => ss.map((s, j) => (j === i ? { ...s, [k]: v } : s)))
+  const addSeg = () => setSegs((ss) => [...ss, { id: `W${ss.length + 1}`, x1: 0, y1: 0, x2: 100, y2: 0 }])
+  const delSeg = (i: number) => setSegs((ss) => ss.filter((_, j) => j !== i).map((s, k) => ({ ...s, id: `W${k + 1}` })))
+
+  return (
+    <main className="mx-auto max-w-5xl px-5 py-10">
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">Structural · Steel</p>
+      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Eccentric weld group</h1>
+      <p className="mt-2 max-w-3xl text-sm text-slate-600">
+        Elastic (weld-as-a-line) method for an eccentrically-loaded fillet weld group. Each unit length
+        carries the direct share P/L_w plus a torsional share T·ρ/(J/t), T = Pᵧ·eₓ − Pₓ·e_y and
+        J/t = Σ[L³/12 + L·ρ_c²]. The fillet throat is 0.707·w (NSCP 510.2.2 / AISC J2.2), so the design
+        strength per unit length is φ·0.60·F_EXX·0.707·w. Add straight segments anywhere.
+      </p>
+
+      <div className="mt-6 grid gap-5 lg:grid-cols-[1.1fr_1fr]">
+        <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-[1.05rem] font-bold text-[#0056b3]">Weld segments (mm)</h2>
+            <button type="button" onClick={addSeg} className="rounded-md border border-slate-300 px-2.5 py-1 text-xs font-semibold text-[#0056b3] hover:bg-blue-50">+ Add segment</button>
+          </div>
+          <div className="max-h-56 overflow-auto">
+            <table className="w-full text-xs">
+              <thead className="text-slate-500"><tr className="text-left"><th className="pr-2 py-1">Weld</th><th className="pr-2">x₁</th><th className="pr-2">y₁</th><th className="pr-2">x₂</th><th className="pr-2">y₂</th><th className="pr-2 text-right">L</th><th /></tr></thead>
+              <tbody>
+                {segs.map((s, i) => (
+                  <tr key={s.id} className="border-t border-slate-100">
+                    <td className="pr-2 py-1 font-medium">{s.id}</td>
+                    {(['x1', 'y1', 'x2', 'y2'] as const).map((k) => (
+                      <td key={k} className="pr-2"><input type="number" value={s[k]} onChange={(e) => setSeg(i, k, num(e.target.value))} className="w-14 rounded border border-slate-200 px-1 py-0.5" /></td>
+                    ))}
+                    <td className="pr-2 text-right font-mono">{f2(Math.hypot(s.x2 - s.x1, s.y2 - s.y1))}</td>
+                    <td className="text-right"><button type="button" onClick={() => delSeg(i)} className="text-slate-400 hover:text-red-600">✕</button></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <h2 className="mb-2 mt-4 text-[1.05rem] font-bold text-[#0056b3]">Load &amp; weld</h2>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+            {([['Load P (kN)', P, setP], ['Angle (° from +X)', angle, setAngle], ['Fillet leg w (mm)', size, setSize],
+              ['Load at x (mm)', px, setPx], ['Load at y (mm)', py, setPy], ['F_EXX (MPa)', FEXX, setFEXX],
+              ['φ (LRFD)', phi, setPhi]] as const).map(([lbl, val, set]) => (
+              <label key={lbl} className="flex flex-col text-sm">
+                <span className="mb-1 text-slate-600">{lbl}</span>
+                <input type="number" value={val} onChange={(e) => set(num(e.target.value))} className="rounded-md border border-slate-300 px-2.5 py-1.5" />
+              </label>
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+            <WeldPlot r={r} segs={segs} px={px} py={py} />
+          </div>
+          <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm text-sm">
+            <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Results</h2>
+            {[['Total weld length L_w', `${f2(r.Lw)} mm`],
+              ['Centroid C', `(${f2(r.Cx)}, ${f2(r.Cy)}) mm`],
+              ['Load components Pₓ / Pᵧ', `${f2(r.Px)} / ${f2(r.Py)} kN`],
+              ['Eccentricity eₓ / e_y', `${f2(r.ex)} / ${f2(r.ey)} mm`],
+              ['Torsion T = Pᵧ·eₓ − Pₓ·e_y', `${f2(r.T / 1000)} kN·m`],
+              ['Polar inertia J/t = Σ[L³/12 + Lρ²]', `${f2(r.Jt / 1e6)} ×10⁶ mm³`],
+              ['Effective throat 0.707·w', `${f2(r.throat)} mm`],
+              ['Design strength / length', `${f2(r.capacityPerLen)} N/mm`]].map(([k, v]) => (
+              <div key={k} className="flex justify-between border-t border-slate-100 py-1"><span className="text-slate-500">{k}</span><span className="font-mono">{v}</span></div>
+            ))}
+            <div className="flex justify-between border-t border-slate-100 py-1">
+              <span className="text-slate-500">Peak force / length f_max (≤ {f2(r.capacityPerLen)})</span>
+              <span className={`font-mono font-semibold ${r.ok ? 'text-emerald-600' : 'text-red-600'}`}>{f2(r.fMax)} N/mm {r.ok ? '✓' : '✗'}</span>
+            </div>
+            <div className="flex justify-between border-t border-slate-100 py-1">
+              <span className="text-slate-500">Required fillet leg</span>
+              <span className="font-mono">{f2(r.reqSize)} mm</span>
+            </div>
+            <div className="mt-2 flex items-baseline justify-between rounded-lg bg-blue-50 p-2">
+              <span className="text-sm font-semibold text-[#0056b3]">Max allowable load P</span>
+              <span className="font-mono text-lg font-bold text-[#0056b3]">{f2(r.maxP)} kN</span>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
## What

Adds an **eccentric fillet-weld group** solver + tool page — the weld-line
counterpart to the existing eccentric *bolt* group (`/bolted-connection`).

## Method (elastic "weld-as-a-line")

Treating the weld as a line of unit throat, forces are per unit length (N/mm):

- **Direct** `fdx = Pₓ/L_w`, `fdy = Pᵧ/L_w`
- **Torsional** about the centroid, `T = Pᵧ·eₓ − Pₓ·e_y`:
  `ftx = −T·y_c/(J/t)`, `fty = T·x_c/(J/t)`
- **Unit-throat polar moment** `J/t = Σ[ L³/12 + L·(x_c² + y_c²) ]` — general
  for any segment orientation (since sin²θ + cos²θ = 1)

The resultant `f = √(fx² + fy²)` is evaluated at every segment endpoint; the
largest governs. Effective throat `= 0.707·w` (NSCP 510.2.2 / AISC J2.2), so
the design strength per unit length is `φ·0.60·F_EXX·0.707·w`. Required weld
leg and the maximum applied load `P` follow (f scales linearly with P).

## Changes

- `engine/weldedConnection.ts` — `solveWeldedConnection({ segments, size, load, FEXX?, phi? })`
- `engine/weldedConnection.test.ts` — hand-verified single vertical line
  (J/t = 2.25×10⁶ mm³, P = 100 kN @ eₓ = 100 → f_max ≈ 745.4 N/mm), concentric =
  pure direct shear, top/bottom bracket J/t, overstress flag
- `pages/WeldedConnection.tsx` — editable segment table, weld-group SVG with
  force-vector critical endpoint, results (L_w, centroid, T, J/t, throat,
  strength/length, required leg, max P)
- route `/welded-connection` + Tools nav entry

## Verification

- `npx tsc -b` clean
- `npm test` — **960 passed** (955 + 5 new)
- `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_