### PR TITLE
feat: UI redesign Phase F — print calc-sheet + letterhead on Beam, Column, Combined Footing (UI only)

### DIFF
--- a/webapp/src/components/calc.tsx
+++ b/webapp/src/components/calc.tsx
@@ -144,14 +144,14 @@ export interface ReportCheckRow { name: string; ratio: number; ok: boolean }
 const SectionRule = ({ n, title }: { n: number; title: string }) => (
   <h2 className="mt-6 border-b-2 border-[#0f1b2a] pb-1.5 text-[12px] font-extrabold uppercase tracking-[.12em] text-[#0f1b2a]">{n} · {title}</h2>
 )
-export function PrintReport({ docTitle, docCode, badges, ok, governing, lh, stats, checks, data, steps, drawing, drawingTitle }: {
+export function PrintReport({ docTitle, docCode, badges, ok, governing, lh, stats = [], checks = [], data = [], steps, drawing, drawingTitle }: {
   docTitle: string; docCode: string; badges: string[]
   ok: boolean; governing: string
   lh: LetterheadState
-  stats: VerdictStat[]; checks: ReportCheckRow[]
-  data: [string, string][]
+  stats?: VerdictStat[]; checks?: ReportCheckRow[]
+  data?: [string, string][]
   steps: SolutionStep[]
-  drawing: ReactNode; drawingTitle: string
+  drawing?: ReactNode; drawingTitle?: string
 }) {
   const today = new Date().toISOString().slice(0, 10)
   const lhCells: [string, string, boolean][] = [
@@ -192,16 +192,16 @@ export function PrintReport({ docTitle, docCode, badges, ok, governing, lh, stat
         ))}
       </div>
 
-      <SectionRule n={1} title="Design Summary" />
-      <div className="print-avoid-break mt-3 grid grid-cols-3 gap-2.5">
+      {(stats.length > 0 || checks.length > 0) && <SectionRule n={1} title="Design Summary" />}
+      {stats.length > 0 && <div className="print-avoid-break mt-3 grid grid-cols-3 gap-2.5">
         {stats.map((st) => (
           <div key={st.label} className="rounded-lg border border-[#e3e1da] px-3.5 py-2.5">
             <p className="text-[8.5px] font-semibold uppercase tracking-widest text-[#a39d8d]">{st.label}</p>
             <p className="mt-0.5 font-mono text-[15px] font-semibold">{st.value}{st.unit && <span className="text-[10px] text-[#a39d8d]"> {st.unit}</span>}</p>
           </div>
         ))}
-      </div>
-      <table className="mt-3 w-full border-collapse text-[10.5px]">
+      </div>}
+      {checks.length > 0 && <table className="mt-3 w-full border-collapse text-[10.5px]">
         <thead><tr>
           <th className="border-b-[1.5px] border-[#0f1b2a] px-2.5 py-1.5 text-left text-[8.5px] font-bold uppercase tracking-widest text-[#5c6675]">Check</th>
           <th className="border-b-[1.5px] border-[#0f1b2a] px-2.5 py-1.5 text-right text-[8.5px] font-bold uppercase tracking-widest text-[#5c6675]">Ratio</th>
@@ -218,16 +218,16 @@ export function PrintReport({ docTitle, docCode, badges, ok, governing, lh, stat
             </tr>
           ))}
         </tbody>
-      </table>
+      </table>}
 
-      <SectionRule n={2} title="Design Data" />
-      <div className="print-avoid-break mt-2 grid grid-cols-2 gap-x-7">
+      {data.length > 0 && <SectionRule n={2} title="Design Data" />}
+      {data.length > 0 && <div className="print-avoid-break mt-2 grid grid-cols-2 gap-x-7">
         {data.map(([k, v]) => (
           <div key={k} className="flex items-baseline justify-between border-b border-[#f3f1ea] py-1 text-[10.5px]">
             <span className="text-[#5c6675]">{k}</span><span className="font-mono font-medium">{v}</span>
           </div>
         ))}
-      </div>
+      </div>}
 
       <SectionRule n={3} title="Worked Solution" />
       {steps.map((st, i) => (
@@ -244,20 +244,52 @@ export function PrintReport({ docTitle, docCode, badges, ok, governing, lh, stat
         </div>
       ))}
 
-      <SectionRule n={4} title="Drawing" />
-      <div className="print-avoid-break mt-3 rounded-lg border border-[#e3e1da] p-3.5 [background-image:linear-gradient(#f0eee7_1px,transparent_1px),linear-gradient(90deg,#f0eee7_1px,transparent_1px)] [background-size:22px_22px]">
+      {drawing && <SectionRule n={4} title="Drawing" />}
+      {drawing && <div className="print-avoid-break mt-3 rounded-lg border border-[#e3e1da] p-3.5 [background-image:linear-gradient(#f0eee7_1px,transparent_1px),linear-gradient(90deg,#f0eee7_1px,transparent_1px)] [background-size:22px_22px]">
         <div className="flex items-baseline justify-between">
-          <span className="text-[10px] font-bold tracking-[.14em] text-[#5c6675]">{(lh.sheet || docCode).split('·')[0].trim()} · {drawingTitle.toUpperCase()}</span>
+          <span className="text-[10px] font-bold tracking-[.14em] text-[#5c6675]">{(lh.sheet || docCode).split('·')[0].trim()} · {(drawingTitle ?? docTitle).toUpperCase()}</span>
           <span className="font-mono text-[9px] text-[#a39d8d]">to scale</span>
         </div>
         <div className="mx-auto w-3/4">{drawing}</div>
-      </div>
+      </div>}
 
       <div className="print-avoid-break mt-6 grid grid-cols-2 gap-7">
         <div><div className="h-11 border-b border-[#0f1b2a]" /><p className="mt-1.5 text-[10px] font-bold">{lh.preparedBy || '\u00a0'}</p><p className="text-[9px] text-[#7a7568]">Prepared by</p></div>
         <div><div className="h-11 border-b border-[#0f1b2a]" /><p className="mt-1.5 text-[10px] font-bold">{'\u00a0'}</p><p className="text-[9px] text-[#7a7568]">Reviewed by · Date</p></div>
       </div>
       <p className="mt-4 text-[8.5px] leading-relaxed text-[#a39d8d]">Computed client-side by the CivEng Toolkit engine · verify before construction use. Load factors per NSCP 2015 §203.3; strength reduction factors per ACI 318-14 Table 21.2.1. Project: {lh.project || '—'}.</p>
+    </div>
+  )
+}
+
+/** Screen report bar for calculator pages that keep a single-column layout:
+ *  inline letterhead fields + the Export (print) action. Pairs with
+ *  PrintReport, which renders the printed letterhead itself. */
+export function ReportBar({ title, lh, onChange }: {
+  title: string; lh: LetterheadState; onChange: (p: Partial<LetterheadState>) => void
+}) {
+  const print = () => {
+    const prev = document.title
+    document.title = title + (lh.project ? ` — ${lh.project}` : '')
+    window.print()
+    window.setTimeout(() => { document.title = prev }, 500)
+  }
+  const field = (label: string, key: keyof LetterheadState, ph: string, mono = false) => (
+    <label className="flex min-w-36 flex-1 flex-col text-sm">
+      <span className="mb-1 text-[11.5px] font-semibold text-[#5c6675]">{label}</span>
+      <input value={lh[key]} onChange={(e) => onChange({ [key]: e.target.value })} placeholder={ph}
+        className={`text-[13px] ${mono ? 'font-mono' : ''}`} />
+    </label>
+  )
+  return (
+    <div className="no-print mt-4 flex flex-wrap items-end gap-3 rounded-lg border border-[#e3e1da] bg-white p-3">
+      {field('Project / job', 'project', 'Lot 12 Residence')}
+      {field('Sheet', 'sheet', 'S-01 · Rev A', true)}
+      {field('Prepared by', 'preparedBy', 'Engineer, CE')}
+      <button type="button" onClick={print}
+        className="ml-auto inline-flex items-center gap-2 rounded-md bg-[#0f4c92] px-4 py-2 text-sm font-semibold text-white hover:bg-[#0d3f78]">
+        ⎙ Export report
+      </button>
     </div>
   )
 }

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -1,11 +1,10 @@
 import { useMemo, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
-import { PageHeader, VerdictPanel, DrawingCard } from '../components/calc'
+import { PageHeader, VerdictPanel, DrawingCard, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
 import { designBeam, beamServiceDeflection, type BeamDesignInput, type BeamDesignResult } from '../engine/beamDesign'
 import type { BeamSupport } from '../engine/beamDeflection'
 import type { CriticalSection } from '../engine/beamSections'
 import { BeamSchematic } from '../components/BeamSchematic'
-import { ReportControls } from '../components/ReportControls'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { buildBeamSolution } from '../lib/beamSolution'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
@@ -68,6 +67,7 @@ export default function BeamDesign() {
   }, [params])
 
   const [f, setF] = useState<FormState>({ ...DEFAULTS, ...(handoff.multi ? {} : handoff.single) })
+  const [lh, setLh] = useState<LetterheadState>({ project: '', sheet: 'S-01 · Rev A', preparedBy: '' })
   const [span, setSpan] = useState<number>(NaN)
   const [support, setSupport] = useState<BeamSupport>('simple')
   const [svcWD, setSvcWD] = useState<number>(NaN)
@@ -149,10 +149,11 @@ export default function BeamDesign() {
                 {t}
               </button>
             ))}
+            <button type="button" onClick={() => { const prev = document.title; document.title = `Beam Design Report${lh.project ? ` — ${lh.project}` : ''}`; window.print(); window.setTimeout(() => { document.title = prev }, 500) }}
+              className="ml-1.5 inline-flex items-center gap-2 rounded-md bg-[#0f4c92] px-4 py-2 text-[12.5px] font-semibold text-white hover:bg-[#0d3f78]">⎙ Export report</button>
           </div>
         } />
       <div className="mx-auto max-w-6xl px-5 pb-8 sm:px-7">
