### PR TITLE
feat: Timoshenko shear deformation in frame elements (Φ = 12EI/G·As·L²) — backlog P3-5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,8 +164,10 @@ Ordered: correctness first, then code completeness, then new capability.
    Fix stale checkboxes in `docs/Roadmap.md` (rock anchors are shipped).
 
 ## P3 — analysis completeness
-5. **Timoshenko shear deformation** in frame elements (deep girders, squat
-   columns read too stiff; shells already handle it).
+5. ~~**Timoshenko shear deformation** in frame elements~~ — ✔ shipped:
+   Φ-modified `kLocal` + per-family shear areas in the bridge (opt-in
+   `shearDeformation`, UI default on). FEMs stay Euler; modal/pushover/
+   buckling still run the Euler element (follow-up if needed).
 6. **Direct-integration time-history** on the full MDOF system with Rayleigh
    damping (currently modal superposition only) — prerequisite for nonlinear TH.
 7. Tension-only / compression-only members (braces, uplift springs);

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -86,6 +86,13 @@ of the app. Everything runs **off the main thread** in a web worker
   (1.2+0.5CaI)D and (0.9−0.5CaI)D with the effective factor in the combo name.
   Toggles in the Loading tab: orthogonal off by default (conditional per code),
   Ev on by default (strength design).
+- **Timoshenko shear deformation** (P3-5): `kLocal` takes Przemieniecki
+  Φ = 12EI/(G·As·L²) modifiers per bending plane; the bridge supplies shear
+  areas per section type (rect 5/6·A, W web d·tw / flanges 5/6·2·bf·tf,
+  HSS walls, tube 0.5·A) behind a `shearDeformation` BridgeOpt — API off /
+  UI on, like crackedSections. Fixed-end forces stay Euler (exact for UDL;
+  O(Φ) approximation on asymmetric point/VDL loads). Modal/pushover/buckling
+  paths still run the Euler element.
 - **Member force diagrams BMD/SFD** (PR #233): inline bending-moment and shear
   diagrams rendered on each member in the 3D view and Analysis tab. Uses the
   existing `xs[]`/`My[]`/`Mz[]`/`Vy[]` arrays on `F3MemberResult`.

--- a/webapp/src/engine/frame3d.test.ts
+++ b/webapp/src/engine/frame3d.test.ts
@@ -609,3 +609,62 @@ describe('frame3d — local-axis rotation (ETABS local axis 2 angle)', () => {
     expect(beam0.rot).toBeUndefined()   // 0 → omitted
   })
 })
