### PR TITLE
feat: 3D floor grid — metric offsets (bubbles 3 m / dims 2 m) + architectural ticks

### DIFF
--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -299,9 +299,9 @@ function AxisBubble({ x, y, z, r, label }: { x: number; y: number; z: number; r:
 
 /** ETABS-style plan grid on the floor: column lines (A, B, …) parallel to Z and
  *  rows (1, 2, …) parallel to X, derived from the unique node coordinates. Bubbles
- *  sit ~2 bays off the top (letters) and left (numbers) edges only, and a dimension
- *  line between the grid and the bubbles reports the bay spacings (m). Flat on the
- *  base plane. */
+ *  sit 3 m off the top (letters) and left (numbers) edges only; a dimension line 2 m
+ *  off each edge — with 45° architectural ticks and the bay spacing (m) sitting above
+ *  the line — reports the bay widths. Flat on the base plane (1 m = one floor square). */
 function GridBubbles3D({ model }: { model: StructuralModel }) {
   const g = useMemo(() => {
     if (!model.nodes.length) return null
@@ -316,61 +316,57 @@ function GridBubbles3D({ model }: { model: StructuralModel }) {
     if (xs.length < 2 && zs.length < 2) return null
     const y0 = Math.min(...model.nodes.map((n) => n.y))
     const x0 = xs[0], x1 = xs[xs.length - 1], z0 = zs[0], z1 = zs[zs.length - 1]
-    const r = Math.max(0.5, Math.max(x1 - x0, z1 - z0, 1) * 0.035)      // bigger bubbles
-    const bayX = xs.length > 1 ? (x1 - x0) / (xs.length - 1) : Math.max(x1 - x0, 1)
-    const bayZ = zs.length > 1 ? (z1 - z0) / (zs.length - 1) : Math.max(z1 - z0, 1)
-    const extZ = 2 * bayZ                                               // letters ~2 boxes off the top (−Z)
-    const extX = 2 * bayX                                               // numbers ~2 boxes off the left (−X)
-    const pad = r
+    const r = Math.max(0.5, Math.max(x1 - x0, z1 - z0, 1) * 0.035)      // bubble radius
+    const BUB = 3, DIM = 2, pad = r                                     // metres out from the grid edge
     // main grid lines — reach the bubble on the labelled side, a touch past on the far side
     const gpts: number[] = []
-    for (const x of xs) gpts.push(x, y0, z0 - extZ, x, y0, z1 + pad)    // column lines ‖ Z
-    for (const z of zs) gpts.push(x0 - extX, y0, z, x1 + pad, y0, z)    // rows ‖ X
+    for (const x of xs) gpts.push(x, y0, z0 - BUB + r, x, y0, z1 + pad) // column lines ‖ Z
+    for (const z of zs) gpts.push(x0 - BUB + r, y0, z, x1 + pad, y0, z) // rows ‖ X
     const geo = new THREE.BufferGeometry()
     geo.setAttribute('position', new THREE.Float32BufferAttribute(gpts, 3))
-    // dimension lines + end ticks, sitting between the grid edge and the bubbles
-    const zDim = z0 - extZ * 0.45, xDim = x0 - extX * 0.45, tick = r * 0.8
+    // dimension lines + 45° architectural ticks, 2 m off the top and left edges
+    const zDim = z0 - DIM, xDim = x0 - DIM, s = r * 0.6
     const dpts: number[] = []
     if (xs.length > 1) {
       dpts.push(x0, y0, zDim, x1, y0, zDim)
-      for (const x of xs) dpts.push(x, y0, zDim - tick, x, y0, zDim + tick)
+      for (const x of xs) dpts.push(x - s, y0, zDim - s, x + s, y0, zDim + s)  // 45° slash tick
     }
     if (zs.length > 1) {
       dpts.push(xDim, y0, z0, xDim, y0, z1)
-      for (const z of zs) dpts.push(xDim - tick, y0, z, xDim + tick, y0, z)
+      for (const z of zs) dpts.push(xDim - s, y0, z - s, xDim + s, y0, z + s)  // 45° slash tick
     }
     const dimGeo = new THREE.BufferGeometry()
     dimGeo.setAttribute('position', new THREE.Float32BufferAttribute(dpts, 3))
     const xDims = xs.slice(1).map((x, i) => ({ mid: (xs[i] + x) / 2, val: x - xs[i] }))
     const zDims = zs.slice(1).map((z, i) => ({ mid: (zs[i] + z) / 2, val: z - zs[i] }))
-    return { xs, zs, y0, x0, z0, r, extZ, extX, zDim, xDim, geo, dimGeo, xDims, zDims }
+    return { xs, zs, y0, x0, z0, r, BUB, zDim, xDim, geo, dimGeo, xDims, zDims }
   }, [model])
   if (!g) return null
-  const dimFont = g.r * 0.72
+  const dimFont = g.r * 0.72, tOff = g.r * 1.4                          // text offset above the line
   return (
     <group>
       <lineSegments geometry={g.geo}>
         <lineBasicMaterial color="#64748b" transparent opacity={0.5} />
       </lineSegments>
       <lineSegments geometry={g.dimGeo}>
-        <lineBasicMaterial color="#94a3b8" transparent opacity={0.7} />
+        <lineBasicMaterial color="#64748b" transparent opacity={0.8} />
       </lineSegments>
-      {/* column-line bubbles (A, B, …) — top edge only */}
+      {/* column-line bubbles (A, B, …) — top edge only, 3 m out */}
       {g.xs.map((x, i) => (
-        <AxisBubble key={`col${i}`} x={x} y={g.y0} z={g.z0 - g.extZ - g.r} r={g.r} label={String.fromCharCode(65 + i)} />
+        <AxisBubble key={`col${i}`} x={x} y={g.y0} z={g.z0 - g.BUB} r={g.r} label={String.fromCharCode(65 + i)} />
       ))}
-      {/* row bubbles (1, 2, …) — left edge only */}
+      {/* row bubbles (1, 2, …) — left edge only, 3 m out */}
       {g.zs.map((z, i) => (
-        <AxisBubble key={`row${i}`} x={g.x0 - g.extX - g.r} y={g.y0} z={z} r={g.r} label={String(i + 1)} />
+        <AxisBubble key={`row${i}`} x={g.x0 - g.BUB} y={g.y0} z={z} r={g.r} label={String(i + 1)} />
       ))}
-      {/* bay dimensions across the top (X spacings) */}
+      {/* bay dimensions across the top (X), text above the line */}
       {g.xDims.map((d, i) => (
-        <Text key={`dx${i}`} position={[d.mid, g.y0 + 0.03, g.zDim]} rotation={[-Math.PI / 2, 0, 0]}
+        <Text key={`dx${i}`} position={[d.mid, g.y0 + 0.03, g.zDim - tOff]} rotation={[-Math.PI / 2, 0, 0]}
           fontSize={dimFont} color="#475569" anchorX="center" anchorY="middle">{`${d.val.toFixed(2)} m`}</Text>
       ))}
-      {/* bay dimensions down the left (Z spacings) */}
+      {/* bay dimensions down the left (Z), text above the line */}
       {g.zDims.map((d, i) => (
-        <Text key={`dz${i}`} position={[g.xDim, g.y0 + 0.03, d.mid]} rotation={[-Math.PI / 2, 0, Math.PI / 2]}
+        <Text key={`dz${i}`} position={[g.xDim - tOff, g.y0 + 0.03, d.mid]} rotation={[-Math.PI / 2, 0, Math.PI / 2]}
           fontSize={dimFont} color="#475569" anchorX="center" anchorY="middle">{`${d.val.toFixed(2)} m`}</Text>
       ))}
     </group>


### PR DESCRIPTION
## What

Follow-up on the `/model` floor grid (#376). The floor squares are **1 m**, so the offsets are now in metres (not structural bays):

- **Bubbles 3 m out** — axis bubbles sit exactly 3 m outside the top (letters) and left (numbers) edges.
- **Dimension lines 2 m out** — inside the bubbles, on each labelled edge.
- **Text above the line** — the bay spacing (`6.00 m`, `5.00 m`, …) is raised above the dimension line at each mid-bay (was centred on the line).
- **Architectural ticks** — thin 45° slash ticks at each grid crossing (replacing the square perpendicular ticks).
- Grid lines still extend to meet the bubble on the labelled side.

## Layer

UI only (`webapp/src/pages/ModelSpace.tsx`) — `GridBubbles3D`. No engine/solver changes.

## Verification

- `npx tsc -b` — clean.
- `npm test` — 1121 passing (89 files).
- `npm run build` — succeeds.
- Grid math checked against the reference model in the screenshot (bays 6,6 × 5): letter bubbles at `z=−3`, number bubbles at `x=−3`, dim lines at `−2`, bay text raised to `−2.70` (above the line, between line and bubbles), 45° ticks at each grid line, grid lines reaching the bubble edge at `−2.50`.

Note: bubbles/ticks/text are three.js/WebGL geometry — best confirmed on the Vercel preview (the screenshot path reads the 3D canvas as black here), so the offsets/ticks are verified in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_