### PR TITLE
feat: plumbing — sanitary drainage (DWV) engine + tab, RNPCP 2000 (Phase 2)

### DIFF
--- a/docs/ValidationMap.md
+++ b/docs/ValidationMap.md
@@ -111,6 +111,7 @@ asserted by that file; all run in CI.
 | Effective length K | `effectiveLength.test.ts` | alignment-chart G-factors vs published values (review anchors) |
 | Timber (wood) member design | `woodDesign.test.ts` | NDS §3 / NSCP §6 ASD adjustment factors (CD/CM/CF/CV), beam CL (§3.3.3) + column CP (§3.7.1) closed-form anchors, beam-column §3.9.2 interaction; `validation.ts` `wood-cp`/`wood-cl` |
 | Plumbing — water supply (RNPCP 2000) | `plumbingFixtures.test.ts`, `waterSupply.test.ts` | Table 6-5/7-2 fixture-unit totals vs Module 2/3/4 worked examples; demand (ΣFU×8), static head, continuity velocity, Hazen-Williams friction; `validation.ts` `plumb-velocity`/`plumb-friction` |
+| Plumbing — drainage/DWV (RNPCP 2000) | `drainage.test.ts` | Table 7-5 drain/vent sizing + max lengths vs Module 3 examples (14 DFU→76/51 mm, 39 DFU→102/65 mm); vent ≥ max(32, drain/2); §1206 slope; `validation.ts` `plumb-drain` |
 | SCWB | `scwb.test.ts` | ΣMnc/ΣMnb ≥ 6/5 (§418.7.3.2) with hand Mn |
 | Slabs | `slabDDM.test.ts`, `woodArmer.test.ts`, `slabDeflection.test.ts` | DDM coefficient tables; Wood–Armer moment transformation identities |
 | RC misc | `devLength.test.ts`, `torsionDesign.test.ts`, `beamDeflection.test.ts`, `shearWallDesign.test.ts` | §425.4 ld, §422.7 threshold/cracking torsion, Branson Ie, wall shear |

--- a/webapp/src/engine/drainage.test.ts
+++ b/webapp/src/engine/drainage.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { designDrainage, sewerSlope, DRAIN_TABLE, MIN_SOIL_MM } from './drainage'
+import type { FixtureCount } from './plumbingFixtures'
+
+describe('designDrainage — Module 3 worked examples', () => {
+  it('ex.1: 2WC(priv)+2LAV+2FD = 14 DFU → drain 76 mm, vent 51 mm, 65/37 m', () => {
+    const items: FixtureCount[] = [{ id: 'water-closet', count: 2 }, { id: 'lavatory', count: 2 }, { id: 'floor-drain', count: 2 }]
+    const r = designDrainage({ items, occupancy: 'private' })
+    expect(r.dfu).toBe(14)
+    expect(r.drainMm).toBe(76)
+    expect(r.ventMm).toBe(51)
+    expect(r.maxDrainM).toBe(65)
+    expect(r.maxVentM).toBe(37)
+    expect(r.ok).toBe(true)
+  })
+  it('ex.2: 5WC(public)+3LAV+3FD = 39 DFU → drain 102 mm, vent 65 mm, 91/55 m', () => {
+    const items: FixtureCount[] = [{ id: 'water-closet', count: 5 }, { id: 'lavatory', count: 3 }, { id: 'floor-drain', count: 3 }]
+    const r = designDrainage({ items, occupancy: 'public' })
+    expect(r.dfu).toBe(39)
+    expect(r.drainMm).toBe(102)
+    expect(r.ventMm).toBe(65)
+    expect(r.maxDrainM).toBe(91)
+    expect(r.maxVentM).toBe(55)
+    expect(r.wcStackWarn).toBe(true)          // 5 WC > 4 on a stack
+  })
+})
+
+describe('code rules', () => {
+  it('a vent is always ≥ 32 mm and ≥ ½ the drain', () => {
+    for (const row of DRAIN_TABLE) expect(row.ventMm).toBeGreaterThanOrEqual(Math.max(32, row.drainMm / 2))
+  })
+  it('a water closet forces a soil drain ≥ 75 mm even at a low DFU count', () => {
+    const r = designDrainage({ items: [{ id: 'water-closet', count: 1 }], occupancy: 'private' })  // 4 DFU
+    expect(r.drainMm).toBeGreaterThanOrEqual(MIN_SOIL_MM)
+  })
+  it('a light no-WC branch can use a small drain', () => {
+    const r = designDrainage({ items: [{ id: 'lavatory', count: 2 }], occupancy: 'private' })  // 2 DFU
+    expect(r.drainMm).toBeLessThan(MIN_SOIL_MM)
+    expect(r.ok).toBe(true)
+  })
+  it('a 1% slope inflates the design DFU (×1/0.8) and can bump the size', () => {
+    const items: FixtureCount[] = [{ id: 'water-closet', count: 2 }, { id: 'lavatory', count: 2 }, { id: 'floor-drain', count: 2 }] // 14 DFU
+    const flat = designDrainage({ items, occupancy: 'private', slopePct: 1.0 })
+    expect(flat.effectiveDfu).toBeCloseTo(14 / 0.8, 6)   // 17.5
+  })
+})
+
+describe('sewerSlope — §1206', () => {
+  it('2% for ≤76 mm, 1% allowed for 102/152 mm, 0.5% for ≥203 mm', () => {
+    expect(sewerSlope(76).minPct).toBe(2.0)
+    expect(sewerSlope(102).minPct).toBe(1.0)
+    expect(sewerSlope(152).minPct).toBe(1.0)
+    expect(sewerSlope(203).minPct).toBe(0.5)
+  })
+  it('reports slope in mm per metre (2% = 20 mm/m)', () => {
+    expect(sewerSlope(76).mmPerM).toBeCloseTo(20, 6)
+  })
+})

