### PR TITLE
feat: timber (wood-frame) ASD design engine — NDS §3 / NSCP §6 (Phase 1)

### DIFF
--- a/docs/ValidationMap.md
+++ b/docs/ValidationMap.md
@@ -109,6 +109,7 @@ asserted by that file; all run in CI.
 | Steel member design | `steelDesign.test.ts`, `aiscSections.test.ts`, `flexure.test.ts`, `shear.test.ts` | §F2/§G2.1/§E3/§H1-1 formula re-derivations; `validation.ts` `steel-phimp`/`steel-phivn` |
 | Steel connections | `steelConnections.test.ts`, `boltedConnection.test.ts`, `weldedConnection.test.ts`, `connectionSolution.test.ts`, `baseplate.test.ts` | IC-method bolt/weld groups vs `validation.ts` `bolt-ecc-rmax`/`weld-ecc-fmax`/`bolt-oop-tension`/`prying-t0`; AISC DG1 base plates |
 | Effective length K | `effectiveLength.test.ts` | alignment-chart G-factors vs published values (review anchors) |
+| Timber (wood) member design | `woodDesign.test.ts` | NDS §3 / NSCP §6 ASD adjustment factors (CD/CM/CF/CV), beam CL (§3.3.3) + column CP (§3.7.1) closed-form anchors, beam-column §3.9.2 interaction; `validation.ts` `wood-cp`/`wood-cl` |
 | SCWB | `scwb.test.ts` | ΣMnc/ΣMnb ≥ 6/5 (§418.7.3.2) with hand Mn |
 | Slabs | `slabDDM.test.ts`, `woodArmer.test.ts`, `slabDeflection.test.ts` | DDM coefficient tables; Wood–Armer moment transformation identities |
 | RC misc | `devLength.test.ts`, `torsionDesign.test.ts`, `beamDeflection.test.ts`, `shearWallDesign.test.ts` | §425.4 ld, §422.7 threshold/cracking torsion, Branson Ie, wall shear |

--- a/webapp/src/engine/validation.ts
+++ b/webapp/src/engine/validation.ts
@@ -23,11 +23,12 @@ import { solveFrame3D, rectJ, type F3Node, type F3Member, type F3Support } from 
 import { solveBoltedConnection } from './boltedConnection'
 import { solveWeldedConnection } from './weldedConnection'
 import { boltGeomFromPositions, outOfPlaneBoltGroup, pryingAction } from './steelDesign'
