### PR TITLE
feat: apply the new engines on 3D Model Space — all-around columns, T-beam action, prestressed checks

### DIFF
--- a/webapp/src/engine/beamDesign.ts
+++ b/webapp/src/engine/beamDesign.ts
@@ -27,6 +27,10 @@ export interface BeamDesignInput {
   fyt?: number         // stirrup yield (default fy)
   Mu: number           // factored moment, kN·m
   Vu: number           // factored shear, kN
+  /** Width used for the §9.6.1.2 minimum-steel floor (defaults to b). A
+   *  flanged sagging section passes bf as b but keeps the WEB width here —
+   *  min steel is a web property, it must not scale with the flange. */
+  bMin?: number
   legs?: number        // stirrup legs (default 2)
   lambda?: number      // lightweight factor (default 1)
 }
@@ -162,9 +166,11 @@ export function designBeam(i: BeamDesignInput): BeamDesignResult {
       mode = 'SRRB'
       const Rn = (i.Mu * 1e6) / (PHI_FLEX * i.b * d * d)
       const rhoCalc = (0.85 * i.fc / i.fy) * (1 - Math.sqrt(Math.max(0, 1 - (2 * Rn) / (0.85 * i.fc))))
-      usedMin = rhoCalc < rMin
-      rho = usedMin ? rMin : rhoCalc
-      As = rho * i.b * d
+      const AsMinArea = rMin * (i.bMin ?? i.b) * d
+      const AsCalc = rhoCalc * i.b * d
+      usedMin = AsCalc < AsMinArea
+      As = usedMin ? AsMinArea : AsCalc
+      rho = As / (i.b * d)
       As1 = 0; As2 = 0; MnResid = 0; cNA = 0; fsPrime = i.fy; fsYields = true; AsPrime = 0
       comprEffective = true
     } else {

--- a/webapp/src/engine/meshValidation.ts
+++ b/webapp/src/engine/meshValidation.ts
@@ -152,6 +152,17 @@ export function validateMesh(model: StructuralModel): MeshIssue[] {
         message: `Node ${n.id} is attached to no member; its free DOFs have no stiffness (singular K).` })
   }
 
+
+  // ── prestressing sanity (L1 rule for RectSection.ps) ────────────────────
+  for (const sec of model.sections) {
+    if (!sec.ps) continue
+    if (sec.material === 'steel')
+      issues.push({ severity: 'error', code: 'PS_STEEL', message: `section ${sec.id}: prestressing is only supported on concrete sections`, refs: [sec.id] })
+    if (!(sec.ps.Aps > 0) || !(sec.ps.fpu > 0) || !(sec.ps.fci > 0))
+      issues.push({ severity: 'error', code: 'PS_PARAMS', message: `section ${sec.id}: Aps, fpu and f'ci must be positive`, refs: [sec.id] })
+    if (!(sec.ps.e > 0) || sec.ps.e > sec.h / 2 - 40)
+      issues.push({ severity: 'error', code: 'PS_ECC', message: `section ${sec.id}: tendon eccentricity must satisfy 0 < e ≤ h/2 − 40 mm`, refs: [sec.id] })
+  }
   return issues
 }
 

--- a/webapp/src/engine/model.ts
+++ b/webapp/src/engine/model.ts
@@ -25,6 +25,10 @@ export interface RectSection {
   /** Steel grade yield/ultimate (steel only). Defaults: Fy 248, Fu 400 (A36). */
   steelFy?: number
   steelFu?: number
+  /** Pretensioned bonded prestressing on this (concrete beam) section — when
+   *  present the pipeline runs the full prestressed check (losses, §24.5
+   *  stresses, fps/φMn, 1.2Mcr) beside the RC design. */
+  ps?: { Aps: number; fpu: number; e: number; fci: number }
 }
 
 export type MemberRole = 'beam' | 'girder' | 'column' | 'brace'

--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -806,3 +806,38 @@ describe('§208.4.1 vertical seismic component Ev in the combo factors', () => {
     expect(up.f.D).toBeLessThan(0.9)   // more severe for uplift/overturning checks
   })
 })
+
+describe('engine integrations — all-around columns & T-beam action', () => {
+  const rTwo = designStructure(makeModel(), soil)!
+  const rInt = designStructure(makeModel(), soil, {}, { colLayout: 'all-around', tBeamAction: true })!
+
+  it('all-around layout is recorded on every column row and stays plausible', () => {
+    expect(rInt.columns.every((c) => c.layout === 'all-around')).toBe(true)
+    expect(rTwo.columns.every((c) => (c.layout ?? 'two-face') === 'two-face')).toBe(true)
+    for (const c of rInt.columns) {
+      const t = rTwo.columns.find((x) => x.id === c.id)!
+      // side bars shift capacity along the demand ray but never wildly
+      expect(c.util).toBeGreaterThan(0)
+      expect(c.util / t.util).toBeGreaterThan(0.5)
+      expect(c.util / t.util).toBeLessThan(2)
+    }
+  })
+
+  it('T-beam action tags only sagging sections, with bf > b, never more steel', () => {
+    let flanged = 0
+    for (const bm of rInt.beams) {
+      const two = rTwo.beams.find((x) => x.id === bm.id)!
+      for (const s of bm.sections) {
+        if (s.bf !== undefined) {
+          flanged++
+          expect(s.Mu).toBeGreaterThan(0)
+          expect(s.bf).toBeGreaterThan(300)
+          const sTwo = two.sections.find((x) => x.label === s.label)
+          if (sTwo) expect(s.design.As).toBeLessThanOrEqual(sTwo.design.As + 1e-6)
+        }
+        if (s.hogging) expect(s.bf).toBeUndefined()
+      }
+    }
+    expect(flanged).toBeGreaterThan(0)                       // slabs adjoin the grid beams
+  })
+})

