### PR TITLE
fix: open-section torsion constant — thin-wall Σbt³/3 instead of polar moment

### DIFF
--- a/webapp/src/engine/aiscSections.test.ts
+++ b/webapp/src/engine/aiscSections.test.ts
@@ -1,5 +1,36 @@
 import { describe, it, expect } from 'vitest'
-import { AISC_SHAPES, shapesOf, shapeByName, effectiveSection, doubleAngle, W_SORTED, nextHeavierW, nextLighterW, sectionBoundingBox, FAMILIES } from './aiscSections'
+import { AISC_SHAPES, shapesOf, shapeByName, effectiveSection, doubleAngle, W_SORTED, nextHeavierW, nextLighterW, sectionBoundingBox, FAMILIES, torsionJ } from './aiscSections'
+
+describe('torsionJ — St-Venant constant per family', () => {
+  it('channel: thin-wall Σbt³/3, orders below the polar moment', () => {
+    // C200x17.1 (d 203, bf 57.4, tf 9.9, tw 5.6):
+    // J = (2·57.4·9.9³ + (203 − 19.8)·5.6³)/3 = 47 854 mm⁴ (hand calc)
+    const c = shapeByName('C200x17.1')!
+    expect(torsionJ(c)).toBeCloseTo(47854.4, 0)
+    // the old polar approximation A(rx²+ry²) ≈ 15.3e6 mm⁴ — ~320× too stiff
+    expect(c.A * (c.rx ** 2 + c.ry ** 2) / torsionJ(c)!).toBeGreaterThan(100)
+  })
+
+  it('angle: Σbt³/3 over the two legs', () => {
+    // L51x51x6.4: J = (51·6.4³ + (51 − 6.4)·6.4³)/3 = 8 353.7 mm⁴ (hand calc)
+    expect(torsionJ(shapeByName('L51x51x6.4')!)).toBeCloseTo(8353.66, 1)
+  })
+
+  it('rect HSS: Bredt J = 4A₀²t/p on the midline', () => {
+    // HSS64x64x4.8: bm = hm = 59.2 → J = 4·(59.2²)²·4.8/(4·59.2) = 995 878 mm⁴
+    expect(torsionJ(shapeByName('HSS64x64x4.8')!)).toBeCloseTo(995878.5, 0)
+  })
+
+  it('round pipe: exact polar (π/32)(D⁴ − Di⁴)', () => {
+    const p = shapesOf('PIPE')[0]
+    const Di = p.D! - 2 * p.t!
+    expect(torsionJ(p)).toBeCloseTo((Math.PI / 32) * (p.D! ** 4 - Di ** 4), 3)
+  })
+
+  it('W/WT return undefined (deriveWSection owns their J)', () => {
+    expect(torsionJ(shapeByName('W310x79')!)).toBeUndefined()
+  })
+})
 
 describe('AISC section library', () => {
   it('every shape has area + radii and a unique name', () => {

--- a/webapp/src/engine/aiscSections.ts
+++ b/webapp/src/engine/aiscSections.ts
@@ -495,6 +495,28 @@ export const FAMILIES: { id: SectionFamily; label: string }[] = [
 export const shapesOf   = (family: SectionFamily) => AISC_SHAPES.filter((s) => s.family === family)
 export const shapeByName = (name: string) => AISC_SHAPES.find((s) => s.name === name)
 
+/** St-Venant torsional constant J (mm⁴) from the tabulated geometry.
+ *  Open shapes (C, L): thin-wall J = Σ(b·t³)/3 (Roark, Table 10.7) — the polar
+ *  moment Ix+Iy overestimates open-section J by 1–2 orders of magnitude, i.e.
+ *  reads UNconservatively stiff in torsion.
+ *  Closed shapes: rect/square HSS by Bredt's second formula J = 4A₀²t/p on the
+ *  midline; round HSS / pipe exactly J = (π/32)(D⁴ − Di⁴) (= Ix+Iy, circular).
+ *  Returns undefined when the needed geometry fields are absent (caller keeps
+ *  its fallback). W/WT use deriveWSection's thin-wall J instead. */
+export function torsionJ(s: AiscShape): number | undefined {
+  if (s.family === 'C' && s.d && s.bf && s.tf && s.tw)
+    return (2 * s.bf * s.tf ** 3 + (s.d - 2 * s.tf) * s.tw ** 3) / 3
+  if (s.family === 'L' && s.leg1 && s.leg2 && s.t)
+    return (s.leg1 * s.t ** 3 + (s.leg2 - s.t) * s.t ** 3) / 3
+  if ((s.family === 'HSS' || s.family === 'PIPE') && s.D && s.t)
+    return (Math.PI / 32) * (s.D ** 4 - (s.D - 2 * s.t) ** 4)
+  if (s.family === 'HSS' && s.b && s.h && s.t) {
+    const bm = s.b - s.t, hm = s.h - s.t              // midline rectangle
+    return (4 * (bm * hm) ** 2 * s.t) / (2 * (bm + hm))
+  }
+  return undefined
+}
+
 /** Overall cross-section bounding box {b (width), h (depth)} in mm, per family.
  *  Used as the RectSection b×h carried alongside a steel member (self-weight uses
  *  the true area, but the box drives fallbacks, quantities and labelling). */

--- a/webapp/src/engine/modelBridge.ts
+++ b/webapp/src/engine/modelBridge.ts
@@ -11,7 +11,7 @@ import { buildDiaphragmGroups } from './diaphragm'
 import { autoRigidOffsets } from './rigidEndZones'
 import { distributePanel, type AreaLoad } from './tributary'
 import type { BeamLoad } from './beamAnalysis'
-import { shapeByName } from './aiscSections'
+import { shapeByName, torsionJ } from './aiscSections'
 import { deriveWSection, E_STEEL } from './steelDesign'
 
 export interface BridgeResult {
@@ -77,10 +77,12 @@ function steelSectionProps(s: RectSection) {
     const d = deriveWSection(shape)
     Iz = d.Ix; Iy = d.Iy; J = d.J
   } else {
-    // generic: I = A·r² about each axis; torsion ≈ box approximation
+    // generic: I = A·r² about each axis; J from the family-correct formula
+    // (thin-wall Σbt³/3 open / Bredt closed) — the polar moment Iz+Iy reads
+    // 1–2 orders too STIFF for open shapes (C, L), which is unconservative.
     Iz = shape.A * shape.rx ** 2
     Iy = shape.A * shape.ry ** 2
-    J = Iz + Iy   // polar (conservative for open shapes; exact for closed tubes)
+    J = torsionJ(shape) ?? Iz + Iy
   }
   return { E, G, A: shape.A, Iz, Iy, J }
 }


### PR DESCRIPTION
## Layer
L2 bridge + AISC section library. Third P1 item of #325.

## Problem
`steelSectionProps` used **J = Iz + Iy** (the polar moment) for every non-W/WT shape, commented *"conservative for open shapes"*. It is the opposite: for open sections the true St-Venant constant is the thin-wall Σbt³/3, and the polar moment over-stiffens torsion by **1–2 orders of magnitude** (C200x17.1: 15.3e6 vs 47 854 mm⁴ — ~320×). Unconservative wherever a channel or angle provides torsional restraint.

## Fix
New `torsionJ(shape)` in `aiscSections.ts`:
- **C / L (open)**: Σ(b·t³)/3 — Roark Table 10.7
- **Rect/square HSS (closed)**: Bredt's second formula 4A₀²t/p on the midline
- **Round HSS / pipe**: exact (π/32)(D⁴ − Di⁴) (unchanged numerically — polar is exact for circular)
- Fallback to the old polar value only when geometry fields are missing; W/WT keep `deriveWSection`'s thin-wall J.

## Tests (1018 passing, +5)
Hand-calc anchored per family, including a guard that the polar/thin-wall ratio for the channel exceeds 100× (documents why the old value was wrong).

Verified: `npm test` 1018/1018, `npx tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)