### PR TITLE
feat: local-axis rotation attribute — analysis matches the drawn orientation

### DIFF
--- a/webapp/src/engine/frame3d.test.ts
+++ b/webapp/src/engine/frame3d.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { solveFrame3D, analyzeFrame3D, rectJ, precomputeFrame, solveWithGeometry, serializePrecomp, deserializePrecomp, appliedResultant, type F3Node, type F3Member, type F3Support, type F3Load, type F3DiaphragmGroup } from './frame3d'
+import { solveFrame3D, analyzeFrame3D, rectJ, localAxes, precomputeFrame, solveWithGeometry, serializePrecomp, deserializePrecomp, appliedResultant, type F3Node, type F3Member, type F3Support, type F3Load, type F3DiaphragmGroup } from './frame3d'
 import { solveFrame2D } from './frame2d'
 import { generateGridModel } from './modelBuilder'
 import { modelToFrame3D } from './modelBridge'
@@ -528,5 +528,43 @@ describe('rigid links / member offsets — Teff = T·H', () => {
     expect(r.reactions[0].F[0]).toBeCloseTo(-Fx, 4)
     // Base moment about Z balances Fx acting at height hArm above the base node.
     expect(r.reactions[0].M[2]).toBeCloseTo(Fx * hArm, 2)
+  })
+})
+
+describe('frame3d — local-axis rotation (ETABS local axis 2 angle)', () => {
+  it('localAxes(dir, 90) turns a vertical member’s depth axis onto global X', () => {
+    const [xp, yp, zp] = localAxes([0, 4, 0], 90)
+    expect(xp[1]).toBeCloseTo(1, 9)
+    expect(yp[0]).toBeCloseTo(1, 6)          // y′ (depth) → +X
+    expect(Math.abs(zp[2])).toBeCloseTo(1, 6) // z′ → ±Z
+  })
+
+  it('rotating a non-square vertical cantilever 90° swaps its strong/weak response', () => {
+    // strongly non-square: Iz (about z′, resisting displacement along y′) ≫ Iy
+    const E = 200000, G = 77000, A = 6650, Iz = 165e6, Iy = 9.2e6, J = 0.23e6, L = 3
+    const nodes: F3Node[] = [{ id: 'a', x: 0, y: 0, z: 0 }, { id: 'b', x: 0, y: L, z: 0 }]
+    const sup: F3Support[] = [{ node: 'a', fixity: 'fixed' }]
+    const tipX: F3Load[] = [{ kind: 'node', node: 'b', Fx: 10, cat: 'D' }]
+    const mk = (rot?: number): F3Member[] => [{ id: 'c', i: 'a', j: 'b', E, G, A, Iy, Iz, J, ...(rot ? { rot } : {}) }]
+    const dx0 = solveFrame3D(nodes, mk(), sup, tipX)!.d[6 + 0]      // rot 0: depth on Z → X is WEAK
+    const dx90 = solveFrame3D(nodes, mk(90), sup, tipX)!.d[6 + 0]   // rot 90: depth on X → X is STRONG
+    expect(Math.abs(dx90)).toBeLessThan(Math.abs(dx0) / 5)
+    // exact: both match PL³/3EI with the respective inertia
+    const del = (I: number) => (10 * L ** 3) / (3 * ((E * I) * 1e-9))
+    expect(Math.abs(dx0)).toBeCloseTo(del(Iy), 6)
+    expect(Math.abs(dx90)).toBeCloseTo(del(Iz), 6)
+  })
+
+  it('the bridge defaults vertical members to rot 90 and honors an explicit value', () => {
+    const section: RectSection = { id: 'S', name: 's', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
+    const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })
+    m.members.find((x) => x.role === 'beam')!.axisRotation = 30
+    const br = modelToFrame3D(m)
+    const col = br.members.find((x) => x.id.startsWith('c'))!
+    const beam30 = br.members.find((x) => m.members.find((y) => y.id === x.id)?.axisRotation === 30)!
+    const beam0 = br.members.find((x) => x.id.startsWith('bx') && x.id !== beam30.id)!
+    expect(col.rot).toBe(90)
+    expect(beam30.rot).toBe(30)
+    expect(beam0.rot).toBeUndefined()   // 0 → omitted
   })
 })

