### PR TITLE
feat: schedule pass/fail chips, T-beam section drawings, PDF section figures, paired bar layers

### DIFF
--- a/webapp/src/components/TSection.tsx
+++ b/webapp/src/components/TSection.tsx
@@ -1,0 +1,55 @@
+import { DimBelow, DimSide } from './dims'
+
+/** Flanged (T / L) beam cross-section to scale: outline, optional compression
+ *  stress block, stirrup + tension-bar layers in the web, and the shared
+ *  dimension-line template (bf above, h left, hf right, bw below). Reused by
+ *  the standalone T-beam page and the 3D Model Space beam schedule. */
+export function TSection({ bf, bw, h, hf, a = 0, bars = 0, barDia = 0, layers = [], cover = 40, stirrupDia = 10 }: {
+  bf: number; bw: number; h: number; hf: number; a?: number
+  bars?: number; barDia?: number; layers?: number[]; cover?: number; stirrupDia?: number
+}) {
+  const W = 340, HT = 285
+  const availW = 210, availH = 200
+  const S = Math.min(availW / bf, availH / h)
+  const w = bf * S, ht = h * S, wf = bw * S, hff = hf * S, A = Math.min(a, h) * S
+  const x0 = (W - w) / 2, y0 = 40
+  const xw = x0 + (w - wf) / 2
+  const inset = (cover + stirrupDia / 2) * S
+  const br = Math.max(2.5, (barDia / 2) * S)
+  const barRows: { y: number; n: number }[] = []
+  layers.forEach((n, li) => {
+    barRows.push({ y: y0 + ht - (cover + stirrupDia + barDia / 2 + li * (barDia + 25)) * S, n })
+  })
+  const bx1 = xw + (cover + stirrupDia + barDia / 2) * S
+  const bx2 = xw + wf - (cover + stirrupDia + barDia / 2) * S
+  return (
+    <svg viewBox={`0 0 ${W} ${HT}`} className="mx-auto block w-full max-w-[360px]" style={{ fontFamily: 'Arial, sans-serif' }}>
+      <path d={`M${x0} ${y0} h${w} v${hff} h${-(w - wf) / 2} v${ht - hff} h${-wf} v${-(ht - hff)} h${-(w - wf) / 2} z`}
+        fill="#eef3f8" stroke="#37526e" strokeWidth="1.6" />
+      {a > 0 && <>
+        <rect x={x0} y={y0} width={w} height={Math.min(A, hff)} fill="#0f4c92" opacity="0.16" />
+        {A > hff && <rect x={xw} y={y0 + hff} width={wf} height={A - hff} fill="#0f4c92" opacity="0.16" />}
+        <line x1={x0 - 6} y1={y0 + A} x2={x0 + w + 6} y2={y0 + A} stroke="#0f4c92" strokeWidth="1.2" strokeDasharray="5 3" />
+        <text x={x0 + w - 4} y={y0 + A + 11} fontSize="8.5" fontFamily="IBM Plex Mono, monospace" fill="#0f4c92" textAnchor="end">a = {a.toFixed(0)}</text>
+      </>}
+      {/* stirrup in the web */}
+      <rect x={xw + inset} y={y0 + hff * 0.35} width={wf - 2 * inset} height={ht - hff * 0.35 - inset}
+        rx={Math.max(2, 2 * stirrupDia * S)} fill="none" stroke="#37526e" strokeWidth={Math.max(1, stirrupDia * S)} opacity="0.8" />
+      {/* tension bars */}
+      {barRows.map((row, li) => Array.from({ length: row.n }, (_, i) => (
+        <circle key={`${li}-${i}`} r={br} fill="#37526e"
+          cx={row.n === 1 ? (bx1 + bx2) / 2 : bx1 + ((bx2 - bx1) * i) / (row.n - 1)} cy={row.y} />
+      )))}
+      {bars > 0 && (
+        <text x={W / 2} y={y0 + ht + 14} fontSize="8.5" fill="#37526e" textAnchor="middle">
+          {bars} ⌀{barDia} mm · stirrup ⌀{stirrupDia}
+        </text>
+      )}
+      {/* dimension lines (shared template) */}
+      <DimBelow xA={x0} xB={x0 + w} featY={y0} dY={y0 - 18} label={`bf = ${Math.round(bf)} mm`} />
+      <DimBelow xA={xw} xB={xw + wf} featY={y0 + ht + (bars > 0 ? 18 : 4)} dY={y0 + ht + (bars > 0 ? 34 : 20)} label={`bw = ${Math.round(bw)} mm`} />
+      <DimSide yA={y0} yB={y0 + ht} featX={x0 > 40 ? x0 + (w - wf) / 2 : x0} dX={Math.min(x0, xw) - 16} label={`h = ${Math.round(h)} mm`} side="left" />
+      <DimSide yA={y0} yB={y0 + hff} featX={x0 + w} dX={x0 + w + 16} label={`hf = ${Math.round(hf)}`} side="right" />
+    </svg>
+  )
+}

