### PR TITLE
fix: surface un-designable steel members instead of silently passing

### DIFF
--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -337,6 +337,40 @@ describe('optimizeStructure', () => {
   })
 })
 
+describe('unchecked members — unsupported steel beam families must not read as OK', () => {
+  function channelBeamModel() {
+    const m = makeModel()
+    const beamSecs = new Set(m.members.filter((x) => x.role === 'beam' || x.role === 'girder').map((x) => x.section))
+    m.sections = m.sections.map((s) =>
+      beamSecs.has(s.id)
+        ? { ...s, material: 'steel' as const, shape: 'C75x8.9', steelFy: 345, steelFu: 448 }
+        : { ...s, material: 'steel' as const, shape: 'W310x97', steelFy: 345, steelFu: 448 })
+    return m
+  }
+
+  it('C-shape beams land in design.unchecked and fail designOK', () => {
+    const d = designStructure(channelBeamModel(), soil)!
+    // previously: no steelBeams row at all and designOK could read true
+    expect(d.steelBeams).toHaveLength(0)
+    expect(d.unchecked).toHaveLength(4)                    // 2 beams + 2 girders
+    expect(d.unchecked.every((u) => u.shape === 'C75x8.9')).toBe(true)
+    expect(designOK(d)).toBe(false)
+  })
+
+  it('the optimizer reports converged=false instead of "fixing" what it never checked', () => {
+    const r = optimizeStructure(channelBeamModel(), soil)!
+    expect(r.converged).toBe(false)
+    expect(r.design.unchecked).toHaveLength(4)
+  })
+
+  it('a full W/WT steel model has no unchecked members (regression)', () => {
+    const m = makeModel()
+    m.sections = m.sections.map((s) => ({ ...s, material: 'steel' as const, shape: 'W310x97', steelFy: 345, steelFu: 448 }))
+    const d = designStructure(m, soil)!
+    expect(d.unchecked).toHaveLength(0)
+  })
+})
+
 describe('optimizeStructure — termination guards (hierarchy revert / catalog top)', () => {
   it('square columns > 300 wide do not hang the batch-shrink loop', () => {
     // enforceSectionHierarchy clamps a column square-or-taller, silently reverting

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -114,6 +114,11 @@ export interface WallScheduleRow {
 export type FootingPlan = Record<string, { type: 'isolated' } | { type: 'combined'; with: string }>
 
 // ── Steel schedule rows (AISC 360-16 LRFD) ──────────────────────────────────
+/** A member the pipeline could NOT design-check (e.g. a steel beam whose shape
+ *  family has no §F2 flexure path). Surfaced instead of silently skipped: any
+ *  unchecked member fails designOK — a green result must mean "all checked". */
+export interface UncheckedMember { id: string; role: string; shape: string; reason: string }
+
 export interface SteelBeamScheduleRow {
   id: string; role: string; L: number; shape: string
   Mu: number; Vu: number          // kN·m, kN
@@ -172,6 +177,8 @@ export interface StructureDesign {
   scwb: SCWBJointRow[]
   totals: { concreteMembers: number; concreteSlabs: number; concrete: number; steelKg: number }
   orphanEdges: number
+  /** Members no design path could check (unsupported shape family). Non-empty ⇒ designOK is false. */
+  unchecked: UncheckedMember[]
 }
 
 export function designOK(d: StructureDesign): boolean {
@@ -179,6 +186,7 @@ export function designOK(d: StructureDesign): boolean {
     && d.steelBeams.every((b) => b.ok) && d.steelColumns.every((c) => c.ok)
     && d.basePlates.every((p) => p.ok)
     && d.footings.every((f) => f.ok) && d.combined.every((c) => c.ok)
+    && d.unchecked.length === 0
 }
 
 // ── Steel member design (reuses steelDesign engine) ──────────────────────────
@@ -440,6 +448,7 @@ function designFromRuns(
   const columns: ColumnScheduleRow[] = []
   const steelBeams: SteelBeamScheduleRow[] = []
   const steelColumns: SteelColumnScheduleRow[] = []
+  const unchecked: UncheckedMember[] = []
   for (const m of model.members) {
     const role = roleOf.get(m.id)
     const sec = secOf(m.id)
@@ -456,6 +465,12 @@ function designFromRuns(
           if (sev > bestSev) { bestSev = sev; best = row; gov = run.name }
         }
         if (best) steelBeams.push({ ...best, gov })
+        // designSteelBeamRow covers W/WT only (§F2 doubly-symmetric / tee flexure).
+        // A C/L/HSS beam would otherwise vanish from the schedule and read as "OK".
+        else unchecked.push({
+          id: m.id, role, shape: sec.shape ?? '(no shape)',
+          reason: 'steel beam flexure covers W/WT shapes only — use a W/WT here or check this member separately',
+        })
       } else {
         let best: BeamScheduleRow | null = null, bestSev = -1, gov = ''
         for (const run of runs) {
@@ -476,6 +491,11 @@ function designFromRuns(
           if (row.ratio > bestRatio) { bestRatio = row.ratio; best = row; gov = run.name }
         }
         if (best) steelColumns.push({ ...best, gov })
+        // designSteelColumnRow bails only on an unresolvable shape name
+        else unchecked.push({
+          id: m.id, role, shape: sec.shape ?? '(no shape)',
+          reason: 'shape not found in the AISC library — column axial/§H1-1 check skipped',
+        })
       } else {
         let best: ColumnScheduleRow | null = null, bestUtil = -1, gov = ''
         const sysOpts = opts.seismicSystem ?? 'gravity'
@@ -660,6 +680,7 @@ function designFromRuns(
     scwb: [] as SCWBJointRow[],
     totals: { concreteMembers, concreteSlabs, concrete: concreteMembers + concreteSlabs, steelKg },
     orphanEdges: br.orphanEdges.length,
+    unchecked,
   }
   partialDesign.joints = designSteelJoints(model, partialDesign)
   // Strong-column/weak-beam is a Special-Moment-Frame requirement (§418.7.3.2).
@@ -1017,6 +1038,7 @@ const countFails = (d: StructureDesign): number =>
   + d.steelBeams.filter((x) => !x.ok).length + d.steelColumns.filter((x) => !x.ok).length
   + d.basePlates.filter((x) => !x.ok).length
   + d.footings.filter((x) => !x.ok).length + d.combined.filter((x) => !x.ok).length
+  + d.unchecked.length
 
 const withSizes = (model: StructuralModel, sizes: Map<string, RectSection>): StructuralModel =>
   ({ ...model, sections: model.sections.map((s) => sizes.get(s.id) ?? s) })

--- a/webapp/src/engine/takeoff.test.ts
+++ b/webapp/src/engine/takeoff.test.ts
@@ -117,6 +117,7 @@ describe('structural steel — per-shape unit weight + costed BOM line items (A2
     govName: '', cases: [], beams: [], columns: [], steelBeams: [], steelColumns: [],
     basePlates: [], joints: [], slabs: [], walls: [], footings: [], combined: [], scwb: [],
     totals: { concreteMembers: 0, concreteSlabs: 0, concrete: 0, steelKg: 0 }, orphanEdges: 0,
+    unchecked: [],
   }
   // Two steel members: one 6 m W200x46.1 beam, two 4 m W250x49.1 columns.
   const steelBeam: RectSection = {

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -3157,6 +3157,16 @@ export default function ModelSpace() {
               {design.totals.steelKg > 0 && ` · steel ${(design.totals.steelKg / 1000).toFixed(2)} t`}
             </span>
           </h2>
+          {design.unchecked.length > 0 && (
+            <div className="rounded-xl border border-red-300 bg-red-50 p-3 text-sm text-red-800">
+              <p className="font-bold">⚠ {design.unchecked.length} member(s) could NOT be design-checked — the result is not a passing design.</p>
+              <ul className="mt-1 list-inside list-disc">
+                {design.unchecked.map((u) => (
+                  <li key={u.id}><span className="font-mono">{u.id}</span> ({u.role}, {u.shape}) — {u.reason}</li>
+                ))}
+              </ul>
+            </div>
+          )}
           <div className="no-print flex flex-wrap items-center gap-2 rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
             <span className="text-sm font-semibold text-[#0056b3]">Consolidated report</span>
             <select value={report} onChange={(e) => { setReport(e.target.value as typeof report); requestAnimationFrame(captureModel) }}


### PR DESCRIPTION
## Bug (P1)

`designSteelBeamRow` covers **W/WT** flexure only (§F2). For a steel beam or
girder with any other family (C, L, HSS — all selectable in the `/model` UI),
the call site did `if (!row) continue`, so the member produced **no schedule
row at all**: it vanished from the design report, `designOK` read **true**, and
the optimizer declared **`converged: true`** over members it never checked.
Demonstrated in the regime probe: 4 channel beams (C75x8.9) on an 8×7 m bay
under 20 kPa — a load that would fail them outright — yielded
`steelBeams rows = 0` and a "converged" optimization.

## Fix

- New `StructureDesign.unchecked: UncheckedMember[]` — id, role, shape, and a
  human-readable reason for every member no design path could check (non-W/WT
  steel beams; steel columns whose shape name doesn't resolve).
- `designOK` is **false** while `unchecked` is non-empty, and `countFails`
  counts them — so a green result again means "everything was checked", and
  the optimizer honestly returns `converged: false` (it exits the grow loop
  immediately since an uncheckable member has no growable utilization).
- `/model` design report shows a red banner listing the unchecked members
  with the guidance to use W/WT or check the member separately.

## Tests (3 new)

- Channel-beam model → `unchecked` has all 4 beams/girders, `designOK` false.
- Optimizer on that model → `converged: false`, unchecked intact.
- All-W steel model → `unchecked` empty (regression).

## Verification

- `npx tsc -b` clean
- `npm test` — **970 passed** (967 + 3)
- `npm run build` succeeds

Second of the two fixes from the optimizer regime check (first: #299 hang fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_