### PR TITLE
feat: mockup-exact calc report (clause margin, PASS chips, tabs) + Beam φMn/φVn bars (UI/lib only)

### DIFF
--- a/webapp/src/components/WorkedSolution.tsx
+++ b/webapp/src/components/WorkedSolution.tsx
@@ -2,39 +2,55 @@ import { useState, type JSX } from 'react'
 import type { SolutionStep } from '../lib/solution'
 import { Math } from '../lib/math'
 
-/** Collapsible step-by-step worked-solution panel (KaTeX, print-friendly). */
-export function WorkedSolution({ steps, title = 'Solution — step by step' }: {
+/** Calculation-report panel (docs/design/uiux-2026-07): numbered steps with a
+ *  code-clause margin column and PASS chips, with Worked solution / Summary
+ *  tabs — the summary keeps only titles, chips and notes. Print-friendly. */
+export function WorkedSolution({ steps, title = 'Calculation report — worked solution' }: {
   steps: SolutionStep[]; title?: string
 }): JSX.Element {
-  const [open, setOpen] = useState(true)
+  const [mode, setMode] = useState<'worked' | 'summary'>('worked')
+  const tab = (id: 'worked' | 'summary', label: string) => (
+    <button type="button" onClick={() => setMode(id)}
+      className={`pb-0.5 text-[11.5px] font-semibold ${mode === id ? 'border-b-2 border-[#0f4c92] text-[#0f4c92]' : 'text-[#a39d8d] hover:text-[#5c6675]'}`}>
+      {label}
+    </button>
+  )
   return (
     <div className="mt-6 rounded-lg border border-[#e3e1da] bg-white print-avoid-break">
-      <button type="button" onClick={() => setOpen((o) => !o)}
-        className="flex w-full items-center gap-2.5 px-4 py-3 text-left">
+      <div className="flex items-center gap-2.5 border-b border-[#eeece5] px-4 py-3">
         <span className="font-mono text-[10.5px] font-semibold text-[#a39d8d]">05</span>
         <h2 className="text-[13.5px] font-bold text-[#0f1b2a]">{title}</h2>
-        <span className="no-print ml-auto text-xs text-[#a39d8d]">{open ? 'Hide ▲' : 'Show ▼'}</span>
-      </button>
-
-      {open && (
-        <ol className="space-y-4 border-t border-[#eeece5] px-4 py-4">
-          {steps.map((s, i) => (
-            <li key={i} className="print-avoid-break">
-              <h3 className="mb-1.5 text-[12.5px] font-bold text-[#0f1b2a]">
+        <span className="no-print ml-auto inline-flex gap-3.5">{tab('worked', 'Worked solution')}{tab('summary', 'Summary only')}</span>
+      </div>
+      <ol className="px-1 py-1.5">
+        {steps.map((s, i) => (
+          <li key={i} className="print-avoid-break grid grid-cols-[1fr_120px] gap-4 border-b border-[#f3f1ea] px-3 py-3 last:border-0">
+            <div>
+              <h3 className="text-[12.5px] font-bold text-[#0f1b2a]">
                 <span className="mr-1.5 font-mono font-semibold text-[#a39d8d]">{i + 1}</span>{s.title}
               </h3>
-              <div className="space-y-1.5 pl-4">
-                {s.lines.map((ln, j) => (
-                  'text' in ln
-                    ? <p key={j} className="text-sm leading-relaxed text-slate-600">{ln.text}</p>
-                    : <div key={j} className="overflow-x-auto text-[0.95rem] text-slate-700"><Math block tex={ln.tex} /></div>
-                ))}
-              </div>
-              {s.note && <p className="mt-1 pl-4 text-xs text-slate-500">{s.note}</p>}
-            </li>
-          ))}
-        </ol>
-      )}
+              {mode === 'worked' && (
+                <div className="mt-1.5 space-y-1.5 pl-4">
+                  {s.lines.map((ln, j) => (
+                    'text' in ln
+                      ? <p key={j} className="text-[12px] leading-relaxed text-[#5c6675]">{ln.text}</p>
+                      : <div key={j} className="overflow-x-auto rounded-md border border-[#eeece5] bg-[#f9f8f4] px-3 py-1 text-[0.92rem] text-[#1e2c3d]"><Math block tex={ln.tex} /></div>
+                  ))}
+                </div>
+              )}
+              {s.note && <p className="mt-1.5 pl-4 text-[10.5px] text-[#a39d8d]">{s.note}</p>}
+            </div>
+            <div className="pt-0.5">
+              {s.pass !== undefined && (
+                <span className={`inline-block rounded px-1.5 py-px font-mono text-[10px] font-semibold ${s.pass ? 'bg-[#ddefe3] text-[#14603a]' : 'bg-[#fbeeea] text-[#c2402a]'}`}>
+                  {s.pass ? 'PASS' : 'FAIL'}
+                </span>
+              )}
+              {s.clause && <p className="mt-1.5 text-[10.5px] leading-snug text-[#a39d8d]">{s.clause}</p>}
+            </div>
+          </li>
+        ))}
+      </ol>
     </div>
   )
 }

--- a/webapp/src/components/calc.tsx
+++ b/webapp/src/components/calc.tsx
@@ -240,7 +240,12 @@ export function PrintReport({ docTitle, docCode, badges, ok, governing, lh, stat
                 : <div key={j} className="overflow-x-auto rounded-md border border-[#eeece5] bg-[#f9f8f4] px-2.5 py-1 text-[10.5px]"><KTex block tex={ln.tex} /></div>)}
             </div>
           </div>
-          <p className="pt-0.5 text-[9px] leading-snug text-[#a39d8d]">{st.note ?? ''}</p>
+          <div className="pt-0.5">
+            {st.pass !== undefined && (
+              <span className={`inline-block rounded px-1.5 py-px font-mono text-[9px] font-semibold ${st.pass ? 'bg-[#ddefe3] text-[#14603a]' : 'bg-[#fbeeea] text-[#c2402a]'}`}>{st.pass ? 'PASS' : 'FAIL'}</span>
+            )}
+            <p className="mt-1 text-[9px] leading-snug text-[#a39d8d]">{st.clause ?? st.note ?? ''}</p>
+          </div>
         </div>
       ))}
 

