### PR TITLE
feat: accidental torsion ±5% E-case variants (NSCP §208.7.2.7) — backlog P1-2

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -75,6 +75,11 @@ of the app. Everything runs **off the main thread** in a web worker
   (0.9·V_B & 0.8·V_A regular / 1.0·V_B irregular) — both feed the same
   `LateralCase` envelope that Design/Optimize consume ("Generate E cases — RSA"
   in the Loading tab; needs a Modal run first).
+- **Accidental torsion ±5%** (`accidentalTorsionLoads`, §208.7.2.7): each
+  directional E case (static or RSA) splits into ⟳/⟲ variants adding a
+  self-equilibrating node-force couple (ΣΔF = 0, ΣΔF·d = ±0.05·L⊥·F_storey,
+  mass-weighted about the storey mass centroid) — works with or without the
+  rigid diaphragm; toggle in the Loading tab, on by default.
 - **Member force diagrams BMD/SFD** (PR #233): inline bending-moment and shear
   diagrams rendered on each member in the 3D view and Analysis tab. Uses the
   existing `xs[]`/`My[]`/`Mz[]`/`Vy[]` arrays on `F3MemberResult`.

--- a/webapp/src/engine/seismic.test.ts
+++ b/webapp/src/engine/seismic.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { computeSeismic, storeyWeights, driftCheck } from './seismic'
+import { computeSeismic, storeyWeights, driftCheck, accidentalTorsionLoads } from './seismic'
+import { buildSeismicMass } from './modal'
 import { generateGridModel } from './modelBuilder'
 import { modelToFrame3D } from './modelBridge'
 import { solveFrame3D, applyF3Combo } from './frame3d'
@@ -135,6 +136,78 @@ describe('§208.5.2.2 Method-B period', () => {
     expect(b.Vraw).toBeLessThan(a.Vraw)
     expect(b.Vraw).toBeCloseTo(a.Vraw / 1.3, 6)
     expect(b.storeys.reduce((s, q) => s + q.Fx, 0)).toBeCloseTo(b.V, 4)
+  })
+})
+
+describe('§208.7.2.7 accidental torsion', () => {
+  const m = makeModel()   // 6 m (X) × 5 m (Z) plan, 2 storeys
+  const seis = computeSeismic(m, params)!
+  const mass = buildSeismicMass(m)
+  const fxOf = (loads: ReturnType<typeof accidentalTorsionLoads>, node: string) =>
+    loads.filter((l) => l.kind === 'node' && l.node === node)
+      .reduce((s, l) => s + ((l as { Fx?: number }).Fx ?? 0), 0)
+
+  it('per level: ΣΔF = 0 and ΣΔF·d = 0.05·L⊥·F_level (hand statics)', () => {
+    const tor = accidentalTorsionLoads(m, seis.loads, 'x', 1)
+    expect(tor.length).toBeGreaterThan(0)
+    for (const s of seis.storeys) {
+      const lvlNodes = m.nodes.filter((n) => Math.abs(n.y - s.elevation) < 1e-6)
+      const cs = lvlNodes.map((n) => n.z)
+      const Lperp = Math.max(...cs) - Math.min(...cs)   // = 5 m
+      expect(Lperp).toBeCloseTo(5, 9)
+      let mTot = 0, mC = 0
+      for (const n of lvlNodes) { const mm = mass.get(n.id) ?? 0; mTot += mm; mC += mm * n.z }
+      const cbar = mC / mTot
+      const sumF = lvlNodes.reduce((t, n) => t + fxOf(tor, n.id), 0)
+      const torque = lvlNodes.reduce((t, n) => t + fxOf(tor, n.id) * (n.z - cbar), 0)
+      expect(sumF).toBeCloseTo(0, 9)                              // self-equilibrating
+      expect(torque).toBeCloseTo(0.05 * Lperp * s.Fx, 6)          // exact 5% torque
+    }
+  })
+
+  it('sign = −1 mirrors the couple exactly', () => {
+    const pos = accidentalTorsionLoads(m, seis.loads, 'x', 1)
+    const neg = accidentalTorsionLoads(m, seis.loads, 'x', -1)
+    expect(neg).toHaveLength(pos.length)
+    for (const n of m.nodes) expect(fxOf(neg, n.id)).toBeCloseTo(-fxOf(pos, n.id), 9)
+  })
+
+  it("dir 'z' uses the X plan dimension and Fz components", () => {
+    // rebuild the base case in z: same magnitudes on Fz
+    const baseZ = seis.loads.map((l) => ({ kind: 'node' as const, node: (l as { node: string }).node, Fz: (l as { Fx?: number }).Fx, cat: 'E' as const }))
+    const tor = accidentalTorsionLoads(m, baseZ, 'z', 1)
+    expect(tor.length).toBeGreaterThan(0)
+    expect(tor.every((l) => (l as { Fx?: number }).Fx === undefined)).toBe(true)
+    const s0 = seis.storeys[0]
+    const lvlNodes = m.nodes.filter((n) => Math.abs(n.y - s0.elevation) < 1e-6)
+    let mTot = 0, mC = 0
+    for (const n of lvlNodes) { const mm = mass.get(n.id) ?? 0; mTot += mm; mC += mm * n.x }
+    const cbar = mC / mTot
+    const fz = (id: string) => tor.filter((l) => l.kind === 'node' && l.node === id)
+      .reduce((s, l) => s + ((l as { Fz?: number }).Fz ?? 0), 0)
+    const torque = lvlNodes.reduce((t, n) => t + fz(n.id) * (n.x - cbar), 0)
+    expect(torque).toBeCloseTo(0.05 * 6 * s0.Fx, 6)               // L⊥ = 6 m in X
+  })
+
+  it('torque flips with the storey-force sign (−X case)', () => {
+    const negBase = seis.loads.map((l) => ({ ...l, Fx: -((l as { Fx?: number }).Fx ?? 0) }))
+    const tor = accidentalTorsionLoads(m, negBase as typeof seis.loads, 'x', 1)
+    const s0 = seis.storeys[0]
+    const lvlNodes = m.nodes.filter((n) => Math.abs(n.y - s0.elevation) < 1e-6)
+    let mTot = 0, mC = 0
+    const massM = buildSeismicMass(m)
+    for (const n of lvlNodes) { const mm = massM.get(n.id) ?? 0; mTot += mm; mC += mm * n.z }
+    const cbar = mC / mTot
+    const torque = lvlNodes.reduce((t, n) => t + fxOf(tor, n.id) * (n.z - cbar), 0)
+    expect(torque).toBeCloseTo(-0.05 * 5 * s0.Fx, 6)
+  })
+
+  it('single frame line (no lever) → no loads, no NaN', () => {
+    const plane = generateGridModel({ baysX: [6], baysZ: [], storeyH: [3], section })
+    // all nodes share z = 0 → denom = 0 for dir 'x'
+    const base = plane.nodes.filter((n) => n.y > 0).map((n) => ({ kind: 'node' as const, node: n.id, Fx: 10, cat: 'E' as const }))
+    const tor = accidentalTorsionLoads(plane, base, 'x', 1)
+    expect(tor).toEqual([])
   })
 })
 

