### PR TITLE
loads: add self-straining thermal category 'T' with proper §203.3 combos (#323)

### DIFF
--- a/webapp/src/engine/beamAnalysis.test.ts
+++ b/webapp/src/engine/beamAnalysis.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { solveFEM, analyzeBeam, threeMoment, nscpCombos, NSCP_COMBOS, type Support, type BeamLoad } from './beamAnalysis'
+import { solveFEM, analyzeBeam, threeMoment, nscpCombos, NSCP_COMBOS, applyCombo, type Support, type BeamLoad } from './beamAnalysis'
 
 describe('NSCP §203.3.1 — f₁ live-load factor', () => {
   it('f₁ scales L in eqs 203-3/4/5 only; default export is the 1.0 set', () => {
@@ -11,6 +11,20 @@ describe('NSCP §203.3.1 — f₁ live-load factor', () => {
     expect(c1[5].f.L).toBe(1.0); expect(c05[5].f.L).toBe(0.5)   // 203-5 (seismic)
     expect(c05[4].f.L).toBeUndefined()                  // 203-6 (0.9D+1.0W) has no L
     expect(NSCP_COMBOS[2].f.L).toBe(1.0)                // conservative default
+  })
+
+  it('self-straining T (§203.3.3 / ASCE 7-16 §2.3.4) rides at 1.2 with factored D, omitted from 0.9D uplift', () => {
+    const c = nscpCombos(1.0)
+    // present in every combo that carries the factored dead load (203-1…203-5)
+    for (const i of [0, 1, 2, 3, 5]) expect(c[i].f.T).toBe(1.2)
+    // excluded from the 0.9D uplift combos (203-6, 203-7) so it can't relieve
+    expect(c[4].f.T).toBeUndefined()                    // 0.9D + 1.0W
+    expect(c[6].f.T).toBeUndefined()                    // 0.9D + 1.0E
+    // a T load is scaled, not dropped, under a gravity combo…
+    const t: BeamLoad = { type: 'udl', x1: 0, x2: 6, w: 10, cat: 'T' }
+    expect(applyCombo([t], c[1].f)[0]).toMatchObject({ w: 12 })   // 1.2 × 10
+    // …and dropped under 0.9D + 1.0W (no T factor → ×0 → filtered out)
+    expect(applyCombo([t], c[4].f)).toHaveLength(0)
   })
 })
 

--- a/webapp/src/engine/beamAnalysis.ts
+++ b/webapp/src/engine/beamAnalysis.ts
@@ -11,7 +11,7 @@
 export type SupportType = 'pin' | 'roller' | 'fixed' | 'spring'
 export interface Support { type: SupportType; x: number; k?: number /* kN/m, spring */ }
 
-export type LoadCategory = 'D' | 'L' | 'Lr' | 'S' | 'R' | 'W' | 'E'
+export type LoadCategory = 'D' | 'L' | 'Lr' | 'S' | 'R' | 'W' | 'E' | 'T'
 export type BeamLoad =
   | { type: 'point'; x: number; P: number; cat: LoadCategory }
   | { type: 'udl'; x1: number; x2: number; w: number; cat: LoadCategory }
@@ -32,16 +32,21 @@ export interface Combo { name: string; f: Partial<Record<LoadCategory, number>> 
  * The live-load factor f₁ (eqs 203-3, 203-4, 203-5) is **1.0** for floors of
  * public assembly, live loads > 4.8 kPa, and garages; **0.5** otherwise.
  * (S is carried for ASCE-7 parity but is zero in the Philippines — no snow.)
+ *
+ * Self-straining force **T** (thermal, shrinkage, settlement — NSCP §203.3.3 /
+ * ASCE 7-16 §2.3.4) is locked-in like dead load, so it rides at 1.2 in every
+ * combination that carries the factored dead load; it is omitted from the 0.9D
+ * uplift combinations so it can never be credited to relieve net uplift.
  */
 export function nscpCombos(f1 = 1.0): Combo[] {
   const lf = f1 === 1 ? '1.0L' : `${f1}L`
   return [
-    { name: '1.4D', f: { D: 1.4 } },                                                          // 203-1
-    { name: '1.2D + 1.6L + 0.5(Lr|S|R)', f: { D: 1.2, L: 1.6, Lr: 0.5, S: 0.5, R: 0.5 } },     // 203-2
-    { name: `1.2D + 1.6(Lr|S|R) + (${lf}|0.5W)`, f: { D: 1.2, Lr: 1.6, S: 1.6, R: 1.6, L: f1, W: 0.5 } }, // 203-3
-    { name: `1.2D + 1.0W + ${lf} + 0.5(Lr|S|R)`, f: { D: 1.2, W: 1.0, L: f1, Lr: 0.5, S: 0.5, R: 0.5 } }, // 203-4
+    { name: '1.4D', f: { D: 1.4, T: 1.2 } },                                                   // 203-1
+    { name: '1.2D + 1.6L + 0.5(Lr|S|R)', f: { D: 1.2, L: 1.6, Lr: 0.5, S: 0.5, R: 0.5, T: 1.2 } },     // 203-2
+    { name: `1.2D + 1.6(Lr|S|R) + (${lf}|0.5W)`, f: { D: 1.2, Lr: 1.6, S: 1.6, R: 1.6, L: f1, W: 0.5, T: 1.2 } }, // 203-3
+    { name: `1.2D + 1.0W + ${lf} + 0.5(Lr|S|R)`, f: { D: 1.2, W: 1.0, L: f1, Lr: 0.5, S: 0.5, R: 0.5, T: 1.2 } }, // 203-4
     { name: '0.9D + 1.0W', f: { D: 0.9, W: 1.0 } },                                            // 203-6
-    { name: `1.2D + 1.0E + ${lf} + 0.2S`, f: { D: 1.2, E: 1.0, L: f1, S: 0.2 } },              // 203-5
+    { name: `1.2D + 1.0E + ${lf} + 0.2S`, f: { D: 1.2, E: 1.0, L: f1, S: 0.2, T: 1.2 } },      // 203-5
     { name: '0.9D + 1.0E', f: { D: 0.9, E: 1.0 } },                                            // 203-7
   ]
 }

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -2616,7 +2616,7 @@ export default function ModelSpace() {
                           const unit = l.kind === 'area' ? 'kPa' : l.kind === 'member-udl' ? 'kN/m' : l.kind === 'member-thermal' ? '°C' : 'kN'
                           return (
                             <tr key={idx} className="border-t border-slate-100">
-                              <td className={`py-0.5 pr-2 font-semibold ${l.cat === 'D' ? 'text-slate-600' : l.cat === 'L' ? 'text-emerald-700' : 'text-purple-700'}`}>{l.cat}</td>
+                              <td className={`py-0.5 pr-2 font-semibold ${l.cat === 'D' ? 'text-slate-600' : l.cat === 'L' ? 'text-emerald-700' : l.cat === 'T' ? 'text-amber-600' : 'text-purple-700'}`}>{l.cat}</td>
                               <td className="py-0.5 pr-2">{l.kind === 'node' ? '·' : l.kind === 'area' ? '▦' : l.kind === 'member-thermal' ? '🌡' : '—'} {target}</td>
                               <td className="py-0.5 pr-1 whitespace-nowrap">
                                 {val !== null ? (
@@ -2681,7 +2681,7 @@ export default function ModelSpace() {
                       disabled={!thMember || !Number.isFinite(thDeltaT) || !Number.isFinite(thAlpha) || thAlpha <= 0}
                       onClick={() => {
                         if (!model || !thMember) return
-                        save({ ...model, loads: [...model.loads, { kind: 'member-thermal', member: thMember, deltaT: thDeltaT, alpha: thAlpha, cat: 'D' }] })
+                        save({ ...model, loads: [...model.loads, { kind: 'member-thermal', member: thMember, deltaT: thDeltaT, alpha: thAlpha, cat: 'T' }] })
                       }}
                       className="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-semibold text-[#0f4c92] hover:border-[#0f4c92] hover:bg-blue-50 disabled:opacity-40">
                       + Add thermal load


### PR DESCRIPTION
Fixes #323.

`member-thermal` loads were tagged `cat: 'D'`, so thermal/self-straining effects were factored as **dead load** (1.2/1.4, always present) rather than as the self-straining force **T**.

- **L1 model** — add `'T'` to `LoadCategory` (JSON-serialisable). Because `member-thermal` is its own load *kind*, the dead-mass / self-weight sums (which filter by `kind`) are untouched, and thermal is no longer miscounted as seismic mass.
- **L4 combos** — thread `T` through `nscpCombos` (the NSCP §203.3 set the frame actually factors, via `applyF3Combo`; `loadCombinations.ts` is the separate standalone calculator). Self-straining `T` rides at **1.2** in every combination carrying the factored dead load (203-1…203-5) and is **omitted** from the `0.9D` uplift combos (203-6/7) so it can't be credited to relieve net uplift (ASCE 7-16 §2.3.4). Any combo without a `T` factor scales it by 0 → dropped, so thermal is never silently mis-factored.
- **UI** — the Model Space thermal-load form now tags `'T'` (was `'D'`), shown with a distinct amber chip in the load list.

## Verification
- `npx tsc -b` clean; `npm test` → **1118 passing** (new test: `T` = 1.2 in 203-1…203-5, absent from the `0.9D` combos, scaled under a gravity combo, dropped under `0.9D + 1.0W`).

Closes #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_