### PR TITLE
fix: CI gate for Pages deploy, W310x342 test timeout, Roadmap truth-up

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,9 +1,11 @@
-# Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+# CI (typecheck + lint + tests) on every push/PR to main; Pages deploy only
+# runs on push to main and only after CI passes.
+name: CI and deploy to Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
+    branches: ["main"]
+  pull_request:
     branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
@@ -15,19 +17,48 @@ permissions:
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
 jobs:
-  # Single deploy job since we're just deploying
+  ci:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: webapp
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: webapp/package-lock.json
+      - name: Install
+        run: npm ci
+      - name: Typecheck
+        run: npx tsc -b
+      # Non-blocking for now: main has 28 pre-existing eslint errors (react-hooks
+      # render-safety in ModelSpace/Diagram/useCalcResult + assorted no-useless-*).
+      # Remove continue-on-error once they're fixed so lint gates like the rest.
+      - name: Lint
+        run: npm run lint
+        continue-on-error: true
+      - name: Test
+        run: npm test
+
   deploy:
+    # Deploy only from pushes to main (and manual dispatch), never from PRs,
+    # and only once CI is green.
+    needs: ci
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+    # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -38,7 +38,7 @@ Target: v1.0  ·  Status: In Progress
 
 Goals:
 - [x] Hand calculations (engine-vs-closed-form benchmarks, `engine/validation.ts`)
-- [x] Automated validation tests (`validation.test.ts`; enforced in CI)
+- [x] Automated validation tests (`validation.test.ts`; run in the GitHub Actions `ci` job — `.github/workflows/static.yml` — gating the Pages deploy)
 - [x] Validation dashboard (`/validation` page with live per-module pass counts)
 - [ ] Validation Manual (docs/validation chapters; frame/modal/RS write-ups)
 - [ ] ETABS / STAAD comparisons (external-tool cross-checks)
@@ -69,7 +69,7 @@ Geotechnical:
 - [x] Soil Nailing (`/soil-nail`, FHWA GEC-7)
 - [x] Micropile Design (`/micropile`, FHWA-NHI-05-039)
 - [x] Shotcrete Design (`/shotcrete-facing`; FHWA GEC-7 facing flexure + punching)
-- [ ] Rock Anchors
+- [x] Rock Anchors (`/rock-anchor`, PTI DC35.1 / FHWA-IF-99-015)
 - [ ] Pressure Grouting
 
 ---

--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -627,6 +627,8 @@ describe('optimizeStructure — steel sections', () => {
     expect(r.steps.some((s) => !s.ok)).toBe(true) // at least one failing iteration logged
   })
 
+  // Shrinking from the heaviest W-shape walks many optimizer iterations
+  // (~6–7 s), past vitest's 5 s default — give it explicit headroom.
   it('shrinks an oversized steel shape (W310x342) while the design stays OK', () => {
     const start = steelModel('W310x342')
     const first = designStructure(start, soil)!
@@ -635,7 +637,7 @@ describe('optimizeStructure — steel sections', () => {
     expect(r.converged).toBe(true)
     // shrink must have stepped at least one section down from the starting shape
     expect(r.model.sections.some((s) => s.shape !== 'W310x342')).toBe(true)
-  })
+  }, 20000)
 
   it('steel self-weight uses shape area × 78.5 kN/m³, not bounding box × 24', () => {
     // W310x79: A = 10000 mm². Self-weight = 10000/1e6 × 78.5 = 0.785 kN/m


### PR DESCRIPTION
## What

1. **CI workflow** — `.github/workflows/static.yml` previously deployed to Pages with zero checks, contradicting Roadmap's "enforced in CI" claim. Added a `ci` job (Node 22, `npm ci`, `npx tsc -b`, `npm run lint`, `npm test` in `webapp/`) that runs on push **and** PR to main; the `deploy` job now `needs: ci` and is skipped on PR events, so a red suite can no longer ship to Pages.
   - ⚠️ **Lint is `continue-on-error: true` for now**: main carries 28 pre-existing eslint errors (react-hooks render-safety in `ModelSpace.tsx`/`Diagram.tsx`/`useCalcResult.ts`, plus assorted `no-useless-*`). Gating on lint today would fail every run and block all deploys. Fixing those is real refactor work flagged as a follow-up task; once fixed, drop the `continue-on-error` line.
2. **Test timeout** — `pipeline.test.ts` "shrinks an oversized steel shape (W310x342)" walks the optimizer from the heaviest W-shape (~6.6 s), past vitest's 5 s default and reproducibly timing out. Per-test 20 s timeout (surgical, rather than raising the global `testTimeout` and masking future slow tests).
3. **Roadmap truth-up** — line 41 now cites the actual CI job instead of the aspirational "enforced in CI"; rock anchors ticked (shipped: `src/engine/rockAnchor.ts` + `/rock-anchor`, PTI DC35.1 / FHWA-IF-99-015).

## Verification (local, Windows)

- `npx tsc -b` ✅
- `npm test` ✅ 83 files, **1003/1003** passing (incl. the previously timing-out W310x342 test, now 8.8 s file runtime with headroom)
- `npm run lint` ❌ 28 pre-existing errors (unchanged by this PR; see above)
- Workflow behavior (needs/if/skip-on-PR) is verified by this PR's own checks run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)