### PR TITLE
fix: surface P-Δ non-convergence and slender-column instability (fail-loud)

### DIFF
--- a/webapp/src/engine/columnDesign.test.ts
+++ b/webapp/src/engine/columnDesign.test.ts
@@ -162,8 +162,24 @@ describe('slenderness — nonsway moment magnification (RC-06 conventions)', () 
       Pu: 1000, M1: -80, M2: 100, k: 0.8, Lu: 4, h: 400, EI: 50000,
     })
     expect(r.Pc).toBeCloseTo((Math.PI ** 2 * 50000) / (0.8 * 4) ** 2, 3)
+    expect(r.stable).toBe(true)
     expect(r.delta).toBeGreaterThanOrEqual(1)
     expect(r.M2min).toBeCloseTo((1000 * (15 + 12)) / 1000, 6)   // 27 kN·m
     expect(r.Mc).toBeCloseTo(r.delta * 100, 6)
+  })
+
+  it('Pu ≥ 0.75Pc → stable=false with δ, Mc = ∞ (no silent clamp to 1.0)', () => {
+    // EI = 10 000 kN·m², kLu = 5 m → Pc = π²·10000/25 ≈ 3947.8 kN; 0.75Pc ≈ 2960.9 kN
+    const base = { M1: -80, M2: 100, k: 1, Lu: 5, h: 400, EI: 10000 }
+    const Pc = (Math.PI ** 2 * 10000) / 25
+    const unstable = momentMagnificationNonsway({ ...base, Pu: 0.80 * Pc })
+    expect(unstable.stable).toBe(false)          // Pu = 0.80Pc > 0.75Pc
+    expect(unstable.delta).toBe(Infinity)
+    expect(unstable.Mc).toBe(Infinity)
+    // just below the threshold the magnifier is finite and large, not clamped
+    const nearLimit = momentMagnificationNonsway({ ...base, Pu: 0.70 * Pc })
+    expect(nearLimit.stable).toBe(true)
+    expect(Number.isFinite(nearLimit.delta)).toBe(true)
+    expect(nearLimit.delta).toBeGreaterThan(1)
   })
 })

--- a/webapp/src/engine/columnDesign.ts
+++ b/webapp/src/engine/columnDesign.ts
@@ -281,9 +281,12 @@ export interface SlendernessResult {
   Cm: number
   EI: number                   // kN·m²
   Pc: number                   // kN
-  delta: number
+  delta: number                // Infinity when !stable
+  /** false when Pu ≥ 0.75·Pc — the §6.6.4.5.2 magnifier is undefined (elastic
+   *  instability); the section must be enlarged, not reported unmagnified. */
+  stable: boolean
   M2min: number                // kN·m
-  Mc: number                   // kN·m
+  Mc: number                   // kN·m (Infinity when !stable)
 }
 
 export function momentMagnificationNonsway(i: SlendernessInput): SlendernessResult {
@@ -303,8 +306,12 @@ export function momentMagnificationNonsway(i: SlendernessInput): SlendernessResu
     EI = (0.4 * Ec * Ig) / (1 + (i.betaD ?? 0.6))
   }
   const Pc = (Math.PI ** 2 * EI) / Math.pow(i.k * i.Lu, 2)
-  const delta = Math.max(1, Cm / (1 - i.Pu / (0.75 * Pc)))
+  // ACI 318-14 §6.6.4.5.2: δ = Cm/(1 − Pu/0.75Pc) ≥ 1.0 is only defined for
+  // Pu < 0.75Pc. At or beyond that load the column is elastically unstable —
+  // surface stable=false (δ, Mc = ∞) instead of silently clamping δ to 1.
+  const stable = i.Pu < 0.75 * Pc
+  const delta = stable ? Math.max(1, Cm / (1 - i.Pu / (0.75 * Pc))) : Infinity
   const M2min = (i.Pu * (15 + 0.03 * i.h)) / 1000
-  const Mc = delta * Math.max(Math.abs(i.M2), M2min)
-  return { r, kLuOverR, limit: lim, slender, Cm, EI, Pc, delta, M2min, Mc }
+  const Mc = stable ? delta * Math.max(Math.abs(i.M2), M2min) : Infinity
+  return { r, kLuOverR, limit: lim, slender, Cm, EI, Pc, delta, stable, M2min, Mc }
 }

