### PR TITLE
feat: UI redesign Phase E — print calc-sheet report + Foundation refinements (UI only)

### DIFF
--- a/webapp/src/components/FootingSchematic.tsx
+++ b/webapp/src/components/FootingSchematic.tsx
@@ -1,9 +1,9 @@
 import type { JSX } from 'react'
 import { DimBelow, DimSide } from './dims'
 
-const STROKE = '#37526e'
-const FILL = '#eef3f8'
-const COL = '#37526e'
+const STROKE = '#0f1b2a'
+const FILL = '#fff'
+const COL = '#0f1b2a'
 
 export interface SchematicProps {
   /** Footing length along x, m. */
@@ -61,19 +61,19 @@ export function FootingSchematic({ Bx, By, Dc, columnWidth, H }: SchematicProps)
   return (
     <svg viewBox={`0 0 ${W} ${totalH}`} xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet"
       style={{ width: '100%', height: 'auto', fontFamily: 'Arial, sans-serif' }}>
-      <text x={14} y={20} fontSize={11} fontWeight={700} fill="#0056b3">PLAN</text>
+      <text x={14} y={20} fontSize={11} fontWeight={700} fill="#a39d8d" fontFamily="IBM Plex Mono, monospace" letterSpacing="2">PLAN</text>
       {/* footing + column */}
-      <rect x={fx} y={fyTop} width={fW} height={fH} rx={2} fill={FILL} stroke={STROKE} strokeWidth={1.4} />
+      <rect x={fx} y={fyTop} width={fW} height={fH} fill={FILL} stroke={STROKE} strokeWidth={1.4} />
       <rect x={cxc - cpx / 2} y={cyc - cpx / 2} width={cpx} height={cpx} fill={COL} />
       <DimBelow xA={fx} xB={fx + fW} featY={fyBot} dY={fyBot + 20} label={`Bx = ${Bx.toFixed(2)} m`} />
       <DimSide yA={fyTop} yB={fyBot} featX={fx + fW} dX={fx + fW + 10} label={`By = ${By.toFixed(2)} m`} side="right" />
 
-      <text x={14} y={secTitleY} fontSize={11} fontWeight={700} fill="#0056b3">SECTION</text>
+      <text x={14} y={secTitleY} fontSize={11} fontWeight={700} fill="#a39d8d" fontFamily="IBM Plex Mono, monospace" letterSpacing="2">SECTION</text>
       {/* ground + soil */}
       <line x1={slabX} y1={gl} x2={slabX + sW} y2={gl} stroke="#8a6d3b" strokeWidth={1.2} />
       {soilTicks}
       {/* slab + column stub */}
-      <rect x={slabX} y={slabY} width={sW} height={slabH} fill="#cfe0f1" stroke={STROKE} strokeWidth={1.4} />
+      <rect x={slabX} y={slabY} width={sW} height={slabH} fill="#fff" stroke={STROKE} strokeWidth={1.4} />
       <rect x={slabX + sW / 2 - stubW / 2} y={gl} width={stubW} height={slabY - gl} fill={COL} />
       <DimSide yA={gl} yB={baseY} featX={slabX} dX={slabX - 12} label={`H = ${H.toFixed(2)} m`} side="left" />
       <DimSide yA={slabY} yB={baseY} featX={slabX + sW} dX={slabX + sW + 8} label={`Dc = ${Math.round(Dc)} mm`} side="right" />

--- a/webapp/src/components/calc.tsx
+++ b/webapp/src/components/calc.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from 'react'
+import type { SolutionStep } from '../lib/solution'
+import { Math as KTex } from '../lib/math'
 
 // Calculator-template building blocks (docs/design/uiux-2026-07, Foundation /
 // Beam mockups): numbered input sections on the left, a sticky verdict panel
@@ -103,5 +105,159 @@ export function DrawingCard({ title, meta, children }: { title: string; meta?: s
         {children}
       </div>
     </section>
+  )
+}
+
+// ── Report letterhead (screen card) ─────────────────────────────────────────
+export interface LetterheadState { project: string; sheet: string; preparedBy: string }
+export function LetterheadCard({ lh, onChange }: { lh: LetterheadState; onChange: (p: Partial<LetterheadState>) => void }) {
+  const today = new Date().toISOString().slice(0, 10)
+  const cell = (label: string, value: string, key: keyof LetterheadState, ph: string, mono = false) => (
+    <div>
+      <span className="text-[10px] font-semibold uppercase tracking-widest text-[#a39d8d]">{label}</span>
+      <input value={value} onChange={(e) => onChange({ [key]: e.target.value })} placeholder={ph}
+        className={`mt-0.5 w-full !border-0 !bg-transparent !p-0 text-[12px] font-semibold text-[#0f1b2a] !shadow-none placeholder:text-[#c8c2b4] ${mono ? 'font-mono font-medium' : ''}`} />
+    </div>
+  )
+  return (
+    <section className="no-print rounded-lg border border-[#e3e1da] bg-white p-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-[13.5px] font-bold text-[#0f1b2a]">Report letterhead</h2>
+        <span className="font-mono text-[10px] text-[#a39d8d]">prints on the calc sheet</span>
+      </div>
+      <div className="mt-2.5 grid grid-cols-2 gap-x-3.5 gap-y-2">
+        {cell('Project', lh.project, 'project', 'Lot 12 Residence')}
+        {cell('Sheet', lh.sheet, 'sheet', 'F-01 · Rev A', true)}
+        {cell('Prepared by', lh.preparedBy, 'preparedBy', 'Engineer, CE')}
+        <div>
+          <span className="text-[10px] font-semibold uppercase tracking-widest text-[#a39d8d]">Date</span>
+          <p className="mt-0.5 font-mono text-[12px] font-medium text-[#0f1b2a]">{today}</p>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+// ── Print calc-sheet (docs/design/uiux-2026-07/Redesign - Report Print) ────
+// Rendered print-only; the browser Print → Save as PDF path stays the export.
+export interface ReportCheckRow { name: string; ratio: number; ok: boolean }
+const SectionRule = ({ n, title }: { n: number; title: string }) => (
+  <h2 className="mt-6 border-b-2 border-[#0f1b2a] pb-1.5 text-[12px] font-extrabold uppercase tracking-[.12em] text-[#0f1b2a]">{n} · {title}</h2>
+)
+export function PrintReport({ docTitle, docCode, badges, ok, governing, lh, stats, checks, data, steps, drawing, drawingTitle }: {
+  docTitle: string; docCode: string; badges: string[]
+  ok: boolean; governing: string
+  lh: LetterheadState
+  stats: VerdictStat[]; checks: ReportCheckRow[]
+  data: [string, string][]
+  steps: SolutionStep[]
+  drawing: ReactNode; drawingTitle: string
+}) {
+  const today = new Date().toISOString().slice(0, 10)
+  const lhCells: [string, string, boolean][] = [
+    ['Project', lh.project || '—', false], ['Sheet', lh.sheet || '—', true],
+    ['Prepared by', lh.preparedBy || '—', false], ['Date', today, true],
+    ['Element', docTitle, false], ['Codes', badges.join(' · '), true],
+  ]
+  return (
+    <div className="print-only">
+      <div className="flex items-baseline justify-between border-b border-[#eeece5] pb-1.5 font-mono text-[9px] text-[#a39d8d]">
+        <span>CIVENG TOOLKIT · {docTitle.toUpperCase()} — CALCULATION REPORT</span>
+        <span>{lh.sheet || docCode} · {today}</span>
+      </div>
+      <div className="mt-3 flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-baseline gap-2">
+            <span className="text-[14px] font-extrabold tracking-[.14em]">CIVENG</span>
+            <span className="text-[8px] font-semibold uppercase tracking-[.22em] text-[#7a7568]">Toolkit</span>
+          </div>
+          <h1 className="mt-2 text-[24px] font-extrabold tracking-tight">{docTitle} — Design Calculation</h1>
+          <div className="mt-2 flex gap-2">
+            {badges.map((b) => <span key={b} className="rounded border border-[#cddcf0] bg-[#eaf1f9] px-1.5 py-px font-mono text-[9.5px] font-medium text-[#0f4c92]">{b}</span>)}
+          </div>
+        </div>
+        <div className={`inline-flex items-center gap-2 rounded-lg border px-3.5 py-2.5 ${ok ? 'border-[#d3e8da] bg-[#ecf6ef]' : 'border-[#efd4cc] bg-[#fbeeea]'}`}>
+          <div>
+            <p className={`text-[11.5px] font-extrabold tracking-wide ${ok ? 'text-[#14603a]' : 'text-[#8f2f1e]'}`}>{ok ? 'DESIGN OK' : 'CHECK FAILED'}</p>
+            <p className={`mt-px text-[9.5px] ${ok ? 'text-[#4d7a5f]' : 'text-[#a95b47]'}`}>{governing}</p>
+          </div>
+        </div>
+      </div>
+      <div className="print-avoid-break mt-4 grid grid-cols-3 overflow-hidden rounded-lg border border-[#e3e1da]">
+        {lhCells.map(([k, v, mono]) => (
+          <div key={k} className="border-b border-r border-[#eeece5] px-3.5 py-2">
+            <p className="text-[8.5px] font-semibold uppercase tracking-widest text-[#a39d8d]">{k}</p>
+            <p className={`mt-0.5 text-[11px] font-semibold text-[#0f1b2a] ${mono ? 'font-mono font-medium' : ''}`}>{v}</p>
+          </div>
+        ))}
+      </div>
+
+      <SectionRule n={1} title="Design Summary" />
+      <div className="print-avoid-break mt-3 grid grid-cols-3 gap-2.5">
+        {stats.map((st) => (
+          <div key={st.label} className="rounded-lg border border-[#e3e1da] px-3.5 py-2.5">
+            <p className="text-[8.5px] font-semibold uppercase tracking-widest text-[#a39d8d]">{st.label}</p>
+            <p className="mt-0.5 font-mono text-[15px] font-semibold">{st.value}{st.unit && <span className="text-[10px] text-[#a39d8d]"> {st.unit}</span>}</p>
+          </div>
+        ))}
+      </div>
+      <table className="mt-3 w-full border-collapse text-[10.5px]">
+        <thead><tr>
+          <th className="border-b-[1.5px] border-[#0f1b2a] px-2.5 py-1.5 text-left text-[8.5px] font-bold uppercase tracking-widest text-[#5c6675]">Check</th>
+          <th className="border-b-[1.5px] border-[#0f1b2a] px-2.5 py-1.5 text-right text-[8.5px] font-bold uppercase tracking-widest text-[#5c6675]">Ratio</th>
+          <th className="border-b-[1.5px] border-[#0f1b2a] px-2.5 py-1.5 text-right text-[8.5px] font-bold uppercase tracking-widest text-[#5c6675]">Status</th>
+        </tr></thead>
+        <tbody>
+          {checks.map((c) => (
+            <tr key={c.name}>
+              <td className="border-b border-[#eeece5] px-2.5 py-1.5 font-semibold">{c.name}</td>
+              <td className="border-b border-[#eeece5] px-2.5 py-1.5 text-right font-mono" style={{ color: c.ratio > 1.0001 ? '#c2402a' : c.ratio >= 0.95 ? '#b97d10' : '#1a7f4b' }}>{c.ratio.toFixed(2)}</td>
+              <td className="border-b border-[#eeece5] px-2.5 py-1.5 text-right">
+                <span className={`inline-block rounded px-1.5 py-px font-mono text-[9px] font-semibold ${c.ok ? 'bg-[#ddefe3] text-[#14603a]' : 'bg-[#fbeeea] text-[#c2402a]'}`}>{c.ok ? 'PASS' : 'FAIL'}</span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <SectionRule n={2} title="Design Data" />
+      <div className="print-avoid-break mt-2 grid grid-cols-2 gap-x-7">
+        {data.map(([k, v]) => (
+          <div key={k} className="flex items-baseline justify-between border-b border-[#f3f1ea] py-1 text-[10.5px]">
+            <span className="text-[#5c6675]">{k}</span><span className="font-mono font-medium">{v}</span>
+          </div>
+        ))}
+      </div>
+
+      <SectionRule n={3} title="Worked Solution" />
+      {steps.map((st, i) => (
+        <div key={i} className="print-avoid-break grid grid-cols-[1fr_110px] gap-4 border-b border-[#f3f1ea] py-3">
+          <div>
+            <h3 className="text-[11.5px] font-bold"><span className="mr-1.5 font-mono font-semibold text-[#a39d8d]">3.{i + 1}</span>{st.title}</h3>
+            <div className="mt-1 space-y-1">
+              {st.lines.map((ln, j) => 'text' in ln
+                ? <p key={j} className="text-[10.5px] leading-relaxed text-[#5c6675]">{ln.text}</p>
+                : <div key={j} className="overflow-x-auto rounded-md border border-[#eeece5] bg-[#f9f8f4] px-2.5 py-1 text-[10.5px]"><KTex block tex={ln.tex} /></div>)}
+            </div>
+          </div>
+          <p className="pt-0.5 text-[9px] leading-snug text-[#a39d8d]">{st.note ?? ''}</p>
+        </div>
+      ))}
+
+      <SectionRule n={4} title="Drawing" />
+      <div className="print-avoid-break mt-3 rounded-lg border border-[#e3e1da] p-3.5 [background-image:linear-gradient(#f0eee7_1px,transparent_1px),linear-gradient(90deg,#f0eee7_1px,transparent_1px)] [background-size:22px_22px]">
+        <div className="flex items-baseline justify-between">
+          <span className="text-[10px] font-bold tracking-[.14em] text-[#5c6675]">{(lh.sheet || docCode).split('·')[0].trim()} · {drawingTitle.toUpperCase()}</span>
+          <span className="font-mono text-[9px] text-[#a39d8d]">to scale</span>
+        </div>
+        <div className="mx-auto w-3/4">{drawing}</div>
+      </div>
+
+      <div className="print-avoid-break mt-6 grid grid-cols-2 gap-7">
+        <div><div className="h-11 border-b border-[#0f1b2a]" /><p className="mt-1.5 text-[10px] font-bold">{lh.preparedBy || '\u00a0'}</p><p className="text-[9px] text-[#7a7568]">Prepared by</p></div>
+        <div><div className="h-11 border-b border-[#0f1b2a]" /><p className="mt-1.5 text-[10px] font-bold">{'\u00a0'}</p><p className="text-[9px] text-[#7a7568]">Reviewed by · Date</p></div>
+      </div>
+      <p className="mt-4 text-[8.5px] leading-relaxed text-[#a39d8d]">Computed client-side by the CivEng Toolkit engine · verify before construction use. Load factors per NSCP 2015 §203.3; strength reduction factors per ACI 318-14 Table 21.2.1. Project: {lh.project || '—'}.</p>
+    </div>
   )
 }

--- a/webapp/src/components/qty.tsx
+++ b/webapp/src/components/qty.tsx
@@ -8,12 +8,13 @@ export function Num({ label, unit, value, onChange, step = 'any', hint }: {
 }) {
   return (
     <label className="flex flex-col text-sm">
-      <span className="mb-1 text-[11.5px] font-semibold text-[#5c6675]">
-        {label}{unit ? <span className="font-mono text-[10.5px] font-normal text-[#a39d8d]"> ({unit})</span> : null}
+      <span className="mb-1 text-[11.5px] font-semibold text-[#5c6675]">{label}</span>
+      <span className="flex overflow-hidden rounded-md border border-[#d6d3c9] bg-[#fcfbf8] focus-within:border-[#0f4c92] focus-within:shadow-[0_0_0_3px_rgba(15,76,146,.14)]">
+        <input type="number" inputMode="decimal" step={step} value={Number.isFinite(value) ? value : ''}
+          onChange={(e) => onChange(parseFloat(e.target.value))}
+          className="min-w-0 flex-1 !rounded-none !border-0 !bg-transparent text-[13px] !shadow-none" />
+        {unit && <span className="flex items-center border-l border-[#eeece5] bg-[#f7f6f1] px-2.5 font-mono text-[10.5px] text-[#a39d8d]">{unit}</span>}
       </span>
-      <input type="number" inputMode="decimal" step={step} value={Number.isFinite(value) ? value : ''}
-        onChange={(e) => onChange(parseFloat(e.target.value))}
-        className="text-[13px]" />
       {hint ? <span className="mt-0.5 text-[10px] text-[#a39d8d]">{hint}</span> : null}
     </label>
   )

--- a/webapp/src/pages/FoundationDesign.tsx
+++ b/webapp/src/pages/FoundationDesign.tsx
@@ -6,13 +6,12 @@ import { netBearing } from '../engine/bearing'
 import { factoredLoad } from '../engine/loads'
 import type { ColumnPosition } from '../engine/shear'
 import { FootingSchematic } from '../components/FootingSchematic'
-import { ReportControls } from '../components/ReportControls'
 import { ExcelImport } from '../components/ExcelImport'
 import type { BatchResult } from '../lib/foundationExcel'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { buildFoundationSolution, type SolutionCtx } from '../lib/foundationSolution'
 import { Math } from '../lib/math'
-import { PageHeader, CalcSection, VerdictPanel, DrawingCard } from '../components/calc'
+import { PageHeader, CalcSection, VerdictPanel, DrawingCard, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
 import { f0, f2, f3 } from '../lib/format'
 import 'katex/dist/katex.min.css'
 
@@ -109,14 +108,15 @@ function NumField({ label, unit, value, onChange, step = 'any' }: {
 }) {
   return (
     <label className="flex flex-col text-sm">
-      <span className="mb-1 text-[11.5px] font-semibold text-[#5c6675]">
-        {label}{unit ? <span className="font-mono text-[10.5px] font-normal text-[#a39d8d]"> ({unit})</span> : null}
+      <span className="mb-1 text-[11.5px] font-semibold text-[#5c6675]">{label}</span>
+      <span className="flex overflow-hidden rounded-md border border-[#d6d3c9] bg-[#fcfbf8] focus-within:border-[#0f4c92] focus-within:shadow-[0_0_0_3px_rgba(15,76,146,.14)]">
+        <input
+          type="number" inputMode="decimal" step={step} value={Number.isFinite(value) ? value : ''}
+          onChange={(e) => onChange(parseFloat(e.target.value))}
+          className="min-w-0 flex-1 !rounded-none !border-0 !bg-transparent text-[13px] !shadow-none"
+        />
+        {unit && <span className="flex items-center border-l border-[#eeece5] bg-[#f7f6f1] px-2.5 font-mono text-[10.5px] text-[#a39d8d]">{unit}</span>}
       </span>
-      <input
-        type="number" inputMode="decimal" step={step} value={Number.isFinite(value) ? value : ''}
-        onChange={(e) => onChange(parseFloat(e.target.value))}
-        className="text-[13px]"
-      />
     </label>
   )
 }
@@ -164,6 +164,7 @@ function steelRow(label: ReactNode, s: DirSteel, db: number) {
 
 export default function FoundationDesign() {
   const [form, setForm] = useState<FormState>(DEFAULTS)
+  const [lh, setLh] = useState<LetterheadState>({ project: '', sheet: 'F-01 · Rev A', preparedBy: '' })
   const [batch, setBatch] = useState<BatchResult | null>(null)
   const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) => setForm((s) => ({ ...s, [k]: v }))
   const ecc = form.loadingType === 'eccentric'
@@ -270,10 +271,15 @@ export default function FoundationDesign() {
 
   return (
     <div>
-      <PageHeader title="Isolated Footing" badges={['ACI 318-14', 'NSCP 2015']} />
+      <PageHeader title="Isolated Footing" badges={['ACI 318-14', 'NSCP 2015']}
+        actions={
+          <button type="button" onClick={() => { const prev = document.title; document.title = `Foundation Design Report${lh.project ? ` — ${lh.project}` : ''}`; window.print(); window.setTimeout(() => { document.title = prev }, 500) }}
+            className="inline-flex items-center gap-2 rounded-md bg-[#0f4c92] px-4 py-2 text-[12.5px] font-semibold text-white hover:bg-[#0d3f78]">
+            ⎙ Export report
+          </button>
+        } />
       <div className="mx-auto max-w-6xl px-5 pb-8 sm:px-7">
-      <ReportControls title="Foundation Design Report" />
-      <ExcelImport onResult={setBatch} />
+      <div className="no-print"><ExcelImport onResult={setBatch} /></div>
 
       {batch && (
         <div className="mt-4 overflow-hidden rounded-lg border border-[#e3e1da] bg-white print-avoid-break">
@@ -486,15 +492,38 @@ export default function FoundationDesign() {
             </div>
           )}
 
-          <div className="rounded-lg border border-[#e3e1da] bg-white p-4 text-sm text-[#5c6675]">
-            <h2 className="mb-2 text-[13.5px] font-bold text-[#0f1b2a]">Basis</h2>
-            <Math block tex={String.raw`q_{net} = q_a - \gamma_s D_s - \gamma_c D_c - q,\quad P_u = \max(1.4D,\ 1.2D + 1.6L)`} />
-            <p className="mt-1 text-xs text-slate-500">NSCP 2015 / ACI 318-14. φ: shear 0.75, flexure 0.90. Short-direction band per §413.3.3.3.</p>
-          </div>
+          <LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} />
         </div>
       </div>
 
-      {solutionSteps && <WorkedSolution steps={solutionSteps} title="Calculation report — worked solution" />}
+      <div className="no-print">{solutionSteps && <WorkedSolution steps={solutionSteps} title="Calculation report — worked solution" />}</div>
+      {view && solutionSteps && (
+        <PrintReport
+          docTitle="Isolated Footing" docCode="F-01" badges={['ACI 318-14', 'NSCP 2015']}
+          ok={allOK} governing={`Governing: ${governing} · ${globalThis.Math.max(punchRatio, beamRatio).toFixed(2)}`}
+          lh={lh}
+          stats={[
+            { label: 'Plan size', value: `${f2(view.Bx)} × ${f2(view.By)}`, unit: 'm' },
+            { label: 'Thickness Dc', value: f0(view.Dc), unit: 'mm' },
+            { label: view.type === 'square' ? 'Steel each way' : 'Steel — long', value: `${view.long.bars}-⌀${form.barDia}`, unit: `@${f0(view.long.spacing)}` },
+          ]}
+          checks={[
+            { name: 'Two-way (punching) shear — d req/prov', ratio: punchRatio, ok: view.punchOK },
+            { name: 'One-way (beam) shear — d req/prov', ratio: beamRatio, ok: view.beamOK },
+          ]}
+          data={[
+            ['Service load P', `${f0(serviceLoad)} kN`], ['Ultimate load Pu', `${f0(ultimateLoad)} kN`],
+            ["Concrete f'c", `${form.fc} MPa`], ['Steel fy', `${form.fy} MPa`],
+            ['Column width c', `${f0(colWidth)} mm (${form.position})`], ['Bar diameter db', `⌀${form.barDia} mm`],
+            ['Allowable bearing qa', `${form.qAllow} kPa`], ['Clear cover', `${form.cover} mm`],
+            ['Unit weight, soil γs', `${form.gammaSoil} kN/m³`], ['Unit weight, concrete γc', `${form.gammaConc} kN/m³`],
+            ['Total depth H', `${f2(form.H)} m`], ['Surcharge', `${form.surcharge} kPa`],
+          ]}
+          steps={solutionSteps}
+          drawingTitle="Isolated Footing"
+          drawing={<FootingSchematic Bx={view.Bx} By={view.By} Dc={view.Dc} columnWidth={colWidth} H={form.H} />}
+        />
+      )}
       </div>
     </div>
   )


### PR DESCRIPTION
**Phase E of the UI/UX redesign** — implements **`Redesign - Report Print.dc.html`** (pulled directly from the user's claude.ai/design project via the design MCP) plus the user's Foundation refinement notes. **UI only — engine untouched** (guard: 0 files under `webapp/src/engine`; suite unchanged at **1063**; tsc clean).

## Print calc-sheet — `PrintReport` (`components/calc.tsx`)
A print-only, sign-off-ready report replacing the old "screen dump" print path, exactly per the mockup:
- mono document header strip (tool · sheet · date), CIVENG brand block, **DESIGN OK / CHECK FAILED chip** with the governing check;
- **letterhead grid** (Project / Sheet / Prepared by / Date / Element / Codes);
- **1 · Design Summary** — stat cards + check table with ratio colors and PASS/FAIL chips;
- **2 · Design Data** — two-column key/value input record;
- **3 · Worked Solution** — numbered 3.n steps with KaTeX formula blocks and the margin note column;
- **4 · Drawing** — the scaled schematic on the drafting-grid sheet with a title block;
- signature blocks (Prepared by / Reviewed by) and the engine disclaimer.
Browser **Print → Save as PDF** remains the export path (wired to the new header "⎙ Export report" button).

## Foundation refinements (user's notes)
- **Unit-suffix inputs**: the unit tag now sits inside the field's right edge, mockup-style — applied to Foundation's fields *and* the shared `qty.Num`, so Beam and the other 18 template pages inherit it.
- **"Basis" card removed**; the editable **Report letterhead card** (Project / Sheet / Prepared by / Date) takes its place in the rail and feeds the printed sheet.
- **Drawing colors**: `FootingSchematic` redrawn to the mockup — ink `#0f1b2a` strokes, **no corner radius**, white fills, mono PLAN/SECTION labels, drafting-blue dimensions.

## Verified (headless Chromium)
14 unit-suffix fields render; Basis gone; letterhead card + header Export present; print emulation shows the full calc sheet — all four numbered sections, 2 PASS chips, signature blocks — with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_