### PR TITLE
fix: helper-text contrast to WCAG AA (slate-400 → slate-500 on light surfaces)

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -58,12 +58,12 @@ export default function App() {
         <Route path="/frame" element={<FrameAnalysis />} />
         <Route path="/load-path" element={<LoadPath />} />
         <Route path="/model" element={
-          <Suspense fallback={<p className="p-8 text-center text-sm text-slate-400">Loading 3D model space…</p>}>
+          <Suspense fallback={<p className="p-8 text-center text-sm text-slate-500">Loading 3D model space…</p>}>
             <ModelSpace />
           </Suspense>
         } />
         <Route path="/truss" element={
-          <Suspense fallback={<p className="p-8 text-center text-sm text-slate-400">Loading truss space…</p>}>
+          <Suspense fallback={<p className="p-8 text-center text-sm text-slate-500">Loading truss space…</p>}>
             <TrussSpace />
           </Suspense>
         } />

--- a/webapp/src/components/AuthModal.tsx
+++ b/webapp/src/components/AuthModal.tsx
@@ -17,18 +17,18 @@ export function AuthModal({ mode, onClose }: { mode: 'login' | 'signup'; onClose
           <span className="text-sm font-bold uppercase tracking-wider text-slate-800">
             {isSignup ? 'Create account' : 'Log in'}
           </span>
-          <button onClick={onClose} className="text-slate-400 hover:text-slate-700">✕</button>
+          <button onClick={onClose} className="text-slate-500 hover:text-slate-700">✕</button>
         </div>
         <div className="space-y-3 p-5">
           <label className="flex flex-col text-xs font-medium text-slate-600">
             Email
             <input type="email" disabled placeholder="you@example.com"
-              className="mt-1 cursor-not-allowed bg-slate-50 text-slate-400" />
+              className="mt-1 cursor-not-allowed bg-slate-50 text-slate-500" />
           </label>
           <label className="flex flex-col text-xs font-medium text-slate-600">
             Password
             <input type="password" disabled placeholder="••••••••"
-              className="mt-1 cursor-not-allowed bg-slate-50 text-slate-400" />
+              className="mt-1 cursor-not-allowed bg-slate-50 text-slate-500" />
           </label>
           <div className="border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
             Accounts &amp; saved projects are coming soon. All tools work without an account today.

--- a/webapp/src/components/DisplacementTable.tsx
+++ b/webapp/src/components/DisplacementTable.tsx
@@ -75,7 +75,7 @@ export function DisplacementTable({
   return (
     <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
       <h2 className="mb-1 text-[1.02rem] font-bold text-[#0056b3]">Nodal Displacements</h2>
-      <p className="mb-3 text-[11px] text-slate-400">Translations in mm, rotations in mrad. Envelope shows the signed extreme across combinations.</p>
+      <p className="mb-3 text-[11px] text-slate-500">Translations in mm, rotations in mrad. Envelope shows the signed extreme across combinations.</p>
 
       <div className="mb-3 flex flex-wrap gap-1">
         <button type="button" onClick={() => setActive('envelope')} className={tabCls(active === 'envelope')}>

--- a/webapp/src/components/ExcelImport.tsx
+++ b/webapp/src/components/ExcelImport.tsx
@@ -72,7 +72,7 @@ export function ExcelImport({ onResult }: { onResult: (r: BatchResult | null) =>
             <div className="flex items-center justify-between border-b border-slate-200 px-5 py-3">
               <h3 className="text-base font-bold text-[#0056b3]">Excel upload format</h3>
               <button type="button" onClick={() => setShowHelp(false)} aria-label="Close"
-                className="text-2xl leading-none text-slate-400 hover:text-slate-700">×</button>
+                className="text-2xl leading-none text-slate-500 hover:text-slate-700">×</button>
             </div>
             <div className="px-5 py-4 text-sm text-slate-600">
               <p>

--- a/webapp/src/components/ModalPanel.tsx
+++ b/webapp/src/components/ModalPanel.tsx
@@ -19,7 +19,7 @@ export function ModalPanel({ result, selectedMode, onSelectMode }: {
   return (
     <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
       <h2 className="mb-1 text-[1.02rem] font-bold text-[#0056b3]">Modal Analysis — natural periods &amp; mass participation</h2>
-      <p className="mb-3 text-[11px] text-slate-400">
+      <p className="mb-3 text-[11px] text-slate-500">
         Lumped-mass free vibration. Effective modal mass per global direction; the cumulative column turns green at the
         NSCP 208.5.5 ≥90% threshold. Total mass {f2(totalMass[0])} t (X), {f2(totalMass[1])} t (Y), {f2(totalMass[2])} t (Z).
         {onSelectMode && <span className="ml-1">Click <span className="font-semibold text-violet-600">3D</span> to animate the mode shape in the canvas.</span>}
@@ -50,7 +50,7 @@ export function ModalPanel({ result, selectedMode, onSelectMode }: {
               const active = selectedMode === i
               return (
                 <tr key={i} className={`border-b border-slate-100 last:border-0 hover:bg-slate-50 ${active ? 'bg-violet-50' : ''}`}>
-                  <td className="py-1 pr-3 font-mono text-slate-700">{i + 1}{domLabel && <span className="ml-1 text-[10px] text-slate-400">{domLabel}</span>}</td>
+                  <td className="py-1 pr-3 font-mono text-slate-700">{i + 1}{domLabel && <span className="ml-1 text-[10px] text-slate-500">{domLabel}</span>}</td>
                   <td className="py-1 pr-3 text-right tabular-nums font-semibold text-slate-800">{f3(m.period)}</td>
                   <td className="py-1 pr-3 text-right tabular-nums text-slate-600">{f2(m.freq)}</td>
                   <td className="py-1 pr-3 text-right tabular-nums text-slate-600">{f2(m.omega)}</td>
@@ -66,7 +66,7 @@ export function ModalPanel({ result, selectedMode, onSelectMode }: {
                         onClick={() => onSelectMode(active ? null : i)}
                         title={active ? 'Hide mode shape' : 'Animate mode shape in 3D view'}
                         className={`rounded px-1.5 py-0.5 text-[10px] font-semibold transition ${
-                          active ? 'bg-violet-100 text-violet-700' : 'text-slate-400 hover:text-violet-600'
+                          active ? 'bg-violet-100 text-violet-700' : 'text-slate-500 hover:text-violet-600'
                         }`}>
                         {active ? '◉' : '◎'} 3D
                       </button>

--- a/webapp/src/components/ResponseSpectrumPanel.tsx
+++ b/webapp/src/components/ResponseSpectrumPanel.tsx
@@ -137,7 +137,7 @@ export function ResponseSpectrumPanel({
       <h2 className="mb-1 text-[1.02rem] font-bold text-[#0056b3]">
         Response Spectrum Analysis — NSCP §208.6
       </h2>
-      <p className="mb-2 text-[11px] text-slate-400">
+      <p className="mb-2 text-[11px] text-slate-500">
         Design spectrum: Sa/g = min(2.5·Ca·I/R, Cv·I/(R·T)) ≥ 0.11·Ca·I/R.
         {' '}Ts = {f3(Ts)} s. CQC combination (ζ = {pct(zeta)}).
         {T1 !== null && seismicT !== undefined && (
@@ -231,12 +231,12 @@ export function ResponseSpectrumPanel({
               <td className="py-0.5 pr-4 text-right tabular-nums font-semibold text-slate-900">{f0(cqc[0])}</td>
               <td className="py-0.5 pr-4 text-right tabular-nums font-semibold text-slate-900">{f0(cqc[2])}</td>
               {staticV && (
-                <td className={`py-0.5 pr-4 text-right tabular-nums text-xs ${cqcRatio[0] !== null ? (cqcRatio[0]! < 0.9 ? 'text-red-600 font-semibold' : 'text-emerald-600') : 'text-slate-400'}`}>
+                <td className={`py-0.5 pr-4 text-right tabular-nums text-xs ${cqcRatio[0] !== null ? (cqcRatio[0]! < 0.9 ? 'text-red-600 font-semibold' : 'text-emerald-600') : 'text-slate-500'}`}>
                   {cqcRatio[0] !== null ? pct(cqcRatio[0]!) : '—'}
                 </td>
               )}
               {staticV && (
-                <td className={`py-0.5 text-right tabular-nums text-xs ${cqcRatio[2] !== null ? (cqcRatio[2]! < 0.9 ? 'text-red-600 font-semibold' : 'text-emerald-600') : 'text-slate-400'}`}>
+                <td className={`py-0.5 text-right tabular-nums text-xs ${cqcRatio[2] !== null ? (cqcRatio[2]! < 0.9 ? 'text-red-600 font-semibold' : 'text-emerald-600') : 'text-slate-500'}`}>
                   {cqcRatio[2] !== null ? pct(cqcRatio[2]!) : '—'}
                 </td>
               )}
@@ -264,7 +264,7 @@ export function ResponseSpectrumPanel({
         </p>
       )}
 
-      <p className="mt-2 text-[11px] text-slate-400">
+      <p className="mt-2 text-[11px] text-slate-500">
         Use CQC base shear (more accurate for closely-spaced modes). SRSS is shown for reference.
         {T1 !== null && seismicT !== undefined && T1 > seismicT && (
           <> T₁ &gt; T_approx — the static ELF base shear is conservative (short-period cap may govern).</>

--- a/webapp/src/components/TrussEditor.tsx
+++ b/webapp/src/components/TrussEditor.tsx
@@ -61,7 +61,7 @@ export function TrussEditor({ model, onChange, onReset }: {
           <h4 className="mb-1 text-xs font-bold uppercase tracking-wide text-slate-500">Nodes (m)</h4>
           <div className="max-h-48 overflow-y-auto pr-1">
             <table className="w-full text-xs">
-              <thead><tr className="text-left text-slate-400"><th className="pr-2">id</th><th className="pr-2">x</th><th className="pr-2">y</th><th /></tr></thead>
+              <thead><tr className="text-left text-slate-500"><th className="pr-2">id</th><th className="pr-2">x</th><th className="pr-2">y</th><th /></tr></thead>
               <tbody>
                 {model.nodes.map((n, i) => (
                   <tr key={n.id}>
@@ -82,7 +82,7 @@ export function TrussEditor({ model, onChange, onReset }: {
           <h4 className="mb-1 text-xs font-bold uppercase tracking-wide text-slate-500">Members</h4>
           <div className="max-h-48 overflow-y-auto pr-1">
             <table className="w-full text-xs">
-              <thead><tr className="text-left text-slate-400"><th className="pr-2">id</th><th className="pr-2">i</th><th className="pr-2">j</th><th className="pr-2">kind</th><th /></tr></thead>
+              <thead><tr className="text-left text-slate-500"><th className="pr-2">id</th><th className="pr-2">i</th><th className="pr-2">j</th><th className="pr-2">kind</th><th /></tr></thead>
               <tbody>
                 {model.members.map((m, i) => (
                   <tr key={m.id}>
@@ -107,7 +107,7 @@ export function TrussEditor({ model, onChange, onReset }: {
         <div>
           <h4 className="mb-1 text-xs font-bold uppercase tracking-wide text-slate-500">Supports</h4>
           <table className="w-full text-xs">
-            <thead><tr className="text-left text-slate-400"><th className="pr-2">node</th><th className="pr-2">ux</th><th className="pr-2">uy</th><th /></tr></thead>
+            <thead><tr className="text-left text-slate-500"><th className="pr-2">node</th><th className="pr-2">ux</th><th className="pr-2">uy</th><th /></tr></thead>
             <tbody>
               {model.supports.map((s, i) => (
                 <tr key={i}>
@@ -126,7 +126,7 @@ export function TrussEditor({ model, onChange, onReset }: {
         <div>
           <h4 className="mb-1 text-xs font-bold uppercase tracking-wide text-slate-500">Loaded joints</h4>
           <table className="w-full text-xs">
-            <thead><tr className="text-left text-slate-400"><th className="pr-2">node</th><th /></tr></thead>
+            <thead><tr className="text-left text-slate-500"><th className="pr-2">node</th><th /></tr></thead>
             <tbody>
               {model.loads.map((l, i) => (
                 <tr key={i}>
@@ -137,7 +137,7 @@ export function TrussEditor({ model, onChange, onReset }: {
             </tbody>
           </table>
           <button type="button" className={addBtn} onClick={addLoad}>+ loaded joint</button>
-          <p className="mt-1 text-[10px] text-slate-400">Magnitudes come from the Dead / Live joint-load fields above.</p>
+          <p className="mt-1 text-[10px] text-slate-500">Magnitudes come from the Dead / Live joint-load fields above.</p>
         </div>
       </div>
       <p className="mt-2 text-[11px] text-slate-500">

--- a/webapp/src/components/WorkedSolution.tsx
+++ b/webapp/src/components/WorkedSolution.tsx
@@ -12,7 +12,7 @@ export function WorkedSolution({ steps, title = 'Solution — step by step' }: {
       <button type="button" onClick={() => setOpen((o) => !o)}
         className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left">
         <h2 className="text-[1.02rem] font-bold text-[#0056b3]">{title}</h2>
-        <span className="no-print text-sm text-slate-400">{open ? 'Hide ▲' : 'Show ▼'}</span>
+        <span className="no-print text-sm text-slate-500">{open ? 'Hide ▲' : 'Show ▼'}</span>
       </button>
 
       {open && (
@@ -20,7 +20,7 @@ export function WorkedSolution({ steps, title = 'Solution — step by step' }: {
           {steps.map((s, i) => (
             <li key={i} className="print-avoid-break">
               <h3 className="mb-1.5 text-sm font-semibold text-slate-800">
-                <span className="text-slate-400">{i + 1}.</span> {s.title}
+                <span className="text-slate-500">{i + 1}.</span> {s.title}
               </h3>
               <div className="space-y-1.5 pl-4">
                 {s.lines.map((ln, j) => (

--- a/webapp/src/components/qty.tsx
+++ b/webapp/src/components/qty.tsx
@@ -10,12 +10,12 @@ export function Num({ label, unit, value, onChange, step = 'any', hint }: {
   return (
     <label className="flex flex-col text-sm">
       <span className="mb-1 font-medium text-slate-600">
-        {label}{unit ? <span className="text-slate-400"> ({unit})</span> : null}
+        {label}{unit ? <span className="text-slate-500"> ({unit})</span> : null}
       </span>
       <input type="number" inputMode="decimal" step={step} value={Number.isFinite(value) ? value : ''}
         onChange={(e) => onChange(parseFloat(e.target.value))}
         className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none focus:ring-1 focus:ring-[#0056b3]" />
-      {hint ? <span className="mt-0.5 text-[10px] text-slate-400">{hint}</span> : null}
+      {hint ? <span className="mt-0.5 text-[10px] text-slate-500">{hint}</span> : null}
     </label>
   )
 }

--- a/webapp/src/pages/BeamAnalysis.tsx
+++ b/webapp/src/pages/BeamAnalysis.tsx
@@ -134,7 +134,7 @@ export default function BeamAnalysis() {
               ))}
             </div>
             <div className="space-y-3">
-              {supports.length === 0 && <p className="text-sm text-slate-400">No supports — add at least 2 (or a single Fixed).</p>}
+              {supports.length === 0 && <p className="text-sm text-slate-500">No supports — add at least 2 (or a single Fixed).</p>}
               {supports.map((s) => (
                 <ItemShell key={s.id} title={s.type} onRemove={() => setSupports((ss) => ss.filter((q) => q.id !== s.id))}>
                   <Num label="x" unit="m" value={s.x} onChange={(v) => setSup(s.id, { x: v })} />
@@ -157,7 +157,7 @@ export default function BeamAnalysis() {
               ))}
             </div>
             <div className="space-y-3">
-              {loads.length === 0 && <p className="text-sm text-slate-400">No loads yet.</p>}
+              {loads.length === 0 && <p className="text-sm text-slate-500">No loads yet.</p>}
               {loads.map((ld) => (
                 <ItemShell key={ld.id} title={ld.type.toUpperCase()} onRemove={() => setLoads((ls) => ls.filter((q) => q.id !== ld.id))}>
                   {ld.type === 'point' && <>
@@ -219,7 +219,7 @@ export default function BeamAnalysis() {
                   </tbody>
                 </table>
               </div>
-              <p className="mt-1 text-[11px] text-slate-400">★ governing (largest |M|). Click a row to view its reactions & diagrams.</p>
+              <p className="mt-1 text-[11px] text-slate-500">★ governing (largest |M|). Click a row to view its reactions & diagrams.</p>
             </ResultCard>
           )}
 
@@ -272,14 +272,14 @@ export default function BeamAnalysis() {
       {res?.tmt && (
         <div className="mt-6 rounded-xl border border-slate-200 bg-white p-4 shadow-sm print-avoid-break">
           <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">
-            Three-moment theorem check <span className="text-xs font-normal text-slate-400">Clapeyron — governing combo, interior support moments</span>
+            Three-moment theorem check <span className="text-xs font-normal text-slate-500">Clapeyron — governing combo, interior support moments</span>
           </h2>
           {res.tmt.positions.map((x, i) => (
             <Row key={i} label={`Support @ x = ${f2(x)} m`}
               value={`M = ${f2(res.tmt!.supportMoments[i])} kN·m`}
               sub={`R = ${f2(res.tmt!.reactions[i])} kN`} />
           ))}
-          <p className="mt-1 text-xs text-slate-400">
+          <p className="mt-1 text-xs text-slate-500">
             M₍ᵢ₋₁₎Lᵢ + 2Mᵢ(Lᵢ+Lᵢ₊₁) + Mᵢ₊₁Lᵢ₊₁ = −6(Q/L)ᵢ − 6(Q/L)ᵢ₊₁ — end moments 0, interior solved from the
             tri-diagonal system. Compare with the FEM reactions above as an independent hand-method check.
           </p>

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -170,7 +170,7 @@ export default function BeamDesign() {
               <Num label={<KTex tex="V_u" />} unit="kN" value={f.Vu} onChange={set('Vu')} />
             </>}
             {hogging && !multi && (
-              <p className="col-span-full text-xs text-slate-400">Negative Mu — hogging: designed with |Mu|; the tension steel goes at the TOP.</p>
+              <p className="col-span-full text-xs text-slate-500">Negative Mu — hogging: designed with |Mu|; the tension steel goes at the TOP.</p>
             )}
           </Card>
 
@@ -183,7 +183,7 @@ export default function BeamDesign() {
                   className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">
                   + Add section
                 </button>
-                <span className="text-xs text-slate-400">or auto-detect from <Link to="/beam-analysis" className="text-[#0056b3] hover:underline">Beam Analysis</Link>. Negative Mu = hogging (top steel).</span>
+                <span className="text-xs text-slate-500">or auto-detect from <Link to="/beam-analysis" className="text-[#0056b3] hover:underline">Beam Analysis</Link>. Negative Mu = hogging (top steel).</span>
               </div>
               <div className="space-y-3">
                 {sections.map((s) => (
@@ -241,7 +241,7 @@ export default function BeamDesign() {
                   </tbody>
                 </table>
               </div>
-              <p className="mt-1 text-[11px] text-slate-400">Click a row to view its drawing, results and worked solution. Red rows have errors.</p>
+              <p className="mt-1 text-[11px] text-slate-500">Click a row to view its drawing, results and worked solution. Red rows have errors.</p>
             </ResultCard>
           )}
 
@@ -256,7 +256,7 @@ export default function BeamDesign() {
                 comprBars={r.comprBars} comprBarDia={f.comprBarDia}
                 naDepth={r.cNA} flexOK={r.flexOK} hogging={hogging} />
             ) : (
-              <p className="py-8 text-center text-sm text-slate-400">Enter a valid section (d must be positive).</p>
+              <p className="py-8 text-center text-sm text-slate-500">Enter a valid section (d must be positive).</p>
             )}
           </div>
 

--- a/webapp/src/pages/BoltedConnection.tsx
+++ b/webapp/src/pages/BoltedConnection.tsx
@@ -46,7 +46,7 @@ export default function BoltedConnection() {
 
   return (
     <main className="mx-auto max-w-5xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">Structural · Steel</p>
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Structural · Steel</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Eccentric bolted connection</h1>
       <p className="mt-2 max-w-3xl text-sm text-slate-600">
         Elastic (vector) method for an eccentrically-loaded bolt group. Each bolt carries the direct
@@ -73,7 +73,7 @@ export default function BoltedConnection() {
                       <td className="pr-2"><input type="number" value={b.x} onChange={(e) => setBolt(i, 'x', num(e.target.value))} className="w-16 rounded border border-slate-200 px-1 py-0.5" /></td>
                       <td className="pr-2"><input type="number" value={b.y} onChange={(e) => setBolt(i, 'y', num(e.target.value))} className="w-16 rounded border border-slate-200 px-1 py-0.5" /></td>
                       <td className="pr-2 text-right font-mono">{force ? f2(force.R) : '—'}</td>
-                      <td className="text-right"><button type="button" onClick={() => delBolt(i)} className="text-slate-400 hover:text-red-600">✕</button></td>
+                      <td className="text-right"><button type="button" onClick={() => delBolt(i)} className="text-slate-500 hover:text-red-600">✕</button></td>
                     </tr>
                   )
                 })}
@@ -209,7 +209,7 @@ export default function BoltedConnection() {
                   <span className="text-sm font-semibold text-[#0056b3]">T + Q ≤ φBn</span>
                   <span className={`font-mono text-sm font-bold ${pry.ok ? 'text-emerald-600' : 'text-red-600'}`}>{pry.ok ? 'OK ✓' : 'NG ✗'}</span>
                 </div>
-                <p className="mt-2 text-[11px] text-slate-400">
+                <p className="mt-2 text-[11px] text-slate-500">
                   Provide fitting t_f ≥ t_req to carry T + Q; t_f ≥ t₀ eliminates prying (α → 0).
                 </p>
               </div>

--- a/webapp/src/pages/ColumnDesign.tsx
+++ b/webapp/src/pages/ColumnDesign.tsx
@@ -165,7 +165,7 @@ export default function ColumnDesign() {
             {system === 'smf' && (
               <>
                 <Num label="Max lateral bar spacing hx" unit="mm" value={hx} onChange={setHx} />
-                <p className="col-span-full text-[10px] text-slate-400">
+                <p className="col-span-full text-[10px] text-slate-500">
                   hx = centre-to-centre of outermost laterally restrained bars (≤ 350 mm).
                   Set 0 to use the column least dimension as the default.
                 </p>
@@ -179,7 +179,7 @@ export default function ColumnDesign() {
             {loadInput === 'individual' ? <>
               <Num label={<>Dead <KTex tex="D" /></>} unit="kN" value={dead} onChange={setDead} />
               <Num label={<>Live <KTex tex="L" /></>} unit="kN" value={live} onChange={setLive} />
-              <p className="col-span-full text-xs text-slate-400">Pu = max(1.4D, 1.2D+1.6L) = {f0(Pu)} kN</p>
+              <p className="col-span-full text-xs text-slate-500">Pu = max(1.4D, 1.2D+1.6L) = {f0(Pu)} kN</p>
             </> : (
               <Num label={<KTex tex="P_u" />} unit="kN" value={PuDirect} onChange={setPuDirect} />
             )}
@@ -196,7 +196,7 @@ export default function ColumnDesign() {
                 <Num label={<KTex tex="M_1" />} unit="kN·m" value={M1} onChange={setM1} />
                 <Num label={<KTex tex="M_2" />} unit="kN·m" value={M2} onChange={setM2} />
                 <Num label="EI (0 = 0.4EcIg/1.6)" unit="kN·m²" value={EIin} onChange={setEIin} />
-                <p className="col-span-full text-xs text-slate-400">
+                <p className="col-span-full text-xs text-slate-500">
                   Sheet convention: M1/M2 negative for single curvature.
                 </p>
               </>}

--- a/webapp/src/pages/CombinedFootingDesign.tsx
+++ b/webapp/src/pages/CombinedFootingDesign.tsx
@@ -65,7 +65,7 @@ function NumField({ label, unit, value, onChange, step = 'any' }: {
   return (
     <label className="flex flex-col text-sm">
       <span className="mb-1 font-medium text-slate-600">
-        {label}{unit ? <span className="text-slate-400"> ({unit})</span> : null}
+        {label}{unit ? <span className="text-slate-500"> ({unit})</span> : null}
       </span>
       <input
         type="number" inputMode="decimal" step={step} value={Number.isFinite(value) ? value : ''}
@@ -187,7 +187,7 @@ export default function CombinedFootingDesign() {
               <NumField label={<>Subgrade <Math tex="k_s" /></>} unit="kN/m³" value={form.ksubgrade} onChange={set('ksubgrade')} />
             )}
             {flexible && (
-              <p className="col-span-full text-xs text-slate-400">
+              <p className="col-span-full text-xs text-slate-500">
                 Beam-on-elastic-foundation FEM (Hermitian elements + consistent Winkler springs). Soil reaction
                 q(x) = k_s·B·y(x). Typical k_s: loose sand ~10–25, dense sand / stiff clay ~40–120 MN/m³.
               </p>
@@ -208,7 +208,7 @@ export default function CombinedFootingDesign() {
             {form.rightRestrict && (
               <NumField label="Right overhang" unit="mm" value={form.rightOverhang} onChange={set('rightOverhang')} />
             )}
-            <p className="col-span-full text-xs text-slate-400">
+            <p className="col-span-full text-xs text-slate-500">
               Both edges restricted → trapezoidal (CTF). Otherwise the slab is rectangular (CRF) and sized about the
               service-load resultant so bearing is uniform.
             </p>
@@ -248,7 +248,7 @@ export default function CombinedFootingDesign() {
                 x1={result.x1} x2={result.x2} col1Width={form.col1Width} col2Width={form.col2Width}
               />
             ) : (
-              <p className="py-8 text-center text-sm text-slate-400">Enter valid inputs — net bearing must be positive.</p>
+              <p className="py-8 text-center text-sm text-slate-500">Enter valid inputs — net bearing must be positive.</p>
             )}
           </div>
 
@@ -289,7 +289,7 @@ export default function CombinedFootingDesign() {
           {result && (
             <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
               <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">
-                Longitudinal flexure {flexible && <span className="text-xs font-normal text-slate-400">(from BEF moments)</span>}
+                Longitudinal flexure {flexible && <span className="text-xs font-normal text-slate-500">(from BEF moments)</span>}
               </h2>
               {(longSections ?? result.longSections).map((s) => (
                 <Row key={s.label} label={s.label}
@@ -335,14 +335,14 @@ export default function CombinedFootingDesign() {
         <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Basis</h2>
         <Math block tex={String.raw`q_{net} = q_a - \gamma_s D_s - \gamma_c D_c - q,\qquad P_u = \max(1.4D,\ 1.2D + 1.6L)`} />
         {flexible ? (
-          <p className="mt-1 text-xs text-slate-400">
+          <p className="mt-1 text-xs text-slate-500">
             Flexible (Winkler) method: footing modelled as a beam on elastic foundation, EI·y'''' + k_s·B·y = column
             loads, solved with Hermitian beam elements and consistent foundation springs. Soil pressure and internal
             V/M follow the settlement field rather than an assumed linear pressure. Geometry/thickness are inherited
             from the rigid sizing. NSCP 2015 / ACI 318-14. φ: shear 0.75, flexure 0.90.
           </p>
         ) : (
-          <p className="mt-1 text-xs text-slate-400">
+          <p className="mt-1 text-xs text-slate-500">
             Rigid (conventional) method: equivalent line load varies linearly so its resultant matches the factored
             column loads; V(x)/M(x) integrated along the footing. NSCP 2015 / ACI 318-14. φ: shear 0.75, flexure 0.90.
           </p>

--- a/webapp/src/pages/FoundationDesign.tsx
+++ b/webapp/src/pages/FoundationDesign.tsx
@@ -110,7 +110,7 @@ function NumField({ label, unit, value, onChange, step = 'any' }: {
   return (
     <label className="flex flex-col text-sm">
       <span className="mb-1 font-medium text-slate-600">
-        {label}{unit ? <span className="text-slate-400"> ({unit})</span> : null}
+        {label}{unit ? <span className="text-slate-500"> ({unit})</span> : null}
       </span>
       <input
         type="number" inputMode="decimal" step={step} value={Number.isFinite(value) ? value : ''}
@@ -302,7 +302,7 @@ export default function FoundationDesign() {
             </table>
           </div>
           {batch.unknownHeaders.length > 0 && (
-            <p className="border-t border-slate-100 px-4 py-2 text-xs text-slate-400">
+            <p className="border-t border-slate-100 px-4 py-2 text-xs text-slate-500">
               Ignored headers: {batch.unknownHeaders.join(', ')}
             </p>
           )}
@@ -343,7 +343,7 @@ export default function FoundationDesign() {
               <NumField label="Width By" unit="m" value={form.fixedBy} onChange={set('fixedBy')} />
             )}
             {ecc && (
-              <p className="col-span-full text-xs text-slate-400">Eccentric is square-only in this pilot; the footing is sized to keep the load in the kern (no uplift).</p>
+              <p className="col-span-full text-xs text-slate-500">Eccentric is square-only in this pilot; the footing is sized to keep the load in the kern (no uplift).</p>
             )}
           </Card>
 
@@ -354,7 +354,7 @@ export default function FoundationDesign() {
               <>
                 <NumField label={<>Dead <Math tex="D" /></>} unit="kN" value={form.deadLoad} onChange={set('deadLoad')} />
                 <NumField label={<>Live <Math tex="L" /></>} unit="kN" value={form.liveLoad} onChange={set('liveLoad')} />
-                <p className="col-span-full text-xs text-slate-400">
+                <p className="col-span-full text-xs text-slate-500">
                   P = D + L = {f0(serviceLoad)} kN · Pu = max(1.4D, 1.2D+1.6L) = {f0(ultimateLoad)} kN
                 </p>
               </>
@@ -377,12 +377,12 @@ export default function FoundationDesign() {
             <Select label="Column position" value={form.position} onChange={set('position')}
               options={[['interior', 'Interior'], ['edge', 'Edge'], ['corner', 'Corner']]} />
             {circular && (
-              <p className="col-span-full text-xs text-slate-400">
+              <p className="col-span-full text-xs text-slate-500">
                 Circular column → equivalent square c = D·√(π/4) = {f0(colWidth)} mm (equal area, legacy convention).
               </p>
             )}
             {rectCol && !rect && (
-              <p className="col-span-full text-xs text-slate-400">
+              <p className="col-span-full text-xs text-slate-500">
                 Punching uses the full cx × cy perimeter (β = max/min); one-way shear & flexure use the smaller
                 dimension (longer cantilever governs both ways on a square footing).
               </p>
@@ -412,7 +412,7 @@ export default function FoundationDesign() {
             {view ? (
               <FootingSchematic Bx={view.Bx} By={view.By} Dc={view.Dc} columnWidth={colWidth} H={form.H} />
             ) : (
-              <p className="py-8 text-center text-sm text-slate-400">Enter valid inputs — net bearing must be positive.</p>
+              <p className="py-8 text-center text-sm text-slate-500">Enter valid inputs — net bearing must be positive.</p>
             )}
           </div>
 
@@ -460,7 +460,7 @@ export default function FoundationDesign() {
           <div className="rounded-xl border border-slate-200 bg-white p-4 text-sm text-slate-600 shadow-sm">
             <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Basis</h2>
             <Math block tex={String.raw`q_{net} = q_a - \gamma_s D_s - \gamma_c D_c - q,\quad P_u = \max(1.4D,\ 1.2D + 1.6L)`} />
-            <p className="mt-1 text-xs text-slate-400">NSCP 2015 / ACI 318-14. φ: shear 0.75, flexure 0.90. Short-direction band per §413.3.3.3.</p>
+            <p className="mt-1 text-xs text-slate-500">NSCP 2015 / ACI 318-14. φ: shear 0.75, flexure 0.90. Short-direction band per §413.3.3.3.</p>
           </div>
         </div>
       </div>

--- a/webapp/src/pages/FrameAnalysis.tsx
+++ b/webapp/src/pages/FrameAnalysis.tsx
@@ -104,7 +104,7 @@ export default function FrameAnalysis() {
             <Num label="b" unit="mm" value={b} onChange={setB} />
             <Num label="h" unit="mm" value={h} onChange={setH} />
             <Num label="f′c" unit="MPa" value={fc} onChange={setFc} />
-            <p className="col-span-full text-xs text-slate-400">
+            <p className="col-span-full text-xs text-slate-500">
               E = 4700√f′c = {f1(E)} MPa · A = {b * h} mm² · I = {(b * h ** 3 / 12 / 1e9).toFixed(3)}×10⁹ mm⁴
             </p>
           </Card>
@@ -253,7 +253,7 @@ export default function FrameAnalysis() {
               className="rounded-md border border-slate-300 px-2.5 py-1.5 text-sm">
               {r.members.map((m) => <option key={m.id} value={m.id}>{m.id}</option>)}
             </select>
-            <span className="text-xs text-slate-400">local x from node i · N &gt; 0 tension</span>
+            <span className="text-xs text-slate-500">local x from node i · N &gt; 0 tension</span>
           </div>
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
             <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">

--- a/webapp/src/pages/Geotech.tsx
+++ b/webapp/src/pages/Geotech.tsx
@@ -19,7 +19,7 @@ function Card({ title, sub, children }: { title: string; sub: string; children: 
   return (
     <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
       <h2 className="text-[1.05rem] font-bold text-[#0056b3]">{title}</h2>
-      <p className="mb-3 text-[11px] text-slate-400">{sub}</p>
+      <p className="mb-3 text-[11px] text-slate-500">{sub}</p>
       {children}
     </section>
   )
@@ -134,7 +134,7 @@ function Slope() {
 export default function Geotech() {
   return (
     <main className="mx-auto max-w-5xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">Geotechnical</p>
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Geotechnical toolkit</h1>
       <p className="mt-2 max-w-3xl text-sm text-slate-600">
         Classic soil-mechanics checks — Rankine lateral earth pressure, shallow-foundation bearing
@@ -146,7 +146,7 @@ export default function Geotech() {
         <Bearing />
         <Slope />
       </div>
-      <p className="mt-6 text-[11px] text-slate-400">
+      <p className="mt-6 text-[11px] text-slate-500">
         Bearing factors: Nq, Nc per Prandtl/Reissner; Nγ per Vesić (2(Nq+1)tanφ). Shape factors per Meyerhof.
         Use engineering judgement and site-specific investigation; these are preliminary checks.
       </p>

--- a/webapp/src/pages/Home.tsx
+++ b/webapp/src/pages/Home.tsx
@@ -96,7 +96,7 @@ export default function Home({ onAuth }: { onAuth: (mode: 'login' | 'signup') =>
                 Browse all {toolCount} tools ↓
               </a>
             </div>
-            <div className="mt-10 flex items-center gap-7 text-xs text-slate-400">
+            <div className="mt-10 flex items-center gap-7 text-xs text-slate-500">
               <span><strong className="text-slate-800">{toolCount}</strong> tools</span>
               <div className="h-3 w-px bg-slate-200" />
               <span><strong className="text-slate-800">Server-side</strong> solvers</span>
@@ -124,14 +124,14 @@ export default function Home({ onAuth }: { onAuth: (mode: 'login' | 'signup') =>
       {/* Sample / test cases */}
       <section className="mx-auto max-w-6xl px-6 py-16">
         <div className="mb-6 flex items-center gap-4">
-          <span className="text-[10px] font-bold uppercase tracking-[0.18em] text-slate-400">Try a sample</span>
+          <span className="text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500">Try a sample</span>
           <div className="h-px flex-1 bg-slate-200" />
         </div>
         <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
           {SAMPLES.map(s => (
             <Link key={s.to} to={s.to}
               className="group flex flex-col border border-slate-200 bg-white p-6 transition-colors hover:border-[#0056b3] hover:bg-[#f4f8ff]">
-              <span className="text-[9px] font-bold uppercase tracking-widest text-slate-400 group-hover:text-[#0056b3]">{s.tag}</span>
+              <span className="text-[9px] font-bold uppercase tracking-widest text-slate-500 group-hover:text-[#0056b3]">{s.tag}</span>
               <span className="mt-2 text-base font-semibold text-slate-900">{s.title}</span>
               <span className="mt-2 text-xs leading-relaxed text-slate-500">{s.desc}</span>
               <span className="mt-5 text-xs font-semibold text-[#0056b3] opacity-0 transition-opacity group-hover:opacity-100">

--- a/webapp/src/pages/LoadCombinations.tsx
+++ b/webapp/src/pages/LoadCombinations.tsx
@@ -40,7 +40,7 @@ export default function LoadCombinations() {
           <Num label="Lr — Roof live"      value={d.Lr} onChange={set('Lr')} />
           <Num label="W — Wind"            value={d.W}  onChange={set('W')} />
           <Num label="E — Earthquake"      value={d.E}  onChange={set('E')} />
-          <p className="mt-2 text-xs text-slate-400">
+          <p className="mt-2 text-xs text-slate-500">
             Any consistent unit (kN, kN/m, kPa, …). W and E enter as positive magnitudes;
             the ±W/±E sign is handled by each combination.
           </p>
@@ -51,7 +51,7 @@ export default function LoadCombinations() {
           <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm">
             <div className="border-b border-slate-100 bg-slate-50 px-4 py-2.5">
               <span className="text-sm font-semibold text-slate-700">Factored Load Combinations</span>
-              <span className="ml-3 text-xs text-slate-400">NSCP 2015 §203.3</span>
+              <span className="ml-3 text-xs text-slate-500">NSCP 2015 §203.3</span>
             </div>
             <table className="w-full text-sm">
               <thead>
@@ -72,7 +72,7 @@ export default function LoadCombinations() {
                     : ''
                   return (
                     <tr key={c.id} className={`border-b border-slate-50 ${highlight}`}>
-                      <td className="px-3 py-2 font-mono text-slate-400">{c.id}</td>
+                      <td className="px-3 py-2 font-mono text-slate-500">{c.id}</td>
                       <td className="px-3 py-2 text-slate-700">{c.label}</td>
                       <td className="px-3 py-2 text-right font-semibold tabular-nums">
                         {f2(c.value)}
@@ -92,12 +92,12 @@ export default function LoadCombinations() {
               <div>
                 <span className="text-slate-500">Max (governing):</span>
                 <span className="ml-1.5 font-bold text-green-700">{f2(r.maxCombo.value)}</span>
-                <span className="ml-1 text-slate-400 text-xs">combo {r.maxCombo.id}</span>
+                <span className="ml-1 text-slate-500 text-xs">combo {r.maxCombo.id}</span>
               </div>
               <div>
                 <span className="text-slate-500">Min:</span>
                 <span className="ml-1.5 font-bold text-slate-700">{f2(r.minCombo.value)}</span>
-                <span className="ml-1 text-slate-400 text-xs">combo {r.minCombo.id}</span>
+                <span className="ml-1 text-slate-500 text-xs">combo {r.minCombo.id}</span>
               </div>
             </div>
           </div>

--- a/webapp/src/pages/LoadPath.tsx
+++ b/webapp/src/pages/LoadPath.tsx
@@ -63,7 +63,7 @@ export default function LoadPath() {
           <Card title="Panel">
             <Num label="Side a" unit="m" value={a} onChange={setA} />
             <Num label="Side b" unit="m" value={b} onChange={setB} />
-            <p className="col-span-full text-xs text-slate-400">
+            <p className="col-span-full text-xs text-slate-500">
               ℓx = short span, ℓy = long span — assigned automatically.
             </p>
           </Card>
@@ -98,7 +98,7 @@ export default function LoadPath() {
             {wallOn && <>
               <Num label="Thickness" unit="mm" value={wallT} onChange={setWallT} />
               <Num label="Height" unit="m" value={wallH} onChange={setWallH} />
-              <p className="col-span-full text-xs text-slate-400">
+              <p className="col-span-full text-xs text-slate-500">
                 w = t·h·24 = {f2(wWall)} kN/m (dead) — added to whichever edge you send to Beam Analysis.
               </p>
             </>}

--- a/webapp/src/pages/Micropile.tsx
+++ b/webapp/src/pages/Micropile.tsx
@@ -48,7 +48,7 @@ export default function Micropile() {
 
   return (
     <main className="mx-auto max-w-3xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">Geotechnical</p>
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Micropile — axial capacity</h1>
       <p className="mt-2 text-sm text-slate-600">
         FHWA-NHI-05-039 allowable-stress check: structural capacity of the bar/casing/grout vs the
@@ -98,7 +98,7 @@ export default function Micropile() {
         <Out label={`Governing allowable (${r.governs})`} value={`${f0(r.allowable)} kN`} />
         <Out label="FS (allowable / demand)" value={f2(r.fs)} ok={r.ok} />
         <Out label="Bond length for FS = 2" value={`${f2(r.bondLengthReq)} m`} ok={bondLength >= r.bondLengthReq} />
-        <p className="mt-2 text-[10px] text-slate-400">
+        <p className="mt-2 text-[10px] text-slate-500">
           Structural: 0.40·f′c·Agrout + 0.47·Fy·As (compression), 0.55·Fy·As (tension). Bond:
           π·Dbond·Lbond·αbond / FS. Verify buckling in very soft soils and group/settlement effects separately.
         </p>

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -1531,7 +1531,7 @@ export default function ModelSpace() {
                 <OrbitControls ref={controlsRef} makeDefault enablePan target={[6, 3, 2.5]} />
               </Canvas>
             ) : (
-              <div className="flex h-full items-center justify-center text-sm text-slate-400">
+              <div className="flex h-full items-center justify-center text-sm text-slate-500">
                 Set the grid and hit “Generate model”.
               </div>
             )}
@@ -1539,11 +1539,11 @@ export default function ModelSpace() {
               <div className="no-print absolute left-3 top-3 flex items-center gap-2 rounded-lg border border-[#0056b3]/30 bg-white/90 px-2.5 py-1 text-xs shadow-sm backdrop-blur">
                 <span className="font-semibold text-[#0056b3]">▣ {selInfo.kind} {selInfo.id}</span>
                 {selInfo.extra && <span className="text-slate-500">{selInfo.extra}</span>}
-                <button type="button" onClick={() => setSelected(null)} className="ml-0.5 text-slate-400 hover:text-red-500" title="Deselect">✕</button>
+                <button type="button" onClick={() => setSelected(null)} className="ml-0.5 text-slate-500 hover:text-red-500" title="Deselect">✕</button>
               </div>
             )}
             {model && (
-              <div className="no-print pointer-events-none absolute bottom-2 left-3 text-[10px] text-slate-400">
+              <div className="no-print pointer-events-none absolute bottom-2 left-3 text-[10px] text-slate-500">
                 drag to orbit · scroll to zoom · hold <b>Shift</b> (or right-drag) to pan
               </div>
             )}
@@ -1581,7 +1581,7 @@ export default function ModelSpace() {
             <div className="no-print mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-slate-600">
               <span className="font-medium">Force diagram:</span>
               <button type="button" onClick={() => setForceDiag(null)}
-                className={`rounded px-1.5 py-0.5 font-semibold ${forceDiag === null ? 'bg-slate-200 text-slate-700' : 'text-slate-400 hover:text-slate-600'}`}>off</button>
+                className={`rounded px-1.5 py-0.5 font-semibold ${forceDiag === null ? 'bg-slate-200 text-slate-700' : 'text-slate-500 hover:text-slate-600'}`}>off</button>
               {(['N', 'Vy', 'Vz', 'My', 'Mz', 'T'] as DiagramComp[]).map((c) => (
                 <button key={c} type="button" onClick={() => setForceDiag(c)}
                   title={`Draw ${c} on every member (governing combo)`}
@@ -1594,7 +1594,7 @@ export default function ModelSpace() {
               ))}
               {forceDiag && (
                 <label className="ml-1 inline-flex items-center gap-1">
-                  <span className="text-slate-400">scale</span>
+                  <span className="text-slate-500">scale</span>
                   <input type="range" min={0.3} max={3} step={0.1} value={forceDiagScale}
                     onChange={(e) => setForceDiagScale(Number(e.target.value))} className="h-1 w-20" />
                 </label>
@@ -1686,7 +1686,7 @@ export default function ModelSpace() {
                       </tbody>
                     </table>
                   </div>
-                  <p className="mt-1 text-[11px] text-slate-400">Coordinates in m (y = up). Removing a node also removes everything attached to it.</p>
+                  <p className="mt-1 text-[11px] text-slate-500">Coordinates in m (y = up). Removing a node also removes everything attached to it.</p>
                 </div>
               )}
 
@@ -1765,7 +1765,7 @@ export default function ModelSpace() {
                       <option value="">node i…</option>
                       {model.nodes.map((n) => <option key={n.id} value={n.id}>{n.id}</option>)}
                     </select>
-                    <span className="text-slate-400">→</span>
+                    <span className="text-slate-500">→</span>
                     <select value={newJ} onChange={(e) => setNewJ(e.target.value)} className="max-w-[5.5rem] rounded border border-slate-200 px-1 py-0.5">
                       <option value="">node j…</option>
                       {model.nodes.map((n) => <option key={n.id} value={n.id}>{n.id}</option>)}
@@ -1816,7 +1816,7 @@ export default function ModelSpace() {
                             ))}
                           </tbody>
                         </table>
-                        <p className="mt-1 text-[10px] text-slate-400">Check to release (zero force/moment). Mz = in-plane bending; My = out-of-plane. Click a member row to select.</p>
+                        <p className="mt-1 text-[10px] text-slate-500">Check to release (zero force/moment). Mz = in-plane bending; My = out-of-plane. Click a member row to select.</p>
                       </div>
                     )
                   })()}
@@ -1860,7 +1860,7 @@ export default function ModelSpace() {
                             ))}
                           </tbody>
                         </table>
-                        <p className="mt-1 text-[10px] text-slate-400">Vector node→member-end (global m). The flexible member spans end→end; node↔end is a rigid arm (purple).</p>
+                        <p className="mt-1 text-[10px] text-slate-500">Vector node→member-end (global m). The flexible member spans end→end; node↔end is a rigid arm (purple).</p>
                         <label className="mt-2 flex items-center gap-2 border-t border-violet-200 pt-2 text-[11px] text-slate-700">
                           <span>Auto rigid-zone factor override</span>
                           <input type="number" min={0} max={1} step={0.1}
@@ -1870,7 +1870,7 @@ export default function ModelSpace() {
                               updMember(sel.id, { rigidZoneFactor: Number.isFinite(v) ? Math.max(0, Math.min(1, v)) : undefined })
                             }}
                             className="w-16 rounded border border-violet-200 px-1 py-0.5 text-right" />
-                          <span className="text-[10px] text-slate-400">blank = model factor · 0 = no zone for this member (needs Auto rigid end zones on)</span>
+                          <span className="text-[10px] text-slate-500">blank = model factor · 0 = no zone for this member (needs Auto rigid end zones on)</span>
                         </label>
                         <label className="mt-2 flex items-center gap-2 border-t border-violet-200 pt-2 text-[11px] text-slate-700">
                           <span>Local axis rotation θ (°)</span>
@@ -1881,7 +1881,7 @@ export default function ModelSpace() {
                               updMember(sel.id, { axisRotation: Number.isFinite(v) ? v : undefined })
                             }}
                             className="w-16 rounded border border-violet-200 px-1 py-0.5 text-right" />
-                          <span className="text-[10px] text-slate-400">ETABS local-axis angle about the member axis. Blank = default (vertical members 90° — depth d on global X); orients section stiffness, rigid zones and the drawn shape.</span>
+                          <span className="text-[10px] text-slate-500">ETABS local-axis angle about the member axis. Blank = default (vertical members 90° — depth d on global X); orients section stiffness, rigid zones and the drawn shape.</span>
                         </label>
                         {(sel.role === 'beam' || sel.role === 'girder') && (
                           <label className="mt-2 flex items-center gap-2 border-t border-violet-200 pt-2 text-[11px] text-slate-700">
@@ -1893,7 +1893,7 @@ export default function ModelSpace() {
                                 updMember(sel.id, { Lb: Number.isFinite(v) && v > 0 ? v : undefined })
                               }}
                               className="w-16 rounded border border-violet-200 px-1 py-0.5 text-right" />
-                            <span className="text-[10px] text-slate-400">§F2 LTB brace spacing — blank = full member length (conservative)</span>
+                            <span className="text-[10px] text-slate-500">§F2 LTB brace spacing — blank = full member length (conservative)</span>
                           </label>
                         )}
                         <div className="mt-2 border-t border-violet-200 pt-2">
@@ -1916,7 +1916,7 @@ export default function ModelSpace() {
                               </label>
                             ))}
                           </div>
-                          <span className="mt-1 block text-[10px] text-slate-400">Simple = shear-only pin (releases My, Mz — the connection hinge); Moment = rigid; drives both analysis and steel connection design.</span>
+                          <span className="mt-1 block text-[10px] text-slate-500">Simple = shear-only pin (releases My, Mz — the connection hinge); Moment = rigid; drives both analysis and steel connection design.</span>
                         </div>
                       </div>
                     )
@@ -1929,7 +1929,7 @@ export default function ModelSpace() {
                 <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
                   <h3 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Slabs / plates</h3>
                   {model.plates.filter((p) => p.role !== 'wall').length === 0 ? (
-                    <p className="text-xs text-slate-400">No slabs — generate a grid or add members forming closed panels.</p>
+                    <p className="text-xs text-slate-500">No slabs — generate a grid or add members forming closed panels.</p>
                   ) : (
                     <div className="max-h-60 overflow-auto">
                       <table className="w-full border-collapse text-xs">
@@ -1961,7 +1961,7 @@ export default function ModelSpace() {
                       </table>
                     </div>
                   )}
-                  <p className="mt-1 text-[11px] text-slate-400">Thickness drives slab self-weight (t·γc) → tributary line loads on the edge beams.</p>
+                  <p className="mt-1 text-[11px] text-slate-500">Thickness drives slab self-weight (t·γc) → tributary line loads on the edge beams.</p>
                 </div>
               )}
 
@@ -2018,7 +2018,7 @@ export default function ModelSpace() {
                       )
                     })()}
                   </div>
-                  <p className="mt-1 text-[11px] text-slate-400">A wall adds its self-weight (t·h·γc) as a line load on the chosen beam. A “shear wall” also braces the storey below it — modelled as an equivalent X of diagonal struts (shear + flexure stiffness) so it carries seismic/wind in the analysis.</p>
+                  <p className="mt-1 text-[11px] text-slate-500">A wall adds its self-weight (t·h·γc) as a line load on the chosen beam. A “shear wall” also braces the storey below it — modelled as an equivalent X of diagonal struts (shear + flexure stiffness) so it carries seismic/wind in the analysis.</p>
                 </div>
               )}
             </div>
@@ -2057,7 +2057,7 @@ export default function ModelSpace() {
                   <Num label="Steel Fy" unit="MPa" value={steelFy} onChange={setSteelFy} step="5" />
                   <Num label="Steel Fu" unit="MPa" value={steelFu} onChange={setSteelFu} step="5" />
                   <Num label="Slab thickness" unit="mm" value={slabThk} onChange={setSlabThk} />
-                  <p className="col-span-full text-[11px] text-slate-400">
+                  <p className="col-span-full text-[11px] text-slate-500">
                     All AISC families (W/C/L/HSS/Pipe/WT) — analysis & 3D extrusion use the true section.
                     HSS/angles suit braces. Auto-design covers W/WT flexure + axial for any family; detailed
                     HSS/angle/channel flexure checks are not yet automated. Concrete f′c is still used for base-plate bearing.
@@ -2093,7 +2093,7 @@ export default function ModelSpace() {
                 <Num label="Clear cover" unit="mm" value={cover} onChange={setCover} step="5" />
                 <Num label="Concrete unit wt γc" unit="kN/m³" value={gammaC} onChange={setGammaC} step="0.5" />
               </Card>
-              <p className="text-[11px] text-slate-400">
+              <p className="text-[11px] text-slate-500">
                 Per-member b×h are editable in the Geometry → Beams &amp; columns table; slab thickness per panel
                 in Geometry → Slabs. f′c, fy, ⌀, cover and slab thickness are applied when you generate a new grid;
                 γc feeds self-weight (members + slabs) and seismic mass — change it, then “Rebuild D + L” (Loading)
@@ -2110,7 +2110,7 @@ export default function ModelSpace() {
                 <Num label="Soil qa" unit="kPa" value={qa} onChange={setQa} />
                 <Num label="Footing depth H" unit="m" value={Hf} onChange={setHf} />
                 <Num label="Soil unit wt γsoil" unit="kN/m³" value={gammaSoil} onChange={setGammaSoil} step="0.5" />
-                <p className="col-span-full text-[11px] text-slate-400">
+                <p className="col-span-full text-[11px] text-slate-500">
                   Base supports are toggled per node in the Geometry → Nodes table (“Sup” column).
                   qa is the allowable bearing; γsoil is the overburden weight deducted for the net bearing
                   (q_net = qa − γsoil·Ds − γc·Dc). Applied on the next Design / Optimize.
@@ -2180,7 +2180,7 @@ export default function ModelSpace() {
                         <label key={s.node} className="flex items-center gap-2 text-xs">
                           <span className="w-16 font-medium">{s.node}</span>
                           {takenBy ? (
-                            <span className="text-slate-400">combined with {takenBy}</span>
+                            <span className="text-slate-500">combined with {takenBy}</span>
                           ) : (
                             <select value={partner}
                               onChange={(e) => setPlanSel((p) => ({ ...p, [s.node]: e.target.value }))}
@@ -2205,7 +2205,7 @@ export default function ModelSpace() {
               <Card title="Slab loads">
                 <Num label="Default SDL" unit="kPa" value={qD} onChange={setQD} />
                 <Num label="Live load" unit="kPa" value={qL} onChange={setQL} />
-                <p className="col-span-full text-[11px] text-slate-400">
+                <p className="col-span-full text-[11px] text-slate-500">
                   “Default SDL” applies to any slab without a composed NSCP-204 SDL below. Live load is shared.
                 </p>
               </Card>
@@ -2226,7 +2226,7 @@ export default function ModelSpace() {
                         <label key={c.id} className="flex items-center gap-2 text-[11px]">
                           <input type="checkbox" checked={sdlDraft.some((x) => x.id === c.id)} onChange={() => toggleSdl204_1(c)} />
                           <span className="flex-1">{c.label}</span>
-                          <span className="text-slate-400">{c.kPa.toFixed(2)}</span>
+                          <span className="text-slate-500">{c.kPa.toFixed(2)}</span>
                         </label>
                       ))}
                     </div>
@@ -2240,12 +2240,12 @@ export default function ModelSpace() {
                         {TABLE_204_2.map((mtl) => <option key={mtl.id} value={mtl.id}>{mtl.label} ({mtl.gamma})</option>)}
                       </select>
                       <input type="number" value={sdlMatT} onChange={(e) => setSdlMatT(parseFloat(e.target.value))}
-                        className="w-20 rounded-md border border-slate-300 px-2 py-1 text-xs" /> <span className="text-[11px] text-slate-400">mm</span>
+                        className="w-20 rounded-md border border-slate-300 px-2 py-1 text-xs" /> <span className="text-[11px] text-slate-500">mm</span>
                       <button type="button" onClick={addSdl204_2}
                         className="rounded-md border border-slate-300 px-2 py-1 text-xs font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">+ Add</button>
                     </div>
                     <div className="mt-2 space-y-0.5">
-                      {sdlDraft.length === 0 && <p className="text-[11px] text-slate-400">No components selected.</p>}
+                      {sdlDraft.length === 0 && <p className="text-[11px] text-slate-500">No components selected.</p>}
                       {sdlDraft.map((it, i) => (
                         <div key={i} className="flex items-center gap-2 text-[11px]">
                           <span className="flex-1">{it.label}</span>
@@ -2267,7 +2267,7 @@ export default function ModelSpace() {
                     title="Select a slab panel in the 3D view first">
                     Apply to selected slab{selPlate && selPlate.role !== 'wall' ? ` (${selPlate.id})` : ''}
                   </button>
-                  <span className="text-[11px] text-slate-400">Empty composition clears a slab back to the default SDL.</span>
+                  <span className="text-[11px] text-slate-500">Empty composition clears a slab back to the default SDL.</span>
                 </div>
               </div>
 
@@ -2344,7 +2344,7 @@ export default function ModelSpace() {
                       </tbody>
                     </table>
                   </div>
-                  <p className="mt-1 text-[11px] text-slate-400">
+                  <p className="mt-1 text-[11px] text-slate-500">
                     “set SDL” writes the composition built above to that panel; the occupancy dropdown sets its NSCP-205 live load. Click a slab id to select it in 3D.
                   </p>
                 </div>
@@ -2383,7 +2383,7 @@ export default function ModelSpace() {
                                     <input type="number" step="0.1" value={val}
                                       onChange={(e) => updLoad(idx, parseFloat(e.target.value))}
                                       className="w-16 rounded border border-slate-200 px-1 py-0.5" /> {unit}
-                                    {l.kind === 'member-thermal' && <span className="ml-1 text-slate-400">(α = {(l.alpha * 1e6).toFixed(1)}×10⁻⁶)</span>}
+                                    {l.kind === 'member-thermal' && <span className="ml-1 text-slate-500">(α = {(l.alpha * 1e6).toFixed(1)}×10⁻⁶)</span>}
                                   </>
                                 ) : (
                                   <span className="text-slate-500">
@@ -2402,7 +2402,7 @@ export default function ModelSpace() {
                       </tbody>
                     </table>
                   </div>
-                  <p className="mt-1 text-[11px] text-slate-400">
+                  <p className="mt-1 text-[11px] text-slate-500">
                     Dead = self-weight (members from b×h, slabs from t, γc = 24 kN/m³) + the SDL input; live = the LL
                     input. “Rebuild” regenerates both after you edit the frame.
                   </p>
@@ -2446,7 +2446,7 @@ export default function ModelSpace() {
                       + Add thermal load
                     </button>
                   </div>
-                  <p className="col-span-full text-[10px] text-slate-400">
+                  <p className="col-span-full text-[10px] text-slate-500">
                     Equivalent axial force P_T = EA·α·ΔT applied as self-equilibrating end forces (AISC 360-16 Commentary §C2). Treated as dead load (D) in NSCP 2015 combinations. Thermal effects appear in the member N diagram after Analyze.
                   </p>
                 </Card>
@@ -2478,7 +2478,7 @@ export default function ModelSpace() {
                       </p>
                       <table className="w-full border-collapse text-xs">
                         <thead>
-                          <tr className="text-left uppercase tracking-wide text-slate-400">
+                          <tr className="text-left uppercase tracking-wide text-slate-500">
                             <th className="py-0.5 pr-2 font-semibold">Level (m)</th>
                             <th className="py-0.5 pr-2 text-right font-semibold">wx (kN)</th>
                             <th className="py-0.5 pr-2 text-right font-semibold">Fx (kN)</th>
@@ -2491,12 +2491,12 @@ export default function ModelSpace() {
                               <td className="py-0.5 pr-2">{f1(s.elevation)}</td>
                               <td className="py-0.5 pr-2 text-right">{f1(s.wx)}</td>
                               <td className="py-0.5 pr-2 text-right font-medium text-[#7c3aed]">{f1(s.Fx)}</td>
-                              <td className="py-0.5 text-right text-slate-400">{s.nodes}</td>
+                              <td className="py-0.5 text-right text-slate-500">{s.nodes}</td>
                             </tr>
                           ))}
                         </tbody>
                       </table>
-                      <p className="text-[10px] text-slate-400">
+                      <p className="text-[10px] text-slate-500">
                         System: <b>{seismicSystem.toUpperCase()}</b> (R = {Rw}) — column tie detailing uses {seismicSystem === 'smf' ? 'NSCP §418.7.5 SMF confinement' : seismicSystem === 'imf' ? 'NSCP §418.4.3 IMF hinge zone' : '§425.7.2 gravity ties only'}.
                       </p>
                     </div>
@@ -2574,7 +2574,7 @@ export default function ModelSpace() {
                     </table>
                   )}
                   {cladding && (
-                    <p className="mt-1 text-[10px] text-slate-400">
+                    <p className="mt-1 text-[10px] text-slate-500">
                       qh = {f2(cladding.qh)} kPa at h = {f1(cladding.h)} m · |GCpi| = {cladding.GCpi} · A = {f1(cladding.area)} m².
                       Corner zone 5 governs cladding suction. Roof C&amp;C and h &gt; 18.3 m (§207E.5) out of scope.
                     </p>
@@ -2616,7 +2616,7 @@ export default function ModelSpace() {
                     <input type="number" min={0} max={1} step={0.1} value={model.rigidZoneFactor ?? 0.5}
                       onChange={(e) => model && save({ ...model, rigidZoneFactor: Math.max(0, Math.min(1, parseFloat(e.target.value) || 0)) })}
                       className="w-20 rounded border border-slate-300 px-2 py-1" />
-                    <span className="text-[11px] text-slate-400">auto offsets = factor × ½·(connecting member depth) at each joint</span>
+                    <span className="text-[11px] text-slate-500">auto offsets = factor × ½·(connecting member depth) at each joint</span>
                   </label>
                 )}
                 <label className="col-span-full flex items-center gap-2 text-sm">
@@ -2625,7 +2625,7 @@ export default function ModelSpace() {
                   <span>Shell elements (slab/wall panels as CST+DKT finite elements, not load sources)</span>
                 </label>
                 {model?.shellElements && (
-                  <p className="col-span-full pl-6 text-[11px] text-slate-400">
+                  <p className="col-span-full pl-6 text-[11px] text-slate-500">
                     Each panel meshes to two triangles on its corner nodes; area loads lump to those nodes.
                     Analysis-path feature — the NSCP design pipeline keeps the tributary load model.
                   </p>
@@ -2656,7 +2656,7 @@ export default function ModelSpace() {
                   <Row label="Extremes" value={`M ${f1(govRes.Mmax)} kN·m`}
                     sub={`V ${f1(govRes.Vmax)} · N ${f1(govRes.Nmax)} kN`} />
                   {orphans > 0 && <Row alert label="⚠ Orphan edges" value={`${orphans}`} sub="slab edges with no member" />}
-                  <p className="mt-1 text-[11px] text-slate-400">Members tinted red by |M| relative to the model max. Click one for its diagrams.</p>
+                  <p className="mt-1 text-[11px] text-slate-500">Members tinted red by |M| relative to the model max. Click one for its diagrams.</p>
                 </ResultCard>
               )}
 
@@ -2740,7 +2740,7 @@ export default function ModelSpace() {
                       </tbody>
                     </table>
                   </div>
-                  <p className="mt-2 text-[10px] text-slate-400">
+                  <p className="mt-2 text-[10px] text-slate-500">
                     Envelope of the per-element Wood-Armer design moments over each panel. As includes the
                     shrinkage/temperature minimum (ρ_min); spacing capped at min(3t, 450) mm. d = t − cover − 1.5⌀.
                   </p>
@@ -2755,7 +2755,7 @@ export default function ModelSpace() {
                       value={`ΔM = ${row.dM.toFixed(1)} mm ${row.ok ? '✓' : '✗'}`}
                       sub={`Δs ${row.ds.toFixed(2)} · limit ${row.limit.toFixed(0)} mm`} />
                   ))}
-                  <p className="mt-1 text-[11px] text-slate-400">
+                  <p className="mt-1 text-[11px] text-slate-500">
                     Limit {seis.T < 0.7 ? '0.025' : '0.020'}·hs (T {seis.T < 0.7 ? '<' : '≥'} 0.7 s) — NSCP 208.5.10.
                   </p>
                 </ResultCard>
@@ -2791,7 +2791,7 @@ export default function ModelSpace() {
                           sub={`G: ${f2(k.Gi.x)} (i) · ${f2(k.Gj.x)} (j)`} />
                         <Row label="K — Z-sway" value={`sway ${f2(k.Kz.sway)} · braced ${f2(k.Kz.braced)}`}
                           sub={`G: ${f2(k.Gi.z)} (i) · ${f2(k.Gj.z)} (j)`} />
-                        <p className="mt-1 text-[10px] text-slate-400">
+                        <p className="mt-1 text-[10px] text-slate-500">
                           G = Σ(EI/L)<sub>col</sub> / Σ(EI/L)<sub>beam</sub> at each joint; fixed base G = 1.0, pinned/no-beam G = 10.
                         </p>
                       </div>
@@ -2886,7 +2886,7 @@ export default function ModelSpace() {
                         {thCsv.name} — {thCsv.npts} pts
                       </span>
                       <button type="button" onClick={() => setThCsv(null)}
-                        className="text-[11px] text-slate-400 hover:text-red-500">✕ clear</button>
+                        className="text-[11px] text-slate-500 hover:text-red-500">✕ clear</button>
                     </div>
                   ) : (
                     <label className="inline-flex cursor-pointer items-center gap-1.5 rounded border border-slate-300 bg-white px-2 py-1 text-[11px] text-slate-600 hover:bg-slate-50">
@@ -3291,7 +3291,7 @@ export default function ModelSpace() {
                       <td className="py-1 pr-2">{d.mode}</td>
                       <td className="py-1 pr-2">{d.bars}⌀{sec?.barDia}{d.layers.length > 1 ? ` (${d.layers.join('+')})` : ''}{s.hogging ? ' top' : ''}</td>
                       <td className="py-1 pr-2">{d.sAdopt > 0 ? `@${Math.round(d.sAdopt)}` : d.region === 'none' ? 'none' : '⚠'}</td>
-                      <td className="py-1 text-slate-400">{k === 0 ? bm.gov : ''}</td>
+                      <td className="py-1 text-slate-500">{k === 0 ? bm.gov : ''}</td>
                     </tr>,
                     open && model && sec && (
                       <tr key={`${key}:sol`}>
@@ -3358,7 +3358,7 @@ export default function ModelSpace() {
                       <td className="py-1 pr-2 text-right">{f1(c.Mu)}</td>
                       <td className="py-1 pr-2">{c.bars}⌀{cs?.barDia} · ties @{Math.round(c.tieSpacingFinal)}{c.seismicSConf !== undefined ? ' ✱' : ''}</td>
                       <td className="py-1 pr-2 text-right">{(c.util * 100).toFixed(0)}%</td>
-                      <td className="py-1 text-slate-400">{c.gov}</td>
+                      <td className="py-1 text-slate-500">{c.gov}</td>
                     </tr>,
                     open && model && cs && (
                       <tr key={`${key}:sol`}>
@@ -3377,11 +3377,11 @@ export default function ModelSpace() {
                                 <div className="border-t border-slate-100 pt-2 text-[11px] text-slate-600">
                                   <p className="mb-0.5 font-semibold text-[#0056b3]">Seismic confinement ({seismicSystem.toUpperCase()})</p>
                                   <p>Confinement zone ℓo = {Math.round(c.seismicLoZone!)} mm</p>
-                                  <p>Ties within ℓo @ {Math.round(c.seismicSConf)} mm <span className="text-slate-400">({c.tieSpacingLabel})</span></p>
+                                  <p>Ties within ℓo @ {Math.round(c.seismicSConf)} mm <span className="text-slate-500">({c.tieSpacingLabel})</span></p>
                                   {c.seismicSOut !== undefined && c.seismicSOut !== c.tieSpacing && (
                                     <p>Ties outside ℓo @ {Math.round(c.seismicSOut)} mm</p>
                                   )}
-                                  <p className="mt-0.5 text-slate-400">✱ Seismic controls over §425.7.2 gravity tie spacing ({Math.round(c.tieSpacing)} mm)</p>
+                                  <p className="mt-0.5 text-slate-500">✱ Seismic controls over §425.7.2 gravity tie spacing ({Math.round(c.tieSpacing)} mm)</p>
                                 </div>
                               )}
                             </div>
@@ -3419,12 +3419,12 @@ export default function ModelSpace() {
                       <td className="py-1 pr-2 text-right font-mono">{f1(j.sumMnb)}</td>
                       <td className="py-1 pr-2 text-right font-mono">{Number.isFinite(j.ratio) ? j.ratio.toFixed(2) : '∞'}</td>
                       <td className={`py-1 pr-2 text-right font-semibold ${j.ok ? 'text-emerald-600' : 'text-red-600'}`}>{j.ok ? '✓' : '✗'}</td>
-                      <td className="py-1 text-slate-400">{j.nCols} / {j.nBeams}</td>
+                      <td className="py-1 text-slate-500">{j.nCols} / {j.nBeams}</td>
                     </tr>
                   ))}
                 </tbody>
               </table>
-              <p className="mt-2 text-[10px] text-slate-400">
+              <p className="mt-2 text-[10px] text-slate-500">
                 ΣMnc ≥ (6/5)·ΣMnb at each beam-column joint (§418.7.3.2). Column Mnc is taken at the design axial Pu;
                 beam Mnb from the heaviest designed tension steel. Failing joints need larger columns or lighter beams.
                 {design.scwb.every((j) => j.ok) ? ' All joints satisfy the requirement.' : ' ✗ One or more joints fail.'}
@@ -3482,7 +3482,7 @@ export default function ModelSpace() {
                                     <tbody>
                                       {dr.locations.map((loc, li) => (
                                         <tr key={li} className="border-t border-slate-100">
-                                          <td className="py-0.5 pr-2">{loc.name} <span className="text-slate-400">({loc.coeff.toFixed(2)})</span></td>
+                                          <td className="py-0.5 pr-2">{loc.name} <span className="text-slate-500">({loc.coeff.toFixed(2)})</span></td>
                                           <td className="py-0.5 pr-2 text-right">{f1(loc.M)}</td>
                                           <td className="py-0.5 pr-2">⌀12 @ {Math.round(loc.column.spacing)}{loc.column.usedMin ? ' (min)' : ''}</td>
                                           <td className="py-0.5">{loc.middle.b > 1 ? `⌀12 @ ${Math.round(loc.middle.spacing)}${loc.middle.usedMin ? ' (min)' : ''}` : '—'}</td>
@@ -3532,7 +3532,7 @@ export default function ModelSpace() {
                   })}
                 </tbody>
               </table>
-              <p className="mt-1 text-[11px] text-slate-400">
+              <p className="mt-1 text-[11px] text-slate-500">
                 NSCP §408.10 Direct Design Method: Mo = wu·ℓ2·ℓn²/8 split into negative/positive then column/middle
                 strips (αf neglected → conservative slab steel). Column-strip width = 2·min(0.25ℓ1, 0.25ℓ2).
                 Deflection per §424.2 (Branson Ie + crossing-strip; λΔ = 2.0).
@@ -3565,7 +3565,7 @@ export default function ModelSpace() {
                     return [
                       <tr key={key} onClick={() => setExpanded(expanded === key ? null : key)}
                         className={`sched-row cursor-pointer border-t border-slate-100 hover:bg-blue-50/40 ${wl.ok ? '' : 'bg-rose-50 text-rose-700'}`}>
-                        <td className="py-1 pr-2 font-medium">{open ? '▾' : '▸'} {wl.id} <span className="text-slate-400">({wl.member})</span></td>
+                        <td className="py-1 pr-2 font-medium">{open ? '▾' : '▸'} {wl.id} <span className="text-slate-500">({wl.member})</span></td>
                         <td className="py-1 pr-2">{f1(wl.lw)} × {f1(wl.hw)}</td>
                         <td className="py-1 pr-2">{Math.round(wl.thickness)}</td>
                         <td className="py-1 pr-2">{wd.aspect.toFixed(2)}</td>
@@ -3599,7 +3599,7 @@ export default function ModelSpace() {
                   })}
                 </tbody>
               </table>
-              <p className="mt-1 text-[11px] text-slate-400">
+              <p className="mt-1 text-[11px] text-slate-500">
                 NSCP §418.10: Vn = Acv(αc·λ√f′c + ρt·fy), φ = 0.75, capped at 0.83·Acv·√f′c. In-plane shear from the
                 enveloped strut forces; distributed web steel ρt, ρℓ ≥ 0.0025. Flexural boundary reinforcement designed separately.
               </p>
@@ -3634,7 +3634,7 @@ export default function ModelSpace() {
                       <tr key={b.id}
                         className={`sched-row cursor-pointer border-t border-slate-100 hover:bg-blue-50 ${b.ok ? '' : 'bg-red-50 text-red-700'}`}
                         onClick={() => setExpanded(open ? null : key)}>
-                        <td className="py-1 pr-2 font-medium">{b.id} <span className="text-slate-400">{open ? '▲' : '▼'}</span></td>
+                        <td className="py-1 pr-2 font-medium">{b.id} <span className="text-slate-500">{open ? '▲' : '▼'}</span></td>
                         <td className="py-1 pr-2 font-mono">{b.shape}</td>
                         <td className="py-1 pr-2 text-right">{f1(b.Mu)}</td>
                         <td className="py-1 pr-2 text-right">{f1(b.phiMn)}</td>
@@ -3727,7 +3727,7 @@ export default function ModelSpace() {
                               </table>
                             </div>
                           </div>
-                          <p className="mt-2 text-[10px] text-slate-400">Lb = member brace spacing (set per-member in Geometry → Properties; blank = full length, conservative). Cb = 1.0. φ = 0.9 (flexure), 1.0 (shear, doubly-symmetric I). δ est. = 5Mu·L²/(48·E·Ix), SS bound vs L/240.</p>
+                          <p className="mt-2 text-[10px] text-slate-500">Lb = member brace spacing (set per-member in Geometry → Properties; blank = full length, conservative). Cb = 1.0. φ = 0.9 (flexure), 1.0 (shear, doubly-symmetric I). δ est. = 5Mu·L²/(48·E·Ix), SS bound vs L/240.</p>
                         </td>
                       </tr>
                     )
@@ -3735,7 +3735,7 @@ export default function ModelSpace() {
                   })}
                 </tbody>
               </table>
-              <p className="mt-1 text-[11px] text-slate-400">
+              <p className="mt-1 text-[11px] text-slate-500">
                 §F2 flexure (Lb = full member length, conservative; Cb = 1.0), §G2.1 shear, §L2 serviceability (δ est. = 5Mu·L²/48EI vs L/240). δ est. column shows estimated midspan deflection (mm) — red if &gt; L/240. Util = max(Mu/φMn, Vu/φVn, δ/lim). Click a row to expand.
               </p>
             </div>
@@ -3768,7 +3768,7 @@ export default function ModelSpace() {
                       <tr key={c.id}
                         className={`sched-row cursor-pointer border-t border-slate-100 hover:bg-blue-50 ${c.ok ? '' : 'bg-red-50 text-red-700'}`}
                         onClick={() => setExpanded(open ? null : key)}>
-                        <td className="py-1 pr-2 font-medium">{c.id} <span className="text-slate-400">{open ? '▲' : '▼'}</span></td>
+                        <td className="py-1 pr-2 font-medium">{c.id} <span className="text-slate-500">{open ? '▲' : '▼'}</span></td>
                         <td className="py-1 pr-2 font-mono">{c.shape}</td>
                         <td className="py-1 pr-2 text-right">{f1(c.Pu)}</td>
                         <td className="py-1 pr-2 text-right">{f1(c.phiPn)}</td>
@@ -3844,7 +3844,7 @@ export default function ModelSpace() {
                               </table>
                             </div>
                           </div>
-                          <p className="mt-2 text-[10px] text-slate-400">K = 1.0 (conservative). §E3: 4.71√(E/Fy) threshold. §H1-1a when Pu/φPn ≥ 0.2, else §H1-1b.</p>
+                          <p className="mt-2 text-[10px] text-slate-500">K = 1.0 (conservative). §E3: 4.71√(E/Fy) threshold. §H1-1a when Pu/φPn ≥ 0.2, else §H1-1b.</p>
                         </td>
                       </tr>
                     )
@@ -3852,7 +3852,7 @@ export default function ModelSpace() {
                   })}
                 </tbody>
               </table>
-              <p className="mt-1 text-[11px] text-slate-400">
+              <p className="mt-1 text-[11px] text-slate-500">
                 §E3 axial buckling (governing KL/r, K = 1.0), §H1-1 combined axial + flexure. Ratio ≤ 100% passes. Click a row to expand the worked solution.
               </p>
             </div>
@@ -3888,7 +3888,7 @@ export default function ModelSpace() {
                   ))}
                 </tbody>
               </table>
-              <p className="mt-1 text-[11px] text-slate-400">
+              <p className="mt-1 text-[11px] text-slate-500">
                 Bearing §J8: φc·0.85f′c·√(A2/A1), φc = 0.65. Plate thickness from cantilever bending
                 t = ℓ√(2fp/(0.9Fy)); ℓ = max(m, n, n′). Uplift sizes anchor rods (φt·0.75·Fu).
                 Adopted t rounded to plate stock.
@@ -3931,25 +3931,25 @@ export default function ModelSpace() {
                         className={`sched-row cursor-pointer border-t border-slate-100 hover:bg-blue-50/40 ${c.ok ? '' : 'bg-red-50 text-red-700'}`}>
                         <td className={`py-1 pr-2 align-top ${ci === 0 ? 'font-medium' : 'text-slate-300'}`}>
                           {open ? '▾' : '▸'} {j.nodeId}
-                          {ci === 0 && <div className="text-[10px] text-slate-400">{j.strongAxisDir.toUpperCase()}-axis</div>}
+                          {ci === 0 && <div className="text-[10px] text-slate-500">{j.strongAxisDir.toUpperCase()}-axis</div>}
                         </td>
                         <td className={`py-1 pr-2 font-mono align-top ${ci === 0 ? '' : 'text-slate-300'}`}>{j.columnShape}</td>
                         <td className="py-1 pr-2 font-medium">{c.beamId}</td>
                         <td className="py-1 pr-2 uppercase">{c.spanDir}</td>
                         <td className="py-1 pr-2 text-[11px]">
                           <span className={c.faceType === 'flange' ? 'font-semibold text-blue-700' : 'text-slate-600'}>col {c.faceType}</span>
-                          <span className="text-slate-400"> → beam {c.beamElement}</span>
+                          <span className="text-slate-500"> → beam {c.beamElement}</span>
                         </td>
                         <td className="py-1 pr-2 text-[11px]">
                           {c.connType === 'moment-flange-weld' ? 'Moment (CJP flange)'
                             : c.connType === 'moment-web-plate' ? 'Moment (web ext. plates)' : 'Shear tab'}
-                          <div className="text-[10px] text-slate-400">{c.pinned ? 'pin — releases Mz' : 'rigid'}</div>
+                          <div className="text-[10px] text-slate-500">{c.pinned ? 'pin — releases Mz' : 'rigid'}</div>
                         </td>
                         <td className="py-1 pr-2 text-right">{f1(c.Vu)}</td>
                         <td className="py-1 pr-2 text-right">{f1(c.Mu)}</td>
                         <td className="py-1 pr-2 text-[11px]">
-                          {c.bolts.n} × M{c.bolts.dia} A325 <span className="text-[10px] text-slate-400">(single shear)</span>
-                          <div className="text-[10px] text-slate-400">R={f1(c.bolts.Rmax)}/{f1(c.bolts.phiRnKn)} kN/bolt · e={Math.round(c.bolts.ecc)}mm</div>
+                          {c.bolts.n} × M{c.bolts.dia} A325 <span className="text-[10px] text-slate-500">(single shear)</span>
+                          <div className="text-[10px] text-slate-500">R={f1(c.bolts.Rmax)}/{f1(c.bolts.phiRnKn)} kN/bolt · e={Math.round(c.bolts.ecc)}mm</div>
                         </td>
                         <td className="py-1 pr-2 text-[11px]">{c.tab.t}×{Math.round(c.tab.hMm)} mm</td>
                         <td className="py-1 pr-2 text-[11px]">
@@ -3959,7 +3959,7 @@ export default function ModelSpace() {
                         <td className="py-1 text-[11px]">
                           <span className={c.ok ? 'text-green-700' : 'text-red-600'}>{c.ok ? '✓ OK' : '✗ NG'}</span>
                           {c.flange && (
-                            <div className="text-[10px] text-slate-400">Tf={f1(c.flange.Tf)} kN</div>
+                            <div className="text-[10px] text-slate-500">Tf={f1(c.flange.Tf)} kN</div>
                           )}
                         </td>
                       </tr>
@@ -3987,27 +3987,27 @@ export default function ModelSpace() {
                         className={`sched-row cursor-pointer border-t border-slate-100 hover:bg-blue-50/40 ${c.ok ? '' : 'bg-red-50 text-red-700'}`}>
                         <td className={`py-1 pr-2 align-top ${ci === 0 ? 'font-medium' : 'text-slate-300'}`}>
                           {open ? '▾' : '▸'} {bj.nodeId}
-                          {ci === 0 && <div className="text-[10px] text-slate-400">beam-to-beam</div>}
+                          {ci === 0 && <div className="text-[10px] text-slate-500">beam-to-beam</div>}
                         </td>
                         <td className={`py-1 pr-2 font-mono align-top ${ci === 0 ? '' : 'text-slate-300'}`}>
                           {bj.girderShape}
-                          {ci === 0 && <div className="text-[10px] text-slate-400">girder {bj.girderId}</div>}
+                          {ci === 0 && <div className="text-[10px] text-slate-500">girder {bj.girderId}</div>}
                         </td>
                         <td className="py-1 pr-2 font-medium">{c.beamId}</td>
                         <td className="py-1 pr-2 uppercase">{c.spanDir}</td>
                         <td className="py-1 pr-2 text-[11px]">
                           <span className="text-slate-600">girder web</span>
-                          <span className="text-slate-400"> → beam web{c.cope ? ` (coped ${c.cope.lengthMm}×${c.cope.depthMm})` : ''}</span>
+                          <span className="text-slate-500"> → beam web{c.cope ? ` (coped ${c.cope.lengthMm}×${c.cope.depthMm})` : ''}</span>
                         </td>
                         <td className="py-1 pr-2 text-[11px]">
                           Fin plate
-                          <div className="text-[10px] text-slate-400">pin — releases Mz</div>
+                          <div className="text-[10px] text-slate-500">pin — releases Mz</div>
                         </td>
                         <td className="py-1 pr-2 text-right">{f1(c.Vu)}</td>
                         <td className="py-1 pr-2 text-right">—</td>
                         <td className="py-1 pr-2 text-[11px]">
-                          {c.bolts.n} × M{c.bolts.dia} A325 <span className="text-[10px] text-slate-400">(single shear)</span>
-                          <div className="text-[10px] text-slate-400">R={f1(c.bolts.Rmax)}/{f1(c.bolts.phiRnKn)} kN/bolt · e={Math.round(c.bolts.ecc)}mm</div>
+                          {c.bolts.n} × M{c.bolts.dia} A325 <span className="text-[10px] text-slate-500">(single shear)</span>
+                          <div className="text-[10px] text-slate-500">R={f1(c.bolts.Rmax)}/{f1(c.bolts.phiRnKn)} kN/bolt · e={Math.round(c.bolts.ecc)}mm</div>
                         </td>
                         <td className="py-1 pr-2 text-[11px]">{c.tab.t}×{Math.round(c.tab.hMm)} mm</td>
                         <td className="py-1 pr-2 text-[11px]">{c.tab.weldSizeMm}mm E70</td>
@@ -4031,7 +4031,7 @@ export default function ModelSpace() {
                   )}
                 </tbody>
               </table>
-              <p className="mt-1 text-[11px] text-slate-400">
+              <p className="mt-1 text-[11px] text-slate-500">
                 Shear tab: A36 plate (Fy=248, Fu=400 MPa), M20 A325 bolts @ 75 mm pitch, 40 mm edge. Plate shear yielding φ=1.0 (§J4.2).
                 Moment connection: CJP groove weld at beam flanges, φFu·A_flange (§J2.6). Weld = E70XX fillet both sides of shear tab.
                 Beam-to-beam: fin plate welded to the girder web, supported-beam top flange coped to clear the girder flange (SCM Pt 9/10).
@@ -4065,7 +4065,7 @@ export default function ModelSpace() {
                       <td className="py-1 pr-2">B = {f2(f.design.B)} m</td>
                       <td className="py-1 pr-2">{Math.round(f.design.Dc)} mm</td>
                       <td className="py-1 pr-2">{f.design.bars}⌀{cs?.barDia} @ {Math.round(f.design.barSpacing)} e.w.</td>
-                      <td className="py-1 text-slate-400">{f.gov}</td>
+                      <td className="py-1 text-slate-500">{f.gov}</td>
                     </tr>,
                     open && model && (
                       <tr key={`${key}:sol`}>
@@ -4127,13 +4127,13 @@ export default function ModelSpace() {
                   })}
                 </tbody>
               </table>
-              <p className="mt-1 text-[11px] text-slate-400">
+              <p className="mt-1 text-[11px] text-slate-500">
                 Column loads split from D-only / L-only frame solves. Click a row for the full worked solution.
               </p>
             </div>
           )}
 
-          <p className="text-xs text-slate-400">
+          <p className="text-xs text-slate-500">
             Pipeline: slab area loads → tributary line loads → 3D frame FEM (governing NSCP combo) → beam/girder
             critical sections (SRRB/DRRB) → column P–M → base reactions → isolated footings. Open any standalone
             page for the full worked solution of a given element.
@@ -4225,7 +4225,7 @@ export default function ModelSpace() {
                   </tr>
                 </tbody>
               </table>
-              <p className="mt-1 text-[11px] text-slate-400">
+              <p className="mt-1 text-[11px] text-slate-500">
                 Edit the unit prices to your local rates (PHP). Steel priced on the purchased (6 m-bar) weight incl. lap/waste;
                 concrete via cement/sand/gravel. Labour, hauling and contingencies not included.
               </p>
@@ -4288,7 +4288,7 @@ export default function ModelSpace() {
                   </tr>
                 </tbody>
               </table>
-              <p className="mt-1 text-[11px] text-slate-400">
+              <p className="mt-1 text-[11px] text-slate-500">
                 Continuous bars spliced (usable 6 − 0.30 m lap); stirrups/ties nested (cuts per 6 m). Fabricated net
                 {' '}{f1(takeoff.totalSteelNetKg)} kg → bought {f1(takeoff.totalSteelPurchasedKg)} kg.
                 Class {concreteClass}: {takeoff.concrete.factor} cement bags/m³ · sand 0.5, gravel 1.0 m³/m³ (NSCP mix).
@@ -4326,7 +4326,7 @@ export default function ModelSpace() {
                   </tr>
                 </tbody>
               </table>
-              <p className="mt-1 text-[11px] text-slate-400">Net mass: ρ = 7 850 kg/m³ · A (mm²) × L (m). Connections, base plates and field splices not included.</p>
+              <p className="mt-1 text-[11px] text-slate-500">Net mass: ρ = 7 850 kg/m³ · A (mm²) × L (m). Connections, base plates and field splices not included.</p>
             </div>
           )}
 
@@ -4398,7 +4398,7 @@ export default function ModelSpace() {
                 ))}
               </tbody>
             </table>
-            <p className="mt-1 text-[11px] text-slate-400">
+            <p className="mt-1 text-[11px] text-slate-500">
               Cut lengths include a 40·d_b lap/anchorage allowance on straight bars and a 2·max(6·d_t, 75 mm) hook
               allowance on stirrups/ties. {takeoff.slabSteelDDM ? 'Slab steel follows the DDM column/middle-strip layout: +M bottom bars span-long, −M top bars cut off 0.3·ℓn over supports.' : ''}
             </p>

--- a/webapp/src/pages/PileCapDesign.tsx
+++ b/webapp/src/pages/PileCapDesign.tsx
@@ -55,7 +55,7 @@ function NumField({ label, unit, value, onChange, step = 'any' }: {
   return (
     <label className="flex flex-col text-sm">
       <span className="mb-1 font-medium text-slate-600">
-        {label}{unit ? <span className="text-slate-400"> ({unit})</span> : null}
+        {label}{unit ? <span className="text-slate-500"> ({unit})</span> : null}
       </span>
       <input
         type="number" inputMode="decimal" step={step} value={Number.isFinite(value) ? value : ''}
@@ -228,7 +228,7 @@ export default function PileCapDesign() {
                 reactions={result.reactions}
               />
             ) : (
-              <p className="py-8 text-center text-sm text-slate-400">Enter valid inputs to preview.</p>
+              <p className="py-8 text-center text-sm text-slate-500">Enter valid inputs to preview.</p>
             )}
           </div>
 
@@ -306,7 +306,7 @@ export default function PileCapDesign() {
               <div className="rounded-xl border border-slate-200 bg-white p-4 text-sm text-slate-600 shadow-sm">
                 <h2 className="mb-1 text-[1.02rem] font-bold text-[#0056b3]">Basis</h2>
                 <KTex block tex={String.raw`R_i = \frac{P}{N} + \frac{M_x \cdot y_i}{\sum y_i^2} + \frac{M_y \cdot x_i}{\sum x_i^2}`} />
-                <p className="mt-1 text-xs text-slate-400">
+                <p className="mt-1 text-xs text-slate-500">
                   NSCP 2015 / ACI 318-14. φ_v = 0.75, φ_f = 0.90.
                   Column punching at d/2 from column face; pile punching at d/2 from pile perimeter (§13.4.6).
                   One-way shear critical section at d from column face.

--- a/webapp/src/pages/RockAnchor.tsx
+++ b/webapp/src/pages/RockAnchor.tsx
@@ -38,7 +38,7 @@ export default function RockAnchor() {
 
   return (
     <main className="mx-auto max-w-3xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">Geotechnical</p>
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Rock / ground anchor</h1>
       <p className="mt-2 text-sm text-slate-600">
         PTI DC35.1 / FHWA-IF-99-015 check: prestressing-tendon design load (0.60·GUTS) and grout-ground
@@ -66,7 +66,7 @@ export default function RockAnchor() {
         <Out label="FS (allowable / demand)" value={f2(r.fs)} ok={r.ok} />
         <Out label="Proof/test load" value={`${f0(r.testLoad)} kN`} />
         <Out label="Bond length for FS = 2" value={`${f2(r.bondLengthReq)} m`} ok={bondLength >= r.bondLengthReq} />
-        <p className="mt-2 text-[10px] text-slate-400">
+        <p className="mt-2 text-[10px] text-slate-500">
           Td = 0.60·GUTS (PTI permanent max). Bond Qult = π·Dhole·Lbond·τult / FS. Proof load
           min(1.33·T, 0.80·GUTS). Provide the unbonded (free) length and corrosion protection separately.
         </p>

--- a/webapp/src/pages/SeismicWizard.tsx
+++ b/webapp/src/pages/SeismicWizard.tsx
@@ -16,7 +16,7 @@ function Choice<T extends string | number>({ value, set, options }: {
           className={`rounded-lg border px-3 py-2 text-left text-sm transition ${value === o.v
             ? 'border-[#0056b3] bg-blue-50 font-semibold text-[#0056b3]'
             : 'border-slate-200 bg-white text-slate-700 hover:border-slate-300'}`}>
-          {o.label}{o.sub ? <span className="block text-[11px] font-normal text-slate-400">{o.sub}</span> : null}
+          {o.label}{o.sub ? <span className="block text-[11px] font-normal text-slate-500">{o.sub}</span> : null}
         </button>
       ))}
     </div>
@@ -56,7 +56,7 @@ export default function SeismicWizard() {
 
   return (
     <main className="mx-auto max-w-3xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">Structural</p>
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Structural</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">NSCP 208 Seismic Wizard</h1>
       <p className="mt-2 text-sm text-slate-600">
         Walk through the NSCP 2015 §208 static lateral-force tables — zone, soil, near-source, occupancy and
@@ -110,7 +110,7 @@ export default function SeismicWizard() {
                 onChange={(e) => setDistance(parseFloat(e.target.value) || 0)}
                 className="w-40 rounded-md border border-slate-300 px-2.5 py-1.5" />
             </label>
-            <p className="mt-2 text-[11px] text-slate-400">Na = {f3(params.Na)}, Nv = {f3(params.Nv)}</p>
+            <p className="mt-2 text-[11px] text-slate-500">Na = {f3(params.Na)}, Nv = {f3(params.Nv)}</p>
           </>
         )}
         {cur.key === 'occupancy' && (
@@ -174,7 +174,7 @@ export default function SeismicWizard() {
             floor 0.11Ca·I {f3(cs.Csmin)}{params.Z >= 0.4 ? ` · Zone-4 0.8Z·Nv·I/R ${f3(cs.Cszone4)}` : ''}
           </p>
         </div>
-        <p className="mt-2 text-[10px] text-slate-400">
+        <p className="mt-2 text-[10px] text-slate-500">
           V = Cs·W (§208.5.2.1). Feed Ca, Cv, I, R into the 3D model space seismic generator for the
           full storey-force distribution. Verify the soil profile with a geotechnical investigation.
         </p>

--- a/webapp/src/pages/ShotcreteFacing.tsx
+++ b/webapp/src/pages/ShotcreteFacing.tsx
@@ -43,7 +43,7 @@ export default function ShotcreteFacing() {
 
   return (
     <main className="mx-auto max-w-3xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">Geotechnical</p>
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Soil-nail shotcrete facing</h1>
       <p className="mt-2 text-sm text-slate-600">
         FHWA GEC-7 facing check. The thin shotcrete panel spans <b>between</b> the nail heads, so earth
@@ -79,7 +79,7 @@ export default function ShotcreteFacing() {
         <Out label="Punching R_FP" value={`${f0(r.Rfp)} kN`} />
         <Out label={`Governing facing strength (${r.governs})`} value={`${f0(r.strength)} kN`} ok={r.ok} />
         <Out label="FS (strength / nail-head force)" value={f2(r.fs)} ok={r.ok} />
-        <p className="mt-2 text-[10px] text-slate-400">
+        <p className="mt-2 text-[10px] text-slate-500">
           R_FF = C_F·(m_neg + m_pos)·8·S_perp/S_span (fixed-strip mechanism). R_FP = φ·0.33·√f′c·bo·d
           around the bearing plate. C_F ≈ 2.0 thin → 1.0 thick facing (FHWA GEC-7 Table). Headed-stud
           tension (permanent facing) and temporary-vs-final facing stages are checked separately.

--- a/webapp/src/pages/SlabDesign.tsx
+++ b/webapp/src/pages/SlabDesign.tsx
@@ -69,7 +69,7 @@ function DirCard({ title, dir, barDia }: { title: string; dir: SlabDirResult; ba
                       <div className="font-semibold text-slate-800">{steelText(loc.middle, barDia)}</div>
                       <div className="text-slate-500">{steelSub(loc.middle)}</div>
                     </>
-                  ) : <span className="text-slate-400">—</span>}
+                  ) : <span className="text-slate-500">—</span>}
                 </td>
               </tr>
             ))}
@@ -205,7 +205,7 @@ export default function SlabDesign() {
               )}
             </>
           ) : (
-            <p className="py-8 text-center text-sm text-slate-400">Enter valid panel inputs to see results.</p>
+            <p className="py-8 text-center text-sm text-slate-500">Enter valid panel inputs to see results.</p>
           )}
         </div>
       </div>

--- a/webapp/src/pages/SoilNail.tsx
+++ b/webapp/src/pages/SoilNail.tsx
@@ -45,7 +45,7 @@ export default function SoilNail() {
 
   return (
     <main className="mx-auto max-w-3xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">Geotechnical</p>
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Soil-nail wall — per-nail check</h1>
       <p className="mt-2 text-sm text-slate-600">
         Preliminary FHWA GEC-7 checks for a single nail: tributary active demand vs bar-tensile and
@@ -82,7 +82,7 @@ export default function SoilNail() {
         <Out label="Pullout Qult = π·DDH·Le·qu" value={`${f2(r.Qult)} kN`} />
         <Out label="FS pullout (Qult / Tmax ≥ 2.0)" value={f2(r.fsPullout)} ok={r.pulloutOK} />
         <Out label="Bond length for FS = 2.0" value={`${f2(r.bondLengthReq)} m`} ok={bondLength >= r.bondLengthReq} />
-        <p className="mt-2 text-[10px] text-slate-400">
+        <p className="mt-2 text-[10px] text-slate-500">
           FHWA GEC-7. Tmax is the tributary active load on one nail at depth z. Allowable bar load Tn/1.8,
           allowable pullout Qult/2.0. Provide Le ≥ the required bond length beyond the slip surface.
           This is a preliminary component check — verify global stability separately.

--- a/webapp/src/pages/StairDesign.tsx
+++ b/webapp/src/pages/StairDesign.tsx
@@ -43,7 +43,7 @@ export default function StairDesign() {
 
   return (
     <main className="mx-auto max-w-3xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">Structural</p>
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Structural</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">RC stair flight — waist slab</h1>
       <p className="mt-2 text-sm text-slate-600">
         One-way waist-slab stair to NSCP 2015 / ACI 318-14. Self-weight of the inclined waist plus
@@ -89,7 +89,7 @@ export default function StairDesign() {
         <Out label="Main bars" value={`⌀${barDia} @ ${f0(r.mainSpacing)} mm`} />
         <Out label="Distribution steel" value={`${f0(r.AsDist)} mm²/m — ⌀10 @ ${f0(r.distSpacing)} mm`} />
         <Out label="Min. waist (ℓ/20…ℓ/28)" value={`${f0(r.tMin)} mm`} ok={r.tMinOK} />
-        <p className="mt-2 text-[10px] text-slate-400">
+        <p className="mt-2 text-[10px] text-slate-500">
           Mu = wu·ℓ²/k (k = 8/9/11 by support). Distribution steel 0.0018·b·t (§424.4.3.2); spacing capped
           at min(3t, 450). Verify the landing and support detailing separately.
         </p>

--- a/webapp/src/pages/SteelDesign.tsx
+++ b/webapp/src/pages/SteelDesign.tsx
@@ -471,7 +471,7 @@ function ConnectionTab() {
             <Num label="In-plane e_x" unit="mm" value={ex_load} onChange={setExLoad} />
             <Num label="In-plane e_y" unit="mm" value={ey_load} onChange={setEyLoad} />
             <Num label="Out-of-plane e_out" unit="mm" value={e_out} onChange={setEOut} />
-            <p className="col-span-full text-[10px] text-slate-400">
+            <p className="col-span-full text-[10px] text-slate-500">
               e_x/e_y: in-plane offset (§J3.6 elastic method).
               e_out: perpendicular to plate → bolt tension + §J3.7 interaction.
             </p>
@@ -479,7 +479,7 @@ function ConnectionTab() {
           {e_out > 0 && (
             <Card title="Prying action §J3.9">
               <Num label="Gage b (bolt CL → web face)" unit="mm" value={b_gage} onChange={setBGage} />
-              <p className="col-span-full text-[10px] text-slate-400">
+              <p className="col-span-full text-[10px] text-slate-500">
                 b = distance from bolt centreline to face of the connecting web or stem.
                 Set 0 to skip prying check. Edge dist a = ex, pitch p = sv, plate tf/Fy reused from above.
               </p>
@@ -541,7 +541,7 @@ function ConnectionTab() {
           <ResultCard title="Per-bolt forces">
             <div className="overflow-x-auto">
               <table className="w-full text-xs">
-                <thead><tr className="text-left text-slate-400">
+                <thead><tr className="text-left text-slate-500">
                   <th className="pr-2 pb-1">id</th><th className="pr-2 pb-1">Vx kN</th><th className="pr-2 pb-1">Vy kN</th>
                   <th className="pr-2 pb-1">R kN</th><th className="pb-1">fbr MPa</th>
                 </tr></thead>
@@ -585,7 +585,7 @@ function ConnectionTab() {
                 value={ok(res.outOfPlane.ok, res.outOfPlane.ok ? 'PASS' : 'FAIL')} />
               <div className="col-span-full overflow-x-auto">
                 <table className="mt-1 w-full text-xs">
-                  <thead><tr className="text-left text-slate-400">
+                  <thead><tr className="text-left text-slate-500">
                     <th className="pr-2 pb-1">id</th><th className="pr-2 pb-1">yi mm</th>
                     <th className="pr-2 pb-1">T kN</th><th className="pr-2 pb-1">frv MPa</th><th className="pb-1">util</th>
                   </tr></thead>

--- a/webapp/src/pages/TrussSpace.tsx
+++ b/webapp/src/pages/TrussSpace.tsx
@@ -208,10 +208,10 @@ export default function TrussSpace() {
                   {f1(Math.abs(selForce.N))} kN {selForce.N >= 0 ? 'tension' : 'compression'}
                 </span>
                 {selDes && <span className="text-slate-500">util {(selDes.util * 100).toFixed(0)}%</span>}
-                <button type="button" onClick={() => setSelected(null)} className="ml-0.5 text-slate-400 hover:text-red-500">✕</button>
+                <button type="button" onClick={() => setSelected(null)} className="ml-0.5 text-slate-500 hover:text-red-500">✕</button>
               </div>
             )}
-            <div className="no-print pointer-events-none absolute bottom-2 left-3 text-[10px] text-slate-400">
+            <div className="no-print pointer-events-none absolute bottom-2 left-3 text-[10px] text-slate-500">
               drag to orbit · scroll to zoom · hold <b>Shift</b> (or right-drag) to pan · <span className="text-blue-700">tension</span> / <span className="text-red-600">compression</span>
             </div>
           </div>
@@ -242,7 +242,7 @@ export default function TrussSpace() {
               <input type="checkbox" checked={includeSW} onChange={(e) => setIncludeSW(e.target.checked)} />
               <span>Add member self-weight (from the section) to Dead</span>
             </label>
-            <p className="col-span-full text-[11px] text-slate-400">
+            <p className="col-span-full text-[11px] text-slate-500">
               Members are enveloped over <b>1.4D</b> and <b>1.2D + 1.6L</b>; each is designed for its governing combination.
             </p>
           </Card>
@@ -334,7 +334,7 @@ export default function TrussSpace() {
                   return (
                     <tr key={f.id} onClick={() => setSelected(f.id)}
                       className={`cursor-pointer border-t border-slate-100 hover:bg-blue-50/40 ${bad ? 'bg-red-50 text-red-700' : ''} ${selected === f.id ? 'bg-amber-50' : ''}`}>
-                      <td className="py-1 pr-2 font-medium">{f.id} <span className="text-slate-400">({f.i}–{f.j})</span></td>
+                      <td className="py-1 pr-2 font-medium">{f.id} <span className="text-slate-500">({f.i}–{f.j})</span></td>
                       <td className="py-1 pr-2">{f.kind}</td>
                       <td className="py-1 pr-2 text-right">{f2(f.L)}</td>
                       <td className="py-1 pr-2 text-right">{f1(Math.abs(f.N))}</td>
@@ -348,7 +348,7 @@ export default function TrussSpace() {
                 })}
               </tbody>
             </table>
-            <p className="mt-1 text-[11px] text-slate-400">
+            <p className="mt-1 text-[11px] text-slate-500">
               Pin-jointed planar truss (axial only). Tension yielding φPn = 0.9·Fy·Ag; compression flexural buckling per AISC §E3
               (Fcr from KL/r, φ = 0.90). KL/r &gt; 200 flagged (⚠). Reactions: pin at the left support, roller at the right.
             </p>
@@ -495,7 +495,7 @@ export default function TrussSpace() {
                     </tr>
                   </tbody>
                 </table>
-                <p className="mt-1 text-[11px] text-slate-400">
+                <p className="mt-1 text-[11px] text-slate-500">
                   Section steel weight = A × L × 7850 kg/m³ per member.
                   Gusset / connection plate allowance added as a fraction of the section steel.
                   Prices in Philippine Peso (₱); edit to match current market rates.

--- a/webapp/src/pages/Validation.tsx
+++ b/webapp/src/pages/Validation.tsx
@@ -16,7 +16,7 @@ function Row({ c }: { c: ValidationCase }) {
     <tr className="border-t border-slate-100 align-top">
       <td className="py-2 pr-3">
         <p className="font-medium text-slate-800">{c.title}</p>
-        <p className="text-[11px] text-slate-400">{c.reference}</p>
+        <p className="text-[11px] text-slate-500">{c.reference}</p>
       </td>
       <td className="py-2 pr-3 font-mono text-[11px] text-slate-600">{c.formula}</td>
       <td className="py-2 pr-3 text-right font-mono">{fmt(c.manual)}</td>
@@ -41,7 +41,7 @@ export default function Validation() {
 
   return (
     <main className="mx-auto max-w-5xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">Reference</p>
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Reference</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Validation</h1>
       <p className="mt-2 max-w-3xl text-sm text-slate-600">
         Each calculation engine is checked against an independent closed-form hand calculation from a
@@ -62,7 +62,7 @@ export default function Validation() {
             </span>
           ))}
         </div>
-        <p className="mt-2 text-[11px] text-slate-400">
+        <p className="mt-2 text-[11px] text-slate-500">
           A benchmark passes when the engine result is within tolerance of the hand calculation
           (typically &lt; 0.01 %). Counts are evaluated live from the same engines the design pages use.
         </p>
@@ -77,7 +77,7 @@ export default function Validation() {
             <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
               <table className="w-full border-collapse text-xs">
                 <thead>
-                  <tr className="text-left uppercase tracking-wide text-slate-400">
+                  <tr className="text-left uppercase tracking-wide text-slate-500">
                     <th className="py-1 pr-3 font-semibold">Benchmark</th>
                     <th className="py-1 pr-3 font-semibold">Formula</th>
                     <th className="py-1 pr-3 text-right font-semibold">Manual</th>
@@ -94,7 +94,7 @@ export default function Validation() {
         )
       })}
 
-      <p className="mt-8 text-[11px] text-slate-400">
+      <p className="mt-8 text-[11px] text-slate-500">
         Codes: NSCP 2015 · ACI 318-14 · AISC 360. See the{' '}
         <Link to="/docs" className="text-[#0056b3] underline">documentation</Link> for the full toolkit guide.
       </p>

--- a/webapp/src/pages/WaterTank.tsx
+++ b/webapp/src/pages/WaterTank.tsx
@@ -41,7 +41,7 @@ export default function WaterTank() {
 
   return (
     <main className="mx-auto max-w-3xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">Structural</p>
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Structural</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Circular RC water tank — wall</h1>
       <p className="mt-2 text-sm text-slate-600">
         Permissible-stress (working-stress) wall design for a circular liquid-retaining tank, following the
@@ -75,7 +75,7 @@ export default function WaterTank() {
         <Out label="Vertical steel As" value={`${f0(r.vertAs)} mm²/m — ⌀${barDia} @ ${f0(r.vertSpacing)} mm`} />
         <Out label={`Concrete tension fct (≤ ${f2(sigmaCt)})`} value={`${f2(r.fct)} MPa`} ok={r.thicknessOK} />
         <Out label="Freeboard ≥ 300 mm" value={`${f2(freeboard)} m`} ok={r.freeboardOK} />
-        <p className="mt-2 text-[10px] text-slate-400">
+        <p className="mt-2 text-[10px] text-slate-500">
           Provide ring steel on both faces near the base where hoop tension peaks; reduce up the wall as
           T = γw·z·D/2 falls. σst ≈ 115–150 MPa controls crack width (IS 3370 / ACI 350). Base slab, roof,
           and the wall-base joint (fixed vs hinged) are designed separately.

--- a/webapp/src/pages/WeldedConnection.tsx
+++ b/webapp/src/pages/WeldedConnection.tsx
@@ -59,7 +59,7 @@ export default function WeldedConnection() {
 
   return (
     <main className="mx-auto max-w-5xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400">Structural · Steel</p>
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Structural · Steel</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Eccentric weld group</h1>
       <p className="mt-2 max-w-3xl text-sm text-slate-600">
         Elastic (weld-as-a-line) method for an eccentrically-loaded fillet weld group. Each unit length
@@ -85,7 +85,7 @@ export default function WeldedConnection() {
                       <td key={k} className="pr-2"><input type="number" value={s[k]} onChange={(e) => setSeg(i, k, num(e.target.value))} className="w-14 rounded border border-slate-200 px-1 py-0.5" /></td>
                     ))}
                     <td className="pr-2 text-right font-mono">{f2(Math.hypot(s.x2 - s.x1, s.y2 - s.y1))}</td>
-                    <td className="text-right"><button type="button" onClick={() => delSeg(i)} className="text-slate-400 hover:text-red-600">✕</button></td>
+                    <td className="text-right"><button type="button" onClick={() => delSeg(i)} className="text-slate-500 hover:text-red-600">✕</button></td>
                   </tr>
                 ))}
               </tbody>


### PR DESCRIPTION
## Scope
Class-only sweep across 35 pages/components. Closes #325 P2 item **4**.

## What
`text-slate-400` helper text (unit hints, sub-labels — ~183 occurrences) sat at **~2.7–2.9:1** against white/slate-50, failing WCAG AA (4.5:1) for exactly the microtext that carries units in an engineering tool. All light-surface instances are now `text-slate-500` (**4.76:1** on white — AA pass).

Three deliberate exceptions stay slate-400 because they sit on dark backgrounds where it reads correctly: the navbar “soon” chip (black), the Home standards strip (black), the Steel 3D spinner (slate-900).

## Verification
Live DOM audit on /beam-design: 36 elements at slate-500, the sole remaining slate-400 is the navbar chip on black. `npm test` 1028/1028 · `npx tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)