### PR TITLE
feat: Import/Export dropdown + flat control rails app-wide + light-blue actions (UI only)

### DIFF
--- a/webapp/src/components/calc.tsx
+++ b/webapp/src/components/calc.tsx
@@ -25,7 +25,7 @@ export function CalcSection({ num, title, hint, children, grid = true }: {
   num: string; title: string; hint?: string; children: ReactNode; grid?: boolean
 }) {
   return (
-    <section className="rounded-lg border border-[#e3e1da] bg-white print-avoid-break">
+    <section className="rail-card rounded-lg border border-[#e3e1da] bg-white print-avoid-break">
       <div className="flex items-baseline gap-2.5 border-b border-[#eeece5] px-4 py-3">
         <span className="font-mono text-[10.5px] font-semibold text-[#a39d8d]">{num}</span>
         <h2 className="text-[13.5px] font-bold text-[#0f1b2a]">{title}</h2>
@@ -61,7 +61,7 @@ export function VerdictPanel({ ok, headline, governing, stats, checks, footnote 
   stats: VerdictStat[]; checks: VerdictCheck[]; footnote?: ReactNode
 }) {
   return (
-    <section className="overflow-hidden rounded-lg border border-[#e3e1da] bg-white print-avoid-break">
+    <section className="rail-card overflow-hidden rounded-lg border border-[#e3e1da] bg-white print-avoid-break">
       <div className={`flex items-center gap-2.5 border-b px-4 py-3 ${ok ? 'border-[#d3e8da] bg-[#ecf6ef]' : 'border-[#efd4cc] bg-[#fbeeea]'}`}>
         <span className={`flex h-[22px] w-[22px] flex-none items-center justify-center rounded-full text-white ${ok ? 'bg-[#1a7f4b]' : 'bg-[#c2402a]'}`}>
           {ok
@@ -96,7 +96,7 @@ export function VerdictPanel({ ok, headline, governing, stats, checks, footnote 
 /** Right-rail card with the drawing-sheet grid backdrop. */
 export function DrawingCard({ title, meta, children }: { title: string; meta?: string; children: ReactNode }) {
   return (
-    <section className="rounded-lg border border-[#e3e1da] bg-white print-avoid-break">
+    <section className="rail-card rounded-lg border border-[#e3e1da] bg-white print-avoid-break">
       <div className="flex items-center justify-between border-b border-[#eeece5] px-4 py-3">
         <h2 className="text-[13.5px] font-bold text-[#0f1b2a]">{title}</h2>
         {meta && <span className="font-mono text-[10px] text-[#a39d8d]">{meta}</span>}
@@ -120,7 +120,7 @@ export function LetterheadCard({ lh, onChange }: { lh: LetterheadState; onChange
     </div>
   )
   return (
-    <section className="no-print rounded-lg border border-[#e3e1da] bg-white p-4">
+    <section className="rail-card no-print rounded-lg border border-[#e3e1da] bg-white p-4">
       <div className="flex items-center justify-between">
         <h2 className="text-[13.5px] font-bold text-[#0f1b2a]">Report letterhead</h2>
         <span className="font-mono text-[10px] text-[#a39d8d]">prints on the calc sheet</span>

--- a/webapp/src/components/qty.tsx
+++ b/webapp/src/components/qty.tsx
@@ -45,7 +45,7 @@ export function ClassPick({ value, onChange }: { value: ConcreteClass; onChange:
  *  `calc-card` CSS counter in index.css — no per-page wiring. */
 export function Card({ title, hint, children }: { title: ReactNode; hint?: ReactNode; children: ReactNode }) {
   return (
-    <section className="calc-card print-avoid-break rounded-lg border border-[#e3e1da] bg-white">
+    <section className="calc-card rail-card print-avoid-break rounded-lg border border-[#e3e1da] bg-white">
       <div className="flex items-baseline gap-2.5 border-b border-[#eeece5] px-4 py-3">
         <span aria-hidden className="calc-card-num font-mono text-[10.5px] font-semibold text-[#a39d8d]" />
         <h2 className="text-[13.5px] font-bold text-[#0f1b2a]">{title}</h2>
@@ -58,7 +58,7 @@ export function Card({ title, hint, children }: { title: ReactNode; hint?: React
 
 export function ResultCard({ title, children }: { title: ReactNode; children: ReactNode }) {
   return (
-    <div className="print-avoid-break rounded-lg border border-[#e3e1da] bg-white p-4">
+    <div className="rail-card print-avoid-break rounded-lg border border-[#e3e1da] bg-white p-4">
       <h2 className="mb-2 text-[13.5px] font-bold text-[#0f1b2a]">{title}</h2>
       {children}
     </div>

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -64,6 +64,25 @@ body { counter-reset: calccard; }
 .calc-card { counter-increment: calccard; }
 .calc-card-num::before { content: counter(calccard, decimal-leading-zero); }
 
+/* ── Flat control rails ─────────────────────────────────────────────────
+   3D Model Space mockup: a vertically stacked run of cards reads as ONE
+   panel — consecutive .rail-card siblings inside any space-y container
+   merge (gap and shared borders collapse; only a soft hairline remains). */
+[class*="space-y"] > .rail-card + .rail-card {
+  margin-top: 0 !important;
+  margin-block-start: 0 !important;
+  border-top: 1px solid var(--hairline-soft);
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+[class*="space-y"] > .rail-card:has(+ .rail-card) {
+  margin-bottom: 0 !important;
+  margin-block-end: 0 !important;   /* Tailwind v4 space-y margins the leading sibling */
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
 /* ── Print / PDF export ──────────────────────────────────────────────
    Screen keeps the interactive chrome; print shows a clean report:
    nav + buttons hidden, white background, cards kept whole across pages. */

--- a/webapp/src/pages/BeamAnalysis.tsx
+++ b/webapp/src/pages/BeamAnalysis.tsx
@@ -128,7 +128,7 @@ export default function BeamAnalysis() {
             <div className="no-print mb-3 flex flex-wrap gap-2">
               {(['pin', 'roller', 'fixed', 'spring'] as SupportType[]).map((t) => (
                 <button key={t} type="button" onClick={() => addSupport(t)}
-                  className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">
+                  className="rounded-md border border-[#cddcf0] bg-[#eaf1f9] px-3 py-1.5 text-sm font-semibold text-[#0f4c92] hover:bg-[#dce9f7]">
                   + {t[0].toUpperCase() + t.slice(1)}
                 </button>
               ))}
@@ -151,7 +151,7 @@ export default function BeamAnalysis() {
             <div className="no-print mb-3 flex flex-wrap gap-2">
               {([['point', '+ Point'], ['udl', '+ UDL'], ['vdl', '+ VDL'], ['moment', '+ Moment']] as const).map(([t, lbl]) => (
                 <button key={t} type="button" onClick={() => addLoad(t)}
-                  className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">
+                  className="rounded-md border border-[#cddcf0] bg-[#eaf1f9] px-3 py-1.5 text-sm font-semibold text-[#0f4c92] hover:bg-[#dce9f7]">
                   {lbl}
                 </button>
               ))}
@@ -246,7 +246,7 @@ export default function BeamAnalysis() {
                     sessionStorage.setItem(SECTIONS_HANDOFF_KEY, JSON.stringify(secs))
                     navigate('/beam-design?sections=auto')
                   }}
-                  className="inline-block rounded-lg bg-gradient-to-br from-[#0056b3] to-[#003f86] px-4 py-2 text-sm font-semibold text-white shadow-md transition hover:shadow-lg">
+                  className="inline-block rounded-md border border-[#cddcf0] bg-[#eaf1f9] px-4 py-2 text-sm font-semibold text-[#0f4c92] transition hover:bg-[#dce9f7]">
                   ⚡ Auto-detect critical sections → design
                 </button>
               </div>

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -196,7 +196,7 @@ export default function BeamDesign() {
               <div className="no-print mb-3 flex flex-wrap items-center gap-2">
                 <button type="button"
                   onClick={() => setSections((ss) => [...ss, { id: uid++, label: `Section ${ss.length + 1}`, x: 0, Mu: 50, Vu: 30 }])}
-                  className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">
+                  className="rounded-md border border-[#cddcf0] bg-[#eaf1f9] px-3 py-1.5 text-sm font-semibold text-[#0f4c92] hover:bg-[#dce9f7]">
                   + Add section
                 </button>
                 <span className="text-xs text-slate-500">or auto-detect from <Link to="/beam-analysis" className="text-[#0056b3] hover:underline">Beam Analysis</Link>. Negative Mu = hogging (top steel).</span>

--- a/webapp/src/pages/FrameAnalysis.tsx
+++ b/webapp/src/pages/FrameAnalysis.tsx
@@ -112,7 +112,7 @@ export default function FrameAnalysis() {
           <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">Nodes</legend>
             <button type="button" onClick={() => setNodes((ns) => [...ns, { uid: uid++, id: `N${ns.length + 1}`, x: 0, y: 0 }])}
-              className="no-print mb-3 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">+ Node</button>
+              className="no-print mb-3 rounded-md border border-[#cddcf0] bg-[#eaf1f9] px-3 py-1.5 text-sm font-semibold text-[#0f4c92] hover:bg-[#dce9f7]">+ Node</button>
             <div className="space-y-3">
               {nodes.map((n) => (
                 <Shell key={n.uid} title={n.id} onRemove={() => setNodes((ns) => ns.filter((q) => q.uid !== n.uid))}>
@@ -131,7 +131,7 @@ export default function FrameAnalysis() {
           <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">Members</legend>
             <button type="button" onClick={() => setMembers((ms) => [...ms, { uid: uid++, id: `m${ms.length + 1}`, i: nodeIds[0] ?? '', j: nodeIds[1] ?? '' }])}
-              className="no-print mb-3 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">+ Member</button>
+              className="no-print mb-3 rounded-md border border-[#cddcf0] bg-[#eaf1f9] px-3 py-1.5 text-sm font-semibold text-[#0f4c92] hover:bg-[#dce9f7]">+ Member</button>
             <div className="space-y-3">
               {members.map((m) => (
                 <Shell key={m.uid} title={m.id} onRemove={() => setMembers((ms) => ms.filter((q) => q.uid !== m.uid))}>
@@ -150,7 +150,7 @@ export default function FrameAnalysis() {
           <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">Supports</legend>
             <button type="button" onClick={() => setSupports((ss) => [...ss, { uid: uid++, node: nodeIds[0] ?? '', type: 'pin' }])}
-              className="no-print mb-3 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">+ Support</button>
+              className="no-print mb-3 rounded-md border border-[#cddcf0] bg-[#eaf1f9] px-3 py-1.5 text-sm font-semibold text-[#0f4c92] hover:bg-[#dce9f7]">+ Support</button>
             <div className="space-y-3">
               {supports.map((s) => (
                 <Shell key={s.uid} title={s.type} onRemove={() => setSupports((ss) => ss.filter((q) => q.uid !== s.uid))}>
@@ -166,11 +166,11 @@ export default function FrameAnalysis() {
             <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">Loads</legend>
             <div className="no-print mb-3 flex flex-wrap gap-2">
               <button type="button" onClick={() => setLoads((ls) => [...ls, { uid: uid++, kind: 'node', node: nodeIds[0] ?? '', Fx: 0, Fy: -50, Mz: 0, cat: 'D' }])}
-                className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">+ Node load</button>
+                className="rounded-md border border-[#cddcf0] bg-[#eaf1f9] px-3 py-1.5 text-sm font-semibold text-[#0f4c92] hover:bg-[#dce9f7]">+ Node load</button>
               <button type="button" onClick={() => setLoads((ls) => [...ls, { uid: uid++, kind: 'member-udl', member: memberIds[0] ?? '', w: 10, cat: 'D' }])}
-                className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">+ Member UDL</button>
+                className="rounded-md border border-[#cddcf0] bg-[#eaf1f9] px-3 py-1.5 text-sm font-semibold text-[#0f4c92] hover:bg-[#dce9f7]">+ Member UDL</button>
               <button type="button" onClick={() => setLoads((ls) => [...ls, { uid: uid++, kind: 'member-point', member: memberIds[0] ?? '', a: 1, P: 50, cat: 'D' }])}
-                className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">+ Member point</button>
+                className="rounded-md border border-[#cddcf0] bg-[#eaf1f9] px-3 py-1.5 text-sm font-semibold text-[#0f4c92] hover:bg-[#dce9f7]">+ Member point</button>
             </div>
             <div className="space-y-3">
               {loads.map((ld) => (

--- a/webapp/src/pages/LoadPath.tsx
+++ b/webapp/src/pages/LoadPath.tsx
@@ -71,7 +71,7 @@ export default function LoadPath() {
           <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">Area loads</legend>
             <button type="button" onClick={() => setAreaLoads((ls) => [...ls, { id: uid++, q: 2, cat: 'L' }])}
-              className="no-print mb-3 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:border-[#0056b3] hover:bg-blue-50">+ Area load</button>
+              className="no-print mb-3 rounded-md border border-[#cddcf0] bg-[#eaf1f9] px-3 py-1.5 text-sm font-semibold text-[#0f4c92] hover:bg-[#dce9f7]">+ Area load</button>
             <div className="space-y-3">
               {areaLoads.map((l) => (
                 <div key={l.id} className="rounded-lg border border-slate-200 bg-slate-50 p-3">

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -829,6 +829,7 @@ export default function ModelSpace() {
   const [modelImg, setModelImg] = useState<string | null>(null)   // 3D snapshot for the PDF report
   const [lh, setLh] = useState<LetterheadState>({ project: '', sheet: '', preparedBy: '' })
   const [exporting, setExporting] = useState(false)               // PDF build in flight
+  const [ioMenu, setIoMenu] = useState(false)                     // Import/Export dropdown
   const [concreteClass, setConcreteClass] = useState<ConcreteClass>((si.concreteClass as ConcreteClass) ?? 'A')   // mix class for the take-off
   const [prices, setPrices] = useState<PriceList>((si.prices as PriceList) ?? {   // unit prices for the costed bill (PHP)
     cementBag: 260, sandM3: 1500, gravelM3: 1600, steelKg: 65, tieWireRoll: 2500, plywoodSheet: 700, lumberM: 25, structuralSteelKg: 120,
@@ -1559,14 +1560,25 @@ export default function ModelSpace() {
           {model && <span className="rounded border border-[#cddcf0] bg-[#eaf1f9] px-1.5 py-px font-mono text-[10px] font-medium text-[#0f4c92]">autosaved</span>}
         </div>
         <div className="no-print ml-auto flex flex-wrap items-center gap-2">
-          <button type="button" onClick={download} disabled={!model}
-            className="rounded-md border border-[#d6d3c9] bg-white px-3 py-2 text-[12.5px] font-semibold text-[#3d4a5c] hover:border-[#0f4c92] hover:text-[#0f4c92] disabled:opacity-40">
-            Export JSON
-          </button>
-          <button type="button" onClick={() => fileRef.current?.click()}
-            className="rounded-md border border-[#d6d3c9] bg-white px-3 py-2 text-[12.5px] font-semibold text-[#3d4a5c] hover:border-[#0f4c92] hover:text-[#0f4c92]">
-            Import
-          </button>
+          {/* Import / Export dropdown (mockup header: one combined button) */}
+          <div className="relative" onMouseLeave={() => setIoMenu(false)}>
+            <button type="button" onClick={() => setIoMenu((v) => !v)}
+              className="rounded-md border border-[#d6d3c9] bg-white px-3 py-2 text-[12.5px] font-semibold text-[#3d4a5c] hover:border-[#0f4c92] hover:text-[#0f4c92]">
+              Import / Export ▾
+            </button>
+            {ioMenu && (
+              <div className="absolute right-0 top-full z-30 w-44 overflow-hidden rounded-md border border-[#e3e1da] bg-white py-1 shadow-lg">
+                <button type="button" disabled={!model} onClick={() => { setIoMenu(false); download() }}
+                  className="block w-full px-3.5 py-2 text-left text-[12.5px] font-semibold text-[#3d4a5c] hover:bg-[#eaf1f9] hover:text-[#0f4c92] disabled:opacity-40">
+                  ⬇ Export model JSON
+                </button>
+                <button type="button" onClick={() => { setIoMenu(false); fileRef.current?.click() }}
+                  className="block w-full px-3.5 py-2 text-left text-[12.5px] font-semibold text-[#3d4a5c] hover:bg-[#eaf1f9] hover:text-[#0f4c92]">
+                  ⬆ Import model JSON…
+                </button>
+              </div>
+            )}
+          </div>
           <input ref={fileRef} type="file" accept=".json" className="sr-only"
             onChange={(e) => { const f = e.target.files?.[0]; if (f) void upload(f) }} />
           <button type="button" onClick={analyze} disabled={!model || !!busy || meshErrors}

--- a/webapp/src/pages/TrussSpace.tsx
+++ b/webapp/src/pages/TrussSpace.tsx
@@ -229,7 +229,7 @@ export default function TrussSpace() {
               <Num label="Height" unit="m" value={height} onChange={setHeight} step="0.25" />
               <Num label="Panels" value={panels} onChange={(v) => setPanels(Math.max(2, Math.round(v)))} step="1" />
               <button type="button" onClick={() => { setCustom(structuredClone(generated)); setSelected(null) }}
-                className="col-span-full mt-1 rounded-md border border-[#0056b3]/40 bg-[#0056b3]/5 px-3 py-1.5 text-sm font-semibold text-[#0056b3] hover:bg-[#0056b3]/10">
+                className="col-span-full mt-1 w-full rounded-md border border-[#cddcf0] bg-[#eaf1f9] px-3 py-2 text-sm font-semibold text-[#0f4c92] hover:bg-[#dce9f7]">
                 ✎ Customize this truss (free-form editor)
               </button>
             </Card>


### PR DESCRIPTION
## What

Follow-ups to the 3D Model Space mockup, applied app-wide:

- **Import / Export dropdown** — the Model Space header's two buttons (Export JSON, Import) merge into one `Import / Export ▾` dropdown, as in the mockup header.
- **Flat control rails everywhere** — `Card`/`ResultCard` (qty) and `CalcSection`/`VerdictPanel`/`DrawingCard`/`LetterheadCard` (calc) now carry a `rail-card` class; a small CSS rule collapses consecutive rail cards inside any `space-y` stack into **one continuous panel** (gaps and shared borders removed, soft hairline separator kept). Left *and* right rails on every calculator page get the flat-panel look with zero per-page edits — the numbered section headers stay.
- **Light-blue action buttons** — the mockup's flat action style replaces the remaining legacy buttons: BeamAnalysis "⚡ Auto-detect critical sections → design" (last gradient in the app), TrussSpace "✎ Customize this truss", and the `+ Node / + Member / + Support / + Load` adders on Frame Analysis, Beam Analysis and Load Path.

## Verification

- Headless Chromium: `/foundation` and `/slab-design` rails render as single flat panels (01–0n sections hairline-separated, verdict+drawing+results merged on the right); `/model` dropdown opens with Export/Import entries (Export disabled with no model).
- `npx tsc -b` clean · **1076/1076 tests**
- Engine guard: **0 files under `src/engine/`**

## Next phases (as requested)
1. Column engine: all-around bar distribution + short/long (slenderness) classification
2. T-beam engine (own PR)
3. Prestressed beam engine (own PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_