+
+describe('frame3d — Timoshenko shear deformation (Φ = 12EI/(G·As·L²))', () => {
+  const L = 3
+  const Asy = (5 / 6) * A, Asz = (5 / 6) * A
+  const GAsy = (G * Asy) / 1000, GAsz = (G * Asz) / 1000   // kN
+  const secT = { ...sec, Asy, Asz }
+  const cantT = (loads: F3Load[], over: Partial<F3Member> = {}) => solveFrame3D(
+    [{ id: 'a', x: 0, y: 0, z: 0 }, { id: 'b', x: L, y: 0, z: 0 }] as F3Node[],
+    [{ id: 'm', i: 'a', j: 'b', ...secT, ...over } as F3Member],
+    [{ node: 'a', fixity: 'fixed' }] as F3Support[],
+    loads)!
+
+  it('tip load (−Y): δ = PL³/3EIz + PL/GAsy — the 2-node element is nodally exact', () => {
+    const P = 20
+    const r = cantT([{ kind: 'node', node: 'b', Fy: -P, cat: 'D' }])
+    expect(r.d[6 + 1]).toBeCloseTo(-(P * L ** 3 / (3 * EIz) + P * L / GAsy), 9)
+    // statics are Φ-independent: base moment and reaction unchanged
+    expect(Math.abs(r.members[0].Mz[0])).toBeCloseTo(P * L, 3)
+    expect(r.reactions[0].F[1]).toBeCloseTo(P, 6)
+  })
+
+  it('second plane (−Z): δ = PL³/3EIy + PL/GAsz', () => {
+    const P = 15
+    const r = cantT([{ kind: 'node', node: 'b', Fz: -P, cat: 'D' }])
+    expect(r.d[6 + 2]).toBeCloseTo(-(P * L ** 3 / (3 * EIy) + P * L / GAsz), 9)
+  })
+
+  it('shear share is significant for a squat member and vanishes for a slender one', () => {
+    const P = 20
+    const euler = (P * L ** 3) / (3 * EIz)
+    const r = cantT([{ kind: 'node', node: 'b', Fy: -P, cat: 'D' }])
+    expect(Math.abs(r.d[6 + 1])).toBeGreaterThan(euler * 1.005)   // 300×500 over 3 m: Φ ≈ 2–3%
+    // As → ∞ recovers Euler–Bernoulli exactly
+    const stiff = cantT([{ kind: 'node', node: 'b', Fy: -P, cat: 'D' }], { Asy: 1e15, Asz: 1e15 })
+    expect(stiff.d[6 + 1]).toBeCloseTo(-euler, 9)
+  })
+
+  it('omitted shear areas keep the classic Euler element (regression anchor)', () => {
+    const P = 20
+    const r = cantT([{ kind: 'node', node: 'b', Fy: -P, cat: 'D' }], { Asy: undefined, Asz: undefined })
+    expect(r.d[6 + 1]).toBeCloseTo(-(P * L ** 3) / (3 * EIz), 9)
+  })
+
+  it('fixed-fixed centre load across two elements: δ = PL³/192EI + PL/4GAs', () => {
+    const P = 40
+    const r = solveFrame3D(
+      [{ id: 'a', x: 0, y: 0, z: 0 }, { id: 'c', x: L / 2, y: 0, z: 0 }, { id: 'b', x: L, y: 0, z: 0 }] as F3Node[],
+      [
+        { id: 'm1', i: 'a', j: 'c', ...secT } as F3Member,
+        { id: 'm2', i: 'c', j: 'b', ...secT } as F3Member,
+      ],
+      [{ node: 'a', fixity: 'fixed' }, { node: 'b', fixity: 'fixed' }] as F3Support[],
+      [{ kind: 'node', node: 'c', Fy: -P, cat: 'D' }])!
+    expect(r.d[6 + 1]).toBeCloseTo(-(P * L ** 3 / (192 * EIz) + P * L / (4 * GAsy)), 9)
+    // equilibrium: ΣRy = P, symmetric halves
+    expect(r.reactions.reduce((t, q) => t + q.F[1], 0)).toBeCloseTo(P, 6)
+    expect(r.reactions[0].F[1]).toBeCloseTo(P / 2, 6)
+  })
+})

