### PR TITLE
feat: Method-B period (§208.5.2.2) + RSA-derived E cases feeding design/optimize (§208.6.4)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -68,6 +68,13 @@ of the app. Everything runs **off the main thread** in a web worker
   skeleton in the 3D canvas (amplitude slider), via imperative R3F `useFrame`.
 - **Response-spectrum analysis** (`engine/responseSpectrum.ts`) + **storey-drift
   check** (`engine/seismic.ts`, NSCP 208) + **wind loads** (`engine/wind.ts`).
+- **Method-B period + RSA-driven design**: `computeSeismic` accepts a modal
+  fundamental period `Tb` (capped at 1.3·Ta Zone 4 / 1.4·Ta, §208.5.2.2) and
+  `rsaEquivalentLoads` back-differences the CQC storey-shear diagram into
+  equivalent static cat-E node loads scaled to the §208.6.4.2 floor
+  (0.9·V_B & 0.8·V_A regular / 1.0·V_B irregular) — both feed the same
+  `LateralCase` envelope that Design/Optimize consume ("Generate E cases — RSA"
+  in the Loading tab; needs a Modal run first).
 - **Member force diagrams BMD/SFD** (PR #233): inline bending-moment and shear
   diagrams rendered on each member in the 3D view and Analysis tab. Uses the
   existing `xs[]`/`My[]`/`Mz[]`/`Vy[]` arrays on `F3MemberResult`.

--- a/webapp/src/engine/responseSpectrum.test.ts
+++ b/webapp/src/engine/responseSpectrum.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { nscp208Spectrum, cqcCorrel, computeResponseSpectrum } from './responseSpectrum'
+import { nscp208Spectrum, cqcCorrel, computeResponseSpectrum, rsaEquivalentLoads } from './responseSpectrum'
 import { modalAnalysis, GRAVITY } from './modal'
 import { generateGridModel } from './modelBuilder'
 import type { RectSection } from './model'
@@ -116,5 +116,76 @@ describe('computeResponseSpectrum', () => {
     const rsa = computeResponseSpectrum(emptyModal, p)
     expect(rsa.srss).toEqual([0, 0, 0])
     expect(rsa.cqc).toEqual([0, 0, 0])
+  })
+})
+
+// ── RSA → equivalent lateral loads (§208.6.4) ────────────────────────────────
+describe('rsaEquivalentLoads', () => {
+  const model = generateGridModel({ baysX: [6, 6], baysZ: [5], storeyH: [3.5, 3], section })
+  const modal = modalAnalysis(model, 12)!
+  const p = { Ca, Cv, I, R }
+  const rel = (a: number, b: number) => Math.abs(a - b) / Math.max(Math.abs(b), 1e-12)
+
+  it('combined base shear reproduces computeResponseSpectrum (CQC and SRSS, X and Z)', () => {
+    const rsa = computeResponseSpectrum(modal, p)
+    const cqcX = rsaEquivalentLoads(model, modal, { ...p, dir: 'x' })!
+    const cqcZ = rsaEquivalentLoads(model, modal, { ...p, dir: 'z' })!
+    const srsX = rsaEquivalentLoads(model, modal, { ...p, dir: 'x', combine: 'srss' })!
+    expect(rel(cqcX.Vdyn, rsa.cqc[0])).toBeLessThan(1e-9)
+    expect(rel(cqcZ.Vdyn, rsa.cqc[2])).toBeLessThan(1e-9)
+    expect(rel(srsX.Vdyn, rsa.srss[0])).toBeLessThan(1e-9)
+  })
+
+  it('single mode: base shear = Sa·effMass (hand calc)', () => {
+    const modal1 = { modes: [modal.modes[0]], totalMass: modal.totalMass, cumRatio: modal.cumRatio }
+    const eq = rsaEquivalentLoads(model, modal1, { ...p, dir: 'x' })!
+    const expected = modal.modes[0].effMass[0] * nscp208Spectrum(modal.modes[0].period, Ca, Cv, I, R)
+    expect(rel(eq.Vdyn, expected)).toBeLessThan(1e-9)
+  })
+
+  it('storey forces back-difference the combined shear diagram (ΣF = V_base)', () => {
+    const eq = rsaEquivalentLoads(model, modal, { ...p, dir: 'x' })!
+    expect(eq.storeys.map((s) => s.elevation)).toEqual([3.5, 6.5])
+    const sumF = eq.storeys.reduce((s, r) => s + r.F, 0)
+    expect(rel(sumF, eq.storeys[0].V)).toBeLessThan(1e-9)
+    expect(rel(eq.storeys[0].V, eq.Vdyn * eq.scale)).toBeLessThan(1e-9)
+    // shear at the roof = roof force alone
+    expect(rel(eq.storeys[1].V, eq.storeys[1].F)).toBeLessThan(1e-9)
+    for (const s of eq.storeys) expect(s.V).toBeGreaterThan(0)
+  })
+
+  it('§208.6.4.2 scaling: forces scale up to the floor, never down', () => {
+    const base = rsaEquivalentLoads(model, modal, { ...p, dir: 'x' })!
+    const up = rsaEquivalentLoads(model, modal, { ...p, dir: 'x', Vfloor: 2 * base.Vdyn })!
+    expect(up.scale).toBeCloseTo(2, 9)
+    expect(rel(up.storeys[0].V, 2 * base.storeys[0].V)).toBeLessThan(1e-9)
+    const down = rsaEquivalentLoads(model, modal, { ...p, dir: 'x', Vfloor: 0.5 * base.Vdyn })!
+    expect(down.scale).toBe(1)
+    expect(rel(down.storeys[0].V, base.storeys[0].V)).toBeLessThan(1e-9)
+  })
+
+  it('node loads: cat E, correct component, per-level sums match storey forces', () => {
+    const eq = rsaEquivalentLoads(model, modal, { ...p, dir: 'x', Vfloor: 800 })!
+    expect(eq.loads.every((l) => l.kind === 'node' && l.cat === 'E')).toBe(true)
+    for (const s of eq.storeys) {
+      const lvlLoads = eq.loads.filter((l) =>
+        l.kind === 'node' && Math.abs(model.nodes.find((n) => n.id === l.node)!.y - s.elevation) < 1e-6)
+      const sum = lvlLoads.reduce((t, l) => t + ((l as { Fx?: number }).Fx ?? 0), 0)
+      expect(rel(sum, s.F)).toBeLessThan(1e-9)
+      for (const l of lvlLoads) expect((l as { Fz?: number }).Fz).toBeUndefined()
+    }
+    const eqZ = rsaEquivalentLoads(model, modal, { ...p, dir: 'z' })!
+    expect(eqZ.loads.every((l) => (l as { Fx?: number }).Fx === undefined)).toBe(true)
+  })
+
+  it('reports directional mass participation (§208.6.4.1 ≥ 90% check)', () => {
+    const eq = rsaEquivalentLoads(model, modal, { ...p, dir: 'x' })!
+    expect(eq.massRatio).toBeGreaterThan(0.9)     // 12 modes on a small grid
+    expect(eq.massRatio).toBeLessThanOrEqual(1 + 1e-6)
+  })
+
+  it('null for empty modes', () => {
+    const emptyModal = { modes: [], totalMass: [0, 0, 0] as [number,number,number], cumRatio: [0,0,0] as [number,number,number] }
+    expect(rsaEquivalentLoads(model, emptyModal, { ...p, dir: 'x' })).toBeNull()
   })
 })

