### PR TITLE
feat: optimizer covers every design check — slabs, walls, SCWB, joints

### DIFF
--- a/webapp/src/engine/model.ts
+++ b/webapp/src/engine/model.ts
@@ -109,7 +109,10 @@ export interface NodeSupport {
 export type ModelLoad =
   | { kind: 'node'; node: string; Fx?: number; Fy?: number; Fz?: number; cat: LoadCategory }
   | { kind: 'member-point'; member: string; t: number /* 0–1 along i→j */; P: number; cat: LoadCategory }
-  | { kind: 'member-udl'; member: string; w: number; cat: LoadCategory }
+  /** `sw` marks a GENERATED self-weight line load (member or wall gravity, from
+   *  buildGravityLoads) so refreshSelfWeight can rebuild exactly those and leave
+   *  user-applied dead line loads untouched. Absent on user loads. */
+  | { kind: 'member-udl'; member: string; w: number; cat: LoadCategory; sw?: boolean }
   | { kind: 'area'; plate: string; q: number /* kPa */; cat: LoadCategory }
   /** Uniform temperature change ΔT (°C, + = rise) with linear expansion α (/°C).
    *  Equivalent axial force P_T = EA·α·ΔT is applied as self-equilibrating end forces

--- a/webapp/src/engine/modelBuilder.ts
+++ b/webapp/src/engine/modelBuilder.ts
@@ -154,12 +154,12 @@ export function buildGravityLoads(model: StructuralModel, sdl: number, ll: numbe
     .map((m) => {
       const sec = secMap.get(m.section) ?? model.sections[0]
       const w = sec ? (sec.b / 1000) * (sec.h / 1000) * gammaC : 0
-      return { kind: 'member-udl' as const, member: m.id, w, cat: 'D' as const }
+      return { kind: 'member-udl' as const, member: m.id, w, cat: 'D' as const, sw: true }
     })
     .filter((l) => l.w > 0)
   // wall self-weight as a line load on its supporting member
   const wallSW: StructuralModel['loads'] = (model.walls ?? [])
-    .map((wl) => ({ kind: 'member-udl' as const, member: wl.member, w: (wl.thickness / 1000) * wl.height * gammaC, cat: 'D' as const }))
+    .map((wl) => ({ kind: 'member-udl' as const, member: wl.member, w: (wl.thickness / 1000) * wl.height * gammaC, cat: 'D' as const, sw: true }))
     .filter((l) => l.w > 0)
   const plateLoads: StructuralModel['loads'] = model.plates
     .filter((p) => p.role !== 'wall')
@@ -178,15 +178,25 @@ export function buildGravityLoads(model: StructuralModel, sdl: number, ll: numbe
 }
 
 /**
- * Recompute member SELF-WEIGHT (member-udl, category D) from each member's
- * CURRENT section, leaving every other load untouched. No-op when the model
- * carries no member self-weight (so user models without it are not altered).
+ * Recompute the GENERATED self-weight line loads (member gravity from each
+ * member's CURRENT section, wall gravity from each wall's CURRENT thickness),
+ * leaving every other load untouched. Generated loads carry the `sw` marker
+ * (buildGravityLoads); user-applied dead line loads are preserved. Legacy
+ * models saved before the marker existed have unmarked self-weight — for
+ * those (no `sw` flag anywhere) every member-udl D load is treated as
+ * self-weight, matching the old behaviour. No-op when the model carries no
+ * self-weight line loads at all.
  */
 export function refreshSelfWeight(model: StructuralModel, gammaC = GAMMA_C): StructuralModel {
-  const hasSW = model.loads.some((l) => l.kind === 'member-udl' && l.cat === 'D')
-  if (!hasSW) return model
+  const marked = model.loads.some((l) => l.kind === 'member-udl' && l.cat === 'D' && l.sw)
+  const isSW = (l: StructuralModel['loads'][number]) =>
+    l.kind === 'member-udl' && l.cat === 'D' && (marked ? !!l.sw : true)
+  if (!model.loads.some(isSW)) return model
   const secMap = new Map(model.sections.map((s) => [s.id, s]))
-  const others = model.loads.filter((l) => !(l.kind === 'member-udl' && l.cat === 'D'))
+  const others = model.loads.filter((l) => !isSW(l))
+  const wallW = new Map<string, number>()
+  for (const wl of model.walls ?? [])
+    wallW.set(wl.member, (wallW.get(wl.member) ?? 0) + (wl.thickness / 1000) * wl.height * gammaC)
   const sw: StructuralModel['loads'] = model.members
     .map((m) => {
       const sec = secMap.get(m.section) ?? model.sections[0]
@@ -199,7 +209,7 @@ export function refreshSelfWeight(model: StructuralModel, gammaC = GAMMA_C): Str
           w = (sec.b / 1000) * (sec.h / 1000) * gammaC
         }
       }
-      return { kind: 'member-udl' as const, member: m.id, w, cat: 'D' as const }
+      return { kind: 'member-udl' as const, member: m.id, w: w + (wallW.get(m.id) ?? 0), cat: 'D' as const, sw: true }
     })
     .filter((l) => l.w > 0)
   return { ...model, loads: [...sw, ...others] }

