### PR TITLE
feat: cracked-section stiffness modifiers per ACI 318-14 §6.6.3.1.1

### DIFF
--- a/webapp/src/engine/modelBridge.test.ts
+++ b/webapp/src/engine/modelBridge.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { modelToFrame3D, effectiveReleases } from './modelBridge'
+import { solveFrame3D } from './frame3d'
 import { emptyModel, type StructuralModel, type RectSection } from './model'
 
 const section: RectSection = {
@@ -62,6 +63,57 @@ describe('modelToFrame3D — rigid offsets', () => {
     }
     const m = modelToFrame3D(model).members.find((x) => x.id === 'm')!
     expect(m.offI).toEqual([0, 0.9, 0])    // manual wins
+  })
+})
+
+describe('modelToFrame3D — cracked-section modifiers (ACI 318-14 §6.6.3.1.1)', () => {
+  // gross I of the 300×500: Iz = 300·500³/12 = 3.125e9 mm⁴, Iy = 500·300³/12 = 1.125e9 mm⁴
+  const IgZ = (300 * 500 ** 3) / 12, IgY = (500 * 300 ** 3) / 12
+  const twoRoles = (): StructuralModel => ({
+    ...baseModel(),
+    nodes: [{ id: 'a', x: 0, y: 0, z: 0 }, { id: 'b', x: 4, y: 0, z: 0 }, { id: 'c', x: 0, y: 3, z: 0 }],
+    members: [
+      { id: 'bm', i: 'a', j: 'b', role: 'beam', section: 'S' },
+      { id: 'col', i: 'a', j: 'c', role: 'column', section: 'S' },
+    ],
+  })
+
+  it('default (opt-out) keeps gross section properties', () => {
+    const br = modelToFrame3D(twoRoles())
+    expect(br.members.find((m) => m.id === 'bm')!.Iz).toBeCloseTo(IgZ, 0)
+    expect(br.members.find((m) => m.id === 'col')!.Iz).toBeCloseTo(IgZ, 0)
+  })
+
+  it('crackedSections: beams 0.35Ig, columns 0.70Ig, both axes; A and J gross', () => {
+    const br = modelToFrame3D(twoRoles(), { crackedSections: true })
+    const bm = br.members.find((m) => m.id === 'bm')!
+    const col = br.members.find((m) => m.id === 'col')!
+    expect(bm.Iz).toBeCloseTo(0.35 * IgZ, 0)
+    expect(bm.Iy).toBeCloseTo(0.35 * IgY, 0)
+    expect(col.Iz).toBeCloseTo(0.70 * IgZ, 0)
+    expect(col.Iy).toBeCloseTo(0.70 * IgY, 0)
+    expect(bm.A).toBeCloseTo(300 * 500, 6)          // 1.0Ag per Table 6.6.3.1.1(a)
+    expect(bm.J).toBeCloseTo(modelToFrame3D(twoRoles()).members[0].J, 6)  // J untouched
+  })
+
+  it('steel members are exempt from cracking factors', () => {
+    const model = twoRoles()
+    model.sections = [{ ...section, material: 'steel' as const }]
+    const gross = modelToFrame3D(model).members.find((m) => m.id === 'bm')!.Iz
+    const cracked = modelToFrame3D(model, { crackedSections: true }).members.find((m) => m.id === 'bm')!.Iz
+    expect(cracked).toBeCloseTo(gross, 6)
+  })
+
+  it('cracked beam deflects 1/0.35× more under the same load (bridge → solver)', () => {
+    // cantilever tip load through the full bridge+solver path: δ ∝ 1/I
+    const load = { kind: 'node' as const, node: 'b', Fy: -10, cat: 'D' as const }
+    const m = { ...baseModel(), loads: [load] }
+    const solve = (cracked: boolean) => {
+      const br = modelToFrame3D(m, { crackedSections: cracked })
+      return solveFrame3D(br.nodes, br.members, br.supports, br.loads)!
+    }
+    const dG = solve(false).d[6 + 1], dC = solve(true).d[6 + 1]
+    expect(dC / dG).toBeCloseTo(1 / 0.35, 3)
   })
 })
 

