### PR TITLE
feat: column P-M with all-around bar distribution + short/long classification

### DIFF
--- a/webapp/src/engine/columnDesign.test.ts
+++ b/webapp/src/engine/columnDesign.test.ts
@@ -183,3 +183,68 @@ describe('slenderness — nonsway moment magnification (RC-06 conventions)', () 
     expect(nearLimit.delta).toBeGreaterThan(1)
   })
 })
+
+// ── All-around bar distribution (multi-layer strain compatibility) ──────────
+describe('interaction — all-around bar layout', () => {
+  const base = { b: 450, h: 450, cover: 40, barDia: 25, tieDia: 10, fc: 28, fy: 415 }
+  const Ab = (Math.PI / 4) * 25 ** 2
+
+  it('8 bars on a square: 3 per face, one 2-bar intermediate row (d′/mid/dt)', () => {
+    const r = interaction({ ...base, numBars: 8, layout: 'all-around' })
+    expect(r.nx).toBe(3)
+    expect(r.ny).toBe(3)
+    expect(r.layers.map((L) => L.n)).toEqual([3, 2, 3])
+    expect(r.layers[0].d).toBeCloseTo(62.5, 9)          // 40 + 10 + 25/2
+    expect(r.layers[1].d).toBeCloseTo(225, 9)           // mid-depth
+    expect(r.layers[2].d).toBeCloseTo(387.5, 9)
+    expect(r.layers.reduce((s, L) => s + L.As, 0)).toBeCloseTo(8 * Ab, 6)
+  })
+
+  it('12 bars on 600×400 (bending about h): more bars on the wide faces', () => {
+    const r = interaction({ ...base, b: 600, h: 400, numBars: 12, layout: 'all-around' })
+    // centre-line sides: bw = 600−125 = 475, hw = 400−2·62.5−? → dt−d′ = 275
+    // interior 8 → per b-face round(4·475/750) = 3 → nx = 5, ny = 3
+    expect(r.nx).toBe(5)
+    expect(r.ny).toBe(3)
+    expect(2 * r.nx + 2 * r.ny - 4).toBe(12)
+  })
+
+  it('4 bars: all-around degenerates to the two-face layout exactly', () => {
+    const a = interaction({ ...base, numBars: 4, layout: 'all-around' })
+    const b2 = interaction({ ...base, numBars: 4 })
+    expect(a.balanced.Pb).toBeCloseTo(b2.balanced.Pb, 9)
+    expect(a.balanced.Mb).toBeCloseTo(b2.balanced.Mb, 9)
+    for (let k = 0; k < a.curve.length; k += 10) {
+      expect(a.curve[k].Pn).toBeCloseTo(b2.curve[k].Pn, 9)
+      expect(a.curve[k].Mn).toBeCloseTo(b2.curve[k].Mn, 9)
+    }
+  })
+
+  it('balanced point matches the hand calc (8⌀25, 450², fc 28, fy 415)', () => {
+    // cb = 600/(1015)·387.5 = 229.064 mm; a = 194.704 mm
+    // Cc = 0.85·28·194.704·450 = 2085.3 kN
+    // top (3 bars, 1472.6 mm²): fs = 600(cb−62.5)/cb = 436 → fy, −0.85f′c displaced → +576.1 kN
+    // mid (2 bars, 981.7 mm²): fs = 600(cb−225)/cb = 10.6 MPa → +10.4 kN
+    // bottom (3 bars): fs → −fy → −611.1 kN
+    // Pb ≈ 2060.7 kN; Mb ≈ 2085.3·0.12765 + 576.1·0.1625 + 611.1·0.1625 ≈ 459.1 kN·m
+    const r = interaction({ ...base, numBars: 8, layout: 'all-around' })
+    expect(r.balanced.c).toBeCloseTo(229.064, 2)
+    expect(r.balanced.Pb).toBeCloseTo(2060.7, 0)
+    expect(r.balanced.Mb).toBeCloseTo(459.1, 0)
+  })
+
+  it('same bars all-around give LOWER Mb than the 2-face idealisation, same Po', () => {
+    const all = interaction({ ...base, numBars: 8, layout: 'all-around' })
+    const two = interaction({ ...base, numBars: 8 })
+    expect(all.balanced.Mb).toBeLessThan(two.balanced.Mb)
+    expect(all.Po).toBeCloseTo(two.Po, 6)
+    expect(all.curve[all.curve.length - 1].Pn).toBeCloseTo(all.Po, 0)   // closes at Po
+  })
+
+  it('capacityAtEccentricity on the all-around curve recovers the balanced point at e = eb', () => {
+    const r = interaction({ ...base, numBars: 8, layout: 'all-around' })
+    const p = capacityAtEccentricity({ ...base, numBars: 8, layout: 'all-around' }, r.balanced.eb)
+    expect(p.Pn).toBeCloseTo(r.balanced.Pb, 0)
+    expect(p.Mn).toBeCloseTo(r.balanced.Mb, 0)
+  })
+})

