### PR TITLE
feat: column-stack continuity — one section through the storeys

### DIFF
--- a/webapp/src/engine/modelBuilder.test.ts
+++ b/webapp/src/engine/modelBuilder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { generateGridModel, removeElements, nodeId, buildGravityLoads } from './modelBuilder'
+import { generateGridModel, removeElements, nodeId, buildGravityLoads, enforceSectionHierarchy } from './modelBuilder'
 import type { RectSection } from './model'
 
 const sec: RectSection = { id: 'S1', name: '300×500', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
@@ -77,5 +77,40 @@ describe('removeElements', () => {
     // untouched collections preserved
     expect(out.nodes).toEqual(m.nodes)
     expect(out.supports).toEqual(m.supports)
+  })
+})
+
+describe('enforceSectionHierarchy — column-stack continuity', () => {
+  const rc = (id: string, b: number, h: number): RectSection =>
+    ({ id, name: `${b}×${h}`, b, h, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 })
+
+  it('concrete columns on one plan position all take the stack maximum b × h', () => {
+    const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3, 3], section: rc('S', 300, 300) })
+    // storey-2 column above c0.0.0 is c0.0.1 — make the lower one bigger
+    const lower = m.sections.find((s) => s.id === 'c0.0.0')!
+    lower.b = 400; lower.h = 450
+    const out = enforceSectionHierarchy(m)
+    const up = out.sections.find((s) => s.id === 'c0.0.1')!
+    expect(up.b).toBe(400)
+    expect(up.h).toBe(450)
+    // a different stack is untouched
+    expect(out.sections.find((s) => s.id === 'c1.0.1')!.b).toBe(300)
+  })
+
+  it('steel stacks unify to the heaviest shape', () => {
+    const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3, 3], section: rc('S', 300, 300) })
+    for (const s of m.sections) Object.assign(s, { material: 'steel', shape: 'W310x38.7', steelFy: 345, steelFu: 448 })
+    m.sections.find((s) => s.id === 'c0.0.0')!.shape = 'W310x97'
+    const out = enforceSectionHierarchy(m)
+    expect(out.sections.find((s) => s.id === 'c0.0.1')!.shape).toBe('W310x97')
+    expect(out.sections.find((s) => s.id === 'c1.0.0')!.shape).toBe('W310x38.7')
+  })
+
+  it('is idempotent', () => {
+    const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3, 3], section: rc('S', 300, 300) })
+    m.sections.find((s) => s.id === 'c0.0.0')!.h = 500
+    const once = enforceSectionHierarchy(m)
+    const twice = enforceSectionHierarchy(once)
+    expect(JSON.stringify(twice.sections)).toBe(JSON.stringify(once.sections))
   })
 })

--- a/webapp/src/engine/modelBuilder.ts
+++ b/webapp/src/engine/modelBuilder.ts
@@ -272,5 +272,43 @@ export function enforceSectionHierarchy(model: StructuralModel): StructuralModel
     }
     if (!changed) break
   }
-  return { ...model, sections: model.sections.map((s) => { const u = sec.get(s.id)!; return { ...u, name: `${u.b}×${u.h}` } }) }
+
+  // ── Column-stack continuity: a physical column is CONTINUOUS through the
+  // storeys, so every column member on the same plan position carries one
+  // section — the stack's largest (concrete: max b × max h; steel: heaviest
+  // shape by area). Grow-only, like the joint hierarchy above; idempotent. ──
+  const nodeXZ = new Map(model.nodes.map((n) => [n.id, n]))
+  const stacks = new Map<string, Member[]>()
+  for (const m of model.members) {
+    if (m.role !== 'column') continue
+    const a = nodeXZ.get(m.i), b = nodeXZ.get(m.j)
+    if (!a || !b) continue
+    if (Math.abs(a.x - b.x) > 1e-4 || Math.abs(a.z - b.z) > 1e-4) continue   // skewed — not a stack
+    const key = `${Math.round(a.x * 1e3)},${Math.round(a.z * 1e3)}`
+    ;(stacks.get(key) ?? stacks.set(key, []).get(key)!).push(m)
+  }
+  for (const stack of stacks.values()) {
+    if (stack.length < 2) continue
+    const secs = stack.map((m) => secOf(m)!).filter(Boolean)
+    if (secs.some((s) => s.material === 'steel')) {
+      // heaviest shape in the stack governs
+      let best: { name: string; A: number } | null = null
+      for (const s of secs) {
+        const shp = s.shape ? shapeByName(s.shape) : undefined
+        if (shp && (!best || shp.A > best.A)) best = { name: shp.name, A: shp.A }
+      }
+      if (best) for (const s of secs) {
+        if (s.shape !== best.name) {
+          const shp = shapeByName(best.name)!
+          s.shape = shp.name; s.b = shp.bf ?? s.b; s.h = shp.d ?? s.h
+        }
+      }
+    } else {
+      const bMax = Math.max(...secs.map((s) => s.b))
+      const hMax = Math.max(...secs.map((s) => s.h))
+      for (const s of secs) { s.b = bMax; s.h = hMax }
+    }
+  }
+
+  return { ...model, sections: model.sections.map((s) => { const u = sec.get(s.id)!; return { ...u, name: u.material === 'steel' && u.shape ? u.shape : `${u.b}×${u.h}` } }) }
 }


### PR DESCRIPTION
## What (user report: "column sections should be the same above/below to be continuous")

Per-member optimization sized each storey's column segment independently, so
the drawn column changed size right at the joint. `enforceSectionHierarchy`
now groups columns by plan position and gives every member in a **stack** the
stack's largest section:

- **Concrete**: max b × max h across the stack.
- **Steel**: the heaviest shape by area.

Grow-only and idempotent like the existing joint-width hierarchy, and it runs
inside the optimizer's `settle` — so growing one storey's column lifts the
whole stack, and a single-segment shrink attempt is silently reverted (caught
by the no-progress guard from #299, so no loops; whole-stack shrinks still
work because the batch passes shrink all eligible segments together).

Skewed (non-plumb) columns are excluded from stacking.

## Tests (3 new)

- Concrete stack takes the max b × h; an adjacent stack stays untouched.
- Steel stack unifies to the heaviest shape (W310x97 over W310x38.7).
- Idempotency.

## Verification

- `npx tsc -b` clean · `npm test` — **991 passed** (988 + 3) · build OK

Part 1 of the round-2 feedback; part 2 (beam ends at the column face in 3D,
roof column extends to beam top, section-view weld at the flanges, dims.tsx
reuse) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_