### PR TITLE
fix: schedule/report verdict parity + section figure beside member name (hooks, dims, location)

### DIFF
--- a/webapp/src/components/TSection.tsx
+++ b/webapp/src/components/TSection.tsx
@@ -35,6 +35,19 @@ export function TSection({ bf, bw, h, hf, a = 0, bars = 0, barDia = 0, layers = 
       {/* stirrup in the web */}
       <rect x={xw + inset} y={y0 + hff * 0.35} width={wf - 2 * inset} height={ht - hff * 0.35 - inset}
         rx={Math.max(2, 2 * stirrupDia * S)} fill="none" stroke="#37526e" strokeWidth={Math.max(1, stirrupDia * S)} opacity="0.8" />
+      {/* 135° stirrup hooks — free ends into the core, ext = max(6ds, 75) mm (ACI 318-14 §425.3.2) */}
+      {(() => {
+        const stX = xw + inset, stY = y0 + hff * 0.35, stW = wf - 2 * inset
+        const rr = Math.max(2, 2 * stirrupDia * S)
+        const hk = (Math.max(6 * stirrupDia, 75) * S) / Math.SQRT2
+        const sw = Math.max(1, stirrupDia * S)
+        return (
+          <g stroke="#37526e" strokeWidth={sw} opacity="0.8" strokeLinecap="round">
+            <line x1={stX + rr} y1={stY + rr} x2={stX + rr + hk} y2={stY + rr + hk} />
+            <line x1={stX + stW - rr} y1={stY + rr} x2={stX + stW - rr - hk} y2={stY + rr + hk} />
+          </g>
+        )
+      })()}
       {/* tension bars */}
       {barRows.map((row, li) => Array.from({ length: row.n }, (_, i) => (
         <circle key={`${li}-${i}`} r={br} fill="#37526e"

--- a/webapp/src/lib/beamSolution.ts
+++ b/webapp/src/lib/beamSolution.ts
@@ -182,7 +182,7 @@ export function buildBeamSolution(i: BeamDesignInput, r: BeamDesignResult): Solu
   // step-building branches above stay untouched.
   const notes: [string, string, boolean | undefined][] = [
     ['Effective depth', '§20.6.1 cover', undefined],
-    ['Reinforcement-ratio limits', '§9.6.1.2 · §21.2.2', r.rho >= r.rhoMin - 1e-9 && r.rho <= r.rhoMax + 1e-9],
+    ['Reinforcement-ratio limits', '§9.6.1.2 · §21.2.2', r.rho <= r.rhoMax + 1e-9 || r.mode === 'DRRB'],
     ['SRRB / DRRB classification', 'ACI 318-14 §22.2', undefined],
     ['Tension steel', 'ACI 318-14 §22.2', r.flexOK],
     ['Compression steel', '§22.2.2', r.comprEffective && r.comprNAOK],

--- a/webapp/src/lib/modelPdf.ts
+++ b/webapp/src/lib/modelPdf.ts
@@ -85,13 +85,17 @@ export async function generateModelPdf({ lh, report, modelImg, badges, fileName 
     return w
   }
   const CONC: [number, number, number] = [238, 243, 248]
-  /** Vector cross-section (bar layout) drawn into a boxW×boxH mm cell at (x, topY). */
+  /** Vector cross-section (bar layout + stirrup hooks + dimension lines) drawn
+   *  into a boxW×boxH mm cell at (x, topY). Gutters are reserved on the bottom
+   *  (width dimension) and right (height dimension) so the callouts stay clear. */
   const drawSection = (sec: ReportSection, x: number, topY: number, boxW: number, boxH: number) => {
+    const padL = 2.5, padR = 8, padT = 3, padB = 6.5     // gutters for dim callouts
+    const availW = boxW - padL - padR, availH = boxH - padT - padB
     const flanged = sec.kind === 'beam' && !!sec.bf && sec.bf > sec.b && !sec.hogging && !!sec.hf
     const drawW = flanged ? sec.bf! : sec.b
-    const s = Math.min((boxW - 3) / drawW, (boxH - 3) / sec.h)
+    const s = Math.min(availW / drawW, availH / sec.h)
     const wv = drawW * s, hv = sec.h * s, bwv = sec.b * s
-    const bx = x + (boxW - wv) / 2, by = topY + (boxH - hv) / 2
+    const bx = x + padL + (availW - wv) / 2, by = topY + padT + (availH - hv) / 2
     const webX = bx + (wv - bwv) / 2
     doc.setLineWidth(0.25); doc.setDrawColor(...INK); doc.setFillColor(...CONC)
     if (flanged) {
@@ -101,10 +105,17 @@ export async function generateModelPdf({ lh, report, modelImg, badges, fileName 
     } else {
       doc.rect(webX, by, bwv, hv, 'FD')
     }
-    // tie / stirrup
+    // tie / stirrup — bend radius r = 4ds/2 = 2ds (ACI 318-14 §407.3.2)
     const ins = (sec.cover + sec.stirrupDia / 2) * s
+    const stX = webX + ins, stY = by + ins, stW = bwv - 2 * ins, stH = hv - 2 * ins
+    const cr = Math.max(0.4, Math.min(1.4, 2 * sec.stirrupDia * s))
     doc.setDrawColor(...MUTED); doc.setLineWidth(0.35)
-    doc.roundedRect(webX + ins, by + ins, bwv - 2 * ins, hv - 2 * ins, 0.6, 0.6, 'S')
+    doc.roundedRect(stX, stY, stW, stH, cr, cr, 'S')
+    // 135° hooks at the top corners — free end angles into the core (down-inward
+    // at 45°), true length ext = max(6ds, 75) mm (ACI 318-14 §425.3.2)
+    const hk = (Math.max(6 * sec.stirrupDia, 75) * s) / Math.SQRT2
+    doc.line(stX + cr, stY + cr, stX + cr + hk, stY + cr + hk)          // left hook
+    doc.line(stX + stW - cr, stY + cr, stX + stW - cr - hk, stY + cr + hk) // right hook
     // bars
     const br = Math.max(0.5, (sec.barDia / 2) * s)
     const barIns = (sec.cover + sec.stirrupDia + sec.barDia / 2) * s
@@ -135,11 +146,21 @@ export async function generateModelPdf({ lh, report, modelImg, badges, fileName 
         doc.circle(bx1, yy, br, 'F'); doc.circle(bx2, yy, br, 'F')
       }
     }
-    setF('mono', 'normal', 5, FAINT)
-    const cap = sec.kind === 'beam'
-      ? `${sec.bars}⌀${sec.barDia}${flanged ? ` · T bf=${Math.round(sec.bf!)}` : ''}`
-      : `${sec.bars}⌀${sec.barDia} · ${sec.b}×${sec.h}`
-    doc.text(cap, x + boxW / 2, topY + boxH - 0.5, { align: 'center' })
+    // dimension lines — width below, height on the right (bf across the top for
+    // flanged sections). Ticks + centred value, true mm from the design.
+    doc.setDrawColor(...FAINT); doc.setLineWidth(0.12)
+    setF('mono', 'normal', 4.3, MUTED)
+    const hDim = (x0: number, x1: number, yd: number, val: number) => {
+      doc.line(x0, yd, x1, yd); doc.line(x0, yd - 0.9, x0, yd + 0.9); doc.line(x1, yd - 0.9, x1, yd + 0.9)
+      doc.text(String(Math.round(val)), (x0 + x1) / 2, yd + 2.4, { align: 'center' })
+    }
+    const wDimY = by + hv + 3.4
+    hDim(webX, webX + bwv, wDimY, sec.b)                       // web width b
+    if (flanged) hDim(bx, bx + wv, by - 2, sec.bf!)            // flange width bf (above)
+    // height h on the right
+    const vx = webX + bwv + 3.6
+    doc.line(vx, by, vx, by + hv); doc.line(vx - 0.9, by, vx + 0.9, by); doc.line(vx - 0.9, by + hv, vx + 0.9, by + hv)
+    doc.text(String(Math.round(sec.h)), vx + 1.4, by + hv / 2, { align: 'center', angle: 90 })
   }
 
   const tableTheme = (right: number[] = []) => ({
@@ -324,13 +345,44 @@ export async function generateModelPdf({ lh, report, modelImg, badges, fileName 
     doc.line(M, y, M + CONTENT_W, y)
     y += 4.5
     g.items.forEach((item) => {
-      ensure(22)
+      const fig = item.section
+      const boxW = 52, boxH = 40
+      ensure(fig ? boxH + 5 : 20)
+      const headTop = y
+      const leftW = fig ? CONTENT_W - boxW - 5 : CONTENT_W
+      // cross-section figure — drawn BESIDE the name (top-right of the block)
+      if (fig) {
+        const fx = M + CONTENT_W - boxW
+        setF('sans', 'bold', 5, FAINT)
+        doc.text('SECTION', fx + 1, headTop + 1.5)
+        doc.setDrawColor(...HAIR); doc.setLineWidth(0.2)
+        doc.roundedRect(fx, headTop + 2.5, boxW, boxH, 1, 1, 'S')
+        drawSection(fig, fx, headTop + 2.5, boxW, boxH)
+      }
+      // left stack — name, sub, bar callout, demand summary, plan location
       setF('sans', 'bold', 7.8, INK)
-      doc.text(item.title, M, y)
+      doc.text(item.title, M, y + 1)
+      y += 4.4
       if (item.sub) {
         setF('mono', 'normal', 5.8, FAINT)
-        doc.text(item.sub, M + CONTENT_W, y, { align: 'right' })
+        for (const w of doc.splitTextToSize(item.sub, leftW)) { doc.text(w, M, y); y += 3 }
       }
+      if (fig) {
+        const flanged = fig.kind === 'beam' && !!fig.bf && fig.bf > fig.b && !fig.hogging && !!fig.hf
+        const cap = `${fig.bars}⌀${fig.barDia}${flanged ? ` · T bf=${Math.round(fig.bf!)}` : ''} · ${fig.b}×${fig.h}`
+        setF('mono', 'bold', 6.6, INK)
+        doc.text(cap, M, y + 0.6); y += 3.6
+      }
+      if (item.details) {
+        setF('sans', 'normal', 6.4, MUTED)
+        doc.text(item.details, M, y + 0.4); y += 3.3
+      }
+      if (item.loc) {
+        setF('sans', 'normal', 6.4, BRAND)
+        for (const w of doc.splitTextToSize(item.loc, leftW)) { doc.text(w, M, y + 0.4); y += 3.3 }
+      }
+      // clear the figure box before the steps begin
+      if (fig) y = Math.max(y, headTop + 2.5 + boxH)
       y += 3.4
       item.steps.forEach((st, si) => {
         ensure(12)
@@ -374,17 +426,6 @@ export async function generateModelPdf({ lh, report, modelImg, badges, fileName 
         doc.line(M, y, M + CONTENT_W, y)
         y += 3
       })
-      // cross-section figure — the bar layout in the section
-      if (item.section) {
-        const boxW = 46, boxH = 34
-        ensure(boxH + 4)
-        setF('sans', 'bold', 5.5, FAINT)
-        doc.text('SECTION', M + 1, y + 2)
-        doc.setDrawColor(...HAIR); doc.setLineWidth(0.2)
-        doc.roundedRect(M, y + 3, boxW, boxH, 1, 1, 'S')
-        drawSection(item.section, M, y + 3, boxW, boxH)
-        y += boxH + 5
-      }
       y += 2
     })
   })

--- a/webapp/src/lib/modelReport.test.ts
+++ b/webapp/src/lib/modelReport.test.ts
@@ -63,6 +63,20 @@ describe('buildModelReport', () => {
     for (const g of rpt.groups) for (const it of g.items) expect(it.steps.length).toBeGreaterThan(0)
   })
 
+  it('beam & column items carry a demand summary and a plan location', () => {
+    const beams = rpt.groups.find((g) => g.title === 'RC beams & girders')!.items
+    for (const it of beams) {
+      expect(it.details).toMatch(/^Mu .* kN·m · Vu .* kN$/)
+      expect(it.loc).toMatch(/·/)                       // "<floor> · <grid>"
+      expect(it.section?.kind).toBe('beam')
+    }
+    const cols = rpt.groups.find((g) => g.title === 'RC columns')!.items
+    for (const it of cols) {
+      expect(it.details).toMatch(/^Pu .* kN · Mu .* kN·m$/)
+      expect(it.loc).toMatch(/^[A-Z]\d · /)             // "<grid> · <floor(s)>"
+    }
+  })
+
   it('every formula line converts to plain text without residual LaTeX', () => {
     for (const g of rpt.groups)
       for (const item of g.items)

--- a/webapp/src/lib/modelReport.ts
+++ b/webapp/src/lib/modelReport.ts
@@ -3,7 +3,7 @@
 // summary checks, schedule tables and EVERY member's worked solution, reusing
 // the same step builders the on-screen schedules use. Presentation only — all
 // numbers come from the pipeline's StructureDesign rows.
-import type { StructuralModel, RectSection } from '../engine/model'
+import type { StructuralModel, RectSection, Node } from '../engine/model'
 import type {
   StructureDesign, SoilOptions,
   SteelBeamScheduleRow, SteelColumnScheduleRow,
@@ -29,7 +29,11 @@ export interface ReportSection {
   bf?: number; hf?: number  // beam: T-flange (sagging flanged section)
   fourFace?: boolean        // column: bars distributed on all four faces
 }
-export interface ReportSolution { title: string; sub?: string; steps: SolutionStep[]; section?: ReportSection }
+export interface ReportSolution {
+  title: string; sub?: string; steps: SolutionStep[]; section?: ReportSection
+  details?: string          // demand summary (Mu/Vu for beams, Pu/Mu for columns)
+  loc?: string              // plan grid line + floor the member sits on
+}
 export interface ReportGroup { title: string; items: ReportSolution[] }
 export interface ModelReport {
   ok: boolean
@@ -101,6 +105,39 @@ export function buildModelReport(
     return c ? sectionFor(c.id) : undefined
   }
   const fallbackSec = model.sections[0]
+
+  // ── Plan grid + floor locator ──
+  // A/B/C column lines from unique X coords, 1/2/3 rows from unique Z coords,
+  // floor from the nearest storey elevation (n.y is the vertical axis, m).
+  const uniqAxis = (vals: number[]): number[] => {
+    const out: number[] = []
+    for (const v of vals.slice().sort((a, b) => a - b))
+      if (!out.length || Math.abs(v - out[out.length - 1]) > 0.05) out.push(v)
+    return out
+  }
+  const xs = uniqAxis(model.nodes.map((n) => n.x))
+  const zs = uniqAxis(model.nodes.map((n) => n.z))
+  const nearestIdx = (arr: number[], v: number) =>
+    arr.reduce((best, c, i) => (Math.abs(c - v) < Math.abs(arr[best] - v) ? i : best), 0)
+  const grid = (n: Node) => `${String.fromCharCode(65 + nearestIdx(xs, n.x))}${nearestIdx(zs, n.z) + 1}`
+  const floorAt = (yy: number) =>
+    model.storeys.length
+      ? model.storeys.reduce((b, s) => (Math.abs(s.elevation - yy) < Math.abs(b.elevation - yy) ? s : b)).name
+      : `El. ${f2(yy)} m`
+  const memberLoc = (memberId: string): string | undefined => {
+    const m = model.members.find((x) => x.id === memberId)
+    if (!m) return undefined
+    const ni = model.nodes.find((n) => n.id === m.i)
+    const nj = model.nodes.find((n) => n.id === m.j)
+    if (!ni || !nj) return undefined
+    if (m.role === 'column') {
+      const lo = ni.y <= nj.y ? ni : nj, hi = ni.y <= nj.y ? nj : ni
+      const a = floorAt(lo.y), b = floorAt(hi.y)
+      return `${grid(lo)} · ${a === b ? a : `${a}→${b}`}`
+    }
+    const g = grid(ni) === grid(nj) ? grid(ni) : `${grid(ni)}–${grid(nj)}`
+    return `${floorAt(Math.max(ni.y, nj.y))} · ${g}`
+  }
 
   // ── Design-summary checks (group verdicts + governing ratios) ──
   const checks: ReportCheck[] = []
@@ -292,6 +329,8 @@ export function buildModelReport(
       return bm.sections.map((s) => ({
         title: `${bm.id} · ${s.label}`,
         sub: `${bm.role} ${sec.name} · L = ${f1(bm.L)} m · ${bm.gov ?? ''}`,
+        details: `Mu ${f1(Math.abs(s.Mu))} kN·m · Vu ${f1(s.Vu)} kN`,
+        loc: memberLoc(bm.id),
         steps: beamSectionSolution(sec, s),
         section: {
           kind: 'beam' as const, b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia, stirrupDia: sec.tieDia,
@@ -321,7 +360,10 @@ export function buildModelReport(
     items: design.columns.flatMap((c) => {
       const cs = sectionFor(c.id)
       return cs ? [{
-        title: c.id, sub: `${cs.name} · L = ${f1(c.L)} m · ${c.gov ?? ''}`, steps: columnRowSolution(cs, c),
+        title: c.id, sub: `${cs.name} · L = ${f1(c.L)} m · ${c.gov ?? ''}`,
+        details: `Pu ${f1(c.Pu)} kN · Mu ${f1(c.Mu)} kN·m`,
+        loc: memberLoc(c.id),
+        steps: columnRowSolution(cs, c),
         section: {
           kind: 'column' as const, b: cs.b, h: cs.h, cover: cs.cover, barDia: cs.barDia, stirrupDia: cs.tieDia,
           bars: c.bars, fourFace: c.layout === 'all-around',


### PR DESCRIPTION
Addresses the Model Space (`/model`) PDF-report & schedule feedback.

## The bug — chip says PASS, solution/report says FAIL
The schedule chip is driven by `beamOK` (`flexOK && comprEffective && comprNAOK && region !== 'inadequate'`), but the worked-solution **"Reinforcement-ratio limits"** step used a stricter, incorrect gate (`ρmin ≤ ρ ≤ ρmax`). That gate false-**FAIL**ed two legitimate cases the chip correctly **PASS**ed:

- **DRRB (doubly-reinforced)** sections — exceeding `ρmax` is expected; the compression steel balances the excess tension.
- **Flanged (T-beam)** sections — design uses `b = bf` so `ρ = As/(bf·d)` sits naturally below `ρmin`, while §9.6.1.2 min steel is checked on the **web** width.

Min steel is satisfied by construction, so the step now passes when `ρ ≤ ρmax **or** mode = DRRB — matching the authoritative schedule verdict. Layer: **L7 (worked-solution presentation)**; no calculation changed.

## Report layout — section figure beside the name
- **Moved** the cross-section figure from the *end* of each member's steps to **beside the name / section id** (top-right of the block).
- **Below the name** now: the bar callout (`n⌀d · b×h`), a **demand summary** (`Mu/Vu` for beams, `Pu/Mu` for columns) and the **plan location** — grid line + floor — via a new `memberLoc` helper (A/B/C from unique X, 1/2/3 from unique Z, floor from the nearest storey elevation; column ranges collapse when both ends map to one storey).
- **Removed** the bar count/diameter caption from *below* the drawing (now under the name).

## Drawing detail
- **135° stirrup hooks** with true lengths — extension `= max(6·ds, 75)` mm, bend `= 4·ds` (ACI 318-14 §425.3.2 / §407.3.2) — added to both the PDF section drawing and the shared on-screen T-section SVG (`TSection.tsx`).
- **Dimension lines** on the PDF drawing: width `b` below, height `h` on the right, flange `bf` above for T-sections.

## Verification
- `npx tsc -b` clean; `npm test` → **1115 passing** (extended `modelReport.test.ts` to lock in `details`/`loc`).
- Headless-rendered the actual export: confirmed the figure sits beside the name with hooks + `b`/`h` dimension callouts, the bar/`Mu`/`Vu`/location block reads under the name, and the **Reinforcement-ratio limits** step now shows a green **PASS** for the previously-failing sections (rectangular beam and column blocks both verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_