--- a/webapp/src/engine/seismic.ts
+++ b/webapp/src/engine/seismic.ts
@@ -15,6 +15,7 @@
 // or 0.020·hs otherwise.
 // ─────────────────────────────────────────────────────────────────────────
 import type { StructuralModel, ModelLoad } from './model'
+import { buildSeismicMass } from './modal'
 
 export interface SeismicParams {
   Ca: number; Cv: number
@@ -140,6 +141,74 @@ export function computeSeismic(model: StructuralModel, p: SeismicParams): Seismi
   }
 
   return { hn, Ta, T, Tmethod, W, Vraw, Vmax, Vmin, Vsrc, V, Ft, storeys, loads }
+}
+
+// ── Accidental torsion (NSCP 208.7.2.7) ──────────────────────────────────
+// The centre of mass of each level is assumed displaced ±5% of the plan
+// dimension perpendicular to the load direction — statically equivalent to the
+// storey force F applied at the mass centroid PLUS a torque T = ±0.05·L⊥·F
+// about the vertical axis. The torque is realised as a self-equilibrating set
+// of node forces in the load direction, distributed about the storey mass
+// centroid:  ΔF_i = T · m_i·d_i / Σ m_j·d_j²   (d = perpendicular offset)
+// so ΣΔF = 0 (statics unchanged) and ΣΔF·d = T (torque exact). This works with
+// or without a rigid diaphragm: the couple simply loads the frames in
+// proportion to a rigid-rotation displacement pattern weighted by mass.
+
+/**
+ * Antisymmetric node-force set adding the §208.7.2.7 accidental torsion to a
+ * directional E-case. `base` is the case's SIGNED node-load set (Fx for
+ * dir 'x', Fz for dir 'z'); the returned loads are ADDED to it. `sign` picks
+ * the eccentricity sense (envelope both). Levels with no torsional lever
+ * (single frame line, denom ≈ 0) contribute nothing.
+ */
+export function accidentalTorsionLoads(
+  model: StructuralModel, base: ModelLoad[], dir: 'x' | 'z', sign: 1 | -1, ecc = 0.05,
+): ModelLoad[] {
+  const nm = new Map(model.nodes.map((n) => [n.id, n]))
+  const mass = buildSeismicMass(model)
+  // perpendicular plan coordinate: force in x ↔ lever arm in z, and vice versa
+  const perp = (n: { x: number; z: number }) => (dir === 'x' ? n.z : n.x)
+
+  // group the case's forces by level (node elevation)
+  const byLevel = new Map<number, { node: string; F: number }[]>()
+  for (const l of base) {
+    if (l.kind !== 'node') continue
+    const n = nm.get(l.node)
+    if (!n) continue
+    const F = (dir === 'x' ? l.Fx : l.Fz) ?? 0
+    if (F === 0) continue
+    const key = [...byLevel.keys()].find((e) => Math.abs(e - n.y) < 1e-6) ?? n.y
+    const arr = byLevel.get(key) ?? []
+    arr.push({ node: l.node, F })
+    byLevel.set(key, arr)
+  }
+
+  const out: ModelLoad[] = []
+  for (const [y, entries] of byLevel) {
+    const Flevel = entries.reduce((s, e) => s + e.F, 0)
+    const nodes = model.nodes.filter((n) => Math.abs(n.y - y) < 1e-6)
+    if (nodes.length < 2 || Math.abs(Flevel) < 1e-12) continue
+    const cs = nodes.map(perp)
+    const Lperp = Math.max(...cs) - Math.min(...cs)          // plan dimension ⊥ force
+    if (!(Lperp > 0)) continue
+    // mass centroid and torsional lever Σm·d² of the level
+    let mTot = 0, mC = 0
+    for (const n of nodes) { const m = mass.get(n.id) ?? 0; mTot += m; mC += m * perp(n) }
+    if (!(mTot > 0)) continue
+    const cbar = mC / mTot
+    let denom = 0
+    for (const n of nodes) denom += (mass.get(n.id) ?? 0) * (perp(n) - cbar) ** 2
+    if (!(denom > 1e-9)) continue                            // no lever — single frame line
+    const T = sign * ecc * Lperp * Flevel                    // kN·m about the vertical axis
+    for (const n of nodes) {
+      const dF = (T * (mass.get(n.id) ?? 0) * (perp(n) - cbar)) / denom
+      if (Math.abs(dF) < 1e-12) continue
+      out.push(dir === 'x'
+        ? { kind: 'node', node: n.id, Fx: dF, cat: 'E' }
+        : { kind: 'node', node: n.id, Fz: dF, cat: 'E' })
+    }
+  }
+  return out
 }
 
 // ── Storey drift (NSCP 208.5.10) ─────────────────────────────────────────

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -22,7 +22,7 @@ import type { SolveProgress } from '../engine/progress'
 import { TABLE_204_1, TABLE_204_2, sdlItemKPa, sdlTotal, type SdlItem } from '../engine/deadLoads'
 import { TABLE_205_1, TABLE_206 } from '../engine/liveLoads'
 import type { ConcreteClass } from '../engine/quantities'
