### PR TITLE
feat: UI redesign Phase B — calculator template + verdict panel on Foundation Design (UI only)

### DIFF
--- a/webapp/src/components/ReportControls.tsx
+++ b/webapp/src/components/ReportControls.tsx
@@ -25,27 +25,26 @@ export function ReportControls({ title }: ReportControlsProps): JSX.Element {
 
   const field = (label: string, value: string, set: (v: string) => void, ph: string) => (
     <label className="flex flex-col text-sm">
-      <span className="mb-1 font-medium text-slate-600">{label}</span>
-      <input value={value} onChange={(e) => set(e.target.value)} placeholder={ph}
-        className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none focus:ring-1 focus:ring-[#0056b3]" />
+      <span className="mb-1 text-[11.5px] font-semibold text-[#5c6675]">{label}</span>
+      <input value={value} onChange={(e) => set(e.target.value)} placeholder={ph} className="text-sm" />
     </label>
   )
 
   return (
     <>
       {/* On-screen controls */}
-      <div className="no-print mt-4 flex flex-wrap items-end gap-3 rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
+      <div className="no-print mt-4 flex flex-wrap items-end gap-3 rounded-lg border border-[#e3e1da] bg-white p-3">
         {field('Project / job', project, setProject, 'e.g. Lot 12 Residence')}
         {field('Prepared by', preparedBy, setPreparedBy, 'Engineer name')}
         <button type="button" onClick={print}
-          className="ml-auto inline-flex items-center gap-2 rounded-lg bg-gradient-to-br from-[#0056b3] to-[#003f86] px-4 py-2 text-sm font-semibold text-white shadow-md transition hover:shadow-lg">
+          className="ml-auto inline-flex items-center gap-2 rounded-md bg-[#0f4c92] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#0d3f78]">
           🖨 Print / Save PDF
         </button>
       </div>
 
       {/* Print-only letterhead */}
-      <div className="print-only mb-4 border-b-2 border-[#0056b3] pb-2">
-        <h1 className="text-xl font-extrabold text-[#0056b3]">{title}</h1>
+      <div className="print-only mb-4 border-b-2 border-[#0f1b2a] pb-2">
+        <h1 className="text-xl font-extrabold text-[#0f1b2a]">{title}</h1>
         <p className="mt-0.5 text-xs text-slate-600">
           Project: <b>{project || '—'}</b> &nbsp;·&nbsp; Prepared by: <b>{preparedBy || '—'}</b> &nbsp;·&nbsp; Date: <b>{today}</b>
         </p>

--- a/webapp/src/components/WorkedSolution.tsx
+++ b/webapp/src/components/WorkedSolution.tsx
@@ -8,19 +8,20 @@ export function WorkedSolution({ steps, title = 'Solution — step by step' }: {
 }): JSX.Element {
   const [open, setOpen] = useState(true)
   return (
-    <div className="mt-6 rounded-xl border border-slate-200 bg-white shadow-sm print-avoid-break">
+    <div className="mt-6 rounded-lg border border-[#e3e1da] bg-white print-avoid-break">
       <button type="button" onClick={() => setOpen((o) => !o)}
-        className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left">
-        <h2 className="text-[1.02rem] font-bold text-[#0056b3]">{title}</h2>
-        <span className="no-print text-sm text-slate-500">{open ? 'Hide ▲' : 'Show ▼'}</span>
+        className="flex w-full items-center gap-2.5 px-4 py-3 text-left">
+        <span className="font-mono text-[10.5px] font-semibold text-[#a39d8d]">05</span>
+        <h2 className="text-[13.5px] font-bold text-[#0f1b2a]">{title}</h2>
+        <span className="no-print ml-auto text-xs text-[#a39d8d]">{open ? 'Hide ▲' : 'Show ▼'}</span>
       </button>
 
       {open && (
-        <ol className="space-y-4 border-t border-slate-100 px-4 py-4">
+        <ol className="space-y-4 border-t border-[#eeece5] px-4 py-4">
           {steps.map((s, i) => (
             <li key={i} className="print-avoid-break">
-              <h3 className="mb-1.5 text-sm font-semibold text-slate-800">
-                <span className="text-slate-500">{i + 1}.</span> {s.title}
+              <h3 className="mb-1.5 text-[12.5px] font-bold text-[#0f1b2a]">
+                <span className="mr-1.5 font-mono font-semibold text-[#a39d8d]">{i + 1}</span>{s.title}
               </h3>
               <div className="space-y-1.5 pl-4">
                 {s.lines.map((ln, j) => (

--- a/webapp/src/components/calc.tsx
+++ b/webapp/src/components/calc.tsx
@@ -1,0 +1,107 @@
+import type { ReactNode } from 'react'
+
+// Calculator-template building blocks (docs/design/uiux-2026-07, Foundation /
+// Beam mockups): numbered input sections on the left, a sticky verdict panel
+// on the right — pass/fail banner, key outputs in mono, utilization bars with
+// the amber ≥ 0.95 warning band. Presentation only; pages feed engine results.
+
+export function PageHeader({ title, badges, actions }: { title: string; badges: string[]; actions?: ReactNode }) {
+  return (
+    <div className="flex flex-wrap items-center gap-3 border-b border-[#e3e1da] bg-white px-5 py-3.5 sm:px-7">
+      <div className="flex min-w-0 flex-wrap items-center gap-3">
+        <h1 className="text-[21px] font-extrabold tracking-tight text-[#0f1b2a]">{title}</h1>
+        {badges.map((b) => (
+          <span key={b} className="whitespace-nowrap rounded border border-[#cddcf0] bg-[#eaf1f9] px-1.5 py-px font-mono text-[10px] font-medium text-[#0f4c92]">{b}</span>
+        ))}
+      </div>
+      {actions && <div className="no-print ml-auto flex items-center gap-2">{actions}</div>}
+    </div>
+  )
+}
+
+export function CalcSection({ num, title, hint, children, grid = true }: {
+  num: string; title: string; hint?: string; children: ReactNode; grid?: boolean
+}) {
+  return (
+    <section className="rounded-lg border border-[#e3e1da] bg-white print-avoid-break">
+      <div className="flex items-baseline gap-2.5 border-b border-[#eeece5] px-4 py-3">
+        <span className="font-mono text-[10.5px] font-semibold text-[#a39d8d]">{num}</span>
+        <h2 className="text-[13.5px] font-bold text-[#0f1b2a]">{title}</h2>
+        {hint && <span className="ml-auto text-[11px] text-[#a39d8d]">{hint}</span>}
+      </div>
+      <div className={grid ? 'grid grid-cols-1 gap-3.5 p-4 sm:grid-cols-2 lg:grid-cols-3' : 'p-4'}>{children}</div>
+    </section>
+  )
+}
+
+export interface VerdictStat { label: string; value: string; unit?: string }
+export interface VerdictCheck { name: string; ratio: number }
+
+const barColor = (r: number) => (r > 1.0001 ? '#c2402a' : r >= 0.95 ? '#b97d10' : '#1a7f4b')
+
+export function UtilBar({ c }: { c: VerdictCheck }) {
+  const color = barColor(c.ratio)
+  return (
+    <div>
+      <div className="flex items-baseline justify-between">
+        <span className="text-[11.5px] font-semibold text-[#3d4a5c]">{c.name}</span>
+        <span className="font-mono text-[11px]" style={{ color }}>{c.ratio.toFixed(2)}</span>
+      </div>
+      <div className="mt-1 h-[5px] overflow-hidden rounded-[3px] bg-[#eeece5]">
+        <div className="h-full rounded-[3px]" style={{ background: color, width: `${Math.min(100, c.ratio * 100)}%` }} />
+      </div>
+    </div>
+  )
+}
+
+export function VerdictPanel({ ok, headline, governing, stats, checks, footnote }: {
+  ok: boolean; headline: string; governing?: string
+  stats: VerdictStat[]; checks: VerdictCheck[]; footnote?: ReactNode
+}) {
+  return (
+    <section className="overflow-hidden rounded-lg border border-[#e3e1da] bg-white print-avoid-break">
+      <div className={`flex items-center gap-2.5 border-b px-4 py-3 ${ok ? 'border-[#d3e8da] bg-[#ecf6ef]' : 'border-[#efd4cc] bg-[#fbeeea]'}`}>
+        <span className={`flex h-[22px] w-[22px] flex-none items-center justify-center rounded-full text-white ${ok ? 'bg-[#1a7f4b]' : 'bg-[#c2402a]'}`}>
+          {ok
+            ? <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+            : <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round"><line x1="6" y1="6" x2="18" y2="18" /><line x1="18" y1="6" x2="6" y2="18" /></svg>}
+        </span>
+        <div className="min-w-0">
+          <p className={`text-[13px] font-extrabold tracking-wide ${ok ? 'text-[#14603a]' : 'text-[#8f2f1e]'}`}>{headline}</p>
+          {governing && <p className={`mt-px truncate text-[11px] ${ok ? 'text-[#4d7a5f]' : 'text-[#a95b47]'}`}>{governing}</p>}
+        </div>
+      </div>
+      {stats.length > 0 && (
+        <div className="grid border-b border-[#eeece5]" style={{ gridTemplateColumns: `repeat(${stats.length}, 1fr)` }}>
+          {stats.map((s, i) => (
+            <div key={s.label} className={`px-3.5 py-3 ${i < stats.length - 1 ? 'border-r border-[#eeece5]' : ''}`}>
+              <p className="text-[10px] font-semibold uppercase tracking-widest text-[#a39d8d]">{s.label}</p>
+              <p className="mt-0.5 truncate font-mono text-[15px] font-semibold text-[#0f1b2a]">
+                {s.value}{s.unit && <span className="text-[11px] text-[#a39d8d]"> {s.unit}</span>}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="flex flex-col gap-2.5 px-4 py-3.5">
+        {checks.map((c) => <UtilBar key={c.name} c={c} />)}
+        {footnote && <p className="mt-0.5 text-[10.5px] text-[#a39d8d]">{footnote}</p>}
+      </div>
+    </section>
+  )
+}
+
+/** Right-rail card with the drawing-sheet grid backdrop. */
+export function DrawingCard({ title, meta, children }: { title: string; meta?: string; children: ReactNode }) {
+  return (
+    <section className="rounded-lg border border-[#e3e1da] bg-white print-avoid-break">
+      <div className="flex items-center justify-between border-b border-[#eeece5] px-4 py-3">
+        <h2 className="text-[13.5px] font-bold text-[#0f1b2a]">{title}</h2>
+        {meta && <span className="font-mono text-[10px] text-[#a39d8d]">{meta}</span>}
+      </div>
+      <div className="p-3 [background-image:linear-gradient(#f0eee7_1px,transparent_1px),linear-gradient(90deg,#f0eee7_1px,transparent_1px)] [background-size:22px_22px]">
+        {children}
+      </div>
+    </section>
+  )
+}

--- a/webapp/src/pages/FoundationDesign.tsx
+++ b/webapp/src/pages/FoundationDesign.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState, type ReactNode } from 'react'
-import { Link } from 'react-router-dom'
 import { designSquareFooting } from '../engine/isolatedFooting'
 import { designRectangularFooting } from '../engine/rectangularFooting'
 import { designEccentricSquareFooting } from '../engine/eccentricFooting'
@@ -13,6 +12,7 @@ import type { BatchResult } from '../lib/foundationExcel'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { buildFoundationSolution, type SolutionCtx } from '../lib/foundationSolution'
 import { Math } from '../lib/math'
+import { PageHeader, CalcSection, VerdictPanel, DrawingCard } from '../components/calc'
 import { f0, f2, f3 } from '../lib/format'
 import 'katex/dist/katex.min.css'
 
@@ -109,13 +109,13 @@ function NumField({ label, unit, value, onChange, step = 'any' }: {
 }) {
   return (
     <label className="flex flex-col text-sm">
-      <span className="mb-1 font-medium text-slate-600">
-        {label}{unit ? <span className="text-slate-500"> ({unit})</span> : null}
+      <span className="mb-1 text-[11.5px] font-semibold text-[#5c6675]">
+        {label}{unit ? <span className="font-mono text-[10.5px] font-normal text-[#a39d8d]"> ({unit})</span> : null}
       </span>
       <input
         type="number" inputMode="decimal" step={step} value={Number.isFinite(value) ? value : ''}
         onChange={(e) => onChange(parseFloat(e.target.value))}
-        className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none focus:ring-1 focus:ring-[#0056b3]"
+        className="text-[13px]"
       />
     </label>
   )
@@ -126,30 +126,31 @@ function Select<T extends string>({ label, value, onChange, options }: {
 }) {
   return (
     <label className="flex flex-col text-sm">
-      <span className="mb-1 font-medium text-slate-600">{label}</span>
-      <select value={value} onChange={(e) => onChange(e.target.value as T)}
-        className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none">
+      <span className="mb-1 text-[11.5px] font-semibold text-[#5c6675]">{label}</span>
+      <select value={value} onChange={(e) => onChange(e.target.value as T)} className="text-[13px]">
         {options.map(([v, t]) => <option key={v} value={v}>{t}</option>)}
       </select>
     </label>
   )
 }
 
+const SECTION_META: Record<string, { num: string; hint: string }> = {
+  'Footing': { num: '01', hint: 'geometry & method' },
+  'Loads & Column': { num: '02', hint: 'P = service, Pu = factored' },
+  'Materials': { num: '03', hint: 'concrete & rebar' },
+  'Soil & Geometry': { num: '04', hint: 'allowable bearing' },
+}
 function Card({ title, children }: { title: string; children: ReactNode }) {
-  return (
-    <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-      <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">{title}</legend>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">{children}</div>
-    </fieldset>
-  )
+  const meta = SECTION_META[title] ?? { num: '··', hint: '' }
+  return <CalcSection num={meta.num} title={title} hint={meta.hint}>{children}</CalcSection>
 }
 
 function Row({ label, value, check }: { label: ReactNode; value: ReactNode; check?: ReactNode }) {
   return (
-    <div className="flex items-baseline justify-between gap-3 border-b border-slate-100 py-1.5 last:border-0">
-      <span className="text-sm text-slate-600">{label}</span>
-      <span className="text-right text-sm font-semibold text-slate-800">{value}</span>
-      {check ? <span className="w-32 text-right text-xs text-slate-500">{check}</span> : null}
+    <div className="flex items-baseline justify-between gap-3 border-b border-[#f3f1ea] py-1.5 last:border-0">
+      <span className="text-[12px] text-[#5c6675]">{label}</span>
+      <span className="text-right font-mono text-[12.5px] font-semibold text-[#0f1b2a]">{value}</span>
+      {check ? <span className="w-32 text-right text-[10.5px] text-[#a39d8d]">{check}</span> : null}
     </div>
   )
 }
@@ -259,18 +260,25 @@ export default function FoundationDesign() {
     return buildFoundationSolution(ctx)
   }, [view, form, serviceLoad, ultimateLoad, individual])
 
+  // Verdict data — presentation of engine outputs only: utilization is the
+  // required-over-provided effective depth per shear mode (capacity grows with
+  // d, so this is the honest "how close to the limit" bar for the report).
+  const punchRatio = view ? view.dPunch / view.dProvided : 0
+  const beamRatio = view ? globalThis.Math.max(view.dBeamLong, view.dBeamShort) / view.dProvided : 0
+  const allOK = !!view && view.punchOK && view.beamOK && (!view.ecc || view.ecc.kernOK)
+  const governing = punchRatio >= beamRatio ? 'two-way punching shear' : 'one-way beam shear'
+
   return (
-    <div className="mx-auto max-w-6xl p-6">
-      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
-      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Foundation Design</h1>
-      <p className="no-print mt-1 text-slate-600">Isolated footing (square / rectangular, concentric / eccentric) — React + typed engine. Results update live.</p>
+    <div>
+      <PageHeader title="Isolated Footing" badges={['ACI 318-14', 'NSCP 2015']} />
+      <div className="mx-auto max-w-6xl px-5 pb-8 sm:px-7">
       <ReportControls title="Foundation Design Report" />
       <ExcelImport onResult={setBatch} />
 
       {batch && (
-        <div className="mt-4 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm print-avoid-break">
+        <div className="mt-4 overflow-hidden rounded-lg border border-[#e3e1da] bg-white print-avoid-break">
           <div className="flex flex-wrap items-baseline justify-between gap-2 border-b border-slate-200 px-4 py-2.5">
-            <h2 className="text-[1.02rem] font-bold text-[#0056b3]">
+            <h2 className="text-[13.5px] font-bold text-[#0f1b2a]">
               Batch schedule <span className="text-sm font-normal text-slate-500">({batch.designed}/{batch.rows.length} designed)</span>
             </h2>
             <button type="button" onClick={() => setBatch(null)} className="no-print text-xs text-slate-500 hover:text-slate-700 hover:underline">Clear</button>
@@ -309,9 +317,9 @@ export default function FoundationDesign() {
         </div>
       )}
 
-      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
+      <div className="mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
         {/* ── Inputs ── */}
-        <div className="space-y-5">
+        <div className="space-y-3.5">
           <Card title="Footing">
             <Select label="Type" value={form.footingType} onChange={set('footingType')}
               options={[['square', 'Isolated Square'], ['rectangular', 'Isolated Rectangular']]} />
@@ -405,20 +413,41 @@ export default function FoundationDesign() {
           </Card>
         </div>
 
-        {/* ── Results ── */}
-        <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
-          <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-            <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Design preview</h2>
+        {/* ── Verdict rail ── */}
+        <div className="space-y-3.5 lg:sticky lg:top-14 lg:self-start">
+          {view && (
+            <VerdictPanel
+              ok={allOK}
+              headline={allOK
+                ? (view.analysis === 'analyze' ? 'SECTION OK — all checks pass' : 'DESIGN OK — all checks pass')
+                : 'CHECK FAILED — section inadequate'}
+              governing={`Governing: ${governing} · d req/prov ${globalThis.Math.max(punchRatio, beamRatio).toFixed(2)}`}
+              stats={[
+                { label: 'Plan size', value: view.type === 'square' ? `${f2(view.Bx)} × ${f2(view.By)}` : `${f2(view.Bx)} × ${f2(view.By)}`, unit: 'm' },
+                { label: 'Thickness Dc', value: f0(view.Dc), unit: 'mm' },
+                { label: view.type === 'square' ? 'Steel each way' : 'Steel — long', value: `${view.long.bars}-⌀${form.barDia}`, unit: `@${f0(view.long.spacing)}` },
+              ]}
+              checks={[
+                { name: 'Punching shear (d req / prov)', ratio: punchRatio },
+                { name: 'Beam shear (d req / prov)', ratio: beamRatio },
+              ]}
+              footnote={view.long.usedMin
+                ? 'Flexure: As,min = 0.0018·b·h governs (ρmin) — §24.4.3.2'
+                : `Flexure: ρ = ${view.long.rho.toFixed(4)} — §24.4.3.2 satisfied`}
+            />
+          )}
+
+          <DrawingCard title="Drawing" meta="plan · section">
             {view ? (
               <FootingSchematic Bx={view.Bx} By={view.By} Dc={view.Dc} columnWidth={colWidth} H={form.H} />
             ) : (
-              <p className="py-8 text-center text-sm text-slate-500">Enter valid inputs — net bearing must be positive.</p>
+              <p className="py-8 text-center text-sm text-[#a39d8d]">Enter valid inputs — net bearing must be positive.</p>
             )}
-          </div>
+          </DrawingCard>
 
           {view && (
-            <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-              <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Results</h2>
+            <div className="rounded-lg border border-[#e3e1da] bg-white p-4">
+              <h2 className="mb-2 text-[13.5px] font-bold text-[#0f1b2a]">Results</h2>
               {view.analysis === 'analyze' && (
                 <Row label="Adequacy" value={view.punchOK && view.beamOK ? '✓ section OK' : '✗ inadequate in shear'}
                   check={`punching ${view.punchOK ? '✓' : '✗'} · beam ${view.beamOK ? '✓' : '✗'}`} />
@@ -457,15 +486,16 @@ export default function FoundationDesign() {
             </div>
           )}
 
-          <div className="rounded-xl border border-slate-200 bg-white p-4 text-sm text-slate-600 shadow-sm">
-            <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Basis</h2>
+          <div className="rounded-lg border border-[#e3e1da] bg-white p-4 text-sm text-[#5c6675]">
+            <h2 className="mb-2 text-[13.5px] font-bold text-[#0f1b2a]">Basis</h2>
             <Math block tex={String.raw`q_{net} = q_a - \gamma_s D_s - \gamma_c D_c - q,\quad P_u = \max(1.4D,\ 1.2D + 1.6L)`} />
             <p className="mt-1 text-xs text-slate-500">NSCP 2015 / ACI 318-14. φ: shear 0.75, flexure 0.90. Short-direction band per §413.3.3.3.</p>
           </div>
         </div>
       </div>
 
-      {solutionSteps && <WorkedSolution steps={solutionSteps} />}
+      {solutionSteps && <WorkedSolution steps={solutionSteps} title="Calculation report — worked solution" />}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
**Phase B of the user-supplied UI/UX redesign** (`docs/design/uiux-2026-07/Redesign - Foundation Design`): the calculator template, with Foundation Design as the reference implementation. **UI only — engine untouched** (guard: `git diff origin/main -- webapp/src/engine` = 0 files; suite unchanged at **1063 passing**; `tsc -b` clean).

## Shared template pieces — `components/calc.tsx`
- `PageHeader` — tool title + mono code badges (`ACI 318-14`, `NSCP 2015`).
- `CalcSection` — numbered input cards (01–04) with mono section numbers and right-aligned hints.
- `VerdictPanel` — the verdict-first results grammar from the audit: PASS/FAIL banner naming the **governing check**, a mono key-output strip (plan size · thickness · steel), and **utilization bars** (green / amber ≥ 0.95 / red > 1.0).
- `DrawingCard` — right-rail drawing on the drafting-grid backdrop.
- `WorkedSolution` + `ReportControls` re-chromed to the theme — every calculator page that already uses them picks up the report style for free.

## Foundation Design restyled
Sticky right rail is now verdict-first (banner → drawing → detailed results → basis); inputs are the numbered 01–04 sections with mono numerals and unit tags; the worked solution becomes section 05 "Calculation report". **All state, engine calls, and result wiring are byte-identical** — only JSX/classes changed.

The utilization bars display the required-over-provided effective depth per shear mode (capacity grows with d), labelled as such in the panel — a presentation of outputs the engine already returns, not a new calculation.

## Verified (headless Chromium)
Default state reproduces the mockup's example: **DESIGN OK** banner, governing *two-way punching shear · 0.93*, stats `2.45 × 2.45 m / 450 mm / 10-⌀20`; switching to analyze-mode with a deliberately thin `Dc = 200 mm` flips to the red **CHECK FAILED** banner. Both bars render; no console errors.

Next phases: same template onto Beam/Steel/Column pages, then wizard / take-off / reference templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_