### PR TITLE
feat: prestressed beam engine + page (ACI §24.5 / §20.3.2.3 + PCI losses)

### DIFF
--- a/docs/ValidationMap.md
+++ b/docs/ValidationMap.md
@@ -133,3 +133,4 @@ asserted by that file; all run in CI.
 | X003 | PCA Column biaxial + slender cross-check (C003, C004) | needs spColumn reference curves |
 | X004 | Excel verification sheets (Roadmap Phase-2 goal) | authoring task — the `/validation` page already renders manual-vs-software tables that can seed them |
 | T-beam flexure (`tbeam.ts`) | §6.3.2 bf table + two-couple T flexure vs hand calc (Asf 1290 mm², rect/true-T switch, εt/φ) | ✅ `tbeam.test.ts` (14) |
+| Prestressed beam (`prestressedBeam.ts`) | PCI losses, §24.5 stress limits, fps §20.3.2.3.1, 1.2Mcr, Vci/Vcw vs hand calc | ✅ `prestressedBeam.test.ts` (12) |

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -8,6 +8,7 @@ import PileCapDesign from './pages/PileCapDesign'
 import CombinedFootingDesign from './pages/CombinedFootingDesign'
 import BeamDesign from './pages/BeamDesign'
 import TBeamDesign from './pages/TBeamDesign'
+import PrestressedBeam from './pages/PrestressedBeam'
 import BeamAnalysis from './pages/BeamAnalysis'
 import ColumnDesign from './pages/ColumnDesign'
 import FrameAnalysis from './pages/FrameAnalysis'