+import { columnStabilityFactor, beamStabilityFactor, getWoodRef } from './woodDesign'
 import type { RectSection } from './model'
 
 export interface ValidationCase {
   id: string
-  category: 'RC' | 'Steel' | 'Connections' | 'Analysis' | 'Seismic' | 'Dynamics' | 'Wind' | 'Geotech'
+  category: 'RC' | 'Steel' | 'Timber' | 'Connections' | 'Analysis' | 'Seismic' | 'Dynamics' | 'Wind' | 'Geotech'
   title: string
   reference: string
   formula: string
@@ -205,6 +206,23 @@ const pryingT0 = (() => {
   return { manual: Math.sqrt((4 * 60 * 1000 * 35) / (0.9 * 248 * 70)), software: r.t_no_prying }
 })()
 
+// ── Timber (wood) — NDS §3 / NSCP §6 ASD stability factors ──────────────────
+const woodCP = (() => {
+  // 140 mm square DFL-SS post, le = 3.0 m, c = 0.8.  CF = 1 (d ≤ 300), CD = 1.
+  const Emin = getWoodRef('DFL-SS')!.ref.Emin, FcStar = getWoodRef('DFL-SS')!.ref.Fc
+  const FcE = (0.822 * Emin) / (3000 / 140) ** 2
+  const r = FcE / FcStar, a = (1 + r) / (2 * 0.8)
+  return { manual: a - Math.sqrt(a * a - r / 0.8), software: columnStabilityFactor(3000, 140, Emin, FcStar, 0.8).CP }
+})()
+
+const woodCL = (() => {
+  // 100 × 300 mm DFL-SS beam, le = 4.0 m.  CF = 1 (d ≤ 300), CD = 1.
+  const Emin = getWoodRef('DFL-SS')!.ref.Emin, FbStar = getWoodRef('DFL-SS')!.ref.Fb
+  const RB = Math.sqrt((4000 * 300) / 100 ** 2), FbE = (1.2 * Emin) / (RB * RB)
+  const r = FbE / FbStar, a = (1 + r) / 1.9
+  return { manual: a - Math.sqrt(a * a - r / 0.95), software: beamStabilityFactor(100, 300, 4000, Emin, FbStar).CL }
+})()
+
 export const VALIDATION_CASES: ValidationCase[] = [
   {
     id: 'rc-beam-mn', category: 'RC', title: 'Singly-reinforced beam — nominal moment',
@@ -315,5 +333,15 @@ export const VALIDATION_CASES: ValidationCase[] = [
     id: 'prying-t0', category: 'Connections', title: 'Prying — thickness eliminating prying',
     reference: 'AISC Manual Part 9 / §J3.9', formula: 't₀ = √(4·φBn·b′ / (φf·Fy·p))',
     manual: pryingT0.manual, software: pryingT0.software, unit: 'mm', tol: 1e-9,
+  },
+  {
+    id: 'wood-cp', category: 'Timber', title: 'Timber column stability factor CP',
+    reference: 'NDS 2018 §3.7.1 / NSCP §6', formula: 'CP = a − √(a² − (FcE/Fc*)/c),  a = (1+FcE/Fc*)/2c',
+    manual: woodCP.manual, software: woodCP.software, unit: '—', tol: 1e-9,
+  },
+  {
+    id: 'wood-cl', category: 'Timber', title: 'Timber beam stability factor CL',
+    reference: 'NDS 2018 §3.3.3 / NSCP §6', formula: 'CL = a − √(a² − (FbE/Fb*)/0.95),  a = (1+FbE/Fb*)/1.9',
+    manual: woodCL.manual, software: woodCL.software, unit: '—', tol: 1e-9,
   },
 ]

--- a/webapp/src/engine/woodDesign.test.ts
+++ b/webapp/src/engine/woodDesign.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest'
+import {
+  WOOD_SPECIES, getWoodRef, loadDurationFactor, sizeFactorTimber, volumeFactorGlulam,
+  effectiveBendingLength, beamStabilityFactor, columnStabilityFactor, woodSectionProps,
+  woodAdjusted, checkWoodBeam, checkWoodColumn,
+} from './woodDesign'
+
+describe('reference value library', () => {
+  it('DFL Select Structural ≈ NDS Table 4A (1500/180/1700 psi → MPa)', () => {
+    const ref = getWoodRef('DFL-SS')!.ref
+    expect(ref.Fb).toBeCloseTo(10.342, 2)     // 1500 psi
+    expect(ref.Fv).toBeCloseTo(1.241, 2)      // 180 psi
+    expect(ref.Fc).toBeCloseTo(11.721, 2)     // 1700 psi
+    expect(ref.E).toBeCloseTo(13100, 0)       // 1.9e6 psi
+    expect(ref.Emin).toBeCloseTo(4757.4, 0)   // 0.69e6 psi
+  })
+  it('every species has strictly positive design values', () => {
+    for (const s of Object.values(WOOD_SPECIES)) {
+      for (const v of Object.values(s.ref)) expect(v).toBeGreaterThan(0)
+      expect(s.ref.Emin).toBeLessThan(s.ref.E)   // stability modulus < mean E
+    }
+  })
+})
+
+describe('load-duration factor CD (NDS Table 2.3.2)', () => {
+  it('permanent 0.9 · normal 1.0 · snow 1.15 · wind/seismic 1.6 · impact 2.0', () => {
+    expect(loadDurationFactor('permanent')).toBe(0.9)
+    expect(loadDurationFactor('ten-year')).toBe(1.0)
+    expect(loadDurationFactor('two-month')).toBe(1.15)
+    expect(loadDurationFactor('ten-minute')).toBe(1.6)
+    expect(loadDurationFactor('impact')).toBe(2.0)
+  })
+})
+
+describe('section properties (solid rectangle)', () => {
+  it('A = b·d, S = b·d²/6, I = b·d³/12', () => {
+    const { A, S, I } = woodSectionProps(150, 350)
+    expect(A).toBe(52500)
+    expect(S).toBeCloseTo((150 * 350 ** 2) / 6, 6)
+    expect(I).toBeCloseTo((150 * 350 ** 3) / 12, 6)
+  })
+})
+
+describe('size factor CF (sawn timbers, §4.3.6.2)', () => {
+  it('CF = 1.0 for d ≤ 300 mm, (300/d)^(1/9) < 1 for deeper', () => {
+    expect(sizeFactorTimber(250)).toBe(1)
+    expect(sizeFactorTimber(300)).toBe(1)
+    expect(sizeFactorTimber(400)).toBeCloseTo(Math.pow(300 / 400, 1 / 9), 9)
+    expect(sizeFactorTimber(400)).toBeLessThan(1)
+  })
+  it('deeper members have a smaller size factor', () => {
+    expect(sizeFactorTimber(600)).toBeLessThan(sizeFactorTimber(400))
+  })
+})
+
+describe('beam stability factor CL (§3.3.3) — literal anchor', () => {
+  // b=100, d=300, le=4000, E′min=4760, Fb*=10.34  →  RB=√120, FbE=47.6, CL≈0.9865
+  const s = beamStabilityFactor(100, 300, 4000, 4760, 10.34)
+  it('RB = √(le·d/b²)', () => expect(s.RB).toBeCloseTo(Math.sqrt(120), 6))
+  it('FbE = 1.2·E′min/RB²', () => expect(s.FbE).toBeCloseTo((1.2 * 4760) / 120, 4))
+  it('CL matches the §3.3.3.8 closed form', () => expect(s.CL).toBeCloseTo(0.9865, 3))
+  it('CL ≤ 1 and shrinks as the unbraced length grows', () => {
+    expect(s.CL).toBeLessThanOrEqual(1)
+    expect(beamStabilityFactor(100, 300, 9000, 4760, 10.34).CL).toBeLessThan(s.CL)
+  })
+})
+
+describe('column stability factor CP (§3.7.1) — literal anchor', () => {
+  // le=3000, d=140, E′min=4760, Fc*=11.72, c=0.8  →  le/d≈21.43, FcE≈8.521, CP≈0.5731
+  const s = columnStabilityFactor(3000, 140, 4760, 11.72, 0.8)
+  it('slenderness = le/d', () => expect(s.slenderness).toBeCloseTo(3000 / 140, 6))
+  it('FcE = 0.822·E′min/(le/d)²', () => expect(s.FcE).toBeCloseTo((0.822 * 4760) / (3000 / 140) ** 2, 4))
+  it('CP matches the §3.7.1.5 closed form', () => expect(s.CP).toBeCloseTo(0.5731, 3))
+  it('a longer/slenderer column has a smaller CP', () => {
+    expect(columnStabilityFactor(4500, 140, 4760, 11.72, 0.8).CP).toBeLessThan(s.CP)
+  })
+})
+
+describe('woodAdjusted', () => {
+  const ref = getWoodRef('DFL-SS')!.ref
+  it('dry / normal duration leaves E unchanged and folds CD·CF into Fb*', () => {
+    const a = woodAdjusted(ref, 'sawn', 350)               // CF(350) < 1, CD=1
+    expect(a.CD).toBe(1)
+    expect(a.CF).toBeCloseTo(sizeFactorTimber(350), 9)
+    expect(a.E).toBeCloseTo(ref.E, 6)
+    expect(a.FbStar).toBeCloseTo(ref.Fb * a.CF, 6)
+  })
+  it('wind duration raises the allowables by CD = 1.6', () => {
+    const dry = woodAdjusted(ref, 'sawn', 200)
+    const wind = woodAdjusted(ref, 'sawn', 200, { duration: 'ten-minute' })
+    expect(wind.FbStar / dry.FbStar).toBeCloseTo(1.6, 6)
+    expect(wind.FvAllow / dry.FvAllow).toBeCloseTo(1.6, 6)
+  })
+  it('wet service reduces Fb, Fc, Fc⊥ and E; Fc⊥ carries no CD', () => {
+    const wet = woodAdjusted(ref, 'sawn', 200, { wet: true })
+    const dry = woodAdjusted(ref, 'sawn', 200)
+    expect(wet.FbStar).toBeLessThan(dry.FbStar)
+    expect(wet.E).toBeCloseTo(dry.E * 0.9, 6)
+    expect(wet.FcPerpAllow).toBeCloseTo(ref.FcPerp * 0.67, 6)   // no CD on bearing
+  })
+})
+
+describe('checkWoodBeam — composition against the parts', () => {
+  const ref = getWoodRef('DFL-SS')!.ref
+  const p = { ref, kind: 'sawn' as const, b: 150, d: 350, length: 5000, M: 25, V: 30 }
+  const r = checkWoodBeam(p)
+  it('fb = M/S and fv = 1.5V/A', () => {
+    const { A, S } = woodSectionProps(150, 350)
+    expect(r.fb).toBeCloseTo((25 * 1e6) / S, 6)
+    expect(r.fv).toBeCloseTo((1.5 * 30 * 1e3) / A, 6)
+  })
+  it('F′b = Fb* · CL with le auto per §3.3.3', () => {
+    const adj = woodAdjusted(ref, 'sawn', 350)
+    const le = effectiveBendingLength(5000, 350)
+    const { CL } = beamStabilityFactor(150, 350, le, adj.Emin, adj.FbStar)
+    expect(r.CL).toBeCloseTo(CL, 6)
+    expect(r.FbPrime).toBeCloseTo(adj.FbStar * CL, 6)
+  })
+  it('governing ratio = max(bending, shear); this section passes', () => {
+    expect(r.ratio).toBeCloseTo(Math.max(r.bendingRatio, r.shearRatio), 9)
+    expect(r.ok).toBe(true)
+  })
+  it('doubling the moment overstresses the beam', () => {
+    expect(checkWoodBeam({ ...p, M: 55 }).ok).toBe(false)
+  })
+})
+
+describe('checkWoodColumn — axial + beam-column interaction', () => {
+  const ref = getWoodRef('DFL-SS')!.ref
+  it('pure axial: fc = P/A and ratio = fc/F′c', () => {
+    const r = checkWoodColumn({ ref, kind: 'sawn', b: 140, d: 140, length: 3000, P: 100 })
+    expect(r.fc).toBeCloseTo((100 * 1e3) / (140 * 140), 6)
+    expect(r.axialRatio).toBeCloseTo(r.fc / r.FcPrime, 9)
+    expect(r.interaction).toBe(0)
+    expect(r.ratio).toBeCloseTo(r.axialRatio, 9)
+  })
+  it('CP uses the governing (larger) slenderness of the two planes', () => {
+    // Same le both planes but b < d → weak axis governs (larger le/b).
+    const r = checkWoodColumn({ ref, kind: 'sawn', b: 100, d: 200, length: 3000, P: 50 })
+    expect(r.slenderness).toBeCloseTo(3000 / 100, 6)
+  })
+  it('adding a moment engages §3.9.2 and raises the demand above pure axial', () => {
+    const axial = checkWoodColumn({ ref, kind: 'sawn', b: 200, d: 200, length: 3000, P: 120 })
+    const bent = checkWoodColumn({ ref, kind: 'sawn', b: 200, d: 200, length: 3000, P: 120, Mx: 15 })
+    expect(bent.interaction).toBeGreaterThan(axial.axialRatio)
+    expect(bent.ratio).toBeGreaterThan(axial.ratio)
+  })
+  it('a very slender column is governed by buckling (CP ≪ 1)', () => {
+    const r = checkWoodColumn({ ref, kind: 'sawn', b: 100, d: 100, length: 4000, P: 10 })
+    expect(r.CP).toBeLessThan(0.5)
+  })
+})
+
+describe('glulam volume factor CV (§5.3.6)', () => {
+  it('CV ≤ 1 and shrinks with member size', () => {
+    const cv = volumeFactorGlulam(130, 600, 8000)
+    expect(cv).toBeLessThanOrEqual(1)
+    expect(volumeFactorGlulam(130, 900, 12000)).toBeLessThan(cv)
+  })
+  it('a glulam beam applies the lesser of CV and CL to F′b', () => {
+    const ref = getWoodRef('GLULAM-24F')!.ref
+    const r = checkWoodBeam({ ref, kind: 'glulam', b: 130, d: 600, length: 8000, M: 120, V: 60 })
+    const adj = woodAdjusted(ref, 'glulam', 600)
+    const CV = volumeFactorGlulam(130, 600, 8000)
+    // F′b must not exceed Fb*·CV nor Fb*·CL (whichever is smaller).
+    expect(r.FbPrime).toBeLessThanOrEqual(adj.FbStar * CV + 1e-9)
+    expect(r.FbPrime).toBeLessThanOrEqual(adj.FbStar * r.CL + 1e-9)
+  })
+})

--- a/webapp/src/engine/woodDesign.ts
+++ b/webapp/src/engine/woodDesign.ts
@@ -1,0 +1,269 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Timber (wood frame) member design — ASD per NDS 2018 §3 / NSCP 2015 §6.
+// NSCP 2015 Chapter 6 (Wood) adopts the same Allowable-Stress-Design
+// adjustment-factor framework as the NDS: an allowable stress F′ is the
+// tabulated reference stress F multiplied by the applicable C-factors, and the
+// member is adequate when the actual stress f ≤ F′.  Reference design values
+// below are NDS Supplement Table 4A/4D (visually-graded sawn lumber, SI
+// conversion 1 psi = 0.00689476 MPa) and Table 5A (glulam); NSCP §6 Philippine
+// species (Yakal, Apitong, Guijo …) share the method and can be supplied as
+// custom reference values.
+//
+// Units: geometry mm; forces kN; moments kN·m; stresses MPa.  Section is a
+// solid rectangle b (width) × d (depth); bending about the strong axis (depth).
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Tabulated ASD reference design values for a species/grade (MPa). */
+export interface WoodRefValues {
+  Fb: number       // bending
+  Ft: number       // tension parallel to grain
+  Fv: number       // shear parallel to grain (horizontal shear)
+  FcPerp: number   // compression perpendicular to grain (bearing)
+  Fc: number       // compression parallel to grain
+  E: number        // modulus of elasticity
+  Emin: number     // reference modulus for stability (5th-percentile, ×safety)
+  G: number        // specific gravity (for density / connector design)
+}
+
+export type WoodKind = 'sawn' | 'glulam'
+
+export interface WoodSpecies {
+  id: string
+  label: string
+  kind: WoodKind
+  ref: WoodRefValues
+}
+
+// psi → MPa
+const K = 0.00689476
+const mpa = (psi: number) => psi * K
+
+// ── Reference design value library ────────────────────────────────────────
+// Sawn: NDS Supplement Table 4A (visually-graded dimension lumber / timbers).
+// Glulam: NDS Supplement Table 5A (bending combinations, Δ = tension zone).
+export const WOOD_SPECIES: Record<string, WoodSpecies> = {
+  'DFL-SS': { id: 'DFL-SS', label: 'Douglas Fir-Larch — Select Structural', kind: 'sawn',
+    ref: { Fb: mpa(1500), Ft: mpa(1000), Fv: mpa(180), FcPerp: mpa(625), Fc: mpa(1700), E: mpa(1_900_000), Emin: mpa(690_000), G: 0.50 } },
+  'DFL-1': { id: 'DFL-1', label: 'Douglas Fir-Larch — No.1', kind: 'sawn',
+    ref: { Fb: mpa(1000), Ft: mpa(675), Fv: mpa(180), FcPerp: mpa(625), Fc: mpa(1500), E: mpa(1_700_000), Emin: mpa(620_000), G: 0.50 } },
+  'DFL-2': { id: 'DFL-2', label: 'Douglas Fir-Larch — No.2', kind: 'sawn',
+    ref: { Fb: mpa(900), Ft: mpa(575), Fv: mpa(180), FcPerp: mpa(625), Fc: mpa(1350), E: mpa(1_600_000), Emin: mpa(580_000), G: 0.50 } },
+  'HF-2': { id: 'HF-2', label: 'Hem-Fir — No.2', kind: 'sawn',
+    ref: { Fb: mpa(850), Ft: mpa(525), Fv: mpa(150), FcPerp: mpa(405), Fc: mpa(1300), E: mpa(1_300_000), Emin: mpa(470_000), G: 0.43 } },
+  'SPF-2': { id: 'SPF-2', label: 'Spruce-Pine-Fir — No.2', kind: 'sawn',
+    ref: { Fb: mpa(875), Ft: mpa(450), Fv: mpa(135), FcPerp: mpa(425), Fc: mpa(1150), E: mpa(1_400_000), Emin: mpa(510_000), G: 0.42 } },
+  'SP-2': { id: 'SP-2', label: 'Southern Pine — No.2', kind: 'sawn',
+    ref: { Fb: mpa(1050), Ft: mpa(650), Fv: mpa(175), FcPerp: mpa(565), Fc: mpa(1700), E: mpa(1_600_000), Emin: mpa(580_000), G: 0.55 } },
+  'GLULAM-24F': { id: 'GLULAM-24F', label: 'Glulam 24F-1.8E (24F-V4 DF)', kind: 'glulam',
+    ref: { Fb: mpa(2400), Ft: mpa(1100), Fv: mpa(265), FcPerp: mpa(650), Fc: mpa(1650), E: mpa(1_800_000), Emin: mpa(950_000), G: 0.50 } },
+}
+
+export function getWoodRef(id: string): WoodSpecies | undefined {
+  return WOOD_SPECIES[id]
+}
+
+// ── Load-duration factor CD (NDS Table 2.3.2) ──────────────────────────────
+export type LoadDuration = 'permanent' | 'ten-year' | 'two-month' | 'seven-day' | 'ten-minute' | 'impact'
+const CD_TABLE: Record<LoadDuration, number> = {
+  permanent: 0.9, 'ten-year': 1.0, 'two-month': 1.15, 'seven-day': 1.25, 'ten-minute': 1.6, impact: 2.0,
+}
+/** CD for the governing load combination.  Wind/seismic → 1.6, snow → 1.15,
+ *  occupancy live → 1.0, dead-only → 0.9. */
+export function loadDurationFactor(d: LoadDuration): number { return CD_TABLE[d] }
+
+// ── Wet-service factors CM (NDS Supplement Table 4A footnotes, sawn lumber) ──
+// Applied when the in-service moisture content exceeds 19% (sawn) / 16% (glulam).
+interface WetFactors { Fb: number; Ft: number; Fv: number; FcPerp: number; Fc: number; E: number }
+const CM_SAWN: WetFactors = { Fb: 0.85, Ft: 1.0, Fv: 0.97, FcPerp: 0.67, Fc: 0.8, E: 0.9 }
+const CM_GLULAM: WetFactors = { Fb: 0.8, Ft: 0.8, Fv: 0.875, FcPerp: 0.53, Fc: 0.73, E: 0.833 }
+
+// ── Size factor CF (sawn timbers, NDS §4.3.6.2 eq. 4.3-1) ───────────────────
+/** Bending/axial size factor for sawn "timbers" (least dimension ≥ 114 mm).
+ *  CF = (300/d)^(1/9) ≤ 1.0 when depth d > 300 mm; else 1.0.  (300 mm ≈ 12 in.)
+ *  Dimension lumber (38–89 mm thick) uses tabulated CF instead — pass it via
+ *  `opts.CF` for those members. */
+export function sizeFactorTimber(depthMm: number): number {
+  return depthMm > 300 ? Math.min(1, Math.pow(300 / depthMm, 1 / 9)) : 1
+}
+
+// ── Volume factor CV (glulam, NDS §5.3.6 eq. 5.3-1) ─────────────────────────
+/** Glulam volume factor; replaces CF and does not act simultaneously with CL
+ *  (the lesser of CV, CL governs — §5.3.6).  KL = 1.0 for the common uniform /
+ *  concentrated-midspan cases; x = 10 (species other than Southern Pine). */
+export function volumeFactorGlulam(bMm: number, dMm: number, lengthMm: number, x = 10, KL = 1.0): number {
+  const b = bMm / 25.4, d = dMm / 25.4, L = lengthMm / 25.4    // → in (formula is in customary units)
+  return Math.min(1, KL * Math.pow(21 / L, 1 / x) * Math.pow(12 / d, 1 / x) * Math.pow(5.125 / b, 1 / x))
+}
+
+// ── Beam stability factor CL (NDS §3.3.3) ──────────────────────────────────
+/** Effective bending length le from unbraced length lu (NDS Table 3.3.3,
+ *  uniformly-distributed load).  d in mm. */
+export function effectiveBendingLength(lu: number, d: number): number {
+  const r = lu / d
+  if (r < 7) return 2.06 * lu
+  if (r <= 14.3) return 1.63 * lu + 3 * d
+  return 1.84 * lu
+}
+
+export interface BeamStability { RB: number; FbE: number; CL: number }
+/** CL from the reference-with-all-other-factors bending stress FbStar (Fb*). */
+export function beamStabilityFactor(b: number, d: number, le: number, Emin: number, FbStar: number): BeamStability {
+  const RB = Math.sqrt((le * d) / (b * b))                 // §3.3.3.6 (≤ 50)
+  const FbE = (1.2 * Emin) / (RB * RB)                     // §3.3.3.8
+  const a = (1 + FbE / FbStar) / 1.9
+  const CL = a - Math.sqrt(Math.max(0, a * a - (FbE / FbStar) / 0.95))
+  return { RB, FbE, CL }
+}
+
+// ── Column stability factor CP (NDS §3.7.1) ────────────────────────────────
+export interface ColumnStability { slenderness: number; FcE: number; CP: number }
+/** CP from the reference-with-all-other-factors compression stress FcStar (Fc*).
+ *  le = effective length (Ke·lu) in the buckling plane; d = section dimension in
+ *  that plane.  c = 0.8 sawn, 0.9 glulam. */
+export function columnStabilityFactor(le: number, d: number, Emin: number, FcStar: number, c = 0.8): ColumnStability {
+  const slenderness = le / d                               // §3.7.1.4 (≤ 50)
+  const FcE = (0.822 * Emin) / (slenderness * slenderness) // §3.7.1.5
+  const ratio = FcE / FcStar
+  const a = (1 + ratio) / (2 * c)
+  const CP = a - Math.sqrt(Math.max(0, a * a - ratio / c))
+  return { slenderness, FcE, CP }
+}
+
+// ── Section properties (solid rectangle) ───────────────────────────────────
+export function woodSectionProps(b: number, d: number): { A: number; S: number; I: number } {
+  return { A: b * d, S: (b * d * d) / 6, I: (b * d * d * d) / 12 }
+}
+
+// ── Common adjustment-factor inputs ────────────────────────────────────────
+export interface WoodAdjustOpts {
+  duration?: LoadDuration   // → CD (default 'ten-year')
+  wet?: boolean             // → CM (default dry, all = 1)
+  Ct?: number               // temperature factor (default 1.0, T ≤ 37.8 °C)
+  Ci?: number               // incising factor (default 1.0, not incised)
+  Cr?: number               // repetitive-member factor for Fb (default 1.0)
+  CF?: number               // explicit size factor override (dimension lumber)
+}
+
+/** All adjustment factors + adjusted stresses that do NOT depend on member
+ *  slenderness (CL/CP are added by the beam/column checks). */
+export interface WoodAdjusted {
+  CD: number; CM: WetFactors; Ct: number; Ci: number; Cr: number; CF: number
+  Emin: number                    // E′min = Emin·CM·Ct·Ci
+  E: number                       // E′ = E·CM·Ct·Ci
+  FbStar: number                  // Fb·(all except CL, CV, Cfu)
+  FcStar: number                  // Fc·(all except CP)
+  FvAllow: number                 // Fv′ (no stability term)
+  FtAllow: number                 // Ft′
+  FcPerpAllow: number             // Fc⊥′
+}
+
+export function woodAdjusted(ref: WoodRefValues, kind: WoodKind, d: number, opts: WoodAdjustOpts = {}): WoodAdjusted {
+  const CD = CD_TABLE[opts.duration ?? 'ten-year']
+  const Ct = opts.Ct ?? 1
+  const Ci = opts.Ci ?? 1
+  const Cr = opts.Cr ?? 1
+  const CF = opts.CF ?? (kind === 'sawn' ? sizeFactorTimber(d) : 1)
+  const cm = opts.wet ? (kind === 'sawn' ? CM_SAWN : CM_GLULAM) : { Fb: 1, Ft: 1, Fv: 1, FcPerp: 1, Fc: 1, E: 1 }
+  const Emin = ref.Emin * cm.E * Ct * Ci
+  const E = ref.E * cm.E * Ct * Ci
+  // Fb* — all bending factors except CL (and CV / Cfu, folded in by the caller).
+  const FbStar = ref.Fb * CD * cm.Fb * Ct * Ci * CF * Cr
+  const FcStar = ref.Fc * CD * cm.Fc * Ct * Ci * CF
+  return {
+    CD, CM: cm, Ct, Ci, Cr, CF, Emin, E, FbStar, FcStar,
+    FvAllow: ref.Fv * CD * cm.Fv * Ct * Ci,
+    FtAllow: ref.Ft * CD * cm.Ft * Ct * Ci * CF,
+    FcPerpAllow: ref.FcPerp * cm.FcPerp * Ct * Ci,   // CD does not apply to Fc⊥
+  }
+}
+
+// ── Beam check (bending + horizontal shear) ────────────────────────────────
+export interface WoodBeamResult {
+  A: number; S: number
+  fb: number; FbPrime: number; CL: number; RB: number      // bending
+  fv: number; FvPrime: number                              // shear
+  bendingRatio: number; shearRatio: number
+  ratio: number; ok: boolean
+  clause: string
+}
+/** Design a solid-rectangular timber beam.  M in kN·m, V in kN; lu = unbraced
+ *  compression-edge length (mm), le auto per §3.3.3 unless overridden. */
+export function checkWoodBeam(p: {
+  ref: WoodRefValues; kind: WoodKind; b: number; d: number; length: number
+  M: number; V: number; lu?: number; le?: number; opts?: WoodAdjustOpts
+}): WoodBeamResult {
+  const { A, S } = woodSectionProps(p.b, p.d)
+  const adj = woodAdjusted(p.ref, p.kind, p.d, p.opts)
+  const lu = p.lu ?? p.length
+  const le = p.le ?? effectiveBendingLength(lu, p.d)
+  const { RB, CL } = beamStabilityFactor(p.b, p.d, le, adj.Emin, adj.FbStar)
+  // Glulam: the lesser of CV and CL applies (§5.3.6); sawn uses CL with CF in Fb*.
+  let FbPrime: number
+  if (p.kind === 'glulam') {
+    const CV = volumeFactorGlulam(p.b, p.d, p.length)
+    FbPrime = adj.FbStar * Math.min(CV, CL)
+  } else {
+    FbPrime = adj.FbStar * CL
+  }
+  const fb = (p.M * 1e6) / S                                // kN·m → N·mm, /mm³ = MPa
+  const fv = (1.5 * p.V * 1e3) / A                          // rectangular: 1.5V/A, kN → N
+  const bendingRatio = fb / FbPrime
+  const shearRatio = fv / adj.FvAllow
+  const ratio = Math.max(bendingRatio, shearRatio)
+  return {
+    A, S, fb, FbPrime, CL, RB, fv, FvPrime: adj.FvAllow,
+    bendingRatio, shearRatio, ratio, ok: ratio <= 1,
+    clause: 'NDS §3.3 / §3.4 (NSCP §6)',
+  }
+}
+
+// ── Column check (axial compression + optional biaxial bending) ────────────
+export interface WoodColumnResult {
+  A: number
+  fc: number; FcPrime: number; CP: number; slenderness: number; FcE: number
+  axialRatio: number
+  interaction: number       // NDS §3.9.2 beam-column, 0 if no moment
+  ratio: number; ok: boolean
+  clause: string
+}
+/** Design a solid-rectangular timber column.  P in kN (compression +),
+ *  Mx/My in kN·m about the section's strong/weak axes; le = Ke·lu (mm) per axis. */
+export function checkWoodColumn(p: {
+  ref: WoodRefValues; kind: WoodKind; b: number; d: number; length: number
+  P: number; Mx?: number; My?: number
+  leD?: number; leB?: number    // effective length for buckling about depth(d)/width(b) axes
+  luBendD?: number              // unbraced bending length for Mx (→ CL), default length
+  opts?: WoodAdjustOpts
+}): WoodColumnResult {
+  const { A, S } = woodSectionProps(p.b, p.d)
+  const adj = woodAdjusted(p.ref, p.kind, p.d, p.opts)
+  const c = p.kind === 'glulam' ? 0.9 : 0.8
+  const leD = p.leD ?? p.length, leB = p.leB ?? p.length
+  // Governing slenderness = larger of the two plane ratios (le/d).
+  const sD = columnStabilityFactor(leD, p.d, adj.Emin, adj.FcStar, c)
+  const sB = columnStabilityFactor(leB, p.b, adj.Emin, adj.FcStar, c)
+  const gov = sD.slenderness >= sB.slenderness ? sD : sB
+  const FcPrime = adj.FcStar * gov.CP
+  const fc = (p.P * 1e3) / A                                 // kN → N, MPa
+  const axialRatio = fc / FcPrime
+
+  let interaction = 0
+  const Mx = p.Mx ?? 0
+  if (Mx !== 0) {
+    // §3.9.2 beam-column: (fc/Fc′)² + fb1/[Fb1′(1 − fc/FcE1)] ≤ 1.0.
+    const le1 = p.luBendD ?? p.length
+    const { CL } = beamStabilityFactor(p.b, p.d, effectiveBendingLength(le1, p.d), adj.Emin, adj.FbStar)
+    const Fb1 = (p.kind === 'glulam')
+      ? adj.FbStar * Math.min(volumeFactorGlulam(p.b, p.d, p.length), CL)
+      : adj.FbStar * CL
+    const fb1 = (Mx * 1e6) / S
+    const FcE1 = sD.FcE                                      // buckling about the bending (depth) axis
+    interaction = axialRatio * axialRatio + fb1 / (Fb1 * (1 - fc / FcE1))
+  }
+  const ratio = Math.max(axialRatio, interaction)
+  return {
+    A, fc, FcPrime, CP: gov.CP, slenderness: gov.slenderness, FcE: gov.FcE,
+    axialRatio, interaction, ratio, ok: ratio <= 1,
+    clause: 'NDS §3.7 / §3.9 (NSCP §6)',
+  }
+}


### PR DESCRIPTION
## What & why

Adds a **wooden frame** as a third structural material alongside reinforced concrete and structural steel, requested for the Properties panel. Per the repo's "big features → ship in phases" rule this is **Phase 1: the calculation core** — a pure, typed, fully-validated timber design engine. Phases 2–3 wire it into the model/pipeline/UI.

**Layer:** L6/L7 (member design), with an L9 validation benchmark.

## `engine/woodDesign.ts`
Allowable-Stress-Design per **NDS 2018 §3**, the framework **NSCP 2015 §6 (Wood)** adopts.

- **Reference value library** — NDS Supplement Table 4A (Douglas Fir-Larch SS/No.1/No.2, Hem-Fir, SPF, Southern Pine) + Table 5A glulam (24F-1.8E), SI-converted (1 psi = 0.00689476 MPa). NSCP §6 Philippine species (Yakal, Apitong, Guijo…) share the identical method and can be supplied as custom reference values.
- **Adjustment factors:** `CD` load duration (Table 2.3.2 — wind/seismic 1.6, snow 1.15, live 1.0, dead 0.9), `CM` wet service, `Ct`/`Ci`, `CF` size (§4.3.6.2), `CV` glulam volume (§5.3.6, with the §5.3.6 *lesser-of-CV-CL* rule), `CL` beam stability (§3.3.3), `CP` column stability (§3.7.1).
- **Member checks** — each returns utilization + pass/fail + clause reference:
  - `checkWoodBeam` — bending (`fb = M/S ≤ F′b`) + horizontal shear (`fv = 1.5V/A ≤ F′v`).
  - `checkWoodColumn` — axial (`fc = P/A ≤ F′c` with governing-plane `CP`) + NDS **§3.9.2** beam-column interaction.

Units follow the repo convention: geometry mm, forces kN, moments kN·m, stress MPa.

## Validation (L9)
- New **`Timber`** category in `validation.ts` — `wood-cp` and `wood-cl` cases check the engine's `CP`/`CL` against an independent closed-form hand calc (tol `1e-9`).
- Coverage row added to `docs/ValidationMap.md`.

## Tests
`woodDesign.test.ts` — 27 cases: library sanity, section properties, `CD` table, `CF`/`CV` formulas, **`CL`/`CP` literal anchors** (0.9865 / 0.5731), full beam & column composition against the parts, glulam `min(CV, CL)`, and pass/fail boundaries.

```
tsc -b     → clean
vitest run → 90 files, 1148 tests pass (+27 new)
```

## Not in this PR (follow-up phases)
- **Phase 2** — thread `'wood'` through the model schema → `modelBridge` (timber E + self-weight) → `pipeline` (wood member schedule + totals) → **Properties panel** option → 3D coloring → take-off. *This is where the wooden-frame option becomes selectable.*
- **Phase 3** — optimizer support + board-feet reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)