### PR TITLE
fix: P-Δ reactions carry the secondary shear/moment (Kg term in reaction recovery)

### DIFF
--- a/webapp/src/engine/frame3d.test.ts
+++ b/webapp/src/engine/frame3d.test.ts
@@ -203,6 +203,21 @@ describe('frame3d — P-Δ second order (vertical cantilever, L = 4)', () => {
     expect(solveFrame3D(colNodes, colMem, sup, lat)!.pDelta).toBeUndefined()
   })
 
+  it('P-Δ base reaction carries the secondary moment: M_base ≈ H·L + P·Δ', () => {
+    const P = 0.25 * Pe
+    // first-order: base moment reaction is exactly H·L, no P·Δ term
+    expect(Math.abs(lin.reactions[0].M[2])).toBeCloseTo(H * L, 6)
+    const r = solveFrame3D(colNodes, colMem, sup,
+      [...lat, { kind: 'node', node: 'top', Fy: -P, cat: 'D' }], { pDelta: true })!
+    const drift = Math.abs(r.d[6 + 0])
+    const Mbase = Math.abs(r.reactions[0].M[2])
+    // reactions now assemble (K + Kg)·d − F, so the P·Δ couple shows up
+    expect(Mbase).toBeGreaterThan(H * L * 1.05)
+    expect(Mbase / (H * L + P * drift)).toBeCloseTo(1, 2)
+    // and global vertical equilibrium is untouched (Kg self-equilibrates)
+    expect(r.reactions.reduce((s, q) => s + q.F[1], 0)).toBeCloseTo(P, 6)
+  })
+
   it('P-Δ that runs out of iterations reports converged:false, not a silent pass', () => {
     // At 0.9Pe the first tangent solve amplifies drift ~10× (relative increment
     // ≈ 0.9 ≫ tol); with maxIter 1 that correction is never confirmed, so the

--- a/webapp/src/engine/frame3d.ts
+++ b/webapp/src/engine/frame3d.ts
@@ -804,6 +804,9 @@ export function solveWithGeometry(
 ): F3Result | null {
   const { idx, members, geoms, shellGeoms, ndof, free, freeIdx, Kff, Kff_raw, supports, diaT, diaNi } = precomp
   let pdStatus: F3PDeltaStatus | undefined
+  // Axial state of the FINAL tangent when P-Δ ran — reactions must then be
+  // (K + Kg)·d − F, or the secondary P-Δ shear/moment never reaches supports.
+  let geoAxial: ((mi: number) => number) | null = null
 
   const mloads = members.map((m, i) => computeMemberLoads(geoms[i], m, loads))
 
@@ -872,6 +875,7 @@ export function solveWithGeometry(
         const dn = luSolve(fac, Ff)
         free.forEach((dof, k) => (d[dof] = dn[k]))
       }
+      geoAxial = (mi) => fixed[mi] ?? 0
     } else if (diaT && diaNi !== undefined) {
       // Constrained solve: transform load to independent DOFs, solve, recover full d_f
       const Ff_ind = applyTtoLoad(Ff, diaT, diaNi)
@@ -897,6 +901,7 @@ export function solveWithGeometry(
           if (res < tol) break
         }
         pdStatus = { converged: !singular && res < tol, singular, iterations: iters, residual: res }
+        geoAxial = axialFromState
       }
     } else {
       const d0 = luSolve(Kff, Ff)
@@ -920,16 +925,26 @@ export function solveWithGeometry(
           if (res < tol) break
         }
         pdStatus = { converged: !singular && res < tol, singular, iterations: iters, residual: res }
+        geoAxial = axialFromState
       }
     }
   }
 
-  // Reactions: compute K·d via member contributions (avoids storing full K)
+  // Reactions: compute K·d via member contributions (avoids storing full K).
+  // When P-Δ ran, add each member's Kg(N)·d so reactions carry the secondary
+  // shear/moment: R = (K + Kg)·d − F, consistent with the tangent that solved d.
+  // Kg is self-equilibrating per member, so ΣR = ΣF is unchanged.
   const Kd = new Array(ndof).fill(0)
-  for (const g of geoms) {
+  for (let mi = 0; mi < geoms.length; mi++) {
+    const g = geoms[mi]
     const de = g.dofs.map((dof) => d[dof])
     const gde = matVec(g.kg, de)
     for (let a = 0; a < 12; a++) Kd[g.dofs[a]] += gde[a]
+    if (geoAxial) {
+      const kgg = mul(mul(transpose(g.T), kgLocal(geoAxial(mi), g.L)), g.T)
+      const gge = matVec(kgg, de)
+      for (let a = 0; a < 12; a++) Kd[g.dofs[a]] += gge[a]
+    }
   }
   for (const sg of shellGeoms) {
     const de = sg.dofs.map((dof) => d[dof])


### PR DESCRIPTION
## Layer
L3 — reaction recovery only; stiffness assembly, solve paths, and member force recovery untouched. Statics self-checks (cantilever δ=PL³/3EI, fixed-end moments, Σreactions=Σloads) all green.

Fifth and final P1 item of #325.

## Problem
Reactions were recovered as **K·d − F** using the elastic stiffness only. After a P-Δ solve the equilibrium state is (K+Kg)·d = F, so the reported reactions dropped the −Kg·d part: a cantilever column under lateral H and axial P reported base moment **H·L** instead of **H·L + P·Δ** — the secondary demand simply never reached the supports (or footing design downstream).

## Fix
When P-Δ ran (iterative or `fixedAxial`), the reaction assembly adds each member's Kg(N_final)·d contribution, with N taken from the same axial state as the final tangent. Kg is self-equilibrating per member, so ΣR = ΣF is unchanged.

## Test (1024 passing, +1)
Vertical cantilever at P = 0.25Pe: first-order base moment ≈ H·L exactly; P-Δ base moment ≈ H·L + P·Δ (within 1%), vertical equilibrium ΣRy = P intact.

Verified: `npm test` 1024/1024, `npx tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)