### PR TITLE
fix: single print output + letterhead card/header on all converted calculators (UI only)

### DIFF
--- a/webapp/src/components/calc.tsx
+++ b/webapp/src/components/calc.tsx
@@ -9,7 +9,7 @@ import { Math as KTex } from '../lib/math'
 
 export function PageHeader({ title, badges, actions }: { title: string; badges: string[]; actions?: ReactNode }) {
   return (
-    <div className="flex flex-wrap items-center gap-3 border-b border-[#e3e1da] bg-white px-5 py-3.5 sm:px-7">
+    <div className="no-print flex flex-wrap items-center gap-3 border-b border-[#e3e1da] bg-white px-5 py-3.5 sm:px-7">
       <div className="flex min-w-0 flex-wrap items-center gap-3">
         <h1 className="text-[21px] font-extrabold tracking-tight text-[#0f1b2a]">{title}</h1>
         {badges.map((b) => (

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -155,7 +155,7 @@ export default function BeamDesign() {
         } />
       <div className="mx-auto max-w-6xl px-5 pb-8 sm:px-7">
 
-      <div className="mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
+      <div className="no-print mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
         <div className="space-y-3.5">
           <Card title="Section">
             <Num label="Width b" unit="mm" value={f.b} onChange={set('b')} />

--- a/webapp/src/pages/ColumnDesign.tsx
+++ b/webapp/src/pages/ColumnDesign.tsx
@@ -1,12 +1,11 @@
 import { useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
 import {
   designAxialColumn, interaction, capacityAtEccentricity, momentMagnificationNonsway,
   type ColumnShape, type LateralSystem,
 } from '../engine/columnDesign'
 import { factoredLoad } from '../engine/loads'
 import { ColumnSchematic } from '../components/ColumnSchematic'
-import { ReportBar, PrintReport, type LetterheadState } from '../components/calc'
+import { PageHeader, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
 import { InteractionDiagram } from '../components/InteractionDiagram'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { axialColumnSolution, eccentricColumnSolution, slendernessSolution } from '../lib/columnSolution'
@@ -114,17 +113,15 @@ export default function ColumnDesign() {
   }, [inter])
 
   return (
-    <div className="mx-auto max-w-6xl p-6">
-      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
-      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Column Design</h1>
-      <p className="no-print mt-1 text-slate-600">
-        RC column — short axial (tied / spiral with §425.7 detailing), eccentric via strain-compatibility
-        P–M interaction (balanced condition, φ transition), and nonsway moment magnification for slender
-        columns. NSCP 2015 / ACI 318-14.
-      </p>
-      <ReportBar title="Column Design Report" lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} />
+    <div>
+      <PageHeader title="RC Column" badges={['ACI 318-14', 'NSCP 2015']}
+        actions={
+          <button type="button" onClick={() => { const prev = document.title; document.title = `Column Design Report${lh.project ? ` — ${lh.project}` : ''}`; window.print(); window.setTimeout(() => { document.title = prev }, 500) }}
+            className="inline-flex items-center gap-2 rounded-md bg-[#0f4c92] px-4 py-2 text-[12.5px] font-semibold text-white hover:bg-[#0d3f78]">⎙ Export report</button>
+        } />
+      <div className="mx-auto max-w-6xl px-5 pb-8 sm:px-7">
 
-      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
+      <div className="no-print mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
         <div className="space-y-5">
           <Card title="Column">
             <Pick label="Loading" value={mode} onChange={(v) => setMode(v as Mode)}
@@ -324,6 +321,7 @@ export default function ColumnDesign() {
         </div>
       )}
 
+      <div className="no-print mt-5"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
       <div className="no-print">{solution.length > 0 && <WorkedSolution steps={solution} title="Calculation report — worked solution" />}</div>
       {axial && solution.length > 0 && (
         <PrintReport
@@ -352,6 +350,7 @@ export default function ColumnDesign() {
             tieSpacing={tied ? axial.tieSpacingFinal : axial.spiralPitch} />}
         />
       )}
+      </div>
     </div>
   )
 }

--- a/webapp/src/pages/CombinedFootingDesign.tsx
+++ b/webapp/src/pages/CombinedFootingDesign.tsx
@@ -1,9 +1,8 @@
 import { useMemo, useState, type ReactNode } from 'react'
-import { Link } from 'react-router-dom'
 import { designCombinedFooting, type CombinedFootingInput } from '../engine/combinedFooting'
 import { designFlexibleCombinedFooting } from '../engine/flexibleCombinedFooting'
 import { CombinedFootingSchematic } from '../components/CombinedFootingSchematic'
-import { ReportBar, PrintReport, type LetterheadState } from '../components/calc'
+import { PageHeader, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
 import { Diagram } from '../components/Diagram'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { buildCombinedFootingSolution } from '../lib/combinedFootingSolution'
@@ -168,17 +167,15 @@ export default function CombinedFootingDesign() {
     : []
 
   return (
-    <div className="mx-auto max-w-6xl p-6">
-      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
-      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Combined Footing Design</h1>
-      <p className="no-print mt-1 text-slate-600">
-        Two-column combined footing. Rectangular when one edge is free, trapezoidal when both are property-restricted.
-        Choose the <b>rigid</b> (linear-pressure) or <b>flexible</b> (Winkler beam-on-elastic-foundation) method —
-        geometry is shared; the flexible method recomputes V/M from the settlement field. Results update live.
-      </p>
-      <ReportBar title="Combined Footing Design Report" lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} />
+    <div>
+      <PageHeader title="Combined Footing" badges={['ACI 318-14', 'NSCP 2015']}
+        actions={
+          <button type="button" onClick={() => { const prev = document.title; document.title = `Combined Footing Design Report${lh.project ? ` — ${lh.project}` : ''}`; window.print(); window.setTimeout(() => { document.title = prev }, 500) }}
+            className="inline-flex items-center gap-2 rounded-md bg-[#0f4c92] px-4 py-2 text-[12.5px] font-semibold text-white hover:bg-[#0d3f78]">⎙ Export report</button>
+        } />
+      <div className="mx-auto max-w-6xl px-5 pb-8 sm:px-7">
 
-      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
+      <div className="no-print mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
         {/* ── Inputs ── */}
         <div className="space-y-5">
           <Card title="Analysis method">
@@ -350,6 +347,7 @@ export default function CombinedFootingDesign() {
         )}
       </div>
 
+      <div className="no-print mt-5"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
       <div className="no-print">
         {solutionSteps && (
           <WorkedSolution steps={solutionSteps} title="Combined footing — worked solution (rigid method)" />
@@ -379,6 +377,7 @@ export default function CombinedFootingDesign() {
             x1={result.x1} x2={result.x2} col1Width={form.col1Width} col2Width={form.col2Width} />}
         />
       )}
+      </div>
     </div>
   )
 }

--- a/webapp/src/pages/FoundationDesign.tsx
+++ b/webapp/src/pages/FoundationDesign.tsx
@@ -282,7 +282,7 @@ export default function FoundationDesign() {
       <div className="no-print"><ExcelImport onResult={setBatch} /></div>
 
       {batch && (
-        <div className="mt-4 overflow-hidden rounded-lg border border-[#e3e1da] bg-white print-avoid-break">
+        <div className="no-print mt-4 overflow-hidden rounded-lg border border-[#e3e1da] bg-white">
           <div className="flex flex-wrap items-baseline justify-between gap-2 border-b border-slate-200 px-4 py-2.5">
             <h2 className="text-[13.5px] font-bold text-[#0f1b2a]">
               Batch schedule <span className="text-sm font-normal text-slate-500">({batch.designed}/{batch.rows.length} designed)</span>
@@ -323,7 +323,7 @@ export default function FoundationDesign() {
         </div>
       )}
 
-      <div className="mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
+      <div className="no-print mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
         {/* ── Inputs ── */}
         <div className="space-y-3.5">
           <Card title="Footing">


### PR DESCRIPTION
Fixes the user-reported issues from the Phase F review, per their screenshots. **UI only — engine untouched** (guard: 0 files under `webapp/src/engine`; suite unchanged at **1063**; tsc clean).

## 1 · Double print fixed
The converted pages were printing the **old screen layout underneath the new calc sheet**. The screen grids (inputs + verdict rail), the Foundation batch table, and `PageHeader` itself are now `no-print` — the print path emits **exactly one document: the `PrintReport` calc sheet**. Pages not yet converted keep the legacy print-the-screen behavior untouched.

## 2 · Letterhead card + header pattern everywhere converted
- **Column Design** and **Combined Footing** move off the interim `ReportBar` onto the same pattern as Beam/Foundation from the user's screenshots: `PageHeader` with title + code badges + **⎙ Export report** in the header, and the **Report letterhead card** (Project / Sheet / Prepared by / Date) on the page.
- All four converted calculators now match: header per screenshot 2, letterhead card per screenshot 1.

## Verified (headless Chromium, print emulation on all four pages)
Exactly one report `h1` per page · **zero** input-field leaks · **zero** screen worked-solution leaks · letterhead card + header Export visible on screen · no console errors. (The only "Project:" text in print is the calc sheet's own disclaimer line — the legacy `ReportControls` is no longer imported by any converted page.)

Remaining for the full "all pages" rollout: the ~15 other calculators (Steel sub-tabs, Pile Cap, Retaining Wall, Stair, Water Tank, geotech pages, estimates) — each needs its own stats/steps/drawing mapping; next phases continue down that list with this now-settled pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_