### PR TITLE
feat: multi-leg stirrups — interior crossties for lateral support (§25.7.2.3)

### DIFF
--- a/webapp/src/components/TSection.tsx
+++ b/webapp/src/components/TSection.tsx
@@ -4,9 +4,9 @@ import { DimBelow, DimSide } from './dims'
  *  stress block, stirrup + tension-bar layers in the web, and the shared
  *  dimension-line template (bf above, h left, hf right, bw below). Reused by
  *  the standalone T-beam page and the 3D Model Space beam schedule. */
-export function TSection({ bf, bw, h, hf, a = 0, bars = 0, barDia = 0, layers = [], cover = 40, stirrupDia = 10 }: {
+export function TSection({ bf, bw, h, hf, a = 0, bars = 0, barDia = 0, layers = [], cover = 40, stirrupDia = 10, legs = 2 }: {
   bf: number; bw: number; h: number; hf: number; a?: number
-  bars?: number; barDia?: number; layers?: number[]; cover?: number; stirrupDia?: number
+  bars?: number; barDia?: number; layers?: number[]; cover?: number; stirrupDia?: number; legs?: number
 }) {
   const W = 340, HT = 285
   const availW = 210, availH = 200
@@ -51,6 +51,30 @@ export function TSection({ bf, bw, h, hf, a = 0, bars = 0, barDia = 0, layers = 
           <g stroke="#37526e" strokeWidth={sw} opacity="0.8" strokeLinecap="round">
             <line x1={bx1} y1={edgeY} x2={bx1 + dx * len} y2={edgeY + dy * len} />
             <line x1={leftX} y1={cy} x2={leftX + dx * len} y2={cy + dy * len} />
+          </g>
+        )
+      })()}
+      {/* interior crossties — each added leg (legs − 2) grips an interior bottom
+          bar with a 135° hook at each end (§25.7.2.3). Drawn before the bars. */}
+      {legs > 2 && barRows.length > 0 && (() => {
+        const nCross = legs - 2, n0 = barRows[0].n
+        const yTop = y0 + hff * 0.35 + inset, yBot = barRows[0].y
+        const d = (Math.max(6 * stirrupDia, 75) * S) / Math.SQRT2
+        const sw = Math.max(1, stirrupDia * S)
+        return (
+          <g stroke="#37526e" strokeWidth={sw} opacity="0.8" strokeLinecap="round">
+            {Array.from({ length: nCross }, (_, k) => {
+              const idx = Math.min(n0 - 2, Math.max(1, Math.round(((n0 - 1) * (k + 1)) / (nCross + 1))))
+              const xc = n0 <= 1 ? (bx1 + bx2) / 2 : bx1 + ((bx2 - bx1) * idx) / (n0 - 1)
+              const hd = xc <= (bx1 + bx2) / 2 ? 1 : -1     // hooks point toward centre
+              return (
+                <g key={k}>
+                  <line x1={xc} y1={yTop} x2={xc} y2={yBot} />
+                  <line x1={xc} y1={yTop} x2={xc + hd * d} y2={yTop + d} />
+                  <line x1={xc} y1={yBot} x2={xc + hd * d} y2={yBot - d} />
+                </g>
+              )
+            })}
           </g>
         )
       })()}

--- a/webapp/src/components/TSection.tsx
+++ b/webapp/src/components/TSection.tsx
@@ -54,26 +54,26 @@ export function TSection({ bf, bw, h, hf, a = 0, bars = 0, barDia = 0, layers = 
           </g>
         )
       })()}
