### PR TITLE
feat: orthogonal 100%+30% E cases + vertical component Ev (NSCP §208.8.1 / §208.4.1) — backlog P1-3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,11 +150,12 @@ Ordered: correctness first, then code completeness, then new capability.
    beams, 0.70Ig columns, 0.25Ig walls/flat plates). The frame runs on gross
    EI → drifts and P-Δ are unconservative. Implement as per-role factors in
    `modelBridge` section props (opt-out toggle), not inside `frame3d`.
-2. **Accidental torsion, 5% eccentricity** (NSCP §208.7.2.7) — required with
-   the rigid diaphragm + RS path. Apply as ±0.05·L storey torques through the
-   diaphragm master DOF.
-3. **Orthogonal effects 100%+30%** (§208.8.1) and **vertical component
-   Ev = 0.5·Ca·I·D** in the strength combos (`loadCombinations.ts`).
+2. ~~**Accidental torsion, 5% eccentricity** (NSCP §208.7.2.7)~~ — ✔ shipped:
+   `accidentalTorsionLoads` applies ±0.05·L⊥ storey torques as mass-weighted
+   node-force couples (works with and without the diaphragm).
+3. ~~**Orthogonal effects 100%+30%** (§208.8.1) and **vertical component
+   Ev = 0.5·Ca·I·D**~~ — ✔ shipped: `buildECases` (case composition) +
+   `withEv` (E-combo D-factor shift) in `pipeline.ts`/`seismic.ts`.
 
 ## P2 — the v1.0 gate
 4. **Fill `docs/ValidationMap.md`** — every row is ⬜ while 863 tests already

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -80,6 +80,12 @@ of the app. Everything runs **off the main thread** in a web worker
   self-equilibrating node-force couple (ΣΔF = 0, ΣΔF·d = ±0.05·L⊥·F_storey,
   mass-weighted about the storey mass centroid) — works with or without the
   rigid diaphragm; toggle in the Loading tab, on by default.
+- **Orthogonal 100%+30% + vertical Ev** (§208.8.1 / §208.4.1): `buildECases`
+  composes dirs × ±0.3·perpendicular × ⟳/⟲ torsion into the cat-E envelope
+  (up to 16 cases); `withEv` shifts the E-combo dead-load factors to
+  (1.2+0.5CaI)D and (0.9−0.5CaI)D with the effective factor in the combo name.
+  Toggles in the Loading tab: orthogonal off by default (conditional per code),
+  Ev on by default (strength design).
 - **Member force diagrams BMD/SFD** (PR #233): inline bending-moment and shear
   diagrams rendered on each member in the 3D view and Analysis tab. Uses the
   existing `xs[]`/`My[]`/`Mz[]`/`Vy[]` arrays on `F3MemberResult`.

--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import { generateGridModel, buildGravityLoads, removeNode, enforceSectionHierarchy, refreshSelfWeight, splitSharedSections, barContinuityGroups } from './modelBuilder'
-import { designStructure, optimizeStructure, selectBarDiameters, designOK, RC_LIMITS, type LateralCase } from './pipeline'
+import { designStructure, optimizeStructure, selectBarDiameters, designOK, withEv, RC_LIMITS, type LateralCase } from './pipeline'
 import { nextHeavierW } from './aiscSections'
 import { computeSeismic } from './seismic'
+import { nscpCombos } from './beamAnalysis'
 import { validateMesh } from './meshValidation'
 import type { RectSection, ModelLoad } from './model'
 
@@ -773,5 +774,35 @@ describe('model editing helpers', () => {
     expect(out.loads.every((l) => l.kind !== 'node' || l.node !== 'n0.0.1')).toBe(true)
     // area loads on the removed slab are gone too
     expect(out.loads.filter((l) => l.kind === 'area')).toHaveLength(0)
+  })
+})
+
+describe('§208.4.1 vertical seismic component Ev in the combo factors', () => {
+  const Ev = 0.5 * 0.44 * 1.0   // Zone 4, I = 1 → 0.22
+
+  it('shifts D on the E combos only: 1.2+Ev additive, 0.9−Ev uplift', () => {
+    const combos = withEv(nscpCombos(1.0), Ev)
+    const add = combos.find((c) => (c.f.E ?? 0) !== 0 && c.f.D! > 1)!
+    const uplift = combos.find((c) => (c.f.E ?? 0) !== 0 && c.f.D! < 1)!
+    expect(add.f.D).toBeCloseTo(1.2 + Ev, 9)
+    expect(uplift.f.D).toBeCloseTo(0.9 - Ev, 9)
+    expect(add.name).toContain('1.42D')
+    expect(uplift.name).toContain('0.68D')
+    // gravity/wind combos untouched
+    for (const c of combos.filter((c) => !(c.f.E ?? 0))) {
+      const orig = nscpCombos(1.0).find((o) => o.name === c.name)!
+      expect(c.f).toEqual(orig.f)
+    }
+  })
+
+  it('identity when Ev is undefined or zero', () => {
+    expect(withEv(nscpCombos(1.0), undefined)).toEqual(nscpCombos(1.0))
+    expect(withEv(nscpCombos(1.0), 0)).toEqual(nscpCombos(1.0))
+  })
+
+  it('uplift combo net dead-load factor drops — reactions shrink under 0.9D−Ev', () => {
+    const Evd = withEv(nscpCombos(1.0), Ev)
+    const up = Evd.find((c) => (c.f.E ?? 0) !== 0 && c.f.D! < 0.9)!
+    expect(up.f.D).toBeLessThan(0.9)   // more severe for uplift/overturning checks
   })
 })

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -56,6 +56,10 @@ export interface AnalyzeOptions {
    *  0.70Ig columns/braces) on concrete members. Default off at the API level;
    *  the Model Space UI enables it by default. */
   crackedSections?: boolean
