### PR TITLE
feat: NSCP 409.3.1.1 minimum-thickness gate on pipeline RC beams

### DIFF
--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -337,6 +337,46 @@ describe('optimizeStructure', () => {
   })
 })
 
+describe('RC serviceability — NSCP Table 409.3.1.1 minimum thickness gate', () => {
+  it('grid beams classify as both-ends continuous with hMin = (L/21)·(0.4 + fy/700)', () => {
+    const r = designStructure(makeModel(), soil)!
+    expect(r.beams.length).toBeGreaterThan(0)
+    for (const b of r.beams) {
+      expect(b.support).toBe('both-ends')
+      expect(b.hMin).toBeCloseTo(((b.L * 1000) / 21) * (0.4 + 415 / 700), 6)
+      expect(b.thickOK).toBe(true)          // 300×500 on ≤6 m spans satisfies the table
+    }
+  })
+
+  it('a long-span shallow beam fails the gate and the optimizer deepens it past hMin', () => {
+    const m = generateGridModel({ baysX: [11], baysZ: [5], storeyH: [3], section: { ...section, h: 400, name: '300×400' } })
+    m.loads = m.plates.flatMap((p) => [
+      { kind: 'area' as const, plate: p.id, q: 4.8, cat: 'D' as const },
+      { kind: 'area' as const, plate: p.id, q: 2.4, cat: 'L' as const },
+    ])
+    const first = designStructure(m, soil)!
+    const span11 = first.beams.filter((b) => b.L > 10)
+    expect(span11.some((b) => !b.thickOK)).toBe(true)      // 400 < hMin ≈ 520 mm
+    expect(designOK(first)).toBe(false)
+    const r = optimizeStructure(m, soil)!
+    expect(r.converged).toBe(true)
+    for (const b of r.design.beams) expect(b.thickOK).toBe(true)
+  }, 120_000)
+
+  it('an overhang beam classifies as a cantilever (L/8 table row)', () => {
+    const m = makeModel()
+    // overhang off node n1.0.0 (a corner column joint): 2 m to a free tip
+    const corner = m.nodes.find((n) => n.y > 0)!
+    m.nodes.push({ id: 'tip', x: corner.x + 2, y: corner.y, z: corner.z })
+    m.members.push({ id: 'ovh', i: corner.id, j: 'tip', role: 'beam', section: m.members.find((x) => x.role === 'beam')!.section })
+    m.loads.push({ kind: 'member-udl', member: 'ovh', w: 10, cat: 'D' })
+    const r = designStructure(m, soil)!
+    const row = r.beams.find((b) => b.id === 'ovh')!
+    expect(row.support).toBe('cantilever')
+    expect(row.hMin).toBeCloseTo(((row.L * 1000) / 8) * (0.4 + 415 / 700), 6)
+  })
+})
+
 describe('unchecked members — unsupported steel beam families must not read as OK', () => {
   function channelBeamModel() {
     const m = makeModel()

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -16,6 +16,7 @@ import { FramePool } from './framePool'
 import { nscpCombos, type Combo } from './beamAnalysis'
 import type { ProgressFn } from './progress'
 import { designBeam, type BeamDesignResult } from './beamDesign'
+import { minBeamThickness, type BeamSupport } from './beamDeflection'
 import { designAxialColumn, capacityAtEccentricity, interaction } from './columnDesign'
 import { designSquareFooting, type SquareFootingResult } from './isolatedFooting'
 import { designCombinedFooting, type CombinedFootingResult } from './combinedFooting'
@@ -58,6 +59,12 @@ export interface BeamSectionDesign {
 export interface BeamScheduleRow {
   id: string; role: string; L: number
   sections: BeamSectionDesign[]
+  /** NSCP Table 409.3.1.1 deemed-to-comply serviceability: span type from the
+   *  joint connectivity, the corresponding minimum thickness ×(0.4 + fy/700),
+   *  and whether the section satisfies it (deflections need not be computed). */
+  support: BeamSupport
+  hMin: number
+  thickOK: boolean
   ok: boolean
   gov?: string   // governing load case (envelope)
   /** Governing-case force diagrams along the member (for the worked solution). */
@@ -281,7 +288,7 @@ function memberSections(mr: F3MemberResult): { label: string; x: number; Mu: num
 }
 
 /** Design one beam/girder member from a single run's member result. */
-function designBeamRow(mr: F3MemberResult, role: string, sec: RectSection): BeamScheduleRow {
+function designBeamRow(mr: F3MemberResult, role: string, sec: RectSection, support: BeamSupport = 'both-ends'): BeamScheduleRow {
   const sections: BeamSectionDesign[] = memberSections(mr)
     .filter((s) => Math.abs(s.Mu) > 1e-6 || s.Vu > 1e-6)
     .map((s) => ({
@@ -292,8 +299,14 @@ function designBeamRow(mr: F3MemberResult, role: string, sec: RectSection): Beam
         fc: sec.fc, fy: sec.fy, Mu: Math.abs(s.Mu), Vu: s.Vu,
       }),
     }))
+  // Table 409.3.1.1 minimum thickness (deemed-to-comply — deflections need not
+  // be computed when h ≥ hMin). Steel beams check L/240 explicitly; this is the
+  // RC counterpart so the optimizer cannot trim a long span into a springboard.
+  const hMin = minBeamThickness(mr.L, support, sec.fy)
+  const thickOK = sec.h >= hMin - 1e-9
   return {
-    id: mr.id, role, L: mr.L, sections, ok: sections.every((s) => beamOK(s.design)),
+    id: mr.id, role, L: mr.L, sections, support, hMin, thickOK,
+    ok: sections.every((s) => beamOK(s.design)) && thickOK,
     diag: { xs: mr.xs, Vy: mr.Vy, Mz: mr.Mz },
   }
 }
@@ -441,6 +454,25 @@ function designFromRuns(
   const roleOf = new Map(model.members.map((m) => [m.id, m.role]))
   const memberOf = (run: FrameRun, id: string) => run.result.members.find((m) => m.id === id)
 
+  // NSCP Table 409.3.1.1 span type from joint connectivity: an end with nothing
+  // beyond the beam itself (no other member, no support) is a cantilever tip;
+  // an end whose joint continues into a column or another flexural member is
+  // continuous; an end held only by a support (e.g. a pin) is discontinuous.
+  const memsAtNode = new Map<string, typeof model.members>()
+  for (const mm of model.members)
+    for (const n of [mm.i, mm.j]) {
+      const list = memsAtNode.get(n); if (list) list.push(mm); else memsAtNode.set(n, [mm])
+    }
+  const supportedNodes = new Set(model.supports.map((s) => s.node))
+  const spanTypeOf = (mm: (typeof model.members)[number]): BeamSupport => {
+    const others = (n: string) => (memsAtNode.get(n) ?? []).filter((o) => o.id !== mm.id)
+    const held = (n: string) => others(n).length > 0 || supportedNodes.has(n)
+    if (!held(mm.i) || !held(mm.j)) return 'cantilever'
+    const cont = (n: string) => others(n).some((o) => o.role === 'column' || o.role === 'beam' || o.role === 'girder')
+    const ci = cont(mm.i), cj = cont(mm.j)
+    return ci && cj ? 'both-ends' : ci || cj ? 'one-end' : 'simple'
+  }
+
   // ── Beams & girders — per-member worst case across all runs ──
   const totalMems = model.members.length
   let memDone = 0
@@ -473,9 +505,10 @@ function designFromRuns(
         })
       } else {
         let best: BeamScheduleRow | null = null, bestSev = -1, gov = ''
+        const support = spanTypeOf(m)
         for (const run of runs) {
           const mr = memberOf(run, m.id); if (!mr) continue
-          const row = designBeamRow(mr, role, sec)
+          const row = designBeamRow(mr, role, sec, support)
           if (row.sections.length === 0) continue
           const sev = beamSeverity(row)
           if (sev > bestSev) { bestSev = sev; best = row; gov = run.name }


### PR DESCRIPTION
## What

Closes the RC/steel serviceability asymmetry found in the optimizer regime
check: steel beam rows check L/240 deflection, but RC beams had **no
serviceability gate at all** — the optimizer could legally trim a 9-m span
down to the 300-mm code floor.

Layer 6 (design pipeline).

## How

Each RC beam/girder row is now gated on the **NSCP Table 409.3.1.1
deemed-to-comply minimum thickness** (×(0.4 + fy/700) for fy ≠ 420), reusing
the existing `minBeamThickness` from `beamDeflection.ts` (#281). The span type
is classified from joint connectivity:

- an end with nothing beyond the beam (no member, no support) → **cantilever** (L/8)
- ends whose joints continue into a column or another flexural member →
  **both-ends** (L/21) / **one-end** (L/18.5)
- support-only ends → **simple** (L/16)

`BeamScheduleRow` gains `support`, `hMin`, `thickOK`; `thickOK` folds into
`row.ok`, so `designStructure` fails the gate honestly and the optimizer
grows `h` until the table is satisfied (and its shrink phase can no longer
trim below it).

## Tests (3 new)

- Grid beams classify `both-ends` with exact `hMin = (L/21)·(0.4 + 415/700)` and pass at 300×500.
- An 11-m 300×400 beam fails the gate (`hMin ≈ 520 mm`); the optimizer converges with every beam `thickOK`.
- An overhang member classifies as `cantilever`.

## Verification

- `npx tsc -b` clean
- `npm test` — **973 passed** (970 + 3)
- `npm run build` succeeds

Next (separate PR): optimizer bail-out reason when only footings/base plates fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_