### PR TITLE
fix: bolt-layout renderer + web/flange pairing drives the connection type

### DIFF
--- a/webapp/src/components/ConnectionDetail2D.tsx
+++ b/webapp/src/components/ConnectionDetail2D.tsx
@@ -46,7 +46,10 @@ export function ConnectionDetail2D({ conn, hostShape, hostKind, faceType, beamSh
   // ── elevation view geometry (mm coordinate space, y down = SVG) ──
   const W = hostW + beamLen + 120, H = Math.max(dB, tab.hMm) + 190
   const cx = 40                       // host left edge
-  const faceX = cx + hostW            // support face
+  const faceX = cx + hostW            // support face (flange tips for a web conn)
+  // where the plate WELDS: a column-web connection welds at the web centreline
+  // and the plate extends past the flange tips to the bolts (engine aMm)
+  const weldX = hostKind === 'column' && faceType === 'web' ? cx + hostW / 2 : faceX
   const cy = H / 2                    // beam centreline
   const beamTop = cy - dB / 2, beamBot = cy + dB / 2
   const plateTop = cy - tab.hMm / 2
@@ -54,7 +57,11 @@ export function ConnectionDetail2D({ conn, hostShape, hostKind, faceType, beamSh
   const a0 = rows[0]?.x ?? 60
 
   // ── end-section view ──
-  const supW = hostKind === 'girder' ? 30 : Math.max(bfB + 60, (g.host?.bf ?? 254))
+  // looking along the beam: a FLANGE conn shows the column flange (bf wide);
+  // a WEB conn shows the column depth d with both flanges edge-on at the sides
+  const supW = hostKind === 'girder' ? 30
+    : faceType === 'web' ? Math.max((g.host?.d ?? 300), bfB + 60)
+    : Math.max(bfB + 60, (g.host?.bf ?? 254))
   const W2 = Math.max(bfB, supW) + 190, H2 = dB + 150
   const cx2 = (W2 - 60) / 2, cy2 = H2 / 2
   const plateX2 = cx2 + twB / 2                                 // plate against the web, near side
@@ -77,6 +84,13 @@ export function ConnectionDetail2D({ conn, hostShape, hostKind, faceType, beamSh
             <rect x={cx + hostW - (g.host?.tf ?? 15)} y={20} width={(g.host?.tf ?? 15)} height={H - 40} fill="#64748b" />
           </>
         )}
+        {hostKind === 'column' && faceType === 'web' && (
+          <>
+            {/* looking at the flange face: the web is the centre plane — the tab welds there */}
+            <line x1={weldX} y1={22} x2={weldX} y2={H - 22} stroke="#475569" strokeDasharray="6 4" />
+            <text x={weldX + 5} y={50} fontSize={9} fill="#64748b">column web (weld line)</text>
+          </>
+        )}
         <text x={cx + hostW / 2} y={34} textAnchor="middle" fontSize={10} fill="#334155">{hostShape}</text>
         {/* beam with flanges (+ cope notch on the top flange) */}
         {cope ? (
@@ -92,10 +106,10 @@ export function ConnectionDetail2D({ conn, hostShape, hostKind, faceType, beamSh
         )}
         {/* plate: WELDED to the support along its FULL height (fillet both sides),
             BOLTED to the beam web — the gold bead runs the whole plate edge */}
-        <rect x={faceX} y={plateTop} width={tab.wMm} height={tab.hMm} fill="none" stroke={PLATE} strokeWidth={2.2} />
-        <rect x={faceX - 2.5} y={plateTop} width={5} height={tab.hMm} fill={WELD} />
-        <path d={`M ${faceX} ${plateTop - 9} l 11 9 l -11 0 z`} fill={WELD} />
-        <text x={faceX + 14} y={plateTop - 11} fontSize={9} fill={WELD}>
+        <rect x={weldX} y={plateTop} width={tab.wMm} height={tab.hMm} fill="none" stroke={PLATE} strokeWidth={2.2} />
+        <rect x={weldX - 2.5} y={plateTop} width={5} height={tab.hMm} fill={WELD} />
+        <path d={`M ${weldX} ${plateTop - 9} l 11 9 l -11 0 z`} fill={WELD} />
+        <text x={weldX + 14} y={plateTop - 11} fontSize={9} fill={WELD}>
           {tab.weldSizeMm} mm E70 fillet × {Math.round(tab.hMm)} mm, both sides (full plate height)
         </text>
         {conn.connType === 'moment-flange-weld' && (
@@ -107,21 +121,36 @@ export function ConnectionDetail2D({ conn, hostShape, hostKind, faceType, beamSh
             <text x={faceX + 17} y={beamBot + 12} fontSize={9} fill={WELD}>CJP flange weld</text>
           </>
         )}
-        {/* bolts at the designed layout */}
+        {conn.connType === 'moment-web-plate' && conn.flange?.webPlate && (
+          <>
+            {/* weak-axis extension plates: welded to the web, butting the beam flanges */}
+            <rect x={weldX} y={beamTop} width={faceX - weldX + 4} height={tfB} fill={PLATE} />
+            <rect x={weldX} y={beamBot - tfB} width={faceX - weldX + 4} height={tfB} fill={PLATE} />
+            <path d={`M ${faceX + 4} ${beamTop} l 14 0 l -14 -11 z`} fill={WELD} />
+            <path d={`M ${faceX + 4} ${beamBot} l 14 0 l -14 11 z`} fill={WELD} />
+            <text x={faceX + 20} y={beamTop - 4} fontSize={9} fill={PLATE} fontWeight={600}>
+              ext. plate PL {conn.flange.webPlate.tMm}×{conn.flange.webPlate.wMm} — CJP to beam flange
+            </text>
+            <text x={faceX + 44} y={beamBot + 26} fontSize={9} fill={PLATE} fontWeight={600}>
+              ext. plate (welded into column web)
+            </text>
+          </>
+        )}
+        {/* bolts at the designed layout (x measured from the WELD line) */}
         {rows.map((bp) => (
           <g key={bp.id}>
-            <circle cx={faceX + bp.x} cy={boltY(bp.y)} r={conn.bolts.dia / 2} fill="none" stroke={BOLT} strokeWidth={2} />
-            <line x1={faceX + bp.x - 7} y1={boltY(bp.y)} x2={faceX + bp.x + 7} y2={boltY(bp.y)} stroke={BOLT} />
-            <line x1={faceX + bp.x} y1={boltY(bp.y) - 7} x2={faceX + bp.x} y2={boltY(bp.y) + 7} stroke={BOLT} />
+            <circle cx={weldX + bp.x} cy={boltY(bp.y)} r={conn.bolts.dia / 2} fill="none" stroke={BOLT} strokeWidth={2} />
+            <line x1={weldX + bp.x - 7} y1={boltY(bp.y)} x2={weldX + bp.x + 7} y2={boltY(bp.y)} stroke={BOLT} />
+            <line x1={weldX + bp.x} y1={boltY(bp.y) - 7} x2={weldX + bp.x} y2={boltY(bp.y) + 7} stroke={BOLT} />
           </g>
         ))}
         {/* dimensions (shared architectural-tick primitives, as in the RC schematics) */}
-        <DimSide yA={plateTop} yB={plateTop + tab.hMm} featX={faceX + tab.wMm} dX={faceX + tab.wMm + 24} label={`h = ${Math.round(tab.hMm)} mm`} side="right" />
-        <DimBelow xA={faceX} xB={faceX + a0} featY={plateTop + tab.hMm} dY={plateTop + tab.hMm + 30} label={`a = ${Math.round(a0)} mm`} />
+        <DimSide yA={plateTop} yB={plateTop + tab.hMm} featX={weldX + tab.wMm} dX={weldX + tab.wMm + 24} label={`h = ${Math.round(tab.hMm)} mm`} side="right" />
+        <DimBelow xA={weldX} xB={weldX + a0} featY={plateTop + tab.hMm} dY={plateTop + tab.hMm + 30} label={`a = ${Math.round(a0)} mm`} />
         {rows.length > 1 && (
-          <DimSide yA={boltY(rows[rows.length - 1].y)} yB={boltY(rows[0].y)} featX={faceX + a0 - 10} dX={faceX + a0 - 26} label={`p = ${conn.bolts.pitchMm} mm`} side="left" />
+          <DimSide yA={boltY(rows[rows.length - 1].y)} yB={boltY(rows[0].y)} featX={weldX + a0 - 10} dX={weldX + a0 - 26} label={`p = ${conn.bolts.pitchMm} mm`} side="left" />
         )}
-        <text x={faceX + tab.wMm / 2} y={plateTop + tab.hMm + 52} textAnchor="middle" fontSize={10} fill={PLATE} fontWeight={600}>
+        <text x={weldX + tab.wMm / 2} y={plateTop + tab.hMm + 52} textAnchor="middle" fontSize={10} fill={PLATE} fontWeight={600}>
           PL {tab.t}×{tab.wMm}×{Math.round(tab.hMm)} mm
         </text>
         {/* Vu arrow */}
@@ -136,6 +165,13 @@ export function ConnectionDetail2D({ conn, hostShape, hostKind, faceType, beamSh
         {/* support face behind: column flange (or girder web edge-band) */}
         <rect x={cx2 - supW / 2} y={cy2 - dB / 2 - 34} width={supW} height={dB + 68}
           fill={STEEL} opacity={0.22} stroke="#94a3b8" strokeDasharray="5 3" />
+        {hostKind === 'column' && faceType === 'web' && (
+          <>
+            {/* column flanges seen edge-on at both ends of the depth d */}
+            <rect x={cx2 - supW / 2} y={cy2 - dB / 2 - 34} width={g.host?.tf ?? 15} height={dB + 68} fill={STEEL} opacity={0.45} />
+            <rect x={cx2 + supW / 2 - (g.host?.tf ?? 15)} y={cy2 - dB / 2 - 34} width={g.host?.tf ?? 15} height={dB + 68} fill={STEEL} opacity={0.45} />
+          </>
+        )}
         <text x={cx2 - supW / 2 + 4} y={cy2 - dB / 2 - 22} fontSize={9} fill="#64748b">
           {hostKind === 'girder' ? `girder web (${hostShape})` : `column ${faceType} (${hostShape})`} behind
         </text>
@@ -155,6 +191,19 @@ export function ConnectionDetail2D({ conn, hostShape, hostKind, faceType, beamSh
             <rect x={cx2 - bfB / 2} y={cy2 + dB / 2} width={bfB} height={6} fill={WELD} />
             <text x={cx2 + bfB / 2 + 6} y={cy2 - dB / 2 - 6} fontSize={9} fill={WELD}>CJP flange weld</text>
             <text x={cx2 + bfB / 2 + 6} y={cy2 + dB / 2 + 12} fontSize={9} fill={WELD}>CJP flange weld</text>
+          </>
+        ) : conn.connType === 'moment-web-plate' && conn.flange?.webPlate ? (
+          <>
+            {/* weak-axis extension plates spanning the column clear depth, at
+                both beam-flange levels — the beam flanges CJP to their edges */}
+            <rect x={cx2 - conn.flange.webPlate.wMm / 2} y={cy2 - dB / 2 - 7} width={conn.flange.webPlate.wMm} height={7} fill={PLATE} />
+            <rect x={cx2 - conn.flange.webPlate.wMm / 2} y={cy2 + dB / 2} width={conn.flange.webPlate.wMm} height={7} fill={PLATE} />
+            <text x={cx2 + conn.flange.webPlate.wMm / 2 + 6} y={cy2 - dB / 2 - 6} fontSize={9} fill={PLATE} fontWeight={600}>
+              ext. plate PL {conn.flange.webPlate.tMm}×{conn.flange.webPlate.wMm}
+            </text>
+            <text x={cx2 + conn.flange.webPlate.wMm / 2 + 6} y={cy2 + dB / 2 + 12} fontSize={9} fill={PLATE} fontWeight={600}>
+              ext. plate (into column web)
+            </text>
           </>
         ) : (
           <>

--- a/webapp/src/components/ConnectionDrawing.tsx
+++ b/webapp/src/components/ConnectionDrawing.tsx
@@ -1,23 +1,21 @@
 // 2D SVG plan view of a bolt/weld group on the connection plate.
 // Coordinate system: origin at bottom-left of plate, Y up.
 // SVG has Y inverted (origin top-left) so we flip: svgY = H_px - plateY * scale.
+//
+// The drawing is SELF-SUFFICIENT: the display plate is derived from the
+// actual (absolute) bolt positions plus an edge margin, so custom layouts
+// (boltGeomFromPositions — whose plateW/H are bolt extents with no origin)
+// render correctly; a grid geometry whose declared plate already covers the
+// bolts keeps its own plate. The canvas always includes the load point.
 
 import type { BoltGroupGeom, BoltForce } from '../engine/steelDesign'
+import { DimBelow, DimSide } from './dims'
 
-const PAD = 36  // px around the plate
+const EDGE = 40   // display edge margin around the outermost bolts, mm
 
 function label(x: number, y: number, text: string, color = '#475569', fs = 10, anchor: 'middle' | 'start' | 'end' = 'middle') {
-  return <text x={x} y={y} textAnchor={anchor} fill={color} fontSize={fs} fontFamily="monospace">{text}</text>
-}
-
-function dimLine(x1: number, y1: number, x2: number, y2: number, text: string, offset: [number, number]) {
-  const mx = (x1 + x2) / 2 + offset[0], my = (y1 + y2) / 2 + offset[1]
-  return (
-    <g>
-      <line x1={x1} y1={y1} x2={x2} y2={y2} stroke="#94a3b8" strokeWidth={0.8} strokeDasharray="3,2" />
-      <text x={mx} y={my} textAnchor="middle" fill="#64748b" fontSize={9} fontFamily="monospace">{text}</text>
-    </g>
-  )
+  return <text x={x} y={y} textAnchor={anchor} fill={color} fontSize={fs} fontFamily="monospace"
+    paintOrder="stroke" stroke="#fff" strokeWidth={2.4}>{text}</text>
 }
 
 export function ConnectionDrawing({ geom, db, boltForces, critical, Vu, Hu, ex_load, ey_load, connType = 'bolt' }: {
@@ -29,96 +27,112 @@ export function ConnectionDrawing({ geom, db, boltForces, critical, Vu, Hu, ex_l
   ex_load: number; ey_load: number
   connType?: 'bolt' | 'weld'
 }) {
-  const DISP_W = 260
-  const scale = Math.min((DISP_W - 2 * PAD) / geom.plateW, (DISP_W - 2 * PAD) / geom.plateH)
-  const pw = geom.plateW * scale, ph = geom.plateH * scale
-  const svgW = pw + 2 * PAD, svgH = ph + 2 * PAD
-
-  const tx = (xmm: number) => PAD + xmm * scale
-  const ty = (ymm: number) => PAD + (geom.plateH - ymm) * scale
-
-  const r = (db / 2) * scale
-
-  // load application point in plate coords (from bottom-left)
+  // absolute bolt positions (plate coords, bottom-left origin, Y up)
+  const abs = geom.bolts.map((b) => ({ id: b.id, x: b.x + geom.Cx, y: b.y + geom.Cy }))
   const loadX = geom.Cx + ex_load, loadY = geom.Cy + ey_load
+
+  // display plate: the declared plate when it already covers every bolt
+  // (grid geometries), else bolt bounds + EDGE margin (custom layouts)
+  const bx0 = Math.min(...abs.map((b) => b.x)), bx1 = Math.max(...abs.map((b) => b.x))
+  const by0 = Math.min(...abs.map((b) => b.y)), by1 = Math.max(...abs.map((b) => b.y))
+  const declaredCovers = abs.length > 0 && bx0 >= 0 && by0 >= 0 && bx1 <= geom.plateW && by1 <= geom.plateH
+  const px0 = declaredCovers ? 0 : bx0 - EDGE
+  const py0 = declaredCovers ? 0 : by0 - EDGE
+  const px1 = declaredCovers ? geom.plateW : bx1 + EDGE
+  const py1 = declaredCovers ? geom.plateH : by1 + EDGE
+  const pw_mm = Math.max(px1 - px0, 1), ph_mm = Math.max(py1 - py0, 1)
+
+  // canvas covers plate ∪ load point (in plate coords), plus dim/label room
+  const vx0 = Math.min(px0, loadX) - 10, vx1 = Math.max(px1, loadX) + 10
+  const vy0 = Math.min(py0, loadY) - 10, vy1 = Math.max(py1, loadY) + 10
+
+  const DISP_W = 340
+  const PAD_L = 64, PAD_R = 24, PAD_T = 40, PAD_B = 44
+  const scale = Math.min((DISP_W - PAD_L - PAD_R) / (vx1 - vx0), (DISP_W - PAD_T - PAD_B) / (vy1 - vy0))
+  const svgW = (vx1 - vx0) * scale + PAD_L + PAD_R
+  const svgH = (vy1 - vy0) * scale + PAD_T + PAD_B
+
+  const tx = (xmm: number) => PAD_L + (xmm - vx0) * scale
+  const ty = (ymm: number) => PAD_T + (vy1 - ymm) * scale
+
+  const r = Math.max((db / 2) * scale, 3)
+  const X0 = tx(px0), X1 = tx(px1), Y0 = ty(py1), Y1 = ty(py0)   // plate rect in px (Y0 = top)
 
   return (
     <div className="print-avoid-break rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
       <h3 className="mb-1.5 text-xs font-bold uppercase tracking-wide text-slate-500">
         Connection face — {connType === 'bolt' ? 'bolt layout' : 'weld layout'}
       </h3>
-      <svg width={svgW} height={svgH + 16} viewBox={`0 0 ${svgW} ${svgH + 16}`}>
+      <svg width="100%" style={{ maxWidth: svgW * 1.15 }} viewBox={`0 0 ${svgW} ${svgH}`} className="h-auto">
         {/* plate */}
-        <rect x={PAD} y={PAD} width={pw} height={ph} fill="#f1f5f9" stroke="#334155" strokeWidth={1.5} rx={1} />
+        <rect x={X0} y={Y0} width={X1 - X0} height={Y1 - Y0} fill="#f1f5f9" stroke="#334155" strokeWidth={1.5} rx={1} />
 
-        {/* dimension lines */}
-        {dimLine(PAD, svgH, PAD + pw, svgH, `${geom.plateW} mm`, [0, 12])}
-        {dimLine(PAD - 18, PAD, PAD - 18, PAD + ph, `${geom.plateH} mm`, [-16, 0])}
+        {/* plate dimensions — shared architectural-tick primitives */}
+        <DimBelow xA={X0} xB={X1} featY={Y1} dY={Y1 + 22} label={`${Math.round(pw_mm)} mm`} />
+        <DimSide yA={Y0} yB={Y1} featX={X0} dX={X0 - 26} label={`${Math.round(ph_mm)} mm`} side="left" />
 
         {connType === 'bolt' ? (
           <>
-            {/* bolt holes */}
-            {geom.bolts.map(b => {
-              const bfEntry = boltForces?.find(bf => bf.id === b.id)
+            {abs.map((b) => {
+              const bfEntry = boltForces?.find((bf) => bf.id === b.id)
               const isCrit = b.id === critical
-              const bxPl = b.x + geom.Cx, byPl = b.y + geom.Cy
-              const cx = tx(bxPl), cy = ty(byPl)
+              const cx = tx(b.x), cy = ty(b.y)
               const util = bfEntry?.utilShear ?? 0
               const holeColor = isCrit ? '#dc2626' : util > 0.8 ? '#f59e0b' : '#334155'
               return (
                 <g key={b.id}>
-                  {/* hole */}
                   <circle cx={cx} cy={cy} r={r} fill="white" stroke={holeColor} strokeWidth={isCrit ? 2 : 1} />
-                  {/* force arrow proportional to R */}
+                  <line x1={cx - r - 2} y1={cy} x2={cx + r + 2} y2={cy} stroke={holeColor} strokeWidth={0.6} />
+                  <line x1={cx} y1={cy - r - 2} x2={cx} y2={cy + r + 2} stroke={holeColor} strokeWidth={0.6} />
                   {bfEntry && bfEntry.R > 0.01 && (() => {
-                    const sc = 25 / Math.max(...(boltForces?.map(f => f.R) ?? [1]))
+                    const sc = 22 / Math.max(...(boltForces?.map((f) => f.R) ?? [1]))
                     const dx = bfEntry.Vx * sc, dy = -bfEntry.Vy * sc
                     return <line x1={cx} y1={cy} x2={cx + dx} y2={cy + dy}
-                      stroke={isCrit ? '#dc2626' : '#3b82f6'} strokeWidth={1.4}
-                      markerEnd="url(#arrow)" />
+                      stroke={isCrit ? '#dc2626' : '#3b82f6'} strokeWidth={1.4} markerEnd="url(#arrow)" />
                   })()}
-                  {label(cx, cy - r - 2, b.id, isCrit ? '#dc2626' : '#475569', 9)}
-                  {bfEntry && label(cx, cy + r + 9, `${bfEntry.R.toFixed(1)}kN`, isCrit ? '#dc2626' : '#64748b', 8)}
+                  {/* id top-left of the hole, force bottom-right — no stacking collisions */}
+                  {label(cx - r - 3, cy - r - 1, b.id, isCrit ? '#dc2626' : '#475569', 9, 'end')}
+                  {bfEntry && label(cx + r + 3, cy + r + 8, `${bfEntry.R.toFixed(1)}kN`, isCrit ? '#dc2626' : '#64748b', 8, 'start')}
                 </g>
               )
             })}
-            {/* edge distance labels for first bolt */}
-            {geom.bolts.length > 0 && (() => {
-              const b0 = { x: geom.bolts[0].x + geom.Cx, y: geom.bolts[0].y + geom.Cy }
-              return (
-                <>
-                  {dimLine(PAD, ty(b0.y), tx(b0.x), ty(b0.y), `ex=${b0.x.toFixed(0)}`, [0, -7])}
-                  {dimLine(tx(b0.x), PAD + ph, tx(b0.x), ty(b0.y), `ey=${b0.y.toFixed(0)}`, [18, 0])}
-                </>
-              )
-            })()}
           </>
         ) : (
           <>
             {/* weld lines (two vertical welds on plate edges) */}
-            <line x1={PAD + 3} y1={PAD + 4} x2={PAD + 3} y2={PAD + ph - 4} stroke="#f59e0b" strokeWidth={4} />
-            <line x1={PAD + pw - 3} y1={PAD + 4} x2={PAD + pw - 3} y2={PAD + ph - 4} stroke="#f59e0b" strokeWidth={4} />
-            {label(PAD + pw / 2, PAD + ph / 2, 'Weld', '#d97706', 11)}
-            {label(PAD + pw / 2, PAD + ph / 2 + 14, `L = ${geom.plateH.toFixed(0)} mm ea.`, '#d97706', 9)}
+            <line x1={X0 + 3} y1={Y0 + 4} x2={X0 + 3} y2={Y1 - 4} stroke="#f59e0b" strokeWidth={4} />
+            <line x1={X1 - 3} y1={Y0 + 4} x2={X1 - 3} y2={Y1 - 4} stroke="#f59e0b" strokeWidth={4} />
+            {label((X0 + X1) / 2, (Y0 + Y1) / 2, 'Weld', '#d97706', 11)}
+            {label((X0 + X1) / 2, (Y0 + Y1) / 2 + 14, `L = ${Math.round(ph_mm)} mm ea.`, '#d97706', 9)}
           </>
         )}
 
-        {/* load application point & eccentricity */}
+        {/* centroid mark */}
+        <g stroke="#059669" strokeWidth={1}>
+          <circle cx={tx(geom.Cx)} cy={ty(geom.Cy)} r={3.5} fill="none" />
+          <line x1={tx(geom.Cx) - 7} y1={ty(geom.Cy)} x2={tx(geom.Cx) + 7} y2={ty(geom.Cy)} />
+          <line x1={tx(geom.Cx)} y1={ty(geom.Cy) - 7} x2={tx(geom.Cx)} y2={ty(geom.Cy) + 7} />
+        </g>
+
+        {/* load application point, eccentricity trace & force arrows */}
         {(() => {
           const lx = tx(loadX), ly = ty(loadY)
+          // keep the label inside the canvas: grow leftwards when the load
+          // point sits on the right half of the drawing
+          const onRight = loadX > (vx0 + vx1) / 2
           return (
             <g>
+              <line x1={tx(geom.Cx)} y1={ty(geom.Cy)} x2={lx} y2={ly} stroke="#16a34a" strokeWidth={0.8} strokeDasharray="4,3" />
               <circle cx={lx} cy={ly} r={4} fill="none" stroke="#16a34a" strokeWidth={1.5} strokeDasharray="3,2" />
-              {Vu > 0 && <line x1={lx} y1={ly - 24} x2={lx} y2={ly - 6}
+              {Vu !== 0 && <line x1={lx} y1={ly - 22} x2={lx} y2={ly - 6}
                 stroke="#16a34a" strokeWidth={1.5} markerEnd="url(#arrow)" />}
-              {Hu !== 0 && <line x1={lx + (Hu > 0 ? -24 : 24)} y1={ly} x2={lx + (Hu > 0 ? -6 : 6)} y2={ly}
+              {Hu !== 0 && <line x1={lx + (Hu > 0 ? -22 : 22)} y1={ly} x2={lx + (Hu > 0 ? -6 : 6)} y2={ly}
                 stroke="#16a34a" strokeWidth={1.5} markerEnd="url(#arrow)" />}
-              {label(lx + 5, ly - 26, `Vu=${Vu}kN`, '#15803d', 9, 'start')}
+              {label(onRight ? lx - 7 : lx + 7, ly - 24, `P @ (${Math.round(loadX)}, ${Math.round(loadY)})`, '#15803d', 8.5, onRight ? 'end' : 'start')}
             </g>
           )
         })()}
 
-        {/* arrowhead marker */}
         <defs>
           <marker id="arrow" markerWidth="6" markerHeight="6" refX="3" refY="3" orient="auto">
             <path d="M0,0 L6,3 L0,6 Z" fill="#1d4ed8" />

--- a/webapp/src/components/JointConnections3D.tsx
+++ b/webapp/src/components/JointConnections3D.tsx
@@ -5,9 +5,12 @@
 //     with every designed bolt drawn at its actual layout position
 //   · moment connection: the same web tab PLUS flange CJP weld beads and
 //     column continuity plates at the beam-flange levels
-// Geometry follows the app's drawn orientation (column depth d along global X,
-// flanges facing ±X): X-beams land on the flange face at d/2, Z-beams on the
-// flange-tip plane at bf/2 — the same faces the rigid end zones use.
+//   · weak-axis moment (moment-web-plate): horizontal extension plates welded
+//     into the column web at both beam-flange levels
+// The weld line follows the ENGINE's web/flange face determination: flange
+// connections weld at the flange face (d/2), web connections at the web plane
+// (tw/2) with the plate extended past the flange tips (bf/2) — matching the
+// designed bolt eccentricity and the rigid-end-zone faces.
 // Units: engine mm → scene metres.
 // ─────────────────────────────────────────────────────────────────────────
 import { useMemo } from 'react'
@@ -43,14 +46,17 @@ function Bolt({ p, axis, dia, len }: { p: THREE.Vector3; axis: THREE.Vector3; di
 }
 
 /** One beam's connection hardware at a joint. `faceOff` = distance from the
- *  joint node to the supporting face along the beam axis (m). */
-function Connection({ conn, node, beamDir, faceOff, beamTw }: {
+ *  joint node to the plate WELD line along the beam axis (m) — the support
+ *  flange face (d/2), or the support web plane (tw/2) for web connections. */
+function Connection({ conn, node, beamDir, faceOff, beamTw, extPlateLen }: {
   conn: BeamConnection
   node: THREE.Vector3
   beamDir: THREE.Vector3          // unit, node → beam span
   faceOff: number
   /** supported beam's web thickness, m (actual shape value). */
   beamTw?: number
+  /** moment-web-plate only: extension-plate run web → past the flange tips, m. */
+  extPlateLen?: number
 }) {
   const parts = useMemo(() => {
     const ex = beamDir.clone()                                   // along the beam
@@ -97,13 +103,28 @@ function Connection({ conn, node, beamDir, faceOff, beamTw }: {
       {bolts.map((b) => (
         <Bolt key={b.id} p={b.p.clone().add(ez.clone().multiplyScalar(plate.t / 2))} axis={ez} dia={conn.bolts.dia} len={b.len} />
       ))}
-      {/* moment connection: flange CJP weld beads at the column face */}
+      {/* strong-axis moment connection: flange CJP weld beads at the column face */}
       {conn.connType === 'moment-flange-weld' && conn.flange && (() => {
         const dB = plate.h + 0.16   // ≈ beam depth proxy from tab height (tab ≈ web depth)
         return [1, -1].map((s) => (
           <mesh key={s} position={F.clone().add(new THREE.Vector3(0, (s * dB) / 2, 0)).add(ex.clone().multiplyScalar(0.012))} quaternion={boxQuat}>
             <boxGeometry args={[0.025, 0.02, Math.max(0.12, plate.w * 0.9)]} />
             <meshStandardMaterial color={BOLT} metalness={0.5} roughness={0.4} />
+          </mesh>
+        ))
+      })()}
+      {/* weak-axis moment connection: horizontal extension plates welded into the
+          column web at both beam-flange levels, running out past the flange tips */}
+      {conn.connType === 'moment-web-plate' && conn.flange?.webPlate && extPlateLen && (() => {
+        const wp = conn.flange.webPlate
+        const dB = plate.h + 0.16
+        const tP = wp.tMm * MM, wP = wp.wMm * MM
+        return [1, -1].map((s) => (
+          <mesh key={`wp${s}`}
+            position={F.clone().add(new THREE.Vector3(0, (s * dB) / 2, 0)).add(ex.clone().multiplyScalar(extPlateLen / 2))}
+            quaternion={boxQuat}>
+            <boxGeometry args={[extPlateLen, tP, wP]} />
+            <meshStandardMaterial color={PLATE} metalness={0.3} roughness={0.55} />
           </mesh>
         ))
       })()}
@@ -121,7 +142,7 @@ export function JointConnections3D({ joints, beamJoints = [], model, nodePos }: 
   const memMap = useMemo(() => new Map(model.members.map((m) => [m.id, m])), [model])
   const secMap = useMemo(() => new Map(model.sections.map((s) => [s.id, s])), [model])
 
-  const renderConn = (nodeId: string, c: BeamConnection, faceOff: number) => {
+  const renderConn = (nodeId: string, c: BeamConnection, faceOff: number, extPlateLen?: number) => {
     const P = nodePos.get(nodeId)
     const mem = memMap.get(c.beamId)
     if (!P || !mem) return null
@@ -133,7 +154,7 @@ export function JointConnections3D({ joints, beamJoints = [], model, nodePos }: 
     const sec = secMap.get(mem.section)
     if (sec?.material !== 'steel') return null
     const beamTw = sec.shape ? (shapeByName(sec.shape)?.tw ?? 8) * MM : undefined
-    return <Connection key={c.beamId} conn={c} node={P} beamDir={dir.normalize()} faceOff={faceOff} beamTw={beamTw} />
+    return <Connection key={c.beamId} conn={c} node={P} beamDir={dir.normalize()} faceOff={faceOff} beamTw={beamTw} extPlateLen={extPlateLen} />
   }
 
   return (
@@ -150,9 +171,10 @@ export function JointConnections3D({ joints, beamJoints = [], model, nodePos }: 
         const P = nodePos.get(j.nodeId)
         const colShape = shapeByName(j.columnShape)
         if (!P || !colShape) return null
-        const col = { d: (colShape.d ?? 300) * MM, bf: (colShape.bf ?? 300) * MM, tf: (colShape.tf ?? 15) * MM }
+        const col = { d: (colShape.d ?? 300) * MM, bf: (colShape.bf ?? 300) * MM, tf: (colShape.tf ?? 15) * MM, tw: (colShape.tw ?? 10) * MM }
 
-        // continuity plates once per joint when ANY moment connection lands here
+        // continuity plates once per joint when a STRONG-axis moment connection
+        // lands here (weak-axis conns bring their own extension plates)
         const momentConns = j.connections.filter((c) => c.connType === 'moment-flange-weld')
         const contPlates = momentConns.length > 0 ? (() => {
           const c0 = momentConns[0]
@@ -169,13 +191,13 @@ export function JointConnections3D({ joints, beamJoints = [], model, nodePos }: 
           <group key={j.nodeId}>
             {contPlates}
             {j.connections.map((c) => {
-              // face per the drawn orientation (column depth d along global X)
-              const mem = memMap.get(c.beamId)
-              if (!mem) return null
-              const otherId = mem.i === j.nodeId ? mem.j : mem.i
-              const Q = nodePos.get(otherId)
-              const dirX = Q ? Math.abs(Q.x - P.x) >= Math.abs(Q.z - P.z) : true
-              return renderConn(j.nodeId, c, dirX ? col.d / 2 : col.bf / 2)
+              // weld line per the ENGINE's face determination: a FLANGE conn
+              // welds at the flange face (d/2); a WEB conn welds at the web
+              // plane (tw/2) — the plate itself runs past the flange tips
+              // (bf/2), matching the designed eccentricity.
+              const faceOff = c.faceType === 'flange' ? col.d / 2 : col.tw / 2
+              const extLen = c.connType === 'moment-web-plate' ? col.bf / 2 - col.tw / 2 + 0.04 : undefined
+              return renderConn(j.nodeId, c, faceOff, extLen)
             })}
           </group>
         )

--- a/webapp/src/engine/steelConnections.test.ts
+++ b/webapp/src/engine/steelConnections.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { generateGridModel, buildGravityLoads } from './modelBuilder'
 import { designStructure } from './pipeline'
 import { designSteelJoints, designBolts } from './steelConnections'
+import { shapeByName } from './aiscSections'
 import type { BoltPos } from './steelDesign'
 import type { RectSection } from './model'
 
@@ -61,8 +62,73 @@ describe('steel joint / connection design', () => {
     for (const j of joints) {
       for (const c of j.connections) {
         expect(['flange', 'web']).toContain(c.faceType)
-        expect(c.beamElement).toBe(c.connType === 'moment-flange-weld' ? 'web+flanges' : 'web')
+        expect(c.beamElement).toBe(c.connType === 'shear-tab' ? 'web' : 'web+flanges')
       }
+    }
+  })
+
+  it('WEB-face tab is extended past the flange tips: larger designed eccentricity', () => {
+    // default vertical orientation (rot 90°): depth d on X ⇒ X-beams hit the
+    // flange (a = 60), Z-beams hit the web (a = 60 + (bf − tw)/2)
+    const all = joints.flatMap((j) => j.connections.map((c) => ({ c, shape: j.columnShape })))
+    const webs = all.filter(({ c }) => c.faceType === 'web')
+    const flanges = all.filter(({ c }) => c.faceType === 'flange')
+    expect(webs.length).toBeGreaterThan(0)
+    expect(flanges.length).toBeGreaterThan(0)
+    for (const { c } of flanges) expect(c.bolts.ecc).toBeCloseTo(60, 3)
+    for (const { c, shape } of webs) {
+      const s = shapeByName(shape)!
+      expect(c.bolts.ecc).toBeCloseTo(60 + ((s.bf ?? 0) - (s.tw ?? 0)) / 2, 3)
+      expect(c.bolts.ecc).toBeGreaterThan(60)
+      // the plate itself grows with the bolt line
+      expect(c.tab.wMm).toBeCloseTo(c.bolts.ecc + 80, 3)
+      // and each bolt still works within φRn at the larger eccentricity
+      expect(c.bolts.Rmax).toBeLessThanOrEqual(c.bolts.phiRnKn + 1e-6)
+    }
+  })
+
+  it('face determination follows the COLUMN orientation (axisRotation), not the beam count', () => {
+    // rotate every column to 0° ⇒ depth d lands on global Z ⇒ the faces swap:
+    // X-beams now hit the WEB, Z-beams the FLANGE
+    const m2 = makeModel()
+    for (const mem of m2.members) if (mem.role === 'column') mem.axisRotation = 0
+    const d2 = designStructure(m2, soil)!
+    const joints2 = designSteelJoints(m2, d2)
+    expect(joints2.length).toBeGreaterThan(0)
+    for (const j of joints2) {
+      expect(j.strongAxisDir).toBe('z')
+      for (const c of j.connections) {
+        if (c.spanDir === 'x') expect(c.faceType).toBe('web')
+        if (c.spanDir === 'z') expect(c.faceType).toBe('flange')
+      }
+    }
+  })
+
+  it('a moment demand on the column WEB face becomes a weak-axis extension-plate connection', () => {
+    const m2 = makeModel()
+    // force a moment end on a Z-spanning beam (hits the web with default rot 90°)
+    const nm = new Map(m2.nodes.map((n) => [n.id, n]))
+    const zBeam = m2.members.find((mem) => {
+      if (mem.role !== 'beam' && mem.role !== 'girder') return false
+      const ni = nm.get(mem.i)!, nj = nm.get(mem.j)!
+      return Math.abs(nj.z - ni.z) > Math.abs(nj.x - ni.x)
+    })!
+    zBeam.connections = { iEnd: 'moment', jEnd: 'moment' }
+    const d2 = designStructure(m2, soil)!
+    const joints2 = designSteelJoints(m2, d2)
+    const conns = joints2.flatMap((j) => j.connections).filter((c) => c.beamId === zBeam.id)
+    expect(conns.length).toBeGreaterThan(0)
+    for (const c of conns) {
+      expect(c.faceType).toBe('web')
+      expect(c.connType).toBe('moment-web-plate')
+      expect(c.pinned).toBe(false)
+      expect(c.beamElement).toBe('web+flanges')
+      const wp = c.flange!.webPlate!
+      expect(wp).toBeTruthy()
+      // both the plate (§J4.1 tension yielding) and its web welds carry Tf
+      expect(wp.phiPlateKn).toBeGreaterThanOrEqual(c.flange!.Tf - 1e-6)
+      expect(wp.phiWeldKn).toBeGreaterThanOrEqual(c.flange!.Tf - 1e-6)
+      expect(c.flange!.phiCapKn).toBeCloseTo(Math.min(wp.phiPlateKn, wp.phiWeldKn), 6)
     }
   })
 

--- a/webapp/src/engine/steelConnections.ts
+++ b/webapp/src/engine/steelConnections.ts
@@ -13,6 +13,7 @@ import type { StructuralModel, Node as ModelNode } from './model'
 import type { StructureDesign, SteelBeamScheduleRow } from './pipeline'
 import { boltGeomFromPositions, eccentricBoltGroup, type BoltPos } from './steelDesign'
 import { shapeByName } from './aiscSections'
+import { localAxes, defaultAxisRotation, type V3 } from './frame3d'
 
 // ── Material constants ──────────────────────────────────────────────────────
 const PHI_SHEAR_BOLT = 0.75           // AISC §J3.6
@@ -41,7 +42,14 @@ export type ConnFaceType = 'flange' | 'web'
 /** Which beam element(s) the connection engages: shear-tab bolts the beam WEB;
  *  a moment connection welds the beam FLANGES and shear-tabs the web. */
 export type BeamAttachment = 'web' | 'web+flanges'
-export type ConnType     = 'shear-tab' | 'moment-flange-weld'
+/** Connection type per web/flange PAIRING of the two members:
+ *  · shear-tab           — beam web → support face, single plate (any face)
+ *  · moment-flange-weld  — beam flanges → column FLANGE, direct CJP welds
+ *  · moment-web-plate    — beam flanges → column WEB (weak axis): the flange
+ *    force cannot CJP into the thin web, so it goes through horizontal
+ *    extension plates welded into the column web between the flanges
+ *    (AISC Design Guide 13 weak-axis moment detail). */
+export type ConnType     = 'shear-tab' | 'moment-flange-weld' | 'moment-web-plate'
 export type SpanDir      = 'x' | 'z' | 'other'
 
 export interface BoltGroup {
@@ -71,11 +79,26 @@ export interface ShearTab {
   phiWeldVn: number // weld capacity kN
 }
 
+/** Weak-axis (column-web) moment detail: horizontal extension plates carry the
+ *  beam-flange force into the column web + flanges (moment-web-plate). */
+export interface WebMomentPlate {
+  tMm: number        // plate thickness mm (stock)
+  wMm: number        // plate width mm (≥ beam bf, spans between column flanges)
+  weldMm: number     // fillet leg to the column web, both sides, mm
+  phiPlateKn: number // φ·Fy·t·w tension yielding (§J4.1) kN
+  phiWeldKn: number  // weld group capacity kN
+  ok: boolean
+}
+
 export interface FlangeMomentConn {
   Tf: number        // design flange force kN  (= Mu / (d - tf))
   flangeArea: number // beam flange area mm²
-  phiCapKn: number  // φ·Fu·A_flange (CJP) kN
+  /** Governing capacity of the flange-force path: CJP (flange face) or
+   *  min(plate, weld) of the extension plates (web face). kN */
+  phiCapKn: number
   ok: boolean
+  /** Present only for moment-web-plate — the extension-plate detail. */
+  webPlate?: WebMomentPlate
 }
 
 export interface BeamConnection {
@@ -165,10 +188,12 @@ export function designBolts(Vu: number, opts: {
   }
 }
 
-/** Design a single-plate shear tab sized to a bolt column of `nBolts`. */
-function designShearTab(Vu: number, nBolts: number, pitchMm = 75, edgeMm = 40): ShearTab {
+/** Design a single-plate shear tab sized to a bolt column of `nBolts`.
+ *  `aMm` = weld-line → bolt-line distance; a WEB-face tab is extended so the
+ *  bolts clear the column flange tips, which grows both `aMm` and the plate. */
+function designShearTab(Vu: number, nBolts: number, pitchMm = 75, edgeMm = 40, aMm = A_WELD_TO_BOLT): ShearTab {
   const hMm = (nBolts - 1) * pitchMm + 2 * edgeMm      // plate height
-  const wMm = A_WELD_TO_BOLT + 2 * edgeMm               // plate width (weld line → bolt + edge)
+  const wMm = aMm + 2 * edgeMm                          // plate width (weld line → bolt + edge)
 
   // plate thickness from shear yielding (governs over rupture for typical cases)
   const tReq = Vu * 1000 / (PHI_PLATE_YIELD * 0.6 * FY_PLATE * hMm)
@@ -192,6 +217,22 @@ function designFlangeConn(Mu: number, d: number, tf: number, bf: number): Flange
   const flangeArea = bf * tf               // mm²
   const phiCapKn = PHI_CJP * FU_PLATE * flangeArea / 1000  // kN
   return { Tf, flangeArea, phiCapKn, ok: phiCapKn >= Tf - 1e-6 }
+}
+
+const PHI_TENSION = 0.9   // AISC §J4.1 tensile yielding of connecting elements
+
+/** Weak-axis moment detail: size the horizontal extension plates that carry the
+ *  beam-flange force Tf into the column web (fillet welds both sides along the
+ *  clear web depth). Plate width ≥ beam bf; tension yielding per §J4.1. */
+function designWebMomentPlate(Tf: number, beamBf: number, colD: number, colTf: number): WebMomentPlate {
+  const wMm = Math.ceil((beamBf + 20) / 10) * 10          // plate a little wider than the beam flange
+  const tReq = (Tf * 1000) / (PHI_TENSION * FY_PLATE * wMm)
+  const tMm = adoptPlate(Math.max(8, tReq))
+  const phiPlateKn = (PHI_TENSION * FY_PLATE * tMm * wMm) / 1000
+  const Lw = 2 * Math.max(colD - 2 * colTf, 100)          // both sides of the plate along the web
+  const weldMm = Math.max(6, Math.ceil(Tf / (phiWeldPerMm(1) * Lw)))
+  const phiWeldKn = phiWeldPerMm(weldMm) * Lw
+  return { tMm, wMm, weldMm, phiPlateKn, phiWeldKn, ok: phiPlateKn >= Tf - 1e-6 && phiWeldKn >= Tf - 1e-6 }
 }
 
 /**
@@ -251,17 +292,29 @@ export function designSteelJoints(
       })
       if (beamMems.length === 0) continue
 
-      // Determine column strong-axis direction from the count of X vs Z beams
-      let xCount = 0, zCount = 0
-      for (const mid of beamMems) {
-        const mem = memMap.get(mid)!
-        const ni = nodeMap.get(mem.i)!, nj = nodeMap.get(mem.j)!
-        if (spanDirOf(ni, nj) === 'x') xCount++
-        else zCount++
-      }
-      // Strong axis faces the direction with more beams (girder direction)
-      // If equal, default to X (primary frame direction)
-      const strongAxisDir: 'x' | 'z' = xCount >= zCount ? 'x' : 'z'
+      // The column member actually present at this node (may be the storey
+      // above/below the loop column) — its section + orientation set the faces.
+      const colAtNode = neighbours.find((mid) => colIds.has(mid)) ?? col.id
+      const colDesign = design.steelColumns.find((c) => c.id === colAtNode)
+        ?? design.steelColumns.find((c) => c.id === col.id)!
+      const colMemAtNode = memMap.get(colAtNode) ?? colMem
+      const colShp = shapeByName(colDesign.shape)
+
+      // Column strong-axis direction from the member's RESOLVED orientation
+      // (explicit axisRotation, or the vertical 90° default that puts depth d
+      // on global X) — the same axes the solver, rigid zones and the drawn
+      // section use. The depth axis is local y′ projected to the horizontal:
+      // a beam spanning along it lands on the FLANGE face; across it, the WEB.
+      const cpi = nodeMap.get(colMemAtNode.i), cpj = nodeMap.get(colMemAtNode.j)
+      const colDir: V3 = cpi && cpj ? [cpj.x - cpi.x, cpj.y - cpi.y, cpj.z - cpi.z] : [0, 1, 0]
+      const [, ypCol] = localAxes(colDir, defaultAxisRotation(colDir, colMemAtNode.axisRotation))
+      const dh = Math.hypot(ypCol[0], ypCol[2])
+      const depthDir: [number, number] = dh > 1e-9 ? [ypCol[0] / dh, ypCol[2] / dh] : [1, 0]
+      const strongAxisDir: 'x' | 'z' = Math.abs(depthDir[0]) >= Math.abs(depthDir[1]) ? 'x' : 'z'
+
+      // A WEB-face tab is welded to the column web and extended past the flange
+      // tips so the bolts are erectable — the bolt line moves out by (bf−tw)/2.
+      const aWebMm = A_WELD_TO_BOLT + Math.max(0, ((colShp?.bf ?? 0) - (colShp?.tw ?? 0)) / 2)
 
       const connections: BeamConnection[] = []
 
@@ -270,8 +323,12 @@ export function designSteelJoints(
         const ni = nodeMap.get(mem.i)!, nj = nodeMap.get(mem.j)!
         const sDir = spanDirOf(ni, nj)
 
-        // The column face the beam frames into
-        const faceType: ConnFaceType = sDir === strongAxisDir ? 'flange' : 'web'
+        // The column face the beam frames into: compare the beam's horizontal
+        // direction with the column DEPTH axis (|cos| ≥ √2/2 ⇒ flange face).
+        const bdx = nj.x - ni.x, bdz = nj.z - ni.z
+        const bl = Math.hypot(bdx, bdz)
+        const cosA = bl > 1e-9 ? Math.abs((bdx * depthDir[0] + bdz * depthDir[1]) / bl) : 1
+        const faceType: ConnFaceType = cosA >= Math.SQRT1_2 ? 'flange' : 'web'
 
         const row = beamRow.get(mid)
         // If no design row (can happen for non-designed members): use a minimal shear
@@ -288,16 +345,25 @@ export function designSteelJoints(
           || (connKind !== 'simple' && phiMn > 1e-9 && (Mu / phiMn) > MOMENT_CONN_THRESHOLD)
 
         // Elastic eccentric bolt group (each bolt placed & checked individually).
-        const bolts = designBolts(Vu, { dia: 20 })
-        const tab = designShearTab(Vu, bolts.n)
+        // Web-face tabs carry the larger extended-plate eccentricity.
+        const aMm = faceType === 'web' ? aWebMm : A_WELD_TO_BOLT
+        const bolts = designBolts(Vu, { dia: 20, aMm })
+        const tab = designShearTab(Vu, bolts.n, undefined, undefined, aMm)
 
+        // Moment path per the FACE the flanges meet: direct CJP into a column
+        // flange; extension plates into a column web (CJP into the thin web
+        // has no stiffness path — AISC DG13 weak-axis detail).
         let flangeConn: FlangeMomentConn | undefined
         if (useMoment && row) {
           flangeConn = designFlangeConn(Mu, row.d, row.tf, row.bf)
+          if (faceType === 'web') {
+            const wp = designWebMomentPlate(flangeConn.Tf, row.bf, colShp?.d ?? 300, colShp?.tf ?? 15)
+            flangeConn = { ...flangeConn, phiCapKn: Math.min(wp.phiPlateKn, wp.phiWeldKn), ok: wp.ok, webPlate: wp }
+          }
         }
 
         // Which beam element(s) the connection engages: web only for a shear tab;
-        // web (shear) + both flanges (CJP welds) for a moment connection.
+        // web (shear) + both flanges (moment path) for a moment connection.
         const beamElement: BeamAttachment = useMoment ? 'web+flanges' : 'web'
 
         const tabOk  = tab.phiVn >= Vu - 1e-6 && tab.phiWeldVn >= Vu - 1e-6
@@ -309,7 +375,7 @@ export function designSteelJoints(
           spanDir: sDir,
           faceType,
           beamElement,
-          connType: useMoment ? 'moment-flange-weld' : 'shear-tab',
+          connType: useMoment ? (faceType === 'web' ? 'moment-web-plate' : 'moment-flange-weld') : 'shear-tab',
           pinned: !useMoment,
           Vu, Mu,
           bolts,
@@ -320,10 +386,6 @@ export function designSteelJoints(
       }
 
       if (connections.length === 0) continue
-
-      // Find the column member id connected to this node (may be i or j)
-      const colAtNode = neighbours.find((mid) => colIds.has(mid)) ?? col.id
-      const colDesign = design.steelColumns.find((c) => c.id === colAtNode) ?? design.steelColumns.find((c) => c.id === col.id)!
 
       joints.push({
         nodeId,

--- a/webapp/src/lib/connectionSolution.test.ts
+++ b/webapp/src/lib/connectionSolution.test.ts
@@ -43,6 +43,29 @@ describe('connectionRowSolution — schedule row worked solution', () => {
     expect(steps.some((s) => s.title.includes('Flange force'))).toBe(true)
   })
 
+  it('a weak-axis (column-web) moment connection adds the extension-plate step', () => {
+    const m2 = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section: steel })
+    m2.loads = buildGravityLoads(m2, 4.8, 2.4)
+    const nm = new Map(m2.nodes.map((n) => [n.id, n]))
+    const zBeam = m2.members.find((mem) => {
+      if (mem.role !== 'beam' && mem.role !== 'girder') return false
+      const ni = nm.get(mem.i)!, nj = nm.get(mem.j)!
+      return Math.abs(nj.z - ni.z) > Math.abs(nj.x - ni.x)
+    })!
+    zBeam.connections = { iEnd: 'moment', jEnd: 'moment' }
+    const d2 = designStructure(m2, soil)!
+    const wc = d2.joints.flatMap((j) => j.connections).find((c) => c.connType === 'moment-web-plate')!
+    expect(wc).toBeTruthy()
+    const j2 = d2.joints.find((j) => j.connections.includes(wc))!
+    const steps = connectionRowSolution(wc, { kind: 'column', shape: j2.columnShape, faceType: wc.faceType })
+    const flat = JSON.stringify(steps)
+    expect(flat).toContain('Weak-axis moment connection')
+    expect(steps.some((s) => s.title.includes('extension plates'))).toBe(true)
+    expect(flat).toContain(`PL ${wc.flange!.webPlate!.tMm}×${wc.flange!.webPlate!.wMm}`)
+    // the element pairing is stated up front
+    expect(flat).toContain('web + flanges')
+  })
+
   it('a coped beam-to-beam fin plate adds the SCM Part 9 cope step', () => {
     const coped = { ...conn, cope: { lengthMm: 98, depthMm: 26 } }
     const steps = connectionRowSolution(coped, { kind: 'girder', shape: 'W360x51' })

--- a/webapp/src/lib/connectionSolution.ts
+++ b/webapp/src/lib/connectionSolution.ts
@@ -26,14 +26,18 @@ export function connectionRowSolution(c: BeamConnection, host: ConnHost): Soluti
   const Ab = (Math.PI / 4) * b.dia * b.dia
   const phiRn = (PHI_BOLT * FNV * Ab) / 1000
 
+  const beamSide = c.beamElement === 'web+flanges' ? 'web + flanges' : 'web'
+  const hostSide = host.kind === 'column' ? `column ${host.shape} ${host.faceType ?? 'flange'} face` : `girder ${host.shape} web`
   steps.push({
     title: 'Design forces and connection type',
     lines: [
-      { text: `Beam ${c.beamId} lands on the ${host.kind === 'column' ? `column ${host.shape} ${host.faceType ?? ''} face` : `web of girder ${host.shape}`}.` },
+      { text: `Element pairing: beam ${c.beamId} ${beamSide} → ${hostSide}. The web/flange pair on each side selects the detail below.` },
       { tex: `V_u = ${sn1(c.Vu)}\\ \\text{kN}${c.Mu > 0 ? `,\\quad M_u = ${sn1(c.Mu)}\\ \\text{kN·m}` : ''}` },
       { text: c.connType === 'moment-flange-weld'
-        ? 'Moment connection: CJP flange welds carry Mu; the single-plate web tab carries Vu (§J1.2 force split).'
-        : `Simple (shear-only) ${host.kind === 'girder' ? 'fin plate' : 'shear tab'} — the end is a pin; only Vu transfers.` },
+        ? 'Strong-axis moment connection (beam flanges meet the column FLANGE): direct CJP flange welds carry Mu; the single-plate web tab carries Vu (§J1.2 force split).'
+        : c.connType === 'moment-web-plate'
+        ? 'Weak-axis moment connection (beam flanges meet the column WEB): CJP into the thin web has no load path, so horizontal extension plates welded into the web carry the flange forces (AISC DG13 detail); the web tab carries Vu.'
+        : `Simple (shear-only) ${host.kind === 'girder' ? 'fin plate' : 'shear tab'} — the end is a pin; only Vu transfers.${host.kind === 'column' && host.faceType === 'web' ? ' The plate is welded to the column web and EXTENDED past the flange tips so the bolts are erectable — the larger eccentricity is carried below.' : ''}` },
     ],
   })
 
@@ -80,6 +84,19 @@ export function connectionRowSolution(c: BeamConnection, host: ConnHost): Soluti
         { tex: `T_f = \\dfrac{M_u}{d - t_f} = ${sn1(c.flange.Tf)}\\ \\text{kN}` },
         { tex: `\\phi R_{CJP} = \\phi F_u A_{fl} = ${sn1(c.flange.phiCapKn)}\\ \\text{kN} \\quad ${c.flange.ok ? '\\checkmark' : '\\text{NG}'} \\qquad (A_{fl} = ${Math.round(c.flange.flangeArea)}\\ \\text{mm}^2)` },
         { text: 'Provide column continuity plates at both beam-flange levels (web crippling/local bending, §J10).' },
+      ],
+    })
+  }
+
+  if (c.connType === 'moment-web-plate' && c.flange?.webPlate) {
+    const wp = c.flange.webPlate
+    steps.push({
+      title: 'Flange force — weak-axis extension plates (§J4.1, §J2.4)',
+      lines: [
+        { tex: `T_f = \\dfrac{M_u}{d - t_f} = ${sn1(c.flange.Tf)}\\ \\text{kN}` },
+        { text: `Horizontal plates PL ${wp.tMm}×${wp.wMm} mm at both beam-flange levels, welded into the column web between the flanges; the beam flanges CJP to the plate edges.` },
+        { tex: `\\phi R_{pl} = 0.9\\, F_y\\, t\\, w = 0.9 \\cdot 248 \\cdot ${wp.tMm} \\cdot ${wp.wMm} / 10^3 = ${sn1(wp.phiPlateKn)}\\ \\text{kN} \\; ${wp.phiPlateKn >= c.flange.Tf ? '\\ge' : '<'} \\; T_f \\quad ${wp.phiPlateKn >= c.flange.Tf ? '\\checkmark' : '\\text{NG}'}` },
+        { tex: `\\phi R_w = ${sn1(wp.phiWeldKn)}\\ \\text{kN} \\; ${wp.phiWeldKn >= c.flange.Tf ? '\\ge' : '<'} \\; T_f \\quad ${wp.phiWeldKn >= c.flange.Tf ? '\\checkmark' : '\\text{NG}'} \\qquad (w = ${wp.weldMm}\\ \\text{mm fillet, both sides along the web})` },
       ],
     })
   }

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -3928,7 +3928,8 @@ export default function ModelSpace() {
                           <span className="text-slate-400"> → beam {c.beamElement}</span>
                         </td>
                         <td className="py-1 pr-2 text-[11px]">
-                          {c.connType === 'moment-flange-weld' ? 'Moment (CJP flange)' : 'Shear tab'}
+                          {c.connType === 'moment-flange-weld' ? 'Moment (CJP flange)'
+                            : c.connType === 'moment-web-plate' ? 'Moment (web ext. plates)' : 'Shear tab'}
                           <div className="text-[10px] text-slate-400">{c.pinned ? 'pin — releases Mz' : 'rigid'}</div>
                         </td>
                         <td className="py-1 pr-2 text-right">{f1(c.Vu)}</td>
@@ -3940,7 +3941,7 @@ export default function ModelSpace() {
                         <td className="py-1 pr-2 text-[11px]">{c.tab.t}×{Math.round(c.tab.hMm)} mm</td>
                         <td className="py-1 pr-2 text-[11px]">
                           {c.tab.weldSizeMm}mm E70
-                          {c.flange && <span className="ml-1 text-blue-600">+ CJP flg</span>}
+                          {c.flange && <span className="ml-1 text-blue-600">{c.flange.webPlate ? '+ ext. plates' : '+ CJP flg'}</span>}
                         </td>
                         <td className="py-1 text-[11px]">
                           <span className={c.ok ? 'text-green-700' : 'text-red-600'}>{c.ok ? '✓ OK' : '✗ NG'}</span>


### PR DESCRIPTION
Fixes the two issues from the screenshots: the colliding bolt-layout labels on `/bolted-connection`, and the joint designer not knowing which element (web vs flange) each side of a connection actually engages.

## Part A — bolt renderer (`ConnectionDrawing.tsx`)
- Display plate is derived from the **actual absolute bolt positions** + 40 mm edge margin, so custom `boltGeomFromPositions` layouts (whose `plateW/H` are extents, not origin-based) render correctly; grid geometries keep their declared plate.
- Canvas always includes the load application point; the `P @ (x, y)` label flips anchor at the right edge so it never clips.
- Labels no longer collide: bolt id top-left of the hole, force resultant bottom-right, both with a white paint-order halo.
- Shared `DimBelow`/`DimSide` architectural-tick dimensions (same primitives as the RC schematics), centroid crosshair, dashed eccentricity trace centroid → load point, responsive SVG.

## Part B — web/flange pairing selects the connection (engine layers 2/6 + UI)
**Engine (`steelConnections.ts`)**
- The column face is now determined from the column's **resolved orientation** (`localAxes` + `defaultAxisRotation`, i.e. explicit `axisRotation` or the vertical 90° default) instead of the beam-count heuristic — the same axes the solver, rigid end zones and the drawn section use. Beam horizontal direction vs the column depth axis (|cos| ≥ √2/2) decides flange vs web.
- **Web-face shear tabs** are extended past the column flange tips for erectability: the bolt line moves out by (bf − tw)/2 and both the plate width and the elastic eccentric bolt-group design carry the larger eccentricity.
- A moment demand landing on a column **web** now becomes a **`moment-web-plate`** connection (weak-axis detail): horizontal extension plates welded into the column web at both beam-flange levels, checked for §J4.1 tension yielding and §J2.4 fillet welds — instead of pretending a CJP into the thin web works. Flange-face moment connections keep the direct CJP detail.
- Beam-to-beam fin plates (girder web) unchanged; `faceType`/`beamElement` state the pairing on every connection.

**Solution (`connectionSolution.ts`)** — step 1 states the element pairing (`beam web + flanges → column web`), the web-face tab notes the extended-plate eccentricity, and weak-axis connections get a dedicated extension-plate step (plate + weld checks, PL callout).

**2D detail (`ConnectionDetail2D.tsx`)** — web-face tabs weld at the **column web centreline** (dashed weld-line marker) and run past the flange tips to the bolts; the SECTION shows the column depth with both flanges edge-on for web faces; `moment-web-plate` draws the extension plates in both views.

**3D (`JointConnections3D.tsx`)** — the weld line follows the engine's face determination (flange face d/2, web plane tw/2 with the plate through the flange-tip plane); weak-axis joints render their extension plates; continuity plates remain strong-axis only. Schedule rows label the new type (`Moment (web ext. plates)` / `+ ext. plates`).

## Verification
- `npm test`: **1003 passed** (4 new: orientation-driven face swap under `axisRotation: 0`, extended web-face eccentricity + plate growth, weak-axis extension-plate design, weak-axis worked-solution step).
- `npx tsc -b` and `npm run build` clean.
- Browser-verified with Playwright screenshots: bolt layout (no collisions, label inside canvas), web-face tab, weak-axis moment and flange-face regression renders of `ConnectionDetail2D`.

Engine layers touched: L2-adjacent joint designer (steelConnections), L6 presentation. No solver changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_