--- a/webapp/src/engine/columnDesign.ts
+++ b/webapp/src/engine/columnDesign.ts
@@ -171,35 +171,79 @@ export function designAxialColumn(i: AxialColumnInput): AxialColumnResult {
 }
 
 // ── Strain-compatibility interaction (tied rectangular, two-face bars) ──
+export type BarLayout = 'two-face' | 'all-around'
 export interface InteractionInput {
   b: number; h: number          // mm; bending about the axis ⟂ h
   cover: number; barDia: number; tieDia: number
   fc: number; fy: number
-  numBars: number               // split evenly between the two faces ⟂ to h
+  numBars: number               // total bars in the section
+  /** 'two-face' (default): bars split between the two faces ⟂ to h.
+   *  'all-around': bars distributed on all four faces (corners shared) —
+   *  intermediate side-bar rows enter the strain-compatibility sum as their
+   *  own layers, so Mn near the balanced point drops vs the 2-face idealised
+   *  layout (side bars sit near the neutral axis). */
+  layout?: BarLayout
 }
+
+/** One reinforcement row in the bending plane: depth d from the compression
+ *  face, n bars, As total (mm²). */
+export interface BarLayer { d: number; n: number; As: number }
 
 export interface PMPoint { c: number; Pn: number; Mn: number; phi: number; et: number }
 export interface InteractionResult {
   dPrime: number; dt: number
-  AsFace: number                // mm² per face
+  AsFace: number                // mm² per extreme face
+  layout: BarLayout
+  layers: BarLayer[]            // compression face → tension face
+  nx: number                    // bars per b-face (incl. corners)
+  ny: number                    // bars per h-face (incl. corners)
   Po: number; PnMax: number; phiC: number
   balanced: { c: number; Pb: number; Mb: number; eb: number }
   curve: PMPoint[]              // c sweep, Pn descending
 }
 
