### PR TITLE
feat: numbered drawing-sheet input cards on every calculator page (UI only)

### DIFF
--- a/webapp/src/components/qty.tsx
+++ b/webapp/src/components/qty.tsx
@@ -40,12 +40,19 @@ export function ClassPick({ value, onChange }: { value: ConcreteClass; onChange:
   )
 }
 
-export function Card({ title, children }: { title: ReactNode; children: ReactNode }) {
+/** Numbered input card (Foundation mockup): mono counter + title header row,
+ *  hairline divider, field grid. Numbers auto-increment in DOM order via the
+ *  `calc-card` CSS counter in index.css — no per-page wiring. */
+export function Card({ title, hint, children }: { title: ReactNode; hint?: ReactNode; children: ReactNode }) {
   return (
-    <fieldset className="print-avoid-break rounded-lg border border-[#e3e1da] bg-white p-4">
-      <legend className="px-2 text-[13.5px] font-bold text-[#0f1b2a]">{title}</legend>
-      <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2 lg:grid-cols-3">{children}</div>
-    </fieldset>
+    <section className="calc-card print-avoid-break rounded-lg border border-[#e3e1da] bg-white">
+      <div className="flex items-baseline gap-2.5 border-b border-[#eeece5] px-4 py-3">
+        <span aria-hidden className="calc-card-num font-mono text-[10.5px] font-semibold text-[#a39d8d]" />
+        <h2 className="text-[13.5px] font-bold text-[#0f1b2a]">{title}</h2>
+        {hint && <span className="ml-auto text-[11px] text-[#a39d8d]">{hint}</span>}
+      </div>
+      <div className="grid grid-cols-1 gap-3.5 p-4 sm:grid-cols-2 lg:grid-cols-3">{children}</div>
+    </section>
   )
 }
 

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -57,6 +57,13 @@ select:focus {
 /* numeric entry reads like a title block */
 input[type="number"] { font-family: var(--font-mono); }
 
+/* ── Numbered input cards ────────────────────────────────────────────────
+   Every qty.tsx <Card> gets a drawing-sheet section number (01, 02, …) in
+   DOM order; display:none'd cards (inactive tabs) don't consume a number. */
+body { counter-reset: calccard; }
+.calc-card { counter-increment: calccard; }
+.calc-card-num::before { content: counter(calccard, decimal-leading-zero); }
+
 /* ── Print / PDF export ──────────────────────────────────────────────
    Screen keeps the interactive chrome; print shows a clean report:
    nav + buttons hidden, white background, cards kept whole across pages. */


### PR DESCRIPTION
## What

Restyles the shared input `Card` (`webapp/src/components/qty.tsx`) to the Foundation-mockup pattern the user pointed at:

- header row with a **mono section number** (`01`, `02`, …), bold title, optional right-aligned hint, hairline divider below
- body keeps the existing responsive field grid (labels above, unit-suffix fields)
- numbers auto-increment in DOM order via a CSS counter (`calc-card` in `index.css`) — every page using `Card` (~20 calculators/estimates) inherits the look with **zero page edits**; cards in inactive tabs (`display:none`) don't consume a number

## Verification

- `npx tsc -b` clean, **1063/1063 tests pass** (suite unchanged)
- Headless Chromium: `/slab-design` shows `01 Panel geometry · 02 Service loads · 03 Materials · 04 Detailing · 05 Span type`; `/steel` shows `01 Section &amp; grade · 02 Span &amp; bracing · 03 Uniform service loads` — matching the mockup screenshot
- Engine guard: `git diff --cached --name-only origin/main | grep -c 'src/engine'` = **0**

## Next phase

Model Space report redesign: direct A4 PDF export (jsPDF) in the calc-sheet style — letterhead + verdict, 3D snapshot, design summary, project/design inputs, member schedules, every-member worked solutions with plain-text equations (per user's formatting answers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_