--- a/webapp/src/lib/beamSolution.ts
+++ b/webapp/src/lib/beamSolution.ts
@@ -178,5 +178,39 @@ export function buildBeamSolution(i: BeamDesignInput, r: BeamDesignResult): Solu
     note: `Provide 135° seismic hooks, ${sn0(r.stirrupHookExt)} mm extension, bent around a corner bar.`,
   })
 
-  return steps
+  // Margin clauses + PASS chips for the calc-report layout: title-keyed so the
+  // step-building branches above stay untouched.
+  const notes: [string, string, boolean | undefined][] = [
+    ['Effective depth', '§20.6.1 cover', undefined],
+    ['Reinforcement-ratio limits', '§9.6.1.2 · §21.2.2', r.rho >= r.rhoMin - 1e-9 && r.rho <= r.rhoMax + 1e-9],
+    ['SRRB / DRRB classification', 'ACI 318-14 §22.2', undefined],
+    ['Tension steel', 'ACI 318-14 §22.2', r.flexOK],
+    ['Compression steel', '§22.2.2', r.comprEffective && r.comprNAOK],
+    ['Bar layout', '§407.7', r.sClear >= r.sMinClear - 1e-9],
+    ['Shear strength of concrete', '§22.5.5.1', undefined],
+    ['Stirrup requirement', '§22.5', undefined],
+    ['Minimum stirrups', '§9.6.3', r.region !== 'inadequate'],
+    ['Stirrup design', '§22.5 · §9.7.6.2.2', r.region !== 'inadequate'],
+    ['Section check (shear)', '§22.5.1.2', r.region !== 'inadequate'],
+    ['Stirrup detailing', '§407.3.2 · §425.3.2', undefined],
+  ]
+  return steps.map((st) => {
+    const hit = notes.find(([k]) => st.title.startsWith(k))
+    return hit ? { ...st, clause: hit[1], ...(hit[2] === undefined ? {} : { pass: hit[2] }) } : st
+  })
+}
+
+/** Provided design capacities for the verdict/utilization display — the same
+ *  arithmetic the worked-solution steps above already spell out (φ = 0.90
+ *  flexure / 0.75 shear; Vs from the adopted stirrup spacing). Presentation
+ *  math in the lib layer; the engine result stays the source of As, d, sAdopt. */
+export function beamProvidedCapacities(
+  i: BeamDesignInput & { fyt: number; legs: number }, r: BeamDesignResult,
+): { phiMn: number; phiVn: number } {
+  const AsProv = r.bars * (Math.PI / 4) * i.barDia ** 2               // provided bars, mm²
+  const a = (AsProv * i.fy) / (0.85 * i.fc * i.b)                     // mm
+  const phiMn = (0.9 * AsProv * i.fy * (r.d - a / 2)) / 1e6           // kN·m (tension steel only — conservative for DRRB)
+  const Av = i.legs * (Math.PI / 4) * i.stirrupDia ** 2               // mm²
+  const phiVs = r.sAdopt > 0 ? (0.75 * Av * i.fyt * r.d) / r.sAdopt / 1e3 : 0   // kN
+  return { phiMn, phiVn: r.phiVc + phiVs }
 }