--- a/webapp/src/engine/beamDesign.test.ts
+++ b/webapp/src/engine/beamDesign.test.ts
@@ -60,6 +60,16 @@ describe('beam design — bar layout & layers (§407.7, Varignon)', () => {
     expect(fits).toBeLessThanOrEqual(bw + 1e-9)
     expect(oneMore).toBeGreaterThan(bw)
   })
+
+  it('never leaves a lone bar in an upper layer — pairs it (2 bars beside the stirrups)', () => {
+    // Sweep demands that land on odd totals; a multi-layer result must never
+    // end in a single-bar top layer, and bars must stay consistent with layers.
+    for (let Mu = 200; Mu <= 900; Mu += 20) {
+      const r = designBeam({ ...base, b: 250, h: 650, Mu, barDia: 20 })
+      if (r.layers.length > 1) expect(r.layers[r.layers.length - 1]).toBeGreaterThanOrEqual(2)
+      expect(r.bars).toBe(r.layers.reduce((s, k) => s + k, 0))
+    }
+  })
 })
 
 describe('beam design — DRRB (compression steel)', () => {

--- a/webapp/src/engine/beamDesign.ts
+++ b/webapp/src/engine/beamDesign.ts
@@ -92,16 +92,26 @@ const PHI_SHEAR = 0.75
 const LAYER_CLEAR = 25       // §407.7.2 clear distance between layers, mm
 const roundDown = (v: number, step: number) => Math.floor(v / step) * step
 
-/** Split n bars into layers of at most maxPerLayer, fullest at the bottom. */
-function splitLayers(n: number, maxPerLayer: number): number[] {
-  const layers: number[] = []
-  let left = n
-  while (left > 0) {
-    const take = Math.min(left, maxPerLayer)
-    layers.push(take)
-    left -= take
+/** Split n bars into layers of at most maxPerLayer, fullest at the bottom.
+ *  Detailing rule: no layer carries a single bar — a lone bar in the top
+ *  (least-full) layer is paired with a second so the two sit beside the
+ *  stirrup legs on each side. Pairing adds one bar (conservative on As).
+ *  Returns the (possibly bumped) total count alongside the layer vector. */
+function splitLayers(n: number, maxPerLayer: number): { bars: number; layers: number[] } {
+  let total = n
+  const build = (m: number): number[] => {
+    const out: number[] = []
+    let left = m
+    while (left > 0) { const take = Math.min(left, maxPerLayer); out.push(take); left -= take }
+    return out
   }
-  return layers
+  let layers = build(total)
+  // pair a lone top-layer bar (only meaningful once the section holds ≥ 2/layer)
+  if (maxPerLayer >= 2 && layers.length > 1 && layers[layers.length - 1] === 1) {
+    total += 1
+    layers = build(total)
+  }
+  return { bars: total, layers }
 }
 
 /** Centroid rise of the bar group above the extreme (bottom) layer — Varignon. */
@@ -191,16 +201,19 @@ export function designBeam(i: BeamDesignInput): BeamDesignResult {
       AsPrime = comprEffective ? (As2 * i.fy) / (fsPrime - 0.85 * i.fc) : 0
     }
 
-    // Tension side: bars → layers → Varignon → new d.
-    bars = Math.max(2, Math.ceil(As / Ab))
-    const newLayers = splitLayers(bars, maxPerLayer)
+    // Tension side: bars → layers (lone-bar pairing) → Varignon → new d.
+    const tenSplit = splitLayers(Math.max(2, Math.ceil(As / Ab)), maxPerLayer)
+    bars = tenSplit.bars
+    const newLayers = tenSplit.layers
     yBar = centroidRise(newLayers, pitch)
     const dNew = dt - yBar
 
     // Compression side: same technique, layered downward from the top face —
     // stacking layers DEEPENS d' (centroid drops), which feeds back into As2.
-    comprBars = mode === 'DRRB' && comprEffective ? Math.max(2, Math.ceil(AsPrime / AbC)) : 0
-    const newComprLayers = comprBars > 0 ? splitLayers(comprBars, comprMaxPerLayer) : []
+    const comprSplit = mode === 'DRRB' && comprEffective
+      ? splitLayers(Math.max(2, Math.ceil(AsPrime / AbC)), comprMaxPerLayer) : { bars: 0, layers: [] as number[] }
+    comprBars = comprSplit.bars
+    const newComprLayers = comprSplit.layers
     comprYBar = centroidRise(newComprLayers, pitchC)
     const dPrimeNew = dPrimeBase + comprYBar
 

--- a/webapp/src/lib/modelPdf.ts
+++ b/webapp/src/lib/modelPdf.ts
@@ -8,7 +8,7 @@
 import { jsPDF } from 'jspdf'
 import autoTable from 'jspdf-autotable'
 import type { LetterheadState } from '../components/calc'
-import type { ModelReport } from './modelReport'
+import type { ModelReport, ReportSection } from './modelReport'
 import { texToPlain } from './texText'
 import { SANS, SANS_BOLD, MONO, MONO_BOLD } from './pdfFonts'
 
@@ -84,6 +84,64 @@ export async function generateModelPdf({ lh, report, modelImg, badges, fileName 
     doc.text(label, x + 1.5, cy)
     return w
   }
+  const CONC: [number, number, number] = [238, 243, 248]
+  /** Vector cross-section (bar layout) drawn into a boxW×boxH mm cell at (x, topY). */
+  const drawSection = (sec: ReportSection, x: number, topY: number, boxW: number, boxH: number) => {
+    const flanged = sec.kind === 'beam' && !!sec.bf && sec.bf > sec.b && !sec.hogging && !!sec.hf
+    const drawW = flanged ? sec.bf! : sec.b
+    const s = Math.min((boxW - 3) / drawW, (boxH - 3) / sec.h)
+    const wv = drawW * s, hv = sec.h * s, bwv = sec.b * s
+    const bx = x + (boxW - wv) / 2, by = topY + (boxH - hv) / 2
+    const webX = bx + (wv - bwv) / 2
+    doc.setLineWidth(0.25); doc.setDrawColor(...INK); doc.setFillColor(...CONC)
+    if (flanged) {
+      const hfv = sec.hf! * s
+      doc.rect(webX, by, bwv, hv, 'FD')       // web (full height)
+      doc.rect(bx, by, wv, hfv, 'FD')         // flange cap
+    } else {
+      doc.rect(webX, by, bwv, hv, 'FD')
+    }
+    // tie / stirrup
+    const ins = (sec.cover + sec.stirrupDia / 2) * s
+    doc.setDrawColor(...MUTED); doc.setLineWidth(0.35)
+    doc.roundedRect(webX + ins, by + ins, bwv - 2 * ins, hv - 2 * ins, 0.6, 0.6, 'S')
+    // bars
+    const br = Math.max(0.5, (sec.barDia / 2) * s)
+    const barIns = (sec.cover + sec.stirrupDia + sec.barDia / 2) * s
+    const bx1 = webX + barIns, bx2 = webX + bwv - barIns
+    const spanX = (n: number, i: number) => (n <= 1 ? (bx1 + bx2) / 2 : bx1 + ((bx2 - bx1) * i) / (n - 1))
+    doc.setFillColor(...INK); doc.setDrawColor(...INK); doc.setLineWidth(0.25)
+    if (sec.kind === 'beam') {
+      const pitch = (sec.barDia + 25) * s
+      const tenBottom = !sec.hogging
+      ;(sec.layers ?? [sec.bars]).forEach((n, li) => {
+        const yb = tenBottom ? by + hv - barIns - li * pitch : by + barIns + li * pitch
+        for (let i = 0; i < n; i++) doc.circle(spanX(n, i), yb, br, 'F')
+      })
+      ;(sec.comprLayers ?? []).forEach((n, li) => {
+        const yb = tenBottom ? by + barIns + li * pitch : by + hv - barIns - li * pitch
+        for (let i = 0; i < n; i++) doc.circle(spanX(n, i), yb, br, 'S')   // hollow
+      })
+    } else {
+      // column — bars around the perimeter (all-around) or two faces
+      const N = Math.max(4, 2 * Math.round(sec.bars / 2))
+      const bwIn = sec.b - 2 * barIns / s, hIn = sec.h - 2 * barIns / s
+      const nx = sec.fourFace ? Math.max(2, Math.min(N / 2, 2 + Math.round(((N - 4) / 2) * (bwIn / (bwIn + hIn))))) : N / 2
+      const ny = sec.fourFace ? N / 2 + 2 - nx : 2
+      const yTop = by + barIns, yBot = by + hv - barIns
+      for (let i = 0; i < nx; i++) { doc.circle(spanX(nx, i), yTop, br, 'F'); doc.circle(spanX(nx, i), yBot, br, 'F') }
+      for (let k = 1; k <= ny - 2; k++) {
+        const yy = yTop + ((yBot - yTop) * k) / (ny - 1)
+        doc.circle(bx1, yy, br, 'F'); doc.circle(bx2, yy, br, 'F')
+      }
+    }
+    setF('mono', 'normal', 5, FAINT)
+    const cap = sec.kind === 'beam'
+      ? `${sec.bars}⌀${sec.barDia}${flanged ? ` · T bf=${Math.round(sec.bf!)}` : ''}`
+      : `${sec.bars}⌀${sec.barDia} · ${sec.b}×${sec.h}`
+    doc.text(cap, x + boxW / 2, topY + boxH - 0.5, { align: 'center' })
+  }
+
   const tableTheme = (right: number[] = []) => ({
     margin: { left: M, right: M, bottom: PAGE_H - FOOT_Y + 2 },
     styles: {
@@ -316,6 +374,17 @@ export async function generateModelPdf({ lh, report, modelImg, badges, fileName 
         doc.line(M, y, M + CONTENT_W, y)
         y += 3
       })
+      // cross-section figure — the bar layout in the section
+      if (item.section) {
+        const boxW = 46, boxH = 34
+        ensure(boxH + 4)
+        setF('sans', 'bold', 5.5, FAINT)
+        doc.text('SECTION', M + 1, y + 2)
+        doc.setDrawColor(...HAIR); doc.setLineWidth(0.2)
+        doc.roundedRect(M, y + 3, boxW, boxH, 1, 1, 'S')
+        drawSection(item.section, M, y + 3, boxW, boxH)
+        y += boxH + 5
+      }
       y += 2
     })
   })

--- a/webapp/src/lib/modelReport.ts
+++ b/webapp/src/lib/modelReport.ts
@@ -17,7 +17,19 @@ import type { SolutionStep, SolutionLine } from './solution'
 export interface ReportStat { label: string; value: string; unit?: string }
 export interface ReportCheck { name: string; detail: string; ratio: number | null; ok: boolean }
 export interface ReportTable { title: string; head: string[]; rows: string[][]; right?: number[] }
-export interface ReportSolution { title: string; sub?: string; steps: SolutionStep[] }
+/** Cross-section geometry for a member, drawn (vector) in the PDF report so the
+ *  reader can see the bar layout in the section. */
+export interface ReportSection {
+  kind: 'beam' | 'column'
+  b: number; h: number; cover: number; barDia: number; stirrupDia: number
+  bars: number
+  layers?: number[]         // beam: tension bars per layer (bottom-first)
+  comprLayers?: number[]    // beam: compression bars per layer (top-first)
+  hogging?: boolean         // beam: tension steel at the top
+  bf?: number; hf?: number  // beam: T-flange (sagging flanged section)
+  fourFace?: boolean        // column: bars distributed on all four faces
+}
+export interface ReportSolution { title: string; sub?: string; steps: SolutionStep[]; section?: ReportSection }
 export interface ReportGroup { title: string; items: ReportSolution[] }
 export interface ModelReport {
   ok: boolean
@@ -281,6 +293,11 @@ export function buildModelReport(
         title: `${bm.id} · ${s.label}`,
         sub: `${bm.role} ${sec.name} · L = ${f1(bm.L)} m · ${bm.gov ?? ''}`,
         steps: beamSectionSolution(sec, s),
+        section: {
+          kind: 'beam' as const, b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia, stirrupDia: sec.tieDia,
+          bars: s.design.bars, layers: s.design.layers, comprLayers: s.design.comprLayers,
+          hogging: s.hogging, bf: s.bf, hf: s.hf,
+        },
       }))
     }),
   })