--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -841,3 +841,35 @@ describe('engine integrations — all-around columns & T-beam action', () => {
     expect(flanged).toBeGreaterThan(0)                       // slabs adjoin the grid beams
   })
 })
+
+describe('engine integrations — prestressed member check', () => {
+  const m = makeModel()
+  // tag every beam section with pretensioned strands (mutate shared sections)
+  m.sections = m.sections.map((s) => ({ ...s, ps: { Aps: 600, fpu: 1860, e: 150, fci: 24 } }))
+  const r = designStructure(m, soil)!
+
+  it('every prestressed-tagged beam gets a row with the full engine result', () => {
+    const beamIds = new Set(r.beams.map((b) => b.id))
+    expect(r.prestressed.length).toBe(beamIds.size)
+    for (const p of r.prestressed) {
+      expect(beamIds.has(p.id)).toBe(true)
+      expect(p.design.lossPct).toBeGreaterThan(5)
+      expect(p.design.lossPct).toBeLessThan(30)
+      expect(p.design.phiMn).toBeGreaterThan(0)
+      expect(p.ok).toBe(p.design.ok)
+    }
+  })
+
+  it('undersized strands fail designOK through the prestressed rows', () => {
+    const bad = makeModel()
+    bad.sections = bad.sections.map((s) => ({ ...s, ps: { Aps: 40, fpu: 1860, e: 150, fci: 24 } }))
+    const rBad = designStructure(bad, soil)!
+    expect(rBad.prestressed.some((p) => !p.ok)).toBe(true)
+    expect(designOK(rBad)).toBe(false)
+  })
+
+  it('untagged models produce no prestressed rows (back-compat)', () => {
+    const plain = designStructure(makeModel(), soil)!
+    expect(plain.prestressed).toEqual([])
+  })
+})

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -7,7 +7,7 @@
 //   factored reactions → isolated footing) → concrete totals.
 // Every stage reuses the existing engines unchanged.
 // ─────────────────────────────────────────────────────────────────────────
-import type { StructuralModel, RectSection, ModelLoad } from './model'
+import type { StructuralModel, RectSection, ModelLoad, Member } from './model'
 import { enforceSectionHierarchy, refreshSelfWeight, barContinuityGroups } from './modelBuilder'
 import { modelToFrame3D } from './modelBridge'
 import { precomputeFrame, solveWithGeometry, applyF3Combo, serializePrecomp, type F3Result, type F3MemberResult, type F3Load } from './frame3d'
@@ -16,8 +16,9 @@ import { FramePool } from './framePool'
 import { nscpCombos, type Combo } from './beamAnalysis'
 import type { ProgressFn } from './progress'
 import { designBeam, type BeamDesignResult } from './beamDesign'
+import { effectiveFlange } from './tbeam'
 import { minBeamThickness, type BeamSupport } from './beamDeflection'
-import { designAxialColumn, capacityAtEccentricity, interaction } from './columnDesign'
+import { designAxialColumn, capacityAtEccentricity, interaction, type BarLayout } from './columnDesign'
 import { designSquareFooting, type SquareFootingResult } from './isolatedFooting'
 import { designCombinedFooting, type CombinedFootingResult } from './combinedFooting'
 import { designSlabDDM, type SlabDesignResult } from './slabDDM'
