### PR TITLE
fix: stirrup hook wraps around the corner bar instead of springing from it

### DIFF
--- a/webapp/src/components/TSection.tsx
+++ b/webapp/src/components/TSection.tsx
@@ -35,19 +35,22 @@ export function TSection({ bf, bw, h, hf, a = 0, bars = 0, barDia = 0, layers = 
       {/* stirrup in the web */}
       <rect x={xw + inset} y={y0 + hff * 0.35} width={wf - 2 * inset} height={ht - hff * 0.35 - inset}
         rx={Math.max(2, 2 * stirrupDia * S)} fill="none" stroke="#37526e" strokeWidth={Math.max(1, stirrupDia * S)} opacity="0.8" />
-      {/* 135° stirrup hook — a single closed tie hook at the bottom-left corner
-          bar (tension side): the bar bends 135° and the tail runs 45° into the
-          core, drawn to the stirrup-bar width, ext = max(6ds, 75) mm (ACI §425.3.2) */}
+      {/* 135° stirrup hook — the tie's free end wraps 135° around the bottom-left
+          corner bar (tension side) and the tail runs 45° into the core. Drawn from
+          the tie corner THROUGH the corner bar (painted on top after, so the tie
+          reads as wrapping it) out into the core, ext = max(6ds, 75) mm (ACI §425.3.2) */}
       {barRows.length > 0 && (() => {
-        const hy = barRows[0].y
         const len = Math.max(6 * stirrupDia, 75) * S
         const wid = Math.max(2, stirrupDia * S)
-        const dx = 1 / Math.SQRT2, dy = -1 / Math.SQRT2      // up-inward
+        const dx = 1 / Math.SQRT2, dy = -1 / Math.SQRT2      // up-inward into core
         const px = -dy, py = dx                              // perpendicular
-        const ax = bx1 + (px * wid) / 2, ay = hy + (py * wid) / 2
+        const back = (stirrupDia / 2 + barDia / 2) * S * Math.SQRT2   // tie corner → corner bar
+        const total = back + len
+        const tcx = xw + inset, tcy = y0 + ht - inset        // tie bottom-left corner
+        const ax = tcx + (px * wid) / 2, ay = tcy + (py * wid) / 2
         const pts = [
-          [ax, ay], [ax + dx * len, ay + dy * len],
-          [ax + dx * len - px * wid, ay + dy * len - py * wid], [ax - px * wid, ay - py * wid],
+          [ax, ay], [ax + dx * total, ay + dy * total],
+          [ax + dx * total - px * wid, ay + dy * total - py * wid], [ax - px * wid, ay - py * wid],
         ].map((p) => p.join(',')).join(' ')
         return <polygon points={pts} fill="none" stroke="#37526e" strokeWidth={Math.max(1, stirrupDia * S * 0.5)} opacity="0.85" />
       })()}

--- a/webapp/src/lib/modelPdf.ts
+++ b/webapp/src/lib/modelPdf.ts
@@ -116,20 +116,24 @@ export async function generateModelPdf({ lh, report, modelImg, badges, fileName 
     const barIns = (sec.cover + sec.stirrupDia + sec.barDia / 2) * s
     const bx1 = webX + barIns, bx2 = webX + bwv - barIns
     const spanX = (n: number, i: number) => (n <= 1 ? (bx1 + bx2) / 2 : bx1 + ((bx2 - bx1) * i) / (n - 1))
-    // 135° stirrup hook — a single closed tie hook at the tension-side corner
-    // bar (bottom for sagging, top for hogging; top for columns): the bar bends
-    // 135° and the free tail runs 45° into the core, drawn to the stirrup-bar
-    // width as a closed blade. Tail ext = max(6ds, 75) mm (ACI 318-14 §425.3.2).
+    // 135° stirrup hook — the tie's free end wraps 135° around the tension-side
+    // corner bar (bottom for sagging, top for hogging; top for columns) and the
+    // tail runs 45° into the core. Drawn as a closed blade from the tie corner
+    // THROUGH the corner bar (which is painted on top, so the tie reads as
+    // wrapping around it) out into the core. Tail ext = max(6ds, 75) mm
+    // (ACI 318-14 §425.3.2).
     const hookBottom = sec.kind === 'beam' ? !sec.hogging : false
-    const hookY = hookBottom ? by + hv - barIns : by + barIns
     const dirX = 1 / Math.SQRT2, dirY = (hookBottom ? -1 : 1) / Math.SQRT2
     const hLen = Math.max(6 * sec.stirrupDia, 75) * s
     const hWid = Math.max(0.45, sec.stirrupDia * s)
-    const pxu = -dirY, pyu = dirX                         // unit perpendicular
+    const back = (sec.stirrupDia / 2 + sec.barDia / 2) * s * Math.SQRT2   // tie corner → corner bar
+    const hkLen = back + hLen
+    const tcx = stX, tcy = hookBottom ? stY + stH : stY                  // tie corner
+    const pxu = -dirY, pyu = dirX                                        // unit perpendicular
     doc.setDrawColor(...MUTED); doc.setLineWidth(0.3)
     doc.lines(
-      [[dirX * hLen, dirY * hLen], [-pxu * hWid, -pyu * hWid], [-dirX * hLen, -dirY * hLen]],
-      bx1 + (pxu * hWid) / 2, hookY + (pyu * hWid) / 2, [1, 1], 'S', true,
+      [[dirX * hkLen, dirY * hkLen], [-pxu * hWid, -pyu * hWid], [-dirX * hkLen, -dirY * hkLen]],
+      tcx + (pxu * hWid) / 2, tcy + (pyu * hWid) / 2, [1, 1], 'S', true,
     )
     doc.setFillColor(...INK); doc.setDrawColor(...INK); doc.setLineWidth(0.25)
     if (sec.kind === 'beam') {


### PR DESCRIPTION
Follow-up on the stirrup tie hook ([#364](https://github.com/BitLess246/civilEngineering/pull/364)).

The hook was drawn springing out of the corner-bar **centre**. A real 135° tie hook wraps **around** the corner longitudinal bar before the tail projects into the core. The hook blade is now drawn from the **tie corner, through the corner bar, and out into the core**; the corner bar is painted on top afterwards, so the tie reads as wrapping around it and the tail emerges past it — matching the two-step reference you provided. Tail extension `= max(6·ds, 75)` mm (ACI 318-14 §425.3.2). Applied to both the PDF drawing and the on-screen `TSection.tsx`.

## Verification
- `npx tsc -b` clean; `npm test` → **1115 passing**.
- Headless-rendered and cropped at 500 dpi: the **End i** (hogging) section shows the tie bending at the top-left corner, wrapping the corner bar, tail into the core; the **Interior** (sagging) section mirrors it around the bottom-left corner bar. Dimension `mm` units intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_