### PR TITLE
fix: member-thermal PT unit bug — N vs kN in modelBridge

### DIFF
--- a/webapp/src/engine/modelBridge.test.ts
+++ b/webapp/src/engine/modelBridge.test.ts
@@ -123,6 +123,21 @@ describe('modelToFrame3D — shell elements', () => {
   })
 })
 
+describe('modelToFrame3D — member-thermal loads', () => {
+  it('converts EA·α·ΔT to kN (hand calc: 300×500 f\'c=28, α=1e-5, ΔT=20 → ≈746 kN)', () => {
+    const model = baseModel()
+    model.loads = [{ kind: 'member-thermal', member: 'm', deltaT: 20, alpha: 1e-5, cat: 'D' }]
+    const br = modelToFrame3D(model)
+    const th = br.loads.find((l) => l.kind === 'member-thermal') as Extract<typeof br.loads[number], { kind: 'member-thermal' }>
+    // E = 4700·√28 = 24 870 MPa, A = 300·500 = 150 000 mm²
+    // PT = E·A·α·ΔT = 24 870 × 150 000 × 1e-5 × 20 = 746 102 N = 746.1 kN
+    const expected = (4700 * Math.sqrt(28) * 150_000 * 1e-5 * 20) / 1000
+    expect(expected).toBeCloseTo(746.1, 1)      // hand-calc sanity anchor
+    expect(th.PT).toBeCloseTo(expected, 6)
+    expect(th.cat).toBe('D')
+  })
+})
+
 describe('connection type → member releases (force behaviour)', () => {
   it("a 'simple' end releases the bending moments My, Mz (a pin)", () => {
     const rel = effectiveReleases({ connections: { iEnd: 'simple' } })

--- a/webapp/src/engine/modelBridge.ts
+++ b/webapp/src/engine/modelBridge.ts
@@ -256,8 +256,8 @@ export function modelToFrame3D(model: StructuralModel, opts?: BridgeOpts): Bridg
       if (!m) continue
       const sec = model.sections.find((s) => s.id === m.section)
       if (!sec) continue
-      const { E, A } = sectionProps(sec)   // E in kN/mm², A in mm²
-      const PT = E * A * ld.alpha * ld.deltaT   // kN
+      const { E, A } = sectionProps(sec)   // E in MPa (N/mm²), A in mm²
+      const PT = (E * A * ld.alpha * ld.deltaT) / 1000   // N → kN (frame3d expects PT in kN)
       loads.push({ kind: 'member-thermal', member: ld.member, PT, cat: ld.cat })
     }
   }


### PR DESCRIPTION
## Summary
**Layer: L2 bridge** (`modelBridge.ts`).

`sectionProps()` returns **E in MPa (N/mm²)** and **A in mm²**, so the member-thermal equivalent axial force `PT = E·A·α·ΔT` evaluated in **newtons** — but `frame3d` consumes `member-thermal` PT in **kN** (its own docstring says kN, and it scales `EA` by `/1000` on every other path; `thermalLoad.test.ts` computes PT with `/1000` too). Every thermal load routed through the model bridge was therefore **1000× too large**.

## Fix
- `PT = (E·A·α·ΔT) / 1000` in the bridge (N → kN), where the unit conversion belongs per the layer map.
- Corrected the misleading `// E in kN/mm²` comment to `// E in MPa (N/mm²)`.

## Test (hand calc)
New case in `modelBridge.test.ts`: 300×500 f'c=28 member (E = 4700·√28 = 24 870 MPa, A = 150 000 mm²), α = 1×10⁻⁵/°C, ΔT = +20 °C → PT = 746.1 kN. The test anchors the expected value to the hand calc with `toBeCloseTo(746.1, 1)` before comparing against the bridge output.

## Verification
- `npm test`: 83 files / 1004 tests pass
- `npx tsc -b`: clean

(One unrelated steel-optimizer test flaked on the first full run and passed on re-run with no code change in between.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)