--- a/webapp/src/engine/modelBridge.ts
+++ b/webapp/src/engine/modelBridge.ts
@@ -4,7 +4,7 @@
 // and land on the matching edge members as vdl/udl gravity loads (categories
 // preserved) — the load path, automated.
 // ─────────────────────────────────────────────────────────────────────────
-import type { StructuralModel, RectSection, MemberReleases, MemberConnections, ConnectionKind, Plate } from './model'
+import type { StructuralModel, RectSection, MemberReleases, MemberConnections, ConnectionKind, Plate, MemberRole } from './model'
 import type { F3Node, F3Member, F3Support, F3Load, F3DiaphragmGroup, F3Shell } from './frame3d'
 import { rectJ, defaultAxisRotation } from './frame3d'
 import { buildDiaphragmGroups } from './diaphragm'
@@ -180,7 +180,19 @@ function releaseFlags(rel: MemberReleases | undefined): Pick<F3Member, 'relI' | 
 /** Bridge options. `useShells` defaults to the model's `shellElements` flag; the
  *  design / modal / buckling paths pass `false` to keep the classic tributary
  *  edge-load model (shells are an analysis-path feature in this phase). */
-export interface BridgeOpts { useShells?: boolean }
+/** ACI 318-14 Table 6.6.3.1.1(a) — cracked flexural stiffness for factored-load
+ *  analysis: beams 0.35Ig, columns 0.70Ig (braces treated as compression
+ *  members → 0.70). Axial area stays 1.0Ag; J is left gross (torsional cracking
+ *  is a separate §22.7 concern). Concrete members only — steel is uncracked. */
+const CRACKED_I: Record<MemberRole, number> = { beam: 0.35, girder: 0.35, column: 0.70, brace: 0.70 }
+
+export interface BridgeOpts {
+  useShells?: boolean
+  /** Apply ACI §6.6.3.1.1 cracked-section I-modifiers to concrete members.
+   *  Off by default at the API level so closed-form benchmarks stay anchored
+   *  to gross-section theory; the Model Space UI enables it by default. */
+  crackedSections?: boolean
+}
 
 export function modelToFrame3D(model: StructuralModel, opts?: BridgeOpts): BridgeResult {
   const useShells = opts?.useShells ?? !!model.shellElements
@@ -200,8 +212,11 @@ export function modelToFrame3D(model: StructuralModel, opts?: BridgeOpts): Bridg
     // analysis strong-axis orientation matches the drawn one (depth d → X)
     const ni = nm.get(m.i), nj = nm.get(m.j)
     const rot = ni && nj ? defaultAxisRotation([nj.x - ni.x, nj.y - ni.y, nj.z - ni.z], m.axisRotation) : (m.axisRotation ?? 0)
+    const props = secById.get(m.section) ?? fallback
+    const ck = opts?.crackedSections && model.sections.find((s) => s.id === m.section)?.material !== 'steel'
+      ? CRACKED_I[m.role] : 1
     return {
-      id: m.id, i: m.i, j: m.j, ...(secById.get(m.section) ?? fallback),
+      id: m.id, i: m.i, j: m.j, ...props, Iz: props.Iz * ck, Iy: props.Iy * ck,
       ...releaseFlags(effectiveReleases(m)),
       ...(offI ? { offI } : {}),
       ...(offJ ? { offJ } : {}),

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -52,6 +52,10 @@ export interface AnalyzeOptions {
    *  'smf' = Special Moment Frame (§418.7.5), 'imf' = Intermediate (§418.4.3).
    *  Default 'gravity' (ordinary ties only, §425.7.2). */
   seismicSystem?: 'gravity' | 'imf' | 'smf'
+  /** ACI 318-14 §6.6.3.1.1 cracked-section I-modifiers (0.35Ig beams/girders,
+   *  0.70Ig columns/braces) on concrete members. Default off at the API level;
+   *  the Model Space UI enables it by default. */
+  crackedSections?: boolean
 }
 
 export interface BeamSectionDesign {
@@ -410,7 +414,7 @@ function buildRuns(model: StructuralModel, opts: AnalyzeOptions, onProgress?: Pr
   // slab tributary line loads and member self-weight; lateral cases are pure
   // node loads applied on top per direction.
   const gravityModel = { ...model, loads: model.loads.filter((l) => l.cat !== 'E' && l.cat !== 'W') }
-  const br = modelToFrame3D(gravityModel, { useShells: false })
+  const br = modelToFrame3D(gravityModel, { useShells: false, crackedSections: opts.crackedSections })
 
   const lateral = opts.lateral?.length ? opts.lateral : defaultLateralCases(model)
   const toF3 = (l: ModelLoad): F3Load =>
@@ -782,7 +786,7 @@ async function buildRunsParallel(
   model: StructuralModel, opts: AnalyzeOptions, pool: FramePool, onProgress?: ProgressFn,
 ): Promise<{ br: BridgeResult; runs: FrameRun[] }> {
   const gravityModel = { ...model, loads: model.loads.filter((l) => l.cat !== 'E' && l.cat !== 'W') }
-  const br = modelToFrame3D(gravityModel, { useShells: false })
+  const br = modelToFrame3D(gravityModel, { useShells: false, crackedSections: opts.crackedSections })
 
   const lateral = opts.lateral?.length ? opts.lateral : defaultLateralCases(model)
   const toF3 = (l: ModelLoad): F3Load =>

--- a/webapp/src/engine/solverWorker.ts
+++ b/webapp/src/engine/solverWorker.ts
@@ -18,7 +18,7 @@ import type { SolveProgress } from './progress'
 
 type DriftReq = { hasSeis: boolean; T: number; R: number; axis: 'x' | 'z'; pDelta: boolean }
 export type SolverRequest =
-  | { id: number; kind: 'analyze'; model: StructuralModel; opts: F3AnalyzeOpts; drift: DriftReq }
+  | { id: number; kind: 'analyze'; model: StructuralModel; opts: F3AnalyzeOpts; drift: DriftReq; crackedSections?: boolean }
   | { id: number; kind: 'design'; model: StructuralModel; soil: SoilOptions; plan: FootingPlan; opts: AnalyzeOptions; tryBars: boolean }
   | { id: number; kind: 'optimize'; model: StructuralModel; soil: SoilOptions; plan: FootingPlan; opts: AnalyzeOptions; tryBars: boolean; maxIter: number }
   | { id: number; kind: 'modal'; model: StructuralModel; nModes: number }
@@ -33,7 +33,7 @@ ctx.onmessage = async (e: MessageEvent<SolverRequest>) => {
   const onProgress = (p: SolveProgress) => ctx.postMessage({ id: msg.id, progress: p })
   try {
     if (msg.kind === 'analyze') {
-      const br = modelToFrame3D(msg.model)
+      const br = modelToFrame3D(msg.model, { crackedSections: msg.crackedSections })
       const analysis = analyzeFrame3D(br.nodes, br.members, br.supports, br.loads, msg.opts, onProgress, br.diaphragmGroups, br.shells)
       let drift = null
       if (msg.drift.hasSeis) {

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -745,6 +745,7 @@ export default function ModelSpace() {
   // Analysis options: f₁ live-load factor (§203.3.1) and P-Δ second order
   const [assembly, setAssembly] = useState(b('assembly', false))
   const [pDelta, setPDelta] = useState(b('pDelta', false))
+  const [cracked, setCracked] = useState(b('cracked', true))       // ACI §6.6.3.1.1 cracked EI (0.35/0.70 Ig)
   const [tryBars, setTryBars] = useState(b('tryBars', true))        // let design/optimize pick bar Ø from a ladder
   const [showLoads, setShowLoads] = useState(true)   // load-diagram overlay
   const [showFootings, setShowFootings] = useState(true)   // designed footing footprints
@@ -848,7 +849,7 @@ export default function ModelSpace() {
         baysX, baysZ, storeyH, colB, colH, girB, girH, beaB, beaH,
         fc, fy, barDia, tieDia, cover, slabThk, gammaC, qD, qL,
         qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs,
-        Vw, expo, Kzt, wDirs, assembly, pDelta, tryBars,
+        Vw, expo, Kzt, wDirs, assembly, pDelta, cracked, tryBars,
         concreteClass, prices, planSel,
         material, colFam, girFam, beaFam, colShape, girShape, beaShape, steelFy, steelFu,
       }))
@@ -856,7 +857,7 @@ export default function ModelSpace() {
   }, [baysX, baysZ, storeyH, colB, colH, girB, girH, beaB, beaH,
     fc, fy, barDia, tieDia, cover, slabThk, gammaC, qD, qL,
     qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs,
-    Vw, expo, Kzt, wDirs, assembly, pDelta, tryBars,
+    Vw, expo, Kzt, wDirs, assembly, pDelta, cracked, tryBars,
     concreteClass, prices, planSel,
     material, colFam, girFam, beaFam, colShape, girShape, beaShape, steelFy, steelFu])
 
@@ -882,14 +883,14 @@ export default function ModelSpace() {
   // Only applies when E loads are present (user clicked "Generate E cases").
   const hasELoads = model?.loads.some((l) => l.cat === 'E') ?? false
   const seismicSystem: 'gravity' | 'imf' | 'smf' = hasELoads ? (Rw >= 8 ? 'smf' : Rw >= 5 ? 'imf' : 'gravity') : 'gravity'
-  const anaOpts = { f1: fLive, pDelta, lateral, seismicSystem }
+  const anaOpts = { f1: fLive, pDelta, lateral, seismicSystem, crackedSections: cracked }
 
   const analyze = () => {
     if (!model || busy || meshErrors) return   // §1 fail-fast: don't solve a singular mesh
     const axis: 'x' | 'z' = (eDirs[0] ?? '+X').includes('X') ? 'x' : 'z'
     // 3D FEM + storey drift run in the worker so the UI stays responsive.
     run('analyze', {
-      model, opts: anaOpts, drift: { hasSeis: !!seis, T: seis?.T ?? 0, R: Rw, axis, pDelta },
+      model, opts: anaOpts, drift: { hasSeis: !!seis, T: seis?.T ?? 0, R: Rw, axis, pDelta }, crackedSections: cracked,
     }).then((r) => {
       const res = r as { analysis: F3Analysis | null; orphans: number; drift: DriftRow[] | null }
       setOrphans(res.orphans)
@@ -2594,6 +2595,10 @@ export default function ModelSpace() {
                 <label className="col-span-full flex items-center gap-2 text-sm">
                   <input type="checkbox" checked={pDelta} onChange={(e) => setPDelta(e.target.checked)} />
                   <span>P-Δ second-order analysis</span>
+                </label>
+                <label className="col-span-full flex items-center gap-2 text-sm">
+                  <input type="checkbox" checked={cracked} onChange={(e) => setCracked(e.target.checked)} />
+                  <span>Cracked sections — ACI §6.6.3.1.1 (0.35Ig beams, 0.70Ig columns; concrete only)</span>
                 </label>
                 <label className="col-span-full flex items-center gap-2 text-sm">
                   <input type="checkbox" disabled={!model} checked={model?.diaphragm ?? false}


### PR DESCRIPTION
## Layer
L2 bridge — per-role factors in section props, exactly as the backlog prescribes; solver/loads/P-Δ/buckling inherit them through the element transform for free.

Second P1 item of #325 (backlog P1#1 in CLAUDE.md).

## What
- `BridgeOpts.crackedSections`: concrete members get **0.35Ig** (beams/girders) and **0.70Ig** (columns/braces) on both bending axes per ACI 318-14 Table 6.6.3.1.1(a). Area stays 1.0Ag, J stays gross (torsional cracking is a §22.7 concern), steel members exempt.
- `AnalyzeOptions.crackedSections` plumbs it through `buildRuns`/`designStructure`, so factored-load drifts, P-Δ and the whole design envelope run on cracked EI.
- Model Space gains a **Cracked sections** checkbox — ON by default (persisted with the other analysis options) for both Analyze and Design/Optimize.
- **API default is OFF** (deliberate deviation from a blanket opt-out): `/validation` benchmarks and hand-calc tests compare against gross-section closed forms; the UI layer supplies the code-compliant default instead.

## Not in scope (follow-ups noted in #325)
Modal/RS path (`modal.ts` bridges internally), wall struts / shell 0.25Ig, βd sustained-load refinement.

## Tests (1013 passing, +4)
Hand-calc anchored: 0.35/0.70 × Ig on both axes, A/J untouched, steel exempt, default-off, and an end-to-end bridge→solver check that a cracked cantilever deflects exactly 1/0.35× more.

Verified: `npm test` 1013/1013, `npx tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)