### PR TITLE
fix: optimizer infinite loop when the hierarchy reverts a shrink

### DIFF
--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { generateGridModel, buildGravityLoads, removeNode, enforceSectionHierarchy, refreshSelfWeight, splitSharedSections } from './modelBuilder'
 import { designStructure, optimizeStructure, designOK, type LateralCase } from './pipeline'
+import { nextHeavierW } from './aiscSections'
 import { computeSeismic } from './seismic'
 import type { RectSection, ModelLoad } from './model'
 
@@ -334,6 +335,40 @@ describe('optimizeStructure', () => {
     expect(col.h).toBeLessThanOrEqual(500)
     expect(designOK(r.design)).toBe(true)
   })
+})
+
+describe('optimizeStructure — termination guards (hierarchy revert / catalog top)', () => {
+  it('square columns > 300 wide do not hang the batch-shrink loop', () => {
+    // enforceSectionHierarchy clamps a column square-or-taller, silently reverting
+    // the h−25 batch proposal; before the sectionsChanged guard this spun forever.
+    const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section: { ...section, b: 450, h: 450, name: '450×450' } })
+    m.loads = m.plates.flatMap((p) => [
+      { kind: 'area' as const, plate: p.id, q: 3, cat: 'D' as const },
+      { kind: 'area' as const, plate: p.id, q: 1.5, cat: 'L' as const },
+    ])
+    const r = optimizeStructure(m, soil)!
+    expect(r.converged).toBe(true)
+    expect(designOK(r.design)).toBe(true)
+    // columns stay square-or-taller per the hierarchy
+    for (const mem of r.model.members.filter((x) => x.role === 'column')) {
+      const s = r.model.sections.find((x) => x.id === mem.section)!
+      expect(s.h).toBeGreaterThanOrEqual(s.b)
+    }
+  }, 120_000)
+
+  it('an un-growable failing design exits the grow loop early instead of burning maxIter', () => {
+    // heaviest W in the catalog under an absurd load: jumpSection cannot step up,
+    // so the grow loop must break on the first no-change iteration.
+    let top = 'W310x342'
+    for (let n = nextHeavierW(top); n; n = nextHeavierW(top)) top = n.name
+    const m = generateGridModel({ baysX: [12], baysZ: [10], storeyH: [3], section })
+    m.sections = m.sections.map((s) => ({ ...s, material: 'steel' as const, shape: top, steelFy: 345, steelFu: 448 }))
+    m.loads = m.plates.flatMap((p) => [{ kind: 'area' as const, plate: p.id, q: 400, cat: 'D' as const }])
+    const r = optimizeStructure(m, soil)!
+    expect(r.converged).toBe(false)
+    expect(r.steps.length).toBeLessThanOrEqual(2)   // initial + the single no-progress attempt
+    expect(r.model.sections.every((s) => s.shape === top)).toBe(true)
+  }, 120_000)
 })
 
 describe('optimizeStructure — steel sections', () => {

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -804,7 +804,9 @@ export async function optimizeStructureAsync(
         const u = utils.get(s.id)
         return [s.id, u !== undefined ? jumpSection(s, u, secRole.get(s.id) ?? '') : s]
       }))
-      work = settle(withSizes(work, sizes))
+      const grown = settle(withSizes(work, sizes))
+      if (!sectionsChanged(work, grown)) break   // nothing can grow (catalog top / unsupported shape)
+      work = grown
       const d = await designStructureWithPool(work, soil, plan, opts, pool, sub(`Optimize iter ${iter}`))
       if (!d) break
       ;({ m: work, d: design } = await detail(work, d, `Optimize iter ${iter}`))
@@ -834,6 +836,7 @@ export async function optimizeStructureAsync(
         batchPass++
         onProgress?.({ phase: 'Optimizing — trimming sections', detail: `batch pass ${batchPass}: ${batchSizes.size} section(s) h↓` })
         const trial = settle(withSizes(work, batchSizes))
+        if (!sectionsChanged(work, trial)) break   // hierarchy reverted every shrink — no progress
         const d = await designStructureWithPool(trial, soil, plan, opts, pool)
         if (d && designOK(d)) { work = trial; design = d } else { batchOk = false }
       }
@@ -851,6 +854,7 @@ export async function optimizeStructureAsync(
         batchPass++
         onProgress?.({ phase: 'Optimizing — trimming sections', detail: `batch pass ${batchPass}: ${batchSizes.size} section(s) b↓` })
         const trial = settle(withSizes(work, batchSizes))
+        if (!sectionsChanged(work, trial)) break   // hierarchy reverted every shrink — no progress
         const d = await designStructureWithPool(trial, soil, plan, opts, pool)
         if (d && designOK(d)) { work = trial; design = d } else { bBatchOk = false }
       }
