### PR TITLE
fix: Steel Design falls back to in-browser engine when the calc API is absent

### DIFF
--- a/webapp/src/lib/calcApi.ts
+++ b/webapp/src/lib/calcApi.ts
@@ -14,15 +14,40 @@ import type {
 // same host, or set VITE_API_URL in .env.local for local dev with split servers).
 const BASE = import.meta.env.VITE_API_URL ?? ''
 
+let warnedLocal = false
+
+/** In-browser fallback when the API is unreachable (dev without the service,
+ *  static deploys) or the route is absent (404). Dynamic import keeps the
+ *  engine in a lazy chunk — the eager path still ships zero engine code. */
+async function localFallback<T>(path: string, body: unknown): Promise<T> {
+  const local = await import('./calcLocal')
+  if (!warnedLocal) {
+    warnedLocal = true
+    console.warn(`calc API unreachable at ${BASE || 'same-origin'} — steel results are computed locally in-browser (same engine).`)
+  }
+  if (path === '/api/steel/beam') return local.localBeam(body as never) as T
+  if (path === '/api/steel/column') return local.localColumn(body as never) as T
+  if (path === '/api/steel/connection') return local.localConnection(body as never) as T
+  throw new Error(`No local fallback for ${path}`)
+}
+
 async function post<T>(path: string, body: unknown): Promise<T> {
-  const res = await fetch(`${BASE}${path}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  })
+  let res: Response
+  try {
+    res = await fetch(`${BASE}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  } catch {
+    return localFallback<T>(path, body)          // network error — API not running
+  }
+  if (res.status === 404) return localFallback<T>(path, body)  // route absent (static host)
   if (!res.ok) {
     const detail = (await res.json().catch(() => null)) as { error?: string } | null
-    throw new Error(detail?.error ?? `Calculation API error (${res.status})`)
+    const err = new Error(detail?.error ?? `Calculation API error (${res.status})`)
+    console.error(err)   // the UI badge says "check console" — make that true
+    throw err
   }
   return (await res.json()) as T
 }

--- a/webapp/src/lib/calcLocal.ts
+++ b/webapp/src/lib/calcLocal.ts
@@ -1,0 +1,66 @@
+// In-browser fallback for the steel calculation API. Loaded ONLY via dynamic
+// import from calcApi.ts when the API is unreachable (dev without the service,
+// static deploys) — so the engine code lands in a lazy chunk, never in the
+// main bundle, preserving calcApi's no-value-imports rule for the eager path.
+// Compositions mirror the API endpoints 1:1 using the same engine functions.
+import {
+  deriveWSection, beamFlexure, beamShear, beamLoadingSimple,
+  columnAxial, weakAxisFlexure, combinedLoading,
+  boltGroupGeom, boltShear, eccentricBoltGroup, outOfPlaneBoltGroup,
+  pryingAction, shearTabBlockShear, weldStrength,
+} from '../engine/steelDesign'
+import { shapeByName } from '../engine/aiscSections'
+import type {
+  BeamCalcInput, BeamCalcResult,
+  ColumnCalcInput, ColumnCalcResult,
+  ConnectionCalcInput, ConnectionCalcResult,
+} from './calcApi'
+
+const shapeOf = (name: string) => {
+  const s = shapeByName(name)
+  if (!s) throw new Error(`Unknown AISC shape "${name}"`)
+  return s
+}
+
+export function localBeam(i: BeamCalcInput): BeamCalcResult {
+  const s = shapeOf(i.shapeName)
+  const props = deriveWSection(s)
+  return {
+    props,
+    flex: beamFlexure(s, props, i.Fy, i.Lb, i.Cb),
+    shear: beamShear(s, props, i.Fy),
+    loads: beamLoadingSimple({ wDead: i.wDead, wLive: i.wLive, L: i.span }, props.Ix),
+  }
+}
+
+export function localColumn(i: ColumnCalcInput): ColumnCalcResult {
+  const s = shapeOf(i.shapeName)
+  const props = deriveWSection(s)
+  const axial = columnAxial(s, i.Fy, i.L, i.Kx, i.Ky)
+  // strong-axis flexure with Lb = member length, Cb = 1 (uniform moment — conservative)
+  const flexX = beamFlexure(s, props, i.Fy, i.L, 1.0)
+  const weak = weakAxisFlexure(s, props, i.Fy)
+  return {
+    props, axial, flexX, weak,
+    comb: combinedLoading(i.Pu, axial.phiPn, i.Mux, flexX.phiMn, i.Muy, weak.phiMny),
+  }
+}
+
+export function localConnection(i: ConnectionCalcInput): ConnectionCalcResult {
+  const geom = boltGroupGeom(i.nRows, i.nCols, i.sx, i.sy, i.ex_edge, i.ey)
+  const phiRnBolt = boltShear(i.boltGrade, i.db, i.Vu, i.tPlate, i.FuPlate, i.threads)
+  const eccentric = eccentricBoltGroup(geom, i.Vu, i.Hu, i.ex_load, i.ey_load, phiRnBolt.phiRn, i.db, i.tPlate)
+  const outOfPlane = i.e_out > 0
+    ? outOfPlaneBoltGroup(geom, eccentric.bolts, i.e_out, i.Vu, i.boltGrade, i.db, i.threads)
+    : null
+  const prying = outOfPlane && i.b_gage > 0
+    ? pryingAction(outOfPlane.Tmax, outOfPlane.phiTn_crit, i.b_gage, i.ex_edge, i.sy, i.tPlate, i.db, i.FyPlate)
+    : null
+  const weld = weldStrength(i.electrode, i.wSize, i.Vu)
+  return {
+    geom, phiRnBolt, eccentric, outOfPlane, prying,
+    blockShear: shearTabBlockShear(i.nRows, i.sy, i.ey, i.ey, i.ex_edge, i.db, i.tPlate, i.FyPlate, i.FuPlate),
+    weld,
+    weldCapacity: weld.phiRnw * 2 * geom.plateH,   // two vertical fillets, full tab height
+  }
+}

--- a/webapp/src/lib/useCalcResult.ts
+++ b/webapp/src/lib/useCalcResult.ts
@@ -24,7 +24,10 @@ export function useCalcResult<T>(
     const t = setTimeout(() => {
       latestFn.current()
         .then((d) => { if (!cancelled) { setData(d); setError(null); setLoading(false) } })
-        .catch((e: unknown) => { if (!cancelled) { setError(String(e)); setLoading(false) } })
+        .catch((e: unknown) => {
+          console.error('calc failed:', e)   // UI badge says "check console" — keep that true
+          if (!cancelled) { setError(String(e)); setLoading(false) }
+        })
     }, debounceMs)
     return () => { cancelled = true; clearTimeout(t) }
     // deps is intentionally spread here; exhaustive-deps lint does not apply.


### PR DESCRIPTION
## Scope
`lib/` only. Closes #325 P2 item **2** (Steel Design dead in dev).

## Problem
`/steel` posts to `${VITE_API_URL}/api/steel/*`. No API service exists in this repo and no `.env` ships an API URL, so in local dev **and on static deploys** every request 404s → red *“API error — check console”* badge (with nothing logged) and a dead page.

## Fix
- **`lib/calcLocal.ts`** — local compositions of the three endpoints from the same canonical engine functions in `engine/steelDesign.ts`.
- **`calcApi.post()`** — on network failure or 404, `await import('./calcLocal')` and compute in-browser with a single `console.warn`. The **dynamic** import keeps the engine in a lazy chunk, so calcApi's *no value-imports / don't bundle the engine on the eager path* rule still holds; a live API keeps full precedence.
- Real API errors (non-404) and hook failures are now `console.error`'d — the badge's “check console” instruction is finally true.

## Live verification (dev server)
- Beam: wu = 58 kN/m, Mu = 261 kN·m, φMn = 187.3 kN·m (hand-check: W310x38.7 φMp ≈ 191, less LTB @ Lb=2 m ✓), shear 47 % ✓, deflection checks render.
- Column: φPn = 1701.7 kN, φMnx = 275.1, §H1-1a combined 129 % ✗ (correctly failing an undersized default).
- Connection: φRn 73.04 kN governing, eccentric group Ip = 9800 mm², block shear 272.9 kN both cases.
- Zero NaN, zero console errors, badge gone; one honest warn: *“calc API unreachable — steel results are computed locally in-browser (same engine)”*.

`npm test` 1024/1024 · `npx tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)