+  /** Vertical seismic component addend Ev = 0.5·Ca·I (NSCP §208.4.1): the
+   *  E-carrying combos get D → D+Ev when additive (1.2D+1.0E) and D → D−Ev on
+   *  the counteracting uplift combo (0.9D+1.0E). Omit → gross combos. */
+  Ev?: number
 }
 
 export interface BeamSectionDesign {
@@ -407,6 +411,41 @@ function defaultLateralCases(model: StructuralModel): LateralCase[] {
   return out
 }
 
+/** §208.4.1 vertical seismic component: E = ρ·Eh + Ev with Ev = 0.5·Ca·I·D for
+ *  strength design. Folded into the E-carrying combos as a dead-load factor
+ *  shift — +Ev on the additive combo (D ≥ 1.0), −Ev on the counteracting 0.9D
+ *  uplift combo — with the effective factor spelled out in the combo name. */
+export function withEv(combos: Combo[], Ev?: number): Combo[] {
+  if (!Ev) return combos
+  return combos.map((c) => {
+    const D = c.f.D ?? 0
+    if (!(c.f.E ?? 0) || D === 0) return c
+    const newD = D >= 1.0 ? D + Ev : D - Ev
+    return { name: c.name.replace(`${D}D`, `${newD.toFixed(2)}D`), f: { ...c.f, D: newD } }
+  })
+}
+
+/** Expand every NSCP combination into its directional variants (once per
+ *  lateral E/W case when the combination carries that factor). Shared by the
+ *  serial and FramePool run builders. */
+function buildComboTasks(lateral: LateralCase[], opts: AnalyzeOptions): { name: string; combo: Combo; lat: F3Load[] }[] {
+  const toF3 = (l: ModelLoad): F3Load =>
+    ({ kind: 'node', node: (l as { node: string }).node, Fx: (l as { Fx?: number }).Fx, Fy: (l as { Fy?: number }).Fy, Fz: (l as { Fz?: number }).Fz, cat: l.cat })
+  const eCases = lateral.filter((c) => c.kind === 'E')
+  const wCases = lateral.filter((c) => c.kind === 'W')
+  const tasks: { name: string; combo: Combo; lat: F3Load[] }[] = []
+  for (const combo of withEv(nscpCombos(opts.f1 ?? 1.0), opts.Ev)) {
+    const hasE = (combo.f.E ?? 0) !== 0
+    const hasW = (combo.f.W ?? 0) !== 0
+    const variants: { tag: string; lat: F3Load[] }[] =
+      hasE && eCases.length ? eCases.map((c) => ({ tag: c.name, lat: c.loads.map(toF3) }))
+        : hasW && wCases.length ? wCases.map((c) => ({ tag: c.name, lat: c.loads.map(toF3) }))
+          : [{ tag: '', lat: [] }]
+    for (const v of variants) tasks.push({ name: combo.name + (v.tag ? ` · ${v.tag}` : ''), combo, lat: v.lat })
+  }
+  return tasks
+}
+
 /** Build the load cases to envelope: every NSCP combination, expanded once per
  *  directional lateral case (E/W) when the combination carries that factor. */
 function buildRuns(model: StructuralModel, opts: AnalyzeOptions, onProgress?: ProgressFn) {
@@ -417,22 +456,8 @@ function buildRuns(model: StructuralModel, opts: AnalyzeOptions, onProgress?: Pr
   const br = modelToFrame3D(gravityModel, { useShells: false, crackedSections: opts.crackedSections })
 
   const lateral = opts.lateral?.length ? opts.lateral : defaultLateralCases(model)
-  const toF3 = (l: ModelLoad): F3Load =>
-    ({ kind: 'node', node: (l as { node: string }).node, Fx: (l as { Fx?: number }).Fx, Fy: (l as { Fy?: number }).Fy, Fz: (l as { Fz?: number }).Fz, cat: l.cat })
-  const eCases = lateral.filter((c) => c.kind === 'E')
-  const wCases = lateral.filter((c) => c.kind === 'W')
-
   // expand every combo into its directional variants up front so progress has a total
-  const tasks: { name: string; combo: Combo; lat: F3Load[] }[] = []
-  for (const combo of nscpCombos(opts.f1 ?? 1.0)) {
-    const hasE = (combo.f.E ?? 0) !== 0
-    const hasW = (combo.f.W ?? 0) !== 0
-    const variants: { tag: string; lat: F3Load[] }[] =
-      hasE && eCases.length ? eCases.map((c) => ({ tag: c.name, lat: c.loads.map(toF3) }))
-        : hasW && wCases.length ? wCases.map((c) => ({ tag: c.name, lat: c.loads.map(toF3) }))
-          : [{ tag: '', lat: [] }]
-    for (const v of variants) tasks.push({ name: combo.name + (v.tag ? ` · ${v.tag}` : ''), combo, lat: v.lat })
-  }
+  const tasks = buildComboTasks(lateral, opts)
 
   const precomp = precomputeFrame(br.nodes, br.members, br.supports)
   const runs: FrameRun[] = []
@@ -789,21 +814,7 @@ async function buildRunsParallel(
   const br = modelToFrame3D(gravityModel, { useShells: false, crackedSections: opts.crackedSections })
 
   const lateral = opts.lateral?.length ? opts.lateral : defaultLateralCases(model)
-  const toF3 = (l: ModelLoad): F3Load =>
-    ({ kind: 'node', node: (l as { node: string }).node, Fx: (l as { Fx?: number }).Fx, Fy: (l as { Fy?: number }).Fy, Fz: (l as { Fz?: number }).Fz, cat: l.cat })
-  const eCases = lateral.filter((c) => c.kind === 'E')
-  const wCases = lateral.filter((c) => c.kind === 'W')
-
-  const tasks: { name: string; combo: Combo; lat: F3Load[] }[] = []
-  for (const combo of nscpCombos(opts.f1 ?? 1.0)) {
-    const hasE = (combo.f.E ?? 0) !== 0
-    const hasW = (combo.f.W ?? 0) !== 0
-    const variants: { tag: string; lat: F3Load[] }[] =
-      hasE && eCases.length ? eCases.map((c) => ({ tag: c.name, lat: c.loads.map(toF3) }))
-        : hasW && wCases.length ? wCases.map((c) => ({ tag: c.name, lat: c.loads.map(toF3) }))
-          : [{ tag: '', lat: [] }]
-    for (const v of variants) tasks.push({ name: combo.name + (v.tag ? ` · ${v.tag}` : ''), combo, lat: v.lat })
-  }
+  const tasks = buildComboTasks(lateral, opts)
 
   const precomp = precomputeFrame(br.nodes, br.members, br.supports)
   await pool.init(serializePrecomp(precomp))

--- a/webapp/src/engine/seismic.test.ts
+++ b/webapp/src/engine/seismic.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { computeSeismic, storeyWeights, driftCheck, accidentalTorsionLoads } from './seismic'
+import { computeSeismic, storeyWeights, driftCheck, accidentalTorsionLoads, buildECases } from './seismic'
 import { buildSeismicMass } from './modal'
 import { generateGridModel } from './modelBuilder'
 import { modelToFrame3D } from './modelBridge'
@@ -227,5 +227,60 @@ describe('drift check', () => {
       expect(row.limit).toBeCloseTo(0.025 * row.hs, 9)   // T < 0.7 s
       expect(row.ok).toBe(row.dM <= row.limit + 1e-9)
     }
+  })
+})
+
+describe('buildECases — §208.8.1 orthogonal 100%+30% composition', () => {
+  const m = makeModel()
+  const seis = computeSeismic(m, params)!
+  const baseX = seis.loads
+  const baseZ = seis.loads.map((l) => ({ kind: 'node' as const, node: (l as { node: string }).node, Fz: (l as { Fx?: number }).Fx, cat: 'E' as const }))
+  const dirs = ['+X', '-X', '+Z', '-Z']
+  const sumOf = (loads: ReturnType<typeof buildECases>[number]['loads'], k: 'Fx' | 'Fz') =>
+    loads.reduce((s, l) => s + ((l as unknown as Record<string, number | undefined>)[k] ?? 0), 0)
+  const V = baseX.reduce((s, l) => s + ((l as { Fx?: number }).Fx ?? 0), 0)   // total base shear
+
+  it('case counts: dirs × orth30 × torsion', () => {
+    expect(buildECases(m, baseX, baseZ, { dirs })).toHaveLength(4)
+    expect(buildECases(m, baseX, baseZ, { dirs, torsion: true })).toHaveLength(8)
+    expect(buildECases(m, baseX, baseZ, { dirs, orth30: true })).toHaveLength(8)
+    expect(buildECases(m, baseX, baseZ, { dirs, orth30: true, torsion: true })).toHaveLength(16)
+  })
+
+  it('100%+30%: ΣFx = ±V and ΣFz = ±0.3·V on an X-primary case', () => {
+    const cases = buildECases(m, baseX, baseZ, { dirs: ['+X'], orth30: true })
+    expect(cases.map((c) => c.name)).toEqual(['E+X+0.3Z', 'E+X−0.3Z'])
+    for (const c of cases) {
+      expect(sumOf(c.loads, 'Fx')).toBeCloseTo(V, 6)
+      expect(Math.abs(sumOf(c.loads, 'Fz'))).toBeCloseTo(0.3 * V, 6)
+    }
+    expect(sumOf(cases[0].loads, 'Fz')).toBeCloseTo(0.3 * V, 6)
+    expect(sumOf(cases[1].loads, 'Fz')).toBeCloseTo(-0.3 * V, 6)
+  })
+
+  it('−Z primary: ΣFz = −V, ΣFx = ±0.3·V', () => {
+    const cases = buildECases(m, baseX, baseZ, { dirs: ['-Z'], orth30: true })
+    for (const c of cases) {
+      expect(sumOf(c.loads, 'Fz')).toBeCloseTo(-V, 6)
+      expect(Math.abs(sumOf(c.loads, 'Fx'))).toBeCloseTo(0.3 * V, 6)
+    }
+  })
+
+  it('torsion on a combined case adds nothing to the direction sums (couples are self-equilibrating)', () => {
+    const cases = buildECases(m, baseX, baseZ, { dirs: ['+X'], orth30: true, torsion: true })
+    expect(cases).toHaveLength(4)
+    for (const c of cases) {
+      expect(sumOf(c.loads, 'Fx')).toBeCloseTo(V, 6)
+      expect(Math.abs(sumOf(c.loads, 'Fz'))).toBeCloseTo(0.3 * V, 6)
+      expect(c.name).toMatch(/E\+X[+−]0\.3Z[⟳⟲]/u)
+    }
+  })
+
+  it('plain single-direction case matches the base loads exactly', () => {
+    const [c] = buildECases(m, baseX, baseZ, { dirs: ['+X'] })
+    expect(c.name).toBe('E+X')
+    expect(c.loads).toHaveLength(baseX.length)
+    expect(sumOf(c.loads, 'Fx')).toBeCloseTo(V, 9)
+    expect(sumOf(c.loads, 'Fz')).toBe(0)
   })
 })

--- a/webapp/src/engine/seismic.ts
+++ b/webapp/src/engine/seismic.ts
@@ -15,6 +15,7 @@
 // or 0.020·hs otherwise.
 // ─────────────────────────────────────────────────────────────────────────
 import type { StructuralModel, ModelLoad } from './model'
+import type { LateralCase } from './pipeline'
 import { buildSeismicMass } from './modal'
 
 export interface SeismicParams {
@@ -206,6 +207,70 @@ export function accidentalTorsionLoads(
       out.push(dir === 'x'
         ? { kind: 'node', node: n.id, Fx: dF, cat: 'E' }
         : { kind: 'node', node: n.id, Fz: dF, cat: 'E' })
+    }
+  }
+  return out
+}
+
+// ── Directional E-case builder (§208.7.2.7 + §208.8.1) ───────────────────
+
+export interface ECaseOpts {
+  /** Directions to envelope: '+X' | '-X' | '+Z' | '-Z'. */
+  dirs: string[]
+  /** §208.7.2.7 accidental torsion: split every case into ⟳/⟲ variants. */
+  torsion?: boolean
+  /** Accidental eccentricity ratio (default 0.05). */
+  ecc?: number
+  /** §208.8.1 orthogonal effects: add ±30% of the perpendicular direction to
+   *  every case (100%+30% rule — corner columns / intersecting systems). */
+  orth30?: boolean
+}
+
+const scaleNodeLoads = (loads: ModelLoad[], f: number): ModelLoad[] =>
+  loads.map((l) => l.kind === 'node'
+    ? {
+      ...l,
+      ...(l.Fx !== undefined ? { Fx: l.Fx * f } : {}),
+      ...(l.Fy !== undefined ? { Fy: l.Fy * f } : {}),
+      ...(l.Fz !== undefined ? { Fz: l.Fz * f } : {}),
+    }
+    : l)
+
+/**
+ * Expands per-axis base E-load sets (from the static §208.5 or RSA §208.6.4
+ * procedure — `baseX` carries Fx, `baseZ` carries Fz, both in the + sense)
+ * into the directional cat-E cases the design pipeline envelopes:
+ *   dirs × (orth30 ? ±0.3·perpendicular : 1) × (torsion ? ⟳/⟲ : 1).
+ * The accidental-torsion couple is built per component (100% primary and 30%
+ * perpendicular each carry their own ±5%·L⊥ torque, same eccentricity sense).
+ */
+export function buildECases(
+  model: StructuralModel, baseX: ModelLoad[], baseZ: ModelLoad[], o: ECaseOpts,
+): LateralCase[] {
+  const out: LateralCase[] = []
+  for (const d of o.dirs) {
+    const axis: 'x' | 'z' = d.includes('X') ? 'x' : 'z'
+    const sign = d.startsWith('-') ? -1 : 1
+    const prim = scaleNodeLoads(axis === 'x' ? baseX : baseZ, sign)
+    const perpAxis: 'x' | 'z' = axis === 'x' ? 'z' : 'x'
+    const perpBase = perpAxis === 'x' ? baseX : baseZ
+    const perpVariants = o.orth30
+      ? ([1, -1] as const).map((ps) => ({
+        tag: `${ps > 0 ? '+' : '−'}0.3${perpAxis.toUpperCase()}`,
+        loads: scaleNodeLoads(perpBase, 0.3 * ps),
+      }))
+      : [{ tag: '', loads: [] as ModelLoad[] }]
+    for (const pv of perpVariants) {
+      const name = `E${d}${pv.tag}`
+      const loads = [...prim, ...pv.loads]
+      if (!o.torsion) { out.push({ name, kind: 'E', loads }); continue }
+      for (const s of [1, -1] as const) {
+        const tor = [
+          ...accidentalTorsionLoads(model, prim, axis, s, o.ecc),
+          ...(pv.loads.length ? accidentalTorsionLoads(model, pv.loads, perpAxis, s, o.ecc) : []),
+        ]
+        out.push({ name: `${name}${s > 0 ? '⟳' : '⟲'}`, kind: 'E', loads: [...loads, ...tor] })
+      }
     }
   }
   return out

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -22,7 +22,7 @@ import type { SolveProgress } from '../engine/progress'
 import { TABLE_204_1, TABLE_204_2, sdlItemKPa, sdlTotal, type SdlItem } from '../engine/deadLoads'
 import { TABLE_205_1, TABLE_206 } from '../engine/liveLoads'
 import type { ConcreteClass } from '../engine/quantities'
-import { computeSeismic, accidentalTorsionLoads, type SeismicResult, type DriftRow } from '../engine/seismic'
+import { computeSeismic, buildECases, type SeismicResult, type DriftRow } from '../engine/seismic'
 import { columnKFactors, type ColumnK } from '../engine/effectiveLength'
 import { freqFromDeflection, dg11Walking, DG11_OCCUPANCY } from '../engine/floorVibration'
 import { buildSeismicMass, GRAVITY } from '../engine/modal'
@@ -734,6 +734,8 @@ export default function ModelSpace() {
   const [seisXZ, setSeisXZ] = useState<{ x: SeismicResult; z: SeismicResult } | null>(null)
   const [methodB, setMethodB] = useState(b('methodB', true))          // §208.5.2.2 analytical period (needs a modal run)
   const [accTor, setAccTor] = useState(b('accTor', true))             // §208.7.2.7 accidental torsion ±5% E-case variants
+  const [orth30, setOrth30] = useState(b('orth30', false))           // §208.8.1 orthogonal 100%+30% E cases
+  const [evOn, setEvOn] = useState(b('evOn', true))                   // §208.4.1 vertical component Ev = 0.5·Ca·I·D
   const [rsaRegular, setRsaRegular] = useState(b('rsaRegular', true)) // §208.6.4.2 floors: 0.9·V_B & 0.8·V_A vs 1.0·V_B
   const [rsaGen, setRsaGen] = useState<{ x: RsaLateralResult; z: RsaLateralResult } | null>(null)   // RSA-derived E cases
   const [drift, setDrift] = useState<DriftRow[] | null>(null)
@@ -853,7 +855,7 @@ export default function ModelSpace() {
       sessionStorage.setItem(INPUTS_KEY, JSON.stringify({
         baysX, baysZ, storeyH, colB, colH, girB, girH, beaB, beaH,
         fc, fy, barDia, tieDia, cover, slabThk, gammaC, qD, qL,
-        qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs, methodB, accTor, rsaRegular,
+        qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs, methodB, accTor, orth30, evOn, rsaRegular,
         Vw, expo, Kzt, wDirs, assembly, pDelta, cracked, tryBars,
         concreteClass, prices, planSel,
         material, colFam, girFam, beaFam, colShape, girShape, beaShape, steelFy, steelFu,
@@ -861,7 +863,7 @@ export default function ModelSpace() {
     } catch { /* quota — ignore */ }
   }, [baysX, baysZ, storeyH, colB, colH, girB, girH, beaB, beaH,
     fc, fy, barDia, tieDia, cover, slabThk, gammaC, qD, qL,
-    qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs, methodB, accTor, rsaRegular,
+    qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs, methodB, accTor, orth30, evOn, rsaRegular,
     Vw, expo, Kzt, wDirs, assembly, pDelta, cracked, tryBars,
     concreteClass, prices, planSel,
     material, colFam, girFam, beaFam, colShape, girShape, beaShape, steelFy, steelFu])
@@ -904,7 +906,8 @@ export default function ModelSpace() {
   // Only applies when E loads are present (user clicked "Generate E cases").
   const hasELoads = model?.loads.some((l) => l.cat === 'E') ?? false
   const seismicSystem: 'gravity' | 'imf' | 'smf' = hasELoads ? (Rw >= 8 ? 'smf' : Rw >= 5 ? 'imf' : 'gravity') : 'gravity'
-  const anaOpts = { f1: fLive, pDelta, lateral, seismicSystem, crackedSections: cracked }
+  // §208.4.1 vertical seismic component folded into the E-combo D factors.
+  const anaOpts = { f1: fLive, pDelta, lateral, seismicSystem, crackedSections: cracked, Ev: evOn ? 0.5 * Ca * Ie : undefined }
 
   const analyze = () => {
     if (!model || busy || meshErrors) return   // §1 fail-fast: don't solve a singular mesh
@@ -1015,23 +1018,13 @@ export default function ModelSpace() {
   }
 
   /** Swap the model's cat-E node loads for the primary direction's case and
-   *  refresh the derived state shared by both E-generation paths. With
-   *  accidental torsion on, each directional case splits into ⟳/⟲ variants
-   *  carrying the ±0.05·L⊥ storey-torque couple (§208.7.2.7). */
+   *  refresh the derived state shared by both E-generation paths. The engine
+   *  builder expands dirs × ±0.3·perpendicular (§208.8.1) × ⟳/⟲ accidental
+   *  torsion (§208.7.2.7) per the toggles. */
   const commitECases = (rx: SeismicResult, rz: SeismicResult, baseOf: (axis: 'x' | 'z') => ModelLoad[]) => {
     if (!model) return
     setSeisXZ({ x: rx, z: rz })
-    const cases: LateralCase[] = []
-    for (const d of eDirs) {
-      const axis: 'x' | 'z' = d.includes('X') ? 'x' : 'z'
-      const c = dirCase(baseOf(axis), 'E', d)
-      if (!accTor) { cases.push(c); continue }
-      for (const s of [1, -1] as const) {
-        const tor = accidentalTorsionLoads(model, c.loads, axis, s)
-        cases.push({ name: `${c.name}${s > 0 ? '⟳' : '⟲'}`, kind: 'E', loads: [...c.loads, ...tor] })
-      }
-    }
-    setECases(cases)
+    setECases(buildECases(model, baseOf('x'), baseOf('z'), { dirs: eDirs, torsion: accTor, orth30 }))
     // commit the primary direction (untorsioned pattern) for the load-diagram
     // overlay + drift check
     const primary = dirCase(baseOf(primAxis), 'E', eDirs[0] ?? '+X')
@@ -2551,6 +2544,20 @@ export default function ModelSpace() {
                   <span>
                     Accidental torsion ±5% (§208.7.2.7) — each E case splits into ⟳/⟲ variants carrying a ±0.05·L⊥ storey torque
                     (a mass-weighted force couple about the level&apos;s mass centroid), enveloped by Design/Optimize.
+                  </span>
+                </label>
+                <label className="col-span-full flex items-start gap-2 text-xs text-slate-600">
+                  <input type="checkbox" checked={orth30} onChange={(e) => setOrth30(e.target.checked)} className="mt-0.5" />
+                  <span>
+                    Orthogonal effects 100%+30% (§208.8.1) — every E case also carries ±30% of the perpendicular direction.
+                    Required for corner columns / elements common to two intersecting lateral systems; doubles the case count.
+                  </span>
+                </label>
+                <label className="col-span-full flex items-start gap-2 text-xs text-slate-600">
+                  <input type="checkbox" checked={evOn} onChange={(e) => setEvOn(e.target.checked)} className="mt-0.5" />
+                  <span>
+                    Vertical component Ev = 0.5·Ca·I·D (§208.4.1) — E combos become {(1.2 + 0.5 * Ca * Ie).toFixed(2)}D + 1.0E + f₁L + 0.2S
+                    and {(0.9 - 0.5 * Ca * Ie).toFixed(2)}D + 1.0E (uplift).
                   </span>
                 </label>
                 <div className="col-span-full">


### PR DESCRIPTION
Second §208 follow-up from #335, completing backlog item P1-3 (and closing out the P1 correctness tier together with #337). **Layer: L4 engine + Loading-tab UI.**

## Orthogonal effects 100%+30% — `buildECases` (`engine/seismic.ts`)
§208.8.1: elements common to two intersecting lateral systems (corner columns, etc.) must be designed for 100% of the prescribed forces in one direction plus 30% perpendicular. Loads are linear, so the combined cases are synthesized as load sets — **no solver or pipeline changes**:

```
dirs (±X/±Z) × (±0.3·perpendicular) × (⟳/⟲ accidental torsion) → up to 16 cat-E LateralCases
```

Each component (100% primary, 30% perpendicular) carries its own ±5%·L⊥ torsion couple with a consistent eccentricity sense. The E-case composition moved from `ModelSpace.commitECases` into the engine, so the static §208.5 and RSA §208.6.4 paths and every toggle combination share one unit-tested code path.

## Vertical component Ev — `withEv` (`engine/pipeline.ts`)
§208.4.1: `E = ρ·Eh + Ev` with `Ev = 0.5·Ca·I·D` for strength design. Folded into the E-carrying combos as a dead-load factor shift — `(1.2+0.5CaI)D + 1.0E + f₁L + 0.2S` and `(0.9−0.5CaI)D + 1.0E` for uplift — with the effective factor spelled out in the combo name (e.g. `1.42D`, `0.68D` at Ca=0.44, I=1). Applied inside a new shared `buildComboTasks`, which also de-duplicates the previously copy-pasted combo-expansion loop between the serial and FramePool run builders.

## UI
- "Orthogonal effects 100%+30%" checkbox — **off by default** (the provision is conditional; label says when it's required).
- "Vertical component Ev" checkbox — **on by default** (required for strength design), label previews the shifted factors live from Ca·I.
- Both persisted alongside the other seismic toggles.

## Verification
- **1053 vitest pass** (8 new: Ev shifts D on E-combos only with renamed labels and identity for Ev=0/undefined; case counts 4/8/16 by toggles; combined-case direction sums ΣF = ±V and ±0.3V exactly; torsion neutrality on combined cases; plain case equals base loads). `tsc -b` clean.
- **Headless Chromium**: all toggles on → 16 cat-E cases, design envelope **37 runs**; **33 schedule rows are governed by an Ev-shifted combo and 33 name a 0.3-orthogonal case** — both provisions actively change member design. No console errors.

Docs: HANDOFF updated; CLAUDE.md P1 backlog items 2 and 3 marked shipped.

Not in scope: the redundancy factor ρ (taken as 1.0, as before) and wind-specific torsion provisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_