### PR TITLE
feat: full-width worked solutions (T-beam/prestressed) + wider page shells

### DIFF
--- a/webapp/src/components/qty.tsx
+++ b/webapp/src/components/qty.tsx
@@ -83,7 +83,7 @@ export function QtyPage({ title, reportTitle, intro, children }: {
   title: string; reportTitle: string; intro: ReactNode; children: ReactNode
 }) {
   return (
-    <div className="mx-auto max-w-6xl px-5 py-5 sm:px-7">
+    <div className="mx-auto max-w-[1500px] px-5 py-5 sm:px-7">
       <h1 className="text-[21px] font-extrabold tracking-tight text-[#0f1b2a]">{title}</h1>
       <p className="no-print mt-1 text-[13px] text-[#5c6675]">{intro}</p>
       <ReportControls title={reportTitle} />

--- a/webapp/src/pages/BeamAnalysis.tsx
+++ b/webapp/src/pages/BeamAnalysis.tsx
@@ -105,7 +105,7 @@ export default function BeamAnalysis() {
   const vlines = supports.map((s) => ({ x: s.x, label: s.type === 'spring' ? 'k' : s.type[0].toUpperCase() }))
 
   return (
-    <div className="mx-auto max-w-6xl p-6">
+    <div className="mx-auto max-w-[1500px] p-6">
       <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
       <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Beam Analysis</h1>
       <p className="no-print mt-1 text-slate-600">

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -153,7 +153,7 @@ export default function BeamDesign() {
               className="ml-1.5 inline-flex items-center gap-2 rounded-md bg-[#0f4c92] px-4 py-2 text-[12.5px] font-semibold text-white hover:bg-[#0d3f78]">⎙ Export report</button>
           </div>
         } />
-      <div className="mx-auto max-w-6xl px-5 pb-8 sm:px-7">
+      <div className="mx-auto max-w-[1500px] px-5 pb-8 sm:px-7">
 
       <div className="no-print mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
         <div className="space-y-3.5">

--- a/webapp/src/pages/BoltedConnection.tsx
+++ b/webapp/src/pages/BoltedConnection.tsx
@@ -46,7 +46,7 @@ export default function BoltedConnection() {
   const delBolt = (i: number) => setBolts((bs) => bs.filter((_, j) => j !== i).map((b, k) => ({ ...b, id: `B${k + 1}` })))
 
   return (
-    <main className="mx-auto max-w-5xl px-5 py-10">
+    <main className="mx-auto max-w-[1400px] px-5 py-10">
       <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Structural · Steel</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Eccentric bolted connection</h1>
       <ReportControls title="Bolted Connection Report" badges={['AISC 360-16']} />

--- a/webapp/src/pages/ColumnDesign.tsx
+++ b/webapp/src/pages/ColumnDesign.tsx
@@ -120,7 +120,7 @@ export default function ColumnDesign() {
           <button type="button" onClick={() => { const prev = document.title; document.title = `Column Design Report${lh.project ? ` — ${lh.project}` : ''}`; window.print(); window.setTimeout(() => { document.title = prev }, 500) }}
             className="inline-flex items-center gap-2 rounded-md bg-[#0f4c92] px-4 py-2 text-[12.5px] font-semibold text-white hover:bg-[#0d3f78]">⎙ Export report</button>
         } />
-      <div className="mx-auto max-w-6xl px-5 pb-8 sm:px-7">
+      <div className="mx-auto max-w-[1500px] px-5 pb-8 sm:px-7">
 
       <div className="no-print mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
         <div className="space-y-5">

--- a/webapp/src/pages/CombinedFootingDesign.tsx
+++ b/webapp/src/pages/CombinedFootingDesign.tsx
@@ -173,7 +173,7 @@ export default function CombinedFootingDesign() {
           <button type="button" onClick={() => { const prev = document.title; document.title = `Combined Footing Design Report${lh.project ? ` — ${lh.project}` : ''}`; window.print(); window.setTimeout(() => { document.title = prev }, 500) }}
             className="inline-flex items-center gap-2 rounded-md bg-[#0f4c92] px-4 py-2 text-[12.5px] font-semibold text-white hover:bg-[#0d3f78]">⎙ Export report</button>
         } />
-      <div className="mx-auto max-w-6xl px-5 pb-8 sm:px-7">
+      <div className="mx-auto max-w-[1500px] px-5 pb-8 sm:px-7">
 
       <div className="no-print mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
         {/* ── Inputs ── */}

--- a/webapp/src/pages/DevLength.tsx
+++ b/webapp/src/pages/DevLength.tsx
@@ -55,7 +55,7 @@ export default function DevLength() {
   }, [f])
 
   return (
-    <div className="mx-auto max-w-6xl p-6">
+    <div className="mx-auto max-w-[1500px] p-6">
       <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
       <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">
         Development &amp; Splice Lengths

--- a/webapp/src/pages/Documentation.tsx
+++ b/webapp/src/pages/Documentation.tsx
@@ -69,7 +69,7 @@ function SectionCard({ section }: { section: DocSection }) {
 
 export default function Documentation() {
   return (
-    <main className="mx-auto max-w-6xl px-5 py-6 sm:px-8">
+    <main className="mx-auto max-w-[1500px] px-5 py-6 sm:px-8">
       <Link to="/" className="no-print text-sm font-medium text-[#0056b3] hover:underline">Back to home</Link>
 
       <header className="mt-4 border-b border-slate-200 pb-8">

--- a/webapp/src/pages/FoundationDesign.tsx
+++ b/webapp/src/pages/FoundationDesign.tsx
@@ -278,7 +278,7 @@ export default function FoundationDesign() {
             ⎙ Export report
           </button>
         } />
-      <div className="mx-auto max-w-6xl px-5 pb-8 sm:px-7">
+      <div className="mx-auto max-w-[1500px] px-5 pb-8 sm:px-7">
       <div className="no-print"><ExcelImport onResult={setBatch} /></div>
 
       {batch && (

--- a/webapp/src/pages/FrameAnalysis.tsx
+++ b/webapp/src/pages/FrameAnalysis.tsx
@@ -88,7 +88,7 @@ export default function FrameAnalysis() {
   const updMember = upd(setMembers)
 
   return (
-    <div className="mx-auto max-w-6xl p-6">
+    <div className="mx-auto max-w-[1500px] p-6">
       <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
       <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Frame Analysis (2D)</h1>
       <p className="no-print mt-1 text-slate-600">

--- a/webapp/src/pages/Geotech.tsx
+++ b/webapp/src/pages/Geotech.tsx
@@ -134,7 +134,7 @@ function Slope() {
 
 export default function Geotech() {
   return (
-    <main className="mx-auto max-w-5xl px-5 py-10">
+    <main className="mx-auto max-w-[1400px] px-5 py-10">
       <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Geotechnical toolkit</h1>
       <ReportControls title="Geotechnical Report" badges={['NSCP 2015']} />

--- a/webapp/src/pages/LoadCombinations.tsx
+++ b/webapp/src/pages/LoadCombinations.tsx
@@ -20,7 +20,7 @@ export default function LoadCombinations() {
   )
 
   return (
-    <div className="mx-auto max-w-4xl p-6">
+    <div className="mx-auto max-w-[1200px] p-6">
       <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
       <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">
         Load Combinations

--- a/webapp/src/pages/LoadPath.tsx
+++ b/webapp/src/pages/LoadPath.tsx
@@ -48,7 +48,7 @@ export default function LoadPath() {
   }
 
   return (
-    <div className="mx-auto max-w-6xl p-6">
+    <div className="mx-auto max-w-[1500px] p-6">
       <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
       <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Slab Load Path (Tributary)</h1>
       <p className="no-print mt-1 text-slate-600">

--- a/webapp/src/pages/PileCapDesign.tsx
+++ b/webapp/src/pages/PileCapDesign.tsx
@@ -165,7 +165,7 @@ export default function PileCapDesign() {
           <button type="button" onClick={() => { const prev = document.title; document.title = `Pile Cap Design Report${lh.project ? ` — ${lh.project}` : ''}`; window.print(); window.setTimeout(() => { document.title = prev }, 500) }}
             className="inline-flex items-center gap-2 rounded-md bg-[#0f4c92] px-4 py-2 text-[12.5px] font-semibold text-white hover:bg-[#0d3f78]">⎙ Export report</button>
         } />
-      <div className="mx-auto max-w-6xl px-5 pb-8 sm:px-7">
+      <div className="mx-auto max-w-[1500px] px-5 pb-8 sm:px-7">
 
       <div className="no-print mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
         {/* ── Inputs ── */}

--- a/webapp/src/pages/PrestressedBeam.tsx
+++ b/webapp/src/pages/PrestressedBeam.tsx
@@ -71,7 +71,7 @@ export default function PrestressedBeam() {
   return (
     <div className="min-h-screen">
       <PageHeader title="Prestressed Beam" badges={[...badges, `class ${klass}`]} />
-      <div className="mx-auto max-w-6xl px-5 py-5 sm:px-7">
+      <div className="mx-auto max-w-[1500px] px-5 py-5 sm:px-7">
         <p className="no-print text-[13px] text-[#5c6675]">
           <Link to="/" className="font-semibold text-[#0f4c92]">← Home</Link> · Pretensioned bonded beam: PCI losses
           (ES/CR/SH/RE), §24.5 transfer & service stress limits, fps per §20.3.2.3.1, φMn ≥ 1.2Mcr, Vci/Vcw, camber.
@@ -98,7 +98,6 @@ export default function PrestressedBeam() {
               <Num label="Superimposed DL" unit="kN/m" value={wSDL} onChange={setWSDL} />
               <Num label="Live load" unit="kN/m" value={wLL} onChange={setWLL} />
             </Card>
-            {r && <WorkedSolution steps={steps} title="Prestressed beam — worked solution" />}
           </div>
           <div className="space-y-4 lg:sticky lg:top-4 lg:self-start">
             {r && (
@@ -124,6 +123,11 @@ export default function PrestressedBeam() {
             <LetterheadCard lh={lh} onChange={(p) => setLh((s) => ({ ...s, ...p }))} />
           </div>
         </div>
+        {r && (
+          <div className="no-print mt-5">
+            <WorkedSolution steps={steps} title="Prestressed beam — worked solution" />
+          </div>
+        )}
       </div>
       {r && (
         <PrintReport docTitle="Prestressed Beam" docCode="PS-01" badges={badges} ok={r.ok}

--- a/webapp/src/pages/PunchingShear.tsx
+++ b/webapp/src/pages/PunchingShear.tsx
@@ -56,7 +56,7 @@ export default function PunchingShear() {
   }, [JSON.stringify(f), allFinite, d])
 
   return (
-    <div className="mx-auto max-w-6xl p-6">
+    <div className="mx-auto max-w-[1500px] p-6">
       <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
       <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">
         Punching Shear

--- a/webapp/src/pages/RetainingWall.tsx
+++ b/webapp/src/pages/RetainingWall.tsx
@@ -48,7 +48,7 @@ export default function RetainingWall() {
           <button type="button" onClick={() => { const prev = document.title; document.title = `Retaining Wall Design Report${lh.project ? ` — ${lh.project}` : ''}`; window.print(); window.setTimeout(() => { document.title = prev }, 500) }}
             className="inline-flex items-center gap-2 rounded-md bg-[#0f4c92] px-4 py-2 text-[12.5px] font-semibold text-white hover:bg-[#0d3f78]">⎙ Export report</button>
         } />
-      <div className="mx-auto max-w-6xl px-5 pb-8 sm:px-7">
+      <div className="mx-auto max-w-[1500px] px-5 pb-8 sm:px-7">
 
       {/* Schematic legend */}
       <pre className="no-print mt-3 rounded-lg border border-slate-200 bg-slate-50 p-3 text-[0.65rem] leading-tight text-slate-500">

--- a/webapp/src/pages/SlabDesign.tsx
+++ b/webapp/src/pages/SlabDesign.tsx
@@ -104,7 +104,7 @@ export default function SlabDesign() {
   const defl = r?.deflection
 
   return (
-    <div className="mx-auto max-w-6xl p-6">
+    <div className="mx-auto max-w-[1500px] p-6">
       <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
       <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Two-Way Slab Design</h1>
       <p className="no-print mt-1 text-slate-600">

--- a/webapp/src/pages/SteelDesign.tsx
+++ b/webapp/src/pages/SteelDesign.tsx
@@ -656,7 +656,7 @@ export default function SteelDesign() {
     </button>
   )
   return (
-    <div className="mx-auto max-w-7xl p-6">
+    <div className="mx-auto max-w-[1500px] p-6">
       <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
       <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Steel Design</h1>
       <p className="no-print mt-1 text-slate-600">

--- a/webapp/src/pages/TBeamDesign.tsx
+++ b/webapp/src/pages/TBeamDesign.tsx
@@ -83,7 +83,7 @@ export default function TBeamDesign() {
   return (
     <div className="min-h-screen">
       <PageHeader title="T-Beam Design" badges={[...badges, kind]} />
-      <div className="mx-auto max-w-6xl px-5 py-5 sm:px-7">
+      <div className="mx-auto max-w-[1500px] px-5 py-5 sm:px-7">
         <p className="no-print text-[13px] text-[#5c6675]">
           <Link to="/" className="font-semibold text-[#0f4c92]">← Home</Link> · Flanged-beam flexure: §6.3.2 effective width,
           rectangular vs true-T stress block, §9.6.1.2 minimum steel, εt/φ per §21.2.2. Positive Mu = flange in compression.
@@ -110,7 +110,6 @@ export default function TBeamDesign() {
             <Card title="Demand" hint="+ sagging / − hogging">
               <Num label="Mu" unit="kN·m" value={Mu} onChange={setMu} />
             </Card>
-            {r && <WorkedSolution steps={steps} title="T-beam — worked solution" />}
           </div>
           <div className="space-y-4 lg:sticky lg:top-4 lg:self-start">
             {r && (
@@ -135,6 +134,11 @@ export default function TBeamDesign() {
             <LetterheadCard lh={lh} onChange={(p) => setLh((s) => ({ ...s, ...p }))} />
           </div>
         </div>
+        {r && (
+          <div className="no-print mt-5">
+            <WorkedSolution steps={steps} title="T-beam — worked solution" />
+          </div>
+        )}
       </div>
       {r && (
         <PrintReport docTitle="T-Beam" docCode="TB-01" badges={badges} ok={r.ok}

--- a/webapp/src/pages/TorsionDesign.tsx
+++ b/webapp/src/pages/TorsionDesign.tsx
@@ -35,7 +35,7 @@ export default function TorsionDesign() {
   )
 
   return (
-    <div className="mx-auto max-w-6xl p-6">
+    <div className="mx-auto max-w-[1500px] p-6">
       <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
       <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">
         Torsion Design

--- a/webapp/src/pages/Validation.tsx
+++ b/webapp/src/pages/Validation.tsx
@@ -40,7 +40,7 @@ export default function Validation() {
   }).filter((g) => g.n > 0)
 
   return (
-    <main className="mx-auto max-w-5xl px-5 py-10">
+    <main className="mx-auto max-w-[1400px] px-5 py-10">
       <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Reference</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Validation</h1>
       <p className="mt-2 max-w-3xl text-sm text-slate-600">

--- a/webapp/src/pages/WeldedConnection.tsx
+++ b/webapp/src/pages/WeldedConnection.tsx
@@ -59,7 +59,7 @@ export default function WeldedConnection() {
   const delSeg = (i: number) => setSegs((ss) => ss.filter((_, j) => j !== i).map((s, k) => ({ ...s, id: `W${k + 1}` })))
 
   return (
-    <main className="mx-auto max-w-5xl px-5 py-10">
+    <main className="mx-auto max-w-[1400px] px-5 py-10">
       <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Structural · Steel</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Eccentric weld group</h1>
       <ReportControls title="Welded Connection Report" badges={['AISC 360-16']} />


### PR DESCRIPTION
## What

- **Full-width worked solutions** — on the T-Beam and Prestressed Beam pages the worked solution moves out of the left input column to a full-width block below the input/verdict grid, so the numbered steps and formulas get the entire sheet width (as requested).
- **Wider page shells** — the side blanks shrink on every calculator page: `max-w-6xl`/`7xl` → **1500px**, `max-w-5xl` → **1400px** (Bolted/Welded Connection, Geotech, Validation), Load Combinations `4xl` → 1200px, plus the shared `QtyPage` shell (Stair, Water Tank, estimates…).

## Verification
- Headless at 1800px viewport: the T-beam worked solution spans **1444px** below the grid; wider shells confirmed.
- `npx tsc -b` clean · **1113/1113 tests** · zero engine changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_