-      <ReportControls title="Beam Design Report" />
 
       <div className="mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
         <div className="space-y-3.5">
@@ -357,12 +358,41 @@ export default function BeamDesign() {
                 sub={`L/240 = ${deflection.limitL240.toFixed(1)} mm${deflection.totalOK ? ' ✓' : ' ✗'}`} />
             </ResultCard>
           )}
+          <LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} />
         </div>
       </div>
 
-      {solution && (
-        <WorkedSolution steps={solution}
-          title={multi && active ? `Calculation report — ${active.label}` : 'Calculation report — worked solution'} />
+      <div className="no-print">
+        {solution && (
+          <WorkedSolution steps={solution}
+            title={multi && active ? `Calculation report — ${active.label}` : 'Calculation report — worked solution'} />
+        )}
+      </div>
+      {r && solution && (
+        <PrintReport
+          docTitle={multi && active ? `RC Beam — ${active.label}` : 'Rectangular RC Beam'} docCode="S-01" badges={['ACI 318-14', 'NSCP 2015']}
+          ok={allOK} governing={r.mode === 'SRRB' ? `Governing: flexure · ${(demand.Mu / r.phiMnMax).toFixed(2)}` : 'DRRB — compression steel engaged'}
+          lh={lh}
+          stats={[
+            { label: hogging ? 'Tension (top)' : 'Tension steel', value: `${r.bars}-⌀${f.barDia}` },
+            { label: 'Stirrups', value: r.sAdopt > 0 ? `⌀${f.stirrupDia} @${f0(r.sAdopt)}` : REGION[r.region] },
+            { label: 'Eff. depth d', value: f0(r.d), unit: 'mm' },
+          ]}
+          checks={checks.map((c) => ({ ...c, ok: c.ratio <= 1.0001 }))}
+          data={[
+            ['Section b × h', `${f.b} × ${f.h} mm`], ['Clear cover', `${f.cover} mm`],
+            ["Concrete f'c", `${f.fc} MPa`], ['Steel fy / fyt', `${f.fy} / ${f.fyt} MPa`],
+            ['Bar ⌀ / stirrup ⌀', `${f.barDia} / ${f.stirrupDia} mm (${f.legs}-leg)`],
+            ['Moment Mu', `${f1(demand.Mu)} kN·m${hogging ? ' (hogging)' : ''}`],
+            ['Shear Vu', `${f1(demand.Vu)} kN`], ['ρ / ρmin / ρmax', `${r.rho.toFixed(4)} / ${r.rhoMin.toFixed(4)} / ${r.rhoMax.toFixed(4)}`],
+          ]}
+          steps={solution}
+          drawingTitle="Beam Section"
+          drawing={<BeamSchematic b={f.b} h={f.h} cover={f.cover} barDia={f.barDia} stirrupDia={f.stirrupDia}
+            bars={r.bars} d={r.d} dPrime={r.comprLayers.length > 0 ? r.dPrime : undefined}
+            layers={r.layers} comprLayers={r.comprLayers} comprBars={r.comprBars} comprBarDia={f.comprBarDia}
+            naDepth={r.cNA} flexOK={r.flexOK} hogging={hogging} />}
+        />
       )}
       </div>
     </div>

--- a/webapp/src/pages/ColumnDesign.tsx
+++ b/webapp/src/pages/ColumnDesign.tsx
@@ -6,8 +6,8 @@ import {
 } from '../engine/columnDesign'
 import { factoredLoad } from '../engine/loads'
 import { ColumnSchematic } from '../components/ColumnSchematic'
+import { ReportBar, PrintReport, type LetterheadState } from '../components/calc'
 import { InteractionDiagram } from '../components/InteractionDiagram'
-import { ReportControls } from '../components/ReportControls'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { axialColumnSolution, eccentricColumnSolution, slendernessSolution } from '../lib/columnSolution'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
@@ -22,6 +22,7 @@ type BarMode = 'design' | 'analyze'
 
 export default function ColumnDesign() {
   const [mode, setMode] = useState<Mode>('axial')
+  const [lh, setLh] = useState<LetterheadState>({ project: '', sheet: 'C-01 · Rev A', preparedBy: '' })
   const [shape, setShape] = useState<ColumnShape>('tied')
   const [b, setB] = useState(400); const [h, setH] = useState(400); const [D, setD] = useState(400)
   const [cover, setCover] = useState(40)
@@ -121,7 +122,7 @@ export default function ColumnDesign() {
         P–M interaction (balanced condition, φ transition), and nonsway moment magnification for slender
         columns. NSCP 2015 / ACI 318-14.
       </p>
-      <ReportControls title="Column Design Report" />
+      <ReportBar title="Column Design Report" lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} />
 
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
         <div className="space-y-5">
@@ -323,7 +324,34 @@ export default function ColumnDesign() {
         </div>
       )}
 
-      {solution.length > 0 && <WorkedSolution steps={solution} />}
+      <div className="no-print">{solution.length > 0 && <WorkedSolution steps={solution} title="Calculation report — worked solution" />}</div>
+      {axial && solution.length > 0 && (
+        <PrintReport
+          docTitle={tied ? 'Tied RC Column' : 'Spiral RC Column'} docCode="C-01" badges={['ACI 318-14', 'NSCP 2015']}
+          ok={(eccentric ? util !== null && util <= 1 && !unstable : axial.axialOK) && axial.rhoOK}
+          governing={eccentric
+            ? (unstable ? 'Slender column unstable — Pu ≥ 0.75·Pc' : `P–M interaction · utilization ${util !== null ? util.toFixed(2) : '—'}`)
+            : `Axial φPn,max = ${f1(axial.phiPnMax)} kN`}
+          lh={lh}
+          stats={[
+            { label: 'Bars', value: `${axial.bars}-⌀${barDia}` },
+            { label: tied ? 'Ties' : 'Spiral pitch', value: tied ? `⌀${Math.max(tieDia, axial.tieDiaMin)} @${f0(axial.tieSpacingFinal)}` : `@${f0(axial.spiralPitch)}`, unit: 'mm' },
+            { label: 'φPn,max', value: f1(axial.phiPnMax), unit: 'kN' },
+          ]}
+          checks={eccentric && util !== null ? [{ name: 'P–M interaction Pu/φPn', ratio: util, ok: util <= 1.0001 }] : []}
+          data={[
+            ['Section', tied ? `${b} × ${h} mm (tied)` : `⌀${D} mm (spiral)`], ['Clear cover', `${cover} mm`],
+            ["Concrete f'c", `${fc} MPa`], ['Steel fy / fyt', `${fy} / ${fyt} MPa`],
+            ['Bar ⌀ / tie ⌀', `${barDia} / ${tieDia} mm`], ['ρ provided', `${(axial.rho * 100).toFixed(2)} %`],
+            ['Pu', `${f1(Pu)} kN`], ...(eccentric ? [['Mu', `${f1(Mu)} kN·m`] as [string, string]] : []),
+          ]}
+          steps={solution}
+          drawingTitle="Column Section"
+          drawing={<ColumnSchematic shape={tied ? 'tied' : 'spiral'} b={b} h={h} D={D} cover={cover}
+            barDia={barDia} tieDia={tieDia} bars={axial.bars}
+            tieSpacing={tied ? axial.tieSpacingFinal : axial.spiralPitch} />}
+        />
+      )}
     </div>
   )
 }

