### PR TITLE
feat: UI redesign Phase C — Beam Design template + shared qty retheme (UI only)

### DIFF
--- a/webapp/src/components/qty.tsx
+++ b/webapp/src/components/qty.tsx
@@ -1,4 +1,3 @@
-import { Link } from 'react-router-dom'
 import type { ReactNode } from 'react'
 import type { ConcreteClass } from '../engine/quantities'
 import { ReportControls } from './ReportControls'
@@ -9,13 +8,13 @@ export function Num({ label, unit, value, onChange, step = 'any', hint }: {
 }) {
   return (
     <label className="flex flex-col text-sm">
-      <span className="mb-1 font-medium text-slate-600">
-        {label}{unit ? <span className="text-slate-500"> ({unit})</span> : null}
+      <span className="mb-1 text-[11.5px] font-semibold text-[#5c6675]">
+        {label}{unit ? <span className="font-mono text-[10.5px] font-normal text-[#a39d8d]"> ({unit})</span> : null}
       </span>
       <input type="number" inputMode="decimal" step={step} value={Number.isFinite(value) ? value : ''}
         onChange={(e) => onChange(parseFloat(e.target.value))}
-        className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none focus:ring-1 focus:ring-[#0056b3]" />
-      {hint ? <span className="mt-0.5 text-[10px] text-slate-500">{hint}</span> : null}
+        className="text-[13px]" />
+      {hint ? <span className="mt-0.5 text-[10px] text-[#a39d8d]">{hint}</span> : null}
     </label>
   )
 }
@@ -25,9 +24,8 @@ export function Pick<T extends string>({ label, value, onChange, options }: {
 }) {
   return (
     <label className="flex flex-col text-sm">
-      <span className="mb-1 font-medium text-slate-600">{label}</span>
-      <select value={value} onChange={(e) => onChange(e.target.value as T)}
-        className="rounded-md border border-slate-300 px-2.5 py-1.5 text-slate-800 focus:border-[#0056b3] focus:outline-none">
+      <span className="mb-1 text-[11.5px] font-semibold text-[#5c6675]">{label}</span>
+      <select value={value} onChange={(e) => onChange(e.target.value as T)} className="text-[13px]">
         {options.map(([v, t]) => <option key={v} value={v}>{t}</option>)}
       </select>
     </label>
@@ -43,17 +41,17 @@ export function ClassPick({ value, onChange }: { value: ConcreteClass; onChange:
 
 export function Card({ title, children }: { title: ReactNode; children: ReactNode }) {
   return (
-    <fieldset className="print-avoid-break rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-      <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">{title}</legend>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">{children}</div>
+    <fieldset className="print-avoid-break rounded-lg border border-[#e3e1da] bg-white p-4">
+      <legend className="px-2 text-[13.5px] font-bold text-[#0f1b2a]">{title}</legend>
+      <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2 lg:grid-cols-3">{children}</div>
     </fieldset>
   )
 }
 
 export function ResultCard({ title, children }: { title: ReactNode; children: ReactNode }) {
   return (
-    <div className="print-avoid-break rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-      <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">{title}</h2>
+    <div className="print-avoid-break rounded-lg border border-[#e3e1da] bg-white p-4">
+      <h2 className="mb-2 text-[13.5px] font-bold text-[#0f1b2a]">{title}</h2>
       {children}
     </div>
   )
@@ -64,10 +62,10 @@ export function Row({ label, value, sub, alert }: {
 }) {
   return (
     <div className={`flex items-baseline justify-between gap-3 border-b py-1.5 last:border-0 ${
-      alert ? 'border-red-100 bg-red-50 px-2 -mx-2 rounded' : 'border-slate-100'}`}>
-      <span className={`text-sm ${alert ? 'text-red-700' : 'text-slate-600'}`}>{label}</span>
-      <span className={`text-right text-sm font-semibold ${alert ? 'text-red-700' : 'text-slate-800'}`}>{value}</span>
-      {sub ? <span className={`w-32 text-right text-xs ${alert ? 'text-red-500' : 'text-slate-500'}`}>{sub}</span> : null}
+      alert ? 'border-[#efd4cc] bg-[#fbeeea] px-2 -mx-2 rounded' : 'border-[#f3f1ea]'}`}>
+      <span className={`text-[12px] ${alert ? 'text-[#8f2f1e]' : 'text-[#5c6675]'}`}>{label}</span>
+      <span className={`text-right font-mono text-[12.5px] font-semibold ${alert ? 'text-[#c2402a]' : 'text-[#0f1b2a]'}`}>{value}</span>
+      {sub ? <span className={`w-32 text-right text-[10.5px] ${alert ? 'text-[#c2402a]' : 'text-[#a39d8d]'}`}>{sub}</span> : null}
     </div>
   )
 }
@@ -77,12 +75,11 @@ export function QtyPage({ title, reportTitle, intro, children }: {
   title: string; reportTitle: string; intro: ReactNode; children: ReactNode
 }) {
   return (
-    <div className="mx-auto max-w-6xl p-6">
-      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
-      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">{title}</h1>
-      <p className="no-print mt-1 text-slate-600">{intro}</p>
+    <div className="mx-auto max-w-6xl px-5 py-5 sm:px-7">
+      <h1 className="text-[21px] font-extrabold tracking-tight text-[#0f1b2a]">{title}</h1>
+      <p className="no-print mt-1 text-[13px] text-[#5c6675]">{intro}</p>
       <ReportControls title={reportTitle} />
-      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">{children}</div>
+      <div className="mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">{children}</div>
     </div>
   )
 }

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
+import { PageHeader, VerdictPanel, DrawingCard } from '../components/calc'
 import { designBeam, beamServiceDeflection, type BeamDesignInput, type BeamDesignResult } from '../engine/beamDesign'
 import type { BeamSupport } from '../engine/beamDeflection'
 import type { CriticalSection } from '../engine/beamSections'
@@ -125,19 +126,36 @@ export default function BeamDesign() {
       ? `⌀${f.stirrupDia} ${f.legs}-leg @ ${f0(rr.sAdopt)} mm`
       : rr.region === 'none' ? '— none' : '⚠ enlarge'
 
+  // Verdict presentation from the engine result: flexure utilization is
+  // Mu/φMn,max (true section utilization while singly reinforced), bar-fit is
+  // required-over-provided clear spacing, shear Vu/φVc while no stirrups are
+  // demanded — all existing outputs, no new calculation.
+  const allOK = !!r && sectionOK(r) && (!deflection || (deflection.liveOK && deflection.totalOK))
+  const checks = r ? [
+    ...(r.mode === 'SRRB' ? [{ name: 'Flexure Mu / φMn,max', ratio: demand.Mu / r.phiMnMax }] : []),
+    ...(r.region === 'none' || r.region === 'minimum' ? [{ name: 'Shear Vu / φVc', ratio: demand.Vu / r.phiVc }] : []),
+    ...(r.region === 'designed' ? [{ name: 'Stirrup spacing s / s,max', ratio: r.sAdopt / r.sMax }] : []),
+    { name: `Bar spacing (${r.layers.length} layer${r.layers.length > 1 ? 's' : ''})`, ratio: r.sMinClear / Math.max(r.sClear, 1e-9) },
+  ] : []
+
   return (
-    <div className="mx-auto max-w-6xl p-6">
-      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
-      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Beam Design</h1>
-      <p className="no-print mt-1 text-slate-600">
-        Rectangular RC beam — SRRB/DRRB flexure, §407.7 bar layout with automatic layering (Varignon d), one-way
-        shear & 135° hooks. Design one section, or a whole list of critical sections (negative Mu = hogging) on the
-        same cross-section — auto-detected from Beam Analysis or entered by hand. NSCP 2015 / ACI 318-14.
-      </p>
+    <div>
+      <PageHeader title="Rectangular RC Beam" badges={['ACI 318-14', 'NSCP 2015']}
+        actions={
+          <div className="flex items-center gap-0.5 rounded-md border border-[#d6d3c9] bg-[#fcfbf8] p-0.5">
+            {([['single', 'Single section'], ['multi', 'Multiple sections']] as const).map(([v, t]) => (
+              <button key={v} type="button" onClick={() => setMulti(v === 'multi')}
+                className={`rounded px-3 py-1.5 text-[11.5px] font-semibold ${(v === 'multi') === multi ? 'bg-[#0f4c92] text-white' : 'text-[#5c6675] hover:text-[#0f1b2a]'}`}>
+                {t}
+              </button>
+            ))}
+          </div>
+        } />
+      <div className="mx-auto max-w-6xl px-5 pb-8 sm:px-7">
       <ReportControls title="Beam Design Report" />
 
-      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
-        <div className="space-y-5">
+      <div className="mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
+        <div className="space-y-3.5">
           <Card title="Section">
             <Num label="Width b" unit="mm" value={f.b} onChange={set('b')} />
             <Num label="Total depth h" unit="mm" value={f.h} onChange={set('h')} />
@@ -162,9 +180,6 @@ export default function BeamDesign() {
           </Card>
 
           <Card title="Factored demands">
-            <Pick label="Mode" value={multi ? 'multi' : 'single'}
-              onChange={(v) => setMulti(v === 'multi')}
-              options={[['single', 'Single section'], ['multi', 'Multiple critical sections']]} />
             {!multi && <>
               <Num label={<KTex tex="M_u" />} unit="kN·m" value={f.Mu} onChange={set('Mu')} />
               <Num label={<KTex tex="V_u" />} unit="kN" value={f.Vu} onChange={set('Vu')} />
@@ -175,8 +190,8 @@ export default function BeamDesign() {
           </Card>
 
           {multi && (
-            <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-              <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">Critical sections</legend>
+            <fieldset className="rounded-lg border border-[#e3e1da] bg-white p-4">
+              <legend className="px-2 text-[13.5px] font-bold text-[#0f1b2a]">Critical sections</legend>
               <div className="no-print mb-3 flex flex-wrap items-center gap-2">
                 <button type="button"
                   onClick={() => setSections((ss) => [...ss, { id: uid++, label: `Section ${ss.length + 1}`, x: 0, Mu: 50, Vu: 30 }])}
@@ -208,7 +223,25 @@ export default function BeamDesign() {
           )}
         </div>
 
-        <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
+        <div className="space-y-3.5 lg:sticky lg:top-14 lg:self-start">
+          {r && (
+            <VerdictPanel
+              ok={allOK}
+              headline={allOK
+                ? `DESIGN OK — ${r.mode}, ${r.layers.length > 1 ? `${r.layers.length} layers` : 'single layer'}`
+                : 'CHECK FAILED — revise the section'}
+              governing={r.mode === 'SRRB'
+                ? `Governing: flexure · utilization ${(demand.Mu / r.phiMnMax).toFixed(2)}`
+                : `DRRB — compression steel engaged (Mu > φMn,max = ${f1(r.phiMnMax)} kN·m)`}
+              stats={[
+                { label: hogging ? 'Tension (top)' : 'Tension steel', value: `${r.bars}-⌀${f.barDia}`, unit: hogging ? 'top' : 'bottom' },
+                { label: 'Stirrups', value: r.sAdopt > 0 ? `⌀${f.stirrupDia}` : '—', unit: r.sAdopt > 0 ? `${f.legs}-leg @${f0(r.sAdopt)}` : REGION[r.region] },
+                { label: 'Eff. depth d', value: f0(r.d), unit: 'mm' },
+              ]}
+              checks={checks}
+              footnote={`ρ = ${r.rho.toFixed(4)} within ρmin ${r.rhoMin.toFixed(4)} … ρmax ${r.rhoMax.toFixed(4)} — §9.6.1.2 / §21.2.2`}
+            />
+          )}
           {multi && (
             <ResultCard title="Section schedule">
               <div className="overflow-x-auto">
@@ -245,10 +278,7 @@ export default function BeamDesign() {
             </ResultCard>
           )}
 
-          <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-            <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">
-              Section preview{multi && active ? ` — ${active.label}` : ''}
-            </h2>
+          <DrawingCard title={`Section${multi && active ? ` — ${active.label}` : ''}`} meta={`${f0(f.b)} × ${f0(f.h)} · to scale`}>
             {r ? (
               <BeamSchematic b={f.b} h={f.h} cover={f.cover} barDia={f.barDia} stirrupDia={f.stirrupDia}
                 bars={r.bars} d={r.d} dPrime={r.comprLayers.length > 0 ? r.dPrime : undefined}
@@ -256,9 +286,9 @@ export default function BeamDesign() {
                 comprBars={r.comprBars} comprBarDia={f.comprBarDia}
                 naDepth={r.cNA} flexOK={r.flexOK} hogging={hogging} />
             ) : (
-              <p className="py-8 text-center text-sm text-slate-500">Enter a valid section (d must be positive).</p>
+              <p className="py-8 text-center text-sm text-[#a39d8d]">Enter a valid section (d must be positive).</p>
             )}
-          </div>
+          </DrawingCard>
 
           {r && (
             <ResultCard title={`Results${multi && active ? ` — ${active.label}` : ''}`}>
@@ -303,7 +333,9 @@ export default function BeamDesign() {
             </ResultCard>
           )}
           {deflection && (
-            <ResultCard title="Serviceability — ACI 318-14 §24.2">
+            <ResultCard title={<span className="flex items-center justify-between">Serviceability — ACI 318-14 §24.2
+              <span className={`rounded px-1.5 py-px font-mono text-[10px] font-semibold ${deflection.liveOK && deflection.totalOK && deflection.hMinOK ? 'bg-[#ddefe3] text-[#14603a]' : 'bg-[#fbeeea] text-[#c2402a]'}`}>
+                {deflection.liveOK && deflection.totalOK && deflection.hMinOK ? 'PASS' : 'CHECK'}</span></span>}>
               <Row label="Min. thickness h_min" value={`${deflection.hMin.toFixed(0)} mm`}
                 alert={!deflection.hMinOK}
                 sub={`Table 409.3.1.1 (${deflection.support})${deflection.hMinOK ? ' — h ≥ h_min ✓, deflection check waivable' : ' — h < h_min ✗, deflection governs'}`} />
@@ -330,8 +362,9 @@ export default function BeamDesign() {
 
       {solution && (
         <WorkedSolution steps={solution}
-          title={multi && active ? `Solution — ${active.label}` : 'Solution — step by step'} />
+          title={multi && active ? `Calculation report — ${active.label}` : 'Calculation report — worked solution'} />
       )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
**Phase C of the UI/UX redesign**, matching the user's reference screenshots: the calculator template applied to **Beam Design**, plus a retheme of the shared `components/qty.tsx` primitives that **19 calculator/estimate pages** inherit in one pass. **UI only — engine untouched** (guard: 0 files under `webapp/src/engine`; suite unchanged at **1063**; tsc clean).

## Beam Design (mockup: `Redesign - Beam Design`)
- `PageHeader` with the **Single section / Multiple sections segmented toggle** (moved out of the inputs, per the reference shot).
- `VerdictPanel`: "DESIGN OK — SRRB, single layer" headline, governing flexure utilization, mono stat strip (tension steel · stirrups · effective depth), utilization bars, and the ρ-limits footnote.
  - Bars stay **honest to what the engine exposes**: `Mu/φMn,max` while singly reinforced, `Vu/φVc` while no stirrups are demanded, `s/s,max` when designed, and bar-fit clear-spacing — no capacity math re-implemented in the UI (the engine doesn't export provided-φMn/φVn; if we want the exact mockup labels, that's a small engine-result addition for a later, separately-reviewed PR).
- Section drawing on the drafting-grid `DrawingCard`; Serviceability card with its **PASS/CHECK chip**; worked solution titled as the calculation report.
- Multi-section flow (schedule table, per-section view, Beam-Analysis handoff) fully preserved.

## qty.tsx retheme
`Num`/`Pick`/`Card`/`ResultCard`/`Row`/`QtyPage` moved to the drawing-sheet system (ink headings, hairline borders, mono values, semantic alert rows) — estimates, connections, geotech and the other calculator pages pick this up without per-page edits.

## Verified (headless Chromium)
Header toggle switches single/multi and renders the schedule; serviceability chip reads PASS with the mockup's example loads; default beam reproduces the reference values; no console errors.

Next: Phase D — 3D Model Space chrome per the reference (header bar with model name + Analyze/Design-all actions, dark canvas surround, right-panel tab strip) — **keeping the existing viewport**, per the user's instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_