### PR TITLE
fix: connection detail polish — real dimension lines, section bolts/weld, shear-plane callout

### DIFF
--- a/webapp/src/components/ConnectionDetail2D.tsx
+++ b/webapp/src/components/ConnectionDetail2D.tsx
@@ -2,9 +2,10 @@
 // 2D detail drawing of a designed steel connection — the schedule row's
 // section views, in the style of the reference figures: an ELEVATION (side
 // view: support at left, beam entering from the right, plate + bolts + cope)
-// and an END SECTION (looking along the beam: support face, plate edge-on
-// against the beam web, bolts across). All geometry comes from the designed
-// row (plate t×w×h, bolt layout, cope) and the AISC shapes. Units mm.
+// and an END SECTION (looking along the beam: support face behind, plate
+// against the beam web with the fillet welds, every bolt drawn shank + head +
+// nut at its row elevation, single-shear plane called out). All geometry comes
+// from the designed row (plate t×w×h, bolt layout, cope) and AISC shapes. mm.
 // ─────────────────────────────────────────────────────────────────────────
 import { useMemo } from 'react'
 import { shapeByName } from '../engine/aiscSections'
@@ -14,6 +15,43 @@ const STEEL = '#94a3b8'      // member outline fill
 const PLATE = '#334155'
 const BOLT = '#b45309'
 const DIM = '#2563eb'
