### PR TITLE
fix: reversed-sign companion runs for model-derived E/W lateral cases

### DIFF
--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -298,6 +298,31 @@ describe('directional lateral load cases (STAAD-style envelope)', () => {
     expect(r.cases).toHaveLength(7)
     expect(r.beams.every((b) => (b.gov ?? '').length > 0)).toBe(true)
   })
+
+  it('model-derived E loads get a reversed-sign companion and a symmetric envelope (§208.5.1.1)', () => {
+    const m = makeModel()
+    m.loads = [...m.loads, ...seismicXcase(m).loads]   // +X node loads ONLY in the model
+    const r = designStructure(m, soil)!                // no opts.lateral → default path
+    // 7 combos: 2 with E → ×2 (E+/E-) = 4; 3 with W (no W loads) → 3; 2 gravity → 2 = 9
+    expect(r.cases).toHaveLength(9)
+    expect(r.cases.filter((c) => c.includes('· E+'))).toHaveLength(2)
+    expect(r.cases.filter((c) => c.includes('· E-'))).toHaveLength(2)
+    // the reversal is actually enveloped: both senses govern somewhere (windward
+    // columns are governed by E-, leeward by E+ — one direction alone can't do both)
+    expect(r.columns.some((c) => (c.gov ?? '').includes('E+'))).toBe(true)
+    expect(r.columns.some((c) => (c.gov ?? '').includes('E-'))).toBe(true)
+    // symmetric structure + ±X seismic → mirrored columns see identical extremes
+    const col = (id: string) => r.columns.find((c) => c.id === id)!
+    for (const [a, b] of [['c0.0.0', 'c1.0.0'], ['c0.1.0', 'c1.1.0']] as const) {
+      expect(col(a).Pu).toBeCloseTo(col(b).Pu, 5)
+      expect(col(a).Mu).toBeCloseTo(col(b).Mu, 5)
+      expect(col(a).util).toBeCloseTo(col(b).util, 6)
+    }
+    // footing axials envelope both sway senses too (0.9D+E uplift side included)
+    const foot = (n: string) => r.footings.find((f) => f.node === n)!
+    expect(foot('n0.0.0').Pu).toBeCloseTo(foot('n1.0.0').Pu, 5)
+    expect(foot('n0.1.0').Pu).toBeCloseTo(foot('n1.1.0').Pu, 5)
+  })
 })
 
 describe('optimizeStructure', () => {

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -44,7 +44,9 @@ export interface AnalyzeOptions {
   pDelta?: boolean
   /** Directional lateral cases (E/W in ±X/±Z). When given, every combination
    *  with an E (or W) factor is run once per E (or W) case and the design is
-   *  enveloped per member — STAAD-style. */
+   *  enveloped per member — STAAD-style. The list is used VERBATIM — include
+   *  both senses (±) yourself; only the default cases auto-derived from the
+   *  model's E/W node loads get a reversed-sign companion added. */
   lateral?: LateralCase[]
   /** Seismic lateral resisting system — drives column tie detailing per NSCP 2015 §418.
    *  'smf' = Special Moment Frame (§418.7.5), 'imf' = Intermediate (§418.4.3).
@@ -377,6 +379,25 @@ const beamSeverity = (r: BeamScheduleRow) =>
 
 interface FrameRun { name: string; result: F3Result }
 
+/** Default directional lateral cases derived from the model's category-E/W node
+ *  loads. Seismic and wind forces act in BOTH senses along each axis (NSCP 2015
+ *  §208.5.1.1 E is reversible; §207A.8 wind on each principal axis), so each
+ *  auto-derived case gets a reversed-sign companion — without it 0.9D + 1.0E/W
+ *  never sees uplift/moment reversal and the envelope is one-sided. A
+ *  caller-supplied opts.lateral list is used verbatim: the caller owns its own
+ *  ± directions (the UI already generates +X/−X/+Z/−Z). */
+function defaultLateralCases(model: StructuralModel): LateralCase[] {
+  const neg = (l: ModelLoad): ModelLoad => l.kind === 'node'
+    ? { ...l, Fx: -(l.Fx ?? 0), Fy: -(l.Fy ?? 0), Fz: -(l.Fz ?? 0) }
+    : l
+  const out: LateralCase[] = []
+  const eL = model.loads.filter((l) => l.kind === 'node' && l.cat === 'E')
+  const wL = model.loads.filter((l) => l.kind === 'node' && l.cat === 'W')
+  if (eL.length) out.push({ name: 'E+', kind: 'E', loads: eL }, { name: 'E-', kind: 'E', loads: eL.map(neg) })
+  if (wL.length) out.push({ name: 'W+', kind: 'W', loads: wL }, { name: 'W-', kind: 'W', loads: wL.map(neg) })
+  return out
+}
+
 /** Build the load cases to envelope: every NSCP combination, expanded once per
  *  directional lateral case (E/W) when the combination carries that factor. */
 function buildRuns(model: StructuralModel, opts: AnalyzeOptions, onProgress?: ProgressFn) {
@@ -386,13 +407,7 @@ function buildRuns(model: StructuralModel, opts: AnalyzeOptions, onProgress?: Pr
   const gravityModel = { ...model, loads: model.loads.filter((l) => l.cat !== 'E' && l.cat !== 'W') }
   const br = modelToFrame3D(gravityModel, { useShells: false })
 
-  let lateral = opts.lateral ?? []
-  if (lateral.length === 0) {
-    const eL = model.loads.filter((l) => l.kind === 'node' && l.cat === 'E')
-    const wL = model.loads.filter((l) => l.kind === 'node' && l.cat === 'W')
-    if (eL.length) lateral = [...lateral, { name: 'E', kind: 'E', loads: eL }]
-    if (wL.length) lateral = [...lateral, { name: 'W', kind: 'W', loads: wL }]
-  }
+  const lateral = opts.lateral?.length ? opts.lateral : defaultLateralCases(model)
   const toF3 = (l: ModelLoad): F3Load =>
     ({ kind: 'node', node: (l as { node: string }).node, Fx: (l as { Fx?: number }).Fx, Fy: (l as { Fy?: number }).Fy, Fz: (l as { Fz?: number }).Fz, cat: l.cat })
   const eCases = lateral.filter((c) => c.kind === 'E')
@@ -762,13 +777,7 @@ async function buildRunsParallel(
   const gravityModel = { ...model, loads: model.loads.filter((l) => l.cat !== 'E' && l.cat !== 'W') }
   const br = modelToFrame3D(gravityModel, { useShells: false })
 
-  let lateral = opts.lateral ?? []
-  if (lateral.length === 0) {
-    const eL = model.loads.filter((l) => l.kind === 'node' && l.cat === 'E')
-    const wL = model.loads.filter((l) => l.kind === 'node' && l.cat === 'W')
-    if (eL.length) lateral = [...lateral, { name: 'E', kind: 'E' as const, loads: eL }]
-    if (wL.length) lateral = [...lateral, { name: 'W', kind: 'W' as const, loads: wL }]
-  }
+  const lateral = opts.lateral?.length ? opts.lateral : defaultLateralCases(model)
   const toF3 = (l: ModelLoad): F3Load =>
     ({ kind: 'node', node: (l as { node: string }).node, Fx: (l as { Fx?: number }).Fx, Fy: (l as { Fy?: number }).Fy, Fz: (l as { Fz?: number }).Fz, cat: l.cat })
   const eCases = lateral.filter((c) => c.kind === 'E')


### PR DESCRIPTION
## Layer
**L6 — design pipeline** (`pipeline.ts` buildRuns / buildRunsParallel).

## Problem
The default lateral path derived from `model.loads` built exactly one E case and one W case at their given sign. Every E/W combo was expanded only over those, so lateral reversal was never enveloped: **0.9D + 1.0E / 0.9D + 1.0W never saw the uplift sense, and beam moment reversal under sway was one-sided.** NSCP 2015 requires the seismic (§208.5.1.1) and wind (§207A.8) lateral force to act in both senses along each axis.

## Fix
- New shared `defaultLateralCases(model)` helper (used by both the sync and worker-pool run builders): the cases auto-derived from category-E/W node loads now come in ± pairs — `E+`/`E-` and `W+`/`W-`, the negated companion flipping Fx/Fy/Fz.
- A caller-supplied `opts.lateral` list is respected **verbatim** and now documented as such — the caller owns its ± directions (the ModelSpace UI already generates +X/−X/+Z/−Z itself, so it is unaffected).

## Test
New combo-envelope test in `pipeline.test.ts`: a model carrying **+X-only** derived seismic node loads now
- runs 9 cases (2 E-combos × E+/E- = 4, 3 W-combos with no W loads, 2 gravity) with both `· E+` and `· E-` tags,
- has **both senses governing** (windward columns governed by E-, leeward by E+ — impossible with one direction),
- gives mirrored columns and footings identical envelope extremes (Pu/Mu/util symmetric to solver precision).

## Verification
- `npx tsc -b` clean.
- `npx vitest run src/engine/pipeline.test.ts`: 54/54 pass.
- Full `npm test`: 1003/1004 — the one failure is `optimizeStructure — steel sections > shrinks an oversized steel shape (W310x342)`, a **pre-existing local flake** (times out at the 5 s default under full-suite load; fails identically on unmodified `main` on this machine, and the test's model has no E/W loads so this change cannot affect it). Flagged separately for an explicit timeout like its RC siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)