### PR TITLE
feat: explain why the optimizer stopped when it cannot converge

### DIFF
--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -401,6 +401,7 @@ describe('unchecked members — unsupported steel beam families must not read as
     const r = optimizeStructure(channelBeamModel(), soil)!
     expect(r.converged).toBe(false)
     expect(r.design.unchecked).toHaveLength(4)
+    expect(r.stopReason).toContain('4 unchecked members')
   })
 
   it('a full W/WT steel model has no unchecked members (regression)', () => {
@@ -442,7 +443,19 @@ describe('optimizeStructure — termination guards (hierarchy revert / catalog t
     expect(r.converged).toBe(false)
     expect(r.steps.length).toBeLessThanOrEqual(2)   // initial + the single no-progress attempt
     expect(r.model.sections.every((s) => s.shape === top)).toBe(true)
+    expect(r.stopReason).toContain('grow')
   }, 120_000)
+
+  it('failures the sections cannot fix (footings on bad soil) get an explanatory stopReason', () => {
+    // qAllow below the overburden ⇒ every isolated footing fails (qNet ≤ 0)
+    // while all members pass: the grow loop must bail with a reason, not iterate.
+    const r = optimizeStructure(makeModel(), { ...soil, qAllow: 5 })!
+    expect(r.converged).toBe(false)
+    expect(r.design.footings.every((f) => !f.ok)).toBe(true)
+    expect(r.design.beams.every((b) => b.ok)).toBe(true)
+    expect(r.stopReason).toContain('cannot fix')
+    expect(r.stopReason).toContain('footing')
+  })
 })
 
 describe('optimizeStructure — steel sections', () => {

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -850,16 +850,23 @@ export async function optimizeStructureAsync(
     steps.push({ iter: 0, grown: 0, fails: countFails(design), ok: designOK(design) })
 
     let iter = 0
+    let stopReason: string | undefined
     while (!designOK(design) && iter++ < maxIter) {
       const utils = buildUtilMap(design, memSecId)
-      if (utils.size === 0) break
+      if (utils.size === 0) {                        // not a member-section problem
+        stopReason = stopReasonFor(design, 'growing member sections cannot fix the remaining checks (adjust soil bearing, footing plan or section shapes)')
+        break
+      }
       onProgress?.({ phase: 'Optimizing — growing sections', current: iter, total: maxIter, detail: `iteration ${iter}: ${utils.size} member(s) grown, ${countFails(design)} failing` })
       const sizes = new Map(work.sections.map((s) => {
         const u = utils.get(s.id)
         return [s.id, u !== undefined ? jumpSection(s, u, secRole.get(s.id) ?? '') : s]
       }))
       const grown = settle(withSizes(work, sizes))
-      if (!sectionsChanged(work, grown)) break   // nothing can grow (catalog top / unsupported shape)
+      if (!sectionsChanged(work, grown)) {     // nothing can grow (catalog top / unsupported shape)
+        stopReason = stopReasonFor(design, 'no failing section can grow any further (top of the W catalog or an unsupported shape family)')
+        break
+      }
       work = grown
       const d = await designStructureWithPool(work, soil, plan, opts, pool, sub(`Optimize iter ${iter}`))
       if (!d) break
@@ -867,6 +874,8 @@ export async function optimizeStructureAsync(
       steps.push({ iter, grown: utils.size, fails: countFails(design), ok: designOK(design) })
     }
     const converged = designOK(design)
+    if (!converged && !stopReason)
+      stopReason = stopReasonFor(design, `iteration cap (${maxIter}) reached — check spans and loads`)
 
     if (converged) {
       let batchPass = 0
@@ -982,7 +991,7 @@ export async function optimizeStructureAsync(
       steps.push({ iter: iter + 1, grown: 0, fails: 0, ok: true })
     }
 
-    return { design, model: work, steps, converged }
+    return { design, model: work, steps, converged, stopReason }
   } finally {
     pool.terminate()
   }
@@ -1064,6 +1073,22 @@ export interface OptimizeResult {
   model: StructuralModel   // model carrying the optimised per-member sections
   steps: OptimizeStep[]
   converged: boolean
+  /** Why the optimizer stopped short, when converged is false. */
+  stopReason?: string
+}
+
+/** Human-readable reason for a non-converged stop. `why` explains the loop exit;
+ *  the failing-check breakdown tells the user what growing sections can't fix. */
+function stopReasonFor(d: StructureDesign, why: string): string {
+  const parts = [
+    [d.beams.filter((x) => !x.ok).length + d.columns.filter((x) => !x.ok).length
+      + d.steelBeams.filter((x) => !x.ok).length + d.steelColumns.filter((x) => !x.ok).length, 'member'],
+    [d.footings.filter((x) => !x.ok).length + d.combined.filter((x) => !x.ok).length, 'footing'],
+    [d.basePlates.filter((x) => !x.ok).length, 'base plate'],
+    [d.unchecked.length, 'unchecked member'],
+  ] as const
+  const failing = parts.filter(([n]) => n > 0).map(([n, l]) => `${n} ${l}${n === 1 ? '' : 's'}`).join(', ')
+  return `${why}${failing ? ` — still failing: ${failing}` : ''}`
 }
 
 const countFails = (d: StructureDesign): number =>
@@ -1214,16 +1239,23 @@ export function optimizeStructure(
   // demand/capacity, re-enforce the hierarchy and refresh self-weight so the
   // heavier sections feed back into the demands on the next iteration.
   let iter = 0
+  let stopReason: string | undefined
   while (!designOK(design) && iter++ < maxIter) {
     const utils = buildUtilMap(design, memSecId)
-    if (utils.size === 0) break                      // only footings fail — not a section problem
+    if (utils.size === 0) {                          // not a member-section problem
+      stopReason = stopReasonFor(design, 'growing member sections cannot fix the remaining checks (adjust soil bearing, footing plan or section shapes)')
+      break
+    }
     onProgress?.({ phase: 'Optimizing — growing sections', current: iter, total: maxIter, detail: `iteration ${iter}: ${utils.size} member(s) grown, ${countFails(design)} failing` })
     const sizes = new Map(work.sections.map((s) => {
       const u = utils.get(s.id)
       return [s.id, u !== undefined ? jumpSection(s, u, secRole.get(s.id) ?? '') : s]
     }))
     const grown = settle(withSizes(work, sizes))
-    if (!sectionsChanged(work, grown)) break   // nothing can grow (catalog top / unsupported shape)
+    if (!sectionsChanged(work, grown)) {       // nothing can grow (catalog top / unsupported shape)
+      stopReason = stopReasonFor(design, 'no failing section can grow any further (top of the W catalog or an unsupported shape family)')
+      break
+    }
     work = grown
     const d = designStructure(work, soil, plan, opts, sub(`Optimize iter ${iter}`))
     if (!d) break
@@ -1231,6 +1263,8 @@ export function optimizeStructure(
     steps.push({ iter, grown: utils.size, fails: countFails(design), ok: designOK(design) })
   }
   const converged = designOK(design)
+  if (!converged && !stopReason)
+    stopReason = stopReasonFor(design, `iteration cap (${maxIter}) reached — check spans and loads`)
 
   // SHRINK: first try trimming all sections simultaneously (batch pass) — much
   // faster for large models when most sections are over-sized by several steps.
@@ -1323,5 +1357,5 @@ export function optimizeStructure(
     steps.push({ iter: iter + 1, grown: 0, fails: 0, ok: true })
   }
 
-  return { design, model: work, steps, converged }
+  return { design, model: work, steps, converged, stopReason }
 }

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -3069,8 +3069,13 @@ export default function ModelSpace() {
             <h3 className="mb-1 text-[1.02rem] font-bold text-[#0056b3]">
               Optimization — {opt.converged
                 ? `converged in ${opt.steps.length} step${opt.steps.length === 1 ? '' : 's'}`
-                : 'did NOT converge (iteration cap hit — check spans/loads)'}
+                : 'did NOT converge'}
             </h3>
+            {!opt.converged && (
+              <p className="mb-2 rounded-lg bg-amber-50 px-3 py-2 text-xs font-medium text-amber-800">
+                {opt.stopReason ?? 'iteration cap hit — check spans/loads'}
+              </p>
+            )}
             <div className="mb-2 space-y-0.5 text-xs text-slate-500">
               <p>Concrete — <b>columns</b> {sizesFor('column')} · <b>girders</b> {sizesFor('girder')} · <b>beams</b> {sizesFor('beam')}</p>
               {(hasSteelBeams || hasSteelCols) && (


### PR DESCRIPTION
## What

The `/model` optimization panel's non-converged message was hardcoded to
*"iteration cap hit — check spans/loads"*, which is the wrong explanation for
the two early-exit paths introduced in #299/#300 (and for the long-standing
"only footings fail" bail-out flagged in the optimizer regime check).

## How

`OptimizeResult.stopReason` is set at each exit path, in both the sync and
async optimizers:

- **Failures growing sections cannot fix** — footings, base plates, unchecked
  members — with a count breakdown, e.g. *"growing member sections cannot fix
  the remaining checks (adjust soil bearing, footing plan or section shapes) —
  still failing: 4 footings"*.
- **No failing section can grow further** — top of the W catalog or an
  unsupported shape family.
- **Genuine iteration cap** — with the remaining failing-check counts.

The optimization panel shows the reason in an amber note; converged runs are
unchanged.

## Tests (1 new + 2 extended)

- Bad-soil model (`qAllow = 5` — every footing fails, every member passes):
  bails immediately with the *cannot fix … footings* reason.
- Top-of-catalog scenario asserts the *grow* reason; channel-beam scenario
  asserts *4 unchecked members*.

## Verification

- `npx tsc -b` clean
- `npm test` — **974 passed** (973 + 1)
- `npm run build` succeeds

This completes the follow-ups from the optimizer regime check (#299 hang fix,
#300 unchecked members, #301 RC min-thickness gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_