--- a/webapp/src/pages/CombinedFootingDesign.tsx
+++ b/webapp/src/pages/CombinedFootingDesign.tsx
@@ -3,8 +3,8 @@ import { Link } from 'react-router-dom'
 import { designCombinedFooting, type CombinedFootingInput } from '../engine/combinedFooting'
 import { designFlexibleCombinedFooting } from '../engine/flexibleCombinedFooting'
 import { CombinedFootingSchematic } from '../components/CombinedFootingSchematic'
+import { ReportBar, PrintReport, type LetterheadState } from '../components/calc'
 import { Diagram } from '../components/Diagram'
-import { ReportControls } from '../components/ReportControls'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { buildCombinedFootingSolution } from '../lib/combinedFootingSolution'
 import { Math } from '../lib/math'
@@ -121,6 +121,7 @@ function Row({ label, value, check }: { label: ReactNode; value: ReactNode; chec
 
 export default function CombinedFootingDesign() {
   const [form, setForm] = useState<FormState>(DEFAULTS)
+  const [lh, setLh] = useState<LetterheadState>({ project: '', sheet: 'F-02 · Rev A', preparedBy: '' })
   const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) => setForm((s) => ({ ...s, [k]: v }))
 
   const valid = useMemo(() => {
@@ -175,7 +176,7 @@ export default function CombinedFootingDesign() {
         Choose the <b>rigid</b> (linear-pressure) or <b>flexible</b> (Winkler beam-on-elastic-foundation) method —
         geometry is shared; the flexible method recomputes V/M from the settlement field. Results update live.
       </p>
-      <ReportControls title="Combined Footing Design Report" />
+      <ReportBar title="Combined Footing Design Report" lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} />
 
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
         {/* ── Inputs ── */}
@@ -349,8 +350,34 @@ export default function CombinedFootingDesign() {
         )}
       </div>
 
-      {solutionSteps && (
-        <WorkedSolution steps={solutionSteps} title="Combined footing — worked solution (rigid method)" />
+      <div className="no-print">
+        {solutionSteps && (
+          <WorkedSolution steps={solutionSteps} title="Combined footing — worked solution (rigid method)" />
+        )}
+      </div>
+      {result && solutionSteps && (
+        <PrintReport
+          docTitle={result.shape === 'Trapezoidal (CTF)' ? 'Combined Footing (Trapezoidal)' : 'Combined Footing (Rectangular)'}
+          docCode="F-02" badges={['ACI 318-14', 'NSCP 2015']}
+          ok={result.qNet > 0} governing="Rigid (conventional) method — resultant matched to factored column loads"
+          lh={lh}
+          stats={[
+            { label: 'Plan', value: result.shape === 'Trapezoidal (CTF)' ? `${f2(result.Bx)} × ${f2(result.By1)}→${f2(result.By2)}` : `${f2(result.Bx)} × ${f2(result.By)}`, unit: 'm' },
+            { label: 'Thickness Dc', value: f0(result.Dc), unit: 'mm' },
+            { label: 'q net', value: f2(result.qNet), unit: 'kPa' },
+          ]}
+          data={[
+            ['Column 1 DL / LL', `${f0(form.dl1)} / ${f0(form.ll1)} kN`], ['Column 2 DL / LL', `${f0(form.dl2)} / ${f0(form.ll2)} kN`],
+            ['Column spacing', `${f2(form.spacing)} m`], ["Concrete f'c", `${form.fc} MPa`],
+            ['Steel fy', `${form.fy} MPa`], ['Allowable qa', `${form.qAllow} kPa`],
+            ['Total depth H', `${f2(form.H)} m`], ['Bar ⌀', `${form.barDia} mm`],
+          ]}
+          steps={solutionSteps}
+          drawingTitle="Combined Footing Plan"
+          drawing={<CombinedFootingSchematic
+            shape={result.shape} Bx={result.Bx} By={result.By} By1={result.By1} By2={result.By2}
+            x1={result.x1} x2={result.x2} col1Width={form.col1Width} col2Width={form.col2Width} />}
+        />
       )}
     </div>
   )


### PR DESCRIPTION
**Phase F of the UI/UX redesign** — rolls the `Redesign - Report Print` calc-sheet and the report letterhead out to the remaining worked-solution calculators, per the user's request. **UI only — engine untouched** (guard: 0 files under `webapp/src/engine`; suite unchanged at **1063**; tsc clean).

## What ships
- **`PrintReport` generalized**: summary stats, check table, design-data and drawing sections are now optional with graceful guards, so any page adopts the sheet with exactly the data it has. New shared **`ReportBar`** (inline Project / Sheet / Prepared-by fields + ⎙ Export) for pages on the classic single-column layout.
- **Beam Design**: letterhead card in the verdict rail + header Export; printed sheet carries the section drawing, utilization checks, and the ρ record — titled per-section in multi-section mode.
- **Column Design**: `ReportBar` + printed sheet with the tied/spiral section drawing, tie-spacing / spiral-pitch record, and the P–M utilization check when eccentric.
- **Combined Footing**: `ReportBar` + printed sheet with the CRF/CTF-aware plan schematic and the rigid-method design record.
- The legacy `ReportControls` print block is retired on these pages — `PrintReport` owns the printed output; on-screen worked solutions are `no-print` so nothing duplicates.

## Coverage after this PR
Foundation (Phase E), Beam, Column, Combined Footing all print the signed four-section calc sheet. **Deferred, flagged rather than silently skipped**: `SteelDesign` (three sub-tab solutions — beam/column/connection — need a per-tab report decision) and `LoadPath` (analysis page, no design verdict).

## Verified (headless Chromium)
Print emulation on all three new pages: calc-sheet title block, all four numbered sections, signature blocks, letterhead UI present on screen — no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_