+const WELD = '#d97706'
+
+/** Drafting dimension: extension lines + dimension line with filled arrowheads
+ *  + centered label. Vertical (measuring y) or horizontal (measuring x). */
+function Dim({ x1, y1, x2, y2, off, label, vertical }: {
+  x1: number; y1: number; x2: number; y2: number
+  /** offset of the dimension line from the measured points (px, signed) */
+  off: number
+  label: string
+  vertical?: boolean
+}) {
+  const A = 5   // arrowhead size
+  if (vertical) {
+    const dx = x1 + off
+    return (
+      <g stroke={DIM} fill={DIM} strokeWidth={0.8}>
+        <line x1={x1} y1={y1} x2={dx + Math.sign(off) * 3} y2={y1} />
+        <line x1={x2} y1={y2} x2={dx + Math.sign(off) * 3} y2={y2} />
+        <line x1={dx} y1={y1} x2={dx} y2={y2} />
+        <path d={`M ${dx} ${y1} l ${-A / 2} ${A} l ${A} 0 z`} />
+        <path d={`M ${dx} ${y2} l ${-A / 2} ${-A} l ${A} 0 z`} />
+        <text x={dx + 5} y={(y1 + y2) / 2 + 3} fontSize={10} stroke="none">{label}</text>
+      </g>
+    )
+  }
+  const dy = y1 + off
+  return (
+    <g stroke={DIM} fill={DIM} strokeWidth={0.8}>
+      <line x1={x1} y1={y1} x2={x1} y2={dy + Math.sign(off) * 3} />
+      <line x1={x2} y1={y2} x2={x2} y2={dy + Math.sign(off) * 3} />
+      <line x1={x1} y1={dy} x2={x2} y2={dy} />
+      <path d={`M ${x1} ${dy} l ${A} ${-A / 2} l 0 ${A} z`} />
+      <path d={`M ${x2} ${dy} l ${-A} ${-A / 2} l 0 ${A} z`} />
+      <text x={(x1 + x2) / 2} y={dy + (off > 0 ? 12 : -5)} textAnchor="middle" fontSize={10} stroke="none">{label}</text>
+    </g>
+  )
+}
 
 export function ConnectionDetail2D({ conn, hostShape, hostKind, faceType, beamShape }: {
   conn: BeamConnection
@@ -37,20 +75,25 @@ export function ConnectionDetail2D({ conn, hostShape, hostKind, faceType, beamSh
 
   const { dB, bfB, tfB, twB, hostW } = g
   const tab = conn.tab
-  const beamLen = Math.max(tab.wMm + 160, 300)
+  const beamLen = Math.max(tab.wMm + 170, 310)
   const cope = conn.cope
+  const rows = conn.bolts.locations
 
-  // ── elevation view geometry (mm coordinate space, y up) ──
-  const W = hostW + beamLen + 90, H = Math.max(dB, tab.hMm) + 170
+  // ── elevation view geometry (mm coordinate space, y down = SVG) ──
+  const W = hostW + beamLen + 120, H = Math.max(dB, tab.hMm) + 190
   const cx = 40                       // host left edge
   const faceX = cx + hostW            // support face
   const cy = H / 2                    // beam centreline
   const beamTop = cy - dB / 2, beamBot = cy + dB / 2
   const plateTop = cy - tab.hMm / 2
+  const boltY = (y: number) => plateTop + tab.hMm - y          // plate y → SVG y
+  const a0 = rows[0]?.x ?? 60
 
   // ── end-section view ──
-  const W2 = Math.max(bfB, 160) + 120, H2 = dB + 120
-  const cx2 = W2 / 2, cy2 = H2 / 2
+  const supW = hostKind === 'girder' ? 30 : Math.max(bfB + 60, (g.host?.bf ?? 254))
+  const W2 = Math.max(bfB, supW) + 190, H2 = dB + 150
+  const cx2 = (W2 - 60) / 2, cy2 = H2 / 2
+  const plateX2 = cx2 + twB / 2                                 // plate against the web, near side
 
   const sc = 0.55                     // mm → px
 
@@ -78,52 +121,81 @@ export function ConnectionDetail2D({ conn, hostShape, hostKind, faceType, beamSh
         <line x1={cope ? faceX + cope.lengthMm : faceX} y1={beamTop + tfB} x2={faceX + beamLen} y2={beamTop + tfB} stroke="#475569" />
         <line x1={faceX} y1={beamBot - tfB} x2={faceX + beamLen} y2={beamBot - tfB} stroke="#475569" />
         {cope && (
-          <text x={faceX + cope.lengthMm + 4} y={beamTop + cope.depthMm - 4} fontSize={9} fill={DIM}>
-            cope {cope.lengthMm}×{cope.depthMm}
-          </text>
+          <Dim x1={faceX} y1={beamTop + cope.depthMm} x2={faceX + cope.lengthMm} y2={beamTop + cope.depthMm} off={-(cope.depthMm + 14)} label={`cope ${cope.lengthMm}×${cope.depthMm}`} />
         )}
-        {/* plate + weld triangles at the support face */}
+        {/* plate + weld triangle at the support face */}
         <rect x={faceX} y={plateTop} width={tab.wMm} height={tab.hMm} fill="none" stroke={PLATE} strokeWidth={2.2} />
-        <path d={`M ${faceX} ${plateTop - 8} l 10 8 l -10 0 z`} fill={PLATE} />
-        <text x={faceX + 12} y={plateTop - 10} fontSize={9} fill={PLATE}>{tab.weldSizeMm} mm E70 (2 sides)</text>
-        {/* bolts at the designed layout (x from the face/weld line, y from the plate bottom) */}
-        {conn.bolts.locations.map((bp) => (
+        <path d={`M ${faceX} ${plateTop - 9} l 11 9 l -11 0 z`} fill={WELD} />
+        <text x={faceX + 14} y={plateTop - 11} fontSize={9} fill={WELD}>{tab.weldSizeMm} mm E70 fillet, 2 sides</text>
+        {/* bolts at the designed layout */}
+        {rows.map((bp) => (
           <g key={bp.id}>
-            <circle cx={faceX + bp.x} cy={plateTop + tab.hMm - bp.y} r={conn.bolts.dia / 2} fill="none" stroke={BOLT} strokeWidth={2} />
-            <line x1={faceX + bp.x - 7} y1={plateTop + tab.hMm - bp.y} x2={faceX + bp.x + 7} y2={plateTop + tab.hMm - bp.y} stroke={BOLT} />
-            <line x1={faceX + bp.x} y1={plateTop + tab.hMm - bp.y - 7} x2={faceX + bp.x} y2={plateTop + tab.hMm - bp.y + 7} stroke={BOLT} />
+            <circle cx={faceX + bp.x} cy={boltY(bp.y)} r={conn.bolts.dia / 2} fill="none" stroke={BOLT} strokeWidth={2} />
+            <line x1={faceX + bp.x - 7} y1={boltY(bp.y)} x2={faceX + bp.x + 7} y2={boltY(bp.y)} stroke={BOLT} />
+            <line x1={faceX + bp.x} y1={boltY(bp.y) - 7} x2={faceX + bp.x} y2={boltY(bp.y) + 7} stroke={BOLT} />
           </g>
         ))}
-        {/* dimensions */}
-        <line x1={faceX + tab.wMm + 16} y1={plateTop} x2={faceX + tab.wMm + 16} y2={plateTop + tab.hMm} stroke={DIM} markerEnd="" />
-        <text x={faceX + tab.wMm + 20} y={cy + 3} fontSize={10} fill={DIM}>h = {Math.round(tab.hMm)}</text>
-        <text x={faceX + tab.wMm / 2} y={plateTop + tab.hMm + 14} textAnchor="middle" fontSize={10} fill={DIM}>
+        {/* dimensions: plate h (right), a (face→bolt line, below), pitch (right of bolts) */}
+        <Dim x1={faceX + tab.wMm} y1={plateTop} x2={faceX + tab.wMm} y2={plateTop + tab.hMm} off={22} label={`h = ${Math.round(tab.hMm)}`} vertical />
+        <Dim x1={faceX} y1={plateTop + tab.hMm} x2={faceX + a0} y2={plateTop + tab.hMm} off={26} label={`a = ${Math.round(a0)}`} />
+        {rows.length > 1 && (
+          <Dim x1={faceX + a0} y1={boltY(rows[1].y)} x2={faceX + a0} y2={boltY(rows[0].y)} off={-24} label={`p = ${conn.bolts.pitchMm}`} vertical />
+        )}
+        <text x={faceX + tab.wMm / 2} y={plateTop + tab.hMm + 52} textAnchor="middle" fontSize={10} fill={PLATE} fontWeight={600}>
           PL {tab.t}×{tab.wMm}×{Math.round(tab.hMm)}
         </text>
-        <text x={faceX + (conn.bolts.locations[0]?.x ?? 60) / 2} y={beamBot + 26} textAnchor="middle" fontSize={9} fill={DIM}>
-          a = {Math.round(conn.bolts.locations[0]?.x ?? 60)}
-        </text>
         {/* Vu arrow */}
-        <line x1={faceX + beamLen - 30} y1={beamTop - 26} x2={faceX + beamLen - 30} y2={beamTop - 4} stroke="#dc2626" strokeWidth={2} />
-        <path d={`M ${faceX + beamLen - 30} ${beamTop - 4} l -5 -8 l 10 0 z`} fill="#dc2626" />
-        <text x={faceX + beamLen - 24} y={beamTop - 12} fontSize={10} fill="#dc2626">Vu = {conn.Vu.toFixed(0)} kN</text>
+        <line x1={faceX + beamLen - 32} y1={beamTop - 28} x2={faceX + beamLen - 32} y2={beamTop - 6} stroke="#dc2626" strokeWidth={2} />
+        <path d={`M ${faceX + beamLen - 32} ${beamTop - 6} l -5 -8 l 10 0 z`} fill="#dc2626" />
+        <text x={faceX + beamLen - 26} y={beamTop - 14} fontSize={10} fill="#dc2626">Vu = {conn.Vu.toFixed(0)} kN</text>
       </svg>
 
       {/* END SECTION */}
       <svg viewBox={`0 0 ${W2} ${H2}`} width={W2 * sc} height={H2 * sc} className="rounded-lg border border-slate-200 bg-white">
-        <text x={cx2} y={16} textAnchor="middle" fontSize={13} fontWeight={700} fill="#0f172a">SECTION</text>
+        <text x={W2 / 2} y={16} textAnchor="middle" fontSize={13} fontWeight={700} fill="#0f172a">SECTION</text>
+        {/* support face behind: column flange (or girder web edge-band) */}
+        <rect x={cx2 - supW / 2} y={cy2 - dB / 2 - 34} width={supW} height={dB + 68}
+          fill={STEEL} opacity={0.22} stroke="#94a3b8" strokeDasharray="5 3" />
+        <text x={cx2 - supW / 2 + 4} y={cy2 - dB / 2 - 22} fontSize={9} fill="#64748b">
+          {hostKind === 'girder' ? `girder web (${hostShape})` : `column ${faceType} (${hostShape})`} behind
+        </text>
         {/* beam I end view */}
         <g stroke="#475569" fill={STEEL} fillOpacity={0.45}>
           <rect x={cx2 - bfB / 2} y={cy2 - dB / 2} width={bfB} height={tfB} />
           <rect x={cx2 - bfB / 2} y={cy2 + dB / 2 - tfB} width={bfB} height={tfB} />
           <rect x={cx2 - twB / 2} y={cy2 - dB / 2 + tfB} width={twB} height={dB - 2 * tfB} />
         </g>
-        {/* plate edge-on beside the web + bolt across */}
-        <rect x={cx2 + twB / 2} y={cy2 - tab.hMm / 2} width={tab.t} height={tab.hMm} fill={PLATE} />
-        <line x1={cx2 - twB / 2 - 14} y1={cy2} x2={cx2 + twB / 2 + tab.t + 14} y2={cy2} stroke={BOLT} strokeWidth={4} />
-        <text x={cx2 + twB / 2 + tab.t + 6} y={cy2 - 8} fontSize={10} fill={PLATE}>t = {tab.t}</text>
-        <text x={cx2} y={cy2 + dB / 2 + 24} textAnchor="middle" fontSize={10} fill="#334155">
-          {beamShape ?? 'beam'} — {conn.bolts.n} × M{conn.bolts.dia}
+        {/* plate against the web + fillet weld triangles top/bottom (to the support) */}
+        <rect x={plateX2} y={cy2 - tab.hMm / 2} width={tab.t + 2} height={tab.hMm} fill={PLATE} />
+        <path d={`M ${plateX2} ${cy2 - tab.hMm / 2} l ${tab.t + 2} 0 l ${-(tab.t + 2) / 2} ${-9} z`} fill={WELD} />
+        <path d={`M ${plateX2} ${cy2 + tab.hMm / 2} l ${tab.t + 2} 0 l ${-(tab.t + 2) / 2} ${9} z`} fill={WELD} />
+        <text x={plateX2 + tab.t + 8} y={cy2 - tab.hMm / 2 - 4} fontSize={9} fill={WELD}>weld to support</text>
+        {/* bolts: shank through web + plate, hex head (plate side) + nut (web side), per row */}
+        {rows.map((bp) => {
+          const y = cy2 + tab.hMm / 2 - bp.y
+          const shankL = twB + tab.t + 2
+          return (
+            <g key={bp.id}>
+              <rect x={cx2 - twB / 2 - 2} y={y - conn.bolts.dia / 2} width={shankL + 4} height={conn.bolts.dia} fill={BOLT} opacity={0.9} />
+              <rect x={plateX2 + tab.t + 2} y={y - conn.bolts.dia * 0.9} width={conn.bolts.dia * 0.7} height={conn.bolts.dia * 1.8} fill={BOLT} />
+              <rect x={cx2 - twB / 2 - 2 - conn.bolts.dia * 0.7} y={y - conn.bolts.dia * 0.9} width={conn.bolts.dia * 0.7} height={conn.bolts.dia * 1.8} fill={BOLT} />
+            </g>
+          )
+        })}
+        {/* single-shear plane callout at the plate ↔ web interface */}
+        {rows.length > 0 && (() => {
+          const y = cy2 + tab.hMm / 2 - rows[rows.length - 1].y
+          return (
+            <g>
+              <line x1={plateX2 - 1} y1={y - 26} x2={plateX2 - 1} y2={y + 26} stroke="#dc2626" strokeDasharray="4 3" strokeWidth={1.4} />
+              <line x1={plateX2 - 1} y1={y - 26} x2={plateX2 + 34} y2={y - 40} stroke="#dc2626" strokeWidth={0.9} />
+              <text x={plateX2 + 36} y={y - 42} fontSize={9.5} fill="#dc2626" fontWeight={600}>single shear plane (m = 1)</text>
+            </g>
+          )
+        })()}
+        <Dim x1={plateX2} y1={cy2 + tab.hMm / 2 + 14} x2={plateX2 + tab.t + 2} y2={cy2 + tab.hMm / 2 + 14} off={10} label={`t = ${tab.t}`} />
+        <text x={cx2} y={H2 - 14} textAnchor="middle" fontSize={10} fill="#334155">
+          {beamShape ?? 'beam'} — {conn.bolts.n} × M{conn.bolts.dia} A325, single shear
         </text>
       </svg>
     </div>

--- a/webapp/src/lib/connectionSolution.test.ts
+++ b/webapp/src/lib/connectionSolution.test.ts
@@ -31,6 +31,9 @@ describe('connectionRowSolution — schedule row worked solution', () => {
     expect(flat).toContain(`M${conn.bolts.dia}`)
     expect(conn.ok).toBe(true)
     expect(flat).toContain('All checks pass')
+    // the shear-plane basis is stated explicitly (single plate ⇒ m = 1)
+    expect(flat).toContain('SINGLE shear')
+    expect(flat).toContain('m = 1 shear plane')
   })
 
   it('a moment connection adds the CJP flange-force step', () => {

--- a/webapp/src/lib/connectionSolution.ts
+++ b/webapp/src/lib/connectionSolution.ts
@@ -44,7 +44,8 @@ export function connectionRowSolution(c: BeamConnection, host: ConnHost): Soluti
   steps.push({
     title: 'Bolt group — elastic eccentric method (§J3.6)',
     lines: [
-      { tex: `\\phi R_n = 0.75 \\cdot F_{nv} A_b = 0.75 \\cdot ${FNV} \\cdot ${sn1(Ab)} / 10^3 = ${sn1(phiRn)}\\ \\text{kN/bolt (M${b.dia} A325-X)}` },
+      { text: 'Single-plate connection ⇒ each bolt works in SINGLE shear: m = 1 shear plane, at the plate ↔ beam-web interface. (A double-angle cleat would give m = 2 and twice the per-bolt capacity.)' },
+      { tex: `\\phi R_n = 0.75 \\cdot F_{nv} A_b \\cdot m = 0.75 \\cdot ${FNV} \\cdot ${sn1(Ab)} \\cdot 1 / 10^3 = ${sn1(phiRn)}\\ \\text{kN/bolt (M${b.dia} A325-X)}` },
       { text: `${b.n} bolt(s), single column @ ${b.pitchMm} mm pitch, ${b.edgeMm} mm edge; bolt line ${Math.round(b.ecc)} mm from the weld line (the eccentricity e).` },
       { tex: `J = \\sum (x_c^2 + y_c^2) = ${sn1(J / 1e3)}\\times 10^3\\ \\text{mm}^2` },
       { tex: `R_d = V_u / n = ${sn1(c.Vu)} / ${b.n} = ${sn2(Rd)}\\ \\text{kN};\\quad R_T = V_u\\, e\\, \\rho / J` },

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -3970,8 +3970,8 @@ export default function ModelSpace() {
                         <td className="py-1 pr-2 text-right">{f1(c.Vu)}</td>
                         <td className="py-1 pr-2 text-right">{f1(c.Mu)}</td>
                         <td className="py-1 pr-2 text-[11px]">
-                          {c.bolts.n} × M{c.bolts.dia} A325
-                          <div className="text-[10px] text-slate-400">R={f1(c.bolts.Rmax)}/{f1(c.bolts.phiRnKn)} kN · e={Math.round(c.bolts.ecc)}mm</div>
+                          {c.bolts.n} × M{c.bolts.dia} A325 <span className="text-[10px] text-slate-400">(single shear)</span>
+                          <div className="text-[10px] text-slate-400">R={f1(c.bolts.Rmax)}/{f1(c.bolts.phiRnKn)} kN/bolt · e={Math.round(c.bolts.ecc)}mm</div>
                         </td>
                         <td className="py-1 pr-2 text-[11px]">{c.tab.t}×{Math.round(c.tab.hMm)} mm</td>
                         <td className="py-1 pr-2 text-[11px]">
@@ -4028,8 +4028,8 @@ export default function ModelSpace() {
                         <td className="py-1 pr-2 text-right">{f1(c.Vu)}</td>
                         <td className="py-1 pr-2 text-right">—</td>
                         <td className="py-1 pr-2 text-[11px]">
-                          {c.bolts.n} × M{c.bolts.dia} A325
-                          <div className="text-[10px] text-slate-400">R={f1(c.bolts.Rmax)}/{f1(c.bolts.phiRnKn)} kN · e={Math.round(c.bolts.ecc)}mm</div>
+                          {c.bolts.n} × M{c.bolts.dia} A325 <span className="text-[10px] text-slate-400">(single shear)</span>
+                          <div className="text-[10px] text-slate-400">R={f1(c.bolts.Rmax)}/{f1(c.bolts.phiRnKn)} kN/bolt · e={Math.round(c.bolts.ecc)}mm</div>
                         </td>
                         <td className="py-1 pr-2 text-[11px]">{c.tab.t}×{Math.round(c.tab.hMm)} mm</td>
                         <td className="py-1 pr-2 text-[11px]">{c.tab.weldSizeMm}mm E70</td>


### PR DESCRIPTION
## What (feedback on the #308 detail drawings)

**1. Dimension lines.** Now proper drafting dimensions — extension lines,
filled arrowheads, centred labels — via a shared `Dim` helper: plate `h`, bolt
line `a`, pitch `p`, plate `t` and the cope `L×D`. No more floating text.

**2. Section view rebuilt.** It now reads like the reference end views:
- the **support face** (column flange / girder web) drawn dashed **behind**
  the beam section, labelled;
- the plate against the beam web with **fillet weld triangles** to the
  support;
- **every bolt at its designed row elevation**, drawn as shank through
  plate + web with a hex head (plate side) and nut (web side) — replacing the
  single bare line at mid-depth.

**3. Single vs double shear made explicit.** To answer the question directly:
the design has **always used the single-shear per-bolt capacity** —
`φRn = 0.75·Fnv·Ab` with **one** shear plane at the plate↔web interface,
which is the correct basis for a single-plate tab/fin. It just never said so.
Now:
- the section view carries a red **"single shear plane (m = 1)"** callout at
  the interface,
- the worked solution states the basis and prints `φRn = φ·Fnv·Ab·m` with
  `m = 1` (noting a double-angle cleat would give m = 2),
- the schedule bolts cell is tagged **"(single shear)"** with per-bolt units
  (`R = … kN/bolt`).

## Verification

- `npx tsc -b` clean · `npm test` — **988 passed** (solution test now asserts
  the shear-plane statement) · build OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_