--- a/webapp/src/engine/drainage.ts
+++ b/webapp/src/engine/drainage.ts
@@ -1,0 +1,125 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Sanitary drainage (DWV) design — RNPCP 2000 (Module 3).  Sizes the drain,
+// waste and vent piping from the drainage-fixture-unit (DFU) load, plus the
+// building-sewer slope.
+//
+//   • Drain/vent size + maximum developed length — RNPCP Table 7-5 (max fixture
+//     unit loading & length of excreta drainage and vent piping).
+//   • A vent must be ≥ 32 mm and ≥ ½ the drain it serves (Table 7-5 note).
+//   • No water closet discharges into a drain < 75 mm (§ soil-pipe rule).
+//   • Building-sewer minimum slope — §1206 (2 %; 1 % for 102/152 mm; 0.5 % for
+//     ≥ 203 mm).  On a 1 % run the horizontal DFU capacity is ×0.8 (Table 7-5,
+//     footnote 5).
+//
+// Units: pipe diameter mm; length m; slope % and mm/m; DFU dimensionless.
+// ─────────────────────────────────────────────────────────────────────────
+import { type FixtureCount, type Occupancy, totalDFU, PLUMBING_FIXTURES } from './plumbingFixtures'
+import { type SolutionStep, sn0, sn1 } from '../lib/solution'
+
+/** No soil (water-closet) drain smaller than this. */
+export const MIN_SOIL_MM = 75
+
+// ── Table 7-5 — max DFU per drain size + companion vent + max lengths ────────
+export interface DrainRow {
+  maxDfu: number      // max drainage fixture units on this size (horizontal branch cap)
+  drainMm: number     // drain / stack diameter
+  ventMm: number      // companion vent diameter
+  maxDrainM: number   // max developed length of the drain/stack, m
+  maxVentM: number    // max developed length of the vent, m
+}
+// Calibrated to the Module 3 worked examples (14 DFU → 76/51 mm, 65/37 m;
+// 39 DFU → 102/65 mm, 91/55 m) and the standard RNPCP/UPC Table 7-5 ladder.
+export const DRAIN_TABLE: DrainRow[] = [
+  { maxDfu: 1, drainMm: 32, ventMm: 32, maxDrainM: 14, maxVentM: 9 },
+  { maxDfu: 3, drainMm: 40, ventMm: 32, maxDrainM: 15, maxVentM: 12 },
+  { maxDfu: 6, drainMm: 50, ventMm: 40, maxDrainM: 18, maxVentM: 18 },
+  { maxDfu: 12, drainMm: 65, ventMm: 40, maxDrainM: 22, maxVentM: 24 },
+  { maxDfu: 20, drainMm: 76, ventMm: 51, maxDrainM: 65, maxVentM: 37 },
+  { maxDfu: 160, drainMm: 102, ventMm: 65, maxDrainM: 91, maxVentM: 55 },
+  { maxDfu: 620, drainMm: 152, ventMm: 76, maxDrainM: 152, maxVentM: 91 },
+  { maxDfu: 1400, drainMm: 203, ventMm: 102, maxDrainM: 200, maxVentM: 120 },
+]
+
+// ── Building-sewer slope — §1206 ────────────────────────────────────────────
+export interface SewerSlope { defaultPct: number; minPct: number; mmPerM: number }
+/** Minimum building-sewer slope allowed for a pipe diameter (§1206): 2 % normal;
+ *  1 % permitted for 102/152 mm; 0.5 % for ≥ 203 mm. mmPerM at the minimum. */
+export function sewerSlope(diameterMm: number): SewerSlope {
+  const minPct = diameterMm >= 203 ? 0.5 : diameterMm >= 102 ? 1.0 : 2.0
+  return { defaultPct: 2.0, minPct, mmPerM: (minPct / 100) * 1000 }
+}
+
+// ── Drainage sizing ─────────────────────────────────────────────────────────
+export interface DrainageResult {
+  dfu: number
+  wcCount: number
+  slopePct: number
+  effectiveDfu: number     // DFU after the 1 %-slope ×1.25 penalty (=÷0.8)
+  drainMm: number          // horizontal + vertical drain size
+  ventMm: number
+  maxDrainM: number
+  maxVentM: number
+  ventOK: boolean          // ≥ max(32, drain/2)
+  wcStackWarn: boolean     // > 4 WC on a stack
+  wcBranchWarn: boolean    // > 3 WC on a horizontal branch
+  sewer: SewerSlope
+  ok: boolean
+}
+
+/** Size the drain, vent and building-sewer slope for a fixture schedule.
+ *  `slopePct` (2 default; 1 allowed for ≥102 mm) reduces the horizontal DFU
+ *  capacity by ×0.8 when 1 % (Table 7-5 fn.5). */
+export function designDrainage(p: { items: FixtureCount[]; occupancy: Occupancy; slopePct?: number }): DrainageResult {
+  const dfu = totalDFU(p.items, p.occupancy)
+  const wcCount = p.items.find((i) => i.id === 'water-closet')?.count ?? 0
+  const slopePct = p.slopePct ?? 2.0
+  // On a 1 % run the table capacity is ×0.8 → size against the inflated load.
+  const effectiveDfu = slopePct <= 1.0 ? dfu / 0.8 : dfu
+  let row = DRAIN_TABLE.find((r) => effectiveDfu <= r.maxDfu) ?? DRAIN_TABLE[DRAIN_TABLE.length - 1]
+  // No water closet into a drain < 75 mm.
+  if (wcCount > 0 && row.drainMm < MIN_SOIL_MM) {
+    row = DRAIN_TABLE.find((r) => r.drainMm >= MIN_SOIL_MM) ?? row
+  }
+  const ventMm = row.ventMm
+  const ventOK = ventMm >= Math.max(32, row.drainMm / 2)
+  return {
+    dfu, wcCount, slopePct, effectiveDfu,
+    drainMm: row.drainMm, ventMm, maxDrainM: row.maxDrainM, maxVentM: row.maxVentM, ventOK,
+    wcStackWarn: wcCount > 4, wcBranchWarn: wcCount > 3,
+    sewer: sewerSlope(row.drainMm),
+    ok: ventOK && (wcCount === 0 || row.drainMm >= MIN_SOIL_MM),
+  }
+}
+
+// ── Worked solution ────────────────────────────────────────────────────────
+export function drainageSolution(p: { items: FixtureCount[]; occupancy: Occupancy }, r: DrainageResult): SolutionStep[] {
+  const breakdown = p.items
+    .filter((i) => i.count > 0 && (PLUMBING_FIXTURES[i.id]?.dfu[p.occupancy] ?? 0) > 0)
+    .map((i) => `${i.count}×${PLUMBING_FIXTURES[i.id].label} (${PLUMBING_FIXTURES[i.id].dfu[p.occupancy]} DFU)`)
+    .join(' + ')
+  return [
+    {
+      title: 'Drainage fixture units', clause: 'RNPCP Table 7-2',
+      lines: [
+        { text: `${breakdown || 'no drainage fixtures'} — Σ DFU = ${sn0(r.dfu)} (${p.occupancy}).` },
+        ...(r.slopePct <= 1.0 ? [{ tex: `\\text{1% slope: } DFU_{eff} = ${sn0(r.dfu)}/0.8 = ${sn1(r.effectiveDfu)}` } as const] : []),
+      ],
+    },
+    {
+      title: 'Drain & vent size', clause: 'RNPCP Table 7-5',
+      lines: [
+        { text: `From Table 7-5 at ${sn1(r.effectiveDfu)} DFU: drain (horizontal & vertical) = ${sn0(r.drainMm)} mm; vent = ${sn0(r.ventMm)} mm.` },
+        { text: `Max developed length — drain/stack ${sn0(r.maxDrainM)} m, vent ${sn0(r.maxVentM)} m.` },
+        { tex: `d_{vent} = ${sn0(r.ventMm)} \\ge \\max(32,\\ ${sn0(r.drainMm)}/2 = ${sn0(r.drainMm / 2)})\\ \\text{mm}` },
+        ...(r.wcCount > 0 ? [{ text: `Contains ${r.wcCount} water closet(s): soil drain ≥ 75 mm ✓${r.wcStackWarn ? ' — warning: > 4 WC on one stack.' : ''}${r.wcBranchWarn && !r.wcStackWarn ? ' — check: > 3 WC on a horizontal branch.' : ''}` } as const] : []),
+      ],
+      pass: r.ventOK,
+    },
+    {
+      title: 'Building-sewer slope', clause: 'RNPCP §1206',
+      lines: [
+        { text: `${sn0(r.drainMm)} mm sewer: minimum slope ${sn1(r.sewer.minPct)} % (${sn1(r.sewer.mmPerM)} mm/m); run at ${sn1(r.sewer.defaultPct)} % where practical.` },
+      ],
+    },
+  ]
+}

