### PR TITLE
feat: bar-diameter continuity guards — one Ø per beam run and column stack

### DIFF
--- a/webapp/src/engine/meshValidation.ts
+++ b/webapp/src/engine/meshValidation.ts
@@ -20,6 +20,7 @@
 // valid model with a false error.
 // ─────────────────────────────────────────────────────────────────────────
 import type { StructuralModel } from './model'
+import { barContinuityGroups } from './modelBuilder'
 
 export type MeshSeverity = 'error' | 'warning'
 export interface MeshIssue {
@@ -68,6 +69,18 @@ export function validateMesh(model: StructuralModel): MeshIssue[] {
     if (prev) issues.push({ severity: 'warning', code: 'duplicate-member', refs: [prev, m.id],
       message: `Members ${prev} and ${m.id} span the same nodes — stiffness is doubled.` })
     else pairSeen.set(key, m.id)
+  }
+
+  // ── bar-diameter continuity (advisory): a continuous beam line or column
+  // stack should carry ONE main-bar Ø — bars pass through the joint / splice
+  // storey to storey. Bar count may differ per span (cuts and splices). ──────
+  const secDia = new Map(model.sections.map((s) => [s.id, s.barDia]))
+  const memSec = new Map(model.members.map((m) => [m.id, m.section]))
+  for (const group of barContinuityGroups(model)) {
+    const dias = [...new Set(group.map((id) => secDia.get(memSec.get(id) ?? '') ?? 0))].filter((d) => d > 0)
+    if (dias.length > 1)
+      issues.push({ severity: 'warning', code: 'bar-dia-discontinuity', refs: group,
+        message: `Members ${group.join(', ')} form a continuous run/stack but mix main-bar diameters (⌀${dias.sort((a, b) => a - b).join(', ⌀')}) — use one Ø through the joint; vary the bar COUNT per span instead.` })
   }
 
   // ── coincident distinct nodes (advisory: usually an unmerged mesh) ───────

--- a/webapp/src/engine/modelBuilder.test.ts
+++ b/webapp/src/engine/modelBuilder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { generateGridModel, removeElements, nodeId, buildGravityLoads, enforceSectionHierarchy } from './modelBuilder'
+import { generateGridModel, removeElements, nodeId, buildGravityLoads, enforceSectionHierarchy, barContinuityGroups } from './modelBuilder'
 import type { RectSection } from './model'
 
 const sec: RectSection = { id: 'S1', name: '300×500', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
@@ -122,5 +122,35 @@ describe('enforceSectionHierarchy — column-stack continuity', () => {
     const once = enforceSectionHierarchy(m)
     const twice = enforceSectionHierarchy(once)
     expect(JSON.stringify(twice.sections)).toBe(JSON.stringify(once.sections))
+  })
+})
+
+
+describe('barContinuityGroups — one bar Ø per beam run / column stack', () => {
+  const rc = (id: string, b: number, h: number): RectSection =>
+    ({ id, name: `${b}×${h}`, b, h, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 })
+
+  it('collinear beam spans through a joint form one run; girders form their own', () => {
+    const m = generateGridModel({ baysX: [6, 6], baysZ: [5], storeyH: [3], section: rc('S', 300, 500) })
+    const groups = barContinuityGroups(m)
+    // the two X-spans on each Z-line are collinear through the middle column
+    const bxRun = groups.find((g) => g.includes('bx0.0.1') && g.includes('bx1.0.1'))
+    expect(bxRun).toBeTruthy()
+    // a girder never joins a perpendicular beam run
+    expect(bxRun!.some((id) => id.startsWith('bz'))).toBe(false)
+  })
+
+  it('column segments on one plan position form a stack group', () => {
+    const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3, 3], section: rc('S', 300, 500) })
+    const groups = barContinuityGroups(m)
+    const stack = groups.find((g) => g.includes('c0.0.0') && g.includes('c0.0.1'))
+    expect(stack).toBeTruthy()
+    expect(stack!.every((id) => id.startsWith('c0.0.'))).toBe(true)
+  })
+
+  it('steel members are excluded (bar diameters are an RC concern)', () => {
+    const m = generateGridModel({ baysX: [6, 6], baysZ: [5], storeyH: [3], section: rc('S', 300, 500) })
+    m.sections = m.sections.map((s) => ({ ...s, material: 'steel' as const, shape: 'W310x79' }))
+    expect(barContinuityGroups(m)).toHaveLength(0)
   })
 })

