### PR TITLE
feat: Connections validation benchmarks + diaphragm tests + docs gap-fill

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -36,8 +36,9 @@ npm run build    # typecheck + production build
 
 ## Current state (analysis-core baseline, PR #239)
 
-> Newer work is tracked in the **Tier 4** (A1–E13, PRs through #273) and
-> **Post-Tier-4** (PRs #275–#278) sections below; latest suite: **863 tests**.
+> Newer work is tracked in the **Tier 4** (A1–E13, PRs through #273),
+> **Post-Tier-4** (PRs #275–#278) and **Phase 3 + connections** (PRs #279–#298)
+> sections below; latest suite: **965 tests**.
 > The repo root is now just `webapp/`, `docs/` and the markdown docs.
 
 ### 3D Model Space analysis core (`/model`) — the centrepiece
@@ -56,9 +57,7 @@ of the app. Everything runs **off the main thread** in a web worker
 - **Spring supports** (PR #229): `fixity:'spring'` with `kx/ky/kz` adds translational
   stiffness to the free-DOF diagonal (pile-head / elastic-foundation modelling).
   UI = fixed/pin/spring selector + stiffness fields in the Supports tab.
-  ⚠️ **Sign fix pending PR** (branch `claude/next-phase-jsoxhl`): reported spring
-  reaction was `+k·d` (wrong); correct restoring force is `−k·d`. Structural
-  solution is unaffected — display-only bug. Merge that PR to close it.
+  (Reaction sign fix — restoring force `−k·d` — shipped in PR #241; no longer pending.)
 - **Rigid floor diaphragm** (PR #231): per-storey master-slave constraint elimination
   (T-matrix) tying in-plane `{ux, uz, θy}` with full rigid-body kinematics (arm
   effect). `engine/diaphragm.ts` groups nodes by storey; opt-in checkbox in Analysis.
@@ -300,6 +299,50 @@ After Tier 4, four cleanup / capability items from an external code review shipp
   N-factors checked against published tables.
 
 _Tests after #278: **863 passing**; `tsc -b` clean; production build OK._
+
+## Phase 3 + steel connections (PRs #279–#298)
+
+Roadmap Phase 3 (specialty structural/geotech tools) plus a full steel-connection
+suite, one PR per phase, all auto-merged after Vercel CI:
+
+- **Validation manual + dashboard** — `docs/validation/` chapters: **frame**
+  (#287), **NSCP seismic** (#288), **modal & response spectrum** (#291),
+  **steel connections** (#298); per-module pass counts on `/validation` (#280).
+  All chapter benchmarks are live in `engine/validation.ts` + `validation.test.ts`.
+- **Beam serviceability** (#281) — NSCP min-thickness table, doubly-reinforced
+  cracked Ie, and an **Ec bug fix**: `beamServiceDeflection` had used steel Es
+  (200 GPa) in the deflection formula; now `Ec = 4700√f′c`.
+- **Phase 3 structural** — RC stair / waist slab (#283, `/stair`), NSCP 208
+  Seismic Wizard (#289, `/seismic-wizard`), circular RC water tank to
+  IS 3370 / ACI 350 hoop+flexure with crack-width service checks (#290,
+  `/water-tank`).
+- **Phase 3 geotech (FHWA/PTI)** — soil-nail wall GEC-7 (#282, `/soil-nail`),
+  micropile axial (#284, `/micropile`), rock/ground anchors PTI (#286,
+  `/rock-anchor`), soil-nail **shotcrete facing** flexure/punching GEC-7 (#292,
+  `/shotcrete-facing`).
+- **Steel connection suite** —
+  - #293: joint designer reflects the **actual connected elements** (column
+    flange vs web × beam web vs flanges) + custom per-bolt locations in
+    `designBolts`.
+  - #294: `/bolted-connection` — eccentric bolt group, elastic vector method,
+    fully custom bolt coordinates, critical/least bolt, max-P back-calc.
+  - #295: **connection kind drives analysis**: `Member.connections.iEnd/jEnd`
+    (`'simple' | 'moment' | 'fixed'`); a `'simple'` end auto-releases My+Mz via
+    `effectiveReleases` in `modelBridge` (the schematic hinge), so force
+    behaviour matches the detailing.
+  - #296: `/welded-connection` — eccentric fillet-weld group (weld-as-a-line,
+    `J/t = Σ[L³/12 + L·ρ²]`, throat 0.707·w per NSCP 510.2.2), required leg +
+    max P.
+  - #297: out-of-plane eccentricity (§J3.7 bolt tension + shear interaction
+    φF′nt) and prying action (§J3.9 T-stub: Q, T+Q, t_req, t₀) on
+    `/bolted-connection`.
+- **Gap-fill** (#298) — `Connections` category on `/validation` (4 hand-checked
+  benchmarks), `diaphragm.test.ts` (last untested logic engine), this HANDOFF
+  refresh.
+
+_Tests after #298: **965 passing**; `tsc -b` clean; production build OK._
+_Remaining roadmap: Pressure Grouting (empirical — skipped by design); Phase 4
+items are owner-driven (marketing/monetisation)._
 
 ## Validation roadmap — toward a formal validation manual
 

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -18,6 +18,7 @@ per-module pass counts, so the manual cannot silently drift from the code.
 | [Frame analysis](./frame.md) | Beam/frame solver vs closed-form elasticity | ✅ |
 | [NSCP seismic](./seismic.md) | 208 static period & base shear + governing logic | ✅ |
 | [Modal & response spectrum](./dynamics.md) | Eigen-solver, SDOF period, pseudo relations | ✅ |
+| [Steel connections](./connections.md) | Eccentric bolt/weld groups, §J3.7 out-of-plane, §J3.9 prying | ✅ |
 | RC design | Beam Mn, column φPn, footing area | in `/validation` (dashboard) |
 | Steel design | φMp, φVn | in `/validation` (dashboard) |
 | Geotechnical | Bearing factors, earth pressure, slope FS | in `/validation` (dashboard) |

--- a/docs/validation/connections.md
+++ b/docs/validation/connections.md
@@ -1,0 +1,107 @@
+# Validation Chapter 4 — Steel connections
+
+Benchmarks for the connection solvers: the in-plane eccentric **bolt** group
+(`engine/boltedConnection.ts`), the eccentric **weld** group
+(`engine/weldedConnection.ts`), the **out-of-plane** bolt-tension model and
+**prying action** (`engine/steelDesign.ts`). Every case below is encoded in
+`webapp/src/engine/validation.ts`, enforced by `validation.test.ts`, and shown
+live on the in-app **/validation** dashboard under the **Connections** module.
+
+Format: **Problem → Reference solution → Software output → Error % → PASS**.
+
+---
+
+## 4.1 Eccentric bolt group — elastic (vector) method
+
+**Problem.** Four bolts on a 100 × 100 mm square (centroid at (50, 50)). A
+vertical load **P = 100 kN** acts 100 mm to the right of the centroid
+(e_x = 100 mm).
+
+**Reference (AISC Manual Part 7, elastic method).**
+
+- Polar moment `J = Σ(x² + y²) = 4·(50² + 50²) = 20 000 mm²`
+- Direct share per bolt `P/N = 25 kN` (↓)
+- Torsion `T = P·e_x = 10 000 kN·mm`; torsional share on a corner bolt
+  `T·ρ/J` with components 25 kN each
+- Critical (right-hand) bolts: `R = √(25² + (25+25)²) = P·√(0.25² + 0.5²)`
+
+> **R_manual = 55.9017 kN**
+
+| Manual | Software (`solveBoltedConnection`) | Error | Result |
+| --- | --- | --- | --- |
+| 55.9017 kN | 55.9017 kN | < 1e-9 % | ✅ PASS |
+
+Dashboard id: `bolt-ecc-rmax`.
+
+## 4.2 Eccentric weld group — elastic (weld-as-a-line) method
+
+**Problem.** A single vertical fillet-weld line 300 mm long. A vertical load
+**P = 100 kN** acts 100 mm from the line (e_x = 100 mm).
+
+**Reference (AISC Manual Part 8; throat per NSCP 510.2.2 / AISC J2.2).**
+
+- Unit-throat polar moment `J/t = L³/12 = 300³/12 = 2.25×10⁶ mm³`
+- Direct `P/L_w = 100 000/300 = 333.33 N/mm`
+- Torsional at the line end (c = 150 mm): `T·c/(J/t) = (10⁷ × 150)/2.25×10⁶ = 666.67 N/mm`
+- Resultant `f = 333.33·√(1² + 2²) = (P·1000/L_w)·√5`
+
+> **f_manual = 745.356 N/mm**
+
+| Manual | Software (`solveWeldedConnection`) | Error | Result |
+| --- | --- | --- | --- |
+| 745.356 N/mm | 745.356 N/mm | < 1e-9 % | ✅ PASS |
+
+Dashboard id: `weld-ecc-fmax`.
+
+## 4.3 Out-of-plane eccentricity — bolt tension (AISC 360 §J3.7)
+
+**Problem.** A 2 × 3 bolt group (rows at y = 0, 100, 200 mm). A shear
+**Vu = 100 kN** is applied at a stand-off **e_out = 100 mm** perpendicular to
+the bolt plane, bending the group about its lowest row.
+
+**Reference.**
+
+- `M_op = Vu·e_out = 10 000 kN·mm`
+- `Σyᵢ² = 2·(100² + 200²) = 100 000 mm²` (about the lowest row)
+- Top-row bolt tension `T = M_op·y_top/Σyᵢ² = 10 000·200/100 000`
+
+> **T_manual = 20.000 kN**
+
+| Manual | Software (`outOfPlaneBoltGroup`) | Error | Result |
+| --- | --- | --- | --- |
+| 20.000 kN | 20.000 kN | < 1e-9 % | ✅ PASS |
+
+Dashboard id: `bolt-oop-tension`.
+
+## 4.4 Prying action — thickness eliminating prying (AISC Part 9 / §J3.9)
+
+**Problem.** A bolted fitting with gage `b = 45 mm`, edge `a = 40 mm`, pitch
+`p = 70 mm`, bolt `d_b = 20 mm`, plate `F_y = 248 MPa`; available bolt tension
+`φB_n = 60 kN`. Find the minimum fitting thickness `t₀` at which prying
+vanishes (α → 0).
+
+**Reference (T-stub model).**
+
+- `b′ = b − d_b/2 = 35 mm`
+- `t₀ = √(4·φB_n·b′ / (φ_f·F_y·p)) = √(4·60 000·35 / (0.90·248·70))`
+
+> **t₀,manual = 23.186 mm**
+
+| Manual | Software (`pryingAction`) | Error | Result |
+| --- | --- | --- | --- |
+| 23.186 mm | 23.186 mm | < 1e-9 % | ✅ PASS |
+
+Dashboard id: `prying-t0`.
+
+---
+
+## Coverage notes
+
+- The **connection type → analysis** wiring (a `'simple'` end releases M_y, M_z —
+  the schematic hinge; `'moment'`/`'fixed'` stay continuous) is verified in
+  `modelBridge.test.ts` (`effectiveReleases`, assembled-frame pin check).
+- The weld solver's `J/t = Σ[L³/12 + L·ρ_c²]` is orientation-general (a line's
+  own second moment about its midpoint is `L³/12` for any inclination);
+  multi-segment bracket cases are covered in `weldedConnection.test.ts`.
+- The combined shear + tension interaction `φF′_nt = 1.3F_nt − (F_nt/(φF_nv))·f_rv ≤ F_nt`
+  (§J3.7) and the full prying α/β/δ chain are exercised in `steelDesign.test.ts`.

--- a/webapp/src/engine/diaphragm.test.ts
+++ b/webapp/src/engine/diaphragm.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { buildDiaphragmGroups } from './diaphragm'
+import { emptyModel, type StructuralModel } from './model'
+
+function model(nodes: Array<[string, number, number, number]>, elevations: number[]): StructuralModel {
+  return {
+    ...emptyModel('t'),
+    nodes: nodes.map(([id, x, y, z]) => ({ id, x, y, z })),
+    storeys: elevations.map((e, i) => ({ id: `s${i}`, name: `L${i + 1}`, elevation: e })),
+  }
+}
+
+describe('buildDiaphragmGroups — rigid floor diaphragm node grouping', () => {
+  it('returns no groups when the model has no storeys', () => {
+    const m = model([['a', 0, 3, 0], ['b', 4, 3, 0]], [])
+    expect(buildDiaphragmGroups(m)).toEqual([])
+  })
+
+  it('groups all nodes at a storey elevation: first = master, rest = slaves', () => {
+    const m = model([['a', 0, 3, 0], ['b', 4, 3, 0], ['c', 4, 3, 5], ['base', 0, 0, 0]], [3])
+    const g = buildDiaphragmGroups(m)
+    expect(g).toHaveLength(1)
+    expect(g[0].masterNode).toBe('a')
+    expect(g[0].slaveNodes).toEqual(['b', 'c'])
+  })
+
+  it('skips storeys with fewer than 2 nodes at that elevation (nothing to tie)', () => {
+    const m = model([['a', 0, 3, 0], ['lone', 0, 6, 0]], [3, 6])
+    const g = buildDiaphragmGroups(m)
+    expect(g).toHaveLength(0)   // one node per level — no constraint possible
+  })
+
+  it('produces one group per storey in a multi-storey model', () => {
+    const m = model(
+      [['a1', 0, 3, 0], ['b1', 4, 3, 0], ['a2', 0, 6, 0], ['b2', 4, 6, 0], ['base', 0, 0, 0]],
+      [3, 6],
+    )
+    const g = buildDiaphragmGroups(m)
+    expect(g).toHaveLength(2)
+    expect(g[0]).toEqual({ masterNode: 'a1', slaveNodes: ['b1'] })
+    expect(g[1]).toEqual({ masterNode: 'a2', slaveNodes: ['b2'] })
+  })
+
+  it('matches elevations within the tolerance but not beyond it', () => {
+    // 1e-5 m off is inside YTOL = 1e-4; 1e-3 m off is outside.
+    const m = model([['a', 0, 3, 0], ['near', 4, 3 + 1e-5, 0], ['far', 8, 3 + 1e-3, 0]], [3])
+    const g = buildDiaphragmGroups(m)
+    expect(g).toHaveLength(1)
+    expect(g[0].slaveNodes).toEqual(['near'])
+  })
+})

--- a/webapp/src/engine/validation.ts
+++ b/webapp/src/engine/validation.ts
@@ -20,11 +20,14 @@ import { jacobiEigen } from './modal'
 import { elasticResponseSpectrum } from './accelSpectrum'
 import { generateGridModel } from './modelBuilder'
 import { solveFrame3D, rectJ, type F3Node, type F3Member, type F3Support } from './frame3d'
+import { solveBoltedConnection } from './boltedConnection'
+import { solveWeldedConnection } from './weldedConnection'
+import { boltGeomFromPositions, outOfPlaneBoltGroup, pryingAction } from './steelDesign'
 import type { RectSection } from './model'
 
 export interface ValidationCase {
   id: string
-  category: 'RC' | 'Steel' | 'Analysis' | 'Seismic' | 'Dynamics' | 'Wind' | 'Geotech'
+  category: 'RC' | 'Steel' | 'Connections' | 'Analysis' | 'Seismic' | 'Dynamics' | 'Wind' | 'Geotech'
   title: string
   reference: string
   formula: string
@@ -157,6 +160,51 @@ const seismic = (() => {
   }
 })()
 
+// ── 12. Steel connections — bolt/weld groups, out-of-plane, prying ───────────
+const boltEcc = (() => {
+  // 4 bolts on a 100×100 square (centroid 50,50); vertical P = 100 kN at
+  // ex = 100 mm. J = 4·(50²+50²) = 20000 mm²; direct P/4 plus torsional
+  // T·ρ/J on the corner bolts ⇒ R = P·√(0.25² + 0.5²) = 0.55902·P.
+  const bolts = [
+    { id: 'B1', x: 0, y: 0 }, { id: 'B2', x: 100, y: 0 },
+    { id: 'B3', x: 0, y: 100 }, { id: 'B4', x: 100, y: 100 },
+  ]
+  const r = solveBoltedConnection({ bolts, dia: 22, allowableStress: 150, load: { P: 100, angleDeg: -90, px: 150, py: 50 } })
+  return { manual: 100 * Math.sqrt(0.25 ** 2 + 0.5 ** 2), software: r.Rmax }
+})()
+
+const weldEcc = (() => {
+  // Single vertical weld line 300 mm; vertical P = 100 kN at 100 mm eccentricity.
+  // J/t = L³/12 = 2.25×10⁶ mm³. Direct P/Lw = 333.33; torsional T·c/(J/t) =
+  // (10⁷·150)/2.25×10⁶ = 666.67 ⇒ f = (P·1000/Lw)·√5.
+  const r = solveWeldedConnection({
+    segments: [{ id: 'w', x1: 0, y1: 0, x2: 0, y2: 300 }], size: 6,
+    load: { P: 100, angleDeg: 90, px: 100, py: 150 },
+  })
+  return { manual: (100_000 / 300) * Math.sqrt(5), software: r.fMax }
+})()
+
+const boltOop = (() => {
+  // 2×3 bolt group (rows y = 0/100/200); Vu = 100 kN at e_out = 100 mm ⇒
+  // M_op = 10 000 kN·mm. Σyi² = 2·(100² + 200²) = 100 000 mm² about the lowest
+  // row ⇒ top-row tension T = M_op·200/Σyi² = 20 kN.
+  const geom = boltGeomFromPositions([
+    { id: 'B1', x: 0, y: 0 }, { id: 'B2', x: 100, y: 0 },
+    { id: 'B3', x: 0, y: 100 }, { id: 'B4', x: 100, y: 100 },
+    { id: 'B5', x: 0, y: 200 }, { id: 'B6', x: 100, y: 200 },
+  ])
+  const r = outOfPlaneBoltGroup(geom, [], 100, 100, 'A325M', 20, true)
+  return { manual: (100 * 100 * 200) / 100_000, software: r.Tmax }
+})()
+
+const pryingT0 = (() => {
+  // Minimum fitting thickness that eliminates prying (AISC Part 9):
+  // t₀ = √(4·φBn·b′/(φf·Fy·p)) with φBn = 60 kN, b′ = 45 − 20/2 = 35 mm,
+  // Fy = 248, p = 70, φf = 0.90.
+  const r = pryingAction(50, 60, 45, 40, 70, 12, 20, 248)
+  return { manual: Math.sqrt((4 * 60 * 1000 * 35) / (0.9 * 248 * 70)), software: r.t_no_prying }
+})()
+
 export const VALIDATION_CASES: ValidationCase[] = [
   {
     id: 'rc-beam-mn', category: 'RC', title: 'Singly-reinforced beam — nominal moment',
@@ -247,5 +295,25 @@ export const VALIDATION_CASES: ValidationCase[] = [
     id: 'spectrum-pseudo', category: 'Dynamics', title: 'Pseudo-acceleration relation',
     reference: 'Chopra, Dynamics of Structures', formula: 'PSA = ω²·Sd',
     manual: dynamics.pseudo.manual, software: dynamics.pseudo.software, unit: 'm/s²', tol: 1e-9,
+  },
+  {
+    id: 'bolt-ecc-rmax', category: 'Connections', title: 'Eccentric bolt group — critical bolt force',
+    reference: 'AISC Manual Part 7 (elastic method)', formula: 'R = √((Pₓ/N + T·y/J)² + (Pᵧ/N + T·x/J)²)',
+    manual: boltEcc.manual, software: boltEcc.software, unit: 'kN', tol: 1e-9,
+  },
+  {
+    id: 'weld-ecc-fmax', category: 'Connections', title: 'Eccentric weld group — peak force per length',
+    reference: 'AISC Manual Part 8 (weld-as-a-line)', formula: 'f = √((P/L_w)² + (T·c/(J/t))²)',
+    manual: weldEcc.manual, software: weldEcc.software, unit: 'N/mm', tol: 1e-9,
+  },
+  {
+    id: 'bolt-oop-tension', category: 'Connections', title: 'Out-of-plane bolt group — top-row tension',
+    reference: 'AISC 360 §J3.7', formula: 'Tᵢ = M_op·yᵢ / Σyᵢ²',
+    manual: boltOop.manual, software: boltOop.software, unit: 'kN', tol: 1e-9,
+  },
+  {
+    id: 'prying-t0', category: 'Connections', title: 'Prying — thickness eliminating prying',
+    reference: 'AISC Manual Part 9 / §J3.9', formula: 't₀ = √(4·φBn·b′ / (φf·Fy·p))',
+    manual: pryingT0.manual, software: pryingT0.software, unit: 'mm', tol: 1e-9,
   },
 ]

--- a/webapp/src/pages/Validation.tsx
+++ b/webapp/src/pages/Validation.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom'
 import { VALIDATION_CASES, pctDiff, type ValidationCase } from '../engine/validation'
 
-const CATS = ['RC', 'Steel', 'Analysis', 'Seismic', 'Dynamics', 'Wind', 'Geotech'] as const
+const CATS = ['RC', 'Steel', 'Connections', 'Analysis', 'Seismic', 'Dynamics', 'Wind', 'Geotech'] as const
 
 function fmt(v: number): string {
   if (!Number.isFinite(v)) return '—'


### PR DESCRIPTION
## What

Gap-fill pass against the CLAUDE.md working rules (validation coverage, engine
test pairing, HANDOFF currency) for the just-shipped connection suite.

## Changes

### `/validation` — new **Connections** module (4 hand-checked benchmarks)
| id | Benchmark | Reference | Manual |
| --- | --- | --- | --- |
| `bolt-ecc-rmax` | Eccentric bolt group critical force `R = P·√(0.25²+0.5²)` | AISC Manual Part 7 | 55.9017 kN |
| `weld-ecc-fmax` | Eccentric weld group peak `f = (P/L_w)·√5` | AISC Manual Part 8 | 745.356 N/mm |
| `bolt-oop-tension` | Out-of-plane top-row tension `T = M_op·yᵢ/Σyᵢ²` | AISC 360 §J3.7 | 20.000 kN |
| `prying-t0` | No-prying thickness `t₀ = √(4φBn·b′/(φf·Fy·p))` | AISC Part 9 / §J3.9 | 23.186 mm |

All four agree to < 1e-9 relative tolerance and are enforced by
`validation.test.ts`; the dashboard pass-count chips pick the category up
automatically.

### Validation Manual chapter 4
`docs/validation/connections.md` — Problem → Reference → Software → Error % →
PASS write-ups for the four benchmarks, plus coverage notes on the
connection-kind→release wiring and the §J3.7 interaction / prying chain.
Indexed in `docs/validation/README.md`.

### `diaphragm.test.ts`
`engine/diaphragm.ts` was the last logic-bearing engine module without a
matching test (the others are worker plumbing / type schemas). 5 tests: empty
storeys, master/slave grouping, single-node skip, per-storey groups, elevation
tolerance.

### HANDOFF.md refresh
- New **Phase 3 + steel connections (PRs #279–#298)** section
- Test count 863 → **965**
- Closed the stale "spring reaction sign fix pending" warning (shipped in #241)

## Verification

- `npx tsc -b` clean
- `npm test` — **965 passed** (960 + 5)
- `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_