--- a/webapp/src/engine/frame3d.test.ts
+++ b/webapp/src/engine/frame3d.test.ts
@@ -190,6 +190,32 @@ describe('frame3d — P-Δ second order (vertical cantilever, L = 4)', () => {
     expect(Math.abs(r2.d[6 + 0]) / d2).toBeCloseTo(2, 6)
   })
 
+  it('iterative P-Δ surfaces {converged, iterations, residual} on the result', () => {
+    const P = 0.25 * Pe
+    const r = solveFrame3D(colNodes, colMem, sup,
+      [...lat, { kind: 'node', node: 'top', Fy: -P, cat: 'D' }], { pDelta: true })!
+    expect(r.pDelta).toBeDefined()
+    expect(r.pDelta!.converged).toBe(true)
+    expect(r.pDelta!.singular).toBe(false)
+    expect(r.pDelta!.iterations).toBeGreaterThanOrEqual(1)
+    expect(r.pDelta!.residual).toBeLessThan(1e-5)
+    // first-order solve carries no status
+    expect(solveFrame3D(colNodes, colMem, sup, lat)!.pDelta).toBeUndefined()
+  })
+
+  it('P-Δ that runs out of iterations reports converged:false, not a silent pass', () => {
+    // At 0.9Pe the first tangent solve amplifies drift ~10× (relative increment
+    // ≈ 0.9 ≫ tol); with maxIter 1 that correction is never confirmed, so the
+    // status must say non-converged instead of silently passing.
+    const r = solveFrame3D(colNodes, colMem, sup,
+      [...lat, { kind: 'node', node: 'top', Fy: -0.9 * Pe, cat: 'D' }], { pDelta: true, maxIter: 1 })!
+    expect(r.pDelta).toBeDefined()
+    expect(r.pDelta!.converged).toBe(false)
+    expect(r.pDelta!.singular).toBe(false)
+    expect(r.pDelta!.iterations).toBe(1)
+    expect(r.pDelta!.residual).toBeGreaterThanOrEqual(1e-5)
+  })
+
   it('fixedAxial tension stiffens; amplification grows without bound toward Pcr', () => {
     const rt = solveFrame3D(colNodes, colMem, sup, lat, { pDelta: true, fixedAxial: [+0.25 * Pe] })!
     expect(Math.abs(rt.d[6 + 0])).toBeLessThan(d1)               // tension below first order

--- a/webapp/src/engine/frame3d.ts
+++ b/webapp/src/engine/frame3d.ts
@@ -88,11 +88,23 @@ export interface F3MemberResult {
   Nmax: number; Vmax: number; Mmax: number; Tmax: number
 }
 export interface F3Reaction { node: string; fixity: F3Fixity; F: [number, number, number]; M: [number, number, number] }
+/** Status of the iterative P-Δ solve (self-consistent Kg(N) path only; the
+ *  `fixedAxial` path is a single solve and returns null outright when singular). */
+export interface F3PDeltaStatus {
+  converged: boolean   // residual < tol reached with a non-singular tangent
+  singular: boolean    // tangent LU failed (elastic instability) — d is the last iterate
+  iterations: number   // iterations performed
+  residual: number     // last relative increment ‖Δd‖/‖d‖ (0 when d = 0 exactly)
+}
+
 export interface F3Result {
   d: number[]
   reactions: F3Reaction[]
   members: F3MemberResult[]
   Mmax: number; Vmax: number; Nmax: number
+  /** Present only when an iterative P-Δ solve ran. Callers must check
+   *  converged/singular rather than trusting d blindly near instability. */
+  pDelta?: F3PDeltaStatus
 }
 
 /** St-Venant torsional constant for a solid rectangle b×h (mm). */
@@ -791,6 +803,7 @@ export function solveWithGeometry(
   precomp: FramePrecomp, loads: F3Load[], opts?: PDeltaOpts,
 ): F3Result | null {
   const { idx, members, geoms, shellGeoms, ndof, free, freeIdx, Kff, Kff_raw, supports, diaT, diaNi } = precomp
+  let pdStatus: F3PDeltaStatus | undefined
 
   const mloads = members.map((m, i) => computeMemberLoads(geoms[i], m, loads))
 
@@ -870,16 +883,20 @@ export function solveWithGeometry(
       if (opts?.pDelta) {
         const maxIter = opts.maxIter ?? 20
         const tol = opts.tol ?? 1e-5
+        let res = Infinity, singular = false, iters = 0
         for (let it = 0; it < maxIter; it++) {
           const Kt_ind = applyTtoK(assembleKtff(axialFromState), diaT, diaNi)
           const Ktff_fac = luFactor(Kt_ind)
-          if (!Ktff_fac) break
+          if (!Ktff_fac) { singular = true; break }   // elastic instability — retain last d, flagged in status
           const dn = applyTrecover(luSolve(Ktff_fac, Ff_ind), diaT)
           let num = 0, den = 0
           free.forEach((dof, k) => { num += (dn[k] - d[dof]) ** 2; den += dn[k] ** 2 })
           free.forEach((dof, k) => (d[dof] = dn[k]))
-          if (den === 0 || Math.sqrt(num / den) < tol) break
+          iters = it + 1
+          res = den === 0 ? 0 : Math.sqrt(num / den)
+          if (res < tol) break
         }
+        pdStatus = { converged: !singular && res < tol, singular, iterations: iters, residual: res }
       }
     } else {
       const d0 = luSolve(Kff, Ff)
@@ -890,15 +907,19 @@ export function solveWithGeometry(
       if (opts?.pDelta) {
         const maxIter = opts.maxIter ?? 20
         const tol = opts.tol ?? 1e-5
+        let res = Infinity, singular = false, iters = 0
         for (let it = 0; it < maxIter; it++) {
           const Ktff_fac = luFactor(assembleKtff(axialFromState))
-          if (!Ktff_fac) break                               // elastic instability — retain last d
+          if (!Ktff_fac) { singular = true; break }          // elastic instability — retain last d, flagged in status
           const dn = luSolve(Ktff_fac, Ff)
           let num = 0, den = 0
           free.forEach((dof, k) => { num += (dn[k] - d[dof]) ** 2; den += dn[k] ** 2 })
           free.forEach((dof, k) => (d[dof] = dn[k]))
-          if (den === 0 || Math.sqrt(num / den) < tol) break
+          iters = it + 1
+          res = den === 0 ? 0 : Math.sqrt(num / den)
+          if (res < tol) break
         }
+        pdStatus = { converged: !singular && res < tol, singular, iterations: iters, residual: res }
       }
     }
   }
@@ -949,6 +970,7 @@ export function solveWithGeometry(
     Mmax: Math.max(...results.map((r) => r.Mmax), 0),
     Vmax: Math.max(...results.map((r) => r.Vmax), 0),
     Nmax: Math.max(...results.map((r) => r.Nmax), 0),
+    ...(pdStatus ? { pDelta: pdStatus } : {}),
   }
 }
 

--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -111,6 +111,11 @@ describe('design pipeline — single-bay single-storey grid', () => {
       r.beams.every((b) => b.ok) && r.columns.every((c) => c.ok) && r.footings.every((f) => f.ok),
     )
   })
+
+  it('P-Δ non-convergence gates designOK (fail-loud, never silently designed)', () => {
+    expect(r.pDeltaIssues).toEqual([])   // first-order runs carry no P-Δ status
+    expect(designOK({ ...r, pDeltaIssues: ['1.2D+1.6L+E(+X)'] })).toBe(false)
+  })
 })
 
 describe('steel design pipeline (AISC routing + base plates)', () => {

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -190,6 +190,10 @@ export interface StructureDesign {
   orphanEdges: number
   /** Members no design path could check (unsupported shape family). Non-empty ⇒ designOK is false. */
   unchecked: UncheckedMember[]
+  /** Load-case runs whose P-Δ iteration failed to converge (singular tangent or
+   *  residual above tol) — the forces from those runs are not trustworthy.
+   *  Non-empty ⇒ designOK is false. Empty for first-order analyses. */
+  pDeltaIssues: string[]
 }
 
 /** Every check the pipeline runs must pass — members, foundations, slabs
@@ -203,6 +207,7 @@ export function designOK(d: StructureDesign): boolean {
     && d.slabs.every((s) => s.ok) && d.walls.every((w) => w.ok)
     && d.joints.every((j) => j.ok) && d.beamJoints.every((j) => j.ok) && d.scwb.every((j) => j.ok)
     && d.unchecked.length === 0
+    && d.pDeltaIssues.length === 0
 }
 
 // ── Steel member design (reuses steelDesign engine) ──────────────────────────
@@ -745,6 +750,8 @@ function designFromRuns(
     totals: { concreteMembers, concreteSlabs, concrete: concreteMembers + concreteSlabs, steelKg },
     orphanEdges: br.orphanEdges.length,
     unchecked,
+    // fail-loud: forces from a non-converged P-Δ run must not silently drive design
+    pDeltaIssues: runs.filter((r) => r.result.pDelta && !r.result.pDelta.converged).map((r) => r.name),
   }
   partialDesign.joints = designSteelJoints(model, partialDesign)
   partialDesign.beamJoints = designBeamBeamJoints(model, partialDesign)

--- a/webapp/src/engine/takeoff.test.ts
+++ b/webapp/src/engine/takeoff.test.ts
@@ -117,7 +117,7 @@ describe('structural steel — per-shape unit weight + costed BOM line items (A2
     govName: '', cases: [], beams: [], columns: [], steelBeams: [], steelColumns: [],
     basePlates: [], joints: [], beamJoints: [], slabs: [], walls: [], footings: [], combined: [], scwb: [],
     totals: { concreteMembers: 0, concreteSlabs: 0, concrete: 0, steelKg: 0 }, orphanEdges: 0,
-    unchecked: [],
+    unchecked: [], pDeltaIssues: [],
   }
   // Two steel members: one 6 m W200x46.1 beam, two 4 m W250x49.1 columns.
   const steelBeam: RectSection = {

--- a/webapp/src/lib/columnSolution.ts
+++ b/webapp/src/lib/columnSolution.ts
@@ -157,10 +157,15 @@ export function slendernessSolution(i: SlendernessInput, r: SlendernessResult): 
       lines: [
         eq(String.raw`C_m = 0.6 - 0.4\,\tfrac{M_1}{M_2} = ${sn3(r.Cm)}`),
         eq(String.raw`P_c = \dfrac{\pi^2 EI}{(k L_u)^2} = \dfrac{\pi^2 (${sn0(r.EI)})}{(${sn2(i.k * i.Lu)})^2} = ${sn1(r.Pc)}\ \text{kN}`),
-        eq(String.raw`\delta = \dfrac{C_m}{1 - \tfrac{P_u}{0.75 P_c}} = ${sn3(r.delta)} \ge 1.0`),
-        eq(String.raw`M_{2,min} = P_u(15 + 0.03h) = ${sn2(r.M2min)}\ \text{kN·m},\qquad M_c = \delta\,M_2 = \mathbf{${sn2(r.Mc)}}\ \text{kN·m}`),
+        ...(r.stable ? [
+          eq(String.raw`\delta = \dfrac{C_m}{1 - \tfrac{P_u}{0.75 P_c}} = ${sn3(r.delta)} \ge 1.0`),
+          eq(String.raw`M_{2,min} = P_u(15 + 0.03h) = ${sn2(r.M2min)}\ \text{kN·m},\qquad M_c = \delta\,M_2 = \mathbf{${sn2(r.Mc)}}\ \text{kN·m}`),
+        ] : [
+          eq(String.raw`P_u = ${sn1(i.Pu)}\ \text{kN} \;\ge\; 0.75P_c = ${sn1(0.75 * r.Pc)}\ \text{kN}`),
+          txt('δ = Cm/(1 − Pu/0.75Pc) is undefined — the column is elastically unstable at this load (§406.6.4). Enlarge the section, raise f\'c, or reduce the effective length; magnified design cannot proceed.'),
+        ]),
       ],
-      note: 'Mc replaces Mu in the eccentric design above.',
+      note: r.stable ? 'Mc replaces Mu in the eccentric design above.' : 'UNSTABLE — no Mc; revise the column before design.',
     },
   ]
 }

--- a/webapp/src/pages/ColumnDesign.tsx
+++ b/webapp/src/pages/ColumnDesign.tsx
@@ -66,13 +66,14 @@ export default function ColumnDesign() {
     })
   }, [eccentric, slenderOn, Pu, M1, M2, kEff, Lu, h, EIin, fc, b])
 
+  const unstable = slender !== null && !slender.stable
   const MuEff = slender ? slender.Mc : Mu
   const inter = useMemo(() => {
     if (!eccentric || !(b > 0 && h > 0)) return null
     try { return interaction({ b, h, cover, barDia, tieDia, fc, fy, numBars }) } catch { return null }
   }, [eccentric, b, h, cover, barDia, tieDia, fc, fy, numBars])
   const cap = useMemo(() => {
-    if (!inter || !(Pu > 0) || !(MuEff > 0)) return null
+    if (!inter || !(Pu > 0) || !(MuEff > 0) || !Number.isFinite(MuEff)) return null
     return capacityAtEccentricity({ b, h, cover, barDia, tieDia, fc, fy, numBars }, MuEff / Pu)
   }, [inter, Pu, MuEff, b, h, cover, barDia, tieDia, fc, fy, numBars])
 
@@ -213,10 +214,13 @@ export default function ColumnDesign() {
 
           {axial && (
             <ResultCard title="Results">
-              {eccentric && slender && (
+              {eccentric && slender && (unstable ? (
+                <Row alert label="Slender column UNSTABLE" value={`Pu ≥ 0.75·Pc (${f1(0.75 * slender.Pc)} kN)`}
+                  sub="δ undefined (§406.6.4) — enlarge the section or reduce kLu" />
+              ) : (
                 <Row label="Magnified Mc" value={`${f2(slender.Mc)} kN·m`}
                   sub={`δ=${slender.delta.toFixed(3)} · ${slender.slender ? 'slender' : 'short'}`} />
-              )}
+              ))}
               {eccentric && util !== null && cap && (
                 <Row alert={util > 1} label="Utilisation" value={`${(util * 100).toFixed(0)} %`}
                   sub={`φPn=${f1(cap.phi * cap.Pn)} kN @ e=${f0((MuEff / Pu) * 1000)} mm`} />

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -3188,6 +3188,14 @@ export default function ModelSpace() {
               {design.totals.steelKg > 0 && ` · steel ${(design.totals.steelKg / 1000).toFixed(2)} t`}
             </span>
           </h2>
+          {design.pDeltaIssues.length > 0 && (
+            <div className="rounded-xl border border-red-300 bg-red-50 p-3 text-sm text-red-800">
+              <p className="font-bold">⚠ P-Δ did not converge for {design.pDeltaIssues.length} load case(s) — forces from these runs are unreliable (possible elastic instability).</p>
+              <ul className="mt-1 list-inside list-disc">
+                {design.pDeltaIssues.map((n) => <li key={n}><span className="font-mono">{n}</span></li>)}
+              </ul>
+            </div>
+          )}
           {design.unchecked.length > 0 && (
             <div className="rounded-xl border border-red-300 bg-red-50 p-3 text-sm text-red-800">
               <p className="font-bold">⚠ {design.unchecked.length} member(s) could NOT be design-checked — the result is not a passing design.</p>


### PR DESCRIPTION
## Layer
L3 (status surfacing only — no numeric change to converged solves) + L6 pipeline gate + UI presentation.

Closes the first P1 item of #325 (from the July 2026 audit).

## What
- `frame3d.ts`: both iterative P-Δ paths now report `F3PDeltaStatus {converged, singular, iterations, residual}` on the result. A singular tangent (elastic instability) is flagged instead of `break`-ing silently and returning the last iterate unmarked.
- `columnDesign.ts`: `momentMagnificationNonsway` — when Pu ≥ 0.75·Pc the ACI 318-14 §6.6.4.5.2 magnifier is undefined; previously `Math.max(1, …)` clamped a negative δ to **1.0**, reporting a stable unamplified column exactly when it is elastically unstable. Now returns `stable:false` with δ, Mc = ∞.
- `pipeline.ts`: `StructureDesign.pDeltaIssues` lists runs whose P-Δ didn't converge and **gates `designOK`** — a green design can never be built on unreliable second-order forces.
- UI: ColumnDesign shows a red UNSTABLE row (and skips the e=∞ capacity solve); ModelSpace lists non-converged cases in a red banner; the worked solution prints the unstable branch with the governing inequality.

## Tests (1009 passing, +4)
- δ clamp: Pu = 0.80Pc → stable:false/∞; Pu = 0.70Pc → finite large δ (not clamped).
- P-Δ status: converged run reports residual < tol; maxIter-starved run at 0.9Pe reports converged:false; first-order result carries no status.
- designOK gated by pDeltaIssues.

Verified: `npm test` 1009/1009, `npx tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)