--- a/webapp/src/engine/modelBuilder.ts
+++ b/webapp/src/engine/modelBuilder.ts
@@ -319,3 +319,70 @@ export function enforceSectionHierarchy(model: StructuralModel): StructuralModel
 
   return { ...model, sections: model.sections.map((s) => { const u = sec.get(s.id)!; return { ...u, name: u.material === 'steel' && u.shape ? u.shape : `${u.b}×${u.h}` } }) }
 }
+
+/**
+ * Bar-diameter CONTINUITY groups (concrete members only): the member sets that
+ * must share one main-bar diameter for buildable joint detailing —
+ *  · a continuous BEAM/GIRDER line: collinear spans running through shared
+ *    joints (top/bottom bars pass through or anchor into the same column), and
+ *  · a COLUMN STACK: segments on one plan position (verticals are spliced
+ *    storey to storey — mixed diameters complicate the splice).
+ * Bar COUNT stays free per span/section (cuts and splices). Returns groups of
+ * member ids with ≥ 2 members.
+ */
+export function barContinuityGroups(model: StructuralModel): string[][] {
+  const nodeById = new Map(model.nodes.map((n) => [n.id, n]))
+  const steelSec = new Set(model.sections.filter((s) => s.material === 'steel').map((s) => s.id))
+  const mems = model.members.filter((m) => !steelSec.has(m.section))
+
+  const parent = new Map<string, string>()
+  const find = (x: string): string => {
+    let r = x
+    while (parent.get(r) !== r) r = parent.get(r)!
+    while (parent.get(x) !== r) { const nx = parent.get(x)!; parent.set(x, r); x = nx }
+    return r
+  }
+  const union = (a: string, b: string) => { parent.set(find(a), find(b)) }
+  for (const m of mems) parent.set(m.id, m.id)
+
+  // column stacks (same plan position, vertical)
+  const stacks = new Map<string, string[]>()
+  for (const m of mems) {
+    if (m.role !== 'column') continue
+    const a = nodeById.get(m.i), b = nodeById.get(m.j)
+    if (!a || !b) continue
+    if (Math.abs(a.x - b.x) > 1e-4 || Math.abs(a.z - b.z) > 1e-4) continue
+    const key = `${Math.round(a.x * 1e3)},${Math.round(a.z * 1e3)}`
+    ;(stacks.get(key) ?? stacks.set(key, []).get(key)!).push(m.id)
+  }
+  for (const ids of stacks.values()) for (let i = 1; i < ids.length; i++) union(ids[0], ids[i])
+
+  // beam/girder runs: collinear continuation through a shared node
+  const flexAt = new Map<string, Member[]>()
+  for (const m of mems) {
+    if (m.role !== 'beam' && m.role !== 'girder') continue
+    for (const n of [m.i, m.j]) (flexAt.get(n) ?? flexAt.set(n, []).get(n)!).push(m)
+  }
+  const outDir = (m: Member, nid: string): [number, number] | null => {
+    const a = nodeById.get(nid), b = nodeById.get(m.i === nid ? m.j : m.i)
+    if (!a || !b) return null
+    const dx = b.x - a.x, dz = b.z - a.z
+    const L = Math.hypot(dx, dz)
+    return L > 1e-9 ? [dx / L, dz / L] : null
+  }
+  for (const [nid, list] of flexAt) {
+    for (let i = 0; i < list.length; i++)
+      for (let j = i + 1; j < list.length; j++) {
+        const da = outDir(list[i], nid), db = outDir(list[j], nid)
+        if (da && db && da[0] * db[0] + da[1] * db[1] < -0.999) union(list[i].id, list[j].id)
+      }
+  }
+
+  const groups = new Map<string, string[]>()
+  for (const m of mems) {
+    if (m.role !== 'column' && m.role !== 'beam' && m.role !== 'girder') continue
+    const r = find(m.id)
+    ;(groups.get(r) ?? groups.set(r, []).get(r)!).push(m.id)
+  }
+  return [...groups.values()].filter((g) => g.length >= 2)
+}

