### PR TITLE
fix: draw the stirrup tie hook as a single 135° corner blade

### DIFF
--- a/webapp/src/components/TSection.tsx
+++ b/webapp/src/components/TSection.tsx
@@ -35,18 +35,21 @@ export function TSection({ bf, bw, h, hf, a = 0, bars = 0, barDia = 0, layers = 
       {/* stirrup in the web */}
       <rect x={xw + inset} y={y0 + hff * 0.35} width={wf - 2 * inset} height={ht - hff * 0.35 - inset}
         rx={Math.max(2, 2 * stirrupDia * S)} fill="none" stroke="#37526e" strokeWidth={Math.max(1, stirrupDia * S)} opacity="0.8" />
-      {/* 135° stirrup hooks — start at the bottom corner bars (tension side) and
-          turn 45° into the core, ext = max(6ds, 75) mm (ACI 318-14 §425.3.2) */}
+      {/* 135° stirrup hook — a single closed tie hook at the bottom-left corner
+          bar (tension side): the bar bends 135° and the tail runs 45° into the
+          core, drawn to the stirrup-bar width, ext = max(6ds, 75) mm (ACI §425.3.2) */}
       {barRows.length > 0 && (() => {
-        const hk = (Math.max(6 * stirrupDia, 75) * S) / Math.SQRT2
-        const sw = Math.max(1, stirrupDia * S)
         const hy = barRows[0].y
-        return (
-          <g stroke="#37526e" strokeWidth={sw} opacity="0.8" strokeLinecap="round">
-            <line x1={bx1} y1={hy} x2={bx1 + hk} y2={hy - hk} />
-            <line x1={bx2} y1={hy} x2={bx2 - hk} y2={hy - hk} />
-          </g>
-        )
+        const len = Math.max(6 * stirrupDia, 75) * S
+        const wid = Math.max(2, stirrupDia * S)
+        const dx = 1 / Math.SQRT2, dy = -1 / Math.SQRT2      // up-inward
+        const px = -dy, py = dx                              // perpendicular
+        const ax = bx1 + (px * wid) / 2, ay = hy + (py * wid) / 2
+        const pts = [
+          [ax, ay], [ax + dx * len, ay + dy * len],
+          [ax + dx * len - px * wid, ay + dy * len - py * wid], [ax - px * wid, ay - py * wid],
+        ].map((p) => p.join(',')).join(' ')
+        return <polygon points={pts} fill="none" stroke="#37526e" strokeWidth={Math.max(1, stirrupDia * S * 0.5)} opacity="0.85" />
       })()}
       {/* tension bars */}
       {barRows.map((row, li) => Array.from({ length: row.n }, (_, i) => (

--- a/webapp/src/lib/modelPdf.ts
+++ b/webapp/src/lib/modelPdf.ts
@@ -116,16 +116,21 @@ export async function generateModelPdf({ lh, report, modelImg, badges, fileName 
     const barIns = (sec.cover + sec.stirrupDia + sec.barDia / 2) * s
     const bx1 = webX + barIns, bx2 = webX + bwv - barIns
     const spanX = (n: number, i: number) => (n <= 1 ? (bx1 + bx2) / 2 : bx1 + ((bx2 - bx1) * i) / (n - 1))
-    // 135° stirrup hooks — start at the two corner bars on the tension side
-    // (bottom for sagging, top for hogging; top for columns) and turn 45° into
-    // the core, true tail ext = max(6ds, 75) mm (ACI 318-14 §425.3.2)
-    const hk = (Math.max(6 * sec.stirrupDia, 75) * s) / Math.SQRT2
+    // 135° stirrup hook — a single closed tie hook at the tension-side corner
+    // bar (bottom for sagging, top for hogging; top for columns): the bar bends
+    // 135° and the free tail runs 45° into the core, drawn to the stirrup-bar
+    // width as a closed blade. Tail ext = max(6ds, 75) mm (ACI 318-14 §425.3.2).
     const hookBottom = sec.kind === 'beam' ? !sec.hogging : false
     const hookY = hookBottom ? by + hv - barIns : by + barIns
-    const hookDy = hookBottom ? -hk : hk
-    doc.setDrawColor(...MUTED); doc.setLineWidth(0.35)
-    doc.line(bx1, hookY, bx1 + hk, hookY + hookDy)      // left corner-bar hook
-    doc.line(bx2, hookY, bx2 - hk, hookY + hookDy)      // right corner-bar hook
+    const dirX = 1 / Math.SQRT2, dirY = (hookBottom ? -1 : 1) / Math.SQRT2
+    const hLen = Math.max(6 * sec.stirrupDia, 75) * s
+    const hWid = Math.max(0.45, sec.stirrupDia * s)
+    const pxu = -dirY, pyu = dirX                         // unit perpendicular
+    doc.setDrawColor(...MUTED); doc.setLineWidth(0.3)
+    doc.lines(
+      [[dirX * hLen, dirY * hLen], [-pxu * hWid, -pyu * hWid], [-dirX * hLen, -dirY * hLen]],
+      bx1 + (pxu * hWid) / 2, hookY + (pyu * hWid) / 2, [1, 1], 'S', true,
+    )
     doc.setFillColor(...INK); doc.setDrawColor(...INK); doc.setLineWidth(0.25)
     if (sec.kind === 'beam') {
       const pitch = (sec.barDia + 25) * s


### PR DESCRIPTION
Follow-up on the stirrup hook in the Model Space PDF section figures ([#363](https://github.com/BitLess246/civilEngineering/pull/363)).

The hook was drawn as two thin hairlines running from both corner bars toward the centre, meeting in a "V" — it didn't read as a tie hook. It's now a **single closed 135° hook** at the tension-side corner bar (bottom for sagging, top for hogging; top for columns), drawn to the **stirrup-bar width** so the bent tail reads as the real hook, matching a standard CAD detail. Tail extension `= max(6·ds, 75)` mm (ACI 318-14 §425.3.2). Applied to both the PDF drawing and the on-screen `TSection.tsx`.

## Verification
- `npx tsc -b` clean; `npm test` → **1115 passing**.
- Headless-rendered and cropped the figures at 500 dpi: the **End i** (hogging) section shows the hook blade at the top-left corner bar angling into the core, and the **Interior** (sagging) section mirrors it to the bottom-left — both matching the reference detail, with `mm` units intact on the dimension lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_