### PR TITLE
feat: plumbing design page + water-supply engine — RNPCP 2000 (Phase 1)

### DIFF
--- a/docs/ValidationMap.md
+++ b/docs/ValidationMap.md
@@ -110,6 +110,7 @@ asserted by that file; all run in CI.
 | Steel connections | `steelConnections.test.ts`, `boltedConnection.test.ts`, `weldedConnection.test.ts`, `connectionSolution.test.ts`, `baseplate.test.ts` | IC-method bolt/weld groups vs `validation.ts` `bolt-ecc-rmax`/`weld-ecc-fmax`/`bolt-oop-tension`/`prying-t0`; AISC DG1 base plates |
 | Effective length K | `effectiveLength.test.ts` | alignment-chart G-factors vs published values (review anchors) |
 | Timber (wood) member design | `woodDesign.test.ts` | NDS §3 / NSCP §6 ASD adjustment factors (CD/CM/CF/CV), beam CL (§3.3.3) + column CP (§3.7.1) closed-form anchors, beam-column §3.9.2 interaction; `validation.ts` `wood-cp`/`wood-cl` |
+| Plumbing — water supply (RNPCP 2000) | `plumbingFixtures.test.ts`, `waterSupply.test.ts` | Table 6-5/7-2 fixture-unit totals vs Module 2/3/4 worked examples; demand (ΣFU×8), static head, continuity velocity, Hazen-Williams friction; `validation.ts` `plumb-velocity`/`plumb-friction` |
 | SCWB | `scwb.test.ts` | ΣMnc/ΣMnb ≥ 6/5 (§418.7.3.2) with hand Mn |
 | Slabs | `slabDDM.test.ts`, `woodArmer.test.ts`, `slabDeflection.test.ts` | DDM coefficient tables; Wood–Armer moment transformation identities |
 | RC misc | `devLength.test.ts`, `torsionDesign.test.ts`, `beamDeflection.test.ts`, `shearWallDesign.test.ts` | §425.4 ld, §422.7 threshold/cracking torsion, Branson Ie, wall shear |

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -40,6 +40,7 @@ import ColumnEstimate from './pages/ColumnEstimate'
 import BeamEstimate from './pages/BeamEstimate'
 import BoxCulvertEstimate from './pages/BoxCulvertEstimate'
 import LoadCombinations from './pages/LoadCombinations'
