### PR TITLE
fix: drawing corrections (column cage, T-beam dims+rebar, prestressed supports/UDL) + smaller report figures

### DIFF
--- a/webapp/src/components/BeamSchematic.tsx
+++ b/webapp/src/components/BeamSchematic.tsx
@@ -48,7 +48,7 @@ export function BeamSchematic({
   comprBars = 0, comprBarDia, naDepth = 0, flexOK = true, hogging = false,
 }: BeamSchematicProps): JSX.Element {
   const W = 330, H = 322
-  const padL = 56, padT = 30, availW = 150, availH = 210
+  const padL = 90, padT = 18, availW = 150, availH = 220
   const s = Math.min(availW / b, availH / h)
   const bw = b * s, hh = h * s
   const x0 = padL + (availW - bw) / 2, y0 = padT
@@ -130,8 +130,6 @@ export function BeamSchematic({
   return (
     <svg viewBox={`0 0 ${W} ${H}`} xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet"
       style={{ width: '100%', height: 'auto', fontFamily: 'Arial, sans-serif' }}>
-      <text x={padL} y={14} fontSize={11} fontWeight={700} fill="#0056b3">SECTION</text>
-
       {/* concrete */}
       <rect x={x0} y={y0} width={bw} height={hh} rx={2} fill={FILL} stroke={STROKE} strokeWidth={1.6} />
 

--- a/webapp/src/components/ColumnSchematic.tsx
+++ b/webapp/src/components/ColumnSchematic.tsx
@@ -35,15 +35,27 @@ export function ColumnSchematic({ shape, b = 0, h = 0, D = 0, cover, barDia, tie
     const x2 = x0 + bw - (cover + tieDia + barDia / 2) * s
     const yT = y0 + (cover + tieDia + barDia / 2) * s
     const yB = y0 + hgt - (cover + tieDia + barDia / 2) * s
-    const nFace = Math.max(2, Math.ceil(bars / 2))
-    const rowX = Array.from({ length: nFace }, (_, i) => (nFace === 1 ? (x1 + x2) / 2 : x1 + ((x2 - x1) * i) / (nFace - 1)))
+    // real cage: 4 corner bars + the rest split between the b- and h-faces in
+    // proportion to the face lengths (mirrors engine barLayers 'all-around')
+    const N = Math.max(4, 2 * Math.round(bars / 2))
+    const bwIn = b - 2 * (cover + tieDia + barDia / 2)
+    const hIn = h - 2 * (cover + tieDia + barDia / 2)
+    let nx = 2 + Math.round(((N - 4) / 2) * (bwIn / (bwIn + hIn)))
+    nx = Math.max(2, Math.min(nx, N / 2))
+    const ny = N / 2 + 2 - nx
+    const rowX = Array.from({ length: nx }, (_, i) => (nx === 1 ? (x1 + x2) / 2 : x1 + ((x2 - x1) * i) / (nx - 1)))
+    const sideY = Array.from({ length: Math.max(0, ny - 2) }, (_, i) => yT + ((yB - yT) * (i + 1)) / (ny - 1))
     body = (
       <g>
         <rect x={x0} y={y0} width={bw} height={hgt} rx={2} fill={FILL} stroke={STROKE} strokeWidth={1.6} />
         <rect x={x0 + inset} y={y0 + inset} width={bw - 2 * inset} height={hgt - 2 * inset}
           rx={Math.max(2, 2.5 * tieDia * s)} fill="none" stroke={BAR} strokeWidth={stW} opacity={0.8} />
         {rowX.map((bx, i) => <circle key={`t${i}`} cx={bx} cy={yT} r={br} fill={BAR} />)}
-        {rowX.slice(0, Math.max(2, Math.floor(bars / 2))).map((bx, i) => <circle key={`b${i}`} cx={bx} cy={yB} r={br} fill={BAR} />)}
+        {rowX.map((bx, i) => <circle key={`b${i}`} cx={bx} cy={yB} r={br} fill={BAR} />)}
+        {sideY.map((sy, i) => <g key={`s${i}`}>
+          <circle cx={x1} cy={sy} r={br} fill={BAR} />
+          <circle cx={x2} cy={sy} r={br} fill={BAR} />
+        </g>)}
       </g>
     )
   } else {

--- a/webapp/src/components/calc.tsx
+++ b/webapp/src/components/calc.tsx
@@ -255,7 +255,7 @@ export function PrintReport({ docTitle, docCode, badges, ok, governing, lh, stat
           <span className="text-[10px] font-bold tracking-[.14em] text-[#5c6675]">{(lh.sheet || docCode).split('·')[0].trim()} · {(drawingTitle ?? docTitle).toUpperCase()}</span>
           <span className="font-mono text-[9px] text-[#a39d8d]">to scale</span>
         </div>
-        <div className="mx-auto w-3/4">{drawing}</div>
+        <div className="mx-auto w-[46%]">{drawing}</div>
       </div>}
 
       <div className="print-avoid-break mt-6 grid grid-cols-2 gap-7">

--- a/webapp/src/lib/modelPdf.ts
+++ b/webapp/src/lib/modelPdf.ts
@@ -96,6 +96,9 @@ export async function generateModelPdf({ lh, report, modelImg, badges, fileName 
     theme: 'plain' as const,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     didParseCell: (d: any) => {
+      // right-aligned numeric columns must right-align their HEADERS too —
+      // headStyles outrank columnStyles in autotable, so set it per cell
+      if (d.section === 'head' && right.includes(d.column.index)) d.cell.styles.halign = 'right'
       if (d.section === 'body' && (d.cell.raw === 'PASS' || d.cell.raw === 'FAIL')) {
         d.cell.styles.font = 'mono'; d.cell.styles.fontStyle = 'bold'; d.cell.styles.fontSize = 6.2
         d.cell.styles.textColor = d.cell.raw === 'PASS' ? OK_FG : FAIL_FG

--- a/webapp/src/pages/PrestressedBeam.tsx
+++ b/webapp/src/pages/PrestressedBeam.tsx
@@ -5,24 +5,47 @@ import { buildPrestressedSolution } from '../lib/prestressedSolution'
 import { PageHeader, VerdictPanel, DrawingCard, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
 import { Num, Pick, Card } from '../components/qty'
 import { WorkedSolution } from '../components/WorkedSolution'
+import { DimBelow, DimSide } from '../components/dims'
 
 const f1 = (v: number) => v.toFixed(1)
 
-/** Elevation: beam, tendon profile (straight, eccentric) and load arrows. */
-function PSElevation({ h, e }: { h: number; e: number }) {
-  const y0 = 60, H = 60, yc = y0 + H / 2, yTendon = yc + (e / h) * H
+/** Elevation to scale-ish: beam on pin + roller supports, UDL arrows landing
+ *  on the top edge, straight eccentric tendon, template dimension lines. */
+function PSElevation({ h, e, span }: { h: number; e: number; span: number }) {
+  const W = 340, HT = 220
+  const x0 = 46, bw = 248
+  const y0 = 74, H = 56
+  const yc = y0 + H / 2, yTendon = Math.min(y0 + H - 5, yc + (e / h) * H)
+  const arrows = [0.08, 0.26, 0.44, 0.62, 0.8, 0.96].map((f) => x0 + f * bw)
   return (
-    <svg viewBox="0 0 300 160" className="mx-auto block w-full max-w-[360px]">
-      <rect x="20" y={y0} width="260" height={H} fill="#fff" stroke="#0f1b2a" strokeWidth="2" />
-      <line x1="20" y1={yTendon} x2="280" y2={yTendon} stroke="#0f4c92" strokeWidth="2.5" strokeDasharray="7 4" />
-      <line x1="20" y1={yc} x2="280" y2={yc} stroke="#a39d8d" strokeWidth="1" strokeDasharray="3 4" />
-      <text x="150" y={yTendon + 12} fontSize="9" textAnchor="middle" fontFamily="IBM Plex Mono, monospace" fill="#0f4c92">Aps · e = {e} mm</text>
-      {[60, 110, 160, 210, 260].map((x) => (
-        <line key={x} x1={x} y1={y0 - 18} x2={x} y2={y0 - 4} stroke="#5c6675" strokeWidth="1.5" markerEnd="url(#arr)" />
+    <svg viewBox={`0 0 ${W} ${HT}`} className="mx-auto block w-full max-w-[380px]" style={{ fontFamily: 'Arial, sans-serif' }}>
+      {/* UDL: top line + arrows touching the beam's top edge */}
+      <line x1={x0} y1={y0 - 26} x2={x0 + bw} y2={y0 - 26} stroke="#5c6675" strokeWidth="1.4" />
+      {arrows.map((x) => (
+        <g key={x} stroke="#5c6675" strokeWidth="1.4">
+          <line x1={x} y1={y0 - 26} x2={x} y2={y0 - 5} />
+          <path d={`M${x - 3.2} ${y0 - 6.5} L${x} ${y0 - 0.5} L${x + 3.2} ${y0 - 6.5} z`} fill="#5c6675" stroke="none" />
+        </g>
       ))}
-      <defs><marker id="arr" markerWidth="6" markerHeight="6" refX="3" refY="5" orient="auto"><path d="M0 0 L6 0 L3 6 z" fill="#5c6675" /></marker></defs>
-      <polygon points="20,126 12,140 28,140" fill="#0f4c92" />
-      <circle cx="280" cy="133" r="6" fill="none" stroke="#0f4c92" strokeWidth="2" />
+      <text x={x0 + bw / 2} y={y0 - 32} fontSize="8.5" fill="#5c6675" textAnchor="middle">w (D + L)</text>
+      {/* beam */}
+      <rect x={x0} y={y0} width={bw} height={H} fill="#eef3f8" stroke="#37526e" strokeWidth="1.6" />
+      <line x1={x0} y1={yc} x2={x0 + bw} y2={yc} stroke="#a39d8d" strokeWidth="0.8" strokeDasharray="3 4" />
+      <line x1={x0} y1={yTendon} x2={x0 + bw} y2={yTendon} stroke="#0f4c92" strokeWidth="2.2" strokeDasharray="8 4" />
+      <text x={x0 + bw / 2} y={y0 + H + 12} fontSize="8.5" fontFamily="IBM Plex Mono, monospace" fill="#0f4c92" textAnchor="middle">
+        Aps · e = {e} mm below cg
+      </text>
+      {/* supports ON the soffit: pin (triangle apex at the beam) + roller */}
+      <g stroke="#37526e" strokeWidth="1.4" fill="#fff">
+        <path d={`M${x0 + 10} ${y0 + H} L${x0 + 1} ${y0 + H + 15} L${x0 + 19} ${y0 + H + 15} z`} />
+        <line x1={x0 - 5} y1={y0 + H + 15} x2={x0 + 25} y2={y0 + H + 15} />
+        <circle cx={x0 + bw - 10} cy={y0 + H + 7.5} r={7} />
+        <line x1={x0 + bw - 25} y1={y0 + H + 15} x2={x0 + bw + 5} y2={y0 + H + 15} />
+      </g>
+      {/* dimensions (shared template) */}
+      <DimBelow xA={x0} xB={x0 + bw} featY={y0 + H + 18} dY={y0 + H + 40} label={`L = ${span} m`} />
+      <DimSide yA={y0} yB={y0 + H} featX={x0 + bw} dX={x0 + bw + 20} label={`h = ${h} mm`} side="right" />
+      <DimSide yA={yc} yB={yTendon} featX={x0} dX={x0 - 18} label={`e`} side="left" />
     </svg>
   )
 }
@@ -95,7 +118,7 @@ export default function PrestressedBeam() {
             )}
             {r && (
               <DrawingCard title="Elevation & tendon profile" meta={`${b}×${h} · L = ${span} m`}>
-                <PSElevation h={h} e={e} />
+                <PSElevation h={h} e={e} span={span} />
               </DrawingCard>
             )}
             <LetterheadCard lh={lh} onChange={(p) => setLh((s) => ({ ...s, ...p }))} />
@@ -123,7 +146,7 @@ export default function PrestressedBeam() {
             ['Losses', `${r.lossPct.toFixed(1)} % → fse ${f1(r.fse)} MPa`],
           ]}
           steps={steps}
-          drawing={<PSElevation h={h} e={e} />}
+          drawing={<PSElevation h={h} e={e} span={span} />}
           drawingTitle="Prestressed beam" />
       )}
     </div>

--- a/webapp/src/pages/TBeamDesign.tsx
+++ b/webapp/src/pages/TBeamDesign.tsx
@@ -5,25 +5,59 @@ import { buildTBeamSolution } from '../lib/tbeamSolution'
 import { PageHeader, VerdictPanel, DrawingCard, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
 import { Num, Pick, Card } from '../components/qty'
 import { WorkedSolution } from '../components/WorkedSolution'
+import { DimBelow, DimSide } from '../components/dims'
 
 const f0 = (v: number) => v.toFixed(0)
 const f1 = (v: number) => v.toFixed(1)
 
-/** T-section sketch with the stress block depth. */
-function TSection({ bf, bw, h, hf, a }: { bf: number; bw: number; h: number; hf: number; a: number }) {
-  const S = 260 / Math.max(bf, h)
-  const W = bf * S, H = h * S, WF = bw * S, HF = hf * S, A = Math.min(a, h) * S
-  const x0 = (300 - W) / 2
+/** T-section to scale: outline, stress block, stirrup + tension bars in the
+ *  web, and template dimension lines (bf above, h left, bw below, hf right). */
+function TSection({ bf, bw, h, hf, a, bars = 0, barDia = 0, layers = [], cover = 40, stirrupDia = 10 }: {
+  bf: number; bw: number; h: number; hf: number; a: number
+  bars?: number; barDia?: number; layers?: number[]; cover?: number; stirrupDia?: number
+}) {
+  const W = 340, HT = 285
+  const availW = 210, availH = 200
+  const S = Math.min(availW / bf, availH / h)
+  const w = bf * S, ht = h * S, wf = bw * S, hff = hf * S, A = Math.min(a, h) * S
+  const x0 = (W - w) / 2, y0 = 40
+  const xw = x0 + (w - wf) / 2
+  const inset = (cover + stirrupDia / 2) * S
+  const br = Math.max(2.5, (barDia / 2) * S)
+  // tension bars in the web, bottom-up layers
+  const barRows: { y: number; n: number }[] = []
+  layers.forEach((n, li) => {
+    barRows.push({ y: y0 + ht - (cover + stirrupDia + barDia / 2 + li * (barDia + 25)) * S, n })
+  })
+  const bx1 = xw + (cover + stirrupDia + barDia / 2) * S
+  const bx2 = xw + wf - (cover + stirrupDia + barDia / 2) * S
   return (
-    <svg viewBox="0 0 300 300" className="mx-auto block w-full max-w-[340px]">
-      <path d={`M${x0} 20 h${W} v${HF} h${-(W - WF) / 2} v${H - HF} h${-WF} v${-(H - HF)} h${-(W - WF) / 2} z`}
-        fill="#fff" stroke="#0f1b2a" strokeWidth="2" />
-      <rect x={x0} y={20} width={W} height={Math.min(A, HF)} fill="#0f4c92" opacity="0.18" />
-      {A > HF && <rect x={x0 + (W - WF) / 2} y={20 + HF} width={WF} height={A - HF} fill="#0f4c92" opacity="0.18" />}
-      <line x1={x0 - 8} y1={20 + A} x2={x0 + W + 8} y2={20 + A} stroke="#0f4c92" strokeWidth="1.5" strokeDasharray="5 3" />
-      <text x={x0 + W + 10} y={24 + A} fontSize="10" fontFamily="IBM Plex Mono, monospace" fill="#0f4c92">a = {f1(a)}</text>
-      <text x="150" y={14} fontSize="10" textAnchor="middle" fontFamily="IBM Plex Mono, monospace" fill="#0f4c92">bf</text>
-      <text x="150" y={20 + H + 14} fontSize="10" textAnchor="middle" fontFamily="IBM Plex Mono, monospace" fill="#0f4c92">bw</text>
+    <svg viewBox={`0 0 ${W} ${HT}`} className="mx-auto block w-full max-w-[360px]" style={{ fontFamily: 'Arial, sans-serif' }}>
+      <path d={`M${x0} ${y0} h${w} v${hff} h${-(w - wf) / 2} v${ht - hff} h${-wf} v${-(ht - hff)} h${-(w - wf) / 2} z`}
+        fill="#eef3f8" stroke="#37526e" strokeWidth="1.6" />
+      {/* stress block */}
+      <rect x={x0} y={y0} width={w} height={Math.min(A, hff)} fill="#0f4c92" opacity="0.16" />
+      {A > hff && <rect x={xw} y={y0 + hff} width={wf} height={A - hff} fill="#0f4c92" opacity="0.16" />}
+      <line x1={x0 - 6} y1={y0 + A} x2={x0 + w + 6} y2={y0 + A} stroke="#0f4c92" strokeWidth="1.2" strokeDasharray="5 3" />
+      <text x={x0 + w - 4} y={y0 + A + 11} fontSize="8.5" fontFamily="IBM Plex Mono, monospace" fill="#0f4c92" textAnchor="end">a = {a.toFixed(0)}</text>
+      {/* stirrup in the web */}
+      <rect x={xw + inset} y={y0 + hff * 0.35} width={wf - 2 * inset} height={ht - hff * 0.35 - inset}
+        rx={Math.max(2, 2 * stirrupDia * S)} fill="none" stroke="#37526e" strokeWidth={Math.max(1, stirrupDia * S)} opacity="0.8" />
+      {/* tension bars */}
+      {barRows.map((row, li) => Array.from({ length: row.n }, (_, i) => (
+        <circle key={`${li}-${i}`} r={br} fill="#37526e"
+          cx={row.n === 1 ? (bx1 + bx2) / 2 : bx1 + ((bx2 - bx1) * i) / (row.n - 1)} cy={row.y} />
+      )))}
+      {bars > 0 && (
+        <text x={W / 2} y={y0 + ht + 14} fontSize="8.5" fill="#37526e" textAnchor="middle">
+          {bars} ⌀{barDia} mm · stirrup ⌀{stirrupDia}
+        </text>
+      )}
+      {/* dimension lines (shared template) */}
+      <DimBelow xA={x0} xB={x0 + w} featY={y0} dY={y0 - 18} label={`bf = ${Math.round(bf)} mm`} />
+      <DimBelow xA={xw} xB={xw + wf} featY={y0 + ht + (bars > 0 ? 18 : 4)} dY={y0 + ht + (bars > 0 ? 34 : 20)} label={`bw = ${Math.round(bw)} mm`} />
+      <DimSide yA={y0} yB={y0 + ht} featX={x0 > 40 ? x0 + (w - wf) / 2 : x0} dX={Math.min(x0, xw) - 16} label={`h = ${Math.round(h)} mm`} side="left" />
+      <DimSide yA={y0} yB={y0 + hff} featX={x0 + w} dX={x0 + w + 16} label={`hf = ${Math.round(hf)}`} side="right" />
     </svg>
   )
 }
@@ -95,7 +129,7 @@ export default function TBeamDesign() {
             )}
             {r && (
               <DrawingCard title="Section & stress block" meta={`${f0(r.bf)}×${hf} flange · ${bw}×${h} web`}>
-                <TSection bf={r.bf} bw={bw} h={h} hf={hf} a={r.a} />
+                <TSection bf={r.bf} bw={bw} h={h} hf={hf} a={r.a} bars={r.bars} barDia={barDia} layers={r.layers} cover={cover} stirrupDia={stirrupDia} />
               </DrawingCard>
             )}
             <LetterheadCard lh={lh} onChange={(p) => setLh((s) => ({ ...s, ...p }))} />
@@ -120,7 +154,7 @@ export default function TBeamDesign() {
             ["f'c / fy", `${fc} / ${fy} MPa`], ['Mu', `${Mu} kN·m`], ['d / dt', `${f1(r.d)} / ${f1(r.dt)} mm`],
           ]}
           steps={steps}
-          drawing={<TSection bf={r.bf} bw={bw} h={h} hf={hf} a={r.a} />}
+          drawing={<TSection bf={r.bf} bw={bw} h={h} hf={hf} a={r.a} bars={r.bars} barDia={barDia} layers={r.layers} cover={cover} stirrupDia={stirrupDia} />}
           drawingTitle="T-beam section" />
       )}
     </div>


### PR DESCRIPTION
## What — drawing corrections + professional report figures

Feedback round on the new engines' drawings:

- **Column section** (`ColumnSchematic`, tied): bars are now drawn as the **real cage on all four faces** — 4 corner bars + face bars split in proportion to the face lengths, matching the engine's all-around `barLayers`. (Previously only the two extreme faces were drawn.)
- **T-beam section** (`TSection`): **template dimension lines** added (bf above, h left, hf right, bw below — the shared `DimBelow`/`DimSide` primitives with 45° ticks), and the **stirrup + tension-bar layers** are now drawn in the web; the stress-block `a` label no longer collides with the hf dimension.
- **Prestressed elevation** (`PSElevation`): supports now **seat on the soffit** (pin triangle apex touching the beam, roller tangent under the far end with ground lines), the **UDL renders correctly** (header line + arrows landing on the top edge), the tendon label moved below the beam, and **template dims** added for L, h and e.
- **Beam section** (`BeamSchematic`): redundant **"SECTION" word removed** from inside the drawing and the ensemble **centred** in its card.
- **Export reports**: the drawing block on the printed calc sheet drops from 75% to **46% width** so the reports read professionally.
- **PDF schedule alignment**: right-aligned numeric columns now right-align their **headers** too (autotable's `headStyles` outrank `columnStyles`, so it's set per cell in `didParseCell`) — fixes the misaligned ΣMnc/ΣMnb/ratio columns visible in the exported structure report.

## Verification
- Headless screenshots of all four drawings confirm the fixes (column 8-bar cage 3/2/3, T-beam dims + rebar, prestressed supports/UDL/dims, centred beam section).
- `npx tsc -b` clean · **1113/1113 tests** · zero engine changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_