--- a/webapp/src/lib/foundationSolution.ts
+++ b/webapp/src/lib/foundationSolution.ts
@@ -296,5 +296,22 @@ export function buildFoundationSolution(c: SolutionCtx): SolutionStep[] {
       })
     }
   }
-  return steps
+  const notes: [string, string, boolean | undefined][] = [
+    ['Net allowable', 'Service condition', undefined],
+    ['Required footing', 'Iterative sizing', undefined],
+    ['Footing size', 'Iterative sizing', undefined],
+    ['Eccentricity', 'Kern check e ≤ B/6', c.ecc ? c.ecc.kernOK : undefined],
+    ['Service pressure', 'Kern check e ≤ B/6', c.ecc ? c.ecc.kernOK : undefined],
+    ['Ultimate soil pressure', 'NSCP §203.3 load factors', undefined],
+    ['Two-way', 'ACI 318-14 §22.6.5.2', c.punchOK],
+    ['Punching', 'ACI 318-14 §22.6.5.2', c.punchOK],
+    ['One-way', 'ACI 318-14 §22.5.5.1', c.beamOK],
+    ['Beam shear', 'ACI 318-14 §22.5.5.1', c.beamOK],
+    ['Flexural', 'ACI 318-14 §24.4.3.2', true],
+    ['Bearing', '§22.8 bearing', undefined],
+  ]
+  return steps.map((st) => {
+    const hit = notes.find(([k]) => st.title.startsWith(k))
+    return hit ? { ...st, clause: hit[1], ...(hit[2] === undefined ? {} : { pass: hit[2] }) } : st
+  })
 }

--- a/webapp/src/lib/solution.ts
+++ b/webapp/src/lib/solution.ts
@@ -2,7 +2,13 @@
 // either a KaTeX equation ({tex}) or an explanatory sentence ({text}, often
 // citing a code clause). Rendered by <WorkedSolution>.
 export type SolutionLine = { tex: string } | { text: string }
-export interface SolutionStep { title: string; lines: SolutionLine[]; note?: string }
+export interface SolutionStep {
+  title: string; lines: SolutionLine[]; note?: string
+  /** Code clause shown in the report's margin column (e.g. 'ACI 318-14 §22.2'). */
+  clause?: string
+  /** Check outcome for the PASS/FAIL chip; omit for informational steps. */
+  pass?: boolean
+}
 
 export const sn0 = (v: number) => Math.round(v).toString()
 export const sn1 = (v: number) => v.toFixed(1)

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -6,7 +6,7 @@ import type { BeamSupport } from '../engine/beamDeflection'
 import type { CriticalSection } from '../engine/beamSections'
 import { BeamSchematic } from '../components/BeamSchematic'
 import { WorkedSolution } from '../components/WorkedSolution'
-import { buildBeamSolution } from '../lib/beamSolution'
+import { buildBeamSolution, beamProvidedCapacities } from '../lib/beamSolution'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { Math as KTex } from '../lib/math'
 import { f0, f1 } from '../lib/format'