--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { generateGridModel, buildGravityLoads, removeNode, enforceSectionHierarchy, refreshSelfWeight, splitSharedSections } from './modelBuilder'
-import { designStructure, optimizeStructure, designOK, RC_LIMITS, type LateralCase } from './pipeline'
+import { generateGridModel, buildGravityLoads, removeNode, enforceSectionHierarchy, refreshSelfWeight, splitSharedSections, barContinuityGroups } from './modelBuilder'
+import { designStructure, optimizeStructure, selectBarDiameters, designOK, RC_LIMITS, type LateralCase } from './pipeline'
 import { nextHeavierW } from './aiscSections'
 import { computeSeismic } from './seismic'
+import { validateMesh } from './meshValidation'
 import type { RectSection, ModelLoad } from './model'
 
 const section: RectSection = { id: 'S1', name: '300×500', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
@@ -542,6 +543,39 @@ describe('optimizeStructure — termination guards (hierarchy revert / catalog t
     expect(r.design.beams.every((b) => b.ok)).toBe(true)
     expect(r.stopReason).toContain('cannot fix')
     expect(r.stopReason).toContain('footing')
+  })
+})
+
+describe('bar-diameter continuity guard (selectBarDiameters)', () => {
+  it('a continuous beam line and each column stack end with ONE bar Ø (count may differ)', () => {
+    // 2×1 bays, 2 storeys: multi-span beam lines + column stacks; mixed start Øs
+    const m = generateGridModel({ baysX: [6, 6], baysZ: [5], storeyH: [3, 3], section, slabThickness: 200 })
+    m.loads = m.plates.flatMap((p) => [
+      { kind: 'area' as const, plate: p.id, q: 4.8, cat: 'D' as const },
+      { kind: 'area' as const, plate: p.id, q: 2.4, cat: 'L' as const },
+    ])
+    m.sections.find((s) => s.id === 'bx0.0.1')!.barDia = 25   // one span Ø25, its continuation Ø20
+    m.sections.find((s) => s.id === 'c0.0.0')!.barDia = 28    // stack base Ø28, upper Ø20
+    const out = selectBarDiameters(m, soil)
+    const secOf = (id: string) => out.sections.find((s) => s.id === id)!
+    for (const g of barContinuityGroups(out)) {
+      const dias = new Set(g.map((mid) => secOf(out.members.find((x) => x.id === mid)!.section).barDia))
+      expect(dias.size).toBe(1)
+    }
+  }, 120_000)
+})
+
+describe('meshValidation — bar-diameter discontinuity warning', () => {
+  it('flags a continuous run mixing Ø25 and Ø20; silent when uniform', () => {
+    const m = generateGridModel({ baysX: [6, 6], baysZ: [5], storeyH: [3], section })
+    expect(validateMesh(m).filter((i) => i.code === 'bar-dia-discontinuity')).toHaveLength(0)
+    m.sections.find((s) => s.id === 'bx0.0.1')!.barDia = 25
+    const issues = validateMesh(m).filter((i) => i.code === 'bar-dia-discontinuity')
+    expect(issues.length).toBeGreaterThanOrEqual(1)
+    expect(issues[0].severity).toBe('warning')
+    expect(issues[0].refs).toContain('bx0.0.1')
+    expect(issues[0].message).toContain('⌀20')
+    expect(issues[0].message).toContain('⌀25')
   })
 })
 

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -8,7 +8,7 @@
 // Every stage reuses the existing engines unchanged.
 // ─────────────────────────────────────────────────────────────────────────
 import type { StructuralModel, RectSection, ModelLoad } from './model'
