### PR TITLE
fix: draw stirrup hooks as hairline strokes bending off the tie legs

### DIFF
--- a/webapp/src/components/TSection.tsx
+++ b/webapp/src/components/TSection.tsx
@@ -35,24 +35,24 @@ export function TSection({ bf, bw, h, hf, a = 0, bars = 0, barDia = 0, layers = 
       {/* stirrup in the web */}
       <rect x={xw + inset} y={y0 + hff * 0.35} width={wf - 2 * inset} height={ht - hff * 0.35 - inset}
         rx={Math.max(2, 2 * stirrupDia * S)} fill="none" stroke="#37526e" strokeWidth={Math.max(1, stirrupDia * S)} opacity="0.8" />
-      {/* 135° stirrup hook — the tie's free end wraps 135° around the bottom-left
-          corner bar (tension side) and the tail runs 45° into the core. Drawn from
-          the tie corner THROUGH the corner bar (painted on top after, so the tie
-          reads as wrapping it) out into the core, ext = max(6ds, 75) mm (ACI §425.3.2) */}
+      {/* 135° stirrup hooks — the tie is a bent bar with a hook at BOTH ends,
+          meeting at the bottom-left (tension) corner. Each free end is a single
+          hairline stroke, same weight as the tie: one bends off the bottom leg,
+          the other off the left leg, straddling the corner bar into the core.
+          Tail ext = max(6ds, 75) mm (ACI 318-14 §425.3.2) */}
       {barRows.length > 0 && (() => {
         const len = Math.max(6 * stirrupDia, 75) * S
-        const wid = Math.max(2, stirrupDia * S)
         const dx = 1 / Math.SQRT2, dy = -1 / Math.SQRT2      // up-inward into core
-        const px = -dy, py = dx                              // perpendicular
-        const back = (stirrupDia / 2 + barDia / 2) * S * Math.SQRT2   // tie corner → corner bar
-        const total = back + len
-        const tcx = xw + inset, tcy = y0 + ht - inset        // tie bottom-left corner
-        const ax = tcx + (px * wid) / 2, ay = tcy + (py * wid) / 2
-        const pts = [
-          [ax, ay], [ax + dx * total, ay + dy * total],
-          [ax + dx * total - px * wid, ay + dy * total - py * wid], [ax - px * wid, ay - py * wid],
-        ].map((p) => p.join(',')).join(' ')
-        return <polygon points={pts} fill="none" stroke="#37526e" strokeWidth={Math.max(1, stirrupDia * S * 0.5)} opacity="0.85" />
+        const cy = barRows[0].y                              // corner bar row
+        const edgeY = y0 + ht - inset                        // tie bottom leg
+        const leftX = xw + inset                             // tie left leg
+        const sw = Math.max(1, stirrupDia * S)
+        return (
+          <g stroke="#37526e" strokeWidth={sw} opacity="0.8" strokeLinecap="round">
+            <line x1={bx1} y1={edgeY} x2={bx1 + dx * len} y2={edgeY + dy * len} />
+            <line x1={leftX} y1={cy} x2={leftX + dx * len} y2={cy + dy * len} />
+          </g>
+        )
       })()}
       {/* tension bars */}
       {barRows.map((row, li) => Array.from({ length: row.n }, (_, i) => (

--- a/webapp/src/lib/modelPdf.ts
+++ b/webapp/src/lib/modelPdf.ts
@@ -116,25 +116,21 @@ export async function generateModelPdf({ lh, report, modelImg, badges, fileName 
     const barIns = (sec.cover + sec.stirrupDia + sec.barDia / 2) * s
     const bx1 = webX + barIns, bx2 = webX + bwv - barIns
     const spanX = (n: number, i: number) => (n <= 1 ? (bx1 + bx2) / 2 : bx1 + ((bx2 - bx1) * i) / (n - 1))
-    // 135° stirrup hook — the tie's free end wraps 135° around the tension-side
-    // corner bar (bottom for sagging, top for hogging; top for columns) and the
-    // tail runs 45° into the core. Drawn as a closed blade from the tie corner
-    // THROUGH the corner bar (which is painted on top, so the tie reads as
-    // wrapping around it) out into the core. Tail ext = max(6ds, 75) mm
-    // (ACI 318-14 §425.3.2).
+    // 135° stirrup hooks — the tie is a bent bar with a 135° hook at BOTH ends,
+    // meeting at the tension-side corner (bottom for sagging, top for hogging;
+    // top for columns). Each free end is a single hairline stroke — same weight
+    // as the tie — that bends 45° into the core, the two straddling the corner
+    // bar they hook around. Tail ext = max(6ds, 75) mm (ACI 318-14 §425.3.2).
     const hookBottom = sec.kind === 'beam' ? !sec.hogging : false
     const dirX = 1 / Math.SQRT2, dirY = (hookBottom ? -1 : 1) / Math.SQRT2
-    const hLen = Math.max(6 * sec.stirrupDia, 75) * s
-    const hWid = Math.max(0.45, sec.stirrupDia * s)
-    const back = (sec.stirrupDia / 2 + sec.barDia / 2) * s * Math.SQRT2   // tie corner → corner bar
-    const hkLen = back + hLen
-    const tcx = stX, tcy = hookBottom ? stY + stH : stY                  // tie corner
-    const pxu = -dirY, pyu = dirX                                        // unit perpendicular
-    doc.setDrawColor(...MUTED); doc.setLineWidth(0.3)
-    doc.lines(
-      [[dirX * hkLen, dirY * hkLen], [-pxu * hWid, -pyu * hWid], [-dirX * hkLen, -dirY * hkLen]],
-      tcx + (pxu * hWid) / 2, tcy + (pyu * hWid) / 2, [1, 1], 'S', true,
-    )
+    const hLen = Math.max(6 * sec.stirrupDia, 75) * s                     // straight tail
+    const cornerBarY = hookBottom ? by + hv - barIns : by + barIns
+    const edgeY = hookBottom ? stY + stH : stY                           // near tie horizontal leg
+    doc.setDrawColor(...MUTED); doc.setLineWidth(0.35)
+    // one end bends off the horizontal leg (above/below the bar), the other off
+    // the vertical leg (beside it); they straddle the corner bar into the core
+    doc.line(bx1, edgeY, bx1 + dirX * hLen, edgeY + dirY * hLen)
+    doc.line(stX, cornerBarY, stX + dirX * hLen, cornerBarY + dirY * hLen)
     doc.setFillColor(...INK); doc.setDrawColor(...INK); doc.setLineWidth(0.25)
     if (sec.kind === 'beam') {
       const pitch = (sec.barDia + 25) * s


### PR DESCRIPTION
Follow-up on the stirrup hook drawing ([#365](https://github.com/BitLess246/civilEngineering/pull/365)).

The tie is drawn as a **hairline single stroke**, so the 135° hooks must match — the previous filled parallelogram was inconsistent. A closed tie is a bent bar with a hook at **both** ends, meeting at the tension-side corner. Each free end is now a **single hairline stroke, same weight as the tie**: one bends off the horizontal leg, the other off the vertical leg, the two straddling the corner bar they hook around and running 45° into the core. Tail extension `= max(6·ds, 75)` mm (ACI 318-14 §425.3.2). Applied to both the PDF drawing and the on-screen `TSection.tsx`.

## Verification
- `npx tsc -b` clean; `npm test` → **1115 passing**.
- Rendered and cropped at 500 dpi (hogging **End i**): the two hooks now emanate from the tie legs at the corner, straddle the corner bar, and run into the core — hairline weight matching the tie, no floating parallelogram.

> ⚠️ Holding merge for visual confirmation from the Vercel preview, per the review-in-progress on this detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_