--- a/webapp/src/engine/frame3d.ts
+++ b/webapp/src/engine/frame3d.ts
@@ -34,6 +34,12 @@ export interface F3Member {
   A: number                 // mm²
   Iy: number; Iz: number    // mm⁴ (Iz: bending under gravity for horizontal members)
   J: number                 // mm⁴
+  /** Shear areas for Timoshenko shear deformation, mm² (Asy: shear along y′,
+   *  pairs with bending about z′; Asz: along z′, pairs with bending about y′).
+   *  Omitted or 0 → rigid in shear (classic Euler–Bernoulli element). Note:
+   *  fixed-end forces stay Euler — exact for symmetric member loads (UDL);
+   *  asymmetric point/VDL FEMs carry a small O(Φ) approximation. */
+  Asy?: number; Asz?: number
   /** Released local DOFs at end i: [ux, uy, uz, θx, θy, θz] (true = force/moment = 0). */
   relI?: [boolean, boolean, boolean, boolean, boolean, boolean]
   /** Released local DOFs at end j: [ux, uy, uz, θx, θy, θz]. */
@@ -156,20 +162,28 @@ export function appliedResultant(loads: F3Load[], memberLen: (id: string) => num
   return [fx, fy, fz]
 }
 
-/** Local 12×12 stiffness. */
-function kLocal(EA: number, GJ: number, EIy: number, EIz: number, L: number): number[][] {
+/** Local 12×12 stiffness. `phiY`/`phiZ` are the Timoshenko shear-flexibility
+ *  parameters Φ = 12EI/(G·As·L²) per bending plane (Przemieniecki, Theory of
+ *  Matrix Structural Analysis §5.6): the bending blocks become
+ *    12EI/L³(1+Φ), 6EI/L²(1+Φ), (4+Φ)EI/L(1+Φ), (2−Φ)EI/L(1+Φ)
+ *  Φ = 0 (the default) recovers the Euler–Bernoulli element exactly. */
+function kLocal(EA: number, GJ: number, EIy: number, EIz: number, L: number, phiY = 0, phiZ = 0): number[][] {
   const k = Array.from({ length: 12 }, () => new Array(12).fill(0))
   const set = (r: number, c: number, v: number) => { k[r][c] = v; k[c][r] = v }
   set(0, 0, EA / L); set(0, 6, -EA / L); set(6, 6, EA / L)
   set(3, 3, GJ / L); set(3, 9, -GJ / L); set(9, 9, GJ / L)
-  // bending about z′ (uy, θz)
-  const az = (12 * EIz) / L ** 3, bz = (6 * EIz) / L ** 2, cz = (4 * EIz) / L, dz = (2 * EIz) / L
+  // bending about z′ (uy, θz) — shear flexibility from Vy → phiZ
+  const fz = 1 + phiZ
+  const az = (12 * EIz) / (L ** 3 * fz), bz = (6 * EIz) / (L ** 2 * fz)
+  const cz = ((4 + phiZ) * EIz) / (L * fz), dz = ((2 - phiZ) * EIz) / (L * fz)
   set(1, 1, az); set(1, 5, bz); set(1, 7, -az); set(1, 11, bz)
   set(5, 5, cz); set(5, 7, -bz); set(5, 11, dz)
   set(7, 7, az); set(7, 11, -bz)
   set(11, 11, cz)
-  // bending about y′ (uz, θy) — mirrored signs
-  const ay = (12 * EIy) / L ** 3, by = (6 * EIy) / L ** 2, cy = (4 * EIy) / L, dy = (2 * EIy) / L
+  // bending about y′ (uz, θy) — mirrored signs; shear flexibility from Vz → phiY
+  const fy = 1 + phiY
+  const ay = (12 * EIy) / (L ** 3 * fy), by = (6 * EIy) / (L ** 2 * fy)
+  const cy = ((4 + phiY) * EIy) / (L * fy), dy = ((2 - phiY) * EIy) / (L * fy)
   set(2, 2, ay); set(2, 4, -by); set(2, 8, -ay); set(2, 10, -by)
   set(4, 4, cy); set(4, 8, by); set(4, 10, dy)
   set(8, 8, ay); set(8, 10, by)
@@ -394,7 +408,12 @@ function prepMemberGeom(m: F3Member, nm: Map<string, F3Node>, idx: Map<string, n
   const GJ = m.G * m.J * 1e-9
   const EIy = m.E * m.Iy * 1e-9
   const EIz = m.E * m.Iz * 1e-9
-  const kl = kLocal(EA, GJ, EIy, EIz, L)
+  // Timoshenko shear flexibility Φ = 12EI/(G·As·L²); 0 without a shear area.
+  const GAsy = m.Asy ? (m.G * m.Asy) / 1000 : 0   // kN
+  const GAsz = m.Asz ? (m.G * m.Asz) / 1000 : 0
+  const phiZ = GAsy > 0 ? (12 * EIz) / (GAsy * L * L) : 0
+  const phiY = GAsz > 0 ? (12 * EIy) / (GAsz * L * L) : 0
+  const kl = kLocal(EA, GJ, EIy, EIz, L, phiY, phiZ)
 
   // Collect released local DOF indices (end i = 0..5, end j = 6..11)
   const relIdx: number[] = []

--- a/webapp/src/engine/modelBridge.test.ts
+++ b/webapp/src/engine/modelBridge.test.ts
@@ -283,3 +283,37 @@ describe('bridge → solver unit contract (absolute closed forms)', () => {
     expect(spring.F[1]).toBeGreaterThan(0)                  // pushes back up
   })
 })
+
+describe('modelToFrame3D — Timoshenko shear areas (opt-in)', () => {
+  it('off by default: members carry no Asy/Asz (Euler benchmarks anchored)', () => {
+    const m = modelToFrame3D(baseModel()).members.find((x) => x.id === 'm')!
+    expect(m.Asy).toBeUndefined()
+    expect(m.Asz).toBeUndefined()
+  })
+
+  it('concrete rectangle: Asy = Asz = 5/6·b·h', () => {
+    const m = modelToFrame3D(baseModel(), { shearDeformation: true }).members.find((x) => x.id === 'm')!
+    expect(m.Asy).toBeCloseTo((5 / 6) * 300 * 500, 6)
+    expect(m.Asz).toBeCloseTo((5 / 6) * 300 * 500, 6)
+  })
+
+  it('steel W-shape: Asy = d·tw (AISC §G2.1 web), Asz = 5/6·2·bf·tf (flanges)', () => {
+    const model = baseModel()
+    model.sections = [{ ...section, material: 'steel' as const, shape: 'W150x13' }]
+    const m = modelToFrame3D(model, { shearDeformation: true }).members.find((x) => x.id === 'm')!
+    // W150x13: d = 150, tw = 5.0, bf = 100, tf = 7.1 (mm)
+    expect(m.Asy).toBeCloseTo(150 * 5.0, 6)
+    expect(m.Asz).toBeCloseTo((5 / 6) * 2 * 100 * 7.1, 6)
+  })
+
+  it('shear-deformable solve is softer than Euler and keeps ΣR = ΣP', () => {
+    const model = baseModel()
+    model.loads = [{ kind: 'node', node: 'b', Fy: -20, cat: 'D' }]
+    const euler = modelToFrame3D(model)
+    const timo = modelToFrame3D(model, { shearDeformation: true })
+    const rE = solveFrame3D(euler.nodes, euler.members, euler.supports, euler.loads)!
+    const rT = solveFrame3D(timo.nodes, timo.members, timo.supports, timo.loads)!
+    expect(Math.abs(rT.d[6 + 1])).toBeGreaterThan(Math.abs(rE.d[6 + 1]))
+    expect(rT.reactions.reduce((t, q) => t + q.F[1], 0)).toBeCloseTo(20, 6)
+  })
+})

--- a/webapp/src/engine/modelBridge.ts
+++ b/webapp/src/engine/modelBridge.ts
@@ -11,7 +11,7 @@ import { buildDiaphragmGroups } from './diaphragm'
 import { autoRigidOffsets } from './rigidEndZones'
 import { distributePanel, type AreaLoad } from './tributary'
 import type { BeamLoad } from './beamAnalysis'
-import { shapeByName, torsionJ } from './aiscSections'
+import { shapeByName, torsionJ, type AiscShape } from './aiscSections'
 import { deriveWSection, E_STEEL } from './steelDesign'
 
 export interface BridgeResult {
@@ -62,7 +62,33 @@ function sectionProps(s: RectSection) {
     Iz: (s.b * s.h ** 3) / 12,  // gravity bending (depth h vertical)
     Iy: (s.h * s.b ** 3) / 12,
     J: rectJ(s.b, s.h),
+    // Timoshenko shear areas: rectangle κ = 5/6 in both directions
+    Asy: (5 / 6) * s.b * s.h,
+    Asz: (5 / 6) * s.b * s.h,
   }
+}
+
+/** Timoshenko shear areas for a steel shape, mm². Asy carries shear along the
+ *  section depth (pairs with strong-axis bending): the web(s) for open shapes
+ *  (d·tw — the same area AISC §G2.1 uses for Vn) and the side walls 2·h·t for
+ *  rect HSS. Asz (shear across the flanges / weak axis) takes κ = 5/6 on the
+ *  flange area. Round sections use the thin-tube κ·A ≈ 0.5·A. Unknown families
+ *  fall back to 5/6·A (rectangle-like). */
+function steelShearAreas(shape: AiscShape): { Asy: number; Asz: number } {
+  const flanges = (bf?: number, tf?: number) => (bf && tf ? (5 / 6) * 2 * bf * tf : (5 / 6) * shape.A)
+  if ((shape.family === 'W' || shape.family === 'C') && shape.d && shape.tw) {
+    return { Asy: shape.d * shape.tw, Asz: flanges(shape.bf, shape.tf) }
+  }
+  if (shape.family === 'WT' && shape.d && shape.tw) {
+    return { Asy: shape.d * shape.tw, Asz: shape.bf && shape.tf ? (5 / 6) * shape.bf * shape.tf : (5 / 6) * shape.A }
+  }
+  if (shape.family === 'HSS' && shape.b && shape.h && shape.t) {
+    return { Asy: 2 * shape.h * shape.t, Asz: 2 * shape.b * shape.t }
+  }
+  if ((shape.family === 'HSS' || shape.family === 'PIPE') && shape.D) {
+    return { Asy: 0.5 * shape.A, Asz: 0.5 * shape.A }   // thin round tube κ·A ≈ 0.5·A
+  }
+  return { Asy: (5 / 6) * shape.A, Asz: (5 / 6) * shape.A }
 }
 
 /** Steel member stiffness from its AISC shape (E = 200 GPa, G = E/2.6, ν = 0.3).
@@ -71,7 +97,12 @@ function sectionProps(s: RectSection) {
 function steelSectionProps(s: RectSection) {
   const E = E_STEEL, G = E / 2.6
   const shape = s.shape ? shapeByName(s.shape) : undefined
-  if (!shape) return { E, G, A: s.b * s.h, Iz: (s.b * s.h ** 3) / 12, Iy: (s.h * s.b ** 3) / 12, J: rectJ(s.b, s.h) }
+  if (!shape) {
+    return {
+      E, G, A: s.b * s.h, Iz: (s.b * s.h ** 3) / 12, Iy: (s.h * s.b ** 3) / 12, J: rectJ(s.b, s.h),
+      Asy: (5 / 6) * s.b * s.h, Asz: (5 / 6) * s.b * s.h,
+    }
+  }
   let Iz: number, Iy: number, J: number
   if (shape.family === 'W' || shape.family === 'WT') {
     const d = deriveWSection(shape)
@@ -84,7 +115,7 @@ function steelSectionProps(s: RectSection) {
     Iy = shape.A * shape.ry ** 2
     J = torsionJ(shape) ?? Iz + Iy
   }
-  return { E, G, A: shape.A, Iz, Iy, J }
+  return { E, G, A: shape.A, Iz, Iy, J, ...steelShearAreas(shape) }
 }
 
 /**
@@ -194,6 +225,11 @@ export interface BridgeOpts {
    *  Off by default at the API level so closed-form benchmarks stay anchored
    *  to gross-section theory; the Model Space UI enables it by default. */
   crackedSections?: boolean
+  /** Thread Timoshenko shear areas (Asy/Asz) into the frame elements so deep
+   *  girders and squat columns carry shear flexibility Φ = 12EI/(G·As·L²).
+   *  Off by default at the API level so closed-form Euler benchmarks stay
+   *  anchored; the Model Space UI enables it by default. */
+  shearDeformation?: boolean
 }
 
 export function modelToFrame3D(model: StructuralModel, opts?: BridgeOpts): BridgeResult {
@@ -217,8 +253,10 @@ export function modelToFrame3D(model: StructuralModel, opts?: BridgeOpts): Bridg
     const props = secById.get(m.section) ?? fallback
     const ck = opts?.crackedSections && model.sections.find((s) => s.id === m.section)?.material !== 'steel'
       ? CRACKED_I[m.role] : 1
+    const { Asy, Asz, ...stiff } = props
     return {
-      id: m.id, i: m.i, j: m.j, ...props, Iz: props.Iz * ck, Iy: props.Iy * ck,
+      id: m.id, i: m.i, j: m.j, ...stiff, Iz: props.Iz * ck, Iy: props.Iy * ck,
+      ...(opts?.shearDeformation ? { Asy, Asz } : {}),
       ...releaseFlags(effectiveReleases(m)),
       ...(offI ? { offI } : {}),
       ...(offJ ? { offJ } : {}),

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -60,6 +60,9 @@ export interface AnalyzeOptions {
    *  E-carrying combos get D → D+Ev when additive (1.2D+1.0E) and D → D−Ev on
    *  the counteracting uplift combo (0.9D+1.0E). Omit → gross combos. */
   Ev?: number
+  /** Timoshenko shear deformation: bridge shear areas into the frame elements
+   *  (Φ = 12EI/(G·As·L²)). Default off at the API level; UI enables it. */
+  shearDeformation?: boolean
 }
 
 export interface BeamSectionDesign {
@@ -453,7 +456,7 @@ function buildRuns(model: StructuralModel, opts: AnalyzeOptions, onProgress?: Pr
   // slab tributary line loads and member self-weight; lateral cases are pure
   // node loads applied on top per direction.
   const gravityModel = { ...model, loads: model.loads.filter((l) => l.cat !== 'E' && l.cat !== 'W') }
-  const br = modelToFrame3D(gravityModel, { useShells: false, crackedSections: opts.crackedSections })
+  const br = modelToFrame3D(gravityModel, { useShells: false, crackedSections: opts.crackedSections, shearDeformation: opts.shearDeformation })
 
   const lateral = opts.lateral?.length ? opts.lateral : defaultLateralCases(model)
   // expand every combo into its directional variants up front so progress has a total
@@ -811,7 +814,7 @@ async function buildRunsParallel(
   model: StructuralModel, opts: AnalyzeOptions, pool: FramePool, onProgress?: ProgressFn,
 ): Promise<{ br: BridgeResult; runs: FrameRun[] }> {
   const gravityModel = { ...model, loads: model.loads.filter((l) => l.cat !== 'E' && l.cat !== 'W') }
-  const br = modelToFrame3D(gravityModel, { useShells: false, crackedSections: opts.crackedSections })
+  const br = modelToFrame3D(gravityModel, { useShells: false, crackedSections: opts.crackedSections, shearDeformation: opts.shearDeformation })
 
   const lateral = opts.lateral?.length ? opts.lateral : defaultLateralCases(model)
   const tasks = buildComboTasks(lateral, opts)

--- a/webapp/src/engine/solverWorker.ts
+++ b/webapp/src/engine/solverWorker.ts
@@ -18,7 +18,7 @@ import type { SolveProgress } from './progress'
 
 type DriftReq = { hasSeis: boolean; T: number; R: number; axis: 'x' | 'z'; pDelta: boolean }
 export type SolverRequest =
-  | { id: number; kind: 'analyze'; model: StructuralModel; opts: F3AnalyzeOpts; drift: DriftReq; crackedSections?: boolean }
+  | { id: number; kind: 'analyze'; model: StructuralModel; opts: F3AnalyzeOpts; drift: DriftReq; crackedSections?: boolean; shearDeformation?: boolean }
   | { id: number; kind: 'design'; model: StructuralModel; soil: SoilOptions; plan: FootingPlan; opts: AnalyzeOptions; tryBars: boolean }
   | { id: number; kind: 'optimize'; model: StructuralModel; soil: SoilOptions; plan: FootingPlan; opts: AnalyzeOptions; tryBars: boolean; maxIter: number }
   | { id: number; kind: 'modal'; model: StructuralModel; nModes: number }
@@ -33,7 +33,7 @@ ctx.onmessage = async (e: MessageEvent<SolverRequest>) => {
   const onProgress = (p: SolveProgress) => ctx.postMessage({ id: msg.id, progress: p })
   try {
     if (msg.kind === 'analyze') {
-      const br = modelToFrame3D(msg.model, { crackedSections: msg.crackedSections })
+      const br = modelToFrame3D(msg.model, { crackedSections: msg.crackedSections, shearDeformation: msg.shearDeformation })
       const analysis = analyzeFrame3D(br.nodes, br.members, br.supports, br.loads, msg.opts, onProgress, br.diaphragmGroups, br.shells)
       let drift = null
       if (msg.drift.hasSeis) {

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -753,6 +753,7 @@ export default function ModelSpace() {
   const [assembly, setAssembly] = useState(b('assembly', false))
   const [pDelta, setPDelta] = useState(b('pDelta', false))
   const [cracked, setCracked] = useState(b('cracked', true))       // ACI §6.6.3.1.1 cracked EI (0.35/0.70 Ig)
+  const [shearDef, setShearDef] = useState(b('shearDef', true))    // Timoshenko shear deformation (deep girders / squat columns)
   const [tryBars, setTryBars] = useState(b('tryBars', true))        // let design/optimize pick bar Ø from a ladder
   const [showLoads, setShowLoads] = useState(true)   // load-diagram overlay
   const [showFootings, setShowFootings] = useState(true)   // designed footing footprints
@@ -856,7 +857,7 @@ export default function ModelSpace() {
         baysX, baysZ, storeyH, colB, colH, girB, girH, beaB, beaH,
         fc, fy, barDia, tieDia, cover, slabThk, gammaC, qD, qL,
         qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs, methodB, accTor, orth30, evOn, rsaRegular,
-        Vw, expo, Kzt, wDirs, assembly, pDelta, cracked, tryBars,
+        Vw, expo, Kzt, wDirs, assembly, pDelta, cracked, shearDef, tryBars,
         concreteClass, prices, planSel,
         material, colFam, girFam, beaFam, colShape, girShape, beaShape, steelFy, steelFu,
       }))
@@ -864,7 +865,7 @@ export default function ModelSpace() {
   }, [baysX, baysZ, storeyH, colB, colH, girB, girH, beaB, beaH,
     fc, fy, barDia, tieDia, cover, slabThk, gammaC, qD, qL,
     qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs, methodB, accTor, orth30, evOn, rsaRegular,
-    Vw, expo, Kzt, wDirs, assembly, pDelta, cracked, tryBars,
+    Vw, expo, Kzt, wDirs, assembly, pDelta, cracked, shearDef, tryBars,
     concreteClass, prices, planSel,
     material, colFam, girFam, beaFam, colShape, girShape, beaShape, steelFy, steelFu])
 
@@ -907,13 +908,13 @@ export default function ModelSpace() {
   const hasELoads = model?.loads.some((l) => l.cat === 'E') ?? false
   const seismicSystem: 'gravity' | 'imf' | 'smf' = hasELoads ? (Rw >= 8 ? 'smf' : Rw >= 5 ? 'imf' : 'gravity') : 'gravity'
   // §208.4.1 vertical seismic component folded into the E-combo D factors.
-  const anaOpts = { f1: fLive, pDelta, lateral, seismicSystem, crackedSections: cracked, Ev: evOn ? 0.5 * Ca * Ie : undefined }
+  const anaOpts = { f1: fLive, pDelta, lateral, seismicSystem, crackedSections: cracked, shearDeformation: shearDef, Ev: evOn ? 0.5 * Ca * Ie : undefined }
 
   const analyze = () => {
     if (!model || busy || meshErrors) return   // §1 fail-fast: don't solve a singular mesh
     // 3D FEM + storey drift run in the worker so the UI stays responsive.
     run('analyze', {
-      model, opts: anaOpts, drift: { hasSeis: !!seis, T: seis?.T ?? 0, R: Rw, axis: primAxis, pDelta }, crackedSections: cracked,
+      model, opts: anaOpts, drift: { hasSeis: !!seis, T: seis?.T ?? 0, R: Rw, axis: primAxis, pDelta }, crackedSections: cracked, shearDeformation: shearDef,
     }).then((r) => {
       const res = r as { analysis: F3Analysis | null; orphans: number; drift: DriftRow[] | null }
       setOrphans(res.orphans)
@@ -2768,6 +2769,10 @@ export default function ModelSpace() {
                 <label className="col-span-full flex items-center gap-2 text-sm">
                   <input type="checkbox" checked={cracked} onChange={(e) => setCracked(e.target.checked)} />
                   <span>Cracked sections — ACI §6.6.3.1.1 (0.35Ig beams, 0.70Ig columns; concrete only)</span>
+                </label>
+                <label className="col-span-full flex items-center gap-2 text-sm">
+                  <input type="checkbox" checked={shearDef} onChange={(e) => setShearDef(e.target.checked)} />
+                  <span>Shear deformation (Timoshenko) — Φ = 12EI/(G·As·L²); softens deep girders &amp; squat columns</span>
                 </label>
                 <label className="col-span-full flex items-center gap-2 text-sm">
                   <input type="checkbox" disabled={!model} checked={model?.diaphragm ?? false}


### PR DESCRIPTION
Backlog **P3-5**: deep girders and squat columns read too stiff on the pure Euler–Bernoulli element. **Layer: L3 solver + L2 bridge + one UI toggle** — solver change justified per the CLAUDE.md L3 rule, with the statics self-checks re-run (full suite green) and the shared-LU path untouched (both paths consume the same `kLocal`).

## Solver — `kLocal` (`engine/frame3d.ts`)
Per-plane shear-flexibility parameters `Φ = 12EI/(G·As·L²)` (Przemieniecki, *Theory of Matrix Structural Analysis* §5.6):

```
12EI/L³(1+Φ) · 6EI/L²(1+Φ) · (4+Φ)EI/L(1+Φ) · (2−Φ)EI/L(1+Φ)
```

`Φ = 0` recovers the Euler element **bit-for-bit**, so every existing closed-form benchmark, release/offset path, P-Δ and force recovery are unchanged unless shear areas are supplied. `F3Member` gains optional `Asy`/`Asz` (mm²).

## Bridge — shear areas per section family (`engine/modelBridge.ts`)
- rectangle (concrete or unknown steel): κ = 5/6 both directions
- W / C: web `d·tw` along the depth (the same area AISC §G2.1 uses for Vn), `5/6·2·bf·tf` across the flanges; WT analogous
- rect HSS: side walls `2·h·t` / `2·b·t`; round HSS/pipe: `0.5·A`
- gated behind `BridgeOpts.shearDeformation`, mirroring `crackedSections`: **API default off** (closed-form benchmarks stay anchored to Euler theory), **Model Space UI on by default**. Analyze/Design/Optimize thread the flag; modal, pushover, and buckling keep the Euler element for now (documented in CLAUDE.md as a possible follow-up).

## Stated approximation
Fixed-end forces stay Euler — exact for symmetric UDLs (the dominant slab-tributary loading), O(Φ) error on asymmetric point/VDL member loads. Documented on `F3Member`.

## Verification
- **1062 vitest pass** (9 new): nodally-exact Timoshenko cantilever `δ = PL³/3EI + PL/GAs` in **both bending planes** (9-decimal match), fixed-fixed centre load `PL³/192EI + PL/4GAs` across two elements, `As→∞` Euler recovery, omitted-`As` regression anchor, per-family bridge areas (rect 5/6·A; W150x13 → `Asy = 750 mm²`, `Asz = 1183 mm²`), opt-in gating, and `ΣR = ΣP` equilibrium with shear on. `tsc -b` clean.
- **Headless Chromium**: new Analysis-tab toggle (default on); storey drift Δs rises 6.73 → 6.82 mm (+1.3%) on an ordinary 300×500/3 m frame and reverts when toggled off — small for normal proportions, exactly as theory predicts, and much larger for the squat/deep members the backlog item targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_