### PR TITLE
fix: joint visual continuity + detail drawing corrections

### DIFF
--- a/webapp/src/components/ConnectionDetail2D.tsx
+++ b/webapp/src/components/ConnectionDetail2D.tsx
@@ -9,49 +9,13 @@
 // ─────────────────────────────────────────────────────────────────────────
 import { useMemo } from 'react'
 import { shapeByName } from '../engine/aiscSections'
+import { DimBelow, DimSide } from './dims'
 import type { BeamConnection } from '../engine/steelConnections'
 
 const STEEL = '#94a3b8'      // member outline fill
 const PLATE = '#334155'
 const BOLT = '#b45309'
-const DIM = '#2563eb'
 const WELD = '#d97706'
-
-/** Drafting dimension: extension lines + dimension line with filled arrowheads
- *  + centered label. Vertical (measuring y) or horizontal (measuring x). */
-function Dim({ x1, y1, x2, y2, off, label, vertical }: {
-  x1: number; y1: number; x2: number; y2: number
-  /** offset of the dimension line from the measured points (px, signed) */
-  off: number
-  label: string
-  vertical?: boolean
-}) {
-  const A = 5   // arrowhead size
-  if (vertical) {
-    const dx = x1 + off
-    return (
-      <g stroke={DIM} fill={DIM} strokeWidth={0.8}>
-        <line x1={x1} y1={y1} x2={dx + Math.sign(off) * 3} y2={y1} />
-        <line x1={x2} y1={y2} x2={dx + Math.sign(off) * 3} y2={y2} />
-        <line x1={dx} y1={y1} x2={dx} y2={y2} />
-        <path d={`M ${dx} ${y1} l ${-A / 2} ${A} l ${A} 0 z`} />
-        <path d={`M ${dx} ${y2} l ${-A / 2} ${-A} l ${A} 0 z`} />
-        <text x={dx + 5} y={(y1 + y2) / 2 + 3} fontSize={10} stroke="none">{label}</text>
-      </g>
-    )
-  }
-  const dy = y1 + off
-  return (
-    <g stroke={DIM} fill={DIM} strokeWidth={0.8}>
-      <line x1={x1} y1={y1} x2={x1} y2={dy + Math.sign(off) * 3} />
-      <line x1={x2} y1={y2} x2={x2} y2={dy + Math.sign(off) * 3} />
-      <line x1={x1} y1={dy} x2={x2} y2={dy} />
-      <path d={`M ${x1} ${dy} l ${A} ${-A / 2} l 0 ${A} z`} />
-      <path d={`M ${x2} ${dy} l ${-A} ${-A / 2} l 0 ${A} z`} />
-      <text x={(x1 + x2) / 2} y={dy + (off > 0 ? 12 : -5)} textAnchor="middle" fontSize={10} stroke="none">{label}</text>
-    </g>
-  )
-}
 
 export function ConnectionDetail2D({ conn, hostShape, hostKind, faceType, beamShape }: {
   conn: BeamConnection
@@ -121,7 +85,7 @@ export function ConnectionDetail2D({ conn, hostShape, hostKind, faceType, beamSh
         <line x1={cope ? faceX + cope.lengthMm : faceX} y1={beamTop + tfB} x2={faceX + beamLen} y2={beamTop + tfB} stroke="#475569" />
         <line x1={faceX} y1={beamBot - tfB} x2={faceX + beamLen} y2={beamBot - tfB} stroke="#475569" />
         {cope && (
-          <Dim x1={faceX} y1={beamTop + cope.depthMm} x2={faceX + cope.lengthMm} y2={beamTop + cope.depthMm} off={-(cope.depthMm + 14)} label={`cope ${cope.lengthMm}×${cope.depthMm}`} />
+          <DimBelow xA={faceX} xB={faceX + cope.lengthMm} featY={beamTop + cope.depthMm} dY={beamTop + cope.depthMm + 16} label={`cope ${cope.lengthMm}×${cope.depthMm}`} />
         )}
         {/* plate + weld triangle at the support face */}
         <rect x={faceX} y={plateTop} width={tab.wMm} height={tab.hMm} fill="none" stroke={PLATE} strokeWidth={2.2} />
@@ -135,11 +99,11 @@ export function ConnectionDetail2D({ conn, hostShape, hostKind, faceType, beamSh
             <line x1={faceX + bp.x} y1={boltY(bp.y) - 7} x2={faceX + bp.x} y2={boltY(bp.y) + 7} stroke={BOLT} />
           </g>
         ))}
-        {/* dimensions: plate h (right), a (face→bolt line, below), pitch (right of bolts) */}
-        <Dim x1={faceX + tab.wMm} y1={plateTop} x2={faceX + tab.wMm} y2={plateTop + tab.hMm} off={22} label={`h = ${Math.round(tab.hMm)}`} vertical />
-        <Dim x1={faceX} y1={plateTop + tab.hMm} x2={faceX + a0} y2={plateTop + tab.hMm} off={26} label={`a = ${Math.round(a0)}`} />
+        {/* dimensions (shared architectural-tick primitives, as in the RC schematics) */}
+        <DimSide yA={plateTop} yB={plateTop + tab.hMm} featX={faceX + tab.wMm} dX={faceX + tab.wMm + 24} label={`h = ${Math.round(tab.hMm)}`} side="right" />
+        <DimBelow xA={faceX} xB={faceX + a0} featY={plateTop + tab.hMm} dY={plateTop + tab.hMm + 30} label={`a = ${Math.round(a0)}`} />
         {rows.length > 1 && (
-          <Dim x1={faceX + a0} y1={boltY(rows[1].y)} x2={faceX + a0} y2={boltY(rows[0].y)} off={-24} label={`p = ${conn.bolts.pitchMm}`} vertical />
+          <DimSide yA={boltY(rows[rows.length - 1].y)} yB={boltY(rows[0].y)} featX={faceX + a0 - 10} dX={faceX + a0 - 26} label={`p = ${conn.bolts.pitchMm}`} side="left" />
         )}
         <text x={faceX + tab.wMm / 2} y={plateTop + tab.hMm + 52} textAnchor="middle" fontSize={10} fill={PLATE} fontWeight={600}>
           PL {tab.t}×{tab.wMm}×{Math.round(tab.hMm)}
@@ -165,11 +129,26 @@ export function ConnectionDetail2D({ conn, hostShape, hostKind, faceType, beamSh
           <rect x={cx2 - bfB / 2} y={cy2 + dB / 2 - tfB} width={bfB} height={tfB} />
           <rect x={cx2 - twB / 2} y={cy2 - dB / 2 + tfB} width={twB} height={dB - 2 * tfB} />
         </g>
-        {/* plate against the web + fillet weld triangles top/bottom (to the support) */}
+        {/* plate against the web */}
         <rect x={plateX2} y={cy2 - tab.hMm / 2} width={tab.t + 2} height={tab.hMm} fill={PLATE} />
-        <path d={`M ${plateX2} ${cy2 - tab.hMm / 2} l ${tab.t + 2} 0 l ${-(tab.t + 2) / 2} ${-9} z`} fill={WELD} />
-        <path d={`M ${plateX2} ${cy2 + tab.hMm / 2} l ${tab.t + 2} 0 l ${-(tab.t + 2) / 2} ${9} z`} fill={WELD} />
-        <text x={plateX2 + tab.t + 8} y={cy2 - tab.hMm / 2 - 4} fontSize={9} fill={WELD}>weld to support</text>
+        {conn.connType === 'moment-flange-weld' ? (
+          <>
+            {/* CJP flange welds: beads on TOP of the top flange and UNDER the
+                bottom flange, against the support behind — as built in 3D */}
+            <rect x={cx2 - bfB / 2} y={cy2 - dB / 2 - 6} width={bfB} height={6} fill={WELD} />
+            <rect x={cx2 - bfB / 2} y={cy2 + dB / 2} width={bfB} height={6} fill={WELD} />
+            <text x={cx2 + bfB / 2 + 6} y={cy2 - dB / 2 - 6} fontSize={9} fill={WELD}>CJP flange weld</text>
+            <text x={cx2 + bfB / 2 + 6} y={cy2 + dB / 2 + 12} fontSize={9} fill={WELD}>CJP flange weld</text>
+          </>
+        ) : (
+          <>
+            {/* fin/tab plate: vertical fillet to the support face behind — marked
+                at the plate's support edge */}
+            <path d={`M ${plateX2} ${cy2 - tab.hMm / 2} l ${tab.t + 2} 0 l ${-(tab.t + 2) / 2} ${-9} z`} fill={WELD} />
+            <path d={`M ${plateX2} ${cy2 + tab.hMm / 2} l ${tab.t + 2} 0 l ${-(tab.t + 2) / 2} ${9} z`} fill={WELD} />
+            <text x={plateX2 + tab.t + 8} y={cy2 + tab.hMm / 2 + 14} fontSize={9} fill={WELD}>fillet to support (behind)</text>
+          </>
+        )}
         {/* bolts: shank through web + plate, hex head (plate side) + nut (web side), per row */}
         {rows.map((bp) => {
           const y = cy2 + tab.hMm / 2 - bp.y
@@ -182,18 +161,18 @@ export function ConnectionDetail2D({ conn, hostShape, hostKind, faceType, beamSh
             </g>
           )
         })}
-        {/* single-shear plane callout at the plate ↔ web interface */}
+        {/* single-shear plane callout at the plate ↔ web interface (leader to the left) */}
         {rows.length > 0 && (() => {
-          const y = cy2 + tab.hMm / 2 - rows[rows.length - 1].y
+          const y = cy2 + tab.hMm / 2 - rows[0].y
           return (
             <g>
-              <line x1={plateX2 - 1} y1={y - 26} x2={plateX2 - 1} y2={y + 26} stroke="#dc2626" strokeDasharray="4 3" strokeWidth={1.4} />
-              <line x1={plateX2 - 1} y1={y - 26} x2={plateX2 + 34} y2={y - 40} stroke="#dc2626" strokeWidth={0.9} />
-              <text x={plateX2 + 36} y={y - 42} fontSize={9.5} fill="#dc2626" fontWeight={600}>single shear plane (m = 1)</text>
+              <line x1={plateX2 - 1} y1={y - 20} x2={plateX2 - 1} y2={y + 20} stroke="#dc2626" strokeDasharray="4 3" strokeWidth={1.4} />
+              <line x1={plateX2 - 1} y1={y + 20} x2={cx2 - bfB / 2 - 8} y2={y + 34} stroke="#dc2626" strokeWidth={0.9} />
+              <text x={cx2 - bfB / 2 - 10} y={y + 38} fontSize={9.5} fill="#dc2626" fontWeight={600} textAnchor="end">single shear plane (m = 1)</text>
             </g>
           )
         })()}
-        <Dim x1={plateX2} y1={cy2 + tab.hMm / 2 + 14} x2={plateX2 + tab.t + 2} y2={cy2 + tab.hMm / 2 + 14} off={10} label={`t = ${tab.t}`} />
+        <DimBelow xA={plateX2} xB={plateX2 + tab.t + 2} featY={cy2 + tab.hMm / 2} dY={cy2 + tab.hMm / 2 + 26} label={`t = ${tab.t}`} />
         <text x={cx2} y={H2 - 14} textAnchor="middle" fontSize={10} fill="#334155">
           {beamShape ?? 'beam'} — {conn.bolts.n} × M{conn.bolts.dia} A325, single shear
         </text>

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -1319,6 +1319,14 @@ export default function ModelSpace() {
   const autoOff = useMemo(
     () => (model?.rigidEndZones ? autoRigidOffsets(model, model.rigidZoneFactor ?? 0.5) : null),
     [model])
+  // VISUAL face offsets (factor 1 = the full support face, independent of the
+  // analysis rigid-zone setting): physical steel stops at the member it lands
+  // on — a beam ends at the column face (the tab bridges the gap), and a roof
+  // column extends UP to the top of the deepest beam so the joint hardware has
+  // something to land on.
+  const faceOff = useMemo(
+    () => (model && model.sections.some((s) => s.material === 'steel') ? autoRigidOffsets(model, 1) : null),
+    [model])
   // model bounds → zoom-to-extents on load / after generate
   const modelBox = useMemo(() => {
     if (!model || model.nodes.length === 0) return null
@@ -1485,24 +1493,49 @@ export default function ModelSpace() {
                   const tint = govRes && govRes.Mmax > 1e-9
                     ? (memForce.get(m.id)?.Mmax ?? 0) / govRes.Mmax : 0
                   const sec = sectionFor(m.id)
-                  // rigid end offsets shift the flexible endpoints; manual offsets win over auto
-                  // rigid end zones. Manual → purple arm (eccentric); auto → muted member zone.
-                  const ao = autoOff?.get(m.id)
                   const manI = m.offsets?.iEnd, manJ = m.offsets?.jEnd
+                  const v3 = (v: [number, number, number]) => new THREE.Vector3(v[0], v[1], v[2])
+                  const isSteel = sec?.material === 'steel' && !!sec.shape
+                  if (isSteel && sec?.shape) {
+                    // PHYSICAL steel: a beam ends AT the support face (the tab/weld
+                    // bridges the gap — it never runs inside the column), and a
+                    // column whose stack ends extends UP past the joint to the top
+                    // of the deepest framing beam so the hardware lands on steel.
+                    const fo = faceOff?.get(m.id)
+                    let aV = a, bV = bb
+                    if (m.role === 'column') {
+                      const contAt = (nid: string) => model.members.some((o) => o.id !== m.id && o.role === 'column' && (o.i === nid || o.j === nid))
+                      aV = manI ? a.clone().add(v3(manI)) : (fo?.offI && !contAt(m.i) ? a.clone().sub(v3(fo.offI)) : a)
+                      bV = manJ ? bb.clone().add(v3(manJ)) : (fo?.offJ && !contAt(m.j) ? bb.clone().sub(v3(fo.offJ)) : bb)
+                    } else {
+                      aV = manI ? a.clone().add(v3(manI)) : (fo?.offI ? a.clone().add(v3(fo.offI)) : a)
+                      bV = manJ ? bb.clone().add(v3(manJ)) : (fo?.offJ ? bb.clone().add(v3(fo.offJ)) : bb)
+                    }
+                    return (
+                      <group key={m.id}>
+                        <MemberSteel3D a={aV} b={bV} role={m.role} shapeName={sec.shape} axisRotation={m.axisRotation}
+                          tint={tint * 0.85} selected={m.id === selected} onPick={() => setSelected(m.id)} />
+                        {manI && <RigidArm3D a={a} b={aV} />}
+                        {manJ && <RigidArm3D a={bb} b={bV} />}
+                      </group>
+                    )
+                  }
+                  // Concrete (monolithic): rigid end offsets shift the flexible endpoints;
+                  // manual → purple arm (eccentric); auto → muted member zone.
+                  const ao = autoOff?.get(m.id)
                   const effI = manI ?? ao?.offI, effJ = manJ ?? ao?.offJ
-                  const aEff = effI ? a.clone().add(new THREE.Vector3(effI[0], effI[1], effI[2])) : a
-                  const bEff = effJ ? bb.clone().add(new THREE.Vector3(effJ[0], effJ[1], effJ[2])) : bb
-                  const memberEl = sec?.material === 'steel' && sec.shape
-                    ? <MemberSteel3D a={aEff} b={bEff} role={m.role} shapeName={sec.shape} axisRotation={m.axisRotation}
-                        tint={tint * 0.85} selected={m.id === selected} onPick={() => setSelected(m.id)} />
-                    : <Member3D a={aEff} b={bEff} role={m.role} tint={tint * 0.85}
-                        sec={sec} selected={m.id === selected} onPick={() => setSelected(m.id)} />
+                  const aEff = effI ? a.clone().add(v3(effI)) : a
+                  const bEff = effJ ? bb.clone().add(v3(effJ)) : bb
+                  const memberEl = (
+                    <Member3D a={aEff} b={bEff} role={m.role} tint={tint * 0.85}
+                      sec={sec} selected={m.id === selected} onPick={() => setSelected(m.id)} />
+                  )
                   if (!effI && !effJ) return <group key={m.id}>{memberEl}</group>
                   return (
                     <group key={m.id}>
                       {memberEl}
-                      {effI && (manI ? <RigidArm3D a={a} b={aEff} /> : <RigidZone3D a={a} b={aEff} role={m.role} sec={sec} shapeName={sec?.material === 'steel' ? sec.shape : undefined} />)}
-                      {effJ && (manJ ? <RigidArm3D a={bb} b={bEff} /> : <RigidZone3D a={bb} b={bEff} role={m.role} sec={sec} shapeName={sec?.material === 'steel' ? sec.shape : undefined} />)}
+                      {effI && (manI ? <RigidArm3D a={a} b={aEff} /> : <RigidZone3D a={a} b={aEff} role={m.role} sec={sec} />)}
+                      {effJ && (manJ ? <RigidArm3D a={bb} b={bEff} /> : <RigidZone3D a={bb} b={bEff} role={m.role} sec={sec} />)}
                     </group>
                   )
                 })}


### PR DESCRIPTION
## What (round-2 feedback on the steel joints, part 2 of 2 — part 1: #311)

### 3D — steel members render as *physical* steel

- **Beams/girders end AT the support face.** A visual face trim (from
  `autoRigidOffsets` at factor 1, independent of the analysis rigid-zone
  setting) stops the member at the column/girder face instead of running to
  the node centreline inside the column. The tab/weld bridges the gap —
  exactly where the 3D hardware already sits.
- **Roof columns extend to the beam top.** A column whose stack ends at a
  joint extends up past the node to the top of the deepest framing beam, so
  the flange welds/bolts land on steel. Intermediate columns keep meeting at
  the node (continuous stack — uniform section per #311).
- Rigid-zone stubs are no longer drawn for steel (they're analytical, not
  physical); manual eccentric offsets keep their purple arms. Concrete keeps
  the monolithic zone rendering.

### 2D detail drawing

- **Dimension lines reuse `dims.tsx`** — the shared architectural-tick
  primitives (`DimBelow`/`DimSide`) the RC schematics use — for plate `h`,
  bolt line `a`, pitch `p`, plate `t` and the cope `L×D`.
- **Section-view weld corrected**: moment connections now show the CJP beads
  **on top of the top flange and under the bottom flange** against the
  support behind — matching the 3D view — while fin/shear tabs keep the
  vertical-fillet marks at the plate. The single-shear leader moved to the
  left; no more overlapping labels.

## Verification

- `npx tsc -b` clean · `npm test` — **991 passed** · build OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_