--- a/webapp/src/engine/responseSpectrum.ts
+++ b/webapp/src/engine/responseSpectrum.ts
@@ -23,7 +23,8 @@
 // Units: T (s), Ca/Cv/Sa (g-fraction or m/s²), mass (t), V (kN).
 // ─────────────────────────────────────────────────────────────────────────
 import type { ModalResult } from './modal'
-import { GRAVITY } from './modal'
+import { GRAVITY, buildSeismicMass } from './modal'
+import type { StructuralModel, ModelLoad } from './model'
 
 export interface SpectrumParams {
   Ca: number; Cv: number
@@ -127,4 +128,130 @@ export function computeResponseSpectrum(
   }) as [number | null, number | null, number | null]
 
   return { params: { ...p, Ts }, modalForces, srss, cqc, cqcRatio }
+}
+
+// ── RSA → equivalent lateral loads (§208.6.4) ───────────────────────────────
+// Turns the combined response-spectrum storey shears into a static storey-force
+// pattern the design pipeline can envelope like any other lateral case:
+//   per mode m:  f_{m,k} = Γ_m · Sa(T_m) · Σ_{n ∈ level k} m_n·φ_{n,dir}
+//   modal storey shear  V_{m,k} = Σ_{j ≥ k} f_{m,j}
+//   combined shear      V_k = SRSS/CQC over modes (per level)
+//   storey force        F_k = V_k − V_{k+1}   (ETABS-style back-difference, so
+//                        the combined shear diagram — the design quantity — is
+//                        reproduced exactly by a single static pattern)
+// §208.6.4.2 scaling: the caller supplies the minimum design base shear
+// (0.9·V_B / 0.8·V_A floors for regular structures, 1.0·V for irregular) and
+// every force is scaled by max(1, Vfloor/V_base).
+// Units: mass t, Sa m/s², forces kN, elevations m.
+
+export interface RsaStoreyRow {
+  elevation: number
+  /** Combined (and scaled) storey shear at this level, kN. */
+  V: number
+  /** Equivalent static storey force at this level, kN (scaled). */
+  F: number
+}
+
+export interface RsaLateralParams {
+  Ca: number; Cv: number; I: number; R: number
+  dir: 'x' | 'z'
+  /** Viscous damping ratio for CQC (default 0.05). */
+  zeta?: number
+  /** Modal combination rule (default 'cqc'). */
+  combine?: 'srss' | 'cqc'
+  /** §208.6.4.2 minimum design base shear, kN; forces are scaled up so the
+   *  combined base shear is at least this. Omit → no scaling. */
+  Vfloor?: number
+}
+
+export interface RsaLateralResult {
+  dir: 'x' | 'z'
+  /** Levels bottom-up with combined shear and equivalent force (scaled). */
+  storeys: RsaStoreyRow[]
+  /** Combined base shear BEFORE scaling, kN. */
+  Vdyn: number
+  /** Scaling floor supplied (0 when none). */
+  Vfloor: number
+  /** Applied scale factor = max(1, Vfloor/Vdyn). */
+  scale: number
+  /** Σ effective-mass ratio captured in `dir` (§208.6.4.1 requires ≥ 0.90). */
+  massRatio: number
+  /** Scaled node loads (cat 'E'), mass-proportional within each level. */
+  loads: ModelLoad[]
+}
+
+/**
+ * Equivalent static lateral loads from a response-spectrum analysis, per
+ * NSCP 2015 §208.6.4. Returns null when the model has no storeys, no modes or
+ * a zero combined base shear in the requested direction.
+ */
+export function rsaEquivalentLoads(
+  model: StructuralModel, modal: ModalResult, p: RsaLateralParams,
+): RsaLateralResult | null {
+  const dirIdx = p.dir === 'x' ? 0 : 2
+  const zeta = p.zeta ?? 0.05
+  const levels = [...new Set(model.storeys.map((s) => s.elevation))].sort((a, b) => a - b)
+  if (levels.length === 0 || modal.modes.length === 0) return null
+  const mass = buildSeismicMass(model)
+  const nodesAt = (e: number) => model.nodes.filter((n) => Math.abs(n.y - e) < 1e-6)
+
+  // per-mode storey forces: Γ·Sa is normalization-invariant (Γ = L/M* rescales
+  // with the shape), so the max|φ|=1 normalized shapes are safe to use here.
+  const modes = modal.modes.map((m) => {
+    let Mstar = 0, L = 0
+    for (const [id, phi] of Object.entries(m.shape)) {
+      const mn = mass.get(id) ?? 0
+      Mstar += mn * (phi[0] * phi[0] + phi[1] * phi[1] + phi[2] * phi[2])
+      L += mn * phi[dirIdx]
+    }
+    const Sa = nscp208Spectrum(m.period, p.Ca, p.Cv, p.I, p.R)
+    const gammaSa = Mstar > 1e-12 ? (L / Mstar) * Sa : 0
+    const f = levels.map((e) => gammaSa * nodesAt(e)
+      .reduce((s, n) => s + (mass.get(n.id) ?? 0) * (m.shape[n.id]?.[dirIdx] ?? 0), 0))
+    // storey shears, accumulated from the roof down
+    const V = new Array<number>(levels.length).fill(0)
+    for (let k = levels.length - 1, acc = 0; k >= 0; k--) { acc += f[k]; V[k] = acc }
+    return { omega: m.omega, V }
+  })
+
+  // combine per level over modes
+  const combine = p.combine ?? 'cqc'
+  const Vk = levels.map((_, k) => {
+    if (combine === 'srss') return Math.sqrt(modes.reduce((s, m) => s + m.V[k] * m.V[k], 0))
+    let sum = 0
+    for (let i = 0; i < modes.length; i++) {
+      for (let j = 0; j < modes.length; j++) {
+        const rho = i === j ? 1 : cqcCorrel(modes[i].omega, modes[j].omega, zeta)
+        sum += rho * modes[i].V[k] * modes[j].V[k]
+      }
+    }
+    return Math.sqrt(Math.max(0, sum))
+  })
+
+  const Vdyn = Vk[0] ?? 0
+  if (!(Vdyn > 0)) return null
+  const scale = p.Vfloor !== undefined && p.Vfloor > Vdyn ? p.Vfloor / Vdyn : 1
+
+  const storeys: RsaStoreyRow[] = levels.map((e, k) => ({
+    elevation: e, V: scale * Vk[k], F: scale * (Vk[k] - (Vk[k + 1] ?? 0)),
+  }))
+
+  // storey force → node loads, split ∝ nodal seismic mass at the level
+  const loads: ModelLoad[] = []
+  for (const s of storeys) {
+    if (Math.abs(s.F) < 1e-9) continue
+    const nodes = nodesAt(s.elevation)
+    if (nodes.length === 0) continue
+    const mTot = nodes.reduce((t, n) => t + (mass.get(n.id) ?? 0), 0)
+    for (const n of nodes) {
+      const F = s.F * (mTot > 1e-12 ? (mass.get(n.id) ?? 0) / mTot : 1 / nodes.length)
+      if (Math.abs(F) < 1e-12) continue
+      loads.push(p.dir === 'x'
+        ? { kind: 'node', node: n.id, Fx: F, cat: 'E' }
+        : { kind: 'node', node: n.id, Fz: F, cat: 'E' })
+    }
+  }
+
+  const massRatio = modal.modes.reduce((s, m) => s + m.effMassRatio[dirIdx], 0)
+  return { dir: p.dir, storeys, Vdyn, Vfloor: p.Vfloor ?? 0, scale, massRatio, loads }
 }

