### PR TITLE
fix: ETABS-consistent auto rigid end zones — orientation + true-profile render

### DIFF
--- a/webapp/src/engine/rigidEndZones.test.ts
+++ b/webapp/src/engine/rigidEndZones.test.ts
@@ -28,17 +28,26 @@ describe('autoRigidOffsets', () => {
     expect(autoRigidOffsets(portal(), 0).size).toBe(0)
   })
 
-  it('beam gets an inward i-end offset = factor·(column width/2) along +X', () => {
+  it('beam gets an inward i-end offset = factor·(column DEPTH/2) along +X (ETABS face offset)', () => {
     const m = autoRigidOffsets(portal(), 1)
     const bm = m.get('bm')!
     expect(bm).toBeTruthy()
-    // column at tl: vertical, cross-section b=400 (along X), h=600 (along Z).
-    // half-extent on the beam axis (X) = b/2 = 0.2 m. factor 1 → offI ≈ [0.2,0,0].
-    expect(bm.offI![0]).toBeCloseTo(0.2, 6)
+    // Columns are oriented depth-along-X in this app (Member3D/MemberSteel3D,
+    // joint designer): h=600 lies along X, b=400 along Z. The X-beam's offset is
+    // the support half-DEPTH h/2 = 0.3 m — matching ETABS auto end offsets.
+    expect(bm.offI![0]).toBeCloseTo(0.3, 6)
     expect(bm.offI![1]).toBeCloseTo(0, 9)
     expect(bm.offI![2]).toBeCloseTo(0, 9)
     // beam free end (tr) has no other member → no jEnd offset
     expect(bm.offJ).toBeUndefined()
+  })
+
+  it('a Z-girder at the same joint gets the column WIDTH/2 (weak-direction face)', () => {
+    const model = portal()
+    model.nodes.push({ id: 'tz', x: 0, y: 4, z: 5 })
+    model.members.push({ id: 'gz', i: 'tl', j: 'tz', role: 'girder', section: 'B' })
+    const gz = autoRigidOffsets(model, 1).get('gz')!
+    expect(gz.offI![2]).toBeCloseTo(0.2, 6)   // b/2 = 400/2 mm along +Z
   })
 
   it('column gets an inward j-end offset = factor·(beam depth/2) along +Y', () => {
@@ -65,7 +74,7 @@ describe('autoRigidOffsets', () => {
 
     const model2 = portal()
     model2.members[1].rigidZoneFactor = 0.5
-    expect(autoRigidOffsets(model2, 1).get('bm')!.offI![0]).toBeCloseTo(0.1, 6)  // 0.5 × 0.2
+    expect(autoRigidOffsets(model2, 1).get('bm')!.offI![0]).toBeCloseTo(0.15, 6)  // 0.5 × h/2 = 0.5 × 0.3
   })
 
   it('resolves steel AISC shape dimensions, not the bounding-box b/h', () => {
@@ -85,9 +94,10 @@ describe('autoRigidOffsets', () => {
       ],
       supports: [{ node: 'bl', fixity: 'fixed' }],
     }
-    // beam i-end zone uses the steel column's width (bf) along X, not h/b = 1 mm.
+    // beam i-end zone uses the steel column's DEPTH d along X (flanges face ±X
+    // per the app orientation — the X-beam frames into the flange), not b/h = 1 mm.
     const bm = autoRigidOffsets(model, 1).get('bm')!
-    expect(bm.offI![0]).toBeCloseTo((shp.bf! / 1000) / 2, 6)
+    expect(bm.offI![0]).toBeCloseTo((shp.d! / 1000) / 2, 6)
   })
 
   it('caps the total offset so the clear span stays positive', () => {

--- a/webapp/src/engine/rigidEndZones.ts
+++ b/webapp/src/engine/rigidEndZones.ts
@@ -55,7 +55,15 @@ export function autoRigidOffsets(
     const dir = sub(pj, pi)
     const L = Math.hypot(...dir)
     if (L <= 1e-9) continue
-    const [xp, yp, zp] = localAxes(dir)
+    const [xp, ypA, zpA] = localAxes(dir)
+    // Columns are DRAWN (and joint-designed) with the section depth along global
+    // X — flanges facing ±X (Member3D / MemberSteel3D). localAxes puts y′ on
+    // global Z for verticals, which would project the WRONG dimension onto the
+    // framing beams (bf/2 where ETABS uses d/2, and vice versa for Z-girders).
+    // Use the app's physical orientation for the panel-zone geometry.
+    const vertical = Math.abs(xp[1]) > 0.999
+    const yp: V3 = vertical ? [1, 0, 0] : ypA
+    const zp: V3 = vertical ? [0, 0, 1] : zpA
     const { depth, width } = depthWidth(secById.get(m.section))
     mgs.push({ id: m.id, i: m.i, j: m.j, e: xp, L, yp, zp, depth, width, factor: m.rigidZoneFactor ?? factor })
   }

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -143,21 +143,49 @@ function RigidArm3D({ a, b }: { a: THREE.Vector3; b: THREE.Vector3 }) {
 }
 
 /** Rigid end-zone segment: the member's own cross-section in a muted shade,
- *  filling node→clear-span-end so members stay connected at joints (ETABS look). */
-function RigidZone3D({ a, b, role, sec }: {
+ *  filling node→clear-span-end so members stay connected at joints (ETABS look).
+ *  Steel members draw their TRUE extruded profile (same orientation rules as
+ *  MemberSteel3D — a bounding-box cuboid on the end of an I-beam is not ETABS). */
+function RigidZone3D({ a, b, role, sec, shapeName }: {
   a: THREE.Vector3; b: THREE.Vector3; role: string; sec?: { b: number; h: number }
+  /** AISC shape name for steel members — switches to the true-profile render. */
+  shapeName?: string
 }) {
-  const { mid, quat, len } = useMemo(() => {
+  const { mid, quat, len, steel } = useMemo(() => {
     const dir = new THREE.Vector3().subVectors(b, a)
     const len = dir.length()
     const quat = new THREE.Quaternion().setFromUnitVectors(
       new THREE.Vector3(1, 0, 0), len > 1e-9 ? dir.clone().normalize() : new THREE.Vector3(1, 0, 0))
-    return { mid: new THREE.Vector3().addVectors(a, b).multiplyScalar(0.5), quat, len }
-  }, [a, b])
+    // steel: extrude the true profile along the member (MemberSteel3D rules)
+    const shape = shapeName ? shapeByName(shapeName) : undefined
+    let steel: { shapes: THREE.Shape[]; quat: THREE.Quaternion } | null = null
+    if (shape && len > 1e-9) {
+      const shapes = buildSectionShapes(effectiveSection(shape, false))
+      const q = new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 0, 1), dir.clone().normalize())
+      if (role === 'column') {
+        const rPre = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 0, 1), -Math.PI / 2)
+        q.multiply(rPre)
+      }
+      steel = { shapes, quat: q }
+    }
+    return { mid: new THREE.Vector3().addVectors(a, b).multiplyScalar(0.5), quat, len, steel }
+  }, [a, b, role, shapeName])
   if (len < 1e-6) return null
+  const color = `#${new THREE.Color(ROLE_COLOR[role] ?? '#64748b').lerp(new THREE.Color('#1e293b'), 0.45).getHexString()}`
+  if (steel && steel.shapes.length > 0) {
+    return (
+      <group position={a} quaternion={steel.quat}>
+        {steel.shapes.map((sh, i) => (
+          <mesh key={i}>
+            <extrudeGeometry args={[sh, { depth: len, bevelEnabled: false, steps: 1 }]} />
+            <meshStandardMaterial color="#334155" metalness={0.35} roughness={0.5} />
+          </mesh>
+        ))}
+      </group>
+    )
+  }
   const ty = sec ? sec.h / 1000 : role === 'column' ? 0.3 : 0.22
   const tz = sec ? sec.b / 1000 : role === 'column' ? 0.3 : 0.22
-  const color = `#${new THREE.Color(ROLE_COLOR[role] ?? '#64748b').lerp(new THREE.Color('#1e293b'), 0.45).getHexString()}`
   return (
     <mesh position={mid} quaternion={quat}>
       <boxGeometry args={[len, ty * 1.04, tz * 1.04]} />
@@ -1461,8 +1489,8 @@ export default function ModelSpace() {
                   return (
                     <group key={m.id}>
                       {memberEl}
-                      {effI && (manI ? <RigidArm3D a={a} b={aEff} /> : <RigidZone3D a={a} b={aEff} role={m.role} sec={sec} />)}
-                      {effJ && (manJ ? <RigidArm3D a={bb} b={bEff} /> : <RigidZone3D a={bb} b={bEff} role={m.role} sec={sec} />)}
+                      {effI && (manI ? <RigidArm3D a={a} b={aEff} /> : <RigidZone3D a={a} b={aEff} role={m.role} sec={sec} shapeName={sec?.material === 'steel' ? sec.shape : undefined} />)}
+                      {effJ && (manJ ? <RigidArm3D a={bb} b={bEff} /> : <RigidZone3D a={bb} b={bEff} role={m.role} sec={sec} shapeName={sec?.material === 'steel' ? sec.shape : undefined} />)}
                     </group>
                   )
                 })}


### PR DESCRIPTION
## What (user report: "auto-rigid zones is not the same like ETABS")

Two distinct problems, both fixed:

### 1. Wrong dimension projected (engine)

`autoRigidOffsets` projected the connecting column's cross-section through the
solver's `localAxes`, which places local y′ on **global Z** for vertical
members. But the app's physical orientation — the one actually drawn
(`Member3D` / `MemberSteel3D`) and assumed by the steel joint designer — puts
the column **depth d along global X** (flanges facing ±X). Net effect: an
X-beam framing into a W310x97 column got a rigid zone of `bf/2 = 152 mm`
where ETABS "auto from connectivity" gives the support half-depth
`d/2 = 154 mm`… and for rectangular concrete columns (400×600) the error is
much larger (200 vs 300 mm), with Z-girders getting the swap. Vertical
members now project with the drawn orientation (depth→X, width→Z).

### 2. Bounding-box cuboids instead of the member profile (render)

`RigidZone3D` drew the rigid zone as a solid `h×b` **bounding box** — the
floating dark cubes visible in the steel screenshots, since a W-shape's
bounding box is much fatter than its I-profile. Steel zones now render as the
member's **true extruded AISC profile** in a darker shade, using the same
orientation rules as the member itself (including the column pre-rotation) —
the ETABS end-offset look. Concrete keeps the box (its members *are* boxes).

## Tests

Updated to the corrected convention (X-beam → column `h/2`·factor; steel →
`d/2`, resolving the AISC shape) plus a new Z-girder case (`b/2`, the
weak-direction face).

## Verification

- `npx tsc -b` clean
- `npm test` — **980 passed** (979 + 1)
- `npm run build` succeeds

Part 1 of the steel-joint work; part 2 (rendering the designed connections —
shear tabs, end plates, bolts, continuity plates per the reference PDF)
follows as the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_