--- a/webapp/src/engine/validation.ts
+++ b/webapp/src/engine/validation.ts
@@ -25,6 +25,7 @@ import { solveWeldedConnection } from './weldedConnection'
 import { boltGeomFromPositions, outOfPlaneBoltGroup, pryingAction } from './steelDesign'
 import { columnStabilityFactor, beamStabilityFactor, getWoodRef } from './woodDesign'
 import { velocity, hazenWilliamsHead, gpmToLps } from './waterSupply'
+import { designDrainage } from './drainage'
 import type { RectSection } from './model'
 
 export interface ValidationCase {
@@ -237,6 +238,12 @@ const plumbFriction = (() => {
   return { manual: (10.67 * L * (Q / 1000) ** 1.852) / (C ** 1.852 * (D / 1000) ** 4.87), software: hazenWilliamsHead(Q, D, C, L) }
 })()
 
+const plumbDrain = (() => {
+  // Module 3 ex.1: 2 WC(priv) + 2 lav + 2 floor drains = 14 DFU → 76 mm drain.
+  const r = designDrainage({ items: [{ id: 'water-closet', count: 2 }, { id: 'lavatory', count: 2 }, { id: 'floor-drain', count: 2 }], occupancy: 'private' })
+  return { manual: 76, software: r.drainMm }
+})()
+
 export const VALIDATION_CASES: ValidationCase[] = [
   {
     id: 'rc-beam-mn', category: 'RC', title: 'Singly-reinforced beam — nominal moment',
@@ -367,5 +374,10 @@ export const VALIDATION_CASES: ValidationCase[] = [
     id: 'plumb-friction', category: 'Plumbing', title: 'Water friction head — Hazen-Williams',
     reference: 'Hazen-Williams (RNPCP Chart A-4…A-7)', formula: 'hf = 10.67·L·Q^1.852 / (C^1.852·D^4.87)',
     manual: plumbFriction.manual, software: plumbFriction.software, unit: 'm', tol: 1e-9,
+  },
+  {
+    id: 'plumb-drain', category: 'Plumbing', title: 'Sanitary drain size (14 DFU)',
+    reference: 'RNPCP Table 7-5 / Module 3', formula: '14 DFU (incl. WC) → 76 mm soil drain',
+    manual: plumbDrain.manual, software: plumbDrain.software, unit: 'mm', tol: 1e-9,
   },
 ]

--- a/webapp/src/pages/PlumbingDesign.tsx
+++ b/webapp/src/pages/PlumbingDesign.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { FIXTURE_LIST, type FixtureCount, type Occupancy, totalWSFU, totalDFU } from '../engine/plumbingFixtures'
 import { designWaterSupply, waterSupplySolution, HAZEN_C, type HunterSystem, type WaterSupplyInput } from '../engine/waterSupply'
+import { designDrainage, drainageSolution } from '../engine/drainage'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { ReportControls } from '../components/ReportControls'
 
@@ -65,6 +66,11 @@ export default function PlumbingDesign() {
   }
   const supply = useMemo(() => designWaterSupply(supplyInput), [supplyInput])
   const supplySteps = useMemo(() => waterSupplySolution(supplyInput, supply), [supplyInput, supply])
+
+  // Drainage (DWV) tab inputs.
+  const [slopePct, setSlopePct] = useState(2)
+  const drainage = useMemo(() => designDrainage({ items, occupancy: occ, slopePct }), [items, occ, slopePct])
+  const drainageSteps = useMemo(() => drainageSolution({ items, occupancy: occ }, drainage), [items, occ, drainage])
 
   const tabBtn = (id: Tab, label: string) => (
     <button type="button" onClick={() => setTab(id)}
@@ -171,12 +177,36 @@ export default function PlumbingDesign() {
       )}
 
       {tab === 'drainage' && (
-        <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-          <p className="text-sm text-slate-500">
-            Sanitary drainage (DWV) sizing — drain, waste and vent lines from the drainage fixture units above
-            (currently {f0(dfu)} DFU). This module ships in an upcoming update.
-          </p>
-        </section>
+        <>
+          <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Drainage run</h2>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <label className="flex flex-col text-sm">
+                <span className="mb-1 font-medium text-slate-600">Sewer slope</span>
+                <select value={slopePct} onChange={(e) => setSlopePct(num(e.target.value))}
+                  className="rounded-md border border-slate-300 px-2.5 py-1.5">
+                  <option value={2}>2% (21 mm/m)</option>
+                  <option value={1}>1% (10.5 mm/m)</option>
+                  <option value={0.5}>0.5% (5.3 mm/m)</option>
+                </select>
+              </label>
+            </div>
+          </section>
+          <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Results</h2>
+            <Out label="Drainage fixture units" value={`${f0(drainage.dfu)} DFU${slopePct <= 1 ? ` · design ${f1(drainage.effectiveDfu)} (1% ×1.25)` : ''}`} />
+            <Out label="Drain (horizontal & vertical)" value={`${f0(drainage.drainMm)} mm`} ok={drainage.wcCount === 0 || drainage.drainMm >= 75} />
+            <Out label="Vent" value={`${f0(drainage.ventMm)} mm`} ok={drainage.ventOK} />
+            <Out label="Max developed length" value={`drain ${f0(drainage.maxDrainM)} m · vent ${f0(drainage.maxVentM)} m`} />
+            <Out label="Building-sewer min slope" value={`${f1(drainage.sewer.minPct)}% (${f1(drainage.sewer.mmPerM)} mm/m)`} />
+            {drainage.wcStackWarn && <p className="mt-1 text-[11px] text-amber-600">⚠ {drainage.wcCount} water closets on one stack — the code allows max 4 per stack; split the stack.</p>}
+            <p className="mt-2 text-[10px] text-slate-500">
+              Drain/vent size &amp; max length from Table 7-5; a vent is ≥ 32 mm and ≥ ½ the drain. No water closet
+              into a drain &lt; 75 mm. Slope per §1206. Set the fixture schedule above.
+            </p>
+          </section>
+          <div className="no-print">{drainageSteps.length > 0 && <WorkedSolution steps={drainageSteps} />}</div>
+        </>
       )}
       {tab === 'septic' && (
         <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">


### PR DESCRIPTION
## What & why

Phase 2 of the **Plumbing System Design** feature (after [#381](https://github.com/BitLess246/civilEngineering/pull/381)) — the **Drainage (DWV)** tab, sizing the drain, waste and vent piping from the shared fixture schedule's DFU load. Module 3.

## Engine (L7) — `drainage.ts`
- **Drain (horizontal & vertical) + companion vent** size and **max developed length** from RNPCP **Table 7-5**, calibrated to reproduce both Module 3 worked examples: 14 DFU → **76 / 51 mm**, 65 / 37 m; 39 DFU → **102 / 65 mm**, 91 / 55 m.
- **Code rules:** vent ≥ 32 mm and ≥ ½ the drain; no water closet into a drain < 75 mm; > 4 WC/stack and > 3 WC/branch warnings.
- **Building-sewer slope** per **§1206** (2 %; 1 % for 102/152 mm; 0.5 % for ≥ 203 mm), with the Table 7-5 fn.5 ×0.8 capacity penalty on a 1 % run.
- Worked-solution output.

## Page
The **Drainage** tab reads the shared fixture schedule, adds a slope selector, and shows drain/vent sizes, max lengths, sewer slope, warnings, and the worked solution. (Septic tab still a placeholder — Phase 3.)

## Validation (L9)
`plumb-drain` case (14 DFU → 76 mm) in `validation.ts` + a drainage coverage row in `docs/ValidationMap.md`.

## Tests & verification
- `drainage.test.ts` — both Module 3 examples, vent/soil-drain rules, the 1 % slope penalty, §1206 slopes.
- **In-browser (verified):** 14 DFU → 76 mm drain / 51 mm vent / 65·37 m / 2 % slope; no runtime errors.

```
tsc -b     → clean
vitest run → 94 files, 1191 tests pass
```

## Follow-up
**Phase 3** — septic-tank / OSST engine (Table B-2 capacity, two-chamber dimensioning) + Septic tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)