@@ -888,6 +892,7 @@ export async function optimizeStructureAsync(
           }
           if (!newSec) { onProgress?.({ phase: 'Optimizing — fine-tuning', current: ++hDone, total: hCandidates.length, detail: `pass ${guard}: h↓ — tested ${s0.name}` }); continue }
           const trial = settle(withSizes(work, new Map([[s0.id, newSec]])))
+          if (!sectionsChanged(work, trial)) { onProgress?.({ phase: 'Optimizing — fine-tuning', current: ++hDone, total: hCandidates.length, detail: `pass ${guard}: h↓ — ${s0.name} reverted` }); continue }
           const d = await designStructureWithPool(trial, soil, plan, opts, pool)
           onProgress?.({ phase: 'Optimizing — fine-tuning', current: ++hDone, total: hCandidates.length, detail: `pass ${guard}: h↓ — tested ${s0.name}` })
           if (d && designOK(d)) { work = trial; design = d; improved = true; hSucceededIds.add(s0.id) }
@@ -907,6 +912,7 @@ export async function optimizeStructureAsync(
         for (const s0 of bCandidates) {
           const newSec = { ...s0, b: s0.b - 25, name: `${s0.b - 25}×${s0.h}` }
           const trial = settle(withSizes(work, new Map([[s0.id, newSec]])))
+          if (!sectionsChanged(work, trial)) { onProgress?.({ phase: 'Optimizing — fine-tuning', current: ++bDone, total: bCandidates.length, detail: `pass ${guard}: b↓ — ${s0.name} reverted` }); continue }
           const d = await designStructureWithPool(trial, soil, plan, opts, pool)
           onProgress?.({ phase: 'Optimizing — fine-tuning', current: ++bDone, total: bCandidates.length, detail: `pass ${guard}: b↓ — tested ${s0.name}` })
           if (d && designOK(d)) { work = trial; design = d; improved = true }
@@ -1014,6 +1020,18 @@ const countFails = (d: StructureDesign): number =>
 
 const withSizes = (model: StructuralModel, sizes: Map<string, RectSection>): StructuralModel =>
   ({ ...model, sections: model.sections.map((s) => sizes.get(s.id) ?? s) })
+
+/** True when any section geometry differs between two settled models.
+ *  enforceSectionHierarchy can silently revert a proposed change (e.g. a square
+ *  column's h-shrink is clamped back to h ≥ b), so a grow/shrink trial can come
+ *  out identical to the current model. Accepting such a trial makes no progress —
+ *  the unbounded batch loops would re-propose the same change forever. */
+const sectionsChanged = (a: StructuralModel, b: StructuralModel): boolean =>
+  a.sections.length !== b.sections.length
+  || a.sections.some((s, i) => {
+    const t = b.sections[i]
+    return s.b !== t.b || s.h !== t.h || s.shape !== t.shape
+  })
 
 /** Copy shape geometry into the section's bounding-box fields so metadata stays consistent. */
 const applyShape = (s: RectSection, sh: AiscShape): RectSection =>
@@ -1149,7 +1167,9 @@ export function optimizeStructure(
       const u = utils.get(s.id)
       return [s.id, u !== undefined ? jumpSection(s, u, secRole.get(s.id) ?? '') : s]
     }))
-    work = settle(withSizes(work, sizes))
+    const grown = settle(withSizes(work, sizes))
+    if (!sectionsChanged(work, grown)) break   // nothing can grow (catalog top / unsupported shape)
+    work = grown
     const d = designStructure(work, soil, plan, opts, sub(`Optimize iter ${iter}`))
     if (!d) break
     ;({ m: work, d: design } = detail(work, d, `Optimize iter ${iter}`))
@@ -1182,6 +1202,7 @@ export function optimizeStructure(
       batchPass++
       onProgress?.({ phase: 'Optimizing — trimming sections', detail: `batch pass ${batchPass}: ${batchSizes.size} section(s) h↓` })
       const trial = settle(withSizes(work, batchSizes))
+      if (!sectionsChanged(work, trial)) break   // hierarchy reverted every shrink — no progress
       const d = designStructure(trial, soil, plan, opts)
       if (d && designOK(d)) { work = trial; design = d } else { batchOk = false }
     }
