### PR TITLE
fix: KaTeX ⌀/§ glyph warnings sanitized at the render chokepoint

### DIFF
--- a/webapp/src/lib/math.test.ts
+++ b/webapp/src/lib/math.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeTex } from './math'
+
+describe('sanitizeTex — KaTeX-incompatible glyph replacement', () => {
+  it('bare ⌀ (math mode) becomes \\varnothing', () => {
+    expect(sanitizeTex(String.raw`4~⌀20~\text{mm}`)).toBe(String.raw`4~\varnothing 20~\text{mm}`)
+  })
+
+  it('\\text{⌀} is lifted out of text mode (\\varnothing throws there)', () => {
+    expect(sanitizeTex(String.raw`8\ \text{⌀}28`)).toBe(String.raw`8\ \varnothing 28`)
+  })
+
+  it('§ becomes \\S (valid in both math and text mode)', () => {
+    expect(sanitizeTex(String.raw`\text{§407.7}`)).toBe(String.raw`\text{\S 407.7}`)
+  })
+
+  it('clean input passes through untouched', () => {
+    const tex = String.raw`\phi M_n = 187.3\ \text{kN·m}`
+    expect(sanitizeTex(tex)).toBe(tex)
+  })
+})

--- a/webapp/src/lib/math.tsx
+++ b/webapp/src/lib/math.tsx
@@ -1,9 +1,19 @@
 import katex from 'katex'
 
+// '⌀' and '§' have no KaTeX glyph metrics — every render logs
+// "LaTeX-incompatible input" / "No character metrics" warnings and falls back
+// to a wrong-font glyph. Swap them for the proper commands before compiling
+// (\varnothing renders ∅; \S renders §). The \text{⌀} form must be lifted out
+// of text mode first or \varnothing would throw there; \S is valid in both.
+export const sanitizeTex = (tex: string) =>
+  tex.replaceAll('\\text{⌀}', '\\varnothing ')
+    .replaceAll('⌀', '\\varnothing ')
+    .replaceAll('§', '\\S ')
+
 // Tiny KaTeX wrapper — renders to an HTML string and injects it. Avoids the
 // react-katex peer-dependency friction with React 19 and keeps full control.
 export function Math({ tex, block = false }: { tex: string; block?: boolean }) {
-  const html = katex.renderToString(tex, { throwOnError: false, displayMode: block })
+  const html = katex.renderToString(sanitizeTex(tex), { throwOnError: false, displayMode: block })
   return block ? (
     <div className="my-1 overflow-x-auto" dangerouslySetInnerHTML={{ __html: html }} />
   ) : (


### PR DESCRIPTION
## Scope
`lib/math.tsx` + test. Closes #325 P2 item **8**.

## Problem
Every RC/steel page logged repeated KaTeX warnings (`LaTeX-incompatible input`, `No character metrics`) because bar callouts put **⌀** and clause citations put **§** into math strings — neither has KaTeX metrics, so both also rendered in a fallback font.

## Fix
All KaTeX in the app flows through one component (`Math`/`KTex` in `lib/math.tsx`), so the fix is a 3-line sanitizer there rather than edits across 31 files: `⌀ → \varnothing` (the `\text{⌀}` form is lifted out of text mode first, where \varnothing would throw) and `§ → \S` (valid in both modes).

## Verification
- Live: column page bar formula renders **8 ∅28**; console warning count frozen across repeated page renders (the buffer entries visible are pre-fix stale ones).
- Unit tests for all three replacement forms + clean-input passthrough.

`npm test` 1028/1028 · `npx tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)