--- a/webapp/src/engine/frame3d.ts
+++ b/webapp/src/engine/frame3d.ts
@@ -44,6 +44,9 @@ export interface F3Member {
   offI?: [number, number, number]
   /** Rigid end offset at end j: vector from node j to the member end in global coords [m]. */
   offJ?: [number, number, number]
+  /** Local-axis rotation about x′, degrees (ETABS local axis 2 angle). Orients
+   *  the section: depth lies along y′. The bridge defaults verticals to 90°. */
+  rot?: number
 }
 /** Flat triangular shell element (CST membrane + DKT plate bending) framing into
  *  three nodes of the model. Carries in-plane (wall) and out-of-plane (slab)
@@ -190,13 +193,30 @@ const dot = (a: V3, b: V3): number => a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
 const norm = (a: V3): V3 => { const l = Math.hypot(...a); return [a[0] / l, a[1] / l, a[2] / l] }
 
 /** Rotation matrix rows = local axes (x′, y′, z′) in global components. */
-export function localAxes(dir: V3): [V3, V3, V3] {
+/** Member local axes [x′, y′, z′]. `rotDeg` is an ETABS-style local-axis
+ *  rotation about x′ (right-hand rule, i→j): +θ turns y′ toward z′. The section
+ *  depth lies along y′, so rotDeg orients the strong axis. */
+export function localAxes(dir: V3, rotDeg = 0): [V3, V3, V3] {
   const xp = norm(dir)
   const up: V3 = Math.abs(dot(xp, [0, 1, 0])) > 0.999 ? [0, 0, 1] : [0, 1, 0]
   const proj = dot(up, xp)
   const yp = norm([up[0] - proj * xp[0], up[1] - proj * xp[1], up[2] - proj * xp[2]])
   const zp = cross(xp, yp)
-  return [xp, yp, zp]
+  if (!rotDeg) return [xp, yp, zp]
+  const c = Math.cos((rotDeg * Math.PI) / 180), s = Math.sin((rotDeg * Math.PI) / 180)
+  const ypr: V3 = [yp[0] * c + zp[0] * s, yp[1] * c + zp[1] * s, yp[2] * c + zp[2] * s]
+  const zpr: V3 = [zp[0] * c - yp[0] * s, zp[1] * c - yp[1] * s, zp[2] * c - yp[2] * s]
+  return [xp, ypr, zpr]
+}
+
+/** Resolve a member's local-axis rotation: an explicit value wins; otherwise
+ *  vertical members default to 90° so the section depth lands on global X —
+ *  the orientation the app draws (Member3D/MemberSteel3D), the joint designer
+ *  assumes, and ETABS uses for columns (local 2 toward +X). */
+export function defaultAxisRotation(dir: V3, explicit?: number): number {
+  if (explicit !== undefined && Number.isFinite(explicit)) return explicit
+  const L = Math.hypot(...dir)
+  return L > 1e-9 && Math.abs(dir[1] / L) > 0.999 ? 90 : 0
 }
 
 function tMatrix(R: [V3, V3, V3]): number[][] {
@@ -357,7 +377,7 @@ function prepMemberGeom(m: F3Member, nm: Map<string, F3Node>, idx: Map<string, n
   const pj: V3 = [nj.x + offJ[0], nj.y + offJ[1], nj.z + offJ[2]]
   const dir: V3 = sub(pj, pi)
   const L = Math.hypot(...dir)
-  const R = localAxes(dir)
+  const R = localAxes(dir, m.rot ?? 0)
   const EA = (m.E * m.A) / 1000
   const GJ = m.G * m.J * 1e-9
   const EIy = m.E * m.Iy * 1e-9

--- a/webapp/src/engine/meshValidation.ts
+++ b/webapp/src/engine/meshValidation.ts
@@ -59,6 +59,10 @@ export function validateMesh(model: StructuralModel): MeshIssue[] {
       issues.push({ severity: 'error', code: 'zero-length-member', refs: [m.id],
         message: `Member ${m.id} has zero length (nodes ${m.i} and ${m.j} coincide) — its stiffness is singular.` })
 
+    if (m.axisRotation !== undefined && !Number.isFinite(m.axisRotation))
+      issues.push({ severity: 'error', code: 'bad-axis-rotation', refs: [m.id],
+        message: `Member ${m.id} has a non-numeric local-axis rotation.` })
+
     const key = [m.i, m.j].sort().join('|')
     const prev = pairSeen.get(key)
     if (prev) issues.push({ severity: 'warning', code: 'duplicate-member', refs: [prev, m.id],

--- a/webapp/src/engine/model.ts
+++ b/webapp/src/engine/model.ts
@@ -71,6 +71,11 @@ export interface Member {
    *  Absent ⇒ the full member length is used (conservative). Set to the real
    *  brace spacing (e.g. purlin/joist pitch) to relieve LTB. */
   Lb?: number
+  /** Local-axis rotation about the member axis, degrees (ETABS "local axis 2
+   *  angle"): +θ turns the section depth (local y′) toward local z′, i→j
+   *  right-hand rule. Absent ⇒ 0 for beams; VERTICAL members default to 90° so
+   *  the depth lands on global X — the drawn orientation. */
+  axisRotation?: number
 }
 
 export type PlateRole = 'slab' | 'wall'

--- a/webapp/src/engine/modelBridge.ts
+++ b/webapp/src/engine/modelBridge.ts
@@ -6,7 +6,7 @@
 // ─────────────────────────────────────────────────────────────────────────
 import type { StructuralModel, RectSection, MemberReleases, MemberConnections, ConnectionKind, Plate } from './model'
 import type { F3Node, F3Member, F3Support, F3Load, F3DiaphragmGroup, F3Shell } from './frame3d'
-import { rectJ } from './frame3d'
+import { rectJ, defaultAxisRotation } from './frame3d'
 import { buildDiaphragmGroups } from './diaphragm'
 import { autoRigidOffsets } from './rigidEndZones'
 import { distributePanel, type AreaLoad } from './tributary'
@@ -196,11 +196,16 @@ export function modelToFrame3D(model: StructuralModel, opts?: BridgeOpts): Bridg
     const a = auto?.get(m.id)
     const offI = m.offsets?.iEnd ?? a?.offI
     const offJ = m.offsets?.jEnd ?? a?.offJ
+    // local-axis rotation: explicit wins; verticals default to 90° so the
+    // analysis strong-axis orientation matches the drawn one (depth d → X)
+    const ni = nm.get(m.i), nj = nm.get(m.j)
+    const rot = ni && nj ? defaultAxisRotation([nj.x - ni.x, nj.y - ni.y, nj.z - ni.z], m.axisRotation) : (m.axisRotation ?? 0)
     return {
       id: m.id, i: m.i, j: m.j, ...(secById.get(m.section) ?? fallback),
       ...releaseFlags(effectiveReleases(m)),
       ...(offI ? { offI } : {}),
       ...(offJ ? { offJ } : {}),
+      ...(rot ? { rot } : {}),
     }
   })
   // shear walls → equivalent diagonal struts (lateral stiffness only)

--- a/webapp/src/engine/rigidEndZones.ts
+++ b/webapp/src/engine/rigidEndZones.ts
@@ -12,7 +12,7 @@
 // Units: section b/h in mm → m; offsets in m (global).
 // ─────────────────────────────────────────────────────────────────────────
 import type { StructuralModel, RectSection } from './model'
-import { localAxes, type V3 } from './frame3d'
+import { localAxes, defaultAxisRotation, type V3 } from './frame3d'
 import { shapeByName } from './aiscSections'
 
 const sub = (a: V3, b: V3): V3 => [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
@@ -55,15 +55,11 @@ export function autoRigidOffsets(
     const dir = sub(pj, pi)
     const L = Math.hypot(...dir)
     if (L <= 1e-9) continue
-    const [xp, ypA, zpA] = localAxes(dir)
-    // Columns are DRAWN (and joint-designed) with the section depth along global
-    // X — flanges facing ±X (Member3D / MemberSteel3D). localAxes puts y′ on
-    // global Z for verticals, which would project the WRONG dimension onto the
-    // framing beams (bf/2 where ETABS uses d/2, and vice versa for Z-girders).
-    // Use the app's physical orientation for the panel-zone geometry.
-    const vertical = Math.abs(xp[1]) > 0.999
-    const yp: V3 = vertical ? [1, 0, 0] : ypA
-    const zp: V3 = vertical ? [0, 0, 1] : zpA
+    // Section orientation = the member's resolved local axes (explicit
+    // axisRotation, or the vertical 90° default that puts depth on global X —
+    // the drawn orientation), so the panel-zone projection always matches the
+    // analysis AND the rendered section.
+    const [xp, yp, zp] = localAxes(dir, defaultAxisRotation(dir, m.axisRotation))
     const { depth, width } = depthWidth(secById.get(m.section))
     mgs.push({ id: m.id, i: m.i, j: m.j, e: xp, L, yp, zp, depth, width, factor: m.rigidZoneFactor ?? factor })
   }

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -200,9 +200,12 @@ function RigidZone3D({ a, b, role, sec, shapeName }: {
  *  extrude (+Z) runs along the member and its strong axis (depth d) stays
  *  vertical for beams/girders. Falls back to the box Member3D if the shape is
  *  unknown. */
-function MemberSteel3D({ a, b, role, shapeName, selected, tint = 0, onPick }: {
+function MemberSteel3D({ a, b, role, shapeName, selected, tint = 0, axisRotation, onPick }: {
   a: THREE.Vector3; b: THREE.Vector3; role: string; shapeName: string
-  selected: boolean; tint?: number; onPick: () => void
+  selected: boolean; tint?: number
+  /** Explicit local-axis rotation (°). Absent ⇒ the role default (columns 90). */
+  axisRotation?: number
+  onPick: () => void
 }) {
   const { shapes, quat, pos, len } = useMemo(() => {
     const shape = shapeByName(shapeName)
@@ -212,14 +215,19 @@ function MemberSteel3D({ a, b, role, shapeName, selected, tint = 0, onPick }: {
     // orient local +Z (extrude dir) onto the member axis; group placed at node i
     const quat = new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 0, 1), dir.clone().normalize())
     // For columns (primarily vertical), pre-rotate the section 90° around local Z
-    // so the depth d aligns with global X and the flanges face ±X.
-    // X-direction girders then frame into the column FLANGE FACE (strong-axis connection).
+    // so the depth d aligns with global X and the flanges face ±X — the 90°
+    // axisRotation default the analysis now shares.
     if (role === 'column') {
       const rPre = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 0, 1), -Math.PI / 2)
       quat.multiply(rPre)
     }
+    // explicit axisRotation: rotate by the difference from the role default
+    // (engine +θ turns depth y′ toward z′ = −rotation about the extrude axis here)
+    const d0 = role === 'column' ? 90 : 0
+    const extra = (axisRotation ?? d0) - d0
+    if (extra) quat.multiply(new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 0, 1), (-extra * Math.PI) / 180))
     return { shapes, quat, pos: a.clone(), len }
-  }, [a, b, shapeName, role])
+  }, [a, b, shapeName, role, axisRotation])
 
   const color = useMemo(() => {
     if (selected) return SEL
@@ -1483,7 +1491,7 @@ export default function ModelSpace() {
                   const aEff = effI ? a.clone().add(new THREE.Vector3(effI[0], effI[1], effI[2])) : a
                   const bEff = effJ ? bb.clone().add(new THREE.Vector3(effJ[0], effJ[1], effJ[2])) : bb
                   const memberEl = sec?.material === 'steel' && sec.shape
-                    ? <MemberSteel3D a={aEff} b={bEff} role={m.role} shapeName={sec.shape}
+                    ? <MemberSteel3D a={aEff} b={bEff} role={m.role} shapeName={sec.shape} axisRotation={m.axisRotation}
                         tint={tint * 0.85} selected={m.id === selected} onPick={() => setSelected(m.id)} />
                     : <Member3D a={aEff} b={bEff} role={m.role} tint={tint * 0.85}
                         sec={sec} selected={m.id === selected} onPick={() => setSelected(m.id)} />
@@ -1896,6 +1904,17 @@ export default function ModelSpace() {
                             }}
                             className="w-16 rounded border border-violet-200 px-1 py-0.5 text-right" />
                           <span className="text-[10px] text-slate-400">blank = model factor · 0 = no zone for this member (needs Auto rigid end zones on)</span>
+                        </label>
+                        <label className="mt-2 flex items-center gap-2 border-t border-violet-200 pt-2 text-[11px] text-slate-700">
+                          <span>Local axis rotation θ (°)</span>
+                          <input type="number" step={15}
+                            value={sel.axisRotation ?? ''} placeholder="auto"
+                            onChange={(e) => {
+                              const v = parseFloat(e.target.value)
+                              updMember(sel.id, { axisRotation: Number.isFinite(v) ? v : undefined })
+                            }}
+                            className="w-16 rounded border border-violet-200 px-1 py-0.5 text-right" />
+                          <span className="text-[10px] text-slate-400">ETABS local-axis angle about the member axis. Blank = default (vertical members 90° — depth d on global X); orients section stiffness, rigid zones and the drawn shape.</span>
                         </label>
                         {(sel.role === 'beam' || sel.role === 'girder') && (
                           <label className="mt-2 flex items-center gap-2 border-t border-violet-200 pt-2 text-[11px] text-slate-700">


### PR DESCRIPTION
## What

`Member.axisRotation` (degrees) — the ETABS **"local axis 2 angle"**: +θ turns
the section depth (local y′) toward z′ about the member axis (i→j right-hand
rule). Layer 1 field → Layer 2 bridge → Layer 3 transform.

## Why (results-affecting fix)

The solver's `localAxes` put a vertical column's depth on **global Z**, while
everything else in the app — the drawn 3D shape, the steel joint designer, the
(#304) rigid zones — orients the depth on **global X** (the ETABS column
default, local 2 → +X). For non-square columns that was a silent 90°
strong-axis error: lateral stiffness in X used the weak inertia and vice
versa. **Vertical members now default to rot = 90°**, so the analysis matches
the physical orientation; an explicit `axisRotation` overrides for skewed
layouts (channels laid flat, rotated columns, etc.).

## L3 justification + inheritance

Wired at the single element-transform point (`prepMemberGeom` →
`localAxes(dir, rot)`), so stiffness, consistent fixed-end loads, force
recovery, P-Δ and buckling all inherit the rotation for free — no
special-casing inside the solver. Statics self-checks re-run: the full suite
(cantilever δ = PL³/3EI, portal vs frame2d, Σreactions = Σloads) stays green.

## Changes

- `frame3d`: `localAxes(dir, rotDeg)`, `defaultAxisRotation`, `F3Member.rot`
- `modelBridge`: resolves explicit / vertical-default rotation per member
- `rigidEndZones`: panel-zone projection now uses the same resolved axes
  (replaces the hard-coded vertical special case from #304)
- `ModelSpace`: member panel input "Local axis rotation θ (°)" (blank = auto);
  steel render applies explicit rotations as a delta from the drawn default
- `meshValidation`: `bad-axis-rotation` rule (CLAUDE.md L1 requirement)

## Tests (3 new)

- Rotated-axes math: `localAxes([0,4,0], 90)` puts y′ on +X.
- **Physical**: a strongly non-square vertical cantilever under a tip load in X
  deflects with exactly `PL³/3EIy` at rot 0 and `PL³/3EIz` at rot 90 — the
  strong/weak swap, verified against closed form both ways.
- Bridge defaults: column → 90, explicit 30 honored, beams omit 0.

## Verification

- `npx tsc -b` clean · `npm test` — **983 passed** (980 + 3) · build OK

⚠️ Note: analyses of existing models with **non-square columns** will shift —
column strong-axis bending moves from Z to X, matching what the model space
has always displayed. This is the correction, not a regression.

Next: beam-to-beam (girder web) connection design + rendering, then the
interactive connection schedule (2D drawing + step-by-step solution per row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_