### PR TITLE
feat: wooden frame — third structural material end-to-end (Phase 2)

### DIFF
--- a/webapp/src/engine/meshValidation.ts
+++ b/webapp/src/engine/meshValidation.ts
@@ -21,6 +21,7 @@
 // ─────────────────────────────────────────────────────────────────────────
 import type { StructuralModel } from './model'
 import { barContinuityGroups } from './modelBuilder'
+import { WOOD_SPECIES } from './woodDesign'
 
 export type MeshSeverity = 'error' | 'warning'
 export interface MeshIssue {
@@ -153,10 +154,19 @@ export function validateMesh(model: StructuralModel): MeshIssue[] {
   }
 
 
+  // ── timber sanity (L1 rule for wood sections) ───────────────────────────
+  for (const sec of model.sections) {
+    if (sec.material !== 'wood') continue
+    if (sec.woodSpecies && !WOOD_SPECIES[sec.woodSpecies])
+      issues.push({ severity: 'error', code: 'WOOD_SPECIES', message: `section ${sec.id}: unknown timber species "${sec.woodSpecies}" — not in the WOOD_SPECIES library`, refs: [sec.id] })
+    if (!(sec.b > 0) || !(sec.h > 0))
+      issues.push({ severity: 'error', code: 'WOOD_DIMS', message: `section ${sec.id}: timber b and d must be positive`, refs: [sec.id] })
+  }
+
   // ── prestressing sanity (L1 rule for RectSection.ps) ────────────────────
   for (const sec of model.sections) {
     if (!sec.ps) continue
-    if (sec.material === 'steel')
+    if (sec.material === 'steel' || sec.material === 'wood')
       issues.push({ severity: 'error', code: 'PS_STEEL', message: `section ${sec.id}: prestressing is only supported on concrete sections`, refs: [sec.id] })
     if (!(sec.ps.Aps > 0) || !(sec.ps.fpu > 0) || !(sec.ps.fci > 0))
       issues.push({ severity: 'error', code: 'PS_PARAMS', message: `section ${sec.id}: Aps, fpu and f'ci must be positive`, refs: [sec.id] })

--- a/webapp/src/engine/model.ts
+++ b/webapp/src/engine/model.ts
@@ -10,12 +10,12 @@ import type { LiveItem } from './liveLoads'
 
 export interface Node { id: string; x: number; y: number; z: number }
 
-export type SectionMaterial = 'concrete' | 'steel'
+export type SectionMaterial = 'concrete' | 'steel' | 'wood'
 
 export interface RectSection {
   id: string
   name: string
-  b: number; h: number          // mm  (concrete; for steel a bounding box ≈ bf × d)
+  b: number; h: number          // mm  (concrete/wood b × d; for steel a bounding box ≈ bf × d)
   fc: number; fy: number
   barDia: number; tieDia: number; cover: number
   /** Material of the member. Absent ⇒ 'concrete' (back-compatible). */
@@ -25,6 +25,14 @@ export interface RectSection {
   /** Steel grade yield/ultimate (steel only). Defaults: Fy 248, Fu 400 (A36). */
   steelFy?: number
   steelFu?: number
+  /** Timber species/grade id (wood only), key into WOOD_SPECIES (woodDesign.ts),
+   *  e.g. 'DFL-2'. Resolves the ASD/LRFD reference design values. */
+  woodSpecies?: string
+  /** Solid-sawn ('sawn') or glued-laminated ('glulam') timber (wood only).
+   *  Absent ⇒ 'sawn'. */
+  woodKind?: 'sawn' | 'glulam'
+  /** Wet-service condition (wood only): in-service MC > 19% sawn / 16% glulam. */
+  woodWet?: boolean
   /** Pretensioned bonded prestressing on this (concrete beam) section — when
    *  present the pipeline runs the full prestressed check (losses, §24.5
    *  stresses, fps/φMn, 1.2Mcr) beside the RC design. */

--- a/webapp/src/engine/modelBridge.ts
+++ b/webapp/src/engine/modelBridge.ts
@@ -13,6 +13,7 @@ import { distributePanel, type AreaLoad } from './tributary'
 import type { BeamLoad } from './beamAnalysis'
 import { shapeByName, torsionJ, type AiscShape } from './aiscSections'
 import { deriveWSection, E_STEEL } from './steelDesign'
+import { getWoodRef } from './woodDesign'
 
 export interface BridgeResult {
   nodes: F3Node[]
@@ -28,9 +29,10 @@ export interface BridgeResult {
 }
 
 /** Concrete shell material for slab/wall panels: E = 4700√fc (NSCP/ACI), ν = 0.2.
- *  fc taken from the model's first concrete section (fallback 28 MPa). */
+ *  fc taken from the model's first CONCRETE section (fallback 28 MPa) — steel and
+ *  wood frames keep concrete slabs/panels. */
 function plateMaterial(model: StructuralModel): { E: number; nu: number } {
-  const fc = model.sections.find((s) => s.material !== 'steel')?.fc ?? 28
+  const fc = model.sections.find((s) => (s.material ?? 'concrete') === 'concrete')?.fc ?? 28
   return { E: 4700 * Math.sqrt(Math.max(fc, 1)), nu: 0.2 }
 }
 
@@ -52,8 +54,27 @@ function plateShells(plate: Plate, mat: { E: number; nu: number }): F3Shell[] {
   ]
 }
 
+/** Timber member stiffness: mean modulus E from the species (wet-adjusted by CM),
+ *  shear modulus G ≈ E/16 (NDS solid-sawn), solid-rectangle I/J and κ = 5/6 shear
+ *  areas. Falls back to a mid-range softwood E if the species is unset/unknown. */
+function woodSectionProps(s: RectSection) {
+  const ref = (s.woodSpecies ? getWoodRef(s.woodSpecies) : undefined)?.ref
+  const cmE = s.woodWet ? (s.woodKind === 'glulam' ? 0.833 : 0.9) : 1
+  const E = (ref?.E ?? 9500) * cmE
+  const G = E / 16
+  return {
+    E, G, A: s.b * s.h,
+    Iz: (s.b * s.h ** 3) / 12,   // gravity bending (depth h vertical)
+    Iy: (s.h * s.b ** 3) / 12,
+    J: rectJ(s.b, s.h),
+    Asy: (5 / 6) * s.b * s.h,
+    Asz: (5 / 6) * s.b * s.h,
+  }
+}
+
 function sectionProps(s: RectSection) {
   if (s.material === 'steel') return steelSectionProps(s)
+  if (s.material === 'wood') return woodSectionProps(s)
   const E = 4700 * Math.sqrt(Math.max(s.fc, 1))
   return {
     E,

--- a/webapp/src/engine/modelBuilder.ts
+++ b/webapp/src/engine/modelBuilder.ts
@@ -9,6 +9,12 @@
 import type { StructuralModel, RectSection, Node, Member, Plate, NodeSupport, MemberRole } from './model'
 import { sdlTotal } from './deadLoads'
 import { shapeByName } from './aiscSections'
+import { getWoodRef, woodUnitWeight } from './woodDesign'
+
+/** Timber self-weight line load basis (kN/m³) from the section's species (γ ≈
+ *  G·9.81); fallback G = 0.5 (~4.9 kN/m³) when the species is unset/unknown. */
+const woodGamma = (sec: RectSection): number =>
+  woodUnitWeight((sec.woodSpecies ? getWoodRef(sec.woodSpecies) : undefined)?.ref.G ?? 0.5)
 
 export interface GridSpec {
   baysX: number[]      // bay widths along x, m
@@ -153,7 +159,8 @@ export function buildGravityLoads(model: StructuralModel, sdl: number, ll: numbe
   const memberSW: StructuralModel['loads'] = model.members
     .map((m) => {
       const sec = secMap.get(m.section) ?? model.sections[0]
-      const w = sec ? (sec.b / 1000) * (sec.h / 1000) * gammaC : 0
+      const gamma = sec?.material === 'wood' ? woodGamma(sec) : gammaC
+      const w = sec ? (sec.b / 1000) * (sec.h / 1000) * gamma : 0
       return { kind: 'member-udl' as const, member: m.id, w, cat: 'D' as const, sw: true }
     })
     .filter((l) => l.w > 0)
@@ -205,6 +212,8 @@ export function refreshSelfWeight(model: StructuralModel, gammaC = GAMMA_C): Str
         if (sec.material === 'steel') {
           const shape = sec.shape ? shapeByName(sec.shape) : undefined
           w = shape ? (shape.A / 1e6) * GAMMA_S : (sec.b / 1000) * (sec.h / 1000) * GAMMA_S
+        } else if (sec.material === 'wood') {
+          w = (sec.b / 1000) * (sec.h / 1000) * woodGamma(sec)
         } else {
           w = (sec.b / 1000) * (sec.h / 1000) * gammaC
         }

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -27,6 +27,7 @@ import { designShearWall, type ShearWallResult } from './shearWallDesign'
 import { checkModelSCWB, type SCWBJointRow } from './scwb'
 import { shapeByName, nextHeavierW, nextLighterW, type AiscShape } from './aiscSections'
 import { deriveWSection, beamFlexure, beamShear, columnAxial, combinedLoading } from './steelDesign'
+import { getWoodRef, checkWoodBeam, checkWoodColumn } from './woodDesign'
 import { designBasePlate, adoptPlateThickness, type BasePlateResult } from './baseplate'
 import { designSteelJoints, designBeamBeamJoints, type SteelJoint, type BeamBeamJoint } from './steelConnections'
 
@@ -194,6 +195,27 @@ export interface BasePlateScheduleRow {
   ok: boolean
 }
 
+// ── Timber schedule rows (NDS §3 / NSCP §6, LRFD via Appendix N) ─────────────
+export interface WoodBeamScheduleRow {
+  id: string; role: string; L: number
+  species: string; kind: string; b: number; d: number
+  Mu: number; Vu: number           // kN·m, kN (factored demand)
+  fb: number; FbPrime: number; CL: number   // MPa
+  fv: number; FvPrime: number      // MPa
+  utilM: number; utilV: number
+  ok: boolean
+  gov?: string
+}
+export interface WoodColumnScheduleRow {
+  id: string; L: number
+  species: string; kind: string; b: number; d: number
+  Pu: number; Mu: number           // kN, kN·m
+  fc: number; FcPrime: number; CP: number; slenderness: number   // MPa
+  ratio: number                    // governing (axial or §3.9.2 interaction)
+  ok: boolean
+  gov?: string
+}
+
 /** Prestressed member check (sections with RectSection.ps): the pipeline
  *  back-derives equivalent UDLs from the D-only / L-only midspan sagging
  *  moments (w = 8M/L², self-weight excluded from SDL) and runs the full
@@ -213,6 +235,9 @@ export interface StructureDesign {
   columns: ColumnScheduleRow[]
   steelBeams: SteelBeamScheduleRow[]
   steelColumns: SteelColumnScheduleRow[]
+  /** Timber beams/girders and columns (NDS §3 / NSCP §6, LRFD Appendix N). */
+  woodBeams: WoodBeamScheduleRow[]
+  woodColumns: WoodColumnScheduleRow[]
   basePlates: BasePlateScheduleRow[]
   joints: SteelJoint[]               // beam-to-column connections (steel frames only)
   /** Beam-to-beam fin plates: beams framing into a girder web (steel only). */
@@ -224,7 +249,7 @@ export interface StructureDesign {
   /** Strong-column/weak-beam joint checks (NSCP §418.7.3.2); only populated for
    *  a Special Moment Frame (`seismicSystem: 'smf'`), empty otherwise. */
   scwb: SCWBJointRow[]
-  totals: { concreteMembers: number; concreteSlabs: number; concrete: number; steelKg: number }
+  totals: { concreteMembers: number; concreteSlabs: number; concrete: number; steelKg: number; woodVolume: number }
   orphanEdges: number
   /** Members no design path could check (unsupported shape family). Non-empty ⇒ designOK is false. */
   unchecked: UncheckedMember[]
@@ -240,6 +265,7 @@ export interface StructureDesign {
 export function designOK(d: StructureDesign): boolean {
   return d.beams.every((b) => b.ok) && d.prestressed.every((p) => p.ok) && d.columns.every((c) => c.ok)
     && d.steelBeams.every((b) => b.ok) && d.steelColumns.every((c) => c.ok)
+    && d.woodBeams.every((b) => b.ok) && d.woodColumns.every((c) => c.ok)
     && d.basePlates.every((p) => p.ok)
     && d.footings.every((f) => f.ok) && d.combined.every((c) => c.ok)
     && d.slabs.every((s) => s.ok) && d.walls.every((w) => w.ok)
@@ -318,6 +344,54 @@ function designSteelColumnRow(mr: F3MemberResult, sec: RectSection): SteelColumn
 
 const beamOK = (d: BeamDesignResult) =>
   d.flexOK && d.comprEffective && d.comprNAOK && d.region !== 'inadequate'
+
+// ── Timber member design (NDS §3 / NSCP §6, LRFD via Appendix N) ─────────────
+/** NDS Appendix N time-effect factor λ from the governing LRFD combo name:
+ *  wind/seismic combos (1.0W/1.0E) → 1.0; the 1.4D dead-only combo → 0.6;
+ *  everything else (gravity D + L) → 0.8. A conservative name-based mapping. */
+function timeEffectFactor(comboName: string): number {
+  if (/1\.0E|1\.0W/.test(comboName)) return 1.0
+  if (/^1\.4D/.test(comboName)) return 0.6
+  return 0.8
+}
+
+/** Design a timber beam/girder from a member result. lu (m) is the unbraced
+ *  compression-edge length for §3.3.3 CL — falls back to the member length. */
+function designWoodBeamRow(
+  mr: F3MemberResult, role: string, sec: RectSection, lambda: number, lu?: number,
+): WoodBeamScheduleRow | null {
+  const ref = (sec.woodSpecies ? getWoodRef(sec.woodSpecies) : undefined)?.ref
+  if (!ref) return null
+  const kind = sec.woodKind === 'glulam' ? 'glulam' : 'sawn'
+  const r = checkWoodBeam({
+    ref, kind, b: sec.b, d: sec.h, length: mr.L * 1000,
+    M: mr.Mmax, V: mr.Vmax, lu: lu && lu > 0 ? lu * 1000 : undefined,
+    opts: { method: 'LRFD', lambda, wet: sec.woodWet },
+  })
+  return {
+    id: mr.id, role, L: mr.L, species: sec.woodSpecies ?? '', kind, b: sec.b, d: sec.h,
+    Mu: mr.Mmax, Vu: mr.Vmax, fb: r.fb, FbPrime: r.FbPrime, CL: r.CL,
+    fv: r.fv, FvPrime: r.FvPrime, utilM: r.bendingRatio, utilV: r.shearRatio, ok: r.ok,
+  }
+}
+
+/** Design a timber column from a member result: axial (governing-plane CP) +
+ *  §3.9.2 beam-column interaction with the peak bending. */
+function designWoodColumnRow(mr: F3MemberResult, sec: RectSection, lambda: number): WoodColumnScheduleRow | null {
+  const ref = (sec.woodSpecies ? getWoodRef(sec.woodSpecies) : undefined)?.ref
+  if (!ref) return null
+  const kind = sec.woodKind === 'glulam' ? 'glulam' : 'sawn'
+  const Pu = Math.max(0, -Math.min(...mr.N))   // compression (N < 0)
+  const r = checkWoodColumn({
+    ref, kind, b: sec.b, d: sec.h, length: mr.L * 1000,
+    P: Pu, Mx: mr.Mmax, opts: { method: 'LRFD', lambda, wet: sec.woodWet },
+  })
+  return {
+    id: mr.id, L: mr.L, species: sec.woodSpecies ?? '', kind, b: sec.b, d: sec.h,
+    Pu, Mu: mr.Mmax, fc: r.fc, FcPrime: r.FcPrime, CP: r.CP, slenderness: r.slenderness,
+    ratio: r.ratio, ok: r.ok,
+  }
+}
 
 /** Critical sections of a frame member: the two ends (which carry the hogging
  *  moments, top steel) plus the interior SAGGING peak — the most positive Mz
@@ -619,11 +693,14 @@ function designFromRuns(
   const columns: ColumnScheduleRow[] = []
   const steelBeams: SteelBeamScheduleRow[] = []
   const steelColumns: SteelColumnScheduleRow[] = []
+  const woodBeams: WoodBeamScheduleRow[] = []
+  const woodColumns: WoodColumnScheduleRow[] = []
   const unchecked: UncheckedMember[] = []
   for (const m of model.members) {
     const role = roleOf.get(m.id)
     const sec = secOf(m.id)
     const isSteel = sec.material === 'steel'
+    const isWood = sec.material === 'wood'
     const roleLabel = role === 'beam' ? 'beam' : role === 'girder' ? 'girder' : role === 'column' ? 'column' : role ?? ''
     onProgress?.({ phase: 'Designing members', current: ++memDone, total: totalMems, detail: `${m.id} (${roleLabel} ${sec.b}×${sec.h})` })
     if (role === 'beam' || role === 'girder') {
@@ -641,6 +718,19 @@ function designFromRuns(
         else unchecked.push({
           id: m.id, role, shape: sec.shape ?? '(no shape)',
           reason: 'steel beam flexure covers W/WT shapes only — use a W/WT here or check this member separately',
+        })
+      } else if (isWood) {
+        let best: WoodBeamScheduleRow | null = null, bestSev = -1, gov = ''
+        for (const run of runs) {
+          const mr = memberOf(run, m.id); if (!mr) continue
+          const row = designWoodBeamRow(mr, role, sec, timeEffectFactor(run.name), m.Lb); if (!row) continue
+          const sev = (row.ok ? 0 : 1e9) + row.Mu
+          if (sev > bestSev) { bestSev = sev; best = row; gov = run.name }
+        }
+        if (best) woodBeams.push({ ...best, gov })
+        else unchecked.push({
+          id: m.id, role, shape: sec.woodSpecies ?? '(no species)',
+          reason: 'timber section has no resolved species — set a WOOD_SPECIES grade for this member',
         })
       } else {
         let best: BeamScheduleRow | null = null, bestSev = -1, gov = ''
@@ -689,6 +779,18 @@ function designFromRuns(
         else unchecked.push({
           id: m.id, role, shape: sec.shape ?? '(no shape)',
           reason: 'shape not found in the AISC library — column axial/§H1-1 check skipped',
+        })
+      } else if (isWood) {
+        let best: WoodColumnScheduleRow | null = null, bestRatio = -1, gov = ''
+        for (const run of runs) {
+          const mr = memberOf(run, m.id); if (!mr) continue
+          const row = designWoodColumnRow(mr, sec, timeEffectFactor(run.name)); if (!row) continue
+          if (row.ratio > bestRatio) { bestRatio = row.ratio; best = row; gov = run.name }
+        }
+        if (best) woodColumns.push({ ...best, gov })
+        else unchecked.push({
+          id: m.id, role: role ?? 'column', shape: sec.woodSpecies ?? '(no species)',
+          reason: 'timber section has no resolved species — set a WOOD_SPECIES grade for this member',
         })
       } else {
         let best: ColumnScheduleRow | null = null, bestUtil = -1, gov = ''
@@ -786,7 +888,7 @@ function designFromRuns(
 
   // ── Concrete & steel totals ──
   const nm = new Map(model.nodes.map((n) => [n.id, n]))
-  let concreteMembers = 0, steelKg = 0
+  let concreteMembers = 0, steelKg = 0, woodVolume = 0
   for (const m of model.members) {
     const a = nm.get(m.i), b2 = nm.get(m.j)
     if (!a || !b2) continue
@@ -795,6 +897,8 @@ function designFromRuns(
     if (s.material === 'steel') {
       const shape = s.shape ? shapeByName(s.shape) : undefined
       if (shape) steelKg += (shape.A / 1e6) * L * 7850   // A m² × L × ρ
+    } else if (s.material === 'wood') {
+      woodVolume += (s.b / 1000) * (s.h / 1000) * L       // m³ of timber
     } else {
       concreteMembers += (s.b / 1000) * (s.h / 1000) * L
     }
@@ -876,12 +980,12 @@ function designFromRuns(
   const partialDesign = {
     govName: runs[govIdx].name,
     cases: runs.map((r) => r.name),
-    beams, prestressed, columns, steelBeams, steelColumns, basePlates,
+    beams, prestressed, columns, steelBeams, steelColumns, woodBeams, woodColumns, basePlates,
     joints: [] as SteelJoint[],
     beamJoints: [] as BeamBeamJoint[],
     slabs, walls, footings, combined,
     scwb: [] as SCWBJointRow[],
-    totals: { concreteMembers, concreteSlabs, concrete: concreteMembers + concreteSlabs, steelKg },
+    totals: { concreteMembers, concreteSlabs, concrete: concreteMembers + concreteSlabs, steelKg, woodVolume },
     orphanEdges: br.orphanEdges.length,
     unchecked,
     // fail-loud: forces from a non-converged P-Δ run must not silently drive design

--- a/webapp/src/engine/takeoff.test.ts
+++ b/webapp/src/engine/takeoff.test.ts
@@ -115,8 +115,9 @@ describe('structural steel — per-shape unit weight + costed BOM line items (A2
   const STEEL_DENSITY = 7850
   const emptyDesign: StructureDesign = {
     govName: '', cases: [], beams: [], prestressed: [], columns: [], steelBeams: [], steelColumns: [],
+    woodBeams: [], woodColumns: [],
     basePlates: [], joints: [], beamJoints: [], slabs: [], walls: [], footings: [], combined: [], scwb: [],
-    totals: { concreteMembers: 0, concreteSlabs: 0, concrete: 0, steelKg: 0 }, orphanEdges: 0,
+    totals: { concreteMembers: 0, concreteSlabs: 0, concrete: 0, steelKg: 0, woodVolume: 0 }, orphanEdges: 0,
     unchecked: [], pDeltaIssues: [],
   }
   // Two steel members: one 6 m W200x46.1 beam, two 4 m W250x49.1 columns.

--- a/webapp/src/engine/woodDesign.test.ts
+++ b/webapp/src/engine/woodDesign.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   WOOD_SPECIES, getWoodRef, loadDurationFactor, sizeFactorTimber, volumeFactorGlulam,
   effectiveBendingLength, beamStabilityFactor, columnStabilityFactor, woodSectionProps,
-  woodAdjusted, checkWoodBeam, checkWoodColumn,
+  woodAdjusted, checkWoodBeam, checkWoodColumn, woodUnitWeight,
 } from './woodDesign'
 
 describe('reference value library', () => {
@@ -148,6 +148,36 @@ describe('checkWoodColumn — axial + beam-column interaction', () => {
   it('a very slender column is governed by buckling (CP ≪ 1)', () => {
     const r = checkWoodColumn({ ref, kind: 'sawn', b: 100, d: 100, length: 4000, P: 10 })
     expect(r.CP).toBeLessThan(0.5)
+  })
+})
+
+describe('unit weight (self-weight only)', () => {
+  it('γ ≈ G·9.81 kN/m³', () => {
+    expect(woodUnitWeight(0.5)).toBeCloseTo(4.905, 3)
+    expect(woodUnitWeight(0.42)).toBeLessThan(woodUnitWeight(0.55))   // SPF lighter than Southern Pine
+  })
+})
+
+describe('NDS Appendix N — LRFD format conversion', () => {
+  const ref = getWoodRef('DFL-SS')!.ref
+  it('strength values scale by KF·φ·λ = 2.16·λ vs the CD = 1 ASD baseline', () => {
+    const asd = woodAdjusted(ref, 'sawn', 200, { duration: 'ten-year' })       // CD = 1
+    const lrfd = woodAdjusted(ref, 'sawn', 200, { method: 'LRFD', lambda: 0.8 })
+    expect(lrfd.FbStar / asd.FbStar).toBeCloseTo(2.16 * 0.8, 6)
+    expect(lrfd.FcStar / asd.FcStar).toBeCloseTo(2.16 * 0.8, 6)
+    expect(lrfd.FvAllow / asd.FvAllow).toBeCloseTo(2.16 * 0.8, 6)
+  })
+  it('Emin (stability) scales by ≈1.50 and carries no λ; service E is unchanged', () => {
+    const asd = woodAdjusted(ref, 'sawn', 200)
+    const lrfd = woodAdjusted(ref, 'sawn', 200, { method: 'LRFD', lambda: 1.0 })
+    expect(lrfd.Emin / asd.Emin).toBeCloseTo(1.496, 3)
+    expect(lrfd.E).toBeCloseTo(asd.E, 6)                                        // deflection modulus not converted
+  })
+  it('a wind combo (λ=1.0) allows more than a gravity combo (λ=0.8)', () => {
+    const wind = checkWoodColumn({ ref, kind: 'sawn', b: 150, d: 150, length: 3000, P: 200, opts: { method: 'LRFD', lambda: 1.0 } })
+    const grav = checkWoodColumn({ ref, kind: 'sawn', b: 150, d: 150, length: 3000, P: 200, opts: { method: 'LRFD', lambda: 0.8 } })
+    expect(wind.FcPrime).toBeGreaterThan(grav.FcPrime)
+    expect(wind.ratio).toBeLessThan(grav.ratio)
   })
 })
 

--- a/webapp/src/engine/woodDesign.ts
+++ b/webapp/src/engine/woodDesign.ts
@@ -134,14 +134,31 @@ export function woodSectionProps(b: number, d: number): { A: number; S: number; 
   return { A: b * d, S: (b * d * d) / 6, I: (b * d * d * d) / 12 }
 }
 
+/** Approximate timber unit weight for self-weight, kN/m³, from specific gravity:
+ *  γ ≈ G·9.81 (softwood G ≈ 0.4–0.5 → ~4–5; dense hardwood G ≈ 0.6 → ~6). For
+ *  self-weight/mass only — NOT a design value. */
+export function woodUnitWeight(G: number): number { return G * 9.81 }
+
+// ── NDS Appendix N — LRFD format-conversion (KF·φ) and time-effect factor λ ──
+// A strength-design timber check compares a FACTORED demand to an LRFD-adjusted
+// design value F′ = F·(C factors)·KF·φ·λ, with CD replaced by λ (Table N3).
+// KF·φ products: strength (Fb/Ft/Fv/Fc) 2.16, bearing (Fc⊥) 1.50, stability
+// (Emin) 1.76·0.85 = 1.50.  λ ≈ 0.6 (1.4D), 0.8 (gravity D+L), 1.0 (W/E).
+const KFP_STRENGTH = 2.16, KFP_BEARING = 1.503, KFP_STABILITY = 1.496
+
 // ── Common adjustment-factor inputs ────────────────────────────────────────
 export interface WoodAdjustOpts {
-  duration?: LoadDuration   // → CD (default 'ten-year')
+  duration?: LoadDuration   // → CD, ASD only (default 'ten-year')
   wet?: boolean             // → CM (default dry, all = 1)
   Ct?: number               // temperature factor (default 1.0, T ≤ 37.8 °C)
   Ci?: number               // incising factor (default 1.0, not incised)
   Cr?: number               // repetitive-member factor for Fb (default 1.0)
   CF?: number               // explicit size factor override (dimension lumber)
+  /** 'ASD' (service demand ≤ allowable, uses CD) or 'LRFD' (factored demand ≤
+   *  KF·φ·λ-adjusted, uses λ instead of CD).  Default 'ASD'. */
+  method?: 'ASD' | 'LRFD'
+  /** LRFD time-effect factor λ (Table N3); default 0.8 (gravity occupancy). */
+  lambda?: number
 }
 
 /** All adjustment factors + adjusted stresses that do NOT depend on member
@@ -158,22 +175,27 @@ export interface WoodAdjusted {
 }
 
 export function woodAdjusted(ref: WoodRefValues, kind: WoodKind, d: number, opts: WoodAdjustOpts = {}): WoodAdjusted {
-  const CD = CD_TABLE[opts.duration ?? 'ten-year']
+  const lrfd = (opts.method ?? 'ASD') === 'LRFD'
+  const lambda = lrfd ? (opts.lambda ?? 0.8) : 1
+  const CD = lrfd ? 1 : CD_TABLE[opts.duration ?? 'ten-year']   // LRFD uses λ, not CD
+  const kF = lrfd ? KFP_STRENGTH : 1                            // KF·φ, strength values
+  const kPerp = lrfd ? KFP_BEARING : 1                          // KF·φ, bearing
+  const kE = lrfd ? KFP_STABILITY : 1                           // KF·φ, stability (Emin)
   const Ct = opts.Ct ?? 1
   const Ci = opts.Ci ?? 1
   const Cr = opts.Cr ?? 1
   const CF = opts.CF ?? (kind === 'sawn' ? sizeFactorTimber(d) : 1)
   const cm = opts.wet ? (kind === 'sawn' ? CM_SAWN : CM_GLULAM) : { Fb: 1, Ft: 1, Fv: 1, FcPerp: 1, Fc: 1, E: 1 }
-  const Emin = ref.Emin * cm.E * Ct * Ci
-  const E = ref.E * cm.E * Ct * Ci
+  const Emin = ref.Emin * cm.E * Ct * Ci * kE
+  const E = ref.E * cm.E * Ct * Ci                              // service modulus (deflection) — never converted
   // Fb* — all bending factors except CL (and CV / Cfu, folded in by the caller).
-  const FbStar = ref.Fb * CD * cm.Fb * Ct * Ci * CF * Cr
-  const FcStar = ref.Fc * CD * cm.Fc * Ct * Ci * CF
+  const FbStar = ref.Fb * CD * cm.Fb * Ct * Ci * CF * Cr * kF * lambda
+  const FcStar = ref.Fc * CD * cm.Fc * Ct * Ci * CF * kF * lambda
   return {
     CD, CM: cm, Ct, Ci, Cr, CF, Emin, E, FbStar, FcStar,
-    FvAllow: ref.Fv * CD * cm.Fv * Ct * Ci,
-    FtAllow: ref.Ft * CD * cm.Ft * Ct * Ci * CF,
-    FcPerpAllow: ref.FcPerp * cm.FcPerp * Ct * Ci,   // CD does not apply to Fc⊥
+    FvAllow: ref.Fv * CD * cm.Fv * Ct * Ci * kF * lambda,
+    FtAllow: ref.Ft * CD * cm.Ft * Ct * Ci * CF * kF * lambda,
+    FcPerpAllow: ref.FcPerp * cm.FcPerp * Ct * Ci * kPerp,   // no CD/λ on bearing
   }
 }
 

--- a/webapp/src/engine/woodFrame.test.ts
+++ b/webapp/src/engine/woodFrame.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import { generateGridModel, buildGravityLoads } from './modelBuilder'
+import { modelToFrame3D } from './modelBridge'
+import { designStructure } from './pipeline'
+import { validateMesh } from './meshValidation'
+import { WOOD_SPECIES } from './woodDesign'
+import { emptyModel, type RectSection, type StructuralModel } from './model'
+
+const woodSec = (id: string, b: number, h: number): RectSection => ({
+  id, name: `${b}×${h}`, b, h, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40,
+  material: 'wood', woodSpecies: 'DFL-1', woodKind: 'sawn',
+})
+const soil = { qAllow: 200, gammaSoil: 18, gammaConc: 24, H: 1.5 }
+
+function woodModel(): StructuralModel {
+  const m = generateGridModel({
+    baysX: [6], baysZ: [5], storeyH: [3],
+    column: woodSec('C', 300, 300), girder: woodSec('G', 300, 450), beam: woodSec('B', 250, 400),
+    slabThickness: 200,
+  })
+  m.loads = buildGravityLoads(m, 4.8, 2.4)
+  return m
+}
+
+describe('bridge — timber member stiffness', () => {
+  it('uses the species mean E and G = E/16 (not the concrete √f′c law)', () => {
+    const model: StructuralModel = {
+      ...emptyModel('t'),
+      nodes: [{ id: 'a', x: 0, y: 0, z: 0 }, { id: 'b', x: 4, y: 0, z: 0 }],
+      sections: [woodSec('S', 200, 400)],
+      members: [{ id: 'm', i: 'a', j: 'b', role: 'beam', section: 'S' }],
+      supports: [{ node: 'a', fixity: 'fixed' }],
+    }
+    const br = modelToFrame3D(model)
+    const m = br.members.find((x) => x.id === 'm')!
+    expect(m.E).toBeCloseTo(WOOD_SPECIES['DFL-1'].ref.E, 3)
+    expect(m.G).toBeCloseTo(WOOD_SPECIES['DFL-1'].ref.E / 16, 3)
+    expect(m.E).toBeLessThan(4700 * Math.sqrt(28))   // far softer than concrete Ec
+  })
+})
+
+describe('self-weight — timber density', () => {
+  it('a wood member self-weight uses γ ≈ G·9.81, much lighter than concrete', () => {
+    const model = woodModel()
+    const memberUdl = model.loads.find((l) => l.kind === 'member-udl' && l.cat === 'D') as { w: number; member: string } | undefined
+    expect(memberUdl).toBeTruthy()
+    const sec = model.sections.find((s) => s.id === model.members.find((mm) => mm.id === memberUdl!.member)!.section)!
+    const gammaWood = WOOD_SPECIES['DFL-1'].ref.G * 9.81
+    expect(memberUdl!.w).toBeCloseTo((sec.b / 1000) * (sec.h / 1000) * gammaWood, 4)
+    expect(gammaWood).toBeLessThan(24)               // lighter than concrete γc
+  })
+})
+
+describe('pipeline — timber frame design', () => {
+  const design = designStructure(woodModel(), soil)!
+
+  it('routes members to the timber schedules, not the concrete ones', () => {
+    expect(design.woodBeams.length).toBeGreaterThan(0)
+    expect(design.woodColumns.length).toBeGreaterThan(0)
+    expect(design.beams.length).toBe(0)              // no RC members
+    expect(design.columns.length).toBe(0)
+    expect(design.steelBeams.length).toBe(0)
+  })
+
+  it('counts timber volume and excludes it from the concrete member total', () => {
+    expect(design.totals.woodVolume).toBeGreaterThan(0)
+    expect(design.totals.concreteMembers).toBe(0)    // wood not miscounted as concrete
+    expect(design.totals.concreteSlabs).toBeGreaterThan(0)   // slabs stay concrete
+  })
+
+  it('every timber check produces a finite utilisation, species and stability factor', () => {
+    for (const b of design.woodBeams) {
+      expect(b.species).toBe('DFL-1')
+      expect(b.kind).toBe('sawn')
+      expect(Number.isFinite(b.utilM)).toBe(true)
+      expect(b.CL).toBeGreaterThan(0)
+      expect(b.CL).toBeLessThanOrEqual(1)
+    }
+    for (const c of design.woodColumns) {
+      expect(Number.isFinite(c.ratio)).toBe(true)
+      expect(c.CP).toBeGreaterThan(0)
+      expect(c.CP).toBeLessThanOrEqual(1)
+      expect(c.Pu).toBeGreaterThanOrEqual(0)
+    }
+  })
+})
+
+describe('mesh validation — timber sanity (L1 rule)', () => {
+  it('flags an unknown species and non-positive dimensions', () => {
+    const model = woodModel()
+    model.sections[0] = { ...model.sections[0], material: 'wood', woodSpecies: 'NOT-A-SPECIES' }
+    const issues = validateMesh(model)
+    expect(issues.some((i) => i.code === 'WOOD_SPECIES')).toBe(true)
+  })
+  it('accepts a valid timber frame with no timber errors', () => {
+    const issues = validateMesh(woodModel())
+    expect(issues.some((i) => i.code === 'WOOD_SPECIES' || i.code === 'WOOD_DIMS')).toBe(false)
+  })
+})

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -57,6 +57,7 @@ import { HintButton, SeismicHint, WindHint } from '../components/LoadHints'
 import { Num, Pick, Row } from '../components/qty'
 import { FitView } from '../components/FitView'
 import { shapeByName, shapesOf, effectiveSection, sectionBoundingBox, FAMILIES, type SectionFamily } from '../engine/aiscSections'
+import { WOOD_SPECIES } from '../engine/woodDesign'
 import { buildSectionShapes } from '../lib/sectionShapes3d'
 import { SectionShape } from '../components/SectionShape'
 import { f1, f2 } from '../lib/format'
@@ -102,7 +103,7 @@ function Member3D({ a, b, role, selected, tint = 0, sec, onPick }: {
   /** 0–1 utilisation tint (|M| relative to the model max) after analysis. */
   tint?: number
   /** the member's own section, drawn to scale (mm → m). */
-  sec?: { b: number; h: number }
+  sec?: { b: number; h: number; material?: string }
   onPick: () => void
 }) {
   const { mid, quat, len } = useMemo(() => {
@@ -116,8 +117,9 @@ function Member3D({ a, b, role, selected, tint = 0, sec, onPick }: {
   const color = useMemo(() => {
     if (selected) return SEL
     const base = new THREE.Color(ROLE_COLOR[role] ?? '#64748b')
+    if (sec?.material === 'wood') base.lerp(new THREE.Color('#a86b34'), 0.6)   // timber brown tint
     return tint > 0 ? `#${base.lerp(new THREE.Color('#dc2626'), tint).getHexString()}` : `#${base.getHexString()}`
-  }, [selected, role, tint])
+  }, [selected, role, tint, sec?.material])
   return (
     <mesh position={mid} quaternion={quat}
       onClick={(e) => { e.stopPropagation(); onPick() }}>
@@ -832,8 +834,12 @@ export default function ModelSpace() {
   const [psAps, setPsAps] = useState(600); const [psFpu, setPsFpu] = useState(1860)
   const [psE, setPsE] = useState(150); const [psFci, setPsFci] = useState(24)
   const [gammaC, setGammaC] = useState(n('gammaC', 24))            // concrete unit weight, kN/m³
-  // Material: 'concrete' (RC) or 'steel' (AISC W-shapes) for the frame members.
-  const [material, setMaterial] = useState<'concrete' | 'steel'>((si.material as 'concrete' | 'steel') ?? 'concrete')
+  // Material: 'concrete' (RC), 'steel' (AISC W-shapes) or 'wood' (timber) for the frame members.
+  const [material, setMaterial] = useState<'concrete' | 'steel' | 'wood'>((si.material as 'concrete' | 'steel' | 'wood') ?? 'concrete')
+  // Timber (wood frame): species/grade, sawn vs glulam, wet service.
+  const [woodSpecies, setWoodSpecies] = useState(s('woodSpecies', 'DFL-2'))
+  const [woodKind, setWoodKind] = useState<'sawn' | 'glulam'>((s('woodKind', 'sawn')) as 'sawn' | 'glulam')
+  const [woodWet, setWoodWet] = useState(b('woodWet', false))
   const [colFam, setColFam] = useState<SectionFamily>((s('colFam', 'W')) as SectionFamily)
   const [girFam, setGirFam] = useState<SectionFamily>((s('girFam', 'W')) as SectionFamily)
   const [beaFam, setBeaFam] = useState<SectionFamily>((s('beaFam', 'W')) as SectionFamily)
@@ -985,6 +991,7 @@ export default function ModelSpace() {
         Vw, expo, Kzt, wDirs, assembly, pDelta, cracked, shearDef, tryBars,
         concreteClass, prices, planSel,
         material, colFam, girFam, beaFam, colShape, girShape, beaShape, steelFy, steelFu,
+        woodSpecies, woodKind, woodWet,
       }))
     } catch { /* quota — ignore */ }
   }, [baysX, baysZ, storeyH, colB, colH, girB, girH, beaB, beaH,
@@ -992,7 +999,8 @@ export default function ModelSpace() {
     qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs, methodB, accTor, orth30, evOn, rsaRegular,
     Vw, expo, Kzt, wDirs, assembly, pDelta, cracked, shearDef, tryBars,
     concreteClass, prices, planSel,
-    material, colFam, girFam, beaFam, colShape, girShape, beaShape, steelFy, steelFu])
+    material, colFam, girFam, beaFam, colShape, girShape, beaShape, steelFy, steelFu,
+    woodSpecies, woodKind, woodWet])
 
   const save = (m: StructuralModel | null) => {
     setModel(m)
@@ -1317,12 +1325,16 @@ export default function ModelSpace() {
     const barsUsed = [...new Set((model?.sections ?? []).filter((s) => s.material !== 'steel').map((s) => s.barDia))].sort((a, b) => a - b)
     const hasConcreteMems = d.beams.length > 0 || d.columns.length > 0
     const hasSteelMems    = d.steelBeams.length > 0 || d.steelColumns.length > 0
+    const hasWoodMems     = d.woodBeams.length > 0 || d.woodColumns.length > 0
+    const woodGrades      = [...new Set([...d.woodBeams, ...d.woodColumns].map((r) => r.species))]
+      .map((id) => WOOD_SPECIES[id]?.label ?? id).join(', ')
     const slabSdls = [...new Set((model?.plates ?? []).filter((p) => p.role !== 'wall')
       .map((p) => (p.sdlItems && p.sdlItems.length ? sdlTotal(p.sdlItems) : qD)))].sort((a, b) => a - b)
     return [
       ['Column grid', `bays X ${baysX} m · bays Z ${baysZ} m · storeys ${storeyH} m`],
       ...(hasConcreteMems ? [['RC material', `f′c ${fc} MPa · fy ${fy} MPa · main ⌀${barsUsed.join('/⌀') || barDia} · ties ⌀${tieDia} · cover ${cover} mm`]] as [string, string][] : []),
       ...(hasSteelMems    ? [['Steel grade',  `Fy ${steelFy} MPa · Fu ${steelFu} MPa (AISC W-shapes)`]] as [string, string][] : []),
+      ...(hasWoodMems     ? [['Timber grade', `${woodGrades}${woodWet ? ' · wet service' : ''} (NDS §3 / NSCP §6)`]] as [string, string][] : []),
       ['Columns', distinct('column')],
       ['Girders', distinct('girder')],
       ['Beams', distinct('beam')],
@@ -1336,6 +1348,9 @@ export default function ModelSpace() {
       ['Concrete', `${f1(d.totals.concrete)} m³ (${f1(d.totals.concreteMembers)} members + ${f1(d.totals.concreteSlabs)} slabs)`],
       ...(d.totals.steelKg > 0
         ? [['Structural steel', `${f1(d.totals.steelKg)} kg (${f2(d.totals.steelKg / 1000)} t)`] as [string, string]]
+        : []),
+      ...(d.totals.woodVolume > 0
+        ? [['Timber', `${f2(d.totals.woodVolume)} m³`] as [string, string]]
         : []),
     ]
   }
@@ -1354,7 +1369,8 @@ export default function ModelSpace() {
         import('../lib/modelReport'), import('../lib/modelPdf'),
       ])
       const badges = ['NSCP 2015', 'ACI 318-14',
-        ...(design.steelBeams.length || design.steelColumns.length ? ['AISC 360-16'] : [])]
+        ...(design.steelBeams.length || design.steelColumns.length ? ['AISC 360-16'] : []),
+        ...(design.woodBeams.length || design.woodColumns.length ? ['NDS §3 / NSCP §6'] : [])]
       await generateModelPdf({
         lh, modelImg: img, badges,
         report: buildModelReport(model, design, reportProps(design), soil),
@@ -1483,7 +1499,7 @@ export default function ModelSpace() {
     return map
   }, [govRes])
 
-  const generate = (matOverride?: 'concrete' | 'steel') => {
+  const generate = (matOverride?: 'concrete' | 'steel' | 'wood') => {
     const mat = { fc, fy, barDia, tieDia, cover }
     const role = (b: number, h: number, id: string): RectSection => ({ id, name: `${b}×${h}`, b, h, ...mat })
     // steel role: bounding box b = bf, h = d from the chosen AISC shape, tagged
@@ -1493,12 +1509,17 @@ export default function ModelSpace() {
       const { b, h } = sh ? sectionBoundingBox(sh) : { b: 200, h: 300 }
       return { id, name: shapeName, b, h, ...mat, material: 'steel', shape: shapeName, steelFy, steelFu }
     }
-    const steel = (matOverride ?? material) === 'steel'
+    // wood role: solid-rectangle b × d tagged with the timber species/grade so
+    // the bridge (E), pipeline (NDS §3 design) and take-off pick it up.
+    const woodRole = (b: number, h: number, id: string): RectSection =>
+      ({ id, name: `${b}×${h}`, b, h, ...mat, material: 'wood', woodSpecies, woodKind, woodWet })
+    const chosen = matOverride ?? material
+    const steel = chosen === 'steel', wood = chosen === 'wood'
     const m = generateGridModel({
       baysX: parseList(baysX), baysZ: parseList(baysZ), storeyH: parseList(storeyH),
-      column: steel ? steelRole(colShape, 'COL') : role(colB, colH, 'COL'),
-      girder: steel ? steelRole(girShape, 'GIR') : role(girB, girH, 'GIR'),
-      beam: steel ? steelRole(beaShape, 'BEA') : role(beaB, beaH, 'BEA'),
+      column: steel ? steelRole(colShape, 'COL') : wood ? woodRole(colB, colH, 'COL') : role(colB, colH, 'COL'),
+      girder: steel ? steelRole(girShape, 'GIR') : wood ? woodRole(girB, girH, 'GIR') : role(girB, girH, 'GIR'),
+      beam: steel ? steelRole(beaShape, 'BEA') : wood ? woodRole(beaB, beaH, 'BEA') : role(beaB, beaH, 'BEA'),
       slabThickness: slabThk,
     })
     // gravity loads: member self-weight (D), slab self-weight + SDL (D), LL (L)
@@ -2319,15 +2340,17 @@ export default function ModelSpace() {
             <div className="divide-y divide-[#eeece5] px-4 py-1">
               <Sec title="Frame material">
                 <Pick label="Members" value={material} onChange={(v) => {
-                  const next = v as 'concrete' | 'steel'
+                  const next = v as 'concrete' | 'steel' | 'wood'
                   setMaterial(next)
                   if (model) generate(next)          // auto-regenerate grid with new frame material
                 }}
-                  options={[['concrete', 'Reinforced concrete'], ['steel', 'Structural steel (AISC W)']]} />
+                  options={[['concrete', 'Reinforced concrete'], ['steel', 'Structural steel (AISC W)'], ['wood', 'Timber (wood frame)']]} />
                 <p className="col-span-full -mt-1 text-[11px] text-slate-500">
                   {material === 'steel'
                     ? 'Members become AISC W-shapes designed to AISC 360-16 LRFD (§F flexure, §G shear, §E/§H1 columns); base plates per §J8. Slabs/footings stay reinforced concrete.'
-                    : 'Members are reinforced concrete designed to NSCP 2015 / ACI 318-14.'}
+                    : material === 'wood'
+                      ? 'Members become solid-rectangular timber designed to NDS §3 / NSCP §6 (LRFD via Appendix N). Slabs/footings stay reinforced concrete.'
+                      : 'Members are reinforced concrete designed to NSCP 2015 / ACI 318-14.'}
                 </p>
               </Sec>
               {material === 'steel' ? (
@@ -2353,6 +2376,34 @@ export default function ModelSpace() {
                     HSS/angle/channel flexure checks are not yet automated. Concrete f′c is still used for base-plate bearing.
                   </p>
                 </Sec>
+              ) : material === 'wood' ? (
+                <Sec title="Timber (wood frame)">
+                  <Pick label="Species / grade" value={woodSpecies} onChange={(v) => {
+                    setWoodSpecies(v); setWoodKind(WOOD_SPECIES[v]?.kind ?? 'sawn')
+                    if (model) generate('wood')
+                  }} options={Object.values(WOOD_SPECIES).map((sp) => [sp.id, sp.label])} />
+                  <label className="col-span-full flex items-center gap-2 text-sm">
+                    <input type="checkbox" checked={woodWet}
+                      onChange={(e) => { setWoodWet(e.target.checked); if (model) generate('wood') }} />
+                    Wet service — MC &gt; 19% sawn / 16% glulam (applies C<sub>M</sub>)
+                  </label>
+                  <p className="col-span-full -mb-1 text-[11px] text-slate-500">
+                    Solid rectangular b × d members. Each starts from its role size and grows independently
+                    when optimised; columns are kept ≥ girders ≥ beams in width.
+                  </p>
+                  <Num label="Column b" unit="mm" value={colB} onChange={setColB} />
+                  <Num label="Column d" unit="mm" value={colH} onChange={setColH} />
+                  <Num label="Girder b" unit="mm" value={girB} onChange={setGirB} />
+                  <Num label="Girder d" unit="mm" value={girH} onChange={setGirH} />
+                  <Num label="Beam b" unit="mm" value={beaB} onChange={setBeaB} />
+                  <Num label="Beam d" unit="mm" value={beaH} onChange={setBeaH} />
+                  <Num label="Slab thickness" unit="mm" value={slabThk} onChange={setSlabThk} />
+                  <p className="col-span-full text-[11px] text-slate-500">
+                    Designed to NDS §3 / NSCP §6: reference values ({WOOD_SPECIES[woodSpecies]?.kind === 'glulam' ? 'glulam' : 'sawn'})
+                    adjusted by C<sub>D</sub>/C<sub>M</sub>/C<sub>F</sub>/C<sub>V</sub>, beam stability C<sub>L</sub> and column
+                    stability C<sub>P</sub>; factored demands checked LRFD (Appendix N, K<sub>F</sub>·φ·λ). Slabs/footings stay reinforced concrete.
+                  </p>
+                </Sec>
               ) : (
                 <Sec title="Initial member sizes (mm)">
                   <p className="col-span-full -mb-1 text-[11px] text-slate-500">
@@ -2373,6 +2424,7 @@ export default function ModelSpace() {
                   Shared material applied to every section when you generate the grid. f′c drives Ec and the
                   flexural/shear capacities; fy the steel; ⌀ and cover the bar layout and effective depth.
                   {material === 'steel' && ' (Used for slabs, footings and base-plate bearing.)'}
+                  {material === 'wood' && ' (Used for the concrete slabs and footings of the timber frame.)'}
                 </p>
                 <Num label="Concrete f′c" unit="MPa" value={fc} onChange={setFc} step="0.5" />
                 <Num label="Steel fy" unit="MPa" value={fy} onChange={setFy} step="5" />
@@ -4051,6 +4103,88 @@ export default function ModelSpace() {
           )}
 
           {/* Steel beam schedule (full width) — only when steel members exist */}
+          {/* Timber beam / girder schedule */}
+          {design.woodBeams.length > 0 && (
+            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Timber beam / girder schedule — NDS §3.3/§3.4 (NSCP §6, LRFD)<SchedChip items={design.woodBeams} ok={(b) => b.ok} /></h3>
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
+                    <th className="py-1 pr-2 font-semibold">Beam</th>
+                    <th className="py-1 pr-2 font-semibold">b×d (mm)</th>
+                    <th className="py-1 pr-2 font-semibold">Grade</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Mu (kN·m)</th>
+                    <th className="py-1 pr-2 text-right font-semibold">F′b (MPa)</th>
+                    <th className="py-1 pr-2 text-right font-semibold">CL</th>
+                    <th className="py-1 pr-2 text-right font-semibold">util M</th>
+                    <th className="py-1 pr-2 text-right font-semibold">util V</th>
+                    <th className="py-1 font-semibold">Case</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {design.woodBeams.map((b) => (
+                    <tr key={b.id} className={`sched-row border-t border-slate-100 ${b.ok ? '' : 'bg-red-50 text-red-700'}`}>
+                      <td className="py-1 pr-2 font-medium">{b.id}</td>
+                      <td className="py-1 pr-2 font-mono">{b.b}×{b.d}</td>
+                      <td className="py-1 pr-2" title={WOOD_SPECIES[b.species]?.label ?? b.species}>{b.species}{b.kind === 'glulam' ? ' (GL)' : ''}</td>
+                      <td className="py-1 pr-2 text-right">{f1(b.Mu)}</td>
+                      <td className="py-1 pr-2 text-right">{b.FbPrime.toFixed(2)}</td>
+                      <td className="py-1 pr-2 text-right">{b.CL.toFixed(2)}</td>
+                      <td className={`py-1 pr-2 text-right font-semibold ${b.utilM > 1 ? 'text-red-600' : b.utilM > 0.9 ? 'text-amber-600' : 'text-green-700'}`}>{(b.utilM * 100).toFixed(0)}%</td>
+                      <td className={`py-1 pr-2 text-right font-semibold ${b.utilV > 1 ? 'text-red-600' : b.utilV > 0.9 ? 'text-amber-600' : 'text-green-700'}`}>{(b.utilV * 100).toFixed(0)}%</td>
+                      <td className="py-1 text-[11px] text-slate-500">{b.gov}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <p className="mt-1 text-[11px] text-slate-500">
+                fb = M/S ≤ F′b (§3.3, beam stability CL §3.3.3); fv = 1.5V/A ≤ F′v (§3.4). Reference values adjusted by
+                CD→λ, CM, CF/CV and converted to LRFD via Appendix N (KF·φ·λ). le auto per §3.3.3.
+              </p>
+            </div>
+          )}
+          {/* Timber column schedule */}
+          {design.woodColumns.length > 0 && (
+            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Timber column schedule — NDS §3.7 + §3.9 (NSCP §6, LRFD)<SchedChip items={design.woodColumns} ok={(c) => c.ok} /></h3>
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
+                    <th className="py-1 pr-2 font-semibold">Column</th>
+                    <th className="py-1 pr-2 font-semibold">b×d (mm)</th>
+                    <th className="py-1 pr-2 font-semibold">Grade</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Pu (kN)</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Mu (kN·m)</th>
+                    <th className="py-1 pr-2 text-right font-semibold">F′c (MPa)</th>
+                    <th className="py-1 pr-2 text-right font-semibold">CP</th>
+                    <th className="py-1 pr-2 text-right font-semibold">le/d</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Ratio</th>
+                    <th className="py-1 font-semibold">Case</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {design.woodColumns.map((c) => (
+                    <tr key={c.id} className={`sched-row border-t border-slate-100 ${c.ok ? '' : 'bg-red-50 text-red-700'}`}>
+                      <td className="py-1 pr-2 font-medium">{c.id}</td>
+                      <td className="py-1 pr-2 font-mono">{c.b}×{c.d}</td>
+                      <td className="py-1 pr-2" title={WOOD_SPECIES[c.species]?.label ?? c.species}>{c.species}{c.kind === 'glulam' ? ' (GL)' : ''}</td>
+                      <td className="py-1 pr-2 text-right">{f1(c.Pu)}</td>
+                      <td className="py-1 pr-2 text-right">{f1(c.Mu)}</td>
+                      <td className="py-1 pr-2 text-right">{c.FcPrime.toFixed(2)}</td>
+                      <td className="py-1 pr-2 text-right">{c.CP.toFixed(2)}</td>
+                      <td className="py-1 pr-2 text-right">{c.slenderness.toFixed(0)}</td>
+                      <td className={`py-1 pr-2 text-right font-semibold ${c.ratio > 1 ? 'text-red-600' : c.ratio > 0.9 ? 'text-amber-600' : 'text-green-700'}`}>{(c.ratio * 100).toFixed(0)}%</td>
+                      <td className="py-1 text-[11px] text-slate-500">{c.gov}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <p className="mt-1 text-[11px] text-slate-500">
+                fc = P/A ≤ F′c with column stability CP (§3.7.1, governing plane le/d); beam-column members add the §3.9.2
+                interaction (fc/F′c)² + fb/[F′b(1 − fc/FcE)]. Ratio = governing of the two.
+              </p>
+            </div>
+          )}
           {design.steelBeams.length > 0 && (
             <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
               <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Steel beam / girder schedule — AISC 360-16 LRFD<SchedChip items={design.steelBeams} ok={(b) => b.ok} /></h3>


### PR DESCRIPTION
## What & why

Adds a **wooden frame** as the third selectable structural material in the 3D Model Space → **Properties** panel, alongside *Reinforced concrete* and *Structural steel*. Phase 1 ([#379](https://github.com/BitLess246/civilEngineering/pull/379)) shipped the timber design engine; this phase wires it through every layer so a timber frame **models, analyses, designs and reports** like the other two materials.

## Layers touched
| Layer | Change |
|-------|--------|
| **L1 Model** | `SectionMaterial` gains `'wood'`; `RectSection` carries `woodSpecies` / `woodKind` / `woodWet` (JSON-serialisable). `meshValidation` adds a timber sanity rule (unknown species / non-positive dims) and rejects prestressing on wood. |
| **L2 Bridge** | Timber member stiffness from the species mean **E**, **G ≈ E/16** (not the concrete √f′c law); `plateMaterial` now selects the first **concrete** section so a wood member isn't mistaken for the slab material. Self-weight (`modelBuilder`) uses **γ ≈ G·9.81** for timber. |
| **L6 Pipeline** | Wood beams/girders + columns route to new `woodBeams`/`woodColumns` schedules via `checkWoodBeam`/`checkWoodColumn` — bending + shear + column stability + §3.9.2 beam-column interaction. Factored LRFD demands checked with **NDS Appendix N** (`KF·φ·λ`); the time-effect factor **λ** is chosen per governing combo (1.4D→0.6, gravity→0.8, W/E→1.0). `totals.woodVolume` added; `designOK` and PDF badges include timber. Wood members are kept **out of the concrete BOM**. |
| **Engine** | `woodDesign` gains the NDS-LRFD path (`method`/`lambda` in `woodAdjusted`) + `woodUnitWeight`; ASD stays the default. |
| **UI** | Material picker + timber sub-panel (species/grade, wet-service, b×d sizes), 3D **timber-brown** tint, timber grade + volume in the design summary, and **Timber beam / column schedule** tables. |

## Correctness note — ASD vs LRFD
The frame pipeline solves **LRFD-factored** NSCP combinations, so timber members are checked with NDS Appendix N (LRFD), not ASD — mixing ASD allowables with factored demands would be wrong by ~1.6×. `λ` is derived from the governing combo; a dead-heavy timber column is correctly governed by **1.4D** (λ = 0.6, lowest allowable).

## Tests & verification
- `woodFrame.test.ts` — bridge stiffness (species E, G=E/16), timber self-weight, full-frame design routing (wood schedules populated, `woodVolume>0`, `concreteMembers=0`), mesh rule. Plus LRFD + unit-weight cases in `woodDesign.test.ts`.
- **In-browser (verified):** a DFL-2 frame generates, `Design all` runs with no console errors, the summary shows *Timber grade DFL-2 · 16.14 m³ · 0 concrete members*, and both schedules render — e.g. beam `250×450 · F′b 10.19 · CL 0.99 · util M 76%`; column `400×400 · F′c 11.21 · CP 0.96 · le/d 9 · Ratio 50%`.

```
tsc -b     → clean
vitest run → 91 files, 1159 tests pass
```

## Follow-up (Phase 3)
Optimizer tuning for timber sections · board-feet take-off · PDF timber schedules · timber base/beam connections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)