### PR TITLE
fix: 3D floor grid — bay text 0.3 m above the line, ticks 50% shorter

### DIFF
--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -325,7 +325,7 @@ function GridBubbles3D({ model }: { model: StructuralModel }) {
     const geo = new THREE.BufferGeometry()
     geo.setAttribute('position', new THREE.Float32BufferAttribute(gpts, 3))
     // dimension lines + 45° architectural ticks, 2 m off the top and left edges
-    const zDim = z0 - DIM, xDim = x0 - DIM, s = r * 0.6
+    const zDim = z0 - DIM, xDim = x0 - DIM, s = r * 0.3
     const dpts: number[] = []
     if (xs.length > 1) {
       dpts.push(x0, y0, zDim, x1, y0, zDim)
@@ -342,7 +342,7 @@ function GridBubbles3D({ model }: { model: StructuralModel }) {
     return { xs, zs, y0, x0, z0, r, BUB, zDim, xDim, geo, dimGeo, xDims, zDims }
   }, [model])
   if (!g) return null
-  const dimFont = g.r * 0.72, tOff = g.r * 1.4                          // text offset above the line
+  const dimFont = g.r * 0.72, tOff = 0.3                                // text 0.3 m above the line (→ 2.3 m out)
   return (
     <group>
       <lineSegments geometry={g.geo}>


### PR DESCRIPTION
## What

Two small tweaks to the `/model` floor-grid dimensions (#377), per feedback:

- **Bay text 0.3 m above the line** — the dimension text now sits 2.3 m out (0.3 m above the 2 m dimension line), down from 2.7 m.
- **Ticks 50% shorter** — the 45° architectural tick half-length is halved (`r·0.3`, was `r·0.6`).

## Layer

UI only (`webapp/src/pages/ModelSpace.tsx`) — `GridBubbles3D`. No engine/solver changes.

## Verification

- `npx tsc -b` — clean.
- `npm test` — 1121 passing (89 files).
- `npm run build` — succeeds.

Note: WebGL geometry — best confirmed on the Vercel preview (the screenshot path reads the 3D canvas as black here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_