### PR TITLE
feat: stirrup leg count & Aᵥ in the worked solution — shear-driven legs (§422.5.10.5.3)

### DIFF
--- a/webapp/src/engine/beamDesign.test.ts
+++ b/webapp/src/engine/beamDesign.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { designBeam, beamServiceDeflection, stirrupLegs, type BeamDesignInput, type BeamDeflectionInput } from './beamDesign'
+import { designBeam, beamServiceDeflection, type BeamDesignInput, type BeamDeflectionInput } from './beamDesign'
 import { beta1 } from './loads'
 
 const base: BeamDesignInput = {
@@ -103,28 +103,22 @@ describe('beam design — DRRB (compression steel)', () => {
   })
 })
 
-describe('stirrup legs — lateral support (§25.7.2.3)', () => {
-  it('closely-spaced bars need only the 2 corner legs; crossties appear past 150 mm', () => {
-    // tight spacing (40 mm clear, 20 mm bar): the corner ties reach many bars
-    expect(stirrupLegs(2, 40, 20)).toBe(2)
-    expect(stirrupLegs(3, 40, 20)).toBe(2)
-    expect(stirrupLegs(6, 40, 20)).toBe(2)
-    expect(stirrupLegs(7, 40, 20)).toBe(3)
-    // wide spacing (200 mm clear): interior bars are > 150 mm from a corner
-    expect(stirrupLegs(3, 200, 20)).toBe(3)   // middle bar needs a crosstie
-    expect(stirrupLegs(4, 200, 20)).toBe(4)   // both interior bars need one
+describe('stirrup legs — shear-driven (§422.5.10.5.3)', () => {
+  it('stays at 2 legs until a 2-leg tie at s_min cannot carry Vs', () => {
+    // ordinary shear → the 2-leg tie spaces out fine → 2 legs
+    expect(designBeam({ ...base, b: 300, h: 550, Mu: 200, Vu: 260 }).legs).toBe(2)
+    // very high Vs (near the crushing limit) → a 2-leg tie would need s < 75 mm → add a leg
+    const hi = designBeam({ ...base, b: 300, h: 550, Mu: 100, Vu: 450 })
+    expect(hi.region).toBe('designed')
+    expect(hi.legs).toBeGreaterThanOrEqual(3)
+    // the adopted leg count keeps the required spacing at/above the practical minimum
+    expect((hi.Av * (base.fyt ?? base.fy) * hi.d) / (hi.VsReq * 1000)).toBeGreaterThanOrEqual(75 - 1e-6)
+    expect(hi.Av).toBeCloseTo(hi.legs * (Math.PI / 4) * 10 * 10, 6)
   })
 
-  it('Av uses the spacing-based leg count; explicit legs override', () => {
-    // wide beam, few widely-spaced bars → a crosstie (> 2 legs)
-    const wide = designBeam({ ...base, b: 800, h: 600, barDia: 25, Mu: 150, Vu: 320 })
-    expect(wide.legs).toBeGreaterThanOrEqual(3)
-    expect(wide.Av).toBeCloseTo(wide.legs * (Math.PI / 4) * 10 * 10, 6)
-    const forced = designBeam({ ...base, b: 800, h: 600, barDia: 25, Mu: 150, Vu: 320, legs: 2 })
+  it('honours an explicit legs override', () => {
+    const forced = designBeam({ ...base, b: 300, h: 550, Mu: 100, Vu: 450, legs: 2 })
     expect(forced.legs).toBe(2)
-    expect(forced.Av).toBeLessThan(wide.Av)
-    // a normal narrow beam stays at 2 legs even when it carries many bars
-    expect(designBeam({ ...base, b: 300, h: 550, Mu: 320, Vu: 260 }).legs).toBe(2)
   })
 })
 

--- a/webapp/src/engine/beamDesign.test.ts
+++ b/webapp/src/engine/beamDesign.test.ts
@@ -104,23 +104,27 @@ describe('beam design — DRRB (compression steel)', () => {
 })
 
 describe('stirrup legs — lateral support (§25.7.2.3)', () => {
-  it('2 legs to 2 bars, a crosstie every other interior bar beyond', () => {
-    expect(stirrupLegs(2)).toBe(2)   // corners only
-    expect(stirrupLegs(3)).toBe(3)   // + 1 crosstie on the middle bar
-    expect(stirrupLegs(4)).toBe(3)
-    expect(stirrupLegs(5)).toBe(4)   // + 2 crossties
-    expect(stirrupLegs(6)).toBe(4)
-    expect(stirrupLegs(7)).toBe(5)
+  it('closely-spaced bars need only the 2 corner legs; crossties appear past 150 mm', () => {
+    // tight spacing (40 mm clear, 20 mm bar): the corner ties reach many bars
+    expect(stirrupLegs(2, 40, 20)).toBe(2)
+    expect(stirrupLegs(3, 40, 20)).toBe(2)
+    expect(stirrupLegs(6, 40, 20)).toBe(2)
+    expect(stirrupLegs(7, 40, 20)).toBe(3)
+    // wide spacing (200 mm clear): interior bars are > 150 mm from a corner
+    expect(stirrupLegs(3, 200, 20)).toBe(3)   // middle bar needs a crosstie
+    expect(stirrupLegs(4, 200, 20)).toBe(4)   // both interior bars need one
   })
 
-  it('Av scales with the auto leg count; explicit legs override', () => {
-    // Wide web, big moment → many bottom bars → ≥ 3 legs → Av > 2-leg Av.
-    const wide = designBeam({ ...base, b: 500, h: 550, Mu: 420, Vu: 260 })
+  it('Av uses the spacing-based leg count; explicit legs override', () => {
+    // wide beam, few widely-spaced bars → a crosstie (> 2 legs)
+    const wide = designBeam({ ...base, b: 800, h: 600, barDia: 25, Mu: 150, Vu: 320 })
     expect(wide.legs).toBeGreaterThanOrEqual(3)
     expect(wide.Av).toBeCloseTo(wide.legs * (Math.PI / 4) * 10 * 10, 6)
-    const forced = designBeam({ ...base, b: 500, h: 550, Mu: 420, Vu: 260, legs: 2 })
+    const forced = designBeam({ ...base, b: 800, h: 600, barDia: 25, Mu: 150, Vu: 320, legs: 2 })
     expect(forced.legs).toBe(2)
     expect(forced.Av).toBeLessThan(wide.Av)
+    // a normal narrow beam stays at 2 legs even when it carries many bars
+    expect(designBeam({ ...base, b: 300, h: 550, Mu: 320, Vu: 260 }).legs).toBe(2)
   })
 })
 

--- a/webapp/src/engine/beamDesign.ts
+++ b/webapp/src/engine/beamDesign.ts
@@ -122,23 +122,11 @@ function centroidRise(layers: number[], pitch: number): number {
   return n > 0 ? sum / n : 0
 }
 
-/** Transverse legs for lateral support of the longitudinal bars
- *  (ACI 318-14 §25.7.2.3): the closed perimeter tie restrains the two corner
- *  bars; a crosstie (one extra leg) is added ONLY where a bar would otherwise be
- *  more than 150 mm clear from a laterally supported bar. Closely-spaced bars
- *  (the usual case) therefore need no crosstie — 2 legs.
- *
- *  With bars evenly spaced at centre-to-centre pitch `p = sClear + db`, a
- *  supported bar keeps `reach = ⌊(150 + db)/p⌋` bars on each side within the
- *  150 mm limit, so consecutive supported legs may span up to `2·reach + 1`
- *  bar spaces. Returns ≥ 2. */
-export function stirrupLegs(barsWidestLayer: number, sClear: number, db: number): number {
-  if (barsWidestLayer <= 2) return 2
-  const pitch = Math.max(sClear, 0) + db
-  const reach = Math.floor((150 + db) / pitch)
-  const gap = 2 * reach + 1                                   // bar spaces between supported legs
-  return 2 + Math.max(0, Math.ceil((barsWidestLayer - 1) / gap) - 1)
-}
+/** Minimum practical stirrup spacing, mm — the tightest a designer will place
+ *  transverse steel before adding legs instead (placement / congestion). Beam
+ *  legs are driven by shear: extra legs are added only when a 2-leg tie at this
+ *  spacing cannot supply the required Aᵥ/s (§422.5.10.5.3). */
+export const S_MIN_STIRRUP = 75
 
 export function designBeam(i: BeamDesignInput): BeamDesignResult {
   const fyt = i.fyt ?? i.fy
@@ -273,37 +261,39 @@ export function designBeam(i: BeamDesignInput): BeamDesignResult {
   const stirrupHookExt = Math.max(6 * i.stirrupDia, 75)
 
   // ── Shear (NSCP 2015 §422.5 / §409.4) ──
-  // Legs: explicit override, else lateral-support detailing of the widest tension
-  // layer (§25.7.2.3) — a crosstie only where a bar would be > 150 mm clear from a
-  // supported bar. The extra crosstie legs also raise Av.
-  const nWide = Math.max(...layers, 1)
-  const sClearWide = nWide > 1 ? (bw - nWide * i.barDia) / (nWide - 1) : bw
-  const legs = i.legs ?? stirrupLegs(nWide, sClearWide, i.barDia)
   const Vc = (lambda * Math.sqrt(i.fc) * i.b * d) / 6 / 1000
   const phiVc = PHI_SHEAR * Vc
-  const Av = legs * (Math.PI / 4) * i.stirrupDia * i.stirrupDia
   const VsMax = (2 / 3) * Math.sqrt(i.fc) * i.b * d / 1000
+  const avPerLeg = (Math.PI / 4) * i.stirrupDia * i.stirrupDia
+
+  // Region + Vs demand (independent of the leg count).
+  let region: ShearRegion
+  let VsReq = 0
+  if (i.Vu <= 0.5 * phiVc) region = 'none'
+  else if (i.Vu <= phiVc) region = 'minimum'
+  else { VsReq = i.Vu / PHI_SHEAR - Vc; region = VsReq > VsMax ? 'inadequate' : 'designed' }
+
+  // Legs: a closed 2-leg tie is the default. Extra legs are added ONLY when a
+  // 2-leg tie — even at the minimum practical spacing — cannot supply the Aᵥ/s
+  // the shear demands (§422.5.10.5.3): shear congestion, not bar spacing, drives
+  // multi-leg beam stirrups. (n_legs = ⌈(Aᵥ/s)_req · s_min / A_v,leg⌉.)
+  let legs = i.legs ?? 2
+  if (i.legs === undefined && region === 'designed') {
+    const avsReq = (VsReq * 1000) / (fyt * d)                 // required Aᵥ/s, mm²/mm
+    legs = Math.max(2, Math.ceil((avsReq * S_MIN_STIRRUP) / avPerLeg))
+  }
+  const Av = legs * avPerLeg
   const sMinArea = (Av * fyt) / Math.max(0.062 * Math.sqrt(i.fc) * i.b, 0.35 * i.b)
 
-  let region: ShearRegion
-  let VsReq = 0, sReq = 0, sMax = 0, sAdopt = 0
-  if (i.Vu <= 0.5 * phiVc) {
-    region = 'none'
-  } else if (i.Vu <= phiVc) {
-    region = 'minimum'
+  let sReq = 0, sMax = 0, sAdopt = 0
+  if (region === 'minimum') {
     sMax = Math.min(d / 2, 600)
     sAdopt = roundDown(Math.min(sMinArea, sMax), 10)
-  } else {
-    VsReq = i.Vu / PHI_SHEAR - Vc
-    if (VsReq > VsMax) {
-      region = 'inadequate'
-    } else {
-      region = 'designed'
-      sReq = (Av * fyt * d) / (VsReq * 1000)
-      const sCap = VsReq <= Math.sqrt(i.fc) * i.b * d / 3 / 1000 ? Math.min(d / 2, 600) : Math.min(d / 4, 300)
-      sMax = sCap
-      sAdopt = roundDown(Math.min(sReq, sCap, sMinArea), 10)
-    }
+  } else if (region === 'designed') {
+    sReq = (Av * fyt * d) / (VsReq * 1000)
+    const sCap = VsReq <= Math.sqrt(i.fc) * i.b * d / 3 / 1000 ? Math.min(d / 2, 600) : Math.min(d / 4, 300)
+    sMax = sCap
+    sAdopt = roundDown(Math.min(sReq, sCap, sMinArea), 10)
   }
 
   return {

--- a/webapp/src/engine/beamDesign.ts
+++ b/webapp/src/engine/beamDesign.ts
@@ -124,11 +124,20 @@ function centroidRise(layers: number[], pitch: number): number {
 
 /** Transverse legs for lateral support of the longitudinal bars
  *  (ACI 318-14 §25.7.2.3): the closed perimeter tie restrains the two corner
- *  bars; every other interior bar of the widest layer then needs a crosstie so
- *  no bar sits more than 150 mm clear from a laterally supported one. Each
- *  crosstie is one added leg. Returns ≥ 2. */
-export function stirrupLegs(barsWidestLayer: number): number {
-  return 2 + Math.max(0, Math.floor((barsWidestLayer - 1) / 2))
+ *  bars; a crosstie (one extra leg) is added ONLY where a bar would otherwise be
+ *  more than 150 mm clear from a laterally supported bar. Closely-spaced bars
+ *  (the usual case) therefore need no crosstie — 2 legs.
+ *
+ *  With bars evenly spaced at centre-to-centre pitch `p = sClear + db`, a
+ *  supported bar keeps `reach = ⌊(150 + db)/p⌋` bars on each side within the
+ *  150 mm limit, so consecutive supported legs may span up to `2·reach + 1`
+ *  bar spaces. Returns ≥ 2. */
+export function stirrupLegs(barsWidestLayer: number, sClear: number, db: number): number {
+  if (barsWidestLayer <= 2) return 2
+  const pitch = Math.max(sClear, 0) + db
+  const reach = Math.floor((150 + db) / pitch)
+  const gap = 2 * reach + 1                                   // bar spaces between supported legs
+  return 2 + Math.max(0, Math.ceil((barsWidestLayer - 1) / gap) - 1)
 }
 
 export function designBeam(i: BeamDesignInput): BeamDesignResult {
@@ -264,9 +273,12 @@ export function designBeam(i: BeamDesignInput): BeamDesignResult {
   const stirrupHookExt = Math.max(6 * i.stirrupDia, 75)
 
   // ── Shear (NSCP 2015 §422.5 / §409.4) ──
-  // Legs: explicit override, else lateral-support detailing of the widest
-  // tension layer (§25.7.2.3). The extra crosstie legs also raise Av.
-  const legs = i.legs ?? stirrupLegs(Math.max(...layers, 1))
+  // Legs: explicit override, else lateral-support detailing of the widest tension
+  // layer (§25.7.2.3) — a crosstie only where a bar would be > 150 mm clear from a
+  // supported bar. The extra crosstie legs also raise Av.
+  const nWide = Math.max(...layers, 1)
+  const sClearWide = nWide > 1 ? (bw - nWide * i.barDia) / (nWide - 1) : bw
+  const legs = i.legs ?? stirrupLegs(nWide, sClearWide, i.barDia)
   const Vc = (lambda * Math.sqrt(i.fc) * i.b * d) / 6 / 1000
   const phiVc = PHI_SHEAR * Vc
   const Av = legs * (Math.PI / 4) * i.stirrupDia * i.stirrupDia

--- a/webapp/src/lib/beamSolution.test.ts
+++ b/webapp/src/lib/beamSolution.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { designBeam, type BeamDesignInput } from '../engine/beamDesign'
+import { buildBeamSolution } from './beamSolution'
+
+const texOf = (steps: ReturnType<typeof buildBeamSolution>, title: string) =>
+  steps.find((s) => s.title.includes(title))!.lines
+    .map((l) => ('tex' in l ? l.tex : l.text)).join(' | ')
+
+describe('beam worked solution — transverse legs & Aᵥ (§25.7.2.3)', () => {
+  it('adds a leg step whose count matches the design and is used in Aᵥ (not hard-coded 2)', () => {
+    // Narrow web + heavy demand → ≥ 3 bottom bars → the tie needs crossties.
+    const i: BeamDesignInput = { b: 300, h: 650, cover: 40, barDia: 20, stirrupDia: 10, fc: 28, fy: 415, Mu: 480, Vu: 320 }
+    const r = designBeam(i)
+    expect(r.legs).toBeGreaterThanOrEqual(3)             // the design chose > 2 legs
+    const steps = buildBeamSolution(i, r)
+    const leg = texOf(steps, 'Transverse legs')
+    expect(leg).toContain(`= \\mathbf{${r.legs}}`)       // the step reports the design's count
+    // Aᵥ uses that leg count, and equals legs·(π/4)·ds²
+    expect(leg).toContain(`A_v = n_{legs}\\cdot\\tfrac{\\pi}{4}d_s^2 = ${r.legs}`)
+    expect(r.Av).toBeCloseTo(r.legs * (Math.PI / 4) * 10 * 10, 6)
+  })
+
+  it('shows a 2-leg perimeter tie (no crossties) for a lightly-reinforced section', () => {
+    const i: BeamDesignInput = { b: 300, h: 500, cover: 40, barDia: 20, stirrupDia: 10, fc: 28, fy: 415, Mu: 40, Vu: 200 }
+    const r = designBeam(i)
+    expect(r.legs).toBe(2)
+    expect(texOf(buildBeamSolution(i, r), 'Transverse legs')).toContain('perimeter tie only')
+  })
+})

--- a/webapp/src/lib/beamSolution.test.ts
+++ b/webapp/src/lib/beamSolution.test.ts
@@ -8,8 +8,8 @@ const texOf = (steps: ReturnType<typeof buildBeamSolution>, title: string) =>
 
 describe('beam worked solution — transverse legs & Aᵥ (§25.7.2.3)', () => {
   it('adds a leg step whose count matches the design and is used in Aᵥ (not hard-coded 2)', () => {
-    // Narrow web + heavy demand → ≥ 3 bottom bars → the tie needs crossties.
-    const i: BeamDesignInput = { b: 300, h: 650, cover: 40, barDia: 20, stirrupDia: 10, fc: 28, fy: 415, Mu: 480, Vu: 320 }
+    // Wide beam, few widely-spaced bars (> 150 mm clear) → the tie needs a crosstie.
+    const i: BeamDesignInput = { b: 800, h: 600, cover: 40, barDia: 25, stirrupDia: 10, fc: 28, fy: 415, Mu: 150, Vu: 320 }
     const r = designBeam(i)
     expect(r.legs).toBeGreaterThanOrEqual(3)             // the design chose > 2 legs
     const steps = buildBeamSolution(i, r)

--- a/webapp/src/lib/beamSolution.test.ts
+++ b/webapp/src/lib/beamSolution.test.ts
@@ -6,24 +6,24 @@ const texOf = (steps: ReturnType<typeof buildBeamSolution>, title: string) =>
   steps.find((s) => s.title.includes(title))!.lines
     .map((l) => ('tex' in l ? l.tex : l.text)).join(' | ')
 
-describe('beam worked solution — transverse legs & Aᵥ (§25.7.2.3)', () => {
+describe('beam worked solution — transverse legs & Aᵥ (§422.5.10.5.3)', () => {
   it('adds a leg step whose count matches the design and is used in Aᵥ (not hard-coded 2)', () => {
-    // Wide beam, few widely-spaced bars (> 150 mm clear) → the tie needs a crosstie.
-    const i: BeamDesignInput = { b: 800, h: 600, cover: 40, barDia: 25, stirrupDia: 10, fc: 28, fy: 415, Mu: 150, Vu: 320 }
+    // Very high Vs → a 2-leg tie would need s < 75 mm → the design adds a leg.
+    const i: BeamDesignInput = { b: 300, h: 550, cover: 40, barDia: 20, stirrupDia: 10, fc: 28, fy: 415, Mu: 100, Vu: 450 }
     const r = designBeam(i)
     expect(r.legs).toBeGreaterThanOrEqual(3)             // the design chose > 2 legs
-    const steps = buildBeamSolution(i, r)
-    const leg = texOf(steps, 'Transverse legs')
+    const leg = texOf(buildBeamSolution(i, r), 'Transverse legs')
     expect(leg).toContain(`= \\mathbf{${r.legs}}`)       // the step reports the design's count
-    // Aᵥ uses that leg count, and equals legs·(π/4)·ds²
-    expect(leg).toContain(`A_v = n_{legs}\\cdot\\tfrac{\\pi}{4}d_s^2 = ${r.legs}`)
+    expect(leg).toContain('(A_v/s)_{req}')               // driven by the shear demand
+    expect(leg).toContain(`= ${r.legs}\\cdot\\tfrac{\\pi}{4}`)   // Aᵥ uses that count
     expect(r.Av).toBeCloseTo(r.legs * (Math.PI / 4) * 10 * 10, 6)
   })
 
-  it('shows a 2-leg perimeter tie (no crossties) for a lightly-reinforced section', () => {
-    const i: BeamDesignInput = { b: 300, h: 500, cover: 40, barDia: 20, stirrupDia: 10, fc: 28, fy: 415, Mu: 40, Vu: 200 }
+  it('shows a 2-leg tie when Vs does not require more (low shear)', () => {
+    const i: BeamDesignInput = { b: 300, h: 500, cover: 40, barDia: 20, stirrupDia: 10, fc: 28, fy: 415, Mu: 120, Vu: 70 }
     const r = designBeam(i)
+    expect(r.region).toBe('minimum')
     expect(r.legs).toBe(2)
-    expect(texOf(buildBeamSolution(i, r), 'Transverse legs')).toContain('perimeter tie only')
+    expect(texOf(buildBeamSolution(i, r), 'Transverse legs')).toContain('Vs does not require more')
   })
 })

--- a/webapp/src/lib/beamSolution.ts
+++ b/webapp/src/lib/beamSolution.ts
@@ -2,7 +2,7 @@
 // an explanation citing the governing provision, then the substituted
 // equations. Mirrors engine/beamDesign.ts (ρ_max,TC with dt/d, DRRB with
 // displaced concrete, §407.7 bar layout with Varignon d-iteration).
-import type { BeamDesignInput, BeamDesignResult } from '../engine/beamDesign'
+import { S_MIN_STIRRUP, type BeamDesignInput, type BeamDesignResult } from '../engine/beamDesign'
 import { type SolutionStep, type SolutionLine, sn0, sn1, sn2, sn3, sn4 } from './solution'
 
 const txt = (text: string): SolutionLine => ({ text })
@@ -129,21 +129,23 @@ export function buildBeamSolution(i: BeamDesignInput, r: BeamDesignResult): Solu
     ],
   })
 
-  // Why 2 legs (or more): lateral support of the longitudinal bars sets the
-  // stirrup leg count, which in turn fixes the shear area Aᵥ.
+  // Why 2 legs (or more): a closed 2-leg tie is the default; extra legs are a
+  // SHEAR response — added only when a 2-leg tie at the minimum practical spacing
+  // cannot supply the Aᵥ/s that Vs demands.
   {
-    const nWide = Math.max(...r.layers, 1)
-    const bw = i.b - 2 * (i.cover + i.stirrupDia)
-    const sClearW = nWide > 1 ? (bw - nWide * i.barDia) / (nWide - 1) : bw
     const crossties = legs - 2
-    steps.push({
-      title: 'Transverse legs & shear-reinforcement area Aᵥ (§25.7.2.3)',
-      lines: [
-        txt('The stirrup leg count comes from lateral support of the longitudinal bars, not the shear demand. The closed perimeter tie restrains the two corner bars; a crosstie (one extra leg) is added ONLY where a bar would otherwise be more than 150 mm clear from a laterally supported bar (§25.7.2.3). Closely-spaced bars — the usual case — need only the two corner legs. Aᵥ is the total area of all legs crossing the shear crack.'),
-        eq(String.raw`s_{clear} = \dfrac{b_w - n\,d_b}{n-1} = \dfrac{${sn0(bw)} - ${nWide}(${sn0(i.barDia)})}{${nWide}-1} = ${sn0(sClearW)}\ \text{mm}\ ${sClearW <= 150 ? String.raw`\le 150 \Rightarrow \text{corner ties suffice}` : String.raw`> 150 \Rightarrow \text{crosstie(s) required}`}`),
-        eq(String.raw`n_{legs} = \mathbf{${legs}}\quad(${crossties <= 0 ? String.raw`\text{perimeter tie only}` : String.raw`${crossties}\ \text{crosstie${crossties === 1 ? '' : 's'}}`}),\qquad A_v = n_{legs}\cdot\tfrac{\pi}{4}d_s^2 = ${legs}\cdot\tfrac{\pi}{4}(${sn0(i.stirrupDia)})^2 = ${sn0(r.Av)}\ \text{mm}^2`),
-      ],
-    })
+    const lines: SolutionLine[] = [
+      txt(`Stirrups are 2-leg closed ties by default. Extra legs are added only if a 2-leg tie — even at the minimum practical spacing s_min = ${S_MIN_STIRRUP} mm — cannot supply the Aᵥ/s that Vs demands (§422.5.10.5.3); i.e. shear congestion, not bar spacing, drives multi-leg beam stirrups. Aᵥ is the total area of all legs crossing the shear crack.`),
+    ]
+    if (r.region === 'designed' && r.VsReq > 0) {
+      const avsReq = (r.VsReq * 1000) / (fyt * d)
+      lines.push(eq(String.raw`(A_v/s)_{req} = \dfrac{V_s\cdot 10^3}{f_{yt}\,d} = \dfrac{${sn1(r.VsReq)}\times 10^3}{${sn0(fyt)}(${sn1(d)})} = ${sn3(avsReq)}\ \text{mm}^2\!/\text{mm}`))
+      lines.push(eq(String.raw`n_{legs} = \max\!\left(2,\ \left\lceil \dfrac{(A_v/s)_{req}\, s_{min}}{\tfrac{\pi}{4}d_s^2} \right\rceil\right) = \max\!\left(2,\ \left\lceil \dfrac{${sn3(avsReq)}(${S_MIN_STIRRUP})}{${sn1((Math.PI / 4) * i.stirrupDia * i.stirrupDia)}} \right\rceil\right) = \mathbf{${legs}}`))
+    } else {
+      lines.push(eq(String.raw`n_{legs} = \mathbf{2}\quad(\text{closed perimeter tie — Vs does not require more})`))
+    }
+    lines.push(eq(String.raw`A_v = n_{legs}\cdot\tfrac{\pi}{4}d_s^2 = ${legs}\cdot\tfrac{\pi}{4}(${sn0(i.stirrupDia)})^2 = ${sn0(r.Av)}\ \text{mm}^2${crossties > 0 ? String.raw`\quad(${crossties}\ \text{extra leg${crossties === 1 ? '' : 's'}})` : ''}`))
+    steps.push({ title: 'Transverse legs & shear-reinforcement area Aᵥ (§422.5.10.5.3)', lines })
   }
 
   if (r.region === 'none') {

--- a/webapp/src/lib/beamSolution.ts
+++ b/webapp/src/lib/beamSolution.ts
@@ -10,7 +10,7 @@ const eq = (tex: string): SolutionLine => ({ tex })
 
 export function buildBeamSolution(i: BeamDesignInput, r: BeamDesignResult): SolutionStep[] {
   const fyt = i.fyt ?? i.fy
-  const legs = i.legs ?? 2
+  const legs = r.legs ?? i.legs ?? 2      // the design's actual leg count (§25.7.2.3)
   const dbC = i.comprBarDia ?? i.barDia
   const d = r.d
   const Ab = (Math.PI / 4) * i.barDia * i.barDia
@@ -129,6 +129,21 @@ export function buildBeamSolution(i: BeamDesignInput, r: BeamDesignResult): Solu
     ],
   })
 
+  // Why 2 legs (or more): lateral support of the longitudinal bars sets the
+  // stirrup leg count, which in turn fixes the shear area Aᵥ.
+  {
+    const nWide = Math.max(...r.layers, 1)
+    const crossties = legs - 2
+    steps.push({
+      title: 'Transverse legs & shear-reinforcement area Aᵥ (§25.7.2.3)',
+      lines: [
+        txt('The stirrup leg count comes from lateral support of the longitudinal bars, not the shear demand: every corner and alternate bar must be held by the corner of a closed tie or by a crosstie, with no bar more than 150 mm clear from a supported one (§25.7.2.3). The closed perimeter tie restrains the two corner bars (2 legs); one crosstie leg is added for every other interior bar of the widest layer. Aᵥ is the total area of all legs crossing the shear crack.'),
+        eq(String.raw`n_{legs} = 2 + \left\lfloor\tfrac{n_{bar}-1}{2}\right\rfloor = 2 + \left\lfloor\tfrac{${nWide}-1}{2}\right\rfloor = \mathbf{${legs}}\quad(${crossties <= 0 ? String.raw`\text{perimeter tie only}` : String.raw`${crossties}\ \text{crosstie${crossties === 1 ? '' : 's'}}`})`),
+        eq(String.raw`A_v = n_{legs}\cdot\tfrac{\pi}{4}d_s^2 = ${legs}\cdot\tfrac{\pi}{4}(${sn0(i.stirrupDia)})^2 = ${sn0(r.Av)}\ \text{mm}^2`),
+      ],
+    })
+  }
+
   if (r.region === 'none') {
     steps.push({
       title: 'Stirrup requirement',
@@ -142,8 +157,8 @@ export function buildBeamSolution(i: BeamDesignInput, r: BeamDesignResult): Solu
     steps.push({
       title: 'Minimum stirrups',
       lines: [
-        txt('Vu exceeds ½φVc but not φVc — minimum shear reinforcement applies (§409.6.3.3), with spacing capped at d/2 ≤ 600 mm (§409.7.6.2.2).'),
-        eq(String.raw`A_v = ${legs}\cdot\tfrac{\pi}{4}d_s^2 = ${sn0(r.Av)}\ \text{mm}^2,\quad s_{max} = \min(d/2,\,600) = ${sn0(r.sMax)}\ \text{mm}`),
+        txt('Vu exceeds ½φVc but not φVc — minimum shear reinforcement applies (§409.6.3.3), with spacing capped at d/2 ≤ 600 mm (§409.7.6.2.2). Aᵥ is the leg area from the step above.'),
+        eq(String.raw`A_{v,min} = \max\!\left(0.062\sqrt{f'_c}\,\tfrac{b\,s}{f_{yt}},\ 0.35\tfrac{b\,s}{f_{yt}}\right),\quad s_{max} = \min(d/2,\,600) = ${sn0(r.sMax)}\ \text{mm}`),
       ],
       note: `Provide ⌀${i.stirrupDia} mm, ${legs}-leg stirrups @ ${sn0(r.sAdopt)} mm.`,
     })

--- a/webapp/src/lib/beamSolution.ts
+++ b/webapp/src/lib/beamSolution.ts
@@ -133,13 +133,15 @@ export function buildBeamSolution(i: BeamDesignInput, r: BeamDesignResult): Solu
   // stirrup leg count, which in turn fixes the shear area Aᵥ.
   {
     const nWide = Math.max(...r.layers, 1)
+    const bw = i.b - 2 * (i.cover + i.stirrupDia)
+    const sClearW = nWide > 1 ? (bw - nWide * i.barDia) / (nWide - 1) : bw
     const crossties = legs - 2
     steps.push({
       title: 'Transverse legs & shear-reinforcement area Aᵥ (§25.7.2.3)',
       lines: [
-        txt('The stirrup leg count comes from lateral support of the longitudinal bars, not the shear demand: every corner and alternate bar must be held by the corner of a closed tie or by a crosstie, with no bar more than 150 mm clear from a supported one (§25.7.2.3). The closed perimeter tie restrains the two corner bars (2 legs); one crosstie leg is added for every other interior bar of the widest layer. Aᵥ is the total area of all legs crossing the shear crack.'),
-        eq(String.raw`n_{legs} = 2 + \left\lfloor\tfrac{n_{bar}-1}{2}\right\rfloor = 2 + \left\lfloor\tfrac{${nWide}-1}{2}\right\rfloor = \mathbf{${legs}}\quad(${crossties <= 0 ? String.raw`\text{perimeter tie only}` : String.raw`${crossties}\ \text{crosstie${crossties === 1 ? '' : 's'}}`})`),
-        eq(String.raw`A_v = n_{legs}\cdot\tfrac{\pi}{4}d_s^2 = ${legs}\cdot\tfrac{\pi}{4}(${sn0(i.stirrupDia)})^2 = ${sn0(r.Av)}\ \text{mm}^2`),
+        txt('The stirrup leg count comes from lateral support of the longitudinal bars, not the shear demand. The closed perimeter tie restrains the two corner bars; a crosstie (one extra leg) is added ONLY where a bar would otherwise be more than 150 mm clear from a laterally supported bar (§25.7.2.3). Closely-spaced bars — the usual case — need only the two corner legs. Aᵥ is the total area of all legs crossing the shear crack.'),
+        eq(String.raw`s_{clear} = \dfrac{b_w - n\,d_b}{n-1} = \dfrac{${sn0(bw)} - ${nWide}(${sn0(i.barDia)})}{${nWide}-1} = ${sn0(sClearW)}\ \text{mm}\ ${sClearW <= 150 ? String.raw`\le 150 \Rightarrow \text{corner ties suffice}` : String.raw`> 150 \Rightarrow \text{crosstie(s) required}`}`),
+        eq(String.raw`n_{legs} = \mathbf{${legs}}\quad(${crossties <= 0 ? String.raw`\text{perimeter tie only}` : String.raw`${crossties}\ \text{crosstie${crossties === 1 ? '' : 's'}}`}),\qquad A_v = n_{legs}\cdot\tfrac{\pi}{4}d_s^2 = ${legs}\cdot\tfrac{\pi}{4}(${sn0(i.stirrupDia)})^2 = ${sn0(r.Av)}\ \text{mm}^2`),
       ],
     })
   }

--- a/webapp/src/lib/modelReport.ts
+++ b/webapp/src/lib/modelReport.ts
@@ -222,7 +222,7 @@ export function buildModelReport(
           `${s.label}${s.hogging ? ' (hog)' : s.bf ? ` · T bf=${Math.round(s.bf)}` : ''}`,
           f1(Math.abs(s.Mu)), f1(s.Vu), d.mode,
           `${d.bars}⌀${sec?.barDia}${d.layers.length > 1 ? ` (${d.layers.join('+')})` : ''}${s.hogging ? ' top' : ''}`,
-          d.sAdopt > 0 ? `⌀${sec?.tieDia}@${Math.round(d.sAdopt)}` : d.region === 'none' ? 'none' : '⚠',
+          d.sAdopt > 0 ? `${d.legs}L-⌀${sec?.tieDia}@${Math.round(d.sAdopt)}` : d.region === 'none' ? 'none' : '⚠',
           k === 0 ? (bm.gov ?? '') : '',
         ]
       })

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -3606,7 +3606,7 @@ export default function ModelSpace() {
                       <td className="py-1 pr-2 text-right">{f1(s.Vu)}</td>
                       <td className="py-1 pr-2">{d.mode}</td>
                       <td className="py-1 pr-2">{d.bars}⌀{sec?.barDia}{d.layers.length > 1 ? ` (${d.layers.join('+')})` : ''}{s.hogging ? ' top' : ''}</td>
-                      <td className="py-1 pr-2">{d.sAdopt > 0 ? `@${Math.round(d.sAdopt)}` : d.region === 'none' ? 'none' : '⚠'}</td>
+                      <td className="py-1 pr-2">{d.sAdopt > 0 ? `${d.legs}L@${Math.round(d.sAdopt)}` : d.region === 'none' ? 'none' : '⚠'}</td>
                       <td className="py-1 text-slate-500">{k === 0 ? bm.gov : ''}</td>
                     </tr>,
                     open && model && sec && (


### PR DESCRIPTION
Adds the stirrup **leg count** and **Aᵥ** derivation to the beam worked solution and schedules, and corrects the driver for extra legs.

**Bug 1 — solution hard-coded 2 legs:** the worked solution used `legs = i.legs ?? 2`, but the input never carries `legs` (it lives on the design *result*), so the report always showed a 2-leg tie / `Aᵥ = 2·(π/4)ds²`. Now uses `r.legs`.

**Bug 2 — extra legs had the wrong driver:** legs were being added for bar count / lateral spacing, so a normal beam was drawn with a spurious 3rd leg. Per review, a beam gets an **extra leg only when the Aᵥ/s that Vs demands can't be supplied by a 2-leg tie even at the minimum practical spacing** — shear congestion, not the 150 mm bar-spacing rule (that governs *columns*). A closed 2-leg tie is the default; in the `designed` region:

```
n_legs = max(2, ⌈ (Aᵥ/s)_req · s_min / A_v,leg ⌉),   s_min = 75 mm
```

**New step & schedules:**
- "Transverse legs & shear-reinforcement area Aᵥ (§422.5.10.5.3)" derives `(Aᵥ/s)_req = Vs·10³/(fyt·d)`, the leg count from it, and `Aᵥ = n_legs·(π/4)ds²` — or states the 2-leg tie suffices when Vs doesn't require more.
- Leg count surfaced in the schedules — report `2L-⌀10@120`, on-screen `2L@120`.

Shared builder → shows in the on-screen solution, the PDF report, and the standalone beam page.

## Verification
- `npx tsc -b` clean; `npm test` → **1120 passing** (ordinary shear → 2 legs; Vs near the crushing limit → ≥ 3 legs with the adopted spacing kept ≥ 75 mm; the step matches the design).
- Rendered a full model: normal beams read `n_legs = max(2, ⌈1.317(75)/78.5⌉) = 2` → `2L-⌀10@120`; a genuinely high-shear beam shows `3L-⌀10@90`. The spurious extra leg is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)