-      {/* interior crossties — each added leg (legs − 2) grips an interior bottom
-          bar with a 135° hook at each end (§25.7.2.3). Drawn before the bars. */}
+      {/* interior crossties — each added leg (legs − 2) is a C-tie that arcs OVER
+          the top bar and UNDER the bottom bar it grips (§25.7.2.3). Before bars. */}
       {legs > 2 && barRows.length > 0 && (() => {
         const nCross = legs - 2, n0 = barRows[0].n
         const yTop = y0 + hff * 0.35 + inset, yBot = barRows[0].y
-        const d = (Math.max(6 * stirrupDia, 75) * S) / Math.SQRT2
+        const rw = br + (stirrupDia / 2) * S, stub = rw * 1.6, NS = 10
         const sw = Math.max(1, stirrupDia * S)
         return (
-          <g stroke="#37526e" strokeWidth={sw} opacity="0.8" strokeLinecap="round">
+          <g stroke="#37526e" strokeWidth={sw} opacity="0.8" fill="none" strokeLinecap="round" strokeLinejoin="round">
             {Array.from({ length: nCross }, (_, k) => {
               const idx = Math.min(n0 - 2, Math.max(1, Math.round(((n0 - 1) * (k + 1)) / (nCross + 1))))
               const xc = n0 <= 1 ? (bx1 + bx2) / 2 : bx1 + ((bx2 - bx1) * idx) / (n0 - 1)
-              const hd = xc <= (bx1 + bx2) / 2 ? 1 : -1     // hooks point toward centre
-              return (
-                <g key={k}>
-                  <line x1={xc} y1={yTop} x2={xc} y2={yBot} />
-                  <line x1={xc} y1={yTop} x2={xc + hd * d} y2={yTop + d} />
-                  <line x1={xc} y1={yBot} x2={xc + hd * d} y2={yBot - d} />
-                </g>
-              )
+              const hd = xc <= (bx1 + bx2) / 2 ? 1 : -1
+              const xo = (o: number) => xc + hd * o
+              const pts: [number, number][] = [[xo(rw), yTop + stub]]
+              for (let j = 0; j <= NS; j++) { const t = (Math.PI * j) / NS; pts.push([xo(rw * Math.cos(t)), yTop - rw * Math.sin(t)]) }
+              pts.push([xo(-rw), yBot])
+              for (let j = 0; j <= NS; j++) { const t = Math.PI - (Math.PI * j) / NS; pts.push([xo(rw * Math.cos(t)), yBot + rw * Math.sin(t)]) }
+              pts.push([xo(rw), yBot - stub])
+              return <polyline key={k} points={pts.map((p) => p.join(',')).join(' ')} />
             })}
           </g>
         )

--- a/webapp/src/engine/beamDesign.test.ts
+++ b/webapp/src/engine/beamDesign.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { designBeam, beamServiceDeflection, type BeamDesignInput, type BeamDeflectionInput } from './beamDesign'
+import { designBeam, beamServiceDeflection, stirrupLegs, type BeamDesignInput, type BeamDeflectionInput } from './beamDesign'
 import { beta1 } from './loads'
 
 const base: BeamDesignInput = {
@@ -100,6 +100,27 @@ describe('beam design — DRRB (compression steel)', () => {
   it('flags flexOK = false when the layout diverges (over-demanded section)', () => {
     const r = designBeam({ ...base, b: 250, h: 400, Mu: 450 })
     expect(r.flexOK).toBe(false)
+  })
+})
+
+describe('stirrup legs — lateral support (§25.7.2.3)', () => {
+  it('2 legs to 2 bars, a crosstie every other interior bar beyond', () => {
+    expect(stirrupLegs(2)).toBe(2)   // corners only
+    expect(stirrupLegs(3)).toBe(3)   // + 1 crosstie on the middle bar
+    expect(stirrupLegs(4)).toBe(3)
+    expect(stirrupLegs(5)).toBe(4)   // + 2 crossties
+    expect(stirrupLegs(6)).toBe(4)
+    expect(stirrupLegs(7)).toBe(5)
+  })
+
+  it('Av scales with the auto leg count; explicit legs override', () => {
+    // Wide web, big moment → many bottom bars → ≥ 3 legs → Av > 2-leg Av.
+    const wide = designBeam({ ...base, b: 500, h: 550, Mu: 420, Vu: 260 })
+    expect(wide.legs).toBeGreaterThanOrEqual(3)
+    expect(wide.Av).toBeCloseTo(wide.legs * (Math.PI / 4) * 10 * 10, 6)
+    const forced = designBeam({ ...base, b: 500, h: 550, Mu: 420, Vu: 260, legs: 2 })
+    expect(forced.legs).toBe(2)
+    expect(forced.Av).toBeLessThan(wide.Av)
   })
 })
 

--- a/webapp/src/engine/beamDesign.ts
+++ b/webapp/src/engine/beamDesign.ts
@@ -82,6 +82,7 @@ export interface BeamDesignResult {
   // Shear
   Vc: number; phiVc: number
   region: ShearRegion
+  legs: number           // stirrup legs: 2 (perimeter) + crossties (§25.7.2.3)
   Av: number
   VsReq: number; VsMax: number
   sReq: number; sMax: number; sAdopt: number
@@ -121,9 +122,17 @@ function centroidRise(layers: number[], pitch: number): number {
   return n > 0 ? sum / n : 0
 }
 
+/** Transverse legs for lateral support of the longitudinal bars
+ *  (ACI 318-14 §25.7.2.3): the closed perimeter tie restrains the two corner
+ *  bars; every other interior bar of the widest layer then needs a crosstie so
+ *  no bar sits more than 150 mm clear from a laterally supported one. Each
+ *  crosstie is one added leg. Returns ≥ 2. */
+export function stirrupLegs(barsWidestLayer: number): number {
+  return 2 + Math.max(0, Math.floor((barsWidestLayer - 1) / 2))
+}
+
 export function designBeam(i: BeamDesignInput): BeamDesignResult {
   const fyt = i.fyt ?? i.fy
-  const legs = i.legs ?? 2
   const lambda = i.lambda ?? 1
   const dbC = i.comprBarDia ?? i.barDia
   const b1 = beta1(i.fc)
@@ -255,6 +264,9 @@ export function designBeam(i: BeamDesignInput): BeamDesignResult {
   const stirrupHookExt = Math.max(6 * i.stirrupDia, 75)
 
   // ── Shear (NSCP 2015 §422.5 / §409.4) ──
+  // Legs: explicit override, else lateral-support detailing of the widest
+  // tension layer (§25.7.2.3). The extra crosstie legs also raise Av.
+  const legs = i.legs ?? stirrupLegs(Math.max(...layers, 1))
   const Vc = (lambda * Math.sqrt(i.fc) * i.b * d) / 6 / 1000
   const phiVc = PHI_SHEAR * Vc
   const Av = legs * (Math.PI / 4) * i.stirrupDia * i.stirrupDia
@@ -292,7 +304,7 @@ export function designBeam(i: BeamDesignInput): BeamDesignResult {
     comprSMinClear, comprMaxPerLayer, comprLayers, comprSClear, comprYBar,
     dPrimeExtreme, comprNAOK,
     stirrupBendDia, stirrupHookExt,
-    Vc, phiVc, region, Av, VsReq, VsMax, sReq, sMax, sAdopt,
+    Vc, phiVc, region, legs, Av, VsReq, VsMax, sReq, sMax, sAdopt,
   }
 }
 

--- a/webapp/src/lib/modelPdf.ts
+++ b/webapp/src/lib/modelPdf.ts
@@ -138,16 +138,23 @@ export async function generateModelPdf({ lh, report, modelImg, badges, fileName 
       const nCross = (sec.legs ?? 2) - 2
       const n0 = (sec.layers && sec.layers[0]) || sec.bars
       const yTop = by + barIns, yBot = by + hv - barIns
-      const chd = (Math.max(6 * sec.stirrupDia, 75) * s) / Math.SQRT2
-      const midX = (bx1 + bx2) / 2
+      const rw = br + (sec.stirrupDia / 2) * s         // tie centreline wraps just outside the bar
+      const stub = rw * 1.6                            // short hook tail
+      const midX = (bx1 + bx2) / 2, NS = 8
       doc.setDrawColor(...MUTED); doc.setLineWidth(0.35)
       for (let k = 0; k < nCross; k++) {
         const idx = Math.min(n0 - 2, Math.max(1, Math.round(((n0 - 1) * (k + 1)) / (nCross + 1))))
         const xc = spanX(n0, idx)
-        const hd = xc <= midX ? 1 : -1               // hooks point toward centre, clear of the corners
-        doc.line(xc, yTop, xc, yBot)                 // crosstie leg
-        doc.line(xc, yTop, xc + hd * chd, yTop + chd)  // top 135° hook
-        doc.line(xc, yBot, xc + hd * chd, yBot - chd)  // bottom 135° hook
+        const hd = xc <= midX ? 1 : -1                 // C opening faces the section centre
+        const xo = (o: number) => xc + hd * o
+        // C-tie: tail → arc OVER the top bar → far-side leg → arc UNDER the
+        // bottom bar → tail, so the tie grips the interior bars top & bottom.
+        const pts: [number, number][] = [[xo(rw), yTop + stub]]
+        for (let j = 0; j <= NS; j++) { const t = (Math.PI * j) / NS; pts.push([xo(rw * Math.cos(t)), yTop - rw * Math.sin(t)]) }
+        pts.push([xo(-rw), yBot])
+        for (let j = 0; j <= NS; j++) { const t = Math.PI - (Math.PI * j) / NS; pts.push([xo(rw * Math.cos(t)), yBot + rw * Math.sin(t)]) }
+        pts.push([xo(rw), yBot - stub])
+        for (let j = 0; j < pts.length - 1; j++) doc.line(pts[j][0], pts[j][1], pts[j + 1][0], pts[j + 1][1])
       }
     }
     doc.setFillColor(...INK); doc.setDrawColor(...INK); doc.setLineWidth(0.25)

--- a/webapp/src/lib/modelPdf.ts
+++ b/webapp/src/lib/modelPdf.ts
@@ -131,6 +131,25 @@ export async function generateModelPdf({ lh, report, modelImg, badges, fileName 
     // the vertical leg (beside it); they straddle the corner bar into the core
     doc.line(bx1, edgeY, bx1 + dirX * hLen, edgeY + dirY * hLen)
     doc.line(stX, cornerBarY, stX + dirX * hLen, cornerBarY + dirY * hLen)
+    // interior crossties — each added leg (legs − 2) is a vertical hairline tie
+    // gripping an interior bar top & bottom with a 135° hook at each end,
+    // alternating sides (§25.7.2.3). Drawn before the bars so they sit on top.
+    if (sec.kind === 'beam' && (sec.legs ?? 2) > 2) {
+      const nCross = (sec.legs ?? 2) - 2
+      const n0 = (sec.layers && sec.layers[0]) || sec.bars
+      const yTop = by + barIns, yBot = by + hv - barIns
+      const chd = (Math.max(6 * sec.stirrupDia, 75) * s) / Math.SQRT2
+      const midX = (bx1 + bx2) / 2
+      doc.setDrawColor(...MUTED); doc.setLineWidth(0.35)
+      for (let k = 0; k < nCross; k++) {
+        const idx = Math.min(n0 - 2, Math.max(1, Math.round(((n0 - 1) * (k + 1)) / (nCross + 1))))
+        const xc = spanX(n0, idx)
+        const hd = xc <= midX ? 1 : -1               // hooks point toward centre, clear of the corners
+        doc.line(xc, yTop, xc, yBot)                 // crosstie leg
+        doc.line(xc, yTop, xc + hd * chd, yTop + chd)  // top 135° hook
+        doc.line(xc, yBot, xc + hd * chd, yBot - chd)  // bottom 135° hook
+      }
+    }
     doc.setFillColor(...INK); doc.setDrawColor(...INK); doc.setLineWidth(0.25)
     if (sec.kind === 'beam') {
       const pitch = (sec.barDia + 25) * s

--- a/webapp/src/lib/modelReport.ts
+++ b/webapp/src/lib/modelReport.ts
@@ -28,6 +28,7 @@ export interface ReportSection {
   hogging?: boolean         // beam: tension steel at the top
   bf?: number; hf?: number  // beam: T-flange (sagging flanged section)
   fourFace?: boolean        // column: bars distributed on all four faces
+  legs?: number             // stirrup legs: 2 perimeter + interior crossties
 }
 export interface ReportSolution {
   title: string; sub?: string; steps: SolutionStep[]; section?: ReportSection
@@ -335,7 +336,7 @@ export function buildModelReport(
         section: {
           kind: 'beam' as const, b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia, stirrupDia: sec.tieDia,
           bars: s.design.bars, layers: s.design.layers, comprLayers: s.design.comprLayers,
-          hogging: s.hogging, bf: s.bf, hf: s.hf,
+          hogging: s.hogging, bf: s.bf, hf: s.hf, legs: s.design.legs,
         },
       }))
     }),

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -3632,7 +3632,7 @@ export default function ModelSpace() {
                                 {s.bf && s.hf ? (
                                   <TSection bf={s.bf} bw={sec.b} h={sec.h} hf={s.hf}
                                     a={(d.bars * (Math.PI / 4) * sec.barDia ** 2 * sec.fy) / (0.85 * sec.fc * s.bf)}
-                                    bars={d.bars} barDia={sec.barDia} layers={d.layers} cover={sec.cover} stirrupDia={sec.tieDia} />
+                                    bars={d.bars} barDia={sec.barDia} layers={d.layers} cover={sec.cover} stirrupDia={sec.tieDia} legs={d.legs} />
                                 ) : (
                                   <BeamSchematic b={sec.b} h={sec.h} cover={sec.cover} barDia={sec.barDia} stirrupDia={sec.tieDia}
                                     bars={d.bars} d={d.d} dPrime={d.comprLayers.length > 0 ? d.dPrime : undefined}


### PR DESCRIPTION
Adds multi-leg stirrups — interior **crossties** — for beams (the first of two phases; the horizontal-tie variant for columns follows).

## Engineering
The closed perimeter tie laterally restrains the two corner bars. Per ACI 318-14 **§25.7.2.3**, every other interior bar of the widest tension layer then needs a crosstie so no bar sits more than 150 mm clear from a laterally supported one. Each crosstie is one added leg, which also raises `Av` for shear (§22.5.10.5.3).

- **`beamDesign`**: new `stirrupLegs(widestLayer)` = `2 + ⌊(n−1)/2⌋` (one crosstie per alternate interior bar); feeds `Av`. An explicit `legs` input still overrides. `legs` is echoed in the result. Hand-checked leg counts (2→2, 3→3, 4→3, 5→4 …) and `Av` scaling in the test.

## Drawing
- **PDF section figure + on-screen `TSection`**: draw `legs − 2` interior crossties. Each is a **hairline vertical tie at the same weight as the perimeter tie**, gripping an interior bar with a 135° hook at top and bottom pointing **toward the section centre** (clear of the corner hooks). Bars paint on top, so the crosstie reads as wrapping them.

## Verification
- `npx tsc -b` clean; `npm test` → **1117 passing** (2 new leg-rule tests).
- Rendered a heavily-loaded frame that produces 3- and 4-leg beams; cropped at 500 dpi — a 4-leg hogging section shows two interior crossties wrapping the interior tension bars, hooks toward centre, hairline weight matching the tie.

> ⚠️ Holding merge for your visual confirmation of the crosstie style before I proceed to the horizontal-tie (column) phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_