### PR TITLE
fix: connection drawing round 3 — full-height tab weld, 3D plate, units, flex panels

### DIFF
--- a/webapp/src/components/ConnectionDetail2D.tsx
+++ b/webapp/src/components/ConnectionDetail2D.tsx
@@ -62,10 +62,13 @@ export function ConnectionDetail2D({ conn, hostShape, hostKind, faceType, beamSh
   const sc = 0.55                     // mm → px
 
   return (
-    <div className="flex flex-wrap gap-4">
+    <div className="flex w-full flex-wrap items-start gap-4 [&>svg]:min-w-[260px] [&>svg]:flex-1">
       {/* ELEVATION */}
-      <svg viewBox={`0 0 ${W} ${H}`} width={W * sc} height={H * sc} className="rounded-lg border border-slate-200 bg-white">
+      <svg viewBox={`0 0 ${W} ${H}`} className="h-auto w-full rounded-lg border border-slate-200 bg-white" style={{ maxWidth: W * sc }}>
         <text x={W / 2} y={16} textAnchor="middle" fontSize={13} fontWeight={700} fill="#0f172a">ELEVATION</text>
+        <text x={W / 2} y={30} textAnchor="middle" fontSize={9} fill="#64748b">
+          single plate — welded to the {hostKind === 'girder' ? 'girder web' : `column ${faceType}`}, bolted to the beam web (mm)
+        </text>
         {/* support (column band / girder web) */}
         <rect x={cx} y={20} width={hostW} height={H - 40} fill={STEEL} opacity={0.5} stroke="#475569" />
         {hostKind === 'column' && faceType === 'flange' && (
@@ -85,12 +88,25 @@ export function ConnectionDetail2D({ conn, hostShape, hostKind, faceType, beamSh
         <line x1={cope ? faceX + cope.lengthMm : faceX} y1={beamTop + tfB} x2={faceX + beamLen} y2={beamTop + tfB} stroke="#475569" />
         <line x1={faceX} y1={beamBot - tfB} x2={faceX + beamLen} y2={beamBot - tfB} stroke="#475569" />
         {cope && (
-          <DimBelow xA={faceX} xB={faceX + cope.lengthMm} featY={beamTop + cope.depthMm} dY={beamTop + cope.depthMm + 16} label={`cope ${cope.lengthMm}×${cope.depthMm}`} />
+          <DimBelow xA={faceX} xB={faceX + cope.lengthMm} featY={beamTop + cope.depthMm} dY={beamTop + cope.depthMm + 16} label={`cope ${cope.lengthMm}×${cope.depthMm} mm`} />
         )}
-        {/* plate + weld triangle at the support face */}
+        {/* plate: WELDED to the support along its FULL height (fillet both sides),
+            BOLTED to the beam web — the gold bead runs the whole plate edge */}
         <rect x={faceX} y={plateTop} width={tab.wMm} height={tab.hMm} fill="none" stroke={PLATE} strokeWidth={2.2} />
+        <rect x={faceX - 2.5} y={plateTop} width={5} height={tab.hMm} fill={WELD} />
         <path d={`M ${faceX} ${plateTop - 9} l 11 9 l -11 0 z`} fill={WELD} />
-        <text x={faceX + 14} y={plateTop - 11} fontSize={9} fill={WELD}>{tab.weldSizeMm} mm E70 fillet, 2 sides</text>
+        <text x={faceX + 14} y={plateTop - 11} fontSize={9} fill={WELD}>
+          {tab.weldSizeMm} mm E70 fillet × {Math.round(tab.hMm)} mm, both sides (full plate height)
+        </text>
+        {conn.connType === 'moment-flange-weld' && (
+          <>
+            {/* CJP flange welds at the column face — matching the SECTION and the 3D view */}
+            <path d={`M ${faceX} ${beamTop} l 14 0 l -14 -11 z`} fill={WELD} />
+            <path d={`M ${faceX} ${beamBot} l 14 0 l -14 11 z`} fill={WELD} />
+            <text x={faceX + 17} y={beamTop - 4} fontSize={9} fill={WELD}>CJP flange weld</text>
+            <text x={faceX + 17} y={beamBot + 12} fontSize={9} fill={WELD}>CJP flange weld</text>
+          </>
+        )}
         {/* bolts at the designed layout */}
         {rows.map((bp) => (
           <g key={bp.id}>
@@ -100,13 +116,13 @@ export function ConnectionDetail2D({ conn, hostShape, hostKind, faceType, beamSh
           </g>
         ))}
         {/* dimensions (shared architectural-tick primitives, as in the RC schematics) */}
-        <DimSide yA={plateTop} yB={plateTop + tab.hMm} featX={faceX + tab.wMm} dX={faceX + tab.wMm + 24} label={`h = ${Math.round(tab.hMm)}`} side="right" />
-        <DimBelow xA={faceX} xB={faceX + a0} featY={plateTop + tab.hMm} dY={plateTop + tab.hMm + 30} label={`a = ${Math.round(a0)}`} />
+        <DimSide yA={plateTop} yB={plateTop + tab.hMm} featX={faceX + tab.wMm} dX={faceX + tab.wMm + 24} label={`h = ${Math.round(tab.hMm)} mm`} side="right" />
+        <DimBelow xA={faceX} xB={faceX + a0} featY={plateTop + tab.hMm} dY={plateTop + tab.hMm + 30} label={`a = ${Math.round(a0)} mm`} />
         {rows.length > 1 && (
-          <DimSide yA={boltY(rows[rows.length - 1].y)} yB={boltY(rows[0].y)} featX={faceX + a0 - 10} dX={faceX + a0 - 26} label={`p = ${conn.bolts.pitchMm}`} side="left" />
+          <DimSide yA={boltY(rows[rows.length - 1].y)} yB={boltY(rows[0].y)} featX={faceX + a0 - 10} dX={faceX + a0 - 26} label={`p = ${conn.bolts.pitchMm} mm`} side="left" />
         )}
         <text x={faceX + tab.wMm / 2} y={plateTop + tab.hMm + 52} textAnchor="middle" fontSize={10} fill={PLATE} fontWeight={600}>
-          PL {tab.t}×{tab.wMm}×{Math.round(tab.hMm)}
+          PL {tab.t}×{tab.wMm}×{Math.round(tab.hMm)} mm
         </text>
         {/* Vu arrow */}
         <line x1={faceX + beamLen - 32} y1={beamTop - 28} x2={faceX + beamLen - 32} y2={beamTop - 6} stroke="#dc2626" strokeWidth={2} />
@@ -115,7 +131,7 @@ export function ConnectionDetail2D({ conn, hostShape, hostKind, faceType, beamSh
       </svg>
 
       {/* END SECTION */}
-      <svg viewBox={`0 0 ${W2} ${H2}`} width={W2 * sc} height={H2 * sc} className="rounded-lg border border-slate-200 bg-white">
+      <svg viewBox={`0 0 ${W2} ${H2}`} className="h-auto w-full rounded-lg border border-slate-200 bg-white" style={{ maxWidth: W2 * sc }}>
         <text x={W2 / 2} y={16} textAnchor="middle" fontSize={13} fontWeight={700} fill="#0f172a">SECTION</text>
         {/* support face behind: column flange (or girder web edge-band) */}
         <rect x={cx2 - supW / 2} y={cy2 - dB / 2 - 34} width={supW} height={dB + 68}
@@ -164,15 +180,16 @@ export function ConnectionDetail2D({ conn, hostShape, hostKind, faceType, beamSh
         {/* single-shear plane callout at the plate ↔ web interface (leader to the left) */}
         {rows.length > 0 && (() => {
           const y = cy2 + tab.hMm / 2 - rows[0].y
+          const lx = 8, ly = H2 - 34   // label INSIDE the frame, bottom-left
           return (
             <g>
               <line x1={plateX2 - 1} y1={y - 20} x2={plateX2 - 1} y2={y + 20} stroke="#dc2626" strokeDasharray="4 3" strokeWidth={1.4} />
-              <line x1={plateX2 - 1} y1={y + 20} x2={cx2 - bfB / 2 - 8} y2={y + 34} stroke="#dc2626" strokeWidth={0.9} />
-              <text x={cx2 - bfB / 2 - 10} y={y + 38} fontSize={9.5} fill="#dc2626" fontWeight={600} textAnchor="end">single shear plane (m = 1)</text>
+              <line x1={plateX2 - 1} y1={y + 20} x2={lx + 66} y2={ly - 10} stroke="#dc2626" strokeWidth={0.9} />
+              <text x={lx} y={ly} fontSize={9.5} fill="#dc2626" fontWeight={600}>single shear plane (m = 1)</text>
             </g>
           )
         })()}
-        <DimBelow xA={plateX2} xB={plateX2 + tab.t + 2} featY={cy2 + tab.hMm / 2} dY={cy2 + tab.hMm / 2 + 26} label={`t = ${tab.t}`} />
+        <DimBelow xA={plateX2} xB={plateX2 + tab.t + 2} featY={cy2 + tab.hMm / 2} dY={cy2 + tab.hMm / 2 + 26} label={`t = ${tab.t} mm`} />
         <text x={cx2} y={H2 - 14} textAnchor="middle" fontSize={10} fill="#334155">
           {beamShape ?? 'beam'} — {conn.bolts.n} × M{conn.bolts.dia} A325, single shear
         </text>

--- a/webapp/src/components/JointConnections3D.tsx
+++ b/webapp/src/components/JointConnections3D.tsx
@@ -44,11 +44,13 @@ function Bolt({ p, axis, dia, len }: { p: THREE.Vector3; axis: THREE.Vector3; di
 
 /** One beam's connection hardware at a joint. `faceOff` = distance from the
  *  joint node to the supporting face along the beam axis (m). */
-function Connection({ conn, node, beamDir, faceOff }: {
+function Connection({ conn, node, beamDir, faceOff, beamTw }: {
   conn: BeamConnection
   node: THREE.Vector3
   beamDir: THREE.Vector3          // unit, node → beam span
   faceOff: number
+  /** supported beam's web thickness, m (actual shape value). */
+  beamTw?: number
 }) {
   const parts = useMemo(() => {
     const ex = beamDir.clone()                                   // along the beam
@@ -57,7 +59,7 @@ function Connection({ conn, node, beamDir, faceOff }: {
 
     const tab = conn.tab
     const t = tab.t * MM, w = tab.wMm * MM, h = tab.hMm * MM
-    const twb = 0.008              // nominal beam web thickness for bolt lengths, m
+    const twb = beamTw ?? 0.008    // beam web thickness for plate offset / bolt lengths, m
     const plateCtr = F.clone()
       .add(ex.clone().multiplyScalar(w / 2))
       .add(ez.clone().multiplyScalar(twb / 2 + t / 2))
@@ -71,7 +73,7 @@ function Connection({ conn, node, beamDir, faceOff }: {
     }))
 
     return { ex, ez, F, plate: { ctr: plateCtr, t, w, h }, bolts }
-  }, [conn, node, beamDir, faceOff])
+  }, [conn, node, beamDir, faceOff, beamTw])
 
   const { ex, ez, F, plate, bolts } = parts
   // orient a unit box so local X→ex, Y→up, Z→ez (right-handed by construction)
@@ -85,7 +87,12 @@ function Connection({ conn, node, beamDir, faceOff }: {
       {/* shear tab plate (every connection has one — moment conns tab the web too) */}
       <mesh position={plate.ctr} quaternion={boxQuat}>
         <boxGeometry args={[plate.w, plate.h, plate.t]} />
-        <meshStandardMaterial color={PLATE} metalness={0.3} roughness={0.55} />
+        <meshStandardMaterial color="#475569" metalness={0.35} roughness={0.5} />
+      </mesh>
+      {/* full-height fillet weld bead: plate → support face (both sides drawn as one gold strip) */}
+      <mesh position={F.clone().add(ex.clone().multiplyScalar(0.006)).add(ez.clone().multiplyScalar(plate.t))} quaternion={boxQuat}>
+        <boxGeometry args={[0.012, plate.h, plate.t + 0.012]} />
+        <meshStandardMaterial color={BOLT} metalness={0.5} roughness={0.4} />
       </mesh>
       {bolts.map((b) => (
         <Bolt key={b.id} p={b.p.clone().add(ez.clone().multiplyScalar(plate.t / 2))} axis={ez} dia={conn.bolts.dia} len={b.len} />
@@ -125,7 +132,8 @@ export function JointConnections3D({ joints, beamJoints = [], model, nodePos }: 
     if (dir.lengthSq() < 1e-9) return null
     const sec = secMap.get(mem.section)
     if (sec?.material !== 'steel') return null
-    return <Connection key={c.beamId} conn={c} node={P} beamDir={dir.normalize()} faceOff={faceOff} />
+    const beamTw = sec.shape ? (shapeByName(sec.shape)?.tw ?? 8) * MM : undefined
+    return <Connection key={c.beamId} conn={c} node={P} beamDir={dir.normalize()} faceOff={faceOff} beamTw={beamTw} />
   }
 
   return (

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -4022,7 +4022,7 @@ export default function ModelSpace() {
                       open && (
                         <tr key={`${key}:detail`}>
                           <td colSpan={12} className="bg-slate-50/60 px-2 pb-2">
-                            <div className="grid grid-cols-1 gap-3 xl:grid-cols-[auto_1fr]">
+                            <div className="grid w-full grid-cols-1 gap-3 xl:grid-cols-[minmax(0,1fr)_minmax(0,1.15fr)]">
                               <ConnectionDetail2D conn={c} hostShape={j.columnShape} hostKind="column" faceType={c.faceType} beamShape={beamShapeName} />
                               {wantSol && <WorkedSolution steps={connectionRowSolution(c, { kind: 'column', shape: j.columnShape, faceType: c.faceType })} title={`Connection ${j.nodeId} · ${c.beamId} — worked solution`} />}
                             </div>
@@ -4074,7 +4074,7 @@ export default function ModelSpace() {
                       open && (
                         <tr key={`${key}:detail`}>
                           <td colSpan={12} className="bg-slate-50/60 px-2 pb-2">
-                            <div className="grid grid-cols-1 gap-3 xl:grid-cols-[auto_1fr]">
+                            <div className="grid w-full grid-cols-1 gap-3 xl:grid-cols-[minmax(0,1fr)_minmax(0,1.15fr)]">
                               <ConnectionDetail2D conn={c} hostShape={bj.girderShape} hostKind="girder" faceType="web" beamShape={beamShapeName} />
                               {wantSol && <WorkedSolution steps={connectionRowSolution(c, { kind: 'girder', shape: bj.girderShape })} title={`Connection ${bj.nodeId} · ${c.beamId} — worked solution`} />}
                             </div>


### PR DESCRIPTION
## What (round-3 feedback)

**"How is the plate connected to the column?"** — It's a **single plate
(shear tab), fillet-welded to the support along the plate's full height on
both sides, and bolted to the beam web** (not an angle cleat). The drawings
now state and draw exactly that:

- **Elevation** — the gold weld bead runs the **whole plate support edge**
  (the previous lone corner triangle was only a weld *symbol* and read like a
  corner weld); the note reads "`w` mm E70 fillet × `h` mm, both sides (full
  plate height)"; a subtitle spells out *"single plate — welded to the column
  flange/web (or girder web), bolted to the beam web"*. **Moment connections
  add the CJP flange-weld marks at the column face**, so elevation, section
  and 3D finally agree.
- **3D** — the tab plate is now clearly visible: lighter slate, positioned
  off the beam's **actual** web thickness (from its AISC shape, not a nominal
  8 mm), plus a **full-height gold weld bead** at the support face. Plate +
  weld + bolts all present, matching the 2D.
- **Units** — every elevation dimension and label carries mm.
- **Clipped label** — "single shear plane (m = 1)" anchored inside the frame
  (bottom-left, leader up to the interface).
- **Flexible panels** — SVGs scale to their container via viewBox (capped at
  natural size), the two views flex-wrap, and the schedule expansion grid
  uses `minmax` columns. No wasted space.

## Verification

- `npx tsc -b` clean · `npm test` — **991 passed** · build OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_