@@ -1199,11 +1220,13 @@ export function optimizeStructure(
       batchPass++
       onProgress?.({ phase: 'Optimizing — trimming sections', detail: `batch pass ${batchPass}: ${batchSizes.size} section(s) b↓` })
       const trial = settle(withSizes(work, batchSizes))
+      if (!sectionsChanged(work, trial)) break   // hierarchy reverted every shrink — no progress
       const d = designStructure(trial, soil, plan, opts)
       if (d && designOK(d)) { work = trial; design = d } else { bBatchOk = false }
     }
 
-    // Fine-tune: per-section — try h↓ first, then b↓ if h can't shrink or fails
+    // Fine-tune: per-section — try h↓ first, then b↓ if h can't shrink or fails.
+    // A trial the hierarchy reverts is skipped (identical model ⇒ not an improvement).
     let improved = true, guard = 0
     while (improved && guard++ < 4) {
       improved = false
@@ -1213,6 +1236,7 @@ export function optimizeStructure(
           if (!lighter) continue
           onProgress?.({ phase: 'Optimizing — fine-tuning', detail: s0.name })
           const trial = settle(withSizes(work, new Map([[s0.id, applyShape(s0, lighter)]])))
+          if (!sectionsChanged(work, trial)) continue
           const d = designStructure(trial, soil, plan, opts)
           if (d && designOK(d)) { work = trial; design = d; improved = true }
         } else {
@@ -1220,13 +1244,16 @@ export function optimizeStructure(
             onProgress?.({ phase: 'Optimizing — fine-tuning', detail: `${s0.name} h↓` })
             const hSec = { ...s0, h: s0.h - 25, name: `${s0.b}×${s0.h - 25}` }
             const trial = settle(withSizes(work, new Map([[s0.id, hSec]])))
-            const d = designStructure(trial, soil, plan, opts)
-            if (d && designOK(d)) { work = trial; design = d; improved = true; continue }
+            if (sectionsChanged(work, trial)) {
+              const d = designStructure(trial, soil, plan, opts)
+              if (d && designOK(d)) { work = trial; design = d; improved = true; continue }
+            }
           }
           if (s0.b - 25 >= 200) {
             onProgress?.({ phase: 'Optimizing — fine-tuning', detail: `${s0.name} b↓` })
             const bSec = { ...s0, b: s0.b - 25, name: `${s0.b - 25}×${s0.h}` }
             const trial = settle(withSizes(work, new Map([[s0.id, bSec]])))
+            if (!sectionsChanged(work, trial)) continue
             const d = designStructure(trial, soil, plan, opts)
             if (d && designOK(d)) { work = trial; design = d; improved = true }
           }


### PR DESCRIPTION
## Bug (P0)

`optimizeStructure` / `optimizeStructureAsync` (the production `/model` optimize
path) **never returns** for any model with lightly-utilised square RC columns
wider than 300 mm — i.e. the most common column in practice.

**Mechanism.** The batch-shrink phase proposes `h − 25` for every section with
utilisation < 0.80, then settles the trial through `enforceSectionHierarchy`,
which clamps columns square-or-taller (`if (h < b) h = b`). For a column with
`b = h > 300` the proposal is **silently reverted**: the trial model is
identical to the current one, passes `designOK`, is accepted, and the unbounded
`while (batchOk)` loop re-proposes the same shrink forever. The grow phase
even *creates* this state — near-square failing columns grow +50/+50 on both
sides. Reproduced: a light 500×500 model was still spinning at 45 s while the
300×900 control finished in under 2 s. Existing tests never caught it because
they all use 300-wide sections, where the 300-mm h-floor is reached before
`h` can hit `b`.

## Fix

New `sectionsChanged(work, trial)` guard applied in **both** the sync and
async optimizers:

- **Batch h/b shrink loops** — break when a settled pass reverts every
  proposal (no progress possible).
- **Fine-tune trials** — skip a candidate whose settled trial is identical
  (don't count a no-op as "improved").
- **Grow loop** — exit early when nothing can grow (top of the W catalog /
  unsupported shape) instead of burning `maxIter` full re-designs
  (30 → 1 wasted iteration in the top-of-catalog case).

## Tests

- `450×450` square-column model: terminates, converges, and columns stay
  hierarchy-consistent (`h ≥ b`) — hangs forever without the fix.
- Heaviest catalog W under an impossible load: exits after one no-progress
  iteration with `converged: false`, sections untouched.

## Verification

- `npx tsc -b` clean
- `npm test` — **967 passed** (965 + 2)
- `npm run build` succeeds

Found during the optimizer regime check (RC/steel × many-failing/none-failing);
the follow-up (non-W/WT steel beams silently unchecked) ships as the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_