@@ -63,11 +64,22 @@ export interface AnalyzeOptions {
   /** Timoshenko shear deformation: bridge shear areas into the frame elements
    *  (Φ = 12EI/(G·As·L²)). Default off at the API level; UI enables it. */
   shearDeformation?: boolean
+  /** Column P–M bar layout: 'all-around' models the real cage (side bars as
+   *  their own strain layers). Default 'two-face' at the API level; the Model
+   *  Space UI enables all-around. */
+  colLayout?: BarLayout
+  /** Flanged (T-beam) action for sagging sections of beams that carry a slab:
+   *  bf per ACI §6.3.2 from the adjoining panels, used when a ≤ hf AND the
+   *  flanged design actually saves steel. */
+  tBeamAction?: boolean
 }
 
 export interface BeamSectionDesign {
   label: string; x: number; Mu: number; Vu: number; hogging: boolean
   design: BeamDesignResult
+  /** T-beam action: effective flange width used for this sagging section
+   *  (ACI §6.3.2) — present only when the block stayed inside the slab. */
+  bf?: number; hf?: number
 }
 export interface BeamScheduleRow {
   id: string; role: string; L: number
@@ -86,6 +98,8 @@ export interface BeamScheduleRow {
 export interface ColumnScheduleRow {
   id: string; L: number
   Pu: number; Mu: number; e: number
+  /** P–M bar layout used for the check (mirrors AnalyzeOptions.colLayout). */
+  layout?: BarLayout
   bars: number; phiPn: number; util: number
   /** Gravity-only tie spacing (§425.7.2), mm. */
   tieSpacing: number
@@ -312,18 +326,65 @@ function memberSections(mr: F3MemberResult): { label: string; x: number; Mu: num
   return out
 }
 
+/** Effective flange for a beam that carries slab panels (T-beam action):
+ *  panels adjoin when both member end nodes are among the plate corners.
+ *  hf = thinnest adjoining slab; sw = clear web-to-web distance approximated
+ *  by the panel width across the beam; interior with 2 panels, edge with 1. */
+function memberFlange(model: StructuralModel, m: Member, L: number): { bf: number; hf: number } | null {
+  const sec = model.sections.find((x) => x.id === m.section)
+  if (!sec || sec.material === 'steel') return null
+  const pos = new Map(model.nodes.map((n) => [n.id, n]))
+  const panels = model.plates.filter((p) => p.role !== 'wall' && p.corners.includes(m.i) && p.corners.includes(m.j))
+  if (!panels.length) return null
+  const hf = Math.min(...panels.map((p) => p.thickness))
+  const a = pos.get(m.i), b = pos.get(m.j)
+  if (!a || !b) return null
+  const across = (p: (typeof model.plates)[number]) => Math.max(...p.corners
+    .filter((cid) => cid !== m.i && cid !== m.j)
+    .map((cid) => {
+      const n = pos.get(cid)!
+      const dx = b.x - a.x, dz = b.z - a.z
+      const len = Math.hypot(dx, dz) || 1
+      return Math.abs(((n.x - a.x) * dz - (n.z - a.z) * dx) / len)
+    }))
+  const swM = Math.max(0.1, Math.min(...panels.map(across)) - sec.b / 1000)
+  const { bf } = effectiveFlange({
+    kind: panels.length >= 2 ? 'interior' : 'edge',
+    bw: sec.b, h: sec.h, hf, ln: L, sw: swM,
+    cover: sec.cover, stirrupDia: sec.tieDia, barDia: sec.barDia,
+    fc: sec.fc, fy: sec.fy, Mu: 0,
+  })
+  return { bf, hf }
+}
+
 /** Design one beam/girder member from a single run's member result. */
-function designBeamRow(mr: F3MemberResult, role: string, sec: RectSection, support: BeamSupport = 'both-ends'): BeamScheduleRow {
+function designBeamRow(
+  mr: F3MemberResult, role: string, sec: RectSection, support: BeamSupport = 'both-ends',
+  flange?: { bf: number; hf: number },
+): BeamScheduleRow {
   const sections: BeamSectionDesign[] = memberSections(mr)
     .filter((s) => Math.abs(s.Mu) > 1e-6 || s.Vu > 1e-6)
-    .map((s) => ({
-      label: s.label, x: s.x, Mu: s.Mu, Vu: s.Vu, hogging: s.Mu < 0,
-      design: designBeam({
+    .map((s) => {
+      const base = {
         b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia,
         comprBarDia: 16, stirrupDia: sec.tieDia,
         fc: sec.fc, fy: sec.fy, Mu: Math.abs(s.Mu), Vu: s.Vu,
-      }),
-    }))
+      }
+      const rect = designBeam(base)
+      // T-beam action (§6.3.2): sagging compression lives in the slab, so the
+      // section may design as a rectangle b = bf — adopted only when the block
+      // stays inside the flange (a ≤ hf) AND it actually saves steel
+      // (designBeam's ρmin scales with b, so a min-governed wide-flange result
+      // would be spurious, not a benefit).
+      if (flange && s.Mu > 0) {
+        const rT = designBeam({ ...base, b: flange.bf, bMin: sec.b })
+        const aT = (rT.As * sec.fy) / (0.85 * sec.fc * flange.bf)
+        if (aT <= flange.hf + 1e-9 && rT.As <= rect.As + 1e-6) {
+          return { label: s.label, x: s.x, Mu: s.Mu, Vu: s.Vu, hogging: false, design: rT, bf: flange.bf, hf: flange.hf }
+        }
+      }
+      return { label: s.label, x: s.x, Mu: s.Mu, Vu: s.Vu, hogging: s.Mu < 0, design: rect }
+    })
   // Table 409.3.1.1 minimum thickness (deemed-to-comply — deflections need not
   // be computed when h ≥ hMin). Steel beams check L/240 explicitly; this is the
   // RC counterpart so the optimizer cannot trim a long span into a springboard.
@@ -341,6 +402,7 @@ function designBeamRow(mr: F3MemberResult, role: string, sec: RectSection, suppo
 function designColumnFromPM(
   sec: RectSection, Pu: number, Mu: number,
   system: 'gravity' | 'imf' | 'smf' = 'gravity', columnLength?: number,
+  layout: BarLayout = 'two-face',
 ) {
   const ax = designAxialColumn({
     shape: 'tied', b: sec.b, h: sec.h, cover: sec.cover,
@@ -351,10 +413,10 @@ function designColumnFromPM(
   const e = Pu > 1e-9 ? Mu / Pu : 0
   if (e > 1e-4) {
     const cap = capacityAtEccentricity(
-      { b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, numBars: ax.bars },
+      { b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, numBars: ax.bars, layout },
       e,
     )
-    const inter = interaction({ b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, numBars: ax.bars })
+    const inter = interaction({ b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, numBars: ax.bars, layout })
     phiPn = Math.min(cap.phi * cap.Pn, 0.65 * inter.PnMax)
   }
   const util = phiPn > 1e-9 ? Pu / phiPn : Infinity
@@ -374,12 +436,13 @@ function designColumnFromPM(
 function designColumnRow(
   mr: F3MemberResult, sec: RectSection,
   system: 'gravity' | 'imf' | 'smf' = 'gravity',
+  layout: BarLayout = 'two-face',
 ): ColumnScheduleRow {
   const Pu = Math.max(0, -Math.min(...mr.N))           // compression (N < 0)
   const Mu = mr.Mmax
-  const r = designColumnFromPM(sec, Pu, Mu, system, mr.L * 1000)   // L m → mm
+  const r = designColumnFromPM(sec, Pu, Mu, system, mr.L * 1000, layout)   // L m → mm
   return {
-    id: mr.id, L: mr.L, Pu, Mu, e: r.e, bars: r.bars, phiPn: r.phiPn, util: r.util,
+    id: mr.id, L: mr.L, Pu, Mu, e: r.e, bars: r.bars, phiPn: r.phiPn, util: r.util, layout,
     tieSpacing: r.tieSpacing,
     tieSpacingFinal: r.tieSpacingFinal,
     tieSpacingLabel: r.tieSpacingLabel,
@@ -565,9 +628,13 @@ function designFromRuns(
       } else {
         let best: BeamScheduleRow | null = null, bestSev = -1, gov = ''
         const support = spanTypeOf(m)
+        const flange = opts.tBeamAction ? (() => {
+          const ni = model.nodes.find((n) => n.id === m.i), nj = model.nodes.find((n) => n.id === m.j)
+          return ni && nj ? memberFlange(model, m, Math.hypot(nj.x - ni.x, nj.y - ni.y, nj.z - ni.z)) : null
+        })() : null
         for (const run of runs) {
           const mr = memberOf(run, m.id); if (!mr) continue
-          const row = designBeamRow(mr, role, sec, support)
+          const row = designBeamRow(mr, role, sec, support, flange ?? undefined)
           if (row.sections.length === 0) continue
           const sev = beamSeverity(row)
           if (sev > bestSev) { bestSev = sev; best = row; gov = run.name }
@@ -593,7 +660,7 @@ function designFromRuns(
         const sysOpts = opts.seismicSystem ?? 'gravity'
         for (const run of runs) {
           const mr = memberOf(run, m.id); if (!mr) continue
-          const row = designColumnRow(mr, sec, sysOpts)
+          const row = designColumnRow(mr, sec, sysOpts, opts.colLayout ?? 'two-face')
           if (row.util > bestUtil) { bestUtil = row.util; best = row; gov = run.name }
         }
         if (best) columns.push({ ...best, gov })

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -17,6 +17,7 @@ import { nscpCombos, type Combo } from './beamAnalysis'
 import type { ProgressFn } from './progress'
 import { designBeam, type BeamDesignResult } from './beamDesign'
 import { effectiveFlange } from './tbeam'
+import { designPrestressed, type PrestressedResult } from './prestressedBeam'
 import { minBeamThickness, type BeamSupport } from './beamDeflection'
 import { designAxialColumn, capacityAtEccentricity, interaction, type BarLayout } from './columnDesign'
 import { designSquareFooting, type SquareFootingResult } from './isolatedFooting'
@@ -193,10 +194,22 @@ export interface BasePlateScheduleRow {
   ok: boolean
 }
 
+/** Prestressed member check (sections with RectSection.ps): the pipeline
+ *  back-derives equivalent UDLs from the D-only / L-only midspan sagging
+ *  moments (w = 8M/L², self-weight excluded from SDL) and runs the full
+ *  prestressedBeam engine — a simple-span GRAVITY idealisation of the member. */
+export interface PrestressedScheduleRow {
+  id: string; L: number
+  design: PrestressedResult
+  ok: boolean
+}
+
 export interface StructureDesign {
   govName: string
   cases: string[]   // every load case (combo × direction) run for the envelope
   beams: BeamScheduleRow[]
+  /** Members whose section carries prestressing (RectSection.ps). */
+  prestressed: PrestressedScheduleRow[]
   columns: ColumnScheduleRow[]
   steelBeams: SteelBeamScheduleRow[]
   steelColumns: SteelColumnScheduleRow[]
@@ -225,7 +238,7 @@ export interface StructureDesign {
  *  (DDM + §408.3.1.2 + §424.2 deflection), shear walls, steel joints and the
  *  §418.7.3.2 strong-column/weak-beam hierarchy. Nothing green is unchecked. */
 export function designOK(d: StructureDesign): boolean {
-  return d.beams.every((b) => b.ok) && d.columns.every((c) => c.ok)
+  return d.beams.every((b) => b.ok) && d.prestressed.every((p) => p.ok) && d.columns.every((c) => c.ok)
     && d.steelBeams.every((b) => b.ok) && d.steelColumns.every((c) => c.ok)
     && d.basePlates.every((p) => p.ok)
     && d.footings.every((f) => f.ok) && d.combined.every((c) => c.ok)
@@ -599,6 +612,7 @@ function designFromRuns(
   const totalMems = model.members.length
   let memDone = 0
   const beams: BeamScheduleRow[] = []
+  const prestressed: PrestressedScheduleRow[] = []
   const columns: ColumnScheduleRow[] = []
   const steelBeams: SteelBeamScheduleRow[] = []
   const steelColumns: SteelColumnScheduleRow[] = []
@@ -640,6 +654,24 @@ function designFromRuns(
           if (sev > bestSev) { bestSev = sev; best = row; gov = run.name }
         }
         if (best) beams.push({ ...best, gov })
+        // prestressed check (section tagged with ps): equivalent UDLs from the
+        // D-only / L-only sagging peaks — simple-span gravity idealisation
+        if (sec.ps && best) {
+          const L = best.L
+          const sag = (res: F3Result | null) => {
+            if (!res) return 0
+            const mr = res.members.find((x) => x.id === m.id)
+            return mr ? Math.max(0, ...mr.Mz) : 0
+          }
+          const wSW = ((sec.b * sec.h) / 1e6) * 24
+          const wD = Math.max(0, (8 * sag(dRes)) / (L * L) - wSW)
+          const wL = (8 * sag(lRes)) / (L * L)
+          const design = designPrestressed({
+            b: sec.b, h: sec.h, span: L, fc: sec.fc, fci: sec.ps.fci,
+            Aps: sec.ps.Aps, fpu: sec.ps.fpu, e: sec.ps.e, wSDL: wD, wLL: wL,
+          })
+          prestressed.push({ id: m.id, L, design, ok: design.ok })
+        }
       }
     } else if (role === 'column') {
       if (isSteel) {
@@ -841,7 +873,7 @@ function designFromRuns(
   const partialDesign = {
     govName: runs[govIdx].name,
     cases: runs.map((r) => r.name),
-    beams, columns, steelBeams, steelColumns, basePlates,
+    beams, prestressed, columns, steelBeams, steelColumns, basePlates,
     joints: [] as SteelJoint[],
     beamJoints: [] as BeamBeamJoint[],
     slabs, walls, footings, combined,

--- a/webapp/src/engine/takeoff.test.ts
+++ b/webapp/src/engine/takeoff.test.ts
@@ -114,7 +114,7 @@ describe('structure take-off / BOM-BOQ', () => {
 describe('structural steel — per-shape unit weight + costed BOM line items (A2)', () => {
   const STEEL_DENSITY = 7850
   const emptyDesign: StructureDesign = {
-    govName: '', cases: [], beams: [], columns: [], steelBeams: [], steelColumns: [],
+    govName: '', cases: [], beams: [], prestressed: [], columns: [], steelBeams: [], steelColumns: [],
     basePlates: [], joints: [], beamJoints: [], slabs: [], walls: [], footings: [], combined: [], scwb: [],
     totals: { concreteMembers: 0, concreteSlabs: 0, concrete: 0, steelKg: 0 }, orphanEdges: 0,
     unchecked: [], pDeltaIssues: [],

--- a/webapp/src/lib/modelReport.ts
+++ b/webapp/src/lib/modelReport.ts
@@ -11,6 +11,7 @@ import type {
 import { designOK } from '../engine/pipeline'
 import { beamSectionSolution, columnRowSolution, footingRowSolution, combinedRowSolution } from './modelSpaceSolutions'
 import { connectionRowSolution } from './connectionSolution'
+import { buildPrestressedSolution } from './prestressedSolution'
 import type { SolutionStep, SolutionLine } from './solution'
 
 export interface ReportStat { label: string; value: string; unit?: string }
@@ -127,6 +128,10 @@ export function buildModelReport(
     + design.beamJoints.reduce((s, j) => s + j.connections.length, 0)
   if (nConn)
     checks.push({ name: 'Steel connections', detail: `${nConn} connections at ${design.joints.length + design.beamJoints.length} joints`, ratio: null, ok: design.joints.every((j) => j.ok) && design.beamJoints.every((j) => j.ok) })
+  if (design.prestressed.length) {
+    const w = worst(design.prestressed, (p) => p.design.Mu / Math.max(p.design.phiMn, 1e-9))!
+    checks.push({ name: 'Prestressed members', detail: `${design.prestressed.length} members · governing ${w.row.id}`, ratio: w.r, ok: design.prestressed.every((p) => p.ok) })
+  }
   if (design.footings.length)
     checks.push({ name: 'Isolated footings', detail: `${design.footings.length} footings`, ratio: null, ok: design.footings.every((f) => f.ok) })
   if (design.combined.length)
@@ -164,7 +169,7 @@ export function buildModelReport(
         const d = s.design
         return [
           k === 0 ? `${bm.id} (${bm.role} ${sec?.name ?? ''}, ${f1(bm.L)} m)` : '',
-          `${s.label}${s.hogging ? ' (hog)' : ''}`,
+          `${s.label}${s.hogging ? ' (hog)' : s.bf ? ` · T bf=${Math.round(s.bf)}` : ''}`,
           f1(Math.abs(s.Mu)), f1(s.Vu), d.mode,
           `${d.bars}⌀${sec?.barDia}${d.layers.length > 1 ? ` (${d.layers.join('+')})` : ''}${s.hogging ? ' top' : ''}`,
           d.sAdopt > 0 ? `⌀${sec?.tieDia}@${Math.round(d.sAdopt)}` : d.region === 'none' ? 'none' : '⚠',
@@ -183,6 +188,14 @@ export function buildModelReport(
         `${c.bars}⌀${cs?.barDia} · ties @${Math.round(c.tieSpacingFinal)}${c.seismicSConf !== undefined ? ' (seismic)' : ''}`,
         `${(c.util * 100).toFixed(0)}%`, c.gov ?? '']
     }),
+  })
+  if (design.prestressed.length) tables.push({
+    title: 'Prestressed member checks (§24.5 · PCI losses)',
+    head: ['Member', 'L (m)', 'Loss %', 'fse (MPa)', 'Transfer', 'Service', 'φMn (kN·m)', 'Mu', '1.2Mcr', 'Status'],
+    right: [1, 2, 3, 6, 7],
+    rows: design.prestressed.map((p) => [p.id, f2(p.L), p.design.lossPct.toFixed(1), f1(p.design.fse),
+      p.design.transferOK ? 'PASS' : 'FAIL', p.design.serviceOK ? 'PASS' : 'FAIL',
+      f1(p.design.phiMn), f1(p.design.Mu), p.design.crackingOK ? 'PASS' : 'FAIL', p.ok ? 'PASS' : 'FAIL']),
   })
   if (design.scwb.length) tables.push({
     title: 'Strong-column / weak-beam joints (NSCP §418.7.3.2)',
@@ -269,6 +282,21 @@ export function buildModelReport(
         sub: `${bm.role} ${sec.name} · L = ${f1(bm.L)} m · ${bm.gov ?? ''}`,
         steps: beamSectionSolution(sec, s),
       }))
+    }),
+  })
+  if (design.prestressed.length) groups.push({
+    title: 'Prestressed members',
+    items: design.prestressed.flatMap((p) => {
+      const sec = sectionFor(p.id)
+      if (!sec?.ps) return []
+      return [{
+        title: p.id,
+        sub: `${sec.name} · L = ${f2(p.L)} m · Aps ${sec.ps.Aps} mm²`,
+        steps: buildPrestressedSolution({
+          b: sec.b, h: sec.h, span: p.L, fc: sec.fc, fci: sec.ps.fci,
+          Aps: sec.ps.Aps, fpu: sec.ps.fpu, e: sec.ps.e, wSDL: 0, wLL: 0,
+        }, p.design),
+      }]
     }),
   })
   if (design.columns.length) groups.push({

--- a/webapp/src/lib/modelSpaceSolutions.ts
+++ b/webapp/src/lib/modelSpaceSolutions.ts
@@ -30,7 +30,7 @@ export function columnRowSolution(sec: RectSection, row: ColumnScheduleRow): Sol
   const ax = designAxialColumn(base)
   const steps: SolutionStep[] = []
   if (row.e > 1e-4 && row.Pu > 0) {
-    const ic = { b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, numBars: ax.bars }
+    const ic = { b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, numBars: ax.bars, layout: row.layout }
     steps.push(...eccentricColumnSolution(ic, interaction(ic), row.Pu, row.Mu, capacityAtEccentricity(ic, row.e)))
   }
   const seismic: SeismicTieOverride | undefined =

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -725,6 +725,10 @@ export default function ModelSpace() {
   const [fc, setFc] = useState(n('fc', 28)); const [fy, setFy] = useState(n('fy', 415))
   const [barDia, setBarDia] = useState(n('barDia', 20)); const [tieDia, setTieDia] = useState(n('tieDia', 10))
   const [cover, setCover] = useState(n('cover', 40)); const [slabThk, setSlabThk] = useState(n('slabThk', 150))
+  // Prestressing (applied to beam/girder sections as RectSection.ps)
+  const [psOn, setPsOn] = useState(false)
+  const [psAps, setPsAps] = useState(600); const [psFpu, setPsFpu] = useState(1860)
+  const [psE, setPsE] = useState(150); const [psFci, setPsFci] = useState(24)
   const [gammaC, setGammaC] = useState(n('gammaC', 24))            // concrete unit weight, kN/m³
   // Material: 'concrete' (RC) or 'steel' (AISC W-shapes) for the frame members.
   const [material, setMaterial] = useState<'concrete' | 'steel'>((si.material as 'concrete' | 'steel') ?? 'concrete')
@@ -768,6 +772,8 @@ export default function ModelSpace() {
   const [pDelta, setPDelta] = useState(b('pDelta', false))
   const [cracked, setCracked] = useState(b('cracked', true))       // ACI §6.6.3.1.1 cracked EI (0.35/0.70 Ig)
   const [shearDef, setShearDef] = useState(b('shearDef', true))    // Timoshenko shear deformation (deep girders / squat columns)
+  const [allAround, setAllAround] = useState(b('allAround', true)) // column P–M bars on all four faces
+  const [tBeamOn, setTBeamOn] = useState(b('tBeamOn', true))       // §6.3.2 flanged sagging design
   const [tryBars, setTryBars] = useState(b('tryBars', true))        // let design/optimize pick bar Ø from a ladder
   const [showLoads, setShowLoads] = useState(true)   // load-diagram overlay
   const [showFootings, setShowFootings] = useState(true)   // designed footing footprints
@@ -925,7 +931,7 @@ export default function ModelSpace() {
   const hasELoads = model?.loads.some((l) => l.cat === 'E') ?? false
   const seismicSystem: 'gravity' | 'imf' | 'smf' = hasELoads ? (Rw >= 8 ? 'smf' : Rw >= 5 ? 'imf' : 'gravity') : 'gravity'
   // §208.4.1 vertical seismic component folded into the E-combo D factors.
-  const anaOpts = { f1: fLive, pDelta, lateral, seismicSystem, crackedSections: cracked, shearDeformation: shearDef, Ev: evOn ? 0.5 * Ca * Ie : undefined }
+  const anaOpts = { f1: fLive, pDelta, lateral, seismicSystem, crackedSections: cracked, shearDeformation: shearDef, Ev: evOn ? 0.5 * Ca * Ie : undefined, colLayout: (allAround ? 'all-around' as const : 'two-face' as const), tBeamAction: tBeamOn }
 
   const analyze = () => {
     if (!model || busy || meshErrors) return   // §1 fail-fast: don't solve a singular mesh
@@ -2274,6 +2280,37 @@ export default function ModelSpace() {
                 <Num label="Clear cover" unit="mm" value={cover} onChange={setCover} step="5" />
                 <Num label="Concrete unit wt γc" unit="kN/m³" value={gammaC} onChange={setGammaC} step="0.5" />
               </Sec>
+              <Sec title="Prestressing — beams & girders" hint="§24.5 · PCI losses">
+                <label className="col-span-full flex items-center gap-2 text-sm">
+                  <input type="checkbox" checked={psOn} onChange={(e) => setPsOn(e.target.checked)} />
+                  <span>Check beam/girder members as pretensioned bonded (beside the RC design)</span>
+                </label>
+                {psOn && (<>
+                  <Num label="Aps" unit="mm²" value={psAps} onChange={setPsAps} />
+                  <Num label="fpu" unit="MPa" value={psFpu} onChange={setPsFpu} />
+                  <Num label="Eccentricity e" unit="mm" value={psE} onChange={setPsE} />
+                  <Num label="f'ci (transfer)" unit="MPa" value={psFci} onChange={setPsFci} />
+                </>)}
+                <div className="col-span-full">
+                  <button type="button" disabled={!model}
+                    onClick={() => model && save({
+                      ...model,
+                      sections: model.sections.map((sc) => {
+                        const isBeamSec = model.members.some((mm) => mm.section === sc.id && mm.role !== 'column')
+                        if (!isBeamSec || sc.material === 'steel') return sc
+                        if (!psOn) { const { ps: _drop, ...rest } = sc; return rest }
+                        return { ...sc, ps: { Aps: psAps, fpu: psFpu, e: psE, fci: psFci } }
+                      }),
+                    })}
+                    className={`w-full ${btn}`}>
+                    {psOn ? 'Apply prestressing to beam sections' : 'Clear prestressing from beam sections'}
+                  </button>
+                </div>
+                <p className="col-span-full text-[11px] text-slate-500">
+                  The pipeline back-derives equivalent gravity UDLs from the D/L solves (w = 8M/L²) and runs the
+                  full prestressed engine per member — losses, transfer/service stresses, fps/φMn, 1.2Mcr.
+                </p>
+              </Sec>
               <p className="text-[11px] text-slate-500">
                 Per-member b×h are editable in the Geometry → Beams &amp; columns table; slab thickness per panel
                 in Geometry → Slabs. f′c, fy, ⌀, cover and slab thickness are applied when you generate a new grid;
@@ -2884,6 +2921,14 @@ export default function ModelSpace() {
                 <label className="col-span-full flex items-center gap-2 text-sm">
                   <input type="checkbox" checked={shearDef} onChange={(e) => setShearDef(e.target.checked)} />
                   <span>Shear deformation (Timoshenko) — Φ = 12EI/(G·As·L²); softens deep girders &amp; squat columns</span>
+                </label>
+                <label className="col-span-full flex items-center gap-2 text-sm">
+                  <input type="checkbox" checked={allAround} onChange={(e) => setAllAround(e.target.checked)} />
+                  <span>Column bars on all four faces — P–M strain-compatibility layers (real cage; lower Mb)</span>
+                </label>
+                <label className="col-span-full flex items-center gap-2 text-sm">
+                  <input type="checkbox" checked={tBeamOn} onChange={(e) => setTBeamOn(e.target.checked)} />
+                  <span>T-beam action — §6.3.2 flange from adjoining slabs for sagging sections (a ≤ hf)</span>
                 </label>
                 <label className="col-span-full flex items-center gap-2 text-sm">
                   <input type="checkbox" disabled={!model} checked={model?.diaphragm ?? false}
@@ -3537,7 +3582,7 @@ export default function ModelSpace() {
                     <tr key={key} onClick={() => setExpanded(expanded === key ? null : key)}
                       className={`sched-row cursor-pointer border-t border-slate-100 hover:bg-blue-50/40 ${bad ? 'bg-red-50 text-red-700' : ''}`}>
                       <td className="py-1 pr-2 font-medium">{k === 0 ? `${open ? '▾' : '▸'} ${bm.id} (${bm.role} ${sec?.name ?? ''}, ${f1(bm.L)} m)` : ''}</td>
-                      <td className="py-1 pr-2">{s.label}{s.hogging ? ' (hog)' : ''}</td>
+                      <td className="py-1 pr-2">{s.label}{s.hogging ? ' (hog)' : s.bf ? ` · T bf=${Math.round(s.bf)}` : ''}</td>
                       <td className="py-1 pr-2 text-right">{f1(Math.abs(s.Mu))}</td>
                       <td className="py-1 pr-2 text-right">{f1(s.Vu)}</td>
                       <td className="py-1 pr-2">{d.mode}</td>
@@ -3578,6 +3623,39 @@ export default function ModelSpace() {
                     ),
                   ]
                 }))}
+              </tbody>
+            </table>
+          </div>}
+
+          {/* Prestressed member checks */}
+          {design.prestressed.length > 0 && <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Prestressed member checks (§24.5 · PCI)</h3>
+            <table className="w-full border-collapse text-xs">
+              <thead>
+                <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
+                  <th className="py-1 pr-2 font-semibold">Member</th>
+                  <th className="py-1 pr-2 text-right font-semibold">Loss %</th>
+                  <th className="py-1 pr-2 text-right font-semibold">fse (MPa)</th>
+                  <th className="py-1 pr-2 font-semibold">Transfer</th>
+                  <th className="py-1 pr-2 font-semibold">Service</th>
+                  <th className="py-1 pr-2 text-right font-semibold">φMn / Mu</th>
+                  <th className="py-1 pr-2 font-semibold">1.2Mcr</th>
+                  <th className="py-1 font-semibold">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {design.prestressed.map((pr) => (
+                  <tr key={pr.id} className={`border-t border-slate-100 ${pr.ok ? '' : 'bg-red-50 text-red-700'}`}>
+                    <td className="py-1 pr-2 font-medium">{pr.id} ({f1(pr.L)} m)</td>
+                    <td className="py-1 pr-2 text-right">{pr.design.lossPct.toFixed(1)}</td>
+                    <td className="py-1 pr-2 text-right">{f1(pr.design.fse)}</td>
+                    <td className="py-1 pr-2">{pr.design.transferOK ? '✓' : '✗'}</td>
+                    <td className="py-1 pr-2">{pr.design.serviceOK ? '✓' : '✗'}</td>
+                    <td className="py-1 pr-2 text-right">{f1(pr.design.phiMn)} / {f1(pr.design.Mu)}</td>
+                    <td className="py-1 pr-2">{pr.design.crackingOK ? '✓' : '✗'}</td>
+                    <td className="py-1">{pr.ok ? '✓ OK' : '✗ FAILS'}</td>
+                  </tr>
+                ))}
               </tbody>
             </table>
           </div>}


### PR DESCRIPTION
## What — the new engines applied on the 3D Model Space page

**Analysis tab** (both toggles ON by default, like crackedSections):
- **Column bars on all four faces** — `AnalyzeOptions.colLayout` threads the all-around cage layout into the pipeline's P–M check (`capacityAtEccentricity`/`interaction` layers); each `ColumnScheduleRow` records the layout and the on-screen/PDF worked solutions mirror it (bar-layout step included).
- **T-beam action** — `memberFlange()` finds slab panels adjoining each beam (both end nodes among the plate corners), takes hf from the thinnest panel and sw from the panel width across the beam, and computes bf per §6.3.2. Sagging sections design with `b = bf` when the block stays in the slab (a ≤ hf) and never need more steel than the plain web; schedule + PDF rows show `T bf=…`. Supporting fix: `beamDesign` gains `bMin` — the §9.6.1.2 minimum-steel floor is a **web** property and must not scale with a flange width passed as b.

**Properties tab — Prestressing (beams & girders)**: apply/clear `RectSection.ps` (`Aps/fpu/e/f'ci`; JSON-serialisable L1 field with meshValidation rules: concrete only, positive params, `0 < e ≤ h/2 − 40`). The pipeline back-derives equivalent gravity UDLs from the D-only/L-only solves (`w = 8M/L²`, self-weight excluded) and runs the **full prestressed engine per member** — losses, §24.5.3/§24.5.4 stresses, fps/φMn, 1.2Mcr, Vci/Vcw. New `PrestressedScheduleRow` gates `designOK`, renders as an on-screen schedule, and lands in the PDF report (summary check with governing ratio, schedule table, clause-annotated worked solutions).

## Verification
- **5 new integration tests** on the standard grid model: layout recorded per row with plausible util shifts, flanged tags only on sagging sections with never-more-steel, prestressed rows per tagged member with loss % in the practical band, undersized strands fail `designOK`, untagged models unchanged (back-compat). `npx tsc -b` clean · **1113/1113 tests**.
- Headless Chromium: toggles live in the Analysis tab; Properties → apply prestressing → Design all renders the "Prestressed member checks" schedule; beam schedule shows `T bf=750` tags.

This completes the requested batch: mockup UI (#354), column all-around + short/long (#355), T-beam engine (#356), prestressed engine (#357), and this Model Space integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_