### PR TITLE
feat: T-beam design engine + page (ACI 318-14 §6.3.2 / §22.2)

### DIFF
--- a/docs/ValidationMap.md
+++ b/docs/ValidationMap.md
@@ -132,3 +132,4 @@ asserted by that file; all run in CI.
 | X002 | STAAD continuous-beam / multi-bay cross-check (FR004, F3D003) | needs STAAD reference output |
 | X003 | PCA Column biaxial + slender cross-check (C003, C004) | needs spColumn reference curves |
 | X004 | Excel verification sheets (Roadmap Phase-2 goal) | authoring task — the `/validation` page already renders manual-vs-software tables that can seed them |
+| T-beam flexure (`tbeam.ts`) | §6.3.2 bf table + two-couple T flexure vs hand calc (Asf 1290 mm², rect/true-T switch, εt/φ) | ✅ `tbeam.test.ts` (14) |

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -7,6 +7,7 @@ import FoundationDesign from './pages/FoundationDesign'
 import PileCapDesign from './pages/PileCapDesign'
 import CombinedFootingDesign from './pages/CombinedFootingDesign'
 import BeamDesign from './pages/BeamDesign'
+import TBeamDesign from './pages/TBeamDesign'
 import BeamAnalysis from './pages/BeamAnalysis'
 import ColumnDesign from './pages/ColumnDesign'
 import FrameAnalysis from './pages/FrameAnalysis'