-function pmAt(i: InteractionInput, dPrime: number, dt: number, AsFace: number, c: number): PMPoint {
+/** Distribute numBars into strain-compatibility layers.
+ *  two-face: numBars/2 at d′ and dt (the classic sheet idealisation).
+ *  all-around: 4 corner bars + the rest split between the b- and h-faces in
+ *  proportion to the face lengths (as a real cage is detailed): nx per b-face,
+ *  ny per h-face with 2nx + 2ny − 4 = numBars; the (ny−2) intermediate rows
+ *  carry 2 bars each at equal spacing between d′ and dt. */
+export function barLayers(i: InteractionInput): { layers: BarLayer[]; nx: number; ny: number } {
+  const dPrime = i.cover + i.tieDia + i.barDia / 2
+  const dt = i.h - dPrime
+  const Ab = (Math.PI / 4) * i.barDia ** 2
+  const N = i.numBars
+  if ((i.layout ?? 'two-face') === 'two-face' || N < 4) {
+    return { layers: [{ d: dPrime, n: N / 2, As: (N / 2) * Ab }, { d: dt, n: N / 2, As: (N / 2) * Ab }], nx: N / 2, ny: 2 }
+  }
+  const Ne = 2 * Math.round(N / 2)                       // even bars all-around
+  const bw = i.b - 2 * dPrime, hw = dt - dPrime          // cage centre-line sides
+  let nx = 2 + Math.round(((Ne - 4) / 2) * (bw / (bw + hw)))
+  nx = Math.max(2, Math.min(nx, Ne / 2))                 // ny = Ne/2 + 2 − nx ≥ 2
+  const ny = Ne / 2 + 2 - nx
+  const layers: BarLayer[] = [{ d: dPrime, n: nx, As: nx * Ab }]
+  for (let k = 1; k <= ny - 2; k++) {
+    const d = dPrime + (k * (dt - dPrime)) / (ny - 1)
+    layers.push({ d, n: 2, As: 2 * Ab })
+  }
+  layers.push({ d: dt, n: nx, As: nx * Ab })
+  return { layers, nx, ny }
+}
+
+function pmAt(i: InteractionInput, layers: BarLayer[], dt: number, c: number): PMPoint {
   const b1 = beta1(i.fc)
   const a = Math.min(b1 * c, i.h)
   const Cc = (0.85 * i.fc * a * i.b) / 1000
-  const layerF = (d: number): number => {
-    const fs = Math.max(-i.fy, Math.min(i.fy, (ES * (c - d)) / c))
-    const displaced = d <= a ? 0.85 * i.fc : 0
-    return (AsFace * (fs - displaced)) / 1000
+  let Pn = Cc
+  let Mn = Cc * (i.h / 2 - a / 2)
+  for (const L of layers) {
+    const fs = Math.max(-i.fy, Math.min(i.fy, (ES * (c - L.d)) / c))
+    const displaced = L.d <= a ? 0.85 * i.fc : 0
+    const F = (L.As * (fs - displaced)) / 1000
+    Pn += F
+    Mn += F * (i.h / 2 - L.d)
   }
-  const F1 = layerF(dPrime)
-  const F2 = layerF(dt)
-  const Pn = Cc + F1 + F2
-  const Mn = (Cc * (i.h / 2 - a / 2) + F1 * (i.h / 2 - dPrime) + F2 * (i.h / 2 - dt)) / 1000
+  Mn /= 1000
   const et = (0.003 * (dt - c)) / c
   const ety = i.fy / 200000
   const phi = et >= 0.005 ? 0.90 : et <= ety ? 0.65 : 0.65 + (0.25 * (et - ety)) / (0.005 - ety)
@@ -211,13 +255,14 @@ export function interaction(i: InteractionInput): InteractionResult {
   const dt = i.h - dPrime
   const Ab = (Math.PI / 4) * i.barDia ** 2
   const AsFace = (i.numBars / 2) * Ab
-  const Ast = i.numBars * Ab
+  const { layers, nx, ny } = barLayers(i)
+  const Ast = layers.reduce((s, L) => s + L.As, 0)
   const Ag = i.b * i.h
   const Po = (0.85 * i.fc * (Ag - Ast) + i.fy * Ast) / 1000
   const PnMax = 0.80 * Po
 
   const cb = (600 / (600 + i.fy)) * dt
-  const bal = pmAt(i, dPrime, dt, AsFace, cb)
+  const bal = pmAt(i, layers, dt, cb)
 
   const curve: PMPoint[] = []
   // Sweep from near-pure-bending (small c) to pure compression. The top end
@@ -228,11 +273,12 @@ export function interaction(i: InteractionInput): InteractionResult {
   const N = 80
   for (let k = 0; k <= N; k++) {
     const c = cMin * Math.pow(cMaxV / cMin, k / N)   // log sweep
-    curve.push(pmAt(i, dPrime, dt, AsFace, c))
+    curve.push(pmAt(i, layers, dt, c))
   }
 
   return {
-    dPrime, dt, AsFace, Po, PnMax, phiC: 0.65,
+    dPrime, dt, AsFace, layout: i.layout ?? 'two-face', layers, nx, ny,
+    Po, PnMax, phiC: 0.65,
     balanced: { c: cb, Pb: bal.Pn, Mb: bal.Mn, eb: bal.Pn > 1e-9 ? bal.Mn / bal.Pn : 0 },
     curve,
   }
@@ -242,16 +288,16 @@ export function interaction(i: InteractionInput): InteractionResult {
 export function capacityAtEccentricity(i: InteractionInput, e: number): PMPoint {
   const dPrime = i.cover + i.tieDia + i.barDia / 2
   const dt = i.h - dPrime
-  const AsFace = ((i.numBars / 2) * Math.PI * i.barDia ** 2) / 4
+  const { layers } = barLayers(i)
   let lo = dPrime * 0.1, hi = i.h * 20
   for (let k = 0; k < 80; k++) {
     const mid = (lo + hi) / 2
-    const p = pmAt(i, dPrime, dt, AsFace, mid)
+    const p = pmAt(i, layers, dt, mid)
     const eAt = p.Pn > 1e-9 ? p.Mn / p.Pn : Infinity
     if (eAt > e) lo = mid
     else hi = mid
   }
-  return pmAt(i, dPrime, dt, AsFace, (lo + hi) / 2)
+  return pmAt(i, layers, dt, (lo + hi) / 2)
 }
 
 /** Bresler reciprocal load for biaxial bending: 1/Pn = 1/Pnx + 1/Pny − 1/Po. */

--- a/webapp/src/lib/columnSolution.ts
+++ b/webapp/src/lib/columnSolution.ts
@@ -110,7 +110,17 @@ export function eccentricColumnSolution(
   const b1 = beta1(i.fc)
   const aB = Math.min(b1 * r.balanced.c, i.h)
 
+  const layoutStep: SolutionStep[] = r.layout === 'all-around' ? [{
+    title: 'Bar layout — all four faces',
+    clause: 'strain compatibility',
+    lines: [
+      txt(`${i.numBars} bars are detailed around the cage: ${r.nx} per ${i.b}-mm face and ${r.ny} per ${i.h}-mm face (corners shared). Each row enters the P–M sum as its own layer — side bars near the neutral axis contribute little moment, so this layout gives a lower Mb than the two-face idealisation.`),
+      eq(String.raw`\text{layers } d_i = [${r.layers.map((L) => sn1(L.d)).join(',\ ')}]\ \text{mm},\quad n_i = [${r.layers.map((L) => L.n).join(',\ ')}]`),
+    ],
+  }] : []
+
   return [
+    ...layoutStep,
     {
       title: 'Eccentricity of the load',
       lines: [
@@ -145,7 +155,8 @@ export function eccentricColumnSolution(
 export function slendernessSolution(i: SlendernessInput, r: SlendernessResult): SolutionStep[] {
   return [
     {
-      title: 'Slenderness classification (nonsway)',
+      title: `Slenderness classification (nonsway) — ${r.slender ? 'LONG column' : 'SHORT column'}`,
+      clause: 'ACI 318-14 §6.2.5',
       lines: [
         txt('For compression members braced against sidesway, slenderness may be neglected when kLu/r ≤ 34 + 12(M1/M2) ≤ 40, with M1/M2 negative in single curvature (RC-06 / §406.2.5). r = 0.3h for rectangular sections.'),
         eq(String.raw`\dfrac{k L_u}{r} = \dfrac{${sn2(i.k)}\times ${sn2(i.Lu)}\times 1000}{${sn1(r.r)}} = ${sn1(r.kLuOverR)} \;${r.slender ? '>' : '\\le'}\; ${sn1(r.limit)}`),

--- a/webapp/src/pages/ColumnDesign.tsx
+++ b/webapp/src/pages/ColumnDesign.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
 import {
   designAxialColumn, interaction, capacityAtEccentricity, momentMagnificationNonsway,
-  type ColumnShape, type LateralSystem,
+  type ColumnShape, type LateralSystem, type BarLayout,
 } from '../engine/columnDesign'
 import { factoredLoad } from '../engine/loads'
 import { ColumnSchematic } from '../components/ColumnSchematic'
@@ -33,12 +33,13 @@ export default function ColumnDesign() {
   const [Mu, setMu] = useState(200)
   const [barMode, setBarMode] = useState<BarMode>('design')
   const [numBars, setNumBars] = useState(8)
+  const [layout, setLayout] = useState<BarLayout>('all-around')   // P–M bar distribution
   // Seismic / lateral system
   const [system, setSystem] = useState<LateralSystem>('gravity')
   const [colLen, setColLen] = useState(3000)  // mm clear height
   const [hx, setHx]         = useState(0)     // mm, max lateral tie spacing (0 = use bMin)
   // Slenderness (nonsway)
-  const [slenderOn, setSlenderOn] = useState(false)
+  const [slenderOn, setSlenderOn] = useState(true)
   const [kEff, setKEff] = useState(1.0); const [Lu, setLu] = useState(3.0)
   const [M1, setM1] = useState(-150); const [M2, setM2] = useState(200)
   const [EIin, setEIin] = useState(0)   // kN·m², 0 → derive 0.4EcIg/(1+βd)
@@ -70,17 +71,17 @@ export default function ColumnDesign() {
   const MuEff = slender ? slender.Mc : Mu
   const inter = useMemo(() => {
     if (!eccentric || !(b > 0 && h > 0)) return null
-    try { return interaction({ b, h, cover, barDia, tieDia, fc, fy, numBars }) } catch { return null }
-  }, [eccentric, b, h, cover, barDia, tieDia, fc, fy, numBars])
+    try { return interaction({ b, h, cover, barDia, tieDia, fc, fy, numBars, layout }) } catch { return null }
+  }, [eccentric, b, h, cover, barDia, tieDia, fc, fy, numBars, layout])
   const cap = useMemo(() => {
     if (!inter || !(Pu > 0) || !(MuEff > 0) || !Number.isFinite(MuEff)) return null
-    return capacityAtEccentricity({ b, h, cover, barDia, tieDia, fc, fy, numBars }, MuEff / Pu)
-  }, [inter, Pu, MuEff, b, h, cover, barDia, tieDia, fc, fy, numBars])
+    return capacityAtEccentricity({ b, h, cover, barDia, tieDia, fc, fy, numBars, layout }, MuEff / Pu)
+  }, [inter, Pu, MuEff, b, h, cover, barDia, tieDia, fc, fy, numBars, layout])
 
   const solution = useMemo(() => {
     const steps: SolutionStep[] = []
     if (slender) steps.push(...slendernessSolution({ Pu, M1, M2, k: kEff, Lu, h, EI: EIin > 0 ? EIin : undefined, fc, b }, slender))
-    if (eccentric && inter && cap) steps.push(...eccentricColumnSolution({ b, h, cover, barDia, tieDia, fc, fy, numBars }, inter, Pu, MuEff, cap))
+    if (eccentric && inter && cap) steps.push(...eccentricColumnSolution({ b, h, cover, barDia, tieDia, fc, fy, numBars, layout }, inter, Pu, MuEff, cap))
     if (axial) steps.push(...axialColumnSolution({
       shape: tied ? 'tied' : 'spiral', b, h, D, cover, barDia, tieDia, fc, fy, fyt, Pu,
       numBars: barMode === 'analyze' || eccentric ? numBars : undefined,
@@ -141,6 +142,10 @@ export default function ColumnDesign() {
               options={eccentric ? [['analyze', 'Given count']] : [['design', 'Design automatically'], ['analyze', 'Given count']]} />
             {(barMode === 'analyze' || eccentric) && (
               <Num label="No. of bars" value={numBars} onChange={setNumBars} />
+            )}
+            {eccentric && (
+              <Pick label="Bar distribution" value={layout} onChange={(v) => setLayout(v as BarLayout)}
+                options={[['all-around', 'All four faces'], ['two-face', 'Two faces (⟂ to h)']]} />
             )}
           </Card>
 
@@ -335,6 +340,10 @@ export default function ColumnDesign() {
             { label: 'Bars', value: `${axial.bars}-⌀${barDia}` },
             { label: tied ? 'Ties' : 'Spiral pitch', value: tied ? `⌀${Math.max(tieDia, axial.tieDiaMin)} @${f0(axial.tieSpacingFinal)}` : `@${f0(axial.spiralPitch)}`, unit: 'mm' },
             { label: 'φPn,max', value: f1(axial.phiPnMax), unit: 'kN' },
+            ...(eccentric && slender ? [{
+              label: 'Column class',
+              value: slender.slender ? 'LONG (slender)' : 'SHORT',
+            }] : []),
           ]}
           checks={eccentric && util !== null ? [{ name: 'P–M interaction Pu/φPn', ratio: util, ok: util <= 1.0001 }] : []}
           data={[


### PR DESCRIPTION
## What — engine layer L7 (`columnDesign.ts`)

Per request: the column engine can now design a section with **bars distributed all around the section**, and the calculator **classifies short vs long columns** as part of the standard flow.

### All-around bar distribution (strain-compatibility layers)
- New `barLayers()`: `'two-face'` keeps the classic sheet idealisation (results bit-identical — existing 18 tests untouched); `'all-around'` details a real cage — 4 corner bars + the rest split between the b- and h-faces in proportion to face lengths (`2nx + 2ny − 4 = N`), with each intermediate 2-bar side row entering the P–M sum as its own layer.
- `pmAt` / `interaction` / `capacityAtEccentricity` generalised to arbitrary layers; `InteractionResult` exposes `layers / nx / ny / layout`.
- **Hand-calc anchor** (in the test file): 8⌀25, 450², f'c 28, fy 415, all-around → cb = 229.1 mm, **Pb = 2060.7 kN, Mb = 459.1 kN·m**. Properties verified: N=4 degenerates to two-face exactly; same-N all-around gives *lower* Mb than two-face with identical Po (side bars sit near the neutral axis); curve closes at Po. **6 new tests — suite 1076 → 1082.**

### Short/long classification
- Slenderness (§6.2.5 nonsway, `momentMagnificationNonsway`) is now **on by default** on the Column page; the verdict gains a **"Column class" stat (SHORT / LONG (slender))**, the worked-solution step carries the clause and an explicit LONG/SHORT title, and the magnified **Mc** feeds the P–M demand ray as before.

### Page + solution
- "Bar distribution" picker (All four faces default / Two faces) threaded through the check and the worked solution; new **"Bar layout — all four faces"** step lists layer depths & bar counts.

## Verification
- `npx tsc -b` clean · **1082/1082 tests**
- Headless: `/column-design` eccentric mode shows the picker, the 8-bar cage drawing, the SHORT/LONG stat and the layout step; P–M curve/balanced point reflect the layered section.

Next: **T-beam engine** (own PR), then **prestressed beam engine** (own PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_