-import { computeSeismic, type SeismicResult, type DriftRow } from '../engine/seismic'
+import { computeSeismic, accidentalTorsionLoads, type SeismicResult, type DriftRow } from '../engine/seismic'
 import { columnKFactors, type ColumnK } from '../engine/effectiveLength'
 import { freqFromDeflection, dg11Walking, DG11_OCCUPANCY } from '../engine/floorVibration'
 import { buildSeismicMass, GRAVITY } from '../engine/modal'
@@ -733,6 +733,7 @@ export default function ModelSpace() {
   // §208 static results per axis (they differ when Method-B periods differ per axis)
   const [seisXZ, setSeisXZ] = useState<{ x: SeismicResult; z: SeismicResult } | null>(null)
   const [methodB, setMethodB] = useState(b('methodB', true))          // §208.5.2.2 analytical period (needs a modal run)
+  const [accTor, setAccTor] = useState(b('accTor', true))             // §208.7.2.7 accidental torsion ±5% E-case variants
   const [rsaRegular, setRsaRegular] = useState(b('rsaRegular', true)) // §208.6.4.2 floors: 0.9·V_B & 0.8·V_A vs 1.0·V_B
   const [rsaGen, setRsaGen] = useState<{ x: RsaLateralResult; z: RsaLateralResult } | null>(null)   // RSA-derived E cases
   const [drift, setDrift] = useState<DriftRow[] | null>(null)
@@ -852,7 +853,7 @@ export default function ModelSpace() {
       sessionStorage.setItem(INPUTS_KEY, JSON.stringify({
         baysX, baysZ, storeyH, colB, colH, girB, girH, beaB, beaH,
         fc, fy, barDia, tieDia, cover, slabThk, gammaC, qD, qL,
-        qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs, methodB, rsaRegular,
+        qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs, methodB, accTor, rsaRegular,
         Vw, expo, Kzt, wDirs, assembly, pDelta, cracked, tryBars,
         concreteClass, prices, planSel,
         material, colFam, girFam, beaFam, colShape, girShape, beaShape, steelFy, steelFu,
@@ -860,7 +861,7 @@ export default function ModelSpace() {
     } catch { /* quota — ignore */ }
   }, [baysX, baysZ, storeyH, colB, colH, girB, girH, beaB, beaH,
     fc, fy, barDia, tieDia, cover, slabThk, gammaC, qD, qL,
-    qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs, methodB, rsaRegular,
+    qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs, methodB, accTor, rsaRegular,
     Vw, expo, Kzt, wDirs, assembly, pDelta, cracked, tryBars,
     concreteClass, prices, planSel,
     material, colFam, girFam, beaFam, colShape, girShape, beaShape, steelFy, steelFu])
@@ -1014,12 +1015,25 @@ export default function ModelSpace() {
   }
 
   /** Swap the model's cat-E node loads for the primary direction's case and
-   *  refresh the derived state shared by both E-generation paths. */
+   *  refresh the derived state shared by both E-generation paths. With
+   *  accidental torsion on, each directional case splits into ⟳/⟲ variants
+   *  carrying the ±0.05·L⊥ storey-torque couple (§208.7.2.7). */
   const commitECases = (rx: SeismicResult, rz: SeismicResult, baseOf: (axis: 'x' | 'z') => ModelLoad[]) => {
     if (!model) return
     setSeisXZ({ x: rx, z: rz })
-    setECases(eDirs.map((d) => dirCase(baseOf(d.includes('X') ? 'x' : 'z'), 'E', d)))
-    // commit the primary direction for the load-diagram overlay + drift check
+    const cases: LateralCase[] = []
+    for (const d of eDirs) {
+      const axis: 'x' | 'z' = d.includes('X') ? 'x' : 'z'
+      const c = dirCase(baseOf(axis), 'E', d)
+      if (!accTor) { cases.push(c); continue }
+      for (const s of [1, -1] as const) {
+        const tor = accidentalTorsionLoads(model, c.loads, axis, s)
+        cases.push({ name: `${c.name}${s > 0 ? '⟳' : '⟲'}`, kind: 'E', loads: [...c.loads, ...tor] })
+      }
+    }
+    setECases(cases)
+    // commit the primary direction (untorsioned pattern) for the load-diagram
+    // overlay + drift check
     const primary = dirCase(baseOf(primAxis), 'E', eDirs[0] ?? '+X')
     saveKeepModal({ ...model, loads: [...model.loads.filter((l) => !(l.cat === 'E' && l.kind === 'node')), ...primary.loads] })
   }
@@ -2530,6 +2544,13 @@ export default function ModelSpace() {
                   <span>
                     Method-B period (§208.5.2.2) — use the modal fundamental period per axis, capped at {Zf >= 0.4 ? '1.3' : '1.4'}·Ta.
                     {!modal && <span className="text-slate-500"> No modal result yet — run Modal (Dynamics) first, else Method A is used.</span>}
+                  </span>
+                </label>
+                <label className="col-span-full flex items-start gap-2 text-xs text-slate-600">
+                  <input type="checkbox" checked={accTor} onChange={(e) => setAccTor(e.target.checked)} className="mt-0.5" />
+                  <span>
+                    Accidental torsion ±5% (§208.7.2.7) — each E case splits into ⟳/⟲ variants carrying a ±0.05·L⊥ storey torque
+                    (a mass-weighted force couple about the level&apos;s mass centroid), enveloped by Design/Optimize.
                   </span>
                 </label>
                 <div className="col-span-full">


### PR DESCRIPTION
First of the two §208 follow-ups from #335. **Layer: L4/L5 engine + Loading-tab UI.**

## Engine — `accidentalTorsionLoads` (`engine/seismic.ts`)
NSCP 2015 §208.7.2.7: the centre of mass is assumed displaced ±5% of the plan dimension perpendicular to the load direction. That's statically equivalent to the storey force at the mass centroid **plus a torque `T = ±0.05·L⊥·F_storey`**, realised here as a self-equilibrating node-force couple in the load direction:

```
ΔF_i = T · m_i·d_i / Σ m_j·d_j²      (d = perpendicular offset from the storey mass centroid)
```

so `ΣΔF = 0` (base shear unchanged) and `ΣΔF·d = T` (torque exact). Because it's a plain force set, it works **with or without the rigid diaphragm** and needs no solver changes. Levels with no torsional lever (single frame line) contribute nothing rather than dividing by zero.

## UI
- Persisted, default-on "Accidental torsion ±5%" checkbox in the Seismic card.
- Both E-generation paths (static §208.5 and RSA §208.6.4 share `commitECases`) split each ±X/±Z case into **⟳/⟲ variants**, which flow into the same `LateralCase` envelope Design/Optimize consume. Torsion is computed from each case's own signed loads, so RSA patterns and −direction cases get consistent torques.

## Verification
- **1045 vitest pass** (5 new hand-statics tests: per-level ΣΔF = 0 with the exact 5% torque, ⟲ mirrors ⟳, Z-direction uses the X plan dimension, torque flips with the storey-force sign, single-frame-line returns empty). `tsc -b` clean.
- **Headless Chromium**: 4 directions → **8 cat-E cases**, design envelope grows 13 → **21 runs**, and **31 schedule rows are governed by a ⟳/⟲ variant** — the eccentricity genuinely changes member design, which is the point of P1-2. Toggle off → back to 4 cases. No console errors.

Next phase (P1-3, separate PR): orthogonal 100%+30% combination (§208.8.1) and vertical component Ev = 0.5·Ca·I·D in the strength combos (§208.4.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_