--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -9,7 +9,9 @@ const section: RectSection = { id: 'S1', name: '300×500', b: 300, h: 500, fc: 2
 const soil = { qAllow: 200, gammaSoil: 18, gammaConc: 24, H: 1.5 }
 
 function makeModel() {
-  const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })
+  // 200-mm slabs: the 6×5 m panel satisfies §424.2 deflection (150 mm does not,
+  // now that slab serviceability gates designOK).
+  const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section, slabThickness: 200 })
   m.loads = m.plates.flatMap((p) => [
     { kind: 'area' as const, plate: p.id, q: 4.8, cat: 'D' as const },
     { kind: 'area' as const, plate: p.id, q: 2.4, cat: 'L' as const },
@@ -99,7 +101,7 @@ describe('design pipeline — single-bay single-storey grid', () => {
   it('concrete totals: members + slab', () => {
     // 4 columns ×3 m + (2×6 + 2×5) m of beams = 12 + 22 = 34 m of 0.15 m² section
     expect(r.totals.concreteMembers).toBeCloseTo(34 * 0.3 * 0.5, 6)
-    expect(r.totals.concreteSlabs).toBeCloseTo(6 * 5 * 0.15, 6)
+    expect(r.totals.concreteSlabs).toBeCloseTo(6 * 5 * 0.20, 6)
   })
 
   it('no plan → no combined footings, designOK reflects the schedules', () => {
@@ -377,6 +379,86 @@ describe('RC serviceability — NSCP Table 409.3.1.1 minimum thickness gate', ()
   })
 })
 
+describe('optimizer covers every design check (slabs, walls, SCWB)', () => {
+  it('slab §424.2 deflection failure gates designOK and the optimizer thickens the panel', () => {
+    const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section, slabThickness: 150 })
+    m.loads = m.plates.flatMap((p) => [
+      { kind: 'area' as const, plate: p.id, q: 4.8, cat: 'D' as const },
+      { kind: 'area' as const, plate: p.id, q: 2.4, cat: 'L' as const },
+    ])
+    const first = designStructure(m, soil)!
+    expect(first.slabs[0].ok).toBe(false)          // 150 mm on 6×5 m violates ℓn/240
+    expect(designOK(first)).toBe(false)
+    const r = optimizeStructure(m, soil)!
+    expect(r.converged).toBe(true)
+    expect(r.model.plates[0].thickness).toBeGreaterThan(150)
+    expect(r.design.slabs.every((s) => s.ok)).toBe(true)
+    // the slab self-weight delta rode along into the panel's area-D load
+    const areaD = r.model.loads.find((l) => l.kind === 'area' && l.cat === 'D') as { q: number }
+    const dt = (r.model.plates[0].thickness - 150) / 1000
+    expect(areaD.q).toBeCloseTo(4.8 + dt * 24, 6)
+  }, 120_000)
+
+  it('failing SCWB joints (§418.7.3.2) gate designOK and the optimizer grows the columns', () => {
+    const m = generateGridModel({
+      baysX: [6], baysZ: [5], storeyH: [3], section, slabThickness: 200,
+      beam: { ...section, h: 600, name: '300×600' }, column: { ...section, b: 300, h: 300, name: '300×300' },
+    })
+    m.loads = m.plates.flatMap((p) => [
+      { kind: 'area' as const, plate: p.id, q: 4.8, cat: 'D' as const },
+      { kind: 'area' as const, plate: p.id, q: 2.4, cat: 'L' as const },
+    ])
+    const first = designStructure(m, soil, {}, { seismicSystem: 'smf' })!
+    expect(first.scwb.some((j) => !j.ok)).toBe(true)   // 300×300 cols vs 300×600 beams
+    expect(designOK(first)).toBe(false)
+    const r = optimizeStructure(m, soil, {}, 30, { seismicSystem: 'smf' })!
+    expect(r.converged).toBe(true)
+    expect(r.design.scwb.every((j) => j.ok)).toBe(true)
+  }, 120_000)
+
+  it('a failing shear wall gates designOK and the optimizer thickens the panel', () => {
+    const m = makeModel()
+    m.walls = [{ id: 'w0', member: 'bx0.0.1', height: 3, thickness: 100, shearWall: true }]
+    const base = computeSeismic(m, { Ca: 0.44, Cv: 0.64, I: 1, R: 8.5, dir: 'x' })!.loads
+    const eX: LateralCase = {
+      name: 'E+X', kind: 'E',
+      loads: base.map((l) => ({ kind: 'node', node: (l as { node: string }).node, Fx: Math.abs((l as { Fx?: number }).Fx ?? 0) * 400, cat: 'E' })),
+    }
+    const first = designStructure(m, soil, {}, { lateral: [eX] })!
+    expect(first.walls[0].ok).toBe(false)
+    expect(designOK(first)).toBe(false)
+    const r = optimizeStructure(m, soil, {}, 30, { lateral: [eX] })!
+    expect(r.converged).toBe(true)
+    expect(r.model.walls![0].thickness).toBeGreaterThan(100)
+    expect(r.design.walls.every((w) => w.ok)).toBe(true)
+  }, 120_000)
+})
+
+describe('refreshSelfWeight — sw marker semantics', () => {
+  it('preserves user-applied dead line loads when generated SW is marked', () => {
+    const m = makeModel()
+    m.loads = [
+      ...buildGravityLoads(m, 1.5, 2.4),                                          // marked sw
+      { kind: 'member-udl' as const, member: 'bx0.0.1', w: 12, cat: 'D' as const }, // user cladding load
+    ]
+    const out = refreshSelfWeight(m)
+    const user = out.loads.filter((l) => l.kind === 'member-udl' && l.cat === 'D' && !(l as { sw?: boolean }).sw)
+    expect(user).toHaveLength(1)
+    expect((user[0] as { w: number }).w).toBe(12)
+  })
+
+  it('re-derives wall self-weight from the current thickness instead of dropping it', () => {
+    const m = makeModel()
+    m.walls = [{ id: 'w0', member: 'bx0.0.1', height: 3, thickness: 200, shearWall: false }]
+    m.loads = buildGravityLoads(m, 1.5, 2.4)
+    m.walls = [{ ...m.walls[0], thickness: 300 }]           // wall thickened after load build
+    const out = refreshSelfWeight(m)
+    const onBeam = out.loads.find((l) => l.kind === 'member-udl' && (l as { member: string }).member === 'bx0.0.1') as { w: number }
+    // member SW (0.3·0.5·24 = 3.6) + wall SW at the CURRENT 300 mm (0.3·3·24 = 21.6)
+    expect(onBeam.w).toBeCloseTo(3.6 + 21.6, 9)
+  })
+})
+
 describe('unchecked members — unsupported steel beam families must not read as OK', () => {
   function channelBeamModel() {
     const m = makeModel()
@@ -438,7 +520,11 @@ describe('optimizeStructure — termination guards (hierarchy revert / catalog t
     for (let n = nextHeavierW(top); n; n = nextHeavierW(top)) top = n.name
     const m = generateGridModel({ baysX: [12], baysZ: [10], storeyH: [3], section })
     m.sections = m.sections.map((s) => ({ ...s, material: 'steel' as const, shape: top, steelFy: 345, steelFu: 448 }))
-    m.loads = m.plates.flatMap((p) => [{ kind: 'area' as const, plate: p.id, q: 400, cat: 'D' as const }])
+    // member POINT loads (not area/udl): keeps slabs out of the design and
+    // survives refreshSelfWeight, so the ONLY failing checks are the
+    // un-growable steel members — the early exit under test
+    m.loads = m.members.filter((x) => x.role !== 'column')
+      .map((x) => ({ kind: 'member-point' as const, member: x.id, t: 0.5, P: 4000, cat: 'D' as const }))
     const r = optimizeStructure(m, soil)!
     expect(r.converged).toBe(false)
     expect(r.steps.length).toBeLessThanOrEqual(2)   // initial + the single no-progress attempt
@@ -575,7 +661,7 @@ describe('model editing helpers', () => {
     expect(sw).toHaveLength(m.members.length)
     for (const l of sw) expect((l as { w: number }).w).toBeCloseTo(0.3 * 0.5 * 24, 9)
     const slabD = loads.find((l) => l.kind === 'area' && l.cat === 'D')!
-    expect((slabD as { q: number }).q).toBeCloseTo(0.15 * 24 + 1.5, 9)
+    expect((slabD as { q: number }).q).toBeCloseTo(0.20 * 24 + 1.5, 9)
     const slabL = loads.find((l) => l.kind === 'area' && l.cat === 'L')!
     expect((slabL as { q: number }).q).toBeCloseTo(2.4, 9)
     expect(loads.filter((l) => l.cat === 'E')).toHaveLength(1)

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -188,11 +188,16 @@ export interface StructureDesign {
   unchecked: UncheckedMember[]
 }
 
+/** Every check the pipeline runs must pass — members, foundations, slabs
+ *  (DDM + §408.3.1.2 + §424.2 deflection), shear walls, steel joints and the
+ *  §418.7.3.2 strong-column/weak-beam hierarchy. Nothing green is unchecked. */
 export function designOK(d: StructureDesign): boolean {
   return d.beams.every((b) => b.ok) && d.columns.every((c) => c.ok)
     && d.steelBeams.every((b) => b.ok) && d.steelColumns.every((c) => c.ok)
     && d.basePlates.every((p) => p.ok)
     && d.footings.every((f) => f.ok) && d.combined.every((c) => c.ok)
+    && d.slabs.every((s) => s.ok) && d.walls.every((w) => w.ok)
+    && d.joints.every((j) => j.ok) && d.scwb.every((j) => j.ok)
     && d.unchecked.length === 0
 }
 
@@ -670,7 +675,15 @@ function designFromRuns(
       fc: cs.fc, fy: cs.fy, h: p.thickness, cover: 20, barDia: 12,
       exterior: { x: extX, y: extZ }, withBeams: true,
     })
-    slabs.push({ plate: p.id, lx, ly: lz, design, ok: design.applicable })
+    // Pass = §408.3.1.2 minimum thickness AND §424.2 immediate-live + long-term
+    // deflection. DDM inapplicability (one-way panel, L > 2D) stays a schedule
+    // note — the strips are still detailed conservatively — so it does not
+    // dead-end the optimizer; serviceability violations DO fail the design.
+    slabs.push({
+      plate: p.id, lx, ly: lz, design,
+      ok: design.h >= design.hmin - 1e-9
+        && design.deflection.liveOK && design.deflection.totalOK,
+    })
   }
 
   // ── Shear walls — in-plane reinforcement ──
@@ -852,17 +865,17 @@ export async function optimizeStructureAsync(
     let iter = 0
     let stopReason: string | undefined
     while (!designOK(design) && iter++ < maxIter) {
-      const utils = buildUtilMap(design, memSecId)
-      if (utils.size === 0) {                        // not a member-section problem
-        stopReason = stopReasonFor(design, 'growing member sections cannot fix the remaining checks (adjust soil bearing, footing plan or section shapes)')
+      const act = buildGrowActions(design, work, memSecId)
+      if (act.n === 0) {                        // not fixable by growing anything
+        stopReason = stopReasonFor(design, 'growing sections or thicknesses cannot fix the remaining checks (adjust soil bearing, footing plan, section shapes or DDM layout)')
         break
       }
-      onProgress?.({ phase: 'Optimizing — growing sections', current: iter, total: maxIter, detail: `iteration ${iter}: ${utils.size} member(s) grown, ${countFails(design)} failing` })
+      onProgress?.({ phase: 'Optimizing — growing sections', current: iter, total: maxIter, detail: `iteration ${iter}: ${act.n} change(s), ${countFails(design)} failing` })
       const sizes = new Map(work.sections.map((s) => {
-        const u = utils.get(s.id)
+        const u = act.utils.get(s.id)
         return [s.id, u !== undefined ? jumpSection(s, u, secRole.get(s.id) ?? '') : s]
       }))
-      const grown = settle(withSizes(work, sizes))
+      const grown = settle(withWallThickness(withPlateThickness(withSizes(work, sizes), act.plates, soil.gammaConc), act.walls))
       if (!sectionsChanged(work, grown)) {     // nothing can grow (catalog top / unsupported shape)
         stopReason = stopReasonFor(design, 'no failing section can grow any further (top of the W catalog or an unsupported shape family)')
         break
@@ -871,7 +884,7 @@ export async function optimizeStructureAsync(
       const d = await designStructureWithPool(work, soil, plan, opts, pool, sub(`Optimize iter ${iter}`))
       if (!d) break
       ;({ m: work, d: design } = await detail(work, d, `Optimize iter ${iter}`))
-      steps.push({ iter, grown: utils.size, fails: countFails(design), ok: designOK(design) })
+      steps.push({ iter, grown: act.n, fails: countFails(design), ok: designOK(design) })
     }
     const converged = designOK(design)
     if (!converged && !stopReason)
@@ -920,6 +933,30 @@ export async function optimizeStructureAsync(
         if (!sectionsChanged(work, trial)) break   // hierarchy reverted every shrink — no progress
         const d = await designStructureWithPool(trial, soil, plan, opts, pool)
         if (d && designOK(d)) { work = trial; design = d } else { bBatchOk = false }
+      }
+      // Phase 3 — trim slab thickness (economy): only panels comfortably inside the
+      // §424.2 deflection limits shrink, and never below §408.3.1.2 hmin (or 100 mm).
+      let sBatchOk = true
+      while (sBatchOk) {
+        const trims = new Map<string, number>()
+        for (const s of design.slabs) {
+          if (!s.ok) continue
+          const d0 = s.design
+          const util = Math.max(
+            d0.deflection.total / Math.max(d0.deflection.limitTotal, 1e-9),
+            d0.deflection.immLive / Math.max(d0.deflection.limitLive, 1e-9),
+          )
+          if (util >= 0.80) continue
+          if (d0.h - 25 < Math.max(d0.hmin, 100)) continue
+          trims.set(s.plate, d0.h - 25)
+        }
+        if (trims.size === 0) break
+        batchPass++
+        onProgress?.({ phase: 'Optimizing — trimming sections', detail: `batch pass ${batchPass}: ${trims.size} slab(s) t↓` })
+        const trial = settle(withPlateThickness(work, trims, soil.gammaConc))
+        if (!sectionsChanged(work, trial)) break
+        const d = await designStructureWithPool(trial, soil, plan, opts, pool)
+        if (d && designOK(d)) { work = trial; design = d } else { sBatchOk = false }
       }
 
       // Fine-tune: sequential per-section trials. Each call to designStructureWithPool
@@ -1085,6 +1122,10 @@ function stopReasonFor(d: StructureDesign, why: string): string {
       + d.steelBeams.filter((x) => !x.ok).length + d.steelColumns.filter((x) => !x.ok).length, 'member'],
     [d.footings.filter((x) => !x.ok).length + d.combined.filter((x) => !x.ok).length, 'footing'],
     [d.basePlates.filter((x) => !x.ok).length, 'base plate'],
+    [d.slabs.filter((x) => !x.ok).length, 'slab'],
+    [d.walls.filter((x) => !x.ok).length, 'shear wall'],
+    [d.joints.filter((x) => !x.ok).length, 'steel joint'],
+    [d.scwb.filter((x) => !x.ok).length, 'SCWB joint'],
     [d.unchecked.length, 'unchecked member'],
   ] as const
   const failing = parts.filter(([n]) => n > 0).map(([n, l]) => `${n} ${l}${n === 1 ? '' : 's'}`).join(', ')
@@ -1096,12 +1137,15 @@ const countFails = (d: StructureDesign): number =>
   + d.steelBeams.filter((x) => !x.ok).length + d.steelColumns.filter((x) => !x.ok).length
   + d.basePlates.filter((x) => !x.ok).length
   + d.footings.filter((x) => !x.ok).length + d.combined.filter((x) => !x.ok).length
+  + d.slabs.filter((x) => !x.ok).length + d.walls.filter((x) => !x.ok).length
+  + d.joints.filter((x) => !x.ok).length + d.scwb.filter((x) => !x.ok).length
   + d.unchecked.length
 
 const withSizes = (model: StructuralModel, sizes: Map<string, RectSection>): StructuralModel =>
   ({ ...model, sections: model.sections.map((s) => sizes.get(s.id) ?? s) })
 
-/** True when any section geometry differs between two settled models.
+/** True when any design geometry differs between two settled models — sections,
+ *  slab thicknesses or wall thicknesses.
  *  enforceSectionHierarchy can silently revert a proposed change (e.g. a square
  *  column's h-shrink is clamped back to h ≥ b), so a grow/shrink trial can come
  *  out identical to the current model. Accepting such a trial makes no progress —
@@ -1112,6 +1156,69 @@ const sectionsChanged = (a: StructuralModel, b: StructuralModel): boolean =>
     const t = b.sections[i]
     return s.b !== t.b || s.h !== t.h || s.shape !== t.shape
   })
+  || a.plates.some((p, i) => p.thickness !== b.plates[i]?.thickness)
+  || (a.walls ?? []).some((w, i) => w.thickness !== (b.walls ?? [])[i]?.thickness)
+
+/** Re-thickness plates and shift each panel's area-D load by Δt·γc — the slab
+ *  self-weight is merged into that load at model build time (buildGravityLoads),
+ *  so a thickness change must carry its dead-load delta into the analysis. */
+function withPlateThickness(model: StructuralModel, t: Map<string, number>, gammaC: number): StructuralModel {
+  if (t.size === 0) return model
+  const t0 = new Map(model.plates.map((p) => [p.id, p.thickness]))
+  const plates = model.plates.map((p) => (t.has(p.id) ? { ...p, thickness: t.get(p.id)! } : p))
+  const adjusted = new Set<string>()   // shift only the FIRST area-D load per plate
+  const loads = model.loads.map((l) => {
+    if (l.kind !== 'area' || l.cat !== 'D' || !t.has(l.plate) || adjusted.has(l.plate)) return l
+    adjusted.add(l.plate)
+    const dq = ((t.get(l.plate)! - (t0.get(l.plate) ?? 0)) / 1000) * gammaC
+    return { ...l, q: l.q + dq }
+  })
+  return { ...model, plates, loads }
+}
+
+/** Re-thickness shear-wall panels; the wall dead load is re-derived from the
+ *  new thickness by refreshSelfWeight inside settle(). */
+const withWallThickness = (model: StructuralModel, t: Map<string, number>): StructuralModel =>
+  t.size === 0 ? model : { ...model, walls: (model.walls ?? []).map((w) => (t.has(w.id) ? { ...w, thickness: t.get(w.id)! } : w)) }
+
+/** Everything the grow phase can change in one iteration: member-section
+ *  demand/capacity ratios (incl. SCWB column bumps), slab thickness targets
+ *  and shear-wall thickness targets. n = number of distinct actions. */
+interface GrowActions { utils: Map<string, number>; plates: Map<string, number>; walls: Map<string, number>; n: number }
+
+function buildGrowActions(design: StructureDesign, model: StructuralModel, memSecId: Map<string, string>): GrowActions {
+  const utils = buildUtilMap(design, memSecId)
+  // SCWB (§418.7.3.2): ΣMnc ≥ (6/5)·ΣMnb. Column Mnc scales ≈ h², the same law
+  // the jump estimator assumes, so feed 1.2/ratio as the demand/capacity of
+  // every column framing the failing joint.
+  for (const j of design.scwb) {
+    if (j.ok) continue
+    const need = Math.max(1.05, 1.2 / Math.max(j.ratio, 1e-6))
+    for (const mm of model.members) {
+      if (mm.role !== 'column' || (mm.i !== j.node && mm.j !== j.node)) continue
+      utils.set(mm.section, Math.max(utils.get(mm.section) ?? 0, need))
+    }
+  }
+  // Slabs: §408.3.1.2 hmin directly; §424.2 deflection via Ie ≈ h³ ⇒ target
+  // h ≈ h·∛(δ/δlim). 25-mm steps, capped like the section jump.
+  const plates = new Map<string, number>()
+  for (const s of design.slabs) {
+    if (s.ok) continue
+    const d = s.design
+    const f = Math.max(
+      d.hmin / Math.max(d.h, 1),
+      Math.cbrt(d.deflection.total / Math.max(d.deflection.limitTotal, 1e-9)),
+      Math.cbrt(d.deflection.immLive / Math.max(d.deflection.limitLive, 1e-9)),
+    )
+    if (f <= 1 + 1e-9) continue
+    const steps = Math.max(1, Math.min(10, Math.ceil(((f - 1) * d.h) / 25)))
+    plates.set(s.plate, d.h + 25 * steps)
+  }
+  // Shear walls: in-plane shear failure → thicken the panel one step per iteration.
+  const walls = new Map<string, number>()
+  for (const w of design.walls) if (!w.ok) walls.set(w.id, w.thickness + 25)
+  return { utils, plates, walls, n: utils.size + plates.size + walls.size }
+}
 
 /** Copy shape geometry into the section's bounding-box fields so metadata stays consistent. */
 const applyShape = (s: RectSection, sh: AiscShape): RectSection =>
@@ -1241,17 +1348,17 @@ export function optimizeStructure(
   let iter = 0
   let stopReason: string | undefined
   while (!designOK(design) && iter++ < maxIter) {
-    const utils = buildUtilMap(design, memSecId)
-    if (utils.size === 0) {                          // not a member-section problem
-      stopReason = stopReasonFor(design, 'growing member sections cannot fix the remaining checks (adjust soil bearing, footing plan or section shapes)')
+    const act = buildGrowActions(design, work, memSecId)
+    if (act.n === 0) {                          // not fixable by growing anything
+      stopReason = stopReasonFor(design, 'growing sections or thicknesses cannot fix the remaining checks (adjust soil bearing, footing plan, section shapes or DDM layout)')
       break
     }
-    onProgress?.({ phase: 'Optimizing — growing sections', current: iter, total: maxIter, detail: `iteration ${iter}: ${utils.size} member(s) grown, ${countFails(design)} failing` })
+    onProgress?.({ phase: 'Optimizing — growing sections', current: iter, total: maxIter, detail: `iteration ${iter}: ${act.n} change(s), ${countFails(design)} failing` })
     const sizes = new Map(work.sections.map((s) => {
-      const u = utils.get(s.id)
+      const u = act.utils.get(s.id)
       return [s.id, u !== undefined ? jumpSection(s, u, secRole.get(s.id) ?? '') : s]
     }))
-    const grown = settle(withSizes(work, sizes))
+    const grown = settle(withWallThickness(withPlateThickness(withSizes(work, sizes), act.plates, soil.gammaConc), act.walls))
     if (!sectionsChanged(work, grown)) {       // nothing can grow (catalog top / unsupported shape)
       stopReason = stopReasonFor(design, 'no failing section can grow any further (top of the W catalog or an unsupported shape family)')
       break
@@ -1260,7 +1367,7 @@ export function optimizeStructure(
     const d = designStructure(work, soil, plan, opts, sub(`Optimize iter ${iter}`))
     if (!d) break
     ;({ m: work, d: design } = detail(work, d, `Optimize iter ${iter}`))
-    steps.push({ iter, grown: utils.size, fails: countFails(design), ok: designOK(design) })
+    steps.push({ iter, grown: act.n, fails: countFails(design), ok: designOK(design) })
   }
   const converged = designOK(design)
   if (!converged && !stopReason)
@@ -1312,6 +1419,30 @@ export function optimizeStructure(
       if (!sectionsChanged(work, trial)) break   // hierarchy reverted every shrink — no progress
       const d = designStructure(trial, soil, plan, opts)
       if (d && designOK(d)) { work = trial; design = d } else { bBatchOk = false }
+    }
+    // Phase 3 — trim slab thickness (economy): only panels comfortably inside the
+    // §424.2 deflection limits shrink, and never below §408.3.1.2 hmin (or 100 mm).
+    let sBatchOk = true
+    while (sBatchOk) {
+      const trims = new Map<string, number>()
+      for (const s of design.slabs) {
+        if (!s.ok) continue
+        const d0 = s.design
+        const util = Math.max(
+          d0.deflection.total / Math.max(d0.deflection.limitTotal, 1e-9),
+          d0.deflection.immLive / Math.max(d0.deflection.limitLive, 1e-9),
+        )
+        if (util >= 0.80) continue
+        if (d0.h - 25 < Math.max(d0.hmin, 100)) continue
+        trims.set(s.plate, d0.h - 25)
+      }
+      if (trims.size === 0) break
+      batchPass++
+      onProgress?.({ phase: 'Optimizing — trimming sections', detail: `batch pass ${batchPass}: ${trims.size} slab(s) t↓` })
+      const trial = settle(withPlateThickness(work, trims, soil.gammaConc))
+      if (!sectionsChanged(work, trial)) break
+      const d = designStructure(trial, soil, plan, opts)
+      if (d && designOK(d)) { work = trial; design = d } else { sBatchOk = false }
     }
 
     // Fine-tune: per-section — try h↓ first, then b↓ if h can't shrink or fails.


### PR DESCRIPTION
## What

Per the request: **a converged optimization now means nothing fails and no
provision is violated, at the most economical sections.** Previously the slab
schedule could show a failing §424.2 long-term deflection and the SCWB table
failing joints (both visible in the reported screenshots) while `designOK` read
true and the optimizer declared "converged".

## Gate — every check counts

`designOK`, `countFails` and the `stopReason` breakdown now include:

- **Slabs** — §408.3.1.2 minimum thickness + §424.2 immediate-live (ℓn/360) and
  long-term (ℓn/240) deflection. DDM inapplicability (one-way panel, L > 2D)
  stays a schedule note so it doesn't dead-end the optimizer.
- **Shear walls** — in-plane shear check.
- **Steel joints** — connection adequacy from `designSteelJoints`.
- **SCWB** — §418.7.3.2 (`smf` systems).

## Optimizer — new grow actions (sync + async)

- **Failing slab** → thickness in 25-mm steps targeting `h·∛(δ/δlim)` and
  `hmin`; the panel's area-D load shifts by `Δt·γc` so the extra self-weight
  feeds back into the frame, footings and everything else.
- **Failing shear wall** → panel thickness +25 mm per iteration.
- **Failing SCWB joint** → the columns framing the joint grow via the standard
  jump estimator with demand `1.2/ratio` (Mnc ≈ h², the estimator's law).

## Optimizer — new economy action

- **Slab-trim batch**: panels comfortably inside the deflection limits
  (util < 0.80) step down 25 mm, never below `hmin` / 100 mm; rejected the
  moment any check anywhere fails.

## Load-handling bugs found and fixed on the way

- `refreshSelfWeight` (run by the optimizer's settle on **every** step)
  rebuilt all member-udl dead loads from sections only, silently **wiping wall
  self-weight** and **user-applied dead line loads**. Generated self-weight now
  carries an `sw` marker (`buildGravityLoads`) and only marked loads are
  rebuilt; wall gravity is re-derived from the wall's **current** thickness.
  Legacy models without markers keep the old behaviour (no regression).

## Test-model correction

Test grids move from 150-mm to 200-mm slabs — a 150-mm slab on a 6×5 m panel
genuinely violates §424.2 (74.9 mm vs ℓn/240 = 23.8 mm), which the old gate
never saw.

## Verified end-to-end (live runs)

| Scenario | Before | After optimize |
| --- | --- | --- |
| 150-mm slab, 6×5 m | defl 40.1 > 23.8 mm, `designOK` false | converged, t = 175 mm, area-D load +Δt·γc |
| 300×300 cols vs 300×600 beams (`smf`) | SCWB ratio 0.34 ✗ | converged, all joints ≥ 6/5 |
| 100-mm shear wall, big E | shear ✗ | converged, t = 325 mm |

## Verification

- `npx tsc -b` clean
- `npm test` — **979 passed** (974 + 5)
- `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_