@@ -59,6 +60,7 @@ export default function App() {
         <Route path="/combined" element={<CombinedFootingDesign />} />
         <Route path="/beam-design" element={<BeamDesign />} />
         <Route path="/tbeam-design" element={<TBeamDesign />} />
+        <Route path="/prestressed-beam" element={<PrestressedBeam />} />
         <Route path="/beam-analysis" element={<BeamAnalysis />} />
         <Route path="/column-design" element={<ColumnDesign />} />
         <Route path="/frame" element={<FrameAnalysis />} />

--- a/webapp/src/engine/prestressedBeam.test.ts
+++ b/webapp/src/engine/prestressedBeam.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import { designPrestressed } from './prestressedBeam'
+
+// 400×800 rectangular pretensioned beam, 12 m simple span, 10×12.7 mm strands
+// (Aps = 987 mm², fpu 1860, low-relax), e = 250 mm, fc 40 / fci 32.
+const base = {
+  b: 400, h: 800, span: 12, fc: 40, fci: 32,
+  Aps: 987, fpu: 1860, e: 250,
+  wSDL: 6, wLL: 12,
+}
+
+describe('designPrestressed — section, moments, losses', () => {
+  const r = designPrestressed(base)
+
+  it('section properties and self-weight moments (hand calc)', () => {
+    expect(r.A).toBe(320000)
+    expect(r.I).toBeCloseTo((400 * 800 ** 3) / 12, 3)
+    expect(r.Sb).toBeCloseTo(r.I / 400, 6)
+    expect(r.wSW).toBeCloseTo(0.32 * 24, 9)                 // 7.68 kN/m
+    expect(r.Msw).toBeCloseTo((7.68 * 144) / 8, 6)          // 138.24 kN·m
+    expect(r.Mu).toBeCloseTo(((1.2 * 13.68 + 1.6 * 12) * 144) / 8, 6)
+  })
+
+  it('losses are ordered sanely and fse lands in the practical band', () => {
+    expect(r.ES).toBeGreaterThan(0)
+    expect(r.CR).toBeGreaterThan(0)
+    expect(r.SH).toBeGreaterThan(0)
+    expect(r.RE).toBeGreaterThan(0)
+    expect(r.lossPct).toBeGreaterThan(8)
+    expect(r.lossPct).toBeLessThan(25)                      // typical 10–20 %
+    expect(r.fse).toBeCloseTo((0.74 * 1860) - r.lossTotal, 6)
+    expect(r.Pe).toBeLessThan(r.Pi)
+  })
+
+  it('elastic shortening matches (Ep/Eci)·fcir at the converged Pi', () => {
+    const Eci = 4700 * Math.sqrt(32)
+    const fcir = (r.Pi * 1000) / r.A + (r.Pi * 1000 * 250 * 250) / r.I - (r.Msw * 1e6 * 250) / r.I
+    expect(r.ES).toBeCloseTo((196500 / Eci) * fcir, 4)
+  })
+})
+
+describe('designPrestressed — stresses vs §24.5 limits', () => {
+  const r = designPrestressed(base)
+
+  it('transfer: Pi/A ± terms with self-weight; limits 0.60f′ci / 0.25√f′ci', () => {
+    const top = (r.Pi * 1000) / r.A - (r.Pi * 1000 * 250) / r.St + (r.Msw * 1e6) / r.St
+    const bot = (r.Pi * 1000) / r.A + (r.Pi * 1000 * 250) / r.Sb - (r.Msw * 1e6) / r.Sb
+    expect(r.transfer.top).toBeCloseTo(top, 9)
+    expect(r.transfer.bot).toBeCloseTo(bot, 9)
+    expect(r.limTransferC).toBeCloseTo(0.60 * 32, 9)
+    expect(r.limTransferT).toBeCloseTo(0.25 * Math.sqrt(32), 9)
+    expect(r.transferOK).toBe(true)
+  })
+
+  it('service: class-U tension bound 0.62√f′c on the precompressed fibre', () => {
+    expect(r.limServiceT).toBeCloseTo(0.62 * Math.sqrt(40), 9)
+    expect(r.serviceOK).toBe(true)
+  })
+
+  it('overloading the service moment breaks the class-U bottom-fibre bound', () => {
+    const rBad = designPrestressed({ ...base, wLL: 40 })
+    expect(rBad.service.bot).toBeLessThan(-rBad.limServiceT)
+    expect(rBad.serviceOK).toBe(false)
+  })
+})
+
+describe('designPrestressed — strength, cracking, shear, camber', () => {
+  const r = designPrestressed(base)
+
+  it('fps per §20.3.2.3.1 with γp = 0.28 (fpy/fpu = 0.9)', () => {
+    const dp = 400 + 250
+    const rhoP = 987 / (400 * dp)
+    const b1 = 0.85 - (0.05 * 12) / 7
+    const fps = 1860 * (1 - (0.28 / b1) * (rhoP * 1860) / 40)
+    expect(r.fps).toBeCloseTo(fps, 6)
+    expect(r.dp).toBe(650)
+  })
+
+  it('φMn from the strand couple covers Mu; φMn ≥ 1.2Mcr', () => {
+    const a = (987 * r.fps) / (0.85 * 40 * 400)
+    expect(r.a).toBeCloseTo(a, 6)
+    expect(r.phiMn).toBeCloseTo((r.phi * 987 * r.fps * (650 - a / 2)) / 1e6, 6)
+    expect(r.strengthOK).toBe(true)
+    expect(r.phiMn).toBeGreaterThanOrEqual(1.2 * r.Mcr)
+  })
+
+  it('Mcr includes the precompression: (fr + Pe/A + Pe·e/Sb)·Sb', () => {
+    const fr = 0.62 * Math.sqrt(40)
+    const expected = ((fr + (r.Pe * 1000) / r.A + (r.Pe * 1000 * 250) / r.Sb) * r.Sb) / 1e6
+    expect(r.Mcr).toBeCloseTo(expected, 6)
+  })
+
+  it('shear: Vc = min(Vci, Vcw) with the 0.17√f′c·bw·dp floor on Vci', () => {
+    expect(r.Vc).toBeCloseTo(Math.min(r.Vci, r.Vcw), 9)
+    expect(r.Vci).toBeGreaterThanOrEqual((0.17 * Math.sqrt(40) * 400 * Math.max(650, 640)) / 1000 - 1e-9)
+    expect(r.Vcw).toBeCloseTo(((0.29 * Math.sqrt(40) + 0.3 * (r.Pe * 1000) / r.A) * 400 * 650) / 1000, 6)
+  })
+
+  it('camber Pe·e·L²/8EI opposes the 5wL⁴/384EI gravity deflection', () => {
+    const Ec = 4700 * Math.sqrt(40)
+    const camber = (r.Pe * 1000 * 250 * 12000 ** 2) / (8 * Ec * r.I)
+    expect(r.camber).toBeCloseTo(camber, 6)
+    expect(r.deltaNet).toBeCloseTo(r.deltaLoad - r.camber, 9)
+  })
+
+  it('overall verdict aggregates every check', () => {
+    expect(r.ok).toBe(true)
+    expect(designPrestressed({ ...base, Aps: 300 }).ok).toBe(false)   // strength fails
+  })
+})

--- a/webapp/src/engine/prestressedBeam.ts
+++ b/webapp/src/engine/prestressedBeam.ts
@@ -1,0 +1,186 @@
+// Prestressed (pretensioned, bonded) beam engine — ACI 318-14 / NSCP 2015
+// with PCI-handbook loss estimates. Units: mm, mm², MPa, kN, kN·m, m.
+//
+// Pipeline: section properties → prestress losses (ES + CR + SH + RE) →
+// extreme-fibre stresses at TRANSFER (Pi + self-weight) vs §24.5.3 limits and
+// at SERVICE (Pe + total moment) vs the §24.5.4 class-U/T/C tension bounds →
+// flexural strength with fps per §20.3.2.3.1 (bonded, γp table) → φMn vs Mu
+// and the §9.6.2.1 φMn ≥ 1.2Mcr guard → Vci/Vcw web/flexure shear (§22.5.8.3)
+// → midspan camber/deflection. Rectangular or direct (A, I, yt, yb) sections.
+
+export interface PrestressedInput {
+  // section: rectangular b×h OR direct properties
+  b?: number; h: number
+  A?: number; I?: number; yt?: number; yb?: number   // mm², mm⁴, mm
+  span: number                    // m, simple span
+  fc: number; fci: number         // MPa (28-day / at transfer)
+  // tendons (pretensioned, bonded)
+  Aps: number                     // mm²
+  fpu: number; fpy?: number       // MPa (fpy default 0.9fpu low-relaxation)
+  fpj?: number                    // jacking/initial stress (default 0.74fpu)
+  e: number                       // midspan tendon eccentricity below centroid, mm
+  Ep?: number                     // MPa, default 196500
+  // loads (unfactored, kN/m) — self-weight auto from A·γc
+  wSDL: number; wLL: number
+  gammaC?: number                 // kN/m³, default 24
+  RH?: number                     // ambient relative humidity %, default 75
+  VS?: number                     // volume/surface ratio mm, default 38
+  /** Serviceability class per §24.5.2 (default 'U'). */
+  klass?: 'U' | 'T' | 'C'
+}
+
+export interface FibreStress { top: number; bot: number }   // MPa, +compression
+export interface PrestressedResult {
+  A: number; I: number; yt: number; yb: number; St: number; Sb: number
+  wSW: number                     // kN/m
+  Msw: number; Msdl: number; Mll: number; Mserv: number; Mu: number   // kN·m
+  // losses (MPa on the tendon)
+  fpi: number; ES: number; CR: number; SH: number; RE: number
+  lossTotal: number; lossPct: number
+  fse: number; Pi: number; Pe: number         // MPa, kN, kN
+  // stresses (+compression, MPa)
+  transfer: FibreStress; service: FibreStress
+  limTransferC: number; limTransferT: number  // 0.60f'ci / 0.25√f'ci
+  limServiceC: number; limServiceT: number    // 0.60f'c / class tension bound
+  transferOK: boolean; serviceOK: boolean
+  // strength
+  rhoP: number; fps: number; a: number; c: number; dp: number
+  phi: number; phiMn: number; strengthOK: boolean
+  fr: number; Mcr: number; crackingOK: boolean   // φMn ≥ 1.2Mcr
+  // shear at the critical section (h/2 → use d/2 from face ≈ dp/2 practical)
+  Vu: number; Vci: number; Vcw: number; Vc: number; shearNote: string
+  // deflection, mm (+down)
+  camber: number; deltaLoad: number; deltaNet: number
+  ok: boolean
+  notes: string[]
+}
+
+const beta1 = (fc: number) => (fc <= 28 ? 0.85 : Math.max(0.65, 0.85 - (0.05 * (fc - 28)) / 7))
+
+export function designPrestressed(i: PrestressedInput): PrestressedResult {
+  const notes: string[] = []
+  const Ep = i.Ep ?? 196500
+  const gammaC = i.gammaC ?? 24
+  // ── section properties ──
+  const rect = !(i.A && i.I && i.yt && i.yb)
+  const A = rect ? (i.b ?? 300) * i.h : i.A!
+  const I = rect ? ((i.b ?? 300) * i.h ** 3) / 12 : i.I!
+  const yt = rect ? i.h / 2 : i.yt!
+  const yb = rect ? i.h / 2 : i.yb!
+  const St = I / yt, Sb = I / yb
+
+  // ── moments (simple span) ──
+  const L = i.span
+  const wSW = (A / 1e6) * gammaC
+  const M = (w: number) => (w * L * L) / 8
+  const Msw = M(wSW), Msdl = M(i.wSDL), Mll = M(i.wLL)
+  const Mserv = Msw + Msdl + Mll
+  const Mu = M(1.2 * (wSW + i.wSDL) + 1.6 * i.wLL)
+
+  // ── losses (PCI general method, low-relaxation strand) ──
+  const fpy = i.fpy ?? 0.9 * i.fpu
+  const fpj = i.fpj ?? 0.74 * i.fpu
+  const Eci = 4700 * Math.sqrt(i.fci)
+  const Ec = 4700 * Math.sqrt(i.fc)
+  // elastic shortening: fcir at the cgs under Pi — fixed-point on
+  // Pi = (fpj − ES(Pi))·Aps (converges in a few passes)
+  let Pi = (0.9 * fpj * i.Aps) / 1000
+  let ES = 0
+  const fcir = () => (Pi * 1000) / A + (Pi * 1000 * i.e * i.e) / I - (Msw * 1e6 * i.e) / I
+  for (let k = 0; k < 12; k++) {
+    ES = (Ep / Eci) * fcir()
+    Pi = ((fpj - ES) * i.Aps) / 1000
+  }
+  const fpi = fpj - ES
+  // creep: CR = 2.0(Ep/Ec)(fcir − fcds), fcds from superimposed dead load
+  const fcds = (Msdl * 1e6 * i.e) / I
+  const CR = Math.max(0, 2.0 * (Ep / Ec) * (fcir() - fcds))
+  // shrinkage: SH = 8.2e-6·Ep(1 − 0.06·V/S/25.4·? ) — PCI (SI): 8.2e-6·Ksh·Ep(1−0.0236·V/S[in])·(100−RH)
+  const VSin = (i.VS ?? 38) / 25.4
+  const SH = 8.2e-6 * Ep * (1 - 0.06 * VSin) * (100 - (i.RH ?? 75))
+  // relaxation (low-relaxation): RE = [Kre − J(SH+CR+ES)]·C ≈ 35 MPa class → use
+  // Kre = 35 MPa, J = 0.04, C ≈ 1 for fpj/fpu = 0.74
+  const RE = Math.max(0, 35 - 0.04 * (SH + CR + ES))
+  const lossTotal = ES + CR + SH + RE
+  const fse = fpj - lossTotal
+  const lossPct = (lossTotal / fpj) * 100
+  if (fse > 0.8 * fpy) notes.push('fse exceeds 0.80fpy — check the jacking stress')
+  const Pe = (fse * i.Aps) / 1000
+
+  // ── fibre stresses (+compression) ──
+  const sigma = (P: number, Mext: number): FibreStress => ({
+    top: (P * 1000) / A - (P * 1000 * i.e) / St + (Mext * 1e6) / St,
+    bot: (P * 1000) / A + (P * 1000 * i.e) / Sb - (Mext * 1e6) / Sb,
+  })
+  const transfer = sigma(Pi, Msw)
+  const service = sigma(Pe, Mserv)
+  const limTransferC = 0.60 * i.fci
+  const limTransferT = 0.25 * Math.sqrt(i.fci)        // §24.5.3.2 (midspan)
+  const limServiceC = 0.60 * i.fc                     // §24.5.4.1 total load
+  const limServiceT = (i.klass ?? 'U') === 'U' ? 0.62 * Math.sqrt(i.fc)
+    : (i.klass === 'T' ? 1.0 * Math.sqrt(i.fc) : Infinity)
+  const okF = (s: FibreStress, limC: number, limT: number) =>
+    s.top <= limC + 1e-9 && s.bot <= limC + 1e-9 && s.top >= -limT - 1e-9 && s.bot >= -limT - 1e-9
+  const transferOK = okF(transfer, limTransferC, limTransferT)
+  const serviceOK = okF(service, limServiceC, limServiceT)
+
+  // ── flexural strength (bonded, §20.3.2.3.1) ──
+  const dp = yt + i.e
+  const b = i.b ?? A / i.h
+  const rhoP = i.Aps / (b * dp)
+  const gp = fpy / i.fpu >= 0.9 ? 0.28 : fpy / i.fpu >= 0.85 ? 0.40 : 0.55
+  const b1 = beta1(i.fc)
+  const fps = i.fpu * (1 - (gp / b1) * (rhoP * i.fpu) / i.fc)
+  const a = (i.Aps * fps) / (0.85 * i.fc * b)
+  const c = a / b1
+  const et = (0.003 * (dp - c)) / c
+  const phi = et >= 0.005 ? 0.90 : et <= 0.002 ? 0.65 : 0.65 + (0.25 * (et - 0.002)) / 0.003
+  const phiMn = (phi * i.Aps * fps * (dp - a / 2)) / 1e6
+  const strengthOK = phiMn + 1e-9 >= Mu
+  // cracking moment (bottom fibre): Mcr = (fr + Pe/A + Pe·e/Sb)·Sb
+  const fr = 0.62 * Math.sqrt(i.fc)
+  const Mcr = ((fr + (Pe * 1000) / A + (Pe * 1000 * i.e) / Sb) * Sb) / 1e6
+  const crackingOK = phiMn + 1e-9 >= 1.2 * Mcr
+  if (!crackingOK) notes.push('φMn < 1.2Mcr (§9.6.2.1) — add strands or bonded steel')
+
+  // ── shear at x = h/2 from support (§22.5.8.3) ──
+  const x = Math.max(i.h / 1000 / 2, 0.05)
+  const wu = 1.2 * (wSW + i.wSDL) + 1.6 * i.wLL
+  const Vu = wu * (L / 2 - x)
+  const MuX = (wu * x * (L - x)) / 2
+  const VuX = Vu
+  const bw = b
+  // Vci = 0.05λ√f'c·bw·dp + Vd + Vi·Mcre/Mmax  (≥ 0.17√f'c·bw·dp)
+  const wd = wSW + i.wSDL
+  const Vd = wd * (L / 2 - x)
+  const Md = (wd * x * (L - x)) / 2
+  const fpe = (Pe * 1000) / A + (Pe * 1000 * i.e) / Sb
+  const fd = (Md * 1e6) / Sb
+  const Mcre = (Sb * (0.5 * Math.sqrt(i.fc) + fpe - fd)) / 1e6
+  const Vi = VuX - Vd
+  const Mmax = MuX - Md
+  const dpv = Math.max(dp, 0.8 * i.h)
+  let Vci = (0.05 * Math.sqrt(i.fc) * bw * dpv) / 1000 + Vd + (Mmax > 1e-9 ? (Vi * Mcre) / Mmax : Infinity)
+  Vci = Math.max(Vci, (0.17 * Math.sqrt(i.fc) * bw * dpv) / 1000)
+  // Vcw = (0.29λ√f'c + 0.3fpc)·bw·dp
+  const fpc = (Pe * 1000) / A
+  const Vcw = ((0.29 * Math.sqrt(i.fc) + 0.3 * fpc) * bw * dpv) / 1000
+  const Vc = Math.min(Vci, Vcw)
+  const shearNote = Vci <= Vcw ? 'Vci governs (flexure-shear)' : 'Vcw governs (web-shear)'
+
+  // ── deflection (midspan): camber up from Pe·e, load down ──
+  const EcI = Ec * I   // N·mm²
+  const camber = (Pe * 1000 * i.e * (L * 1000) ** 2) / (8 * EcI)
+  const deltaLoad = (5 * (wSW + i.wSDL + i.wLL) * (L * 1000) ** 4) / (384 * EcI * 1000)
+  const deltaNet = deltaLoad - camber
+
+  const ok = transferOK && serviceOK && strengthOK && crackingOK
+  return {
+    A, I, yt, yb, St, Sb, wSW, Msw, Msdl, Mll, Mserv, Mu,
+    fpi, ES, CR, SH, RE, lossTotal, lossPct, fse, Pi, Pe,
+    transfer, service, limTransferC, limTransferT, limServiceC, limServiceT, transferOK, serviceOK,
+    rhoP, fps, a, c, dp, phi, phiMn, strengthOK, fr, Mcr, crackingOK,
+    Vu: VuX, Vci, Vcw, Vc, shearNote,
+    camber, deltaLoad, deltaNet, ok, notes,
+  }
+}

--- a/webapp/src/lib/prestressedSolution.ts
+++ b/webapp/src/lib/prestressedSolution.ts
@@ -1,0 +1,80 @@
+// Worked solution for the prestressed beam engine (engine/prestressedBeam.ts).
+import type { PrestressedInput, PrestressedResult } from '../engine/prestressedBeam'
+import { type SolutionStep, type SolutionLine, sn0, sn1, sn2 } from './solution'
+
+const txt = (text: string): SolutionLine => ({ text })
+const eq = (tex: string): SolutionLine => ({ tex })
+const f = (v: number) => sn1(v)
+
+export function buildPrestressedSolution(i: PrestressedInput, r: PrestressedResult): SolutionStep[] {
+  return [
+    {
+      title: 'Section properties & moments',
+      clause: 'simple span',
+      lines: [
+        eq(String.raw`A = ${sn0(r.A)}\ \text{mm}^2,\quad I = ${sn0(r.I / 1e6)}\times 10^6\ \text{mm}^4,\quad S_t = ${sn0(r.St / 1e3)}\times 10^3,\ S_b = ${sn0(r.Sb / 1e3)}\times 10^3\ \text{mm}^3`),
+        eq(String.raw`w_{sw} = ${sn2(r.wSW)}\ \text{kN/m} \Rightarrow M_{sw} = ${f(r.Msw)},\ M_{serv} = ${f(r.Mserv)},\ M_u = ${f(r.Mu)}\ \text{kN·m}`),
+      ],
+    },
+    {
+      title: 'Prestress losses (PCI: ES + CR + SH + RE)',
+      clause: 'PCI handbook',
+      lines: [
+        txt(`Jacking at ${sn0(i.fpj ?? 0.74 * i.fpu)} MPa. Elastic shortening from fcir at the strand cg (fixed-point on Pi); creep 2.0(Ep/Ec)(fcir − fcds); shrinkage with V/S and RH; low-relaxation RE.`),
+        eq(String.raw`ES = ${f(r.ES)},\quad CR = ${f(r.CR)},\quad SH = ${f(r.SH)},\quad RE = ${f(r.RE)}\ \text{MPa}`),
+        eq(String.raw`f_{se} = ${f(r.fse)}\ \text{MPa}\ (${f(r.lossPct)}\%\ \text{loss}),\qquad P_i = ${f(r.Pi)},\ P_e = ${f(r.Pe)}\ \text{kN}`),
+      ],
+    },
+    {
+      title: 'Stresses at transfer (Pi + self-weight)',
+      clause: 'ACI 318-14 §24.5.3',
+      pass: r.transferOK,
+      lines: [
+        eq(String.raw`\sigma = \tfrac{P_i}{A} \mp \tfrac{P_i e}{S} \pm \tfrac{M_{sw}}{S}:\quad \sigma_{top} = ${f(r.transfer.top)},\ \sigma_{bot} = ${f(r.transfer.bot)}\ \text{MPa}`),
+        eq(String.raw`\text{limits: } +${f(r.limTransferC)}\ (0.60 f'_{ci})\ /\ -${f(r.limTransferT)}\ (0.25\sqrt{f'_{ci}})\ ${r.transferOK ? '\\checkmark' : '\\times'}`),
+      ],
+    },
+    {
+      title: `Stresses at service (Pe + total) — class ${i.klass ?? 'U'}`,
+      clause: 'ACI 318-14 §24.5.4',
+      pass: r.serviceOK,
+      lines: [
+        eq(String.raw`\sigma_{top} = ${f(r.service.top)},\quad \sigma_{bot} = ${f(r.service.bot)}\ \text{MPa}`),
+        eq(String.raw`\text{limits: } +${f(r.limServiceC)}\ (0.60 f'_c)\ /\ -${Number.isFinite(r.limServiceT) ? f(r.limServiceT) : '\\infty'}\ (0.62\sqrt{f'_c},\ \text{class U})\ ${r.serviceOK ? '\\checkmark' : '\\times'}`),
+      ],
+    },
+    {
+      title: 'Flexural strength',
+      clause: 'ACI 318-14 §20.3.2.3.1',
+      pass: r.strengthOK,
+      lines: [
+        eq(String.raw`f_{ps} = f_{pu}\left(1 - \tfrac{\gamma_p}{\beta_1}\rho_p\tfrac{f_{pu}}{f'_c}\right) = ${f(r.fps)}\ \text{MPa},\quad a = ${f(r.a)}\ \text{mm},\ \phi = ${sn2(r.phi)}`),
+        eq(String.raw`\phi M_n = \phi A_{ps} f_{ps}(d_p - \tfrac{a}{2}) = ${f(r.phiMn)}\ \text{kN·m}\ ${r.strengthOK ? '\\ge' : '<'}\ M_u = ${f(r.Mu)}\ ${r.strengthOK ? '\\checkmark' : '\\times'}`),
+      ],
+    },
+    {
+      title: 'Cracking-moment guard',
+      clause: 'ACI 318-14 §9.6.2.1',
+      pass: r.crackingOK,
+      lines: [
+        eq(String.raw`M_{cr} = (f_r + \tfrac{P_e}{A} + \tfrac{P_e e}{S_b})S_b = ${f(r.Mcr)}\ \text{kN·m};\quad \phi M_n = ${f(r.phiMn)}\ ${r.crackingOK ? '\\ge' : '<'}\ 1.2 M_{cr} = ${f(1.2 * r.Mcr)}\ ${r.crackingOK ? '\\checkmark' : '\\times'}`),
+      ],
+    },
+    {
+      title: 'Concrete shear Vci / Vcw',
+      clause: 'ACI 318-14 §22.5.8.3',
+      lines: [
+        eq(String.raw`V_{ci} = ${f(r.Vci)},\quad V_{cw} = ${f(r.Vcw)}\ \text{kN} \Rightarrow V_c = ${f(r.Vc)}\ \text{kN}`),
+        txt(`${r.shearNote}. Vu at the critical section = ${f(r.Vu)} kN — stirrups per §9.7.6.2.2 where φVc is exceeded.`),
+      ],
+    },
+    {
+      title: 'Camber & deflection (midspan, elastic)',
+      clause: 'serviceability',
+      lines: [
+        eq(String.raw`\Delta_{p} = \tfrac{P_e e L^2}{8 E_c I} = ${f(r.camber)}\ \text{mm}\uparrow,\quad \Delta_{w} = \tfrac{5 w L^4}{384 E_c I} = ${f(r.deltaLoad)}\ \text{mm}\downarrow \Rightarrow \Delta_{net} = ${f(r.deltaNet)}\ \text{mm}`),
+      ],
+      note: r.notes.join(' · ') || undefined,
+    },
+  ]
+}

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -17,6 +17,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
     tools: [
       { to: '/beam-design',   name: 'Beam Design',        sub: 'RC beam · ACI 318-14',      group: 'Concrete' },
       { to: '/tbeam-design',  name: 'T-Beam Design',      sub: 'flanged beam · §6.3.2',     group: 'Concrete' },
+      { to: '/prestressed-beam', name: 'Prestressed Beam', sub: 'PCI losses · §24.5 · fps',  group: 'Concrete' },
       { to: '/column-design', name: 'Column Design',      sub: 'RC column · biaxial',       group: 'Concrete' },
       { to: '/slab-design',   name: 'Slab Design',        sub: 'Two-way DDM · ACI 318',     group: 'Concrete' },
       { to: '/stair',         name: 'Stair Design',       sub: 'RC waist slab · NSCP',      group: 'Concrete' },

--- a/webapp/src/pages/PrestressedBeam.tsx
+++ b/webapp/src/pages/PrestressedBeam.tsx
@@ -1,0 +1,131 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { designPrestressed } from '../engine/prestressedBeam'
+import { buildPrestressedSolution } from '../lib/prestressedSolution'
+import { PageHeader, VerdictPanel, DrawingCard, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
+import { Num, Pick, Card } from '../components/qty'
+import { WorkedSolution } from '../components/WorkedSolution'
+
+const f1 = (v: number) => v.toFixed(1)
+
+/** Elevation: beam, tendon profile (straight, eccentric) and load arrows. */
+function PSElevation({ h, e }: { h: number; e: number }) {
+  const y0 = 60, H = 60, yc = y0 + H / 2, yTendon = yc + (e / h) * H
+  return (
+    <svg viewBox="0 0 300 160" className="mx-auto block w-full max-w-[360px]">
+      <rect x="20" y={y0} width="260" height={H} fill="#fff" stroke="#0f1b2a" strokeWidth="2" />
+      <line x1="20" y1={yTendon} x2="280" y2={yTendon} stroke="#0f4c92" strokeWidth="2.5" strokeDasharray="7 4" />
+      <line x1="20" y1={yc} x2="280" y2={yc} stroke="#a39d8d" strokeWidth="1" strokeDasharray="3 4" />
+      <text x="150" y={yTendon + 12} fontSize="9" textAnchor="middle" fontFamily="IBM Plex Mono, monospace" fill="#0f4c92">Aps · e = {e} mm</text>
+      {[60, 110, 160, 210, 260].map((x) => (
+        <line key={x} x1={x} y1={y0 - 18} x2={x} y2={y0 - 4} stroke="#5c6675" strokeWidth="1.5" markerEnd="url(#arr)" />
+      ))}
+      <defs><marker id="arr" markerWidth="6" markerHeight="6" refX="3" refY="5" orient="auto"><path d="M0 0 L6 0 L3 6 z" fill="#5c6675" /></marker></defs>
+      <polygon points="20,126 12,140 28,140" fill="#0f4c92" />
+      <circle cx="280" cy="133" r="6" fill="none" stroke="#0f4c92" strokeWidth="2" />
+    </svg>
+  )
+}
+
+export default function PrestressedBeam() {
+  const [b, setB] = useState(400); const [h, setH] = useState(800)
+  const [span, setSpan] = useState(12)
+  const [fc, setFc] = useState(40); const [fci, setFci] = useState(32)
+  const [Aps, setAps] = useState(987); const [fpu, setFpu] = useState(1860)
+  const [e, setE] = useState(250); const [fpjPct, setFpjPct] = useState(74)
+  const [wSDL, setWSDL] = useState(6); const [wLL, setWLL] = useState(12)
+  const [RH, setRH] = useState(75)
+  const [klass, setKlass] = useState<'U' | 'T'>('U')
+  const [lh, setLh] = useState<LetterheadState>({ project: '', sheet: '', preparedBy: '' })
+
+  const inp = useMemo(() => ({
+    b, h, span, fc, fci, Aps, fpu, e, fpj: (fpjPct / 100) * fpu, wSDL, wLL, RH, klass,
+  }), [b, h, span, fc, fci, Aps, fpu, e, fpjPct, wSDL, wLL, RH, klass])
+  const r = useMemo(() => { try { return designPrestressed(inp) } catch { return null } }, [inp])
+  const steps = useMemo(() => (r ? buildPrestressedSolution(inp, r) : []), [inp, r])
+  const badges = ['ACI 318-14', 'PCI', 'NSCP 2015']
+
+  return (
+    <div className="min-h-screen">
+      <PageHeader title="Prestressed Beam" badges={[...badges, `class ${klass}`]} />
+      <div className="mx-auto max-w-6xl px-5 py-5 sm:px-7">
+        <p className="no-print text-[13px] text-[#5c6675]">
+          <Link to="/" className="font-semibold text-[#0f4c92]">← Home</Link> · Pretensioned bonded beam: PCI losses
+          (ES/CR/SH/RE), §24.5 transfer & service stress limits, fps per §20.3.2.3.1, φMn ≥ 1.2Mcr, Vci/Vcw, camber.
+        </p>
+        <div className="no-print mt-4 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.3fr)_minmax(330px,1fr)]">
+          <div className="space-y-4">
+            <Card title="Section & span">
+              <Num label="Width b" unit="mm" value={b} onChange={setB} />
+              <Num label="Depth h" unit="mm" value={h} onChange={setH} />
+              <Num label="Simple span L" unit="m" value={span} onChange={setSpan} />
+              <Num label="f'c (28-day)" unit="MPa" value={fc} onChange={setFc} />
+              <Num label="f'ci (transfer)" unit="MPa" value={fci} onChange={setFci} />
+            </Card>
+            <Card title="Tendons" hint="pretensioned · bonded">
+              <Num label="Aps" unit="mm²" value={Aps} onChange={setAps} />
+              <Num label="fpu" unit="MPa" value={fpu} onChange={setFpu} />
+              <Num label="Eccentricity e" unit="mm" value={e} onChange={setE} />
+              <Num label="Jacking (% fpu)" unit="%" value={fpjPct} onChange={setFpjPct} />
+              <Num label="Ambient RH" unit="%" value={RH} onChange={setRH} />
+              <Pick label="Class (§24.5.2)" value={klass} onChange={(v) => setKlass(v as 'U' | 'T')}
+                options={[['U', 'U — uncracked'], ['T', 'T — transition']]} />
+            </Card>
+            <Card title="Loads" hint="unfactored, self-weight auto">
+              <Num label="Superimposed DL" unit="kN/m" value={wSDL} onChange={setWSDL} />
+              <Num label="Live load" unit="kN/m" value={wLL} onChange={setWLL} />
+            </Card>
+            {r && <WorkedSolution steps={steps} title="Prestressed beam — worked solution" />}
+          </div>
+          <div className="space-y-4 lg:sticky lg:top-4 lg:self-start">
+            {r && (
+              <VerdictPanel ok={r.ok} headline={r.ok ? 'DESIGN OK' : 'CHECK FAILED'}
+                governing={`losses ${r.lossPct.toFixed(1)}% · fse ${f1(r.fse)} MPa · ${r.shearNote}`}
+                stats={[
+                  { label: 'φMn', value: f1(r.phiMn), unit: 'kN·m' },
+                  { label: 'Pe', value: f1(r.Pe), unit: 'kN' },
+                  { label: 'Net Δ', value: f1(r.deltaNet), unit: 'mm' },
+                ]}
+                checks={[
+                  { name: 'Strength Mu/φMn', ratio: r.phiMn > 0 ? r.Mu / r.phiMn : 99 },
+                  { name: 'Service σ,bot / limit', ratio: Number.isFinite(r.limServiceT) ? Math.max(0, -r.service.bot) / r.limServiceT : 0 },
+                  { name: 'Transfer σ,bot / 0.60f\'ci', ratio: r.transfer.bot / r.limTransferC },
+                  { name: '1.2Mcr / φMn', ratio: r.phiMn > 0 ? (1.2 * r.Mcr) / r.phiMn : 99 },
+                ]} />
+            )}
+            {r && (
+              <DrawingCard title="Elevation & tendon profile" meta={`${b}×${h} · L = ${span} m`}>
+                <PSElevation h={h} e={e} />
+              </DrawingCard>
+            )}
+            <LetterheadCard lh={lh} onChange={(p) => setLh((s) => ({ ...s, ...p }))} />
+          </div>
+        </div>
+      </div>
+      {r && (
+        <PrintReport docTitle="Prestressed Beam" docCode="PS-01" badges={badges} ok={r.ok}
+          governing={`losses ${r.lossPct.toFixed(1)}% · utilization ${(r.Mu / Math.max(r.phiMn, 1e-9)).toFixed(2)}`}
+          lh={lh}
+          stats={[
+            { label: 'φMn', value: f1(r.phiMn), unit: 'kN·m' },
+            { label: 'fse', value: f1(r.fse), unit: 'MPa' },
+            { label: 'Pe', value: f1(r.Pe), unit: 'kN' },
+          ]}
+          checks={[
+            { name: 'Transfer stresses §24.5.3', ratio: r.transfer.bot / r.limTransferC, ok: r.transferOK },
+            { name: 'Service stresses §24.5.4', ratio: Number.isFinite(r.limServiceT) ? Math.max(0, -r.service.bot) / r.limServiceT : 0, ok: r.serviceOK },
+            { name: 'Strength Mu/φMn', ratio: r.Mu / Math.max(r.phiMn, 1e-9), ok: r.strengthOK },
+            { name: 'φMn ≥ 1.2Mcr', ratio: (1.2 * r.Mcr) / Math.max(r.phiMn, 1e-9), ok: r.crackingOK },
+          ]}
+          data={[
+            ['Section', `${b} × ${h} mm`], ['Span', `${span} m`], ["f'c / f'ci", `${fc} / ${fci} MPa`],
+            ['Tendons', `Aps ${Aps} mm² · fpu ${fpu} · e ${e} mm`], ['Loads', `SDL ${wSDL} · LL ${wLL} kN/m`],
+            ['Losses', `${r.lossPct.toFixed(1)} % → fse ${f1(r.fse)} MPa`],
+          ]}
+          steps={steps}
+          drawing={<PSElevation h={h} e={e} />}
+          drawingTitle="Prestressed beam" />
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## What — new standalone engine (L7): prestressed (pretensioned, bonded) beam

`engine/prestressedBeam.ts` — the full serviceability + strength pipeline:

- **PCI losses**: elastic shortening solved as a fixed point on `Pi = (fpj − ES(Pi))·Aps` with `fcir` at the strand cg; creep `2.0(Ep/Ec)(fcir − fcds)`; shrinkage with V/S and RH; low-relaxation RE — each component reported plus the % of jacking stress.
- **Transfer stresses** (`Pi + Msw`) vs §24.5.3 limits (0.60f'ci compression / 0.25√f'ci tension) and **service stresses** (`Pe + Mserv`) vs the §24.5.4 **class U/T** tension bounds.
- **Strength**: `fps` per §20.3.2.3.1 (γp from fpy/fpu), φ from εt, `φMn` vs Mu **and** the §9.6.2.1 `φMn ≥ 1.2Mcr` guard with Mcr including the precompression `(fr + Pe/A + Pe·e/Sb)·Sb`.
- **Shear**: `Vci` (with the 0.17√f'c·bw·dp floor) and `Vcw = (0.29√f'c + 0.3fpc)·bw·dp` per §22.5.8.3 at the critical section; governing mode reported.
- **Camber/deflection**: `Pe·e·L²/8EI` up vs `5wL⁴/384EI` down, net Δ.
- Rectangular or direct `(A, I, yt, yb)` section input (I-girders via properties).

**12 tests** with hand-calc identities (section/moments, converged ES, stress superposition, class-U violation case, fps/φMn/Mcr closed forms, Vcw, camber, verdict aggregation) — suite **1096 → 1108**.

Also: `lib/prestressedSolution.ts` (8 clause-annotated steps with PASS chips), `/prestressed-beam` page (flat rails, verdict utilization bars, tendon-profile elevation SVG, letterhead + PrintReport calc sheet), tool-directory entry, ValidationMap row.

## Verification
- `npx tsc -b` clean · **1108/1108 tests**
- Headless: page renders DESIGN OK with 13.5 % losses on the default 400×800 / 12 m / 987 mm² strand case — inside the typical 10–20 % band.

Next (final phase of this batch): integrate the new engines on the 3D Model Space page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_