@@ -303,7 +320,13 @@ export function buildModelReport(
     title: 'RC columns',
     items: design.columns.flatMap((c) => {
       const cs = sectionFor(c.id)
-      return cs ? [{ title: c.id, sub: `${cs.name} · L = ${f1(c.L)} m · ${c.gov ?? ''}`, steps: columnRowSolution(cs, c) }] : []
+      return cs ? [{
+        title: c.id, sub: `${cs.name} · L = ${f1(c.L)} m · ${c.gov ?? ''}`, steps: columnRowSolution(cs, c),
+        section: {
+          kind: 'column' as const, b: cs.b, h: cs.h, cover: cs.cover, barDia: cs.barDia, stirrupDia: cs.tieDia,
+          bars: c.bars, fourFace: c.layout === 'all-around',
+        },
+      }] : []
     }),
   })
   if (design.steelBeams.length) groups.push({

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -49,6 +49,7 @@ import { elasticResponseSpectrum, nscp208DesignCurve, type AccelSpectrum, type D
 import { parseAccelerogram } from '../engine/accelerogram'
 import type { TimeHistoryModelResult, GroundMotionKind, CsvAccelerogramOpts } from '../engine/timeHistoryModel'
 import { BeamSchematic } from '../components/BeamSchematic'
+import { TSection } from '../components/TSection'
 import { ColumnSchematic } from '../components/ColumnSchematic'
 import { FootingSchematic } from '../components/FootingSchematic'
 import { DimBelow, DimSide } from '../components/dims'
@@ -588,6 +589,19 @@ function TabBtn({ id, label, active, onClick }: { id: Tab; label: string; active
       className={`rounded-[5px] px-2.5 py-[5px] text-[11.5px] font-semibold transition ${active ? 'bg-[#0f4c92] text-white' : 'text-[#5c6675] hover:bg-[#eaf1f9] hover:text-[#0f1b2a]'}`}>
       {label}
     </button>
+  )
+}
+
+/** Pass/fail pill for a schedule title — "all passed" (green) or "n failed"
+ *  (red). `items` are the rows, `ok` maps a row to its verdict. */
+function SchedChip<T>({ items, ok }: { items: T[]; ok: (r: T) => boolean }) {
+  const failed = items.reduce((n, r) => n + (ok(r) ? 0 : 1), 0)
+  const good = failed === 0
+  return (
+    <span className={`ml-2 inline-block rounded px-1.5 py-px align-middle font-mono text-[10px] font-semibold ${
+      good ? 'bg-[#ddefe3] text-[#14603a]' : 'bg-[#fbeeea] text-[#c2402a]'}`}>
+      {good ? 'all passed' : `${failed} failed`}
+    </span>
   )
 }
 
@@ -2280,6 +2294,15 @@ export default function ModelSpace() {
                 <Num label="Clear cover" unit="mm" value={cover} onChange={setCover} step="5" />
                 <Num label="Concrete unit wt γc" unit="kN/m³" value={gammaC} onChange={setGammaC} step="0.5" />
               </Sec>
+              <Sec title="Beam design method" hint="flanged / rectangular">
+                <label className="col-span-full flex items-center gap-2 text-sm">
+                  <input type="checkbox" checked={tBeamOn} onChange={(e) => setTBeamOn(e.target.checked)} />
+                  <span>Design beams as T-beams — §6.3.2 flange from the adjoining slabs for sagging sections (when a ≤ hf). Off = plain rectangular web.</span>
+                </label>
+                <p className="col-span-full text-[11px] text-slate-500">
+                  Sagging sections that get flange action are tagged “T bf=…” in the schedule and drawn as a T-section.
+                </p>
+              </Sec>
               <Sec title="Prestressing — beams & girders" hint="§24.5 · PCI losses">
                 <label className="col-span-full flex items-center gap-2 text-sm">
                   <input type="checkbox" checked={psOn} onChange={(e) => setPsOn(e.target.checked)} />
@@ -2927,10 +2950,6 @@ export default function ModelSpace() {
                   <span>Column bars on all four faces — P–M strain-compatibility layers (real cage; lower Mb)</span>
                 </label>
                 <label className="col-span-full flex items-center gap-2 text-sm">
-                  <input type="checkbox" checked={tBeamOn} onChange={(e) => setTBeamOn(e.target.checked)} />
-                  <span>T-beam action — §6.3.2 flange from adjoining slabs for sagging sections (a ≤ hf)</span>
-                </label>
-                <label className="col-span-full flex items-center gap-2 text-sm">
                   <input type="checkbox" disabled={!model} checked={model?.diaphragm ?? false}
                     onChange={(e) => model && save({ ...model, diaphragm: e.target.checked })} />
                   <span>Rigid floor diaphragm (ties in-plane lateral DOFs per storey)</span>
@@ -3557,7 +3576,7 @@ export default function ModelSpace() {
 
           {/* Beam & girder schedule — RC only */}
           {design.beams.length > 0 && <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-            <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">RC beam & girder schedule</h3>
+            <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">RC beam & girder schedule<SchedChip items={design.beams} ok={(b) => b.ok} /></h3>
             <table className="w-full border-collapse text-xs">
               <thead>
                 <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
@@ -3609,11 +3628,17 @@ export default function ModelSpace() {
                             <div className="space-y-3 self-start rounded-lg border border-slate-200 bg-white p-3">
                               <BeamRebarElevation L={bm.L} h={sec.h} sections={bm.sections} />
                               <div className="border-t border-slate-100 pt-2">
-                                <p className="mb-1 text-[11px] font-semibold text-[#0f4c92]">SECTION — {s.label}</p>
-                                <BeamSchematic b={sec.b} h={sec.h} cover={sec.cover} barDia={sec.barDia} stirrupDia={sec.tieDia}
-                                  bars={d.bars} d={d.d} dPrime={d.comprLayers.length > 0 ? d.dPrime : undefined}
-                                  layers={d.layers} comprLayers={d.comprLayers} comprBars={d.comprBars} comprBarDia={16}
-                                  naDepth={d.cNA} flexOK={d.flexOK} hogging={s.hogging} />
+                                <p className="mb-1 text-[11px] font-semibold text-[#0f4c92]">SECTION — {s.label}{s.bf ? ' (T-beam)' : ''}</p>
+                                {s.bf && s.hf ? (
+                                  <TSection bf={s.bf} bw={sec.b} h={sec.h} hf={s.hf}
+                                    a={(d.bars * (Math.PI / 4) * sec.barDia ** 2 * sec.fy) / (0.85 * sec.fc * s.bf)}
+                                    bars={d.bars} barDia={sec.barDia} layers={d.layers} cover={sec.cover} stirrupDia={sec.tieDia} />
+                                ) : (
+                                  <BeamSchematic b={sec.b} h={sec.h} cover={sec.cover} barDia={sec.barDia} stirrupDia={sec.tieDia}
+                                    bars={d.bars} d={d.d} dPrime={d.comprLayers.length > 0 ? d.dPrime : undefined}
+                                    layers={d.layers} comprLayers={d.comprLayers} comprBars={d.comprBars} comprBarDia={16}
+                                    naDepth={d.cNA} flexOK={d.flexOK} hogging={s.hogging} />
+                                )}
                               </div>
                             </div>
                             )}
@@ -3629,7 +3654,7 @@ export default function ModelSpace() {
 
           {/* Prestressed member checks */}
           {design.prestressed.length > 0 && <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-            <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Prestressed member checks (§24.5 · PCI)</h3>
+            <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Prestressed member checks (§24.5 · PCI)<SchedChip items={design.prestressed} ok={(pr) => pr.ok} /></h3>
             <table className="w-full border-collapse text-xs">
               <thead>
                 <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
@@ -3662,7 +3687,7 @@ export default function ModelSpace() {
 
           {/* Column schedule (full width) — RC only */}
           {design.columns.length > 0 && <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-            <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">RC column schedule</h3>
+            <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">RC column schedule<SchedChip items={design.columns} ok={(c) => c.ok} /></h3>
             <table className="w-full border-collapse text-xs">
               <thead>
                 <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
@@ -3729,7 +3754,7 @@ export default function ModelSpace() {
           {/* Strong-column/weak-beam joint check — NSCP §418.7.3.2 (SMF only) */}
           {design.scwb.length > 0 && report !== 'draw-only' && (
             <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Strong-column / weak-beam — NSCP §418.7.3.2</h3>
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Strong-column / weak-beam — NSCP §418.7.3.2<SchedChip items={design.scwb} ok={(j) => j.ok} /></h3>
               <table className="w-full border-collapse text-xs">
                 <thead>
                   <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
@@ -3765,7 +3790,7 @@ export default function ModelSpace() {
           {/* Slab schedule (full width) — two-way DDM */}
           {design.slabs.length > 0 && report !== 'draw-only' && (
             <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Slab schedule (two-way DDM)</h3>
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Slab schedule (two-way DDM)<SchedChip items={design.slabs} ok={(x) => x.ok} /></h3>
               <table className="w-full border-collapse text-xs">
                 <thead>
                   <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
@@ -3873,7 +3898,7 @@ export default function ModelSpace() {
           {/* Shear-wall schedule (full width) — in-plane reinforcement */}
           {design.walls.length > 0 && report !== 'draw-only' && (
             <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Shear-wall schedule (in-plane)</h3>
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Shear-wall schedule (in-plane)<SchedChip items={design.walls} ok={(w) => w.ok} /></h3>
               <table className="w-full border-collapse text-xs">
                 <thead>
                   <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
@@ -3939,7 +3964,7 @@ export default function ModelSpace() {
           {/* Steel beam schedule (full width) — only when steel members exist */}
           {design.steelBeams.length > 0 && (
             <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Steel beam / girder schedule — AISC 360-16 LRFD</h3>
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Steel beam / girder schedule — AISC 360-16 LRFD<SchedChip items={design.steelBeams} ok={(b) => b.ok} /></h3>
               <table className="w-full border-collapse text-xs">
                 <thead>
                   <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
@@ -4074,7 +4099,7 @@ export default function ModelSpace() {
           {/* Steel column schedule (full width) */}
           {design.steelColumns.length > 0 && (
             <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Steel column schedule — AISC §E3 + §H1-1</h3>
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Steel column schedule — AISC §E3 + §H1-1<SchedChip items={design.steelColumns} ok={(c) => c.ok} /></h3>
               <table className="w-full border-collapse text-xs">
                 <thead>
                   <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
@@ -4191,7 +4216,7 @@ export default function ModelSpace() {
           {/* Base-plate schedule (full width) */}
           {design.basePlates.length > 0 && (
             <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Base-plate schedule — AISC §J8 / Design Guide 1</h3>
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Base-plate schedule — AISC §J8 / Design Guide 1<SchedChip items={design.basePlates} ok={(pl) => pl.ok} /></h3>
               <table className="w-full border-collapse text-xs">
                 <thead>
                   <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
@@ -4229,7 +4254,7 @@ export default function ModelSpace() {
           {/* Steel connection schedule — only for steel frames */}
           {(design.joints.length > 0 || design.beamJoints.length > 0) && (
             <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Steel connection schedule — AISC SCM</h3>
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Steel connection schedule — AISC SCM<SchedChip items={[...design.joints.flatMap((j) => j.connections), ...design.beamJoints.flatMap((j) => j.connections)]} ok={(cn) => cn.ok} /></h3>
               <p className="mb-2 text-[11px] text-slate-500">
                 Columns oriented with depth <em>d</em> in X (flanges face ±X); X-direction girders land on the column <strong>flange</strong> face (strong-axis moment connection), Z-direction beams land on the column <strong>web</strong> face (shear tab). Bolts: M20 A325 single-shear (φRₙ = 116.5 kN/bolt). Welds: E70XX fillet, both sides of plate.
               </p>
@@ -4371,7 +4396,7 @@ export default function ModelSpace() {
 
           {/* Footing schedule (full width) */}
           <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-            <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Footing schedule</h3>
+            <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Footing schedule<SchedChip items={design.footings} ok={(f) => f.ok} /></h3>
             <table className="w-full border-collapse text-xs">
               <thead>
                 <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
@@ -4421,7 +4446,7 @@ export default function ModelSpace() {
           {/* Combined footing schedule (full width) */}
           {design.combined.length > 0 && report !== 'draw-only' && (
             <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Combined footing schedule</h3>
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Combined footing schedule<SchedChip items={design.combined} ok={(c) => c.ok} /></h3>
               <table className="w-full border-collapse text-xs">
                 <thead>
                   <tr className="sched-head text-left uppercase tracking-wide text-slate-500">

--- a/webapp/src/pages/TBeamDesign.tsx
+++ b/webapp/src/pages/TBeamDesign.tsx
@@ -5,62 +5,11 @@ import { buildTBeamSolution } from '../lib/tbeamSolution'
 import { PageHeader, VerdictPanel, DrawingCard, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
 import { Num, Pick, Card } from '../components/qty'
 import { WorkedSolution } from '../components/WorkedSolution'
-import { DimBelow, DimSide } from '../components/dims'
+import { TSection } from '../components/TSection'
 
 const f0 = (v: number) => v.toFixed(0)
 const f1 = (v: number) => v.toFixed(1)
 
-/** T-section to scale: outline, stress block, stirrup + tension bars in the
- *  web, and template dimension lines (bf above, h left, bw below, hf right). */
-function TSection({ bf, bw, h, hf, a, bars = 0, barDia = 0, layers = [], cover = 40, stirrupDia = 10 }: {
-  bf: number; bw: number; h: number; hf: number; a: number
-  bars?: number; barDia?: number; layers?: number[]; cover?: number; stirrupDia?: number
-}) {
-  const W = 340, HT = 285
-  const availW = 210, availH = 200
-  const S = Math.min(availW / bf, availH / h)
-  const w = bf * S, ht = h * S, wf = bw * S, hff = hf * S, A = Math.min(a, h) * S
-  const x0 = (W - w) / 2, y0 = 40
-  const xw = x0 + (w - wf) / 2
-  const inset = (cover + stirrupDia / 2) * S
-  const br = Math.max(2.5, (barDia / 2) * S)
-  // tension bars in the web, bottom-up layers
-  const barRows: { y: number; n: number }[] = []
-  layers.forEach((n, li) => {
-    barRows.push({ y: y0 + ht - (cover + stirrupDia + barDia / 2 + li * (barDia + 25)) * S, n })
-  })
-  const bx1 = xw + (cover + stirrupDia + barDia / 2) * S
-  const bx2 = xw + wf - (cover + stirrupDia + barDia / 2) * S
-  return (
-    <svg viewBox={`0 0 ${W} ${HT}`} className="mx-auto block w-full max-w-[360px]" style={{ fontFamily: 'Arial, sans-serif' }}>
-      <path d={`M${x0} ${y0} h${w} v${hff} h${-(w - wf) / 2} v${ht - hff} h${-wf} v${-(ht - hff)} h${-(w - wf) / 2} z`}
-        fill="#eef3f8" stroke="#37526e" strokeWidth="1.6" />
-      {/* stress block */}
-      <rect x={x0} y={y0} width={w} height={Math.min(A, hff)} fill="#0f4c92" opacity="0.16" />
-      {A > hff && <rect x={xw} y={y0 + hff} width={wf} height={A - hff} fill="#0f4c92" opacity="0.16" />}
-      <line x1={x0 - 6} y1={y0 + A} x2={x0 + w + 6} y2={y0 + A} stroke="#0f4c92" strokeWidth="1.2" strokeDasharray="5 3" />
-      <text x={x0 + w - 4} y={y0 + A + 11} fontSize="8.5" fontFamily="IBM Plex Mono, monospace" fill="#0f4c92" textAnchor="end">a = {a.toFixed(0)}</text>
-      {/* stirrup in the web */}
-      <rect x={xw + inset} y={y0 + hff * 0.35} width={wf - 2 * inset} height={ht - hff * 0.35 - inset}
-        rx={Math.max(2, 2 * stirrupDia * S)} fill="none" stroke="#37526e" strokeWidth={Math.max(1, stirrupDia * S)} opacity="0.8" />
-      {/* tension bars */}
-      {barRows.map((row, li) => Array.from({ length: row.n }, (_, i) => (
-        <circle key={`${li}-${i}`} r={br} fill="#37526e"
-          cx={row.n === 1 ? (bx1 + bx2) / 2 : bx1 + ((bx2 - bx1) * i) / (row.n - 1)} cy={row.y} />
-      )))}
-      {bars > 0 && (
-        <text x={W / 2} y={y0 + ht + 14} fontSize="8.5" fill="#37526e" textAnchor="middle">
-          {bars} ⌀{barDia} mm · stirrup ⌀{stirrupDia}
-        </text>
-      )}
-      {/* dimension lines (shared template) */}
-      <DimBelow xA={x0} xB={x0 + w} featY={y0} dY={y0 - 18} label={`bf = ${Math.round(bf)} mm`} />
-      <DimBelow xA={xw} xB={xw + wf} featY={y0 + ht + (bars > 0 ? 18 : 4)} dY={y0 + ht + (bars > 0 ? 34 : 20)} label={`bw = ${Math.round(bw)} mm`} />
-      <DimSide yA={y0} yB={y0 + ht} featX={x0 > 40 ? x0 + (w - wf) / 2 : x0} dX={Math.min(x0, xw) - 16} label={`h = ${Math.round(h)} mm`} side="left" />
-      <DimSide yA={y0} yB={y0 + hff} featX={x0 + w} dX={x0 + w + 16} label={`hf = ${Math.round(hf)}`} side="right" />
-    </svg>
-  )
-}
 
 export default function TBeamDesign() {
   const [kind, setKind] = useState<TBeamKind>('interior')


### PR DESCRIPTION
Addresses the 3D Model Space feedback batch.

## Changes

**Engine — beam bar layering (`beamDesign`).** The layering detailing never leaves a single bar in an upper layer: a lone top-layer bar is paired with a second so the two sit beside the stirrup legs on each side. `splitLayers` now returns the (possibly bumped) count so `bars` stays consistent with the layer vector. +1 sweep test asserting no multi-layer result ends in a single bar.

**3D Model Space**
- **Schedule pass/fail chips** — every schedule title (RC beams, columns, prestressed, SCWB, slabs, walls, steel beams/columns, base plates, connections, footings, combined) carries a chip: `all passed` (green) or `n failed` (red), via a generic `SchedChip` over each schedule's rows.
- **T-beam section drawings** — interior (sagging) sections that get flange action now draw as a proper **T-section** (flange, web, stirrup, tension bars, dims) instead of a plain rectangle; hogging/rectangular sections are unchanged. The `TSection` component is extracted to `components/TSection.tsx` and shared with the standalone T-beam page (no duplication).
- **T-beam design toggle moved** from the Analysis tab to a new **"Beam design method"** section in the **Properties** tab, grouped with the prestressing option — the more natural home.

**Exported PDF report (`modelPdf` / `modelReport`).** Each RC beam and column worked solution now carries a vector **SECTION figure** — concrete outline (including the T-flange when flanged), tie/stirrup, and the tension / compression / all-around bar layout — so the reader can see the bars in the section. The report payload gains a `ReportSection`; `modelPdf` draws it with jsPDF primitives (crisp vector, no rasterization).

## Verification
- `npx tsc -b` clean · **1114/1114 tests** (1113 + 1).
- Headless Chromium: schedule chips render (`all passed` / `4 failed`); the Properties toggle is present; the interior section draws as a T on screen; the exported PDF shows both rectangular and T-beam SECTION figures with the bar layout.
- Rebased cleanly onto current `main` (#360) — #359's drawing corrections and #360's widths/full-width solutions are all preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_