--- a/webapp/src/engine/seismic.test.ts
+++ b/webapp/src/engine/seismic.test.ts
@@ -93,6 +93,51 @@ describe('NSCP 208-11 — Seismic Zone 4 base shear floor', () => {
   })
 })
 
+describe('§208.5.2.2 Method-B period', () => {
+  const m = makeModel()
+  const Ta = 0.0731 * Math.pow(6, 0.75)
+
+  it('defaults to Method A when Tb is not supplied', () => {
+    const r = computeSeismic(m, params)!
+    expect(r.Tmethod).toBe('A')
+    expect(r.Ta).toBeCloseTo(Ta, 9)
+    expect(r.T).toBeCloseTo(Ta, 9)
+  })
+
+  it('uses the analytical period when below the cap', () => {
+    const Tb = 1.2 * Ta
+    const r = computeSeismic(m, { ...params, Z: 0.4, Tb })!
+    expect(r.Tmethod).toBe('B')
+    expect(r.T).toBeCloseTo(Tb, 9)
+    expect(r.Ta).toBeCloseTo(Ta, 9)                       // Ta still reported
+    expect(r.Vraw).toBeCloseTo((params.Cv * params.I * r.W) / (params.R * Tb), 6)
+  })
+
+  it('caps at 1.3·Ta in Seismic Zone 4', () => {
+    const r = computeSeismic(m, { ...params, Z: 0.4, Tb: 5 * Ta })!
+    expect(r.T).toBeCloseTo(1.3 * Ta, 9)
+  })
+
+  it('caps at 1.4·Ta outside Zone 4', () => {
+    const r = computeSeismic(m, { ...params, Z: 0.2, Tb: 5 * Ta })!
+    expect(r.T).toBeCloseTo(1.4 * Ta, 9)
+    // no Z supplied at all → also 1.4 (zone unknown ⇒ not Zone 4)
+    const r2 = computeSeismic(m, { ...params, Tb: 5 * Ta })!
+    expect(r2.T).toBeCloseTo(1.4 * Ta, 9)
+  })
+
+  it('longer Method-B period lowers the raw base shear (velocity branch)', () => {
+    const tall = generateGridModel({ baysX: [6], baysZ: [5], storeyH: Array(12).fill(3), section })
+    tall.loads = tall.plates.map((p) => ({ kind: 'area' as const, plate: p.id, q: 5, cat: 'D' as const }))
+    const a = computeSeismic(tall, params)!
+    const b = computeSeismic(tall, { ...params, Tb: 1.3 * a.Ta })!
+    expect(a.T).toBeGreaterThan(0.7)                      // velocity branch governs
+    expect(b.Vraw).toBeLessThan(a.Vraw)
+    expect(b.Vraw).toBeCloseTo(a.Vraw / 1.3, 6)
+    expect(b.storeys.reduce((s, q) => s + q.Fx, 0)).toBeCloseTo(b.V, 4)
+  })
+})
+
 describe('drift check', () => {
   it('ΔM = 0.7RΔs against the elastic frame solution', () => {
     const m = makeModel()

--- a/webapp/src/engine/seismic.ts
+++ b/webapp/src/engine/seismic.ts
@@ -1,7 +1,9 @@
 // ─────────────────────────────────────────────────────────────────────────
 // NSCP 2015 §208 (UBC-97) static lateral force procedure + storey drift —
 // Phase 7 of the 3D roadmap.
-//   T = Ct·hn^(3/4)                  (Ct = 0.0731 for RC moment frames, m)
+//   Ta = Ct·hn^(3/4)                 (Method A; Ct = 0.0731 for RC frames, m)
+//   T  = min(Tb, 1.3·Ta) Zone 4 / min(Tb, 1.4·Ta) else, when a Method-B
+//        analytical period Tb is supplied (§208.5.2.2); otherwise T = Ta.
 //   V = Cv·I·W / (R·T)               2.5·Ca·I·W/R ≥ V ≥ 0.11·Ca·I·W
 //   Ft = 0.07·T·V ≤ 0.25·V  (T > 0.7 s, else 0)
 //   Fx = (V − Ft)·wx·hx / Σ(w·h)     (+Ft at the roof)
@@ -22,6 +24,10 @@ export interface SeismicParams {
   Ct?: number               // default 0.0731 (RC moment frame, metres)
   gammaC?: number           // concrete unit weight for member self-weight (default 24)
   dir: 'x' | 'z'
+  /** §208.5.2.2 Method B: analytical fundamental period (s) in the load
+   *  direction (e.g. from modal analysis). Used for V and Ft, but capped at
+   *  1.3·Ta in Seismic Zone 4 (Z ≥ 0.4) and 1.4·Ta elsewhere. Omit → Method A. */
+  Tb?: number
 }
 
 export interface StoreyForce {
@@ -29,7 +35,14 @@ export interface StoreyForce {
 }
 
 export interface SeismicResult {
-  hn: number; T: number; W: number
+  hn: number
+  /** Method-A empirical period Ct·hn^¾, s (§208.5.2.1). */
+  Ta: number
+  /** Period used for V and Ft, s: Ta, or the capped Method-B period. */
+  T: number
+  /** Which §208.5.2 method produced T ('B' only when Tb was supplied). */
+  Tmethod: 'A' | 'B'
+  W: number
   Vraw: number; Vmax: number; Vmin: number; Vsrc: number; V: number
   Ft: number
   storeys: StoreyForce[]
@@ -91,7 +104,12 @@ export function computeSeismic(model: StructuralModel, p: SeismicParams): Seismi
   if (!(hn > 0) || !(W > 0)) return null
 
   const Ct = p.Ct ?? 0.0731
-  const T = Ct * Math.pow(hn, 0.75)
+  const Ta = Ct * Math.pow(hn, 0.75)
+  // §208.5.2.2 Method B: the analytical period may replace Ta, but shall not
+  // exceed it by more than 30% in Seismic Zone 4 (Z ≥ 0.4) or 40% elsewhere.
+  const useB = p.Tb !== undefined && p.Tb > 0
+  const T = useB ? Math.min(p.Tb!, ((p.Z ?? 0) >= 0.4 ? 1.3 : 1.4) * Ta) : Ta
+  const Tmethod: 'A' | 'B' = useB ? 'B' : 'A'
   const Vraw = (p.Cv * p.I * W) / (p.R * T)
   const Vmax = (2.5 * p.Ca * p.I * W) / p.R          // 208-9 upper bound
   const Vmin = 0.11 * p.Ca * p.I * W                  // 208-10 lower bound
@@ -121,7 +139,7 @@ export function computeSeismic(model: StructuralModel, p: SeismicParams): Seismi
     }
   }
 
-  return { hn, T, W, Vraw, Vmax, Vmin, Vsrc, V, Ft, storeys, loads }
+  return { hn, Ta, T, Tmethod, W, Vraw, Vmax, Vmin, Vsrc, V, Ft, storeys, loads }
 }
 
 // ── Storey drift (NSCP 208.5.10) ─────────────────────────────────────────

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -10,7 +10,7 @@ import { type F3Analysis, type F3MemberResult, type V3 } from '../engine/frame3d
 import { memberDiagramRibbon, diagramScale, type DiagramComp } from '../engine/memberDiagram3d'
 import { validateMesh, hasMeshErrors } from '../engine/meshValidation'
 import { type ModalResult } from '../engine/modal'
-import { computeResponseSpectrum, type ResponseSpectrumResult } from '../engine/responseSpectrum'
+import { computeResponseSpectrum, rsaEquivalentLoads, type ResponseSpectrumResult, type RsaLateralResult } from '../engine/responseSpectrum'
 import { type StructureDesign, type FootingPlan, type OptimizeResult, type LateralCase } from '../engine/pipeline'
 import type { SteelJoint } from '../engine/steelConnections'
 import { estimateTakeoff, costBill, type PriceList } from '../engine/takeoff'
@@ -730,7 +730,11 @@ export default function ModelSpace() {
   const [Rw, setRw] = useState(n('Rw', 8.5)); const [Ie, setIe] = useState(n('Ie', 1.0))
   const [Zf, setZf] = useState(n('Zf', 0.4)); const [Nv, setNv] = useState(n('Nv', 1.0))   // Zone factor + near-source (208-11)
   const [eDirs, setEDirs] = useState<string[]>((si.eDirs as string[]) ?? ['+X', '-X', '+Z', '-Z'])  // directional E cases to envelope
-  const [seis, setSeis] = useState<SeismicResult | null>(null)
+  // §208 static results per axis (they differ when Method-B periods differ per axis)
+  const [seisXZ, setSeisXZ] = useState<{ x: SeismicResult; z: SeismicResult } | null>(null)
+  const [methodB, setMethodB] = useState(b('methodB', true))          // §208.5.2.2 analytical period (needs a modal run)
+  const [rsaRegular, setRsaRegular] = useState(b('rsaRegular', true)) // §208.6.4.2 floors: 0.9·V_B & 0.8·V_A vs 1.0·V_B
+  const [rsaGen, setRsaGen] = useState<{ x: RsaLateralResult; z: RsaLateralResult } | null>(null)   // RSA-derived E cases
   const [drift, setDrift] = useState<DriftRow[] | null>(null)
   // Wind (NSCP 207B directional procedure, MWFRS)
   const [Vw, setVw] = useState(n('Vw', 50)); const [expo, setExpo] = useState<'B' | 'C' | 'D'>((si.expo as 'B' | 'C' | 'D') ?? 'C')
@@ -848,7 +852,7 @@ export default function ModelSpace() {
       sessionStorage.setItem(INPUTS_KEY, JSON.stringify({
         baysX, baysZ, storeyH, colB, colH, girB, girH, beaB, beaH,
         fc, fy, barDia, tieDia, cover, slabThk, gammaC, qD, qL,
-        qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs,
+        qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs, methodB, rsaRegular,
         Vw, expo, Kzt, wDirs, assembly, pDelta, cracked, tryBars,
         concreteClass, prices, planSel,
         material, colFam, girFam, beaFam, colShape, girShape, beaShape, steelFy, steelFu,
@@ -856,7 +860,7 @@ export default function ModelSpace() {
     } catch { /* quota — ignore */ }
   }, [baysX, baysZ, storeyH, colB, colH, girB, girH, beaB, beaH,
     fc, fy, barDia, tieDia, cover, slabThk, gammaC, qD, qL,
-    qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs,
+    qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs, methodB, rsaRegular,
     Vw, expo, Kzt, wDirs, assembly, pDelta, cracked, tryBars,
     concreteClass, prices, planSel,
     material, colFam, girFam, beaFam, colShape, girShape, beaShape, steelFy, steelFu])
@@ -876,8 +880,24 @@ export default function ModelSpace() {
     } catch { /* quota — ignore */ }
   }
 
+  /** save() for node-load-only edits (E/W case generation): mass and stiffness
+   *  are untouched, so the modal result — which Method B and the RSA E-cases
+   *  need on the NEXT generate click — stays valid and is kept. */
+  const saveKeepModal = (m: StructuralModel) => {
+    setModel(m)
+    setAnalysis(null)
+    setDesign(null)
+    setOpt(null)
+    setExpanded(null)
+    setDrift(null)
+    try { sessionStorage.setItem(AUTOSAVE_KEY, JSON.stringify(m)) } catch { /* quota — ignore */ }
+  }
+
   // §203.3.1: f₁ = 1.0 for assembly/garage or live load > 4.8 kPa, else 0.5.
   const fLive = assembly || qL > 4.8 ? 1.0 : 0.5
+  // Primary lateral axis (headline §208 summary + drift check direction).
+  const primAxis: 'x' | 'z' = (eDirs[0] ?? '+X').includes('X') ? 'x' : 'z'
+  const seis = seisXZ?.[primAxis] ?? null
   const lateral = [...eCases, ...wCases]
   // Infer seismic lateral system from R for column tie-detailing.
   // Only applies when E loads are present (user clicked "Generate E cases").
@@ -887,10 +907,9 @@ export default function ModelSpace() {
 
   const analyze = () => {
     if (!model || busy || meshErrors) return   // §1 fail-fast: don't solve a singular mesh
-    const axis: 'x' | 'z' = (eDirs[0] ?? '+X').includes('X') ? 'x' : 'z'
     // 3D FEM + storey drift run in the worker so the UI stays responsive.
     run('analyze', {
-      model, opts: anaOpts, drift: { hasSeis: !!seis, T: seis?.T ?? 0, R: Rw, axis, pDelta }, crackedSections: cracked,
+      model, opts: anaOpts, drift: { hasSeis: !!seis, T: seis?.T ?? 0, R: Rw, axis: primAxis, pDelta }, crackedSections: cracked,
     }).then((r) => {
       const res = r as { analysis: F3Analysis | null; orphans: number; drift: DriftRow[] | null }
       setOrphans(res.orphans)
@@ -908,7 +927,7 @@ export default function ModelSpace() {
       if (m && m.modes.length > 0) {
         setRsa(computeResponseSpectrum(m, {
           Ca, Cv, I: Ie, R: Rw,
-          staticV: seis ? [seis.V, 0, seis.V] : undefined,
+          staticV: seisXZ ? [seisXZ.x.V, 0, seisXZ.z.V] : undefined,
         }))
       } else {
         setRsa(null)
@@ -969,30 +988,72 @@ export default function ModelSpace() {
     setSlabFE(out ? out.rows : null)
   }
 
-  // Re-sign / re-axis a base node-load set into a directional case.
+  // Re-sign / re-axis a base node-load set into a directional case. The base
+  // value's sign is preserved (RSA storey-force patterns can locally reverse),
+  // so '−' cases are the exact mirror of '+' cases.
   const dirCase = (base: ModelLoad[], kind: 'E' | 'W', d: string): LateralCase => {
     const axis = d.includes('X') ? 'Fx' : 'Fz'
     const sign = d.startsWith('-') ? -1 : 1
     return {
       name: `${kind}${d}`, kind,
       loads: base.map((l) => {
-        const mag = Math.abs((l as { Fx?: number }).Fx ?? 0) || Math.abs((l as { Fz?: number }).Fz ?? 0)
-        return { kind: 'node', node: (l as { node: string }).node, [axis]: sign * mag, cat: kind }
+        const v = (l as { Fx?: number }).Fx ?? (l as { Fz?: number }).Fz ?? 0
+        return { kind: 'node', node: (l as { node: string }).node, [axis]: sign * v, cat: kind }
       }),
     }
   }
 
+  /** §208.5.2.2 Method-B period per axis: the modal period of the mode with the
+   *  largest effective-mass share in that direction (the fundamental
+   *  translational mode). undefined when no modal result is available. */
+  const fundamentalT = (axis: 'x' | 'z'): number | undefined => {
+    if (!modal || modal.modes.length === 0) return undefined
+    const d = axis === 'x' ? 0 : 2
+    const best = modal.modes.reduce((a, m) => (m.effMassRatio[d] > a.effMassRatio[d] ? m : a))
+    return best.effMassRatio[d] > 0 ? best.period : undefined
+  }
+
+  /** Swap the model's cat-E node loads for the primary direction's case and
+   *  refresh the derived state shared by both E-generation paths. */
+  const commitECases = (rx: SeismicResult, rz: SeismicResult, baseOf: (axis: 'x' | 'z') => ModelLoad[]) => {
+    if (!model) return
+    setSeisXZ({ x: rx, z: rz })
+    setECases(eDirs.map((d) => dirCase(baseOf(d.includes('X') ? 'x' : 'z'), 'E', d)))
+    // commit the primary direction for the load-diagram overlay + drift check
+    const primary = dirCase(baseOf(primAxis), 'E', eDirs[0] ?? '+X')
+    saveKeepModal({ ...model, loads: [...model.loads.filter((l) => !(l.cat === 'E' && l.kind === 'node')), ...primary.loads] })
+  }
+
   const generateE = () => {
     if (!model) return
-    // base magnitude is direction-independent (storey force per node), so one
-    // solve gives every ±X/±Z case.
-    const r = computeSeismic(model, { Ca, Cv, I: Ie, R: Rw, Z: Zf, Nv, gammaC, dir: 'x' })
-    if (!r) return
-    setSeis(r)
-    setECases(eDirs.map((d) => dirCase(r.loads, 'E', d)))
-    // commit the primary direction for the load-diagram overlay + drift check
-    const primary = dirCase(r.loads, 'E', eDirs[0] ?? '+X')
-    save({ ...model, loads: [...model.loads.filter((l) => !(l.cat === 'E' && l.kind === 'node')), ...primary.loads] })
+    // one solve per axis: distribution is direction-independent, but with a
+    // Method-B period V (and so every Fx) can differ between X and Z.
+    const base = { Ca, Cv, I: Ie, R: Rw, Z: Zf, Nv, gammaC }
+    const rx = computeSeismic(model, { ...base, dir: 'x' as const, Tb: methodB ? fundamentalT('x') : undefined })
+    const rz = computeSeismic(model, { ...base, dir: 'z' as const, Tb: methodB ? fundamentalT('z') : undefined })
+    if (!rx || !rz) return
+    setRsaGen(null)   // static pattern replaces any RSA-derived cases
+    commitECases(rx, rz, (axis) => (axis === 'x' ? rx : rz).loads)
+  }
+
+  /** §208.6.4 dynamic path: RSA storey forces (CQC), scaled to the §208.6.4.2
+   *  static-base-shear floor, become the cat-E cases the design envelopes. */
+  const generateRsaE = () => {
+    if (!model || !modal || modal.modes.length === 0) return
+    const base = { Ca, Cv, I: Ie, R: Rw, Z: Zf, Nv, gammaC }
+    const gen = (axis: 'x' | 'z') => {
+      const vA = computeSeismic(model, { ...base, dir: axis })                            // Method-A static V
+      const vB = computeSeismic(model, { ...base, dir: axis, Tb: fundamentalT(axis) })    // Method-B static V (§208.6.4.2)
+      if (!vA || !vB) return null
+      // regular: ≥ 90% of V(T_B), and never below 80% of V(T_A); irregular: 100% of V(T_B)
+      const Vfloor = rsaRegular ? Math.max(0.9 * vB.V, 0.8 * vA.V) : vB.V
+      const rsa = rsaEquivalentLoads(model, modal, { Ca, Cv, I: Ie, R: Rw, dir: axis, combine: 'cqc', Vfloor })
+      return rsa ? { stat: vB, rsa } : null
+    }
+    const gx = gen('x'), gz = gen('z')
+    if (!gx || !gz) return
+    setRsaGen({ x: gx.rsa, z: gz.rsa })
+    commitECases(gx.stat, gz.stat, (axis) => (axis === 'x' ? gx : gz).rsa.loads)
   }
 
   const generateW = () => {
@@ -1009,7 +1070,7 @@ export default function ModelSpace() {
       return dirCase(base, 'W', d)
     }))
     const primary = dirCase(primaryRes.loads, 'W', wDirs[0] ?? '+X')
-    save({ ...model, loads: [...model.loads.filter((l) => !(l.cat === 'W' && l.kind === 'node')), ...primary.loads] })
+    saveKeepModal({ ...model, loads: [...model.loads.filter((l) => !(l.cat === 'W' && l.kind === 'node')), ...primary.loads] })
   }
 
   const runCladding = () => {
@@ -1251,7 +1312,8 @@ export default function ModelSpace() {
     // gravity loads: member self-weight (D), slab self-weight + SDL (D), LL (L)
     m.loads = buildGravityLoads(m, qD, qL, gammaC)
     setSelected(null)
-    setSeis(null)
+    setSeisXZ(null)
+    setRsaGen(null)
     setWind(null)
     setECases([])
     setWCases([])
@@ -2463,34 +2525,60 @@ export default function ModelSpace() {
                 <Num label="Z (zone)" value={Zf} onChange={setZf} />
                 <Num label="Nv (near-source)" value={Nv} onChange={setNv} />
                 <DirPicker value={eDirs} onChange={setEDirs} />
+                <label className="col-span-full flex items-start gap-2 text-xs text-slate-600">
+                  <input type="checkbox" checked={methodB} onChange={(e) => setMethodB(e.target.checked)} className="mt-0.5" />
+                  <span>
+                    Method-B period (§208.5.2.2) — use the modal fundamental period per axis, capped at {Zf >= 0.4 ? '1.3' : '1.4'}·Ta.
+                    {!modal && <span className="text-slate-500"> No modal result yet — run Modal (Dynamics) first, else Method A is used.</span>}
+                  </span>
+                </label>
                 <div className="col-span-full">
                   <button type="button" onClick={generateE} disabled={!model || eDirs.length === 0}
                     className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50 disabled:opacity-40">⚡ Generate E cases</button>
-                  {seis && (
+                  {seis && (() => {
+                    const other = seisXZ ? seisXZ[primAxis === 'x' ? 'z' : 'x'] : null
+                    const twoAxis = !!other && (Math.abs(other.V - seis.V) > 1e-6 || Math.abs(other.T - seis.T) > 1e-9)
+                    const sx = seisXZ?.x, sz = seisXZ?.z
+                    return (
                     <div className="mt-1 space-y-1">
                       <p className="text-xs text-slate-500">
-                        T = {seis.T.toFixed(3)} s · W = {f1(seis.W)} kN · V = {f1(seis.V)} kN
+                        {twoAxis ? `${primAxis.toUpperCase()}: ` : ''}T = {seis.T.toFixed(3)} s{seis.Tmethod === 'B' ? ` (Method B, Ta = ${seis.Ta.toFixed(3)} s)` : ''} · W = {f1(seis.W)} kN · V = {f1(seis.V)} kN
                         {seis.V === seis.Vmax ? ' (2.5CaIW/R cap governs)'
                           : seis.Vsrc > 0 && seis.V === seis.Vsrc ? ' (Zone-4 0.8ZNvIW/R floor governs)'
                             : seis.V === seis.Vmin ? ' (0.11CaIW floor governs)' : ''}
                         {seis.Ft > 0 ? ` · Ft = ${f1(seis.Ft)} kN` : ''} — {eCases.length} cat-E case{eCases.length === 1 ? '' : 's'} ({eDirs.join(', ') || 'none'}).
                         {Zf >= 0.4 ? ` Zone-4 floor = ${f1(seis.Vsrc)} kN.` : ' (Zone-4 floor off: Z < 0.4)'}
                       </p>
+                      {twoAxis && other && (
+                        <p className="text-xs text-slate-500">
+                          {primAxis === 'x' ? 'Z' : 'X'}: T = {other.T.toFixed(3)} s{other.Tmethod === 'B' ? ` (Method B, Ta = ${other.Ta.toFixed(3)} s)` : ''} · V = {f1(other.V)} kN{other.Ft > 0 ? ` · Ft = ${f1(other.Ft)} kN` : ''}
+                        </p>
+                      )}
                       <table className="w-full border-collapse text-xs">
                         <thead>
                           <tr className="text-left uppercase tracking-wide text-slate-500">
                             <th className="py-0.5 pr-2 font-semibold">Level (m)</th>
                             <th className="py-0.5 pr-2 text-right font-semibold">wx (kN)</th>
-                            <th className="py-0.5 pr-2 text-right font-semibold">Fx (kN)</th>
+                            {twoAxis ? (
+                              <>
+                                <th className="py-0.5 pr-2 text-right font-semibold">F·X (kN)</th>
+                                <th className="py-0.5 pr-2 text-right font-semibold">F·Z (kN)</th>
+                              </>
+                            ) : <th className="py-0.5 pr-2 text-right font-semibold">Fx (kN)</th>}
                             <th className="py-0.5 text-right font-semibold">Nodes</th>
                           </tr>
                         </thead>
                         <tbody>
-                          {seis.storeys.map((s) => (
+                          {seis.storeys.map((s, i) => (
                             <tr key={s.elevation} className="border-t border-slate-100">
                               <td className="py-0.5 pr-2">{f1(s.elevation)}</td>
                               <td className="py-0.5 pr-2 text-right">{f1(s.wx)}</td>
-                              <td className="py-0.5 pr-2 text-right font-medium text-[#7c3aed]">{f1(s.Fx)}</td>
+                              {twoAxis && sx && sz ? (
+                                <>
+                                  <td className="py-0.5 pr-2 text-right font-medium text-[#7c3aed]">{f1(sx.storeys[i]?.Fx ?? 0)}</td>
+                                  <td className="py-0.5 pr-2 text-right font-medium text-[#7c3aed]">{f1(sz.storeys[i]?.Fx ?? 0)}</td>
+                                </>
+                              ) : <td className="py-0.5 pr-2 text-right font-medium text-[#7c3aed]">{f1(s.Fx)}</td>}
                               <td className="py-0.5 text-right text-slate-500">{s.nodes}</td>
                             </tr>
                           ))}
@@ -2498,6 +2586,59 @@ export default function ModelSpace() {
                       </table>
                       <p className="text-[10px] text-slate-500">
                         System: <b>{seismicSystem.toUpperCase()}</b> (R = {Rw}) — column tie detailing uses {seismicSystem === 'smf' ? 'NSCP §418.7.5 SMF confinement' : seismicSystem === 'imf' ? 'NSCP §418.4.3 IMF hinge zone' : '§425.7.2 gravity ties only'}.
+                      </p>
+                    </div>
+                    )
+                  })()}
+                </div>
+                <div className="col-span-full border-t border-slate-100 pt-2">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <button type="button" onClick={generateRsaE}
+                      disabled={!model || eDirs.length === 0 || !modal || modal.modes.length === 0}
+                      className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#7c3aed] hover:border-[#7c3aed] hover:bg-purple-50 disabled:opacity-40">〜 Generate E cases — RSA (§208.6.4)</button>
+                    <label className="flex items-center gap-1.5 text-xs text-slate-600">
+                      <input type="checkbox" checked={rsaRegular} onChange={(e) => setRsaRegular(e.target.checked)} />
+                      <span>regular structure — 0.9·V(T_B) &amp; 0.8·V(T_A) floors (unticked: irregular, 100%·V)</span>
+                    </label>
+                  </div>
+                  {(!modal || modal.modes.length === 0) && (
+                    <p className="mt-1 text-[10px] text-slate-500">Needs a Modal run (Dynamics) — the CQC storey shears are combined from the mode shapes, then scaled to the §208.6.4.2 static floor and enveloped by Design/Optimize like any E case.</p>
+                  )}
+                  {rsaGen && (
+                    <div className="mt-1 space-y-1">
+                      {(['x', 'z'] as const).map((ax) => {
+                        const g = rsaGen[ax]
+                        return (
+                          <p key={ax} className="text-xs text-slate-500">
+                            {ax.toUpperCase()}: V<sub>CQC</sub> = {f1(g.Vdyn)} kN · §208.6.4.2 floor = {f1(g.Vfloor)} kN → scale ×{g.scale.toFixed(3)} · mass participation {Math.round(g.massRatio * 100)}%
+                            {g.massRatio < 0.9 && <span className="font-semibold text-amber-600"> — below 90% (§208.6.4.1): raise the mode count in Dynamics</span>}
+                          </p>
+                        )
+                      })}
+                      <table className="w-full border-collapse text-xs">
+                        <thead>
+                          <tr className="text-left uppercase tracking-wide text-slate-500">
+                            <th className="py-0.5 pr-2 font-semibold">Level (m)</th>
+                            <th className="py-0.5 pr-2 text-right font-semibold">F·X (kN)</th>
+                            <th className="py-0.5 pr-2 text-right font-semibold">V·X (kN)</th>
+                            <th className="py-0.5 pr-2 text-right font-semibold">F·Z (kN)</th>
+                            <th className="py-0.5 text-right font-semibold">V·Z (kN)</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {rsaGen.x.storeys.map((s, i) => (
+                            <tr key={s.elevation} className="border-t border-slate-100">
+                              <td className="py-0.5 pr-2">{f1(s.elevation)}</td>
+                              <td className="py-0.5 pr-2 text-right font-medium text-[#7c3aed]">{f1(s.F)}</td>
+                              <td className="py-0.5 pr-2 text-right">{f1(s.V)}</td>
+                              <td className="py-0.5 pr-2 text-right font-medium text-[#7c3aed]">{f1(rsaGen.z.storeys[i]?.F ?? 0)}</td>
+                              <td className="py-0.5 text-right">{f1(rsaGen.z.storeys[i]?.V ?? 0)}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                      <p className="text-[10px] text-slate-500">
+                        Storey forces back-difference the CQC storey-shear diagram, scaled so the base shear meets the §208.6.4.2 floor, split to the level&apos;s nodes ∝ seismic mass. They replace the static pattern in the cat-E cases enveloped by Analyze/Design/Optimize.
                       </p>
                     </div>
                   )}


### PR DESCRIPTION
Closes the two gaps flagged in the modal/pushover audit: the modal results now feed the design path in both the static and the dynamic lateral procedures. **Layers: L4/L5 engine + ModelSpace UI.**

## (a) Method-B period — `engine/seismic.ts`
- `SeismicParams.Tb`: analytical fundamental period from modal analysis. Per NSCP 2015 §208.5.2.2 it replaces the Method-A `Ta = Ct·hn^¾` but is capped at **1.3·Ta in Zone 4 (Z ≥ 0.4) and 1.4·Ta elsewhere**; V and Ft use the capped T.
- `SeismicResult` now reports `Ta`, the used `T`, and `Tmethod: 'A' | 'B'`.
- Static E generation in ModelSpace is now **per axis** (one `computeSeismic` per X/Z with that axis's fundamental translational mode — largest effective-mass share), since Method-B periods differ per direction. Falls back silently to Method A when no modal result exists (hint shown in the panel).

## (b) RSA-derived E cases — `engine/responseSpectrum.ts`
New `rsaEquivalentLoads(model, modal, params)`:
- per-mode storey forces `Γ·Sa(T_m)·Σ m_n·φ_n` (normalization-invariant), storey shears accumulated from the roof, **CQC/SRSS-combined per level**;
- combined shear diagram back-differenced into an equivalent static storey-force pattern (ETABS-style), so the design quantity — the storey shear profile — is reproduced exactly;
- **§208.6.4.2 scaling**: caller supplies the minimum design base shear; ModelSpace uses `max(0.9·V(T_B), 0.8·V(T_A))` for regular structures and `1.0·V(T_B)` for irregular (checkbox);
- storey forces split to the level's nodes ∝ seismic mass, emitted as **cat-'E' node loads** → the same `LateralCase` envelope `pipeline.ts` design/optimize already consume;
- reports directional mass participation with a &lt;90% warning (§208.6.4.1).

## UI (Loading tab, Seismic card)
- Method-B checkbox (persisted), per-axis T/V summary + two-column storey table when the axes differ.
- "Generate E cases — RSA (§208.6.4)" button (disabled until a Modal run exists) with V_CQC/floor/scale/participation per axis and the scaled F/V storey table.
- E/W case generation now uses a `saveKeepModal` variant: node-load-only edits don't touch mass/stiffness, so the modal result stays valid for the next generate click instead of being wiped.
- `dirCase` preserves the base-load sign (RSA patterns can locally reverse), so ± cases mirror exactly.

## Verification
- **1036 vitest tests pass** (12 new: Method-B use/caps/V, RSA base-shear equivalence to `computeResponseSpectrum` CQC/SRSS, single-mode hand calc `V = Sa·effMass`, back-difference/ΣF identity, scaling floors up-only, per-level node-load sums, participation, null guards). `npx tsc -b` clean.
- **Headless Chromium end-to-end** (no preview tools in this session): grid → Modal → Generate E shows `T = 0.302 s (Method B, Ta = 0.298 s)` per axis; RSA generation scales ×1.699 (X) / ×1.886 (Z) up to the 0.9·V floor (157.8 kN, per-level sums check out); Design runs an envelope of 13 cases on the RSA loads; without a modal run the RSA button is disabled and static generation falls back to Method A. No console errors.

Notes / follow-ups (not in this PR): RSA storey forces are applied as ± whole-pattern cases (no directional 100/30 combination — that's backlog P1-3); accidental torsion (P1-2) still pending; `docs/ValidationMap.md` row transcription remains the P2 gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_