### PR TITLE
fix: beam stirrup legs driven by transverse spacing limit (beam width), shear a secondary bump

### DIFF
--- a/webapp/src/engine/beamDesign.test.ts
+++ b/webapp/src/engine/beamDesign.test.ts
@@ -103,22 +103,23 @@ describe('beam design — DRRB (compression steel)', () => {
   })
 })
 
-describe('stirrup legs — shear-driven (§422.5.10.5.3)', () => {
-  it('stays at 2 legs until a 2-leg tie at s_min cannot carry Vs', () => {
-    // ordinary shear → the 2-leg tie spaces out fine → 2 legs
-    expect(designBeam({ ...base, b: 300, h: 550, Mu: 200, Vu: 260 }).legs).toBe(2)
-    // very high Vs (near the crushing limit) → a 2-leg tie would need s < 75 mm → add a leg
-    const hi = designBeam({ ...base, b: 300, h: 550, Mu: 100, Vu: 450 })
-    expect(hi.region).toBe('designed')
-    expect(hi.legs).toBeGreaterThanOrEqual(3)
-    // the adopted leg count keeps the required spacing at/above the practical minimum
-    expect((hi.Av * (base.fyt ?? base.fy) * hi.d) / (hi.VsReq * 1000)).toBeGreaterThanOrEqual(75 - 1e-6)
-    expect(hi.Av).toBeCloseTo(hi.legs * (Math.PI / 4) * 10 * 10, 6)
+describe('stirrup legs — width-driven (hx limit) + shear bump', () => {
+  it('normal beams stay at 2 legs; wide beams add legs; seismic hx tightens it', () => {
+    expect(designBeam({ ...base, b: 300 }).legs).toBe(2)                    // normal gravity → 2
+    expect(designBeam({ ...base, b: 900 }).legs).toBe(3)                    // wide gravity (hx 600) → 3
+    expect(designBeam({ ...base, b: 900, legSpacingLimit: 350 }).legs).toBe(4)  // seismic hx 350 → 4
+    expect(designBeam({ ...base, b: 400, legSpacingLimit: 350 }).legs).toBe(2)  // normal seismic → still 2
+    expect(designBeam({ ...base, b: 900, legs: 2 }).legs).toBe(2)           // explicit override wins
+    expect(designBeam({ ...base, b: 900 }).legSpacingLimit).toBe(600)       // limit echoed on the result
   })
 
-  it('honours an explicit legs override', () => {
-    const forced = designBeam({ ...base, b: 300, h: 550, Mu: 100, Vu: 450, legs: 2 })
-    expect(forced.legs).toBe(2)
+  it('a very high Vs bumps the leg count even on a normal-width beam', () => {
+    const hi = designBeam({ ...base, b: 300, h: 550, Mu: 100, Vu: 450 })
+    expect(hi.region).toBe('designed')
+    expect(hi.legs).toBeGreaterThanOrEqual(3)                              // shear bump beyond width's 2
+    // the adopted legs keep the required spacing at/above the practical minimum
+    expect((hi.Av * (base.fyt ?? base.fy) * hi.d) / (hi.VsReq * 1000)).toBeGreaterThanOrEqual(75 - 1e-6)
+    expect(hi.Av).toBeCloseTo(hi.legs * (Math.PI / 4) * 10 * 10, 6)
   })
 })
 

--- a/webapp/src/engine/beamDesign.ts
+++ b/webapp/src/engine/beamDesign.ts
@@ -31,7 +31,8 @@ export interface BeamDesignInput {
    *  flanged sagging section passes bf as b but keeps the WEB width here —
    *  min steel is a web property, it must not scale with the flange. */
   bMin?: number
-  legs?: number        // stirrup legs (default 2)
+  legs?: number        // stirrup legs — explicit override (else auto: width + shear)
+  legSpacingLimit?: number  // max transverse leg spacing hx, mm (350 seismic, 600 gravity)
   lambda?: number      // lightweight factor (default 1)
 }
 
@@ -82,7 +83,8 @@ export interface BeamDesignResult {
   // Shear
   Vc: number; phiVc: number
   region: ShearRegion
-  legs: number           // stirrup legs: 2 (perimeter) + crossties (§25.7.2.3)
+  legs: number           // stirrup legs — width-driven (hx ≤ limit), bumped by shear
+  legSpacingLimit: number // the transverse leg-spacing limit hx used, mm
   Av: number
   VsReq: number; VsMax: number
   sReq: number; sMax: number; sAdopt: number
@@ -123,9 +125,9 @@ function centroidRise(layers: number[], pitch: number): number {
 }
 
 /** Minimum practical stirrup spacing, mm — the tightest a designer will place
- *  transverse steel before adding legs instead (placement / congestion). Beam
- *  legs are driven by shear: extra legs are added only when a 2-leg tie at this
- *  spacing cannot supply the required Aᵥ/s (§422.5.10.5.3). */
+ *  transverse steel before adding legs instead (placement / congestion). Used as
+ *  the SECONDARY (shear-congestion) leg driver; beam legs are primarily set by the
+ *  transverse leg-spacing limit hx (beam width). */
 export const S_MIN_STIRRUP = 75
 
 export function designBeam(i: BeamDesignInput): BeamDesignResult {
@@ -273,15 +275,20 @@ export function designBeam(i: BeamDesignInput): BeamDesignResult {
   else if (i.Vu <= phiVc) region = 'minimum'
   else { VsReq = i.Vu / PHI_SHEAR - Vc; region = VsReq > VsMax ? 'inadequate' : 'designed' }
 
-  // Legs: a closed 2-leg tie is the default. Extra legs are added ONLY when a
-  // 2-leg tie — even at the minimum practical spacing — cannot supply the Aᵥ/s
-  // the shear demands (§422.5.10.5.3): shear congestion, not bar spacing, drives
-  // multi-leg beam stirrups. (n_legs = ⌈(Aᵥ/s)_req · s_min / A_v,leg⌉.)
-  let legs = i.legs ?? 2
-  if (i.legs === undefined && region === 'designed') {
-    const avsReq = (VsReq * 1000) / (fyt * d)                 // required Aᵥ/s, mm²/mm
-    legs = Math.max(2, Math.ceil((avsReq * S_MIN_STIRRUP) / avPerLeg))
-  }
+  // Legs — PRIMARY driver is beam WIDTH: the transverse (horizontal) spacing
+  // between legs must stay within hx so the stirrup engages the full width and
+  // laterally supports the bars (hx ≤ 350 mm seismic §418.6.4.3; ~600 mm gravity).
+  // legSpan = c/c of the two outer perimeter legs → n_legs = ⌈legSpan/hx⌉ + 1.
+  const legSpacingLimit = i.legSpacingLimit ?? 600
+  const legWidth = i.bMin ?? i.b                    // stirrups sit in the web (T-beams)
+  const legSpan = legWidth - 2 * (i.cover + i.stirrupDia / 2)
+  const widthLegs = Math.max(1, Math.ceil(legSpan / legSpacingLimit)) + 1
+  // SECONDARY: a shear-congestion bump — a 2-leg tie at the minimum practical
+  // spacing may not supply the Aᵥ/s the shear demands (§422.5.10.5.3).
+  const shearLegs = region === 'designed'
+    ? Math.max(2, Math.ceil((((VsReq * 1000) / (fyt * d)) * S_MIN_STIRRUP) / avPerLeg))
+    : 2
+  const legs = i.legs ?? Math.max(widthLegs, shearLegs)
   const Av = legs * avPerLeg
   const sMinArea = (Av * fyt) / Math.max(0.062 * Math.sqrt(i.fc) * i.b, 0.35 * i.b)
 
@@ -306,7 +313,7 @@ export function designBeam(i: BeamDesignInput): BeamDesignResult {
     comprSMinClear, comprMaxPerLayer, comprLayers, comprSClear, comprYBar,
     dPrimeExtreme, comprNAOK,
     stirrupBendDia, stirrupHookExt,
-    Vc, phiVc, region, legs, Av, VsReq, VsMax, sReq, sMax, sAdopt,
+    Vc, phiVc, region, legs, legSpacingLimit, Av, VsReq, VsMax, sReq, sMax, sAdopt,
   }
 }
 

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -373,15 +373,18 @@ function memberFlange(model: StructuralModel, m: Member, L: number): { bf: numbe
 /** Design one beam/girder member from a single run's member result. */
 function designBeamRow(
   mr: F3MemberResult, role: string, sec: RectSection, support: BeamSupport = 'both-ends',
-  flange?: { bf: number; hf: number },
+  flange?: { bf: number; hf: number }, system: 'gravity' | 'imf' | 'smf' = 'gravity',
 ): BeamScheduleRow {
+  // Transverse stirrup-leg spacing limit hx (§418.6.4.3): 350 mm for seismic
+  // frame beams, ~600 mm good-practice for gravity.
+  const legSpacingLimit = system === 'smf' || system === 'imf' ? 350 : 600
   const sections: BeamSectionDesign[] = memberSections(mr)
     .filter((s) => Math.abs(s.Mu) > 1e-6 || s.Vu > 1e-6)
     .map((s) => {
       const base = {
         b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia,
         comprBarDia: 16, stirrupDia: sec.tieDia,
-        fc: sec.fc, fy: sec.fy, Mu: Math.abs(s.Mu), Vu: s.Vu,
+        fc: sec.fc, fy: sec.fy, Mu: Math.abs(s.Mu), Vu: s.Vu, legSpacingLimit,
       }
       const rect = designBeam(base)
       // T-beam action (§6.3.2): sagging compression lives in the slab, so the
@@ -648,7 +651,7 @@ function designFromRuns(
         })() : null
         for (const run of runs) {
           const mr = memberOf(run, m.id); if (!mr) continue
-          const row = designBeamRow(mr, role, sec, support, flange ?? undefined)
+          const row = designBeamRow(mr, role, sec, support, flange ?? undefined, opts.seismicSystem ?? 'gravity')
           if (row.sections.length === 0) continue
           const sev = beamSeverity(row)
           if (sev > bestSev) { bestSev = sev; best = row; gov = run.name }

--- a/webapp/src/lib/beamSolution.test.ts
+++ b/webapp/src/lib/beamSolution.test.ts
@@ -6,24 +6,28 @@ const texOf = (steps: ReturnType<typeof buildBeamSolution>, title: string) =>
   steps.find((s) => s.title.includes(title))!.lines
     .map((l) => ('tex' in l ? l.tex : l.text)).join(' | ')
 
-describe('beam worked solution — transverse legs & Aᵥ (§422.5.10.5.3)', () => {
-  it('adds a leg step whose count matches the design and is used in Aᵥ (not hard-coded 2)', () => {
-    // Very high Vs → a 2-leg tie would need s < 75 mm → the design adds a leg.
-    const i: BeamDesignInput = { b: 300, h: 550, cover: 40, barDia: 20, stirrupDia: 10, fc: 28, fy: 415, Mu: 100, Vu: 450 }
+describe('beam worked solution — transverse legs & Aᵥ (§418.6.4.3 · §422.5)', () => {
+  it('width-driven: a wide beam step reports the design count and uses it in Aᵥ', () => {
+    // Wide beam → the hx limit forces interior legs.
+    const i: BeamDesignInput = { b: 900, h: 550, cover: 40, barDia: 20, stirrupDia: 10, fc: 28, fy: 415, Mu: 200, Vu: 150 }
     const r = designBeam(i)
-    expect(r.legs).toBeGreaterThanOrEqual(3)             // the design chose > 2 legs
+    expect(r.legs).toBeGreaterThanOrEqual(3)             // width forced > 2 legs
     const leg = texOf(buildBeamSolution(i, r), 'Transverse legs')
-    expect(leg).toContain(`= \\mathbf{${r.legs}}`)       // the step reports the design's count
-    expect(leg).toContain('(A_v/s)_{req}')               // driven by the shear demand
-    expect(leg).toContain(`= ${r.legs}\\cdot\\tfrac{\\pi}{4}`)   // Aᵥ uses that count
+    expect(leg).toContain(`= \\mathbf{${r.legs}}`)       // reports the design's count
+    expect(leg).toContain('h_x')                         // width / transverse-spacing driven
     expect(r.Av).toBeCloseTo(r.legs * (Math.PI / 4) * 10 * 10, 6)
   })
 
-  it('shows a 2-leg tie when Vs does not require more (low shear)', () => {
+  it('adds a shear-bump line when Vs governs on a normal-width beam', () => {
+    const i: BeamDesignInput = { b: 300, h: 550, cover: 40, barDia: 20, stirrupDia: 10, fc: 28, fy: 415, Mu: 100, Vu: 450 }
+    const r = designBeam(i)
+    expect(r.legs).toBeGreaterThanOrEqual(3)
+    expect(texOf(buildBeamSolution(i, r), 'Transverse legs')).toContain('shear bump')
+  })
+
+  it('normal-width, low shear → a 2-leg tie', () => {
     const i: BeamDesignInput = { b: 300, h: 500, cover: 40, barDia: 20, stirrupDia: 10, fc: 28, fy: 415, Mu: 120, Vu: 70 }
     const r = designBeam(i)
-    expect(r.region).toBe('minimum')
     expect(r.legs).toBe(2)
-    expect(texOf(buildBeamSolution(i, r), 'Transverse legs')).toContain('Vs does not require more')
   })
 })

--- a/webapp/src/lib/beamSolution.ts
+++ b/webapp/src/lib/beamSolution.ts
@@ -129,23 +129,26 @@ export function buildBeamSolution(i: BeamDesignInput, r: BeamDesignResult): Solu
     ],
   })
 
-  // Why 2 legs (or more): a closed 2-leg tie is the default; extra legs are a
-  // SHEAR response — added only when a 2-leg tie at the minimum practical spacing
-  // cannot supply the Aᵥ/s that Vs demands.
+  // Why 2 legs (or more): the leg count is set PRIMARILY by the beam width — the
+  // transverse spacing between legs must stay within hx — and BUMPED by shear if a
+  // 2-leg tie at the minimum spacing can't carry Vs.
   {
+    const hx = r.legSpacingLimit
+    const legWidth = (i.bMin ?? i.b)
+    const legSpan = legWidth - 2 * (i.cover + i.stirrupDia / 2)
+    const hxUsed = legSpan / (legs - 1)
     const crossties = legs - 2
     const lines: SolutionLine[] = [
-      txt(`Stirrups are 2-leg closed ties by default. Extra legs are added only if a 2-leg tie — even at the minimum practical spacing s_min = ${S_MIN_STIRRUP} mm — cannot supply the Aᵥ/s that Vs demands (§422.5.10.5.3); i.e. shear congestion, not bar spacing, drives multi-leg beam stirrups. Aᵥ is the total area of all legs crossing the shear crack.`),
+      txt(`The number of legs is set primarily by the beam WIDTH: the transverse (horizontal) spacing between legs must stay within hx = ${sn0(hx)} mm (§418.6.4.3 — 350 mm for seismic frame beams, ~600 mm gravity) so the stirrup engages the full width and laterally supports the bars. A 2-leg tie is the default; a wide beam needs interior legs. Aᵥ is the total leg area crossing the shear crack.`),
+      eq(String.raw`n_{legs} = \left\lceil \dfrac{b_{web} - 2(c + d_s/2)}{h_x} \right\rceil + 1 = \left\lceil \dfrac{${sn0(legSpan)}}{${sn0(hx)}} \right\rceil + 1 = ${Math.max(1, Math.ceil(legSpan / hx)) + 1}\quad(h_x^{used} = ${sn0(hxUsed)}\ \text{mm})`),
     ]
     if (r.region === 'designed' && r.VsReq > 0) {
       const avsReq = (r.VsReq * 1000) / (fyt * d)
-      lines.push(eq(String.raw`(A_v/s)_{req} = \dfrac{V_s\cdot 10^3}{f_{yt}\,d} = \dfrac{${sn1(r.VsReq)}\times 10^3}{${sn0(fyt)}(${sn1(d)})} = ${sn3(avsReq)}\ \text{mm}^2\!/\text{mm}`))
-      lines.push(eq(String.raw`n_{legs} = \max\!\left(2,\ \left\lceil \dfrac{(A_v/s)_{req}\, s_{min}}{\tfrac{\pi}{4}d_s^2} \right\rceil\right) = \max\!\left(2,\ \left\lceil \dfrac{${sn3(avsReq)}(${S_MIN_STIRRUP})}{${sn1((Math.PI / 4) * i.stirrupDia * i.stirrupDia)}} \right\rceil\right) = \mathbf{${legs}}`))
-    } else {
-      lines.push(eq(String.raw`n_{legs} = \mathbf{2}\quad(\text{closed perimeter tie — Vs does not require more})`))
+      const shearLegs = Math.max(2, Math.ceil((avsReq * S_MIN_STIRRUP) / ((Math.PI / 4) * i.stirrupDia * i.stirrupDia)))
+      lines.push(eq(String.raw`\text{shear bump: } n_{legs} \ge \left\lceil \dfrac{(A_v/s)_{req}\, s_{min}}{\tfrac{\pi}{4}d_s^2} \right\rceil = \left\lceil \dfrac{${sn3(avsReq)}(${S_MIN_STIRRUP})}{${sn1((Math.PI / 4) * i.stirrupDia * i.stirrupDia)}} \right\rceil = ${shearLegs}`))
     }
-    lines.push(eq(String.raw`A_v = n_{legs}\cdot\tfrac{\pi}{4}d_s^2 = ${legs}\cdot\tfrac{\pi}{4}(${sn0(i.stirrupDia)})^2 = ${sn0(r.Av)}\ \text{mm}^2${crossties > 0 ? String.raw`\quad(${crossties}\ \text{extra leg${crossties === 1 ? '' : 's'}})` : ''}`))
-    steps.push({ title: 'Transverse legs & shear-reinforcement area Aᵥ (§422.5.10.5.3)', lines })
+    lines.push(eq(String.raw`n_{legs} = \mathbf{${legs}},\qquad A_v = n_{legs}\cdot\tfrac{\pi}{4}d_s^2 = ${legs}\cdot\tfrac{\pi}{4}(${sn0(i.stirrupDia)})^2 = ${sn0(r.Av)}\ \text{mm}^2${crossties > 0 ? String.raw`\quad(${crossties}\ \text{extra leg${crossties === 1 ? '' : 's'}})` : ''}`))
+    steps.push({ title: 'Transverse legs & shear-reinforcement area Aᵥ (§418.6.4.3 · §422.5)', lines })
   }
 
   if (r.region === 'none') {


### PR DESCRIPTION
Follow-up to #373. As you found in testing, extra legs almost never triggered — because Vs‑req rarely governs before `VsMax` (adding legs doesn't raise the crushing ceiling). The real driver for multi‑leg beam stirrups is **beam width**: the transverse (horizontal) spacing between legs must stay within `hx` so the stirrup engages the full width and laterally supports the bars.

**Change:**
- `designBeam`: `n_legs = ⌈legSpan/hx⌉ + 1` (`legSpan` = c/c of the two outer perimeter legs, using the **web** width for T‑beams), `MAX`'d with the secondary shear‑congestion bump `⌈(Aᵥ/s)_req·s_min/A_v,leg⌉`. New input `legSpacingLimit`, echoed on the result.
- `hx` per §418.6.4.3: **350 mm** for seismic frame beams (SMF/IMF), **~600 mm** gravity — threaded from `opts.seismicSystem` through `designBeamRow`.
- Worked‑solution step now derives the count from the **width/hx** (primary), adds a "shear bump" line when Vs governs, and reports `hx_used = legSpan/(legs−1)`.

**Result:** multi‑leg triggers where it should — wide/band beams and seismic frame beams — instead of being effectively unreachable. Normal beams stay at 2 legs.

## Verification
- `npx tsc -b` clean; `npm test` → **1121 passing** (normal → 2 legs; wide gravity beam → 3; seismic `hx` tightens it to 4; a very high Vs still bumps a normal beam).
- Rendered a 750×450 model: gravity reads `nlegs = ⌈660/600⌉ + 1 = 3 (hx_used = 330 mm)` → `3L-⌀10@190`. Normal-width beams stay `2L`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_