+import PlumbingDesign from './pages/PlumbingDesign'
 
 export default function App() {
   const [auth, setAuth] = useState<'login' | 'signup' | null>(null)
@@ -97,6 +98,7 @@ export default function App() {
         <Route path="/estimate/chb" element={<ChbEstimate />} />
         <Route path="/estimate/box-culvert" element={<BoxCulvertEstimate />} />
               <Route path="/load-combinations" element={<LoadCombinations />} />
+        <Route path="/plumbing" element={<PlumbingDesign />} />
             </Routes>
           </AppShell>
         } />

--- a/webapp/src/engine/plumbingFixtures.test.ts
+++ b/webapp/src/engine/plumbingFixtures.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { PLUMBING_FIXTURES, totalWSFU, totalDFU, largestTrap, type FixtureCount } from './plumbingFixtures'
+
+describe('WSFU totals — RNPCP Table 6-5 (Module 2 worked examples)', () => {
+  it('residential 2WC+2SH+2L+4HB+1KS = 26 WSFU (private)', () => {
+    const items: FixtureCount[] = [
+      { id: 'water-closet', count: 2 }, { id: 'shower', count: 2 }, { id: 'lavatory', count: 2 },
+      { id: 'hose-bibb', count: 4 }, { id: 'kitchen-sink', count: 1 },
+    ]
+    expect(totalWSFU(items, 'private')).toBe(26)
+  })
+  it('design ex.1: 2WC+2L+1KS+1BT = 12 WSFU (private)', () => {
+    const items: FixtureCount[] = [
+      { id: 'water-closet', count: 2 }, { id: 'lavatory', count: 2 }, { id: 'kitchen-sink', count: 1 }, { id: 'bathtub', count: 1 },
+    ]
+    expect(totalWSFU(items, 'private')).toBe(12)
+  })
+  it('design ex.2 (commercial): 5WC+5L+2BT+3KS+10U = 85 WSFU (public)', () => {
+    const items: FixtureCount[] = [
+      { id: 'water-closet', count: 5 }, { id: 'lavatory', count: 5 }, { id: 'bathtub', count: 2 },
+      { id: 'kitchen-sink', count: 3 }, { id: 'urinal', count: 10 },
+    ]
+    expect(totalWSFU(items, 'public')).toBe(85)
+  })
+})
+
+describe('DFU totals — RNPCP Table 7-2 (Module 3/4 worked examples)', () => {
+  it('2WC(priv)+2LAV+2FD = 14 DFU', () => {
+    const items: FixtureCount[] = [{ id: 'water-closet', count: 2 }, { id: 'lavatory', count: 2 }, { id: 'floor-drain', count: 2 }]
+    expect(totalDFU(items, 'private')).toBe(14)
+  })
+  it('5WC(public)+3LAV+3FD = 39 DFU', () => {
+    const items: FixtureCount[] = [{ id: 'water-closet', count: 5 }, { id: 'lavatory', count: 3 }, { id: 'floor-drain', count: 3 }]
+    expect(totalDFU(items, 'public')).toBe(39)
+  })
+  it('septic ex: 3WC+3LAV+3SHO+5FD+1DISH = 33 DFU (private)', () => {
+    const items: FixtureCount[] = [
+      { id: 'water-closet', count: 3 }, { id: 'lavatory', count: 3 }, { id: 'shower', count: 3 },
+      { id: 'floor-drain', count: 5 }, { id: 'dishwasher', count: 1 },
+    ]
+    expect(totalDFU(items, 'private')).toBe(33)
+  })
+})
+
+describe('fixture catalog integrity', () => {
+  it('a water closet needs the largest trap (75 mm) and a lavatory the smallest (32 mm)', () => {
+    expect(PLUMBING_FIXTURES['water-closet'].minTrapMm).toBe(75)
+    expect(largestTrap([{ id: 'lavatory', count: 1 }, { id: 'water-closet', count: 1 }])).toBe(75)
+  })
+  it('public WSFU ≥ private for every fixture; hose bibbs have no DFU', () => {
+    for (const f of Object.values(PLUMBING_FIXTURES)) expect(f.wsfu.public).toBeGreaterThanOrEqual(f.wsfu.private)
+    expect(PLUMBING_FIXTURES['hose-bibb'].dfu.private).toBe(0)
+  })
+})

--- a/webapp/src/engine/plumbingFixtures.ts
+++ b/webapp/src/engine/plumbingFixtures.ts
@@ -1,0 +1,62 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Plumbing fixture-unit catalog — Revised National Plumbing Code of the
+// Philippines (RNPCP 2000): Table 6-5 water-supply fixture units (WSFU) and
+// Table 7-2 drainage fixture units (DFU) + minimum trap/waste size.  Shared
+// foundation for the water-supply, drainage (DWV) and septic-tank engines.
+//
+// Fixture-unit values distinguish PRIVATE (residence, private bath) from PUBLIC
+// (commercial, shared) service, per the code and the module worked examples.
+// Units: fixture units (dimensionless); trap size mm.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type Occupancy = 'private' | 'public'
+
+export interface PlumbingFixture {
+  id: string
+  label: string
+  /** Water-supply fixture units — RNPCP Table 6-5. */
+  wsfu: { private: number; public: number }
+  /** Drainage fixture units — RNPCP Table 7-2. */
+  dfu: { private: number; public: number }
+  /** Minimum trap / fixture-drain diameter, mm — RNPCP Table 7-2. 0 = no DWV
+   *  connection (e.g. a hose bibb draws supply only). */
+  minTrapMm: number
+}
+
+// Values as used in the Module 2/3/4 worked examples (RNPCP flush-tank set).
+export const PLUMBING_FIXTURES: Record<string, PlumbingFixture> = {
+  'water-closet': { id: 'water-closet', label: 'Water closet (flush tank)', wsfu: { private: 3, public: 5 }, dfu: { private: 4, public: 6 }, minTrapMm: 75 },
+  'lavatory': { id: 'lavatory', label: 'Lavatory', wsfu: { private: 1, public: 2 }, dfu: { private: 1, public: 1 }, minTrapMm: 32 },
+  'kitchen-sink': { id: 'kitchen-sink', label: 'Kitchen sink', wsfu: { private: 2, public: 4 }, dfu: { private: 2, public: 2 }, minTrapMm: 40 },
+  'bathtub': { id: 'bathtub', label: 'Bathtub', wsfu: { private: 2, public: 4 }, dfu: { private: 2, public: 2 }, minTrapMm: 40 },
+  'shower': { id: 'shower', label: 'Shower head', wsfu: { private: 2, public: 2 }, dfu: { private: 2, public: 2 }, minTrapMm: 50 },
+  'urinal': { id: 'urinal', label: 'Urinal (flush tank)', wsfu: { private: 3, public: 3 }, dfu: { private: 2, public: 2 }, minTrapMm: 40 },
+  'hose-bibb': { id: 'hose-bibb', label: 'Hose bibb', wsfu: { private: 3, public: 3 }, dfu: { private: 0, public: 0 }, minTrapMm: 0 },
+  'floor-drain': { id: 'floor-drain', label: 'Floor drain', wsfu: { private: 0, public: 0 }, dfu: { private: 2, public: 2 }, minTrapMm: 50 },
+  'dishwasher': { id: 'dishwasher', label: 'Dishwasher', wsfu: { private: 2, public: 2 }, dfu: { private: 2, public: 2 }, minTrapMm: 40 },
+  'slop-sink': { id: 'slop-sink', label: 'Slop / service sink', wsfu: { private: 3, public: 4 }, dfu: { private: 3, public: 3 }, minTrapMm: 65 },
+  'laundry-sink': { id: 'laundry-sink', label: 'Laundry / residential sink', wsfu: { private: 2, public: 2 }, dfu: { private: 2, public: 2 }, minTrapMm: 40 },
+}
+
+export const FIXTURE_LIST: PlumbingFixture[] = Object.values(PLUMBING_FIXTURES)
+
+/** A fixture group on a plumbing schedule: a fixture id and how many. */
+export interface FixtureCount { id: string; count: number }
+
+/** Total water-supply fixture units (Table 6-5) for a schedule. */
+export function totalWSFU(items: FixtureCount[], occ: Occupancy): number {
+  return items.reduce((s, it) => s + (PLUMBING_FIXTURES[it.id]?.wsfu[occ] ?? 0) * Math.max(0, it.count), 0)
+}
+
+/** Total drainage fixture units (Table 7-2) for a schedule. */
+export function totalDFU(items: FixtureCount[], occ: Occupancy): number {
+  return items.reduce((s, it) => s + (PLUMBING_FIXTURES[it.id]?.dfu[occ] ?? 0) * Math.max(0, it.count), 0)
+}
+
+/** Largest minimum trap size among the connected drainage fixtures, mm. */
+export function largestTrap(items: FixtureCount[]): number {
+  return items.reduce((m, it) => {
+    const f = PLUMBING_FIXTURES[it.id]
+    return f && it.count > 0 && f.dfu.private > 0 ? Math.max(m, f.minTrapMm) : m
+  }, 0)
+}

--- a/webapp/src/engine/validation.ts
+++ b/webapp/src/engine/validation.ts
@@ -24,11 +24,12 @@ import { solveBoltedConnection } from './boltedConnection'
 import { solveWeldedConnection } from './weldedConnection'
 import { boltGeomFromPositions, outOfPlaneBoltGroup, pryingAction } from './steelDesign'
 import { columnStabilityFactor, beamStabilityFactor, getWoodRef } from './woodDesign'
+import { velocity, hazenWilliamsHead, gpmToLps } from './waterSupply'
 import type { RectSection } from './model'
 
 export interface ValidationCase {
   id: string
-  category: 'RC' | 'Steel' | 'Timber' | 'Connections' | 'Analysis' | 'Seismic' | 'Dynamics' | 'Wind' | 'Geotech'
+  category: 'RC' | 'Steel' | 'Timber' | 'Connections' | 'Analysis' | 'Seismic' | 'Dynamics' | 'Wind' | 'Geotech' | 'Plumbing'
   title: string
   reference: string
   formula: string
@@ -223,6 +224,19 @@ const woodCL = (() => {
   return { manual: a - Math.sqrt(a * a - r / 0.95), software: beamStabilityFactor(100, 300, 4000, Emin, FbStar).CL }
 })()
 
+// ── Plumbing (RNPCP 2000) — water-supply hydraulics ─────────────────────────
+const plumbVelocity = (() => {
+  // ¾" Type L copper (19.94 mm ID) at 10 gpm — continuity v = Q/A.
+  const lps = gpmToLps(10), D = 19.94
+  return { manual: (lps / 1000) / ((Math.PI * (D / 1000) ** 2) / 4), software: velocity(lps, D) }
+})()
+
+const plumbFriction = (() => {
+  // Hazen-Williams head loss, 20 gpm in 1" copper (C = 140) over 100 m.
+  const Q = gpmToLps(20), D = 26.04, C = 140, L = 100
+  return { manual: (10.67 * L * (Q / 1000) ** 1.852) / (C ** 1.852 * (D / 1000) ** 4.87), software: hazenWilliamsHead(Q, D, C, L) }
+})()
+
 export const VALIDATION_CASES: ValidationCase[] = [
   {
     id: 'rc-beam-mn', category: 'RC', title: 'Singly-reinforced beam — nominal moment',
@@ -343,5 +357,15 @@ export const VALIDATION_CASES: ValidationCase[] = [
     id: 'wood-cl', category: 'Timber', title: 'Timber beam stability factor CL',
     reference: 'NDS 2018 §3.3.3 / NSCP §6', formula: 'CL = a − √(a² − (FbE/Fb*)/0.95),  a = (1+FbE/Fb*)/1.9',
     manual: woodCL.manual, software: woodCL.software, unit: '—', tol: 1e-9,
+  },
+  {
+    id: 'plumb-velocity', category: 'Plumbing', title: 'Supply pipe velocity (continuity)',
+    reference: 'RNPCP 2000 / Module 2', formula: 'v = Q / A = 4Q / (π·D²)',
+    manual: plumbVelocity.manual, software: plumbVelocity.software, unit: 'm/s', tol: 1e-9,
+  },
+  {
+    id: 'plumb-friction', category: 'Plumbing', title: 'Water friction head — Hazen-Williams',
+    reference: 'Hazen-Williams (RNPCP Chart A-4…A-7)', formula: 'hf = 10.67·L·Q^1.852 / (C^1.852·D^4.87)',
+    manual: plumbFriction.manual, software: plumbFriction.software, unit: 'm', tol: 1e-9,
   },
 ]

--- a/webapp/src/engine/waterSupply.test.ts
+++ b/webapp/src/engine/waterSupply.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import {
+  waterDemand, hunterFlowGpm, hunterFlowLps, staticHead, velocity, hazenWilliamsHead, frictionDrop,
+  sizeSupplyPipe, designWaterSupply, gpmToLps, GPM_PER_FU,
+} from './waterSupply'
+import type { FixtureCount } from './plumbingFixtures'
+
+describe('maximum demand', () => {
+  it('Σ FU × 8 gpm (Module 2: 20 FU → 160 gpm)', () => {
+    const items: FixtureCount[] = [{ id: 'water-closet', count: 3 }, { id: 'lavatory', count: 3 }, { id: 'kitchen-sink', count: 1 }, { id: 'shower', count: 3 }]
+    const d = waterDemand(items, 'private')    // 9+3+2+6 = 20 FU
+    expect(d.wsfu).toBe(20)
+    expect(d.maxGpm).toBe(20 * GPM_PER_FU)     // 160 gpm
+  })
+})
+
+describe("Hunter's curve — probable design flow", () => {
+  it('interpolates the flush-tank table (10 FU → 14.6 gpm exactly)', () => {
+    expect(hunterFlowGpm(10, 'tank')).toBeCloseTo(14.6, 6)
+    expect(hunterFlowGpm(25, 'tank')).toBeCloseTo(25.4, 6)
+  })
+  it('interpolates linearly between tabulated points (12.5 FU between 12 and 15)', () => {
+    expect(hunterFlowGpm(12.5, 'tank')).toBeCloseTo(16.3 + (18.7 - 16.3) * (0.5 / 3), 6)
+  })
+  it('is far below the linear Σ FU × 8 max (diversity of use)', () => {
+    expect(hunterFlowGpm(50, 'tank')).toBeLessThan(50 * GPM_PER_FU)   // 38.3 ≪ 400
+  })
+  it('flush-valve systems draw more than flush-tank at the same load', () => {
+    expect(hunterFlowGpm(20, 'valve')).toBeGreaterThan(hunterFlowGpm(20, 'tank'))
+  })
+  it('grows monotonically with fixture units', () => {
+    expect(hunterFlowLps(30, 'tank')).toBeGreaterThan(hunterFlowLps(10, 'tank'))
+  })
+})
+
+describe('static head', () => {
+  it('γw·Z = 9.81·Z kPa (Z = 5 m → 49.05 kPa)', () => {
+    expect(staticHead(5)).toBeCloseTo(49.05, 2)
+  })
+})
+
+describe('velocity (continuity)', () => {
+  it('¾" Type L (19.94 mm ID) at 10 gpm ≈ 6.6 ft/s (2.02 m/s) — Module 2 example', () => {
+    const v = velocity(gpmToLps(10), 19.94)
+    expect(v).toBeCloseTo(2.02, 2)              // m/s
+    expect(v / 0.3048).toBeCloseTo(6.62, 1)     // ft/s ≈ module's 6.6
+  })
+  it('velocity scales with 1/D²', () => {
+    expect(velocity(gpmToLps(10), 26.04)).toBeLessThan(velocity(gpmToLps(10), 19.94))
+  })
+})
+
+describe('friction — Hazen-Williams', () => {
+  it('matches the closed form and stays within chart tolerance of Module 2 (20 gpm, 1" copper ≈ 227 kPa/100 m)', () => {
+    const Q = gpmToLps(20), D = 26.04, C = 140, L = 100
+    const expected = (10.67 * L * (Q / 1000) ** 1.852) / (C ** 1.852 * (D / 1000) ** 4.87)
+    expect(hazenWilliamsHead(Q, D, C, L)).toBeCloseTo(expected, 9)
+    const kpaPer100 = frictionDrop(Q, D, C, L)
+    expect(kpaPer100).toBeGreaterThan(200)
+    expect(kpaPer100).toBeLessThan(275)          // module chart read ~227 kPa/100 m
+  })
+  it('a larger diameter has far less friction (D^-4.87)', () => {
+    expect(frictionDrop(gpmToLps(20), 38.24, 140, 100)).toBeLessThan(frictionDrop(gpmToLps(20), 26.04, 140, 100))
+  })
+})
+
+describe('pipe sizing', () => {
+  it('never returns below the 19 mm minimum service size', () => {
+    const r = sizeSupplyPipe({ lps: 0.05, Lm: 5, allowableDropKPa: 500 })
+    expect(r.size!.idMm).toBeGreaterThanOrEqual(19)
+  })
+  it('picks a larger pipe when the allowable friction drop is tight', () => {
+    const tight = sizeSupplyPipe({ lps: 1.5, Lm: 30, allowableDropKPa: 20 })
+    const loose = sizeSupplyPipe({ lps: 1.5, Lm: 30, allowableDropKPa: 400 })
+    expect(tight.size!.idMm).toBeGreaterThanOrEqual(loose.size!.idMm)
+  })
+})
+
+describe('designWaterSupply — integration', () => {
+  const houseItems: FixtureCount[] = [
+    { id: 'water-closet', count: 2 }, { id: 'shower', count: 2 }, { id: 'lavatory', count: 2 },
+    { id: 'hose-bibb', count: 4 }, { id: 'kitchen-sink', count: 1 },
+  ]
+  it("uses Hunter's design flow (not Σ FU × 8) and reproduces the module's available head", () => {
+    const r = designWaterSupply({
+      items: houseItems, occupancy: 'private',
+      Lpipe: 21, fittingLength: 0, riseZ: 5,
+      pMainKPa: 206.85, pMeterKPa: 6.9, pFixtureKPa: 103.43, material: 'copper',
+    })
+    expect(r.demand.wsfu).toBe(26)
+    expect(r.flowSource).toBe('hunter')
+    expect(r.designFlowLps).toBeCloseTo(hunterFlowLps(26, 'tank'), 6)
+    expect(r.designFlowLps).toBeLessThan(r.demand.maxLps)         // ≪ the linear max
+    expect(r.staticKPa).toBeCloseTo(49.05, 1)
+    expect(r.availableForFriction).toBeCloseTo(206.85 - (49.05 + 6.9 + 103.43), 2)  // ≈ 47.5 kPa
+    expect(r.pipe.size).toBeTruthy()
+    expect(r.ok).toBe(true)
+  })
+  it('honours a chart-specific design-flow override', () => {
+    const r = designWaterSupply({
+      items: houseItems, occupancy: 'private', designFlowLps: 0.44,   // module's chart flow
+      Lpipe: 21, fittingLength: 0, riseZ: 5,
+      pMainKPa: 206.85, pMeterKPa: 6.9, pFixtureKPa: 103.43,
+    })
+    expect(r.flowSource).toBe('override')
+    expect(r.designFlowLps).toBe(0.44)
+    expect(r.pipe.size!.idMm).toBeGreaterThanOrEqual(19)
+  })
+  it('flags an inadequate system when the main pressure cannot cover static + residual', () => {
+    const r = designWaterSupply({
+      items: [{ id: 'water-closet', count: 2 }], occupancy: 'private',
+      Lpipe: 20, fittingLength: 5, riseZ: 30, pMainKPa: 200, pMeterKPa: 80, pFixtureKPa: 100,
+    })
+    expect(r.availableForFriction).toBeLessThan(0)
+    expect(r.ok).toBe(false)
+  })
+})

--- a/webapp/src/engine/waterSupply.ts
+++ b/webapp/src/engine/waterSupply.ts
@@ -1,0 +1,255 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Building water-supply design — RNPCP 2000 (Module 2).  Fixture-unit demand,
+// design flow via Hunter's curve, static head, friction loss, velocity and
+// building-supply pipe sizing.
+//
+// Two demands matter and must not be confused:
+//   • MAXIMUM demand  = Σ WSFU × 8 gpm  — every fixture discharging at once (an
+//     upper bound, used for the drainage side and as a sanity ceiling).
+//   • DESIGN (probable) flow — the realistic simultaneous flow, read from the
+//     code's Chart A-2 / A-3, which is HUNTER'S CURVE: a nonlinear FU→flow map
+//     embedding diversity of use.  This engine evaluates Hunter's curve directly
+//     (flush-tank / flush-valve tables) instead of a chart read; the value can
+//     be overridden with a chart-specific flow.
+//
+// Friction uses Hazen-Williams (the physics behind Charts A-4…A-7).  Sizing
+// picks the smallest standard pipe whose friction over the developed length
+// stays within the available head and whose velocity stays under the code cap
+// (≤ 2.4 m/s target, 3 m/s max).
+//
+// Units: flow L/s (also gpm at the boundary); diameter mm; length m; pressure
+// kPa; velocity m/s.
+// ─────────────────────────────────────────────────────────────────────────
+import { type FixtureCount, type Occupancy, totalWSFU } from './plumbingFixtures'
+import { type SolutionStep, sn0, sn1, sn2, sn3 } from '../lib/solution'
+
+// ── Unit conversions ────────────────────────────────────────────────────────
+export const GPM_PER_LPS = 15.850323      // 1 L/s = 15.8503 gpm
+export const LPS_PER_GPM = 1 / GPM_PER_LPS
+export const KPA_PER_PSI = 6.89476
+export const gpmToLps = (gpm: number) => gpm * LPS_PER_GPM
+export const lpsToGpm = (lps: number) => lps * GPM_PER_LPS
+
+/** Water density head: 1 m of water column = 9.81 kPa (γ = 9.81 kN/m³). */
+export const GAMMA_W = 9.81               // kPa per metre of head
+
+// ── Demand ──────────────────────────────────────────────────────────────────
+/** 1 fixture unit ≈ 8 gpm of instantaneous discharge (RNPCP; Module 2). */
+export const GPM_PER_FU = 8
+
+export interface WaterDemand {
+  wsfu: number
+  maxGpm: number; maxLps: number          // theoretical maximum (Σ FU × 8)
+}
+
+/** Maximum demand (Σ WSFU × 8 gpm) for a fixture schedule — an upper bound. */
+export function waterDemand(items: FixtureCount[], occ: Occupancy): WaterDemand {
+  const wsfu = totalWSFU(items, occ)
+  const maxGpm = wsfu * GPM_PER_FU
+  return { wsfu, maxGpm, maxLps: gpmToLps(maxGpm) }
+}
+
+// ── Hunter's curve — probable design flow from fixture units (Chart A-2/A-3) ──
+export type HunterSystem = 'tank' | 'valve'
+// [fixture units, gpm]; standard Hunter values (Wujek & Dagostino; the basis of
+// RNPCP Chart A-2 flush-tank / A-3 flush-valve). Diversity is already embedded.
+const HUNTER_TANK: [number, number][] = [
+  [1, 3.0], [2, 5.0], [3, 6.5], [4, 8.0], [5, 9.4], [6, 10.7], [8, 12.8], [10, 14.6],
+  [12, 16.3], [15, 18.7], [20, 22.2], [25, 25.4], [30, 28.3], [40, 33.6], [50, 38.3],
+  [60, 42.6], [80, 50.3], [100, 57.1], [150, 72.0], [200, 84.8], [300, 107.0], [500, 143.0], [1000, 216.0],
+]
+const HUNTER_VALVE: [number, number][] = [
+  [5, 15.0], [10, 27.0], [15, 34.5], [20, 41.0], [25, 46.5], [30, 51.5], [40, 60.5], [50, 68.5],
+  [60, 75.5], [80, 88.0], [100, 99.0], [150, 121.0], [200, 142.5], [300, 175.0], [500, 227.0], [1000, 321.0],
+]
+
+/** Probable design flow (gpm) for a total fixture-unit load, by system type,
+ *  via piecewise-linear interpolation of Hunter's curve. */
+export function hunterFlowGpm(wsfu: number, system: HunterSystem = 'tank'): number {
+  const t = system === 'valve' ? HUNTER_VALVE : HUNTER_TANK
+  if (wsfu <= t[0][0]) return (wsfu / t[0][0]) * t[0][1]          // scale down to origin
+  for (let i = 1; i < t.length; i++) {
+    if (wsfu <= t[i][0]) {
+      const [x0, y0] = t[i - 1], [x1, y1] = t[i]
+      return y0 + ((y1 - y0) * (wsfu - x0)) / (x1 - x0)
+    }
+  }
+  return t[t.length - 1][1]                                        // clamp at the top
+}
+export const hunterFlowLps = (wsfu: number, system: HunterSystem = 'tank') =>
+  gpmToLps(hunterFlowGpm(wsfu, system))
+
+// ── Static head ───────────────────────────────────────────────────────────
+/** Pressure change from an elevation rise Z (m) — a loss going up: γ·Z kPa. */
+export const staticHead = (Zm: number) => GAMMA_W * Zm     // magnitude, kPa
+
+// ── Velocity (continuity) ─────────────────────────────────────────────────
+/** Average velocity v = Q/A for a round pipe (m/s), from flow (L/s) and inside
+ *  diameter (mm).  Equals the customary v = 0.409·Q[gpm]/D[in]². */
+export function velocity(lps: number, dMm: number): number {
+  if (dMm <= 0) return Infinity
+  return (4000 * lps) / (Math.PI * dMm * dMm)              // (L/s→m³/s)/(π D²/4)
+}
+
+// ── Friction loss — Hazen-Williams ────────────────────────────────────────
+/** Hazen-Williams roughness C by pipe material. */
+export const HAZEN_C: Record<string, number> = {
+  copper: 140, plastic: 150, brass: 130, ferrous: 120, 'galvanized-old': 100,
+}
+
+/** Head loss (m) over length L (m) for flow Q (L/s) in a pipe of inside
+ *  diameter D (mm): hf = 10.67·L·Q^1.852 / (C^1.852·D^4.87), SI form. */
+export function hazenWilliamsHead(lps: number, dMm: number, C: number, Lm: number): number {
+  if (dMm <= 0 || C <= 0) return Infinity
+  const Q = lps / 1000, D = dMm / 1000                    // → m³/s, m
+  return (10.67 * Lm * Math.pow(Q, 1.852)) / (Math.pow(C, 1.852) * Math.pow(D, 4.87))
+}
+
+/** Friction pressure drop, kPa, over length L. */
+export const frictionDrop = (lps: number, dMm: number, C: number, Lm: number) =>
+  hazenWilliamsHead(lps, dMm, C, Lm) * GAMMA_W
+
+// ── Building-supply pipe schedule (copper Type L inside diameters, mm) ──────
+export interface PipeSize { nominalIn: number; label: string; idMm: number }
+export const COPPER_TYPE_L: PipeSize[] = [
+  { nominalIn: 0.5, label: '½"', idMm: 13.84 },
+  { nominalIn: 0.75, label: '¾"', idMm: 19.94 },
+  { nominalIn: 1.0, label: '1"', idMm: 26.04 },
+  { nominalIn: 1.25, label: '1¼"', idMm: 32.13 },
+  { nominalIn: 1.5, label: '1½"', idMm: 38.24 },
+  { nominalIn: 2.0, label: '2"', idMm: 50.42 },
+  { nominalIn: 2.5, label: '2½"', idMm: 62.61 },
+  { nominalIn: 3.0, label: '3"', idMm: 74.80 },
+  { nominalIn: 4.0, label: '4"', idMm: 99.4 },
+]
+
+/** RNPCP: no building water-service pipe smaller than 19 mm (¾"). */
+export const MIN_SERVICE_MM = 19
+/** Velocity cap: RNPCP notes velocities shall not exceed ~3 m/s; 2.4 m/s is the
+ *  common design target to limit noise and erosion. */
+export const V_TARGET = 2.4
+export const V_MAX = 3.0
+
+export interface PipeSizingResult {
+  size: PipeSize | null
+  velocity: number          // m/s at the chosen size
+  frictionDrop: number      // kPa over L at the chosen size
+  velocityOK: boolean       // ≤ vMax
+  frictionOK: boolean       // ≤ allowable
+  governedBy: 'velocity' | 'friction' | 'min-size' | 'none'
+}
+
+/** Smallest schedule pipe (≥ 19 mm) whose friction over L stays within the
+ *  available head AND whose velocity stays ≤ vMax. */
+export function sizeSupplyPipe(p: {
+  lps: number; Lm: number; allowableDropKPa: number
+  material?: keyof typeof HAZEN_C; schedule?: PipeSize[]; vMax?: number
+}): PipeSizingResult {
+  const C = HAZEN_C[p.material ?? 'copper']
+  const vMax = p.vMax ?? V_MAX
+  const schedule = (p.schedule ?? COPPER_TYPE_L).filter((s) => s.idMm >= MIN_SERVICE_MM)
+  for (const size of schedule) {
+    const v = velocity(p.lps, size.idMm)
+    const drop = frictionDrop(p.lps, size.idMm, C, p.Lm)
+    if (v <= vMax && drop <= p.allowableDropKPa) {
+      return { size, velocity: v, frictionDrop: drop, velocityOK: true, frictionOK: true, governedBy: 'velocity' }
+    }
+  }
+  // none satisfy both — report the largest with the failing check flagged
+  const largest = schedule[schedule.length - 1]
+  if (!largest) return { size: null, velocity: Infinity, frictionDrop: Infinity, velocityOK: false, frictionOK: false, governedBy: 'none' }
+  const v = velocity(p.lps, largest.idMm), drop = frictionDrop(p.lps, largest.idMm, C, p.Lm)
+  return {
+    size: largest, velocity: v, frictionDrop: drop,
+    velocityOK: v <= vMax, frictionOK: drop <= p.allowableDropKPa,
+    governedBy: drop > p.allowableDropKPa ? 'friction' : 'velocity',
+  }
+}
+
+// ── Full design ────────────────────────────────────────────────────────────
+export interface WaterSupplyInput {
+  items: FixtureCount[]
+  occupancy: Occupancy
+  hunterSystem?: HunterSystem   // 'tank' (Chart A-2) or 'valve' (Chart A-3)
+  designFlowLps?: number        // override the Hunter estimate with a chart value
+  Lpipe: number                 // developed pipe length, m
+  fittingLength: number         // equivalent length of fittings, m (Table A-2)
+  riseZ: number                 // elevation of highest fixture above source, m
+  pMainKPa: number              // pressure at the water main / service
+  pMeterKPa: number             // pressure drop across the meter
+  pFixtureKPa: number           // required residual pressure at the fixture
+  material?: keyof typeof HAZEN_C
+}
+
+export interface WaterSupplyResult {
+  demand: WaterDemand
+  designFlowLps: number         // flow used for sizing (Hunter or override)
+  designFlowGpm: number
+  flowSource: 'hunter' | 'override'
+  developedLength: number       // Lpipe + fittingLength, m
+  staticKPa: number
+  availableForFriction: number  // kPa left for friction after static + meter + residual
+  allowablePer30m: number       // kPa per 30.4 m (the chart basis)
+  pipe: PipeSizingResult
+  ok: boolean
+}
+
+/** Method-1 building-supply sizing (RNPCP §609): available head after static
+ *  lift, meter loss and the required residual is spent on friction over the
+ *  developed length; the smallest pipe that fits the Hunter design flow governs. */
+export function designWaterSupply(inp: WaterSupplyInput): WaterSupplyResult {
+  const demand = waterDemand(inp.items, inp.occupancy)
+  const flowSource: 'hunter' | 'override' = inp.designFlowLps != null ? 'override' : 'hunter'
+  const designFlowLps = inp.designFlowLps ?? hunterFlowLps(demand.wsfu, inp.hunterSystem ?? 'tank')
+  const developedLength = inp.Lpipe + inp.fittingLength
+  const staticKPa = staticHead(inp.riseZ)
+  const availableForFriction = inp.pMainKPa - (staticKPa + inp.pMeterKPa + inp.pFixtureKPa)
+  const allowablePer30m = developedLength > 0 ? (availableForFriction * 30.4) / developedLength : Infinity
+  const pipe = sizeSupplyPipe({
+    lps: designFlowLps, Lm: developedLength,
+    allowableDropKPa: Math.max(0, availableForFriction), material: inp.material,
+  })
+  return {
+    demand, designFlowLps, designFlowGpm: lpsToGpm(designFlowLps), flowSource,
+    developedLength, staticKPa, availableForFriction, allowablePer30m, pipe,
+    ok: availableForFriction > 0 && pipe.frictionOK && pipe.velocityOK && !!pipe.size,
+  }
+}
+
+// ── Worked solution ────────────────────────────────────────────────────────
+export function waterSupplySolution(inp: WaterSupplyInput, r: WaterSupplyResult): SolutionStep[] {
+  const d = r.demand
+  return [
+    {
+      title: 'Fixture units & design flow', clause: 'RNPCP Table 6-5 / Chart A-2·A-3',
+      lines: [
+        { text: `Σ WSFU = ${sn0(d.wsfu)} (${inp.occupancy}). Maximum demand Σ FU × 8 = ${sn0(d.maxGpm)} gpm (upper bound).` },
+        { tex: `Q_{design} = ${r.flowSource === 'override' ? '\\text{(chart)}' : `\\text{Hunter}(${sn0(d.wsfu)})`} = ${sn1(r.designFlowGpm)}\\ \\text{gpm} = ${sn3(r.designFlowLps)}\\ \\text{L/s}` },
+        { text: `Hunter's curve (${inp.hunterSystem === 'valve' ? 'flush-valve, Chart A-3' : 'flush-tank, Chart A-2'}) already embeds simultaneous-use diversity.` },
+      ],
+    },
+    {
+      title: 'Available head for friction', clause: 'RNPCP §609.6',
+      lines: [
+        { tex: `P_{static} = \\gamma_w Z = 9.81\\times ${sn2(inp.riseZ)} = ${sn2(r.staticKPa)}\\ \\text{kPa}` },
+        { tex: `\\Delta P_{avail} = P_{main} - (P_{static}+P_{meter}+P_{fixture})` },
+        { tex: `= ${sn1(inp.pMainKPa)} - (${sn1(r.staticKPa)}+${sn1(inp.pMeterKPa)}+${sn1(inp.pFixtureKPa)}) = ${sn1(r.availableForFriction)}\\ \\text{kPa}` },
+        { text: `Developed length L = ${sn1(inp.Lpipe)} + ${sn1(inp.fittingLength)} (fittings) = ${sn1(r.developedLength)} m; allowable ≈ ${sn1(r.allowablePer30m)} kPa per 30.4 m.` },
+      ],
+      pass: r.availableForFriction > 0,
+    },
+    {
+      title: 'Pipe size (Hazen-Williams friction + velocity cap)', clause: 'RNPCP Chart A-4…A-7',
+      lines: r.pipe.size ? [
+        { text: `Smallest ${inp.material ?? 'copper'} pipe (C = ${HAZEN_C[inp.material ?? 'copper']}) meeting both limits: ${r.pipe.size.label} (${sn1(r.pipe.size.idMm)} mm ID).` },
+        { tex: `v = \\dfrac{4000\\,Q}{\\pi D^2} = ${sn2(r.pipe.velocity)}\\ \\text{m/s}\\ (\\le ${sn1(V_MAX)})` },
+        { tex: `\\Delta P_{friction} = ${sn1(r.pipe.frictionDrop)}\\ \\text{kPa} \\le ${sn1(Math.max(0, r.availableForFriction))}\\ \\text{kPa}` },
+      ] : [{ text: 'No schedule pipe satisfies both the head and velocity limits — increase available pressure or shorten the run.' }],
+      pass: r.ok,
+      note: `Minimum building-service pipe is 19 mm (¾"). Velocity target ${sn1(V_TARGET)} m/s, max ${sn1(V_MAX)} m/s.`,
+    },
+  ]
+}
+
+// re-export for the page
+export { sn0, sn1, sn2, sn3 }

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -44,6 +44,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/shotcrete-facing', name: 'Shotcrete Facing', sub: 'FHWA · flexure · punching', group: 'Geotechnical' },
       { to: '/seismic-wizard',   name: 'Seismic Wizard',   sub: 'NSCP 208 Ca/Cv/I/R',       group: 'Seismic & Loads' },
       { to: '/load-combinations', name: 'Load Combinations', sub: 'NSCP 2015 §203.3 LRFD',  group: 'Seismic & Loads' },
+      { to: '/plumbing',         name: 'Plumbing Design',  sub: 'Water · DWV · septic · RNPCP', group: 'Plumbing & Sanitary' },
     ],
   },
   {

--- a/webapp/src/pages/PlumbingDesign.tsx
+++ b/webapp/src/pages/PlumbingDesign.tsx
@@ -1,0 +1,191 @@
+import { useMemo, useState } from 'react'
+import { FIXTURE_LIST, type FixtureCount, type Occupancy, totalWSFU, totalDFU } from '../engine/plumbingFixtures'
+import { designWaterSupply, waterSupplySolution, HAZEN_C, type HunterSystem, type WaterSupplyInput } from '../engine/waterSupply'
+import { WorkedSolution } from '../components/WorkedSolution'
+import { ReportControls } from '../components/ReportControls'
+
+function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
+const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
+const f1 = (n: number) => (Number.isFinite(n) ? n.toFixed(1) : '—')
+const f0 = (n: number) => (Number.isFinite(n) ? Math.round(n).toString() : '—')
+
+function Field({ label, value, onChange, unit, step = 'any', hint }: {
+  label: string; value: number; onChange: (v: number) => void; unit?: string; step?: string; hint?: string
+}) {
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="mb-1 font-medium text-slate-600">{label}{unit ? ` (${unit})` : ''}</span>
+      <input type="number" step={step} value={value} onChange={(e) => onChange(num(e.target.value))}
+        className="rounded-md border border-slate-300 px-2.5 py-1.5" />
+      {hint && <span className="mt-0.5 text-[10px] text-slate-400">{hint}</span>}
+    </label>
+  )
+}
+
+function Out({ label, value, ok }: { label: string; value: string; ok?: boolean }) {
+  return (
+    <div className="flex items-baseline justify-between border-t border-slate-100 py-1 text-sm">
+      <span className="text-slate-500">{label}</span>
+      <span className={`font-mono font-medium ${ok === undefined ? 'text-slate-800' : ok ? 'text-emerald-600' : 'text-red-600'}`}>{value}</span>
+    </div>
+  )
+}
+
+type Tab = 'supply' | 'drainage' | 'septic'
+
+export default function PlumbingDesign() {
+  const [tab, setTab] = useState<Tab>('supply')
+  const [occ, setOcc] = useState<Occupancy>('private')
+  // Shared fixture schedule — feeds every tab. Defaults reproduce the Module 2
+  // design problem (26 WSFU).
+  const [counts, setCounts] = useState<Record<string, number>>({
+    'water-closet': 2, 'shower': 2, 'lavatory': 2, 'hose-bibb': 4, 'kitchen-sink': 1,
+  })
+  const setCount = (id: string, v: number) => setCounts((c) => ({ ...c, [id]: Math.max(0, Math.round(v)) }))
+  const items: FixtureCount[] = useMemo(
+    () => FIXTURE_LIST.map((f) => ({ id: f.id, count: counts[f.id] ?? 0 })).filter((i) => i.count > 0),
+    [counts])
+  const wsfu = totalWSFU(items, occ)
+  const dfu = totalDFU(items, occ)
+
+  // Water-supply tab inputs (defaults = Module 2 design problem).
+  const [Lpipe, setLpipe] = useState(21)
+  const [fittingLength, setFittingLength] = useState(0)
+  const [riseZ, setRiseZ] = useState(5)
+  const [pMain, setPMain] = useState(206.85)     // 30 psi
+  const [pMeter, setPMeter] = useState(6.9)
+  const [pFixture, setPFixture] = useState(103.43) // 15 psi
+  const [hunterSystem, setHunterSystem] = useState<HunterSystem>('tank')
+  const [flowOverride, setFlowOverride] = useState(0)   // L/s; 0 ⇒ use Hunter's curve
+  const [material, setMaterial] = useState<keyof typeof HAZEN_C>('copper')
+
+  const supplyInput: WaterSupplyInput = {
+    items, occupancy: occ, hunterSystem, designFlowLps: flowOverride > 0 ? flowOverride : undefined,
+    Lpipe, fittingLength, riseZ, pMainKPa: pMain, pMeterKPa: pMeter, pFixtureKPa: pFixture, material,
+  }
+  const supply = useMemo(() => designWaterSupply(supplyInput), [supplyInput])
+  const supplySteps = useMemo(() => waterSupplySolution(supplyInput, supply), [supplyInput, supply])
+
+  const tabBtn = (id: Tab, label: string) => (
+    <button type="button" onClick={() => setTab(id)}
+      className={`border-b-2 px-1 pb-1.5 text-sm font-semibold ${tab === id ? 'border-[#0056b3] text-[#0056b3]' : 'border-transparent text-slate-400 hover:text-slate-600'}`}>
+      {label}
+    </button>
+  )
+
+  return (
+    <main className="mx-auto max-w-3xl px-5 py-10">
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Plumbing &amp; Sanitary</p>
+      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Plumbing System Design</h1>
+      <ReportControls title="Plumbing Design Report" badges={['RNPCP 2000']} />
+      <p className="mt-2 text-sm text-slate-600">
+        Water supply, sanitary drainage (DWV) and on-site sewage treatment to the Revised National Plumbing Code
+        of the Philippines (RNPCP 2000). Set the fixture schedule once; every tab reads from it.
+      </p>
+
+      {/* Shared fixture schedule */}
+      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-[1.05rem] font-bold text-[#0056b3]">Fixture schedule</h2>
+          <label className="flex items-center gap-2 text-sm">
+            <span className="font-medium text-slate-600">Occupancy</span>
+            <select value={occ} onChange={(e) => setOcc(e.target.value as Occupancy)}
+              className="rounded-md border border-slate-300 px-2 py-1">
+              <option value="private">Private</option>
+              <option value="public">Public</option>
+            </select>
+          </label>
+        </div>
+        <div className="grid grid-cols-2 gap-x-6 gap-y-1 sm:grid-cols-3">
+          {FIXTURE_LIST.map((f) => (
+            <label key={f.id} className="flex items-center justify-between gap-2 text-sm">
+              <span className="text-slate-600" title={`WSFU ${f.wsfu[occ]} · DFU ${f.dfu[occ]}`}>{f.label}</span>
+              <input type="number" min={0} step={1} value={counts[f.id] ?? 0}
+                onChange={(e) => setCount(f.id, num(e.target.value))}
+                className="w-16 rounded-md border border-slate-300 px-2 py-1 text-right" />
+            </label>
+          ))}
+        </div>
+        <div className="mt-3 flex flex-wrap gap-x-6 gap-y-1 border-t border-slate-100 pt-2 text-sm">
+          <span className="text-slate-500">Total supply units <b className="font-mono text-slate-800">{f0(wsfu)} WSFU</b></span>
+          <span className="text-slate-500">Total drainage units <b className="font-mono text-slate-800">{f0(dfu)} DFU</b></span>
+        </div>
+      </section>
+
+      {/* Tabs */}
+      <div className="mt-6 flex gap-5 border-b border-slate-200">
+        {tabBtn('supply', 'Water Supply')}
+        {tabBtn('drainage', 'Drainage (DWV)')}
+        {tabBtn('septic', 'Septic Tank')}
+      </div>
+
+      {tab === 'supply' && (
+        <>
+          <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Supply run &amp; pressures</h2>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <Field label="Pipe length" unit="m" value={Lpipe} onChange={setLpipe} />
+              <Field label="Fittings (equiv. L)" unit="m" value={fittingLength} onChange={setFittingLength} hint="Table A-2" />
+              <Field label="Highest fixture rise Z" unit="m" value={riseZ} onChange={setRiseZ} />
+              <label className="flex flex-col text-sm">
+                <span className="mb-1 font-medium text-slate-600">System (Chart A-2/A-3)</span>
+                <select value={hunterSystem} onChange={(e) => setHunterSystem(e.target.value as HunterSystem)}
+                  className="rounded-md border border-slate-300 px-2.5 py-1.5">
+                  <option value="tank">Flush tanks (A-2)</option>
+                  <option value="valve">Flush valves (A-3)</option>
+                </select>
+              </label>
+              <Field label="Design flow override" unit="L/s" value={flowOverride} onChange={setFlowOverride} step="0.01" hint="0 = use Hunter's curve" />
+              <Field label="Main pressure" unit="kPa" value={pMain} onChange={setPMain} hint={`${f0(pMain / 6.89476)} psi`} />
+              <Field label="Meter drop" unit="kPa" value={pMeter} onChange={setPMeter} hint="Chart A-1" />
+              <Field label="Residual (fixture)" unit="kPa" value={pFixture} onChange={setPFixture} hint={`${f0(pFixture / 6.89476)} psi`} />
+              <label className="flex flex-col text-sm">
+                <span className="mb-1 font-medium text-slate-600">Pipe material</span>
+                <select value={material} onChange={(e) => setMaterial(e.target.value as keyof typeof HAZEN_C)}
+                  className="rounded-md border border-slate-300 px-2.5 py-1.5">
+                  {Object.keys(HAZEN_C).map((m) => <option key={m} value={m}>{m} (C = {HAZEN_C[m]})</option>)}
+                </select>
+              </label>
+            </div>
+          </section>
+
+          <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Results</h2>
+            <Out label="Maximum demand (ΣFU×8)" value={`${f1(supply.demand.maxGpm)} gpm · ${f2(supply.demand.maxLps)} L/s`} />
+            <Out label={`Design flow (${supply.flowSource === 'override' ? 'chart' : "Hunter's curve"})`} value={`${f1(supply.designFlowGpm)} gpm · ${f2(supply.designFlowLps)} L/s`} />
+            <Out label="Static head (γw·Z)" value={`${f1(supply.staticKPa)} kPa`} />
+            <Out label="Available for friction" value={`${f1(supply.availableForFriction)} kPa`} ok={supply.availableForFriction > 0} />
+            <Out label="Developed length" value={`${f1(supply.developedLength)} m · allow ≈ ${f1(supply.allowablePer30m)} kPa/30.4 m`} />
+            <Out label="Recommended pipe" value={supply.pipe.size ? `${supply.pipe.size.label} (${f1(supply.pipe.size.idMm)} mm ID)` : '—'} ok={!!supply.pipe.size && supply.ok} />
+            <Out label="Velocity at size" value={`${f2(supply.pipe.velocity)} m/s`} ok={supply.pipe.velocityOK} />
+            <Out label="Friction at size" value={`${f1(supply.pipe.frictionDrop)} kPa`} ok={supply.pipe.frictionOK} />
+            <p className="mt-2 text-[10px] text-slate-500">
+              Design flow from Hunter's curve (Charts A-2/A-3) — override with a chart-read flow if needed.
+              Friction by Hazen-Williams (the physics behind Charts A-4…A-7). Minimum service pipe 19 mm (¾");
+              velocity capped at 3 m/s.
+            </p>
+          </section>
+
+          <div className="no-print">{supplySteps.length > 0 && <WorkedSolution steps={supplySteps} />}</div>
+        </>
+      )}
+
+      {tab === 'drainage' && (
+        <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+          <p className="text-sm text-slate-500">
+            Sanitary drainage (DWV) sizing — drain, waste and vent lines from the drainage fixture units above
+            (currently {f0(dfu)} DFU). This module ships in an upcoming update.
+          </p>
+        </section>
+      )}
+      {tab === 'septic' && (
+        <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+          <p className="text-sm text-slate-500">
+            Septic-tank / on-site sewage treatment sizing (RNPCP Appendix B) from the drainage fixture units
+            above ({f0(dfu)} DFU). This module ships in an upcoming update.
+          </p>
+        </section>
+      )}
+    </main>
+  )
+}


### PR DESCRIPTION
## What & why

First phase of a **Plumbing System Design** feature built from the three attached course modules (RNPCP 2000 — Revised National Plumbing Code of the Philippines). A single new standalone page `/plumbing` with three tabs (per your choice), delivered one module per PR:

1. **Water supply** (Module 2) — *this PR*
2. Sanitary drainage / DWV (Module 3) — Phase 2
3. Septic tank / OSST (Module 4) — Phase 3

## Engines (L7)
**`plumbingFixtures.ts`** — the shared fixture-unit catalog used by all three modules: RNPCP **Table 6-5** (WSFU) + **Table 7-2** (DFU) + minimum trap size, occupancy-aware (private/public). Totals reproduce **every** Module 2/3/4 worked example (26 / 12 / 85 WSFU; 14 / 39 / 33 DFU).

**`waterSupply.ts`** — Module 2 design:
- **Maximum demand** ΣFU × 8 gpm (upper bound).
- **Design flow** via **Hunter's curve** (flush-tank / flush-valve — the basis of Charts A-2/A-3), overridable with a chart-read flow.
- **Static head** γw·Z, **Hazen-Williams** friction (the physics behind Charts A-4…A-7), **continuity velocity**.
- **Pipe sizing** — smallest ≥ 19 mm pipe whose friction stays within the available head and whose velocity stays ≤ 3 m/s.
- Worked-solution output.

> **Correctness note:** sizing uses Hunter's **design** flow, *not* the linear ΣFU×8 **maximum** — the two are distinct demands and conflating them oversizes the pipe by several times. (I caught and fixed exactly this during in-browser verification.)

## Page
`PlumbingDesign.tsx` — a shared **fixture schedule** (occupancy toggle + live WSFU/DFU totals) feeds every tab. The **Water Supply** tab adds run/pressure inputs, results, and the worked-solution report. Drainage and Septic tabs are labelled placeholders for the next phases. Routed in `App.tsx`; sidebar + ⌘K entry under a new **"Plumbing & Sanitary"** group.

## Validation (L9)
New **`Plumbing`** category in `validation.ts` (`plumb-velocity`, `plumb-friction` vs closed form) + a coverage row in `docs/ValidationMap.md`.

## Tests & verification
- `plumbingFixtures.test.ts` + `waterSupply.test.ts` — fixture-unit totals vs the module examples, Hunter interpolation, velocity/friction closed forms, sizing, and full integration.
- **In-browser (verified):** `/plumbing` renders with 26 WSFU / 16 DFU, design flow **1.64 L/s → 1¼" pipe** at 2.02 m/s (30.2 kPa ≤ 47.5 kPa available), the worked solution, tab switching, and the sidebar entry — no console errors. (Screenshot tool was hanging in this environment, so proof is DOM/JS introspection.)

```
tsc -b     → clean
vitest run → 93 files, 1183 tests pass
```

## Follow-ups
- **Phase 2** — Drainage (DWV) engine (drain/vent sizing, slope, building sewer per Tables 7-5 / 12-2) + Drainage tab.
- **Phase 3** — Septic-tank engine (Table B-2 capacity, two-chamber dimensioning) + Septic tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)