@@ -57,6 +58,7 @@ export default function App() {
         <Route path="/pile-cap" element={<PileCapDesign />} />
         <Route path="/combined" element={<CombinedFootingDesign />} />
         <Route path="/beam-design" element={<BeamDesign />} />
+        <Route path="/tbeam-design" element={<TBeamDesign />} />
         <Route path="/beam-analysis" element={<BeamAnalysis />} />
         <Route path="/column-design" element={<ColumnDesign />} />
         <Route path="/frame" element={<FrameAnalysis />} />

--- a/webapp/src/engine/tbeam.test.ts
+++ b/webapp/src/engine/tbeam.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import { designTBeam, effectiveFlange, tBeamCapacity, beta1 } from './tbeam'
+
+// Base: interior T, bw 300, h 600, hf 100, cover 40, ⌀10 stirrups, ⌀25 bars,
+// f'c 21, fy 415, ln 6 m, sw 2.7 m → dt = 600−40−10−12.5 = 537.5 mm.
+const base = {
+  kind: 'interior' as const, bw: 300, h: 600, hf: 100,
+  ln: 6, sw: 2.7, cover: 40, stirrupDia: 10, barDia: 25,
+  fc: 21, fy: 415, Mu: 400,
+}
+
+describe('effective flange width — ACI Table 6.3.2.1', () => {
+  it('interior: bw + 2·min(8hf, sw/2, ln/8)', () => {
+    // 8hf = 800, sw/2 = 1350, ln/8 = 750 → overhang 750 → bf = 300+1500 = 1800? no:
+    // min = 750 (ln/8) → bf = 300 + 2·750 = 1800
+    const { bf, govern } = effectiveFlange(base)
+    expect(bf).toBeCloseTo(300 + 2 * 750, 9)
+    expect(govern).toContain('ln/8')
+  })
+  it('8hf governs when the slab is thin', () => {
+    const { bf, govern } = effectiveFlange({ ...base, hf: 75 })
+    expect(bf).toBeCloseTo(300 + 2 * 8 * 75, 9)
+    expect(govern).toContain('8hf')
+  })
+  it('edge (L) beam: one overhang, ln/12', () => {
+    const { bf } = effectiveFlange({ ...base, kind: 'edge' })
+    expect(bf).toBeCloseTo(300 + Math.min(6 * 100, 1350, 500), 9)
+  })
+  it('isolated: bf ≤ 4bw and hf ≥ bw/2 flag', () => {
+    const r = effectiveFlange({ ...base, kind: 'isolated', bfGiven: 1500 })
+    expect(r.bf).toBe(1200)
+    expect(r.isolatedOK).toBe(false)       // hf 100 < bw/2 = 150
+    expect(effectiveFlange({ ...base, kind: 'isolated', hf: 150, bfGiven: 1000 }).isolatedOK).toBe(true)
+  })
+})
+
+describe('designTBeam — rectangular behaviour (a ≤ hf)', () => {
+  const r = designTBeam(base)   // Mu = 400 kN·m
+  it('block stays in the flange and the capacity covers Mu', () => {
+    expect(r.tBehavior).toBe(false)
+    expect(r.a).toBeLessThanOrEqual(base.hf)
+    expect(r.phiMn).toBeGreaterThanOrEqual(400)
+    expect(r.ok).toBe(true)
+  })
+  it('hand calc: Rn with b = bf = 1800 → As ≈ Mu/(0.9·fy·(d−a/2))', () => {
+    // a = As·fy/(0.85·f'c·bf); iterate ≈ jd ~ 0.98d. With d = 537.5:
+    // Rn = 400e6/(0.9·1800·537.5²) = 0.855 MPa → ρ = 0.85·21/415·(1−√(1−2·0.855/17.85))
+    const Rn = 400e6 / (0.9 * 1800 * 537.5 ** 2)
+    const rho = ((0.85 * 21) / 415) * (1 - Math.sqrt(1 - (2 * Rn) / (0.85 * 21)))
+    expect(r.As).toBeCloseTo(Math.max(rho * 1800 * 537.5, r.AsMin), 6)
+  })
+  it('εt ≥ 0.005 → φ = 0.90 (shallow block, tension-controlled)', () => {
+    expect(r.et).toBeGreaterThan(0.005)
+    expect(r.phi).toBeCloseTo(0.90, 9)
+  })
+})
+
+describe('designTBeam — true T behaviour (a > hf)', () => {
+  // Push the demand up and shrink the flange so the block enters the web.
+  const inp = { ...base, bfGiven: 700, hf: 75, Mu: 520, h: 650 }  // dt = 587.5
+  const r = designTBeam(inp)
+  it('splits into flange couple Asf + web remainder', () => {
+    expect(r.tBehavior).toBe(true)
+    expect(r.a).toBeGreaterThan(inp.hf)
+    // Asf = 0.85·f'c·(bf−bw)·hf/fy = 0.85·21·400·75/415
+    expect(r.Asf).toBeCloseTo((0.85 * 21 * (700 - 300) * 75) / 415, 3)
+    expect(r.As).toBeGreaterThan(r.Asf)
+  })
+  it('capacity from equilibrium covers the demand', () => {
+    expect(r.phiMn).toBeGreaterThanOrEqual(520 * 0.999)
+  })
+  it('capacity function is consistent: recompute at the provided steel', () => {
+    const cap = tBeamCapacity(inp, r.bf, r.d, r.dt, r.bars * ((Math.PI / 4) * 25 ** 2))
+    expect(cap.phiMn).toBeCloseTo(r.phiMn, 6)
+    expect(cap.a).toBeGreaterThan(inp.hf)
+  })
+})
+
+describe('minimum steel and hogging (flange in tension)', () => {
+  it('As,min = max(0.25√f\'c, 1.4)/fy·bw·d governs tiny moments', () => {
+    const r = designTBeam({ ...base, Mu: 20 })
+    expect(r.minGoverns).toBe(true)
+    expect(r.As).toBeCloseTo((Math.max(0.25 * Math.sqrt(21), 1.4) / 415) * 300 * r.d, 3)
+  })
+  it('negative moment designs the web rectangle (b = bw) and doubles bw,min when determinate', () => {
+    const r = designTBeam({ ...base, Mu: -150 })
+    expect(r.tBehavior).toBe(false)
+    const rDet = designTBeam({ ...base, Mu: -20, determinate: true })
+    const rInd = designTBeam({ ...base, Mu: -20 })
+    expect(rDet.AsMin).toBeCloseTo(2 * rInd.AsMin, 3)   // min(2bw, bf) = 600
+  })
+})
+
+describe('tension-controlled cap', () => {
+  it('AsMax corresponds to c = 3/8·dt (block may cross into the web)', () => {
+    const r = designTBeam(base)
+    const cTC = (3 / 8) * r.dt, aTC = beta1(21) * cTC
+    const Cc = aTC <= base.hf ? 0.85 * 21 * r.bf * aTC : 0.85 * 21 * ((r.bf - 300) * 100 + 300 * aTC)
+    expect(r.AsMax).toBeCloseTo(Cc / 415, 3)
+  })
+  it('an over-reinforced analyze case is flagged not-ok', () => {
+    const r = designTBeam({ ...base, bfGiven: 400, AsGiven: 12000, Mu: 100 })
+    expect(r.ok).toBe(false)
+    expect(r.notes.join(' ')).toContain('tension-controlled')
+  })
+})

--- a/webapp/src/engine/tbeam.ts
+++ b/webapp/src/engine/tbeam.ts
@@ -1,0 +1,182 @@
+// T-beam / L-beam flexural design — ACI 318-14 / NSCP 2015.
+// Units: mm, mm², MPa, kN·m. Positive moment puts the flange in compression.
+//
+// Effective flange width per ACI Table 6.3.2.1 (NSCP §406.3.2): overhang each
+// side ≤ min(8hf, sw/2, ln/8) for interior Ts, ≤ min(6hf, sw/2, ln/12) one
+// side for edge (L) beams; isolated Ts must satisfy hf ≥ bw/2, bf ≤ 4bw
+// (§6.3.2.2). Flexure follows the classic two-couple split: flange overhang
+// couple Asf = 0.85f'c(bf−bw)hf/fy plus a web rectangle for the remainder
+// (§22.2); φ from εt (§21.2.2); As,min per §9.6.1.2 (with the 2bw rule when a
+// flange is in tension on statically determinate spans).
+
+export type TBeamKind = 'interior' | 'edge' | 'isolated'
+
+export interface TBeamInput {
+  kind: TBeamKind
+  bw: number; h: number; hf: number   // web width, total depth, flange thickness
+  bfGiven?: number                    // flange width; omit to derive from ln/sw
+  ln?: number                         // clear span, m (for bf table)
+  sw?: number                         // clear web-to-web spacing, m
+  cover: number; stirrupDia: number; barDia: number
+  fc: number; fy: number
+  Mu: number                          // kN·m (+ = flange in compression)
+  /** Analyze a given steel area instead of designing. */
+  AsGiven?: number
+  /** Flange in tension & statically determinate → §9.6.1.2(b) min-steel rule. */
+  determinate?: boolean
+}
+
+export interface TBeamResult {
+  bf: number; bfGovern: string
+  d: number; dt: number
+  isolatedOK: boolean                 // §6.3.2.2 limits (isolated only)
+  MnfPhi: number                      // φ·flange-couple capacity at a = hf, kN·m
+  tBehavior: boolean                  // a > hf → true T behaviour
+  a: number; c: number; et: number; phi: number
+  Asf: number; Asw: number; As: number      // required (design) or given (analyze)
+  AsMin: number; minGoverns: boolean
+  AsMax: number                       // tension-controlled cap (εt = 0.005)
+  bars: number; layers: number[]; sClear: number; sClearMin: number
+  phiMn: number                       // capacity at the FINAL As, kN·m
+  ok: boolean
+  notes: string[]
+}
+
+const ES = 200000
+export const beta1 = (fc: number) => (fc <= 28 ? 0.85 : Math.max(0.65, 0.85 - (0.05 * (fc - 28)) / 7))
+
+/** Effective flange width, mm — ACI Table 6.3.2.1 / §6.3.2.2. */
+export function effectiveFlange(i: TBeamInput): { bf: number; govern: string; isolatedOK: boolean } {
+  const lnMm = (i.ln ?? 0) * 1000, swMm = (i.sw ?? 0) * 1000
+  if (i.kind === 'isolated') {
+    const bf = Math.min(i.bfGiven ?? 4 * i.bw, 4 * i.bw)
+    return { bf, govern: 'isolated: bf ≤ 4bw (§6.3.2.2)', isolatedOK: i.hf >= i.bw / 2 && bf <= 4 * i.bw }
+  }
+  const per = i.kind === 'interior'
+    ? [8 * i.hf, swMm > 0 ? swMm / 2 : Infinity, lnMm > 0 ? lnMm / 8 : Infinity]
+    : [6 * i.hf, swMm > 0 ? swMm / 2 : Infinity, lnMm > 0 ? lnMm / 12 : Infinity]
+  const over = Math.min(...per)
+  const labels = i.kind === 'interior' ? ['8hf', 'sw/2', 'ln/8'] : ['6hf', 'sw/2', 'ln/12']
+  const govern = labels[per.indexOf(over)]
+  const sides = i.kind === 'interior' ? 2 : 1
+  let bf = i.bw + sides * (Number.isFinite(over) ? over : 0)
+  if (i.bfGiven && i.bfGiven > 0) bf = Math.min(bf, i.bfGiven)
+  return { bf, govern: `overhang = ${govern} (Table 6.3.2.1)`, isolatedOK: true }
+}
+
+/** φMn of a T section with steel As (positive moment). Returns a possibly
+ *  web-penetrating stress block from force equilibrium. */
+export function tBeamCapacity(
+  i: Pick<TBeamInput, 'bw' | 'hf' | 'fc' | 'fy'>, bf: number, d: number, dt: number, As: number,
+): { a: number; c: number; et: number; phi: number; phiMn: number; tBehavior: boolean } {
+  const T = As * i.fy
+  const Cflange = 0.85 * i.fc * bf * i.hf
+  let a: number, Mn: number
+  if (T <= Cflange) {
+    a = T / (0.85 * i.fc * bf)
+    Mn = T * (d - a / 2)
+  } else {
+    // block into the web: overhangs full at hf, web block depth a
+    const Cover = 0.85 * i.fc * (bf - i.bw) * i.hf
+    a = (T - Cover) / (0.85 * i.fc * i.bw)
+    Mn = Cover * (d - i.hf / 2) + (T - Cover) * (d - a / 2)
+  }
+  const c = a / beta1(i.fc)
+  const et = (0.003 * (dt - c)) / c
+  const ety = i.fy / ES
+  const phi = et >= 0.005 ? 0.90 : et <= ety ? 0.65 : 0.65 + (0.25 * (et - ety)) / (0.005 - ety)
+  return { a, c, et, phi, phiMn: (phi * Mn) / 1e6, tBehavior: a > i.hf }
+}
+
+export function designTBeam(i: TBeamInput): TBeamResult {
+  const notes: string[] = []
+  const { bf, govern, isolatedOK } = effectiveFlange(i)
+  const Ab = (Math.PI / 4) * i.barDia ** 2
+  const dt = i.h - i.cover - i.stirrupDia - i.barDia / 2
+  let d = dt                                  // refined after layering
+  const b1 = beta1(i.fc)
+
+  // tension-controlled steel cap (c = 3/8·dt): block may enter the web
+  const cTC = (3 / 8) * dt
+  const aTC = b1 * cTC
+  const CcTC = aTC <= i.hf
+    ? 0.85 * i.fc * bf * aTC
+    : 0.85 * i.fc * ((bf - i.bw) * i.hf + i.bw * aTC)
+  const AsMax = CcTC / i.fy
+
+  // §9.6.1.2: As,min = max(0.25√f'c, 1.4)/fy · bw·d; flange-in-tension
+  // determinate spans use bw → min(2bw, bf) (§9.6.1.2(b) via Mu < 0 case).
+  const bwMin = i.Mu < 0 && i.determinate ? Math.min(2 * i.bw, bf) : i.bw
+  const AsMin = (Math.max(0.25 * Math.sqrt(i.fc), 1.4) / i.fy) * bwMin * d
+
+  // φ·capacity with the block exactly filling the flange — the T/rect switch
+  const MnfPhi = (0.90 * 0.85 * i.fc * bf * i.hf * (d - i.hf / 2)) / 1e6
+
+  let As: number, Asf = 0, Asw: number
+  const MuAbs = Math.abs(i.Mu)
+  if (i.AsGiven && i.AsGiven > 0) {
+    As = i.AsGiven
+    Asw = As
+  } else if (i.Mu < 0) {
+    // flange in tension → rectangular web design, b = bw
+    const Rn = (MuAbs * 1e6) / (0.9 * i.bw * d * d)
+    const disc = 1 - (2 * Rn) / (0.85 * i.fc)
+    if (disc <= 0) notes.push('web section inadequate for the hogging moment — enlarge bw/h')
+    const rho = disc > 0 ? ((0.85 * i.fc) / i.fy) * (1 - Math.sqrt(disc)) : AsMax / (i.bw * d)
+    As = Math.max(rho * i.bw * d, AsMin)
+    Asw = As
+  } else if (MuAbs * 1e6 <= 0.9 * 0.85 * i.fc * bf * i.hf * (d - i.hf / 2)) {
+    // a ≤ hf → rectangular with b = bf
+    const Rn = (MuAbs * 1e6) / (0.9 * bf * d * d)
+    const rho = ((0.85 * i.fc) / i.fy) * (1 - Math.sqrt(Math.max(0, 1 - (2 * Rn) / (0.85 * i.fc))))
+    As = Math.max(rho * bf * d, AsMin)
+    Asw = As
+  } else {
+    // true T: flange-overhang couple + web rectangle for the remainder
+    Asf = (0.85 * i.fc * (bf - i.bw) * i.hf) / i.fy
+    const Muf = (0.90 * Asf * i.fy * (d - i.hf / 2)) / 1e6
+    const Muw = MuAbs - Muf
+    const Rn = (Muw * 1e6) / (0.9 * i.bw * d * d)
+    const disc = 1 - (2 * Rn) / (0.85 * i.fc)
+    if (disc <= 0) notes.push('web remainder exceeds singly-reinforced capacity — enlarge the section')
+    const rho = disc > 0 ? ((0.85 * i.fc) / i.fy) * (1 - Math.sqrt(disc)) : 0
+    Asw = rho * i.bw * d
+    As = Math.max(Asf + Asw, AsMin)
+  }
+  const minGoverns = !(i.AsGiven && i.AsGiven > 0) && As <= AsMin + 1e-9
+
+  // bar layout in the web: fit per layer with §25.2.1 clear spacing
+  const bars = Math.max(2, Math.ceil(As / Ab))
+  const sClearMin = Math.max(25, i.barDia)
+  const web = i.bw - 2 * (i.cover + i.stirrupDia)
+  const perLayer = Math.max(2, Math.floor((web + sClearMin) / (i.barDia + sClearMin)))
+  const layers: number[] = []
+  for (let left = bars; left > 0; left -= perLayer) layers.push(Math.min(perLayer, left))
+  const sClear = layers[0] > 1 ? (web - layers[0] * i.barDia) / (layers[0] - 1) : web
+  if (layers.length > 1) {
+    // shift d to the group centroid (25 mm clear between layers)
+    const pitch = i.barDia + 25
+    const n = layers.reduce((s, x) => s + x, 0)
+    const yBar = layers.reduce((s, x, k) => s + x * k * pitch, 0) / n
+    d = dt - yBar
+    notes.push(`${layers.length} bar layers — d reduced to the group centroid`)
+  }
+
+  const AsProv = bars * Ab
+  const capAs = i.AsGiven && i.AsGiven > 0 ? i.AsGiven : AsProv
+  const cap = tBeamCapacity(i, i.Mu < 0 ? i.bw : bf, d, dt, capAs)
+  const tcOK = capAs <= AsMax + 1e-9
+  if (!tcOK) notes.push('As exceeds the tension-controlled cap (εt < 0.005) — enlarge the section')
+
+  const ok = cap.phiMn + 1e-9 >= MuAbs && tcOK && isolatedOK
+    && !notes.some((n) => n.includes('inadequate') || n.includes('exceeds'))
+
+  return {
+    bf, bfGovern: govern, d, dt, isolatedOK,
+    MnfPhi, tBehavior: cap.tBehavior,
+    a: cap.a, c: cap.c, et: cap.et, phi: cap.phi,
+    Asf, Asw, As, AsMin, minGoverns, AsMax,
+    bars, layers, sClear, sClearMin,
+    phiMn: cap.phiMn, ok, notes,
+  }
+}

--- a/webapp/src/lib/tbeamSolution.ts
+++ b/webapp/src/lib/tbeamSolution.ts
@@ -1,0 +1,64 @@
+// Worked solution for the T-beam engine (engine/tbeam.ts).
+import type { TBeamInput, TBeamResult } from '../engine/tbeam'
+import { beta1 } from '../engine/tbeam'
+import { type SolutionStep, type SolutionLine, sn0, sn1, sn2, sn4 } from './solution'
+
+const txt = (text: string): SolutionLine => ({ text })
+const eq = (tex: string): SolutionLine => ({ tex })
+
+export function buildTBeamSolution(i: TBeamInput, r: TBeamResult): SolutionStep[] {
+  const hog = i.Mu < 0
+  const steps: SolutionStep[] = [
+    {
+      title: 'Effective flange width',
+      clause: 'ACI 318-14 §6.3.2',
+      pass: i.kind === 'isolated' ? r.isolatedOK : undefined,
+      lines: [
+        txt(`${i.kind} T-beam: ${r.bfGovern}.`),
+        eq(String.raw`b_f = ${sn0(r.bf)}\ \text{mm},\qquad d_t = h - cover - d_s - \tfrac{d_b}{2} = ${sn1(r.dt)}\ \text{mm},\quad d = ${sn1(r.d)}\ \text{mm}`),
+      ],
+    },
+    {
+      title: hog ? 'Hogging — flange in tension, web rectangle resists' : 'Rectangular or T behaviour?',
+      clause: 'ACI 318-14 §22.2',
+      lines: hog ? [
+        txt('Negative moment puts the flange in tension — compression lives in the web, so the section designs as a rectangle b = bw.'),
+      ] : [
+        txt('If the flange alone can supply the compression (a ≤ hf) the section behaves as a rectangle b = bf; otherwise the stress block enters the web.'),
+        eq(String.raw`\phi M_{n,f} = 0.90(0.85 f'_c)\,b_f h_f (d - \tfrac{h_f}{2}) = ${sn1(r.MnfPhi)}\ \text{kN·m}\ ${Math.abs(i.Mu) <= r.MnfPhi ? String.raw`\ge M_u \Rightarrow \text{rectangular}` : String.raw`< M_u \Rightarrow \textbf{true T}`}`),
+      ],
+    },
+  ]
+  if (!hog && r.tBehavior) steps.push({
+    title: 'Two-couple split (true T)',
+    clause: 'flange couple + web',
+    lines: [
+      eq(String.raw`A_{sf} = \dfrac{0.85 f'_c (b_f - b_w) h_f}{f_y} = ${sn0(r.Asf)}\ \text{mm}^2`),
+      eq(String.raw`A_{sw} = ${sn0(r.Asw)}\ \text{mm}^2\ (\text{web rectangle for } M_u - M_{uf})`),
+    ],
+  })
+  steps.push(
+    {
+      title: 'Steel area and minimum',
+      clause: 'ACI 318-14 §9.6.1.2',
+      pass: r.As <= r.AsMax + 1e-9,
+      lines: [
+        eq(String.raw`A_{s,min} = \dfrac{\max(0.25\sqrt{f'_c},\ 1.4)}{f_y}\, b_w d = ${sn0(r.AsMin)}\ \text{mm}^2${r.minGoverns ? String.raw`\ \Rightarrow\ \text{governs}` : ''}`),
+        eq(String.raw`A_s = ${sn0(r.As)}\ \text{mm}^2 \;\le\; A_{s,max}(\varepsilon_t = 0.005) = ${sn0(r.AsMax)}\ \text{mm}^2\ ${r.As <= r.AsMax ? '\\checkmark' : '\\times'}`),
+        eq(String.raw`n = ${r.bars}\ \text{–}\ \varnothing${i.barDia}\ (\text{layers } [${r.layers.join(', ')}]),\quad s_{clear} = ${sn0(r.sClear)} \ge ${sn0(r.sClearMin)}\ \text{mm}`),
+      ],
+    },
+    {
+      title: 'Design strength at the provided steel',
+      clause: 'ACI 318-14 §21.2.2',
+      pass: r.ok,
+      lines: [
+        eq(String.raw`a = ${sn1(r.a)}\ \text{mm}\ (${r.tBehavior ? 'a > h_f' : 'a \\le h_f'}),\quad c = a/\beta_1 = ${sn1(r.c)}\ \text{mm}\ (\beta_1 = ${sn2(beta1(i.fc))})`),
+        eq(String.raw`\varepsilon_t = 0.003\,\tfrac{d_t - c}{c} = ${sn4(r.et)} \Rightarrow \phi = ${sn2(r.phi)}`),
+        eq(String.raw`\phi M_n = ${sn1(r.phiMn)}\ \text{kN·m}\ ${r.phiMn >= Math.abs(i.Mu) ? '\\ge' : '<'}\ M_u = ${sn1(Math.abs(i.Mu))}\ \text{kN·m}\ ${r.ok ? '\\checkmark' : '\\times'}`),
+      ],
+      note: r.notes.join(' · ') || undefined,
+    },
+  )
+  return steps
+}

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -16,6 +16,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
     label: 'Structural',
     tools: [
       { to: '/beam-design',   name: 'Beam Design',        sub: 'RC beam · ACI 318-14',      group: 'Concrete' },
+      { to: '/tbeam-design',  name: 'T-Beam Design',      sub: 'flanged beam · §6.3.2',     group: 'Concrete' },
       { to: '/column-design', name: 'Column Design',      sub: 'RC column · biaxial',       group: 'Concrete' },
       { to: '/slab-design',   name: 'Slab Design',        sub: 'Two-way DDM · ACI 318',     group: 'Concrete' },
       { to: '/stair',         name: 'Stair Design',       sub: 'RC waist slab · NSCP',      group: 'Concrete' },

--- a/webapp/src/pages/TBeamDesign.tsx
+++ b/webapp/src/pages/TBeamDesign.tsx
@@ -1,0 +1,128 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { designTBeam, type TBeamKind } from '../engine/tbeam'
+import { buildTBeamSolution } from '../lib/tbeamSolution'
+import { PageHeader, VerdictPanel, DrawingCard, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
+import { Num, Pick, Card } from '../components/qty'
+import { WorkedSolution } from '../components/WorkedSolution'
+
+const f0 = (v: number) => v.toFixed(0)
+const f1 = (v: number) => v.toFixed(1)
+
+/** T-section sketch with the stress block depth. */
+function TSection({ bf, bw, h, hf, a }: { bf: number; bw: number; h: number; hf: number; a: number }) {
+  const S = 260 / Math.max(bf, h)
+  const W = bf * S, H = h * S, WF = bw * S, HF = hf * S, A = Math.min(a, h) * S
+  const x0 = (300 - W) / 2
+  return (
+    <svg viewBox="0 0 300 300" className="mx-auto block w-full max-w-[340px]">
+      <path d={`M${x0} 20 h${W} v${HF} h${-(W - WF) / 2} v${H - HF} h${-WF} v${-(H - HF)} h${-(W - WF) / 2} z`}
+        fill="#fff" stroke="#0f1b2a" strokeWidth="2" />
+      <rect x={x0} y={20} width={W} height={Math.min(A, HF)} fill="#0f4c92" opacity="0.18" />
+      {A > HF && <rect x={x0 + (W - WF) / 2} y={20 + HF} width={WF} height={A - HF} fill="#0f4c92" opacity="0.18" />}
+      <line x1={x0 - 8} y1={20 + A} x2={x0 + W + 8} y2={20 + A} stroke="#0f4c92" strokeWidth="1.5" strokeDasharray="5 3" />
+      <text x={x0 + W + 10} y={24 + A} fontSize="10" fontFamily="IBM Plex Mono, monospace" fill="#0f4c92">a = {f1(a)}</text>
+      <text x="150" y={14} fontSize="10" textAnchor="middle" fontFamily="IBM Plex Mono, monospace" fill="#0f4c92">bf</text>
+      <text x="150" y={20 + H + 14} fontSize="10" textAnchor="middle" fontFamily="IBM Plex Mono, monospace" fill="#0f4c92">bw</text>
+    </svg>
+  )
+}
+
+export default function TBeamDesign() {
+  const [kind, setKind] = useState<TBeamKind>('interior')
+  const [bw, setBw] = useState(300); const [h, setH] = useState(600); const [hf, setHf] = useState(100)
+  const [bfGiven, setBfGiven] = useState(0)
+  const [ln, setLn] = useState(6); const [sw, setSw] = useState(2.7)
+  const [cover, setCover] = useState(40); const [stirrupDia, setStirrupDia] = useState(10); const [barDia, setBarDia] = useState(25)
+  const [fc, setFc] = useState(21); const [fy, setFy] = useState(415)
+  const [Mu, setMu] = useState(400)
+  const [lh, setLh] = useState<LetterheadState>({ project: '', sheet: '', preparedBy: '' })
+
+  const inp = useMemo(() => ({
+    kind, bw, h, hf, bfGiven: bfGiven > 0 ? bfGiven : undefined, ln, sw,
+    cover, stirrupDia, barDia, fc, fy, Mu,
+  }), [kind, bw, h, hf, bfGiven, ln, sw, cover, stirrupDia, barDia, fc, fy, Mu])
+  const r = useMemo(() => { try { return designTBeam(inp) } catch { return null } }, [inp])
+  const steps = useMemo(() => (r ? buildTBeamSolution(inp, r) : []), [inp, r])
+  const badges = ['ACI 318-14', 'NSCP 2015']
+
+  return (
+    <div className="min-h-screen">
+      <PageHeader title="T-Beam Design" badges={[...badges, kind]} />
+      <div className="mx-auto max-w-6xl px-5 py-5 sm:px-7">
+        <p className="no-print text-[13px] text-[#5c6675]">
+          <Link to="/" className="font-semibold text-[#0f4c92]">← Home</Link> · Flanged-beam flexure: §6.3.2 effective width,
+          rectangular vs true-T stress block, §9.6.1.2 minimum steel, εt/φ per §21.2.2. Positive Mu = flange in compression.
+        </p>
+        <div className="no-print mt-4 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.3fr)_minmax(330px,1fr)]">
+          <div className="space-y-4">
+            <Card title="Section" hint="web + flange">
+              <Pick label="Beam type" value={kind} onChange={(v) => setKind(v as TBeamKind)}
+                options={[['interior', 'Interior T'], ['edge', 'Edge (L-beam)'], ['isolated', 'Isolated T']]} />
+              <Num label="Web bw" unit="mm" value={bw} onChange={setBw} />
+              <Num label="Total depth h" unit="mm" value={h} onChange={setH} />
+              <Num label="Flange hf" unit="mm" value={hf} onChange={setHf} />
+              <Num label="bf override (0 = table)" unit="mm" value={bfGiven} onChange={setBfGiven} />
+              <Num label="Clear span ln" unit="m" value={ln} onChange={setLn} />
+              <Num label="Web clear spacing sw" unit="m" value={sw} onChange={setSw} />
+            </Card>
+            <Card title="Materials & detailing">
+              <Num label="f'c" unit="MPa" value={fc} onChange={setFc} />
+              <Num label="fy" unit="MPa" value={fy} onChange={setFy} />
+              <Num label="Cover" unit="mm" value={cover} onChange={setCover} />
+              <Num label="Stirrup ⌀" unit="mm" value={stirrupDia} onChange={setStirrupDia} />
+              <Num label="Bar ⌀" unit="mm" value={barDia} onChange={setBarDia} />
+            </Card>
+            <Card title="Demand" hint="+ sagging / − hogging">
+              <Num label="Mu" unit="kN·m" value={Mu} onChange={setMu} />
+            </Card>
+            {r && <WorkedSolution steps={steps} title="T-beam — worked solution" />}
+          </div>
+          <div className="space-y-4 lg:sticky lg:top-4 lg:self-start">
+            {r && (
+              <VerdictPanel ok={r.ok} headline={r.ok ? 'DESIGN OK' : 'CHECK FAILED'}
+                governing={`${r.tBehavior ? 'true T (a > hf)' : Mu < 0 ? 'web rectangle (hogging)' : 'rectangular (a ≤ hf)'} · bf ${f0(r.bf)} mm`}
+                stats={[
+                  { label: 'Steel', value: `${r.bars}-⌀${barDia}`, unit: `mm (${f0(r.As)} mm²)` },
+                  { label: 'φMn', value: f1(r.phiMn), unit: 'kN·m' },
+                  { label: 'εt / φ', value: `${r.et.toFixed(4)} / ${r.phi.toFixed(2)}` },
+                ]}
+                checks={[
+                  { name: 'Flexure Mu/φMn', ratio: r.phiMn > 0 ? Math.abs(Mu) / r.phiMn : 99 },
+                  { name: 'Tension-controlled As/As,max', ratio: r.AsMax > 0 ? r.As / r.AsMax : 99 },
+                ]}
+                footnote={r.notes.join(' · ') || undefined} />
+            )}
+            {r && (
+              <DrawingCard title="Section & stress block" meta={`${f0(r.bf)}×${hf} flange · ${bw}×${h} web`}>
+                <TSection bf={r.bf} bw={bw} h={h} hf={hf} a={r.a} />
+              </DrawingCard>
+            )}
+            <LetterheadCard lh={lh} onChange={(p) => setLh((s) => ({ ...s, ...p }))} />
+          </div>
+        </div>
+      </div>
+      {r && (
+        <PrintReport docTitle="T-Beam" docCode="TB-01" badges={badges} ok={r.ok}
+          governing={`${r.tBehavior ? 'true T behaviour' : 'rectangular behaviour'} · utilization ${(Math.abs(Mu) / Math.max(r.phiMn, 1e-9)).toFixed(2)}`}
+          lh={lh}
+          stats={[
+            { label: 'Steel', value: `${r.bars}-⌀${barDia}` },
+            { label: 'φMn', value: f1(r.phiMn), unit: 'kN·m' },
+            { label: 'bf', value: f0(r.bf), unit: 'mm' },
+          ]}
+          checks={[
+            { name: 'Flexure Mu/φMn', ratio: Math.abs(Mu) / Math.max(r.phiMn, 1e-9), ok: r.phiMn >= Math.abs(Mu) },
+            { name: 'Tension-controlled', ratio: r.As / Math.max(r.AsMax, 1e-9), ok: r.As <= r.AsMax },
+          ]}
+          data={[
+            ['Type', kind], ['Web bw × h', `${bw} × ${h} mm`], ['Flange bf × hf', `${f0(r.bf)} × ${hf} mm`],
+            ["f'c / fy", `${fc} / ${fy} MPa`], ['Mu', `${Mu} kN·m`], ['d / dt', `${f1(r.d)} / ${f1(r.dt)} mm`],
+          ]}
+          steps={steps}
+          drawing={<TSection bf={r.bf} bw={bw} h={h} hf={hf} a={r.a} />}
+          drawingTitle="T-beam section" />
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## What — new standalone engine (L7): T-beam / L-beam flexure

`engine/tbeam.ts` — in-depth flanged-beam design to ACI 318-14 / NSCP 2015:

- **Effective flange width** per Table 6.3.2.1: interior `bw + 2·min(8hf, sw/2, ln/8)`, edge `min(6hf, sw/2, ln/12)` one side, isolated `bf ≤ 4bw` with the `hf ≥ bw/2` legality flag (§6.3.2.2); governing criterion reported.
- **Rectangular vs true-T switch** on the flange-couple capacity `φMn,f` at `a = hf`; true-T design by the classic two-couple split `Asf = 0.85f'c(bf−bw)hf/fy` + web rectangle for the remainder (§22.2).
- **Hogging path** (flange in tension): web rectangle `b = bw`, with the §9.6.1.2(b) `min(2bw, bf)` minimum-steel rule for statically determinate spans.
- **Tension-controlled cap** at `c = 3/8·dt` — the TC stress block is allowed to cross into the web; over-reinforced sections are flagged, never silently passed.
- **Bar layout**: per-layer fit with §25.2.1 clear spacing, multi-layer centroid correction of `d`, then a **capacity re-check at the provided steel** (a from equilibrium, εt/φ per §21.2.2) — `φMn` reported at the real bars, not the required area.
- Analyze mode (`AsGiven`) for checking existing sections.

**14 tests** with hand-calc anchors: bf table cases per criterion, Rn/ρ rectangular design identity, `Asf = 1290.4 mm²` flange couple, capacity consistency at provided steel, determinate hogging minimum doubling, TC-cap formula, over-reinforced flagging.

Also: `lib/tbeamSolution.ts` worked solution (clause margins + PASS chips), `/tbeam-design` page (flat rails, verdict panel with Mu/φMn + TC bars, T-section stress-block SVG, letterhead + PrintReport calc sheet), tool-directory entry, ValidationMap row.

## Verification
- `npx tsc -b` clean · **1096/1096 tests** (1082 + 14)
- Headless: `/tbeam-design` renders DESIGN OK, rectangular (a ≤ hf) on defaults, full worked solution present

Next: **prestressed beam engine** (own PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_