### PR TITLE
feat: searchable all-tools index, grouped Structural dropdown, ARIA menus

### DIFF
--- a/webapp/src/components/Navbar.tsx
+++ b/webapp/src/components/Navbar.tsx
@@ -1,9 +1,19 @@
 import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { TOOL_CATEGORIES, type ToolCategory } from '../lib/tools'
+import { TOOL_CATEGORIES, toolGroups, type ToolCategory, type ToolDef } from '../lib/tools'
 
 // Flat, sharp-cornered top navigation. Tool calculators live in category
 // dropdowns; auth actions sit on the right. Hidden in print via `no-print`.
+
+function ToolLink({ t, onClose }: { t: ToolDef; onClose: () => void }) {
+  return (
+    <Link to={t.to} role="menuitem" onClick={onClose}
+      className="group flex flex-col px-4 py-2 hover:bg-[#f4f8ff]">
+      <span className="text-sm font-medium text-slate-800 group-hover:text-[#0056b3]">{t.name}</span>
+      <span className="text-[10px] uppercase tracking-wider text-slate-500">{t.sub}</span>
+    </Link>
+  )
+}
 
 function Dropdown({ category, open, onToggle, onClose }: {
   category: ToolCategory
@@ -11,23 +21,32 @@ function Dropdown({ category, open, onToggle, onClose }: {
   onToggle: () => void
   onClose: () => void
 }) {
+  const groups = toolGroups(category)
+  const grouped = groups.some(g => g.group !== '')
   return (
     <div className="relative">
-      <button onClick={onToggle}
+      <button onClick={onToggle} aria-haspopup="menu" aria-expanded={open}
         className={`flex h-11 items-center gap-1.5 px-3 text-xs font-semibold tracking-wide transition-colors ${
           open ? 'bg-white/10 text-white' : 'text-slate-300 hover:text-white'}`}>
         {category.label}
-        <span className={`text-[8px] transition-transform ${open ? 'rotate-180' : ''}`}>▼</span>
+        <span aria-hidden className={`text-[8px] transition-transform ${open ? 'rotate-180' : ''}`}>▼</span>
       </button>
       {open && (
-        <div className="absolute left-0 top-11 z-50 w-64 border border-slate-200 bg-white shadow-xl">
-          {category.tools.map(t => (
-            <Link key={t.to} to={t.to} onClick={onClose}
-              className="group flex flex-col border-b border-slate-100 px-4 py-2.5 last:border-0 hover:bg-[#f4f8ff]">
-              <span className="text-sm font-medium text-slate-800 group-hover:text-[#0056b3]">{t.name}</span>
-              <span className="text-[10px] uppercase tracking-wider text-slate-400">{t.sub}</span>
-            </Link>
-          ))}
+        <div role="menu" aria-label={category.label}
+          className={`absolute left-0 top-11 z-50 max-h-[calc(100vh-3.5rem)] overflow-y-auto border border-slate-200 bg-white shadow-xl ${
+            grouped ? 'grid w-[36rem] grid-cols-2 gap-x-2 p-2' : 'w-64'}`}>
+          {grouped
+            ? groups.map(g => (
+                <div key={g.group} className="mb-2 break-inside-avoid">
+                  <p className="px-4 pb-1 pt-2 text-[9px] font-bold uppercase tracking-[0.18em] text-[#0056b3]">{g.group}</p>
+                  {g.tools.map(t => <ToolLink key={t.to} t={t} onClose={onClose} />)}
+                </div>
+              ))
+            : category.tools.map(t => (
+                <div key={t.to} className="border-b border-slate-100 last:border-0">
+                  <ToolLink t={t} onClose={onClose} />
+                </div>
+              ))}
         </div>
       )}
     </div>

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -1,7 +1,7 @@
 // Single source of truth for the app's tool catalog. Consumed by the navbar
 // dropdowns and the home page. Add new categories here as they ship.
 
-export interface ToolDef { to: string; name: string; sub: string }
+export interface ToolDef { to: string; name: string; sub: string; group?: string }
 export interface ToolCategory { label: string; tools: ToolDef[] }
 
 export const TOOL_CATEGORIES: ToolCategory[] = [
@@ -15,33 +15,33 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
   {
     label: 'Structural',
     tools: [
-      { to: '/foundation',    name: 'Foundation Design',  sub: 'Isolated pad footing'  },
-      { to: '/pile-cap',      name: 'Pile Cap Design',    sub: 'Group pile cap'        },
-      { to: '/combined',      name: 'Combined Footing',   sub: 'Two-column footing'    },
-      { to: '/beam-design',   name: 'Beam Design',        sub: 'RC beam · ACI 318-14'  },
-      { to: '/beam-analysis', name: 'Beam Analysis',      sub: 'FEM multi-span'        },
-      { to: '/column-design', name: 'Column Design',      sub: 'RC column · biaxial'   },
-      { to: '/frame',         name: 'Frame Analysis',     sub: '2D stiffness method'   },
-      { to: '/load-path',     name: 'Slab Load Path',     sub: 'Two-way tributary'     },
-      { to: '/model',         name: '3D Model Space',     sub: 'BIM-lite viewer'       },
-      { to: '/truss',         name: 'Truss Space',        sub: 'Plane truss solver'    },
-      { to: '/steel',         name: 'Steel Design',       sub: 'AISC 360-16 LRFD'      },
-      { to: '/bolted-connection', name: 'Bolted Connection', sub: 'Eccentric bolt group' },
-      { to: '/welded-connection', name: 'Welded Connection', sub: 'Eccentric weld group' },
-      { to: '/slab-design',   name: 'Slab Design',        sub: 'Two-way DDM · ACI 318'  },
-      { to: '/stair',         name: 'Stair Design',       sub: 'RC waist slab · NSCP'   },
-      { to: '/water-tank',    name: 'Water Tank',         sub: 'Circular · IS 3370/ACI 350' },
-      { to: '/torsion',       name: 'Torsion Design',     sub: 'RC torsion · ACI 318-14' },
-      { to: '/dev-length',    name: 'Dev & Splice',       sub: 'ACI 318-14 §25.4–25.5'   },
-      { to: '/punching-shear', name: 'Punching Shear',   sub: 'Two-way §22.6 · ACI 318' },
-      { to: '/retaining-wall',   name: 'Retaining Wall',   sub: 'Cantilever · Rankine'     },
-      { to: '/geotech',          name: 'Geotechnical',     sub: 'Bearing · earth · slope'  },
-      { to: '/soil-nail',        name: 'Soil-Nail Wall',   sub: 'FHWA · tensile · pullout' },
-      { to: '/micropile',        name: 'Micropile',        sub: 'FHWA · structural · bond' },
-      { to: '/rock-anchor',      name: 'Rock Anchor',      sub: 'PTI · tendon · bond'      },
-      { to: '/shotcrete-facing', name: 'Shotcrete Facing',  sub: 'FHWA · flexure · punching' },
-      { to: '/seismic-wizard',   name: 'Seismic Wizard',   sub: 'NSCP 208 Ca/Cv/I/R'       },
-      { to: '/load-combinations', name: 'Load Combinations', sub: 'NSCP 2015 §203.3 LRFD'   },
+      { to: '/beam-design',   name: 'Beam Design',        sub: 'RC beam · ACI 318-14',      group: 'Concrete' },
+      { to: '/column-design', name: 'Column Design',      sub: 'RC column · biaxial',       group: 'Concrete' },
+      { to: '/slab-design',   name: 'Slab Design',        sub: 'Two-way DDM · ACI 318',     group: 'Concrete' },
+      { to: '/stair',         name: 'Stair Design',       sub: 'RC waist slab · NSCP',      group: 'Concrete' },
+      { to: '/water-tank',    name: 'Water Tank',         sub: 'Circular · IS 3370/ACI 350', group: 'Concrete' },
+      { to: '/torsion',       name: 'Torsion Design',     sub: 'RC torsion · ACI 318-14',   group: 'Concrete' },
+      { to: '/dev-length',    name: 'Dev & Splice',       sub: 'ACI 318-14 §25.4–25.5',     group: 'Concrete' },
+      { to: '/punching-shear', name: 'Punching Shear',    sub: 'Two-way §22.6 · ACI 318',   group: 'Concrete' },
+      { to: '/model',         name: '3D Model Space',     sub: 'BIM-lite viewer',           group: 'Analysis & Modelling' },
+      { to: '/frame',         name: 'Frame Analysis',     sub: '2D stiffness method',       group: 'Analysis & Modelling' },
+      { to: '/beam-analysis', name: 'Beam Analysis',      sub: 'FEM multi-span',            group: 'Analysis & Modelling' },
+      { to: '/truss',         name: 'Truss Space',        sub: 'Plane truss solver',        group: 'Analysis & Modelling' },
+      { to: '/load-path',     name: 'Slab Load Path',     sub: 'Two-way tributary',         group: 'Analysis & Modelling' },
+      { to: '/steel',         name: 'Steel Design',       sub: 'AISC 360-16 LRFD',          group: 'Steel & Connections' },
+      { to: '/bolted-connection', name: 'Bolted Connection', sub: 'Eccentric bolt group',   group: 'Steel & Connections' },
+      { to: '/welded-connection', name: 'Welded Connection', sub: 'Eccentric weld group',   group: 'Steel & Connections' },
+      { to: '/foundation',    name: 'Foundation Design',  sub: 'Isolated pad footing',      group: 'Foundations' },
+      { to: '/pile-cap',      name: 'Pile Cap Design',    sub: 'Group pile cap',            group: 'Foundations' },
+      { to: '/combined',      name: 'Combined Footing',   sub: 'Two-column footing',        group: 'Foundations' },
+      { to: '/retaining-wall',   name: 'Retaining Wall',   sub: 'Cantilever · Rankine',     group: 'Geotechnical' },
+      { to: '/geotech',          name: 'Geotechnical',     sub: 'Bearing · earth · slope',  group: 'Geotechnical' },
+      { to: '/soil-nail',        name: 'Soil-Nail Wall',   sub: 'FHWA · tensile · pullout', group: 'Geotechnical' },
+      { to: '/micropile',        name: 'Micropile',        sub: 'FHWA · structural · bond', group: 'Geotechnical' },
+      { to: '/rock-anchor',      name: 'Rock Anchor',      sub: 'PTI · tendon · bond',      group: 'Geotechnical' },
+      { to: '/shotcrete-facing', name: 'Shotcrete Facing', sub: 'FHWA · flexure · punching', group: 'Geotechnical' },
+      { to: '/seismic-wizard',   name: 'Seismic Wizard',   sub: 'NSCP 208 Ca/Cv/I/R',       group: 'Seismic & Loads' },
+      { to: '/load-combinations', name: 'Load Combinations', sub: 'NSCP 2015 §203.3 LRFD',  group: 'Seismic & Loads' },
     ],
   },
   {
@@ -55,3 +55,16 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
     ],
   },
 ]
+
+/** Tools of a category bucketed by their `group` tag, preserving first-seen
+ *  group order. Ungrouped tools land under '' (render without a header). */
+export function toolGroups(category: ToolCategory): { group: string; tools: ToolDef[] }[] {
+  const order: string[] = []
+  const byGroup = new Map<string, ToolDef[]>()
+  for (const t of category.tools) {
+    const g = t.group ?? ''
+    if (!byGroup.has(g)) { byGroup.set(g, []); order.push(g) }
+    byGroup.get(g)!.push(t)
+  }
+  return order.map((group) => ({ group, tools: byGroup.get(group)! }))
+}

--- a/webapp/src/pages/Home.tsx
+++ b/webapp/src/pages/Home.tsx
@@ -1,5 +1,6 @@
+import { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { TOOL_CATEGORIES } from '../lib/tools'
+import { TOOL_CATEGORIES, toolGroups } from '../lib/tools'
 
 // Flat structural-frame line illustration — distributed load on a portal frame
 // with a hint of the bending diagram. Pure SVG, no assets, scales cleanly.
@@ -49,6 +50,21 @@ const SAMPLES: Sample[] = [
 
 export default function Home({ onAuth }: { onAuth: (mode: 'login' | 'signup') => void }) {
   const toolCount = TOOL_CATEGORIES.reduce((n, c) => n + c.tools.length, 0)
+  const [query, setQuery] = useState('')
+
+  // Full catalog as {heading, tools} sections: grouped categories (Structural)
+  // contribute one section per discipline group, flat ones a single section.
+  const sections = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    const all = TOOL_CATEGORIES.flatMap((c) =>
+      toolGroups(c).map((g) => ({
+        heading: g.group ? g.group : c.label,
+        tools: g.tools.filter((t) =>
+          !q || t.name.toLowerCase().includes(q) || t.sub.toLowerCase().includes(q)
+          || (t.group ?? '').toLowerCase().includes(q)),
+      })))
+    return all.filter((s) => s.tools.length > 0)
+  }, [query])
 
   return (
     <div className="min-h-screen bg-slate-50">
@@ -76,6 +92,9 @@ export default function Home({ onAuth }: { onAuth: (mode: 'login' | 'signup') =>
                 className="border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 hover:border-slate-800">
                 Create account
               </button>
+              <a href="#tools" className="px-2 py-3 text-sm font-semibold text-[#0056b3] hover:underline">
+                Browse all {toolCount} tools ↓
+              </a>
             </div>
             <div className="mt-10 flex items-center gap-7 text-xs text-slate-400">
               <span><strong className="text-slate-800">{toolCount}</strong> tools</span>
@@ -123,12 +142,42 @@ export default function Home({ onAuth }: { onAuth: (mode: 'login' | 'signup') =>
         </div>
       </section>
 
+      {/* All tools — searchable index */}
+      <section id="tools" className="border-t border-slate-200 bg-white">
+        <div className="mx-auto max-w-6xl px-6 py-16">
+          <div className="mb-6 flex flex-wrap items-center gap-4">
+            <span className="text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500">All {toolCount} tools</span>
+            <div className="h-px flex-1 bg-slate-200" />
+            <input type="search" value={query} onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search tools… (beam, footing, seismic)" aria-label="Search tools"
+              className="w-full border border-slate-300 px-3.5 py-2 text-sm outline-none focus:border-[#0056b3] sm:w-72" />
+          </div>
+          {sections.length === 0 && (
+            <p className="py-8 text-sm text-slate-500">No tool matches “{query}”.</p>
+          )}
+          {sections.map(sec => (
+            <div key={sec.heading} className="mb-8 last:mb-0">
+              <p className="mb-3 text-[10px] font-bold uppercase tracking-[0.18em] text-[#0056b3]">{sec.heading}</p>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                {sec.tools.map(t => (
+                  <Link key={t.to} to={t.to}
+                    className="group flex flex-col border border-slate-200 bg-white p-4 transition-colors hover:border-[#0056b3] hover:bg-[#f4f8ff]">
+                    <span className="text-sm font-semibold text-slate-900 group-hover:text-[#0056b3]">{t.name}</span>
+                    <span className="mt-1 text-[11px] text-slate-500">{t.sub}</span>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
       {/* Closing CTA */}
       <section className="border-t border-slate-200 bg-white">
         <div className="mx-auto flex max-w-6xl flex-col items-start justify-between gap-6 px-6 py-12 sm:flex-row sm:items-center">
           <div>
-            <h2 className="text-xl font-bold text-slate-900">Browse every tool from the menu.</h2>
-            <p className="mt-1 text-sm text-slate-500">Pick a category in the top navigation — Structural or Quantity Take-Off.</p>
+            <h2 className="text-xl font-bold text-slate-900">Every calculation, code-referenced.</h2>
+            <p className="mt-1 text-sm text-slate-500">NSCP 2015, ACI 318-14 and AISC 360-16 clause citations on every worked solution.</p>
           </div>
           <button onClick={() => onAuth('signup')}
             className="bg-[#0056b3] px-6 py-3 text-sm font-semibold text-white hover:bg-[#0066d6]">


### PR DESCRIPTION
## Scope
UI only — no engine changes. Closes #325 P2 items **1** (tool-index landing grid) and **3** (sub-grouped Structural dropdown), plus the ARIA-menu half of item 7.

## What
- **`lib/tools.ts`** (single source of truth): each Structural tool now carries a `group` — Concrete / Analysis & Modelling / Steel & Connections / Foundations / Geotechnical / Seismic & Loads. New `toolGroups()` helper.
- **Navbar**: the ~27-item flat 16-rem scrolling column becomes a two-column 36-rem panel with discipline headers. Dropdown triggers get `aria-haspopup`/`aria-expanded`; the panel is `role=menu` with `menuitem` links. Sub-label contrast raised slate-400 → slate-500.
- **Home**: new **searchable “All 34 tools” section** — live filter over name/sub/group, cards grouped by discipline, linked from a hero anchor. The closing CTA no longer tells users to go hunt in the menu.

## Live verification (dev server, DOM-level — screenshots time out on this machine)
- Search “footing” → exactly 2 cards under a single *Foundations* header.
- Structural dropdown: 6 group headers, 27 menuitems, 576 px two-column panel, `aria-expanded` true/false toggling.
- Zero console errors on load and while filtering.

`npm test` 1024/1024 · `npx tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)