-import { enforceSectionHierarchy, refreshSelfWeight } from './modelBuilder'
+import { enforceSectionHierarchy, refreshSelfWeight, barContinuityGroups } from './modelBuilder'
 import { modelToFrame3D } from './modelBridge'
 import { precomputeFrame, solveWithGeometry, applyF3Combo, serializePrecomp, type F3Result, type F3MemberResult, type F3Load } from './frame3d'
 import type { BridgeResult } from './modelBridge'
@@ -1097,6 +1097,24 @@ export function selectBarDiameters(
     for (const db of ladder(BAR_LADDER_COLUMN, sec.barDia)) {
       const r = designColumnFromPM({ ...sec, barDia: db }, row.Pu, row.Mu)
       if (r.ok && columnBarsFit(sec, db, r.bars)) { if (db !== sec.barDia) chosen.set(sec.id, db); break }
+    }
+  }
+
+  // ── Bar-diameter continuity guard: one Ø through each continuous beam line
+  // and each column stack — bars run through the joint / splice storey to
+  // storey, so a Ø25 span meeting a Ø20 span at the same column is a detailing
+  // error. The group adopts its LARGEST required diameter; bar COUNT stays
+  // free per section (cuts and splices handle the difference). This also
+  // repairs user-set mismatches whenever bar selection runs.
+  for (const group of barContinuityGroups(model)) {
+    const diaOf = (mid: string) => {
+      const sec = secById.get(memSecId.get(mid) ?? '')
+      return sec ? (chosen.get(sec.id) ?? sec.barDia) : 0
+    }
+    const dmax = Math.max(...group.map(diaOf))
+    for (const mid of group) {
+      const sec = secById.get(memSecId.get(mid) ?? '')
+      if (sec && diaOf(mid) !== dmax) chosen.set(sec.id, dmax)
     }
   }
 


### PR DESCRIPTION
## What (user request)

A Ø25 beam continuing past a column into a Ø20 span — or a column stack
splicing Ø28 onto Ø20 verticals — is a joint-detailing error: the main bars
run **through** the joint (beams) or splice storey-to-storey (columns). Bar
**count** may still differ per span/section via cuts and splices; the
**diameter** may not.

## Guards

- **`barContinuityGroups`** (modelBuilder) — union-find grouping of concrete
  members into continuous **beam/girder lines** (collinear spans through
  shared joints) and **column stacks** (one plan position). Steel members are
  excluded (bar diameters are an RC concern).
- **`selectBarDiameters`** — after the per-member economic pick, every group
  is unified to its **largest required Ø**; the section designers then choose
  the bar count per span as before. This also repairs user-set mismatches
  whenever bar selection runs (Design/Optimize with "try alternative bar
  sizes"). A marginal section that dislikes the bigger bar (smaller effective
  d) is caught by the normal `designOK` gate and the optimizer grows it.
- **`meshValidation`** — advisory `bar-dia-discontinuity` warning whenever a
  run/stack mixes diameters, so hand-edited models get flagged **before**
  analysis without being force-changed.

## Tests (5 new)

- Grouping: collinear X-spans form one run that never absorbs perpendicular
  girders; storey segments form a stack; all-steel models produce no groups.
- Property test: after `selectBarDiameters` on a 2-bay × 2-storey grid seeded
  with mixed Øs (25/20 beams, 28/20 columns), **every** continuity group ends
  with exactly one diameter.
- Validation: warning fires on a mixed run (lists ⌀20, ⌀25), silent when
  uniform.

## Verification

- `npx tsc -b` clean · `npm test` — **999 passed** (994 + 5) · build OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_