@@ -131,10 +131,10 @@ export default function BeamDesign() {
   // required-over-provided clear spacing, shear Vu/φVc while no stirrups are
   // demanded — all existing outputs, no new calculation.
   const allOK = !!r && sectionOK(r) && (!deflection || (deflection.liveOK && deflection.totalOK))
-  const checks = r ? [
-    ...(r.mode === 'SRRB' ? [{ name: 'Flexure Mu / φMn,max', ratio: demand.Mu / r.phiMnMax }] : []),
-    ...(r.region === 'none' || r.region === 'minimum' ? [{ name: 'Shear Vu / φVc', ratio: demand.Vu / r.phiVc }] : []),
-    ...(r.region === 'designed' ? [{ name: 'Stirrup spacing s / s,max', ratio: r.sAdopt / r.sMax }] : []),
+  const cap = r ? beamProvidedCapacities(f, r) : null
+  const checks = r && cap ? [
+    { name: 'Flexure Mu/φMn', ratio: demand.Mu / cap.phiMn },
+    { name: 'Shear Vu/φVn', ratio: demand.Vu / cap.phiVn },
     { name: `Bar spacing (${r.layers.length} layer${r.layers.length > 1 ? 's' : ''})`, ratio: r.sMinClear / Math.max(r.sClear, 1e-9) },
   ] : []
 
@@ -231,9 +231,7 @@ export default function BeamDesign() {
               headline={allOK
                 ? `DESIGN OK — ${r.mode}, ${r.layers.length > 1 ? `${r.layers.length} layers` : 'single layer'}`
                 : 'CHECK FAILED — revise the section'}
-              governing={r.mode === 'SRRB'
-                ? `Governing: flexure · utilization ${(demand.Mu / r.phiMnMax).toFixed(2)}`
-                : `DRRB — compression steel engaged (Mu > φMn,max = ${f1(r.phiMnMax)} kN·m)`}
+              governing={`Governing: flexure · utilization ${cap ? (demand.Mu / cap.phiMn).toFixed(2) : '—'}${r.mode === 'DRRB' ? ' · DRRB (compression steel engaged)' : ''}`}
               stats={[
                 { label: hogging ? 'Tension (top)' : 'Tension steel', value: `${r.bars}-⌀${f.barDia}`, unit: hogging ? 'top' : 'bottom' },
                 { label: 'Stirrups', value: r.sAdopt > 0 ? `⌀${f.stirrupDia}` : '—', unit: r.sAdopt > 0 ? `${f.legs}-leg @${f0(r.sAdopt)}` : REGION[r.region] },
@@ -371,7 +369,7 @@ export default function BeamDesign() {
       {r && solution && (
         <PrintReport
           docTitle={multi && active ? `RC Beam — ${active.label}` : 'Rectangular RC Beam'} docCode="S-01" badges={['ACI 318-14', 'NSCP 2015']}
-          ok={allOK} governing={r.mode === 'SRRB' ? `Governing: flexure · ${(demand.Mu / r.phiMnMax).toFixed(2)}` : 'DRRB — compression steel engaged'}
+          ok={allOK} governing={`Governing: flexure · utilization ${cap ? (demand.Mu / cap.phiMn).toFixed(2) : '—'}${r.mode === 'DRRB' ? ' · DRRB' : ''}`}
           lh={lh}
           stats={[
             { label: hogging ? 'Tension (top)' : 'Tension steel', value: `${r.bars}-⌀${f.barDia}` },


### PR DESCRIPTION
Implements the two design files the user pointed at — **`Redesign - Beam Design.dc.html`** and **`Redesign - Foundation Design.dc.html`**, re-imported fresh from their claude.ai/design project via the design MCP. The files are unchanged since the original zip, so this pass **completes the last fidelity gaps** rather than re-implementing the pages. **UI/lib only — engine untouched** (guard: 0 files under `webapp/src/engine`; suite unchanged at **1063**; tsc clean).

## What was still missing vs the mockups, now closed
1. **Calculation report layout** (both pages): `WorkedSolution` now renders the mockup's report grammar — numbered steps with a **code-clause margin column** (e.g. `ACI 318-14 §22.6.5.2`) and **PASS/FAIL chips** per check step, plus the **"Worked solution / Summary only" tabs** (summary keeps titles, chips and notes). The printed calc sheet's solution section shows the same margin + chips.
   - Data path: `SolutionStep` (lib) gains optional `clause`/`pass`; `beamSolution` and `foundationSolution` annotate every step via title-keyed maps, so their step-building logic is untouched.
2. **Beam verdict bars with the mockup's exact metrics**: `Flexure Mu/φMn` and `Shear Vu/φVn` against **provided** capacities. Computed in `lib/beamSolution.beamProvidedCapacities` — the identical arithmetic the worked-solution steps already spell out (φ 0.90/0.75, `a = As·fy/0.85f'c·b`, `Vs = Av·fyt·d/s`), now returned structured. The engine result remains the sole source of `As`, `d`, `φVc`, `s,adopt`; per the repo rule this presentation math lives in the lib layer, not components — and **no engine file changed**.
3. Governing line reads `Governing: flexure · utilization X` from the same provided-capacity ratio, matching the mockup's banner.

## Verified (headless Chromium)
Beam: bars `0.95 / 0.81 / 0.63` (exact for the engine's adopted bar count — the mockup's illustrative 0.78 assumed 5-⌀20), clause margins present, 4 PASS chips, tabs toggle hides formulas in summary mode. Foundation: clause margins + 3 PASS chips + tabs. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_