### PR TITLE
feat: plumbing — septic tank (OSST) engine + tab, RNPCP 2000 (Phase 3)

### DIFF
--- a/docs/ValidationMap.md
+++ b/docs/ValidationMap.md
@@ -112,6 +112,7 @@ asserted by that file; all run in CI.
 | Timber (wood) member design | `woodDesign.test.ts` | NDS §3 / NSCP §6 ASD adjustment factors (CD/CM/CF/CV), beam CL (§3.3.3) + column CP (§3.7.1) closed-form anchors, beam-column §3.9.2 interaction; `validation.ts` `wood-cp`/`wood-cl` |
 | Plumbing — water supply (RNPCP 2000) | `plumbingFixtures.test.ts`, `waterSupply.test.ts` | Table 6-5/7-2 fixture-unit totals vs Module 2/3/4 worked examples; demand (ΣFU×8), static head, continuity velocity, Hazen-Williams friction; `validation.ts` `plumb-velocity`/`plumb-friction` |
 | Plumbing — drainage/DWV (RNPCP 2000) | `drainage.test.ts` | Table 7-5 drain/vent sizing + max lengths vs Module 3 examples (14 DFU→76/51 mm, 39 DFU→102/65 mm); vent ≥ max(32, drain/2); §1206 slope; `validation.ts` `plumb-drain` |
+| Plumbing — septic tank/OSST (RNPCP 2000) | `septicTank.test.ts` | Table B-2 capacity by DFU (+94.6 L/FU over 100); Appendix B two-chamber layout (2/3·1/3, freeboard, depth 0.6–1.8 m) vs Module 4 example (78 DFU→11,355 L→2.0×4.8×1.5 m); `validation.ts` `plumb-septic` |
 | SCWB | `scwb.test.ts` | ΣMnc/ΣMnb ≥ 6/5 (§418.7.3.2) with hand Mn |
 | Slabs | `slabDDM.test.ts`, `woodArmer.test.ts`, `slabDeflection.test.ts` | DDM coefficient tables; Wood–Armer moment transformation identities |
 | RC misc | `devLength.test.ts`, `torsionDesign.test.ts`, `beamDeflection.test.ts`, `shearWallDesign.test.ts` | §425.4 ld, §422.7 threshold/cracking torsion, Branson Ie, wall shear |

--- a/webapp/src/engine/septicTank.test.ts
+++ b/webapp/src/engine/septicTank.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import {
+  septicCapacity, designSepticTank, designSepticFromSchedule, SEPTIC_TABLE_B2,
+  L_PER_DFU_OVER_100, FREEBOARD_M,
+} from './septicTank'
+import type { FixtureCount } from './plumbingFixtures'
+
+describe('septicCapacity — Table B-2', () => {
+  it('steps to the row whose max DFU ≥ the load (80 DFU → 11,355 L)', () => {
+    expect(septicCapacity(78)).toBe(11355.0)   // 78 falls in the 80-DFU row
+    expect(septicCapacity(20)).toBe(3785.0)
+    expect(septicCapacity(45)).toBe(7570.0)
+  })
+  it('adds 94.6 L per fixture unit beyond 100 DFU', () => {
+    expect(septicCapacity(120)).toBeCloseTo(13247.5 + 20 * L_PER_DFU_OVER_100, 4)
+  })
+  it('floors at the smallest table capacity for a light load', () => {
+    expect(septicCapacity(5)).toBe(SEPTIC_TABLE_B2[0].liters)
+  })
+})
+
+describe('designSepticTank — Module 4 worked example (78 DFU apartment)', () => {
+  const r = designSepticTank({ dfu: 78, width: 2.0, liquidDepth: 1.2 })
+  it('capacity 11,355 L → length 4.8 m, height 1.5 m', () => {
+    expect(r.capacityL).toBe(11355.0)
+    expect(r.length).toBeCloseTo(4.8, 6)                 // ceil(4.73) to 0.1 m
+    expect(r.totalHeight).toBeCloseTo(1.5, 6)            // ceil(1.2 + 0.2286)
+  })
+  it('chambers split 2/3 · 1/3 → 3.2 m digestive, 1.6 m leaching', () => {
+    expect(r.inletLength).toBeCloseTo(3.2, 6)
+    expect(r.outletLength).toBeCloseTo(1.6, 6)
+    expect(r.inletVol).toBeCloseTo(2.0 * 3.2 * 1.2, 6)   // 7.68 m³
+    expect(r.outletVol).toBeCloseTo(2.0 * 1.6 * 1.2, 6)  // 3.84 m³
+  })
+  it('passes every Appendix B check', () => {
+    expect(r.capacityOK).toBe(true)
+    expect(r.inletVolOK).toBe(true)      // 7.68 ≥ 2 m³
+    expect(r.outletVolOK).toBe(true)     // 3.84 ≥ 1 m³
+    expect(r.inletDimOK).toBe(true)      // 2.0 ≥ 0.9, 3.2 ≥ 1.5
+    expect(r.depthOK).toBe(true)         // 1.2 within 0.6–1.8
+    expect(r.ok).toBe(true)
+  })
+})
+
+describe('code limits', () => {
+  it('freeboard is 228.6 mm above the liquid', () => {
+    expect(FREEBOARD_M).toBeCloseTo(0.2286, 6)
+  })
+  it('rejects a liquid depth outside 0.6–1.8 m', () => {
+    expect(designSepticTank({ dfu: 20, width: 2, liquidDepth: 2.0 }).depthOK).toBe(false)
+    expect(designSepticTank({ dfu: 20, width: 2, liquidDepth: 0.5 }).depthOK).toBe(false)
+  })
+  it('drives from a fixture schedule (33 DFU residence → 1,500-gal row = 5,677.5 L)', () => {
+    const items: FixtureCount[] = [
+      { id: 'water-closet', count: 3 }, { id: 'lavatory', count: 3 }, { id: 'shower', count: 3 },
+      { id: 'floor-drain', count: 5 }, { id: 'dishwasher', count: 1 },
+    ]
+    const r = designSepticFromSchedule({ items, occupancy: 'private', width: 1.5, liquidDepth: 1.2 })
+    expect(r.dfu).toBe(33)
+    expect(r.capacityL).toBe(5677.5)
+  })
+})

--- a/webapp/src/engine/septicTank.ts
+++ b/webapp/src/engine/septicTank.ts
@@ -1,0 +1,139 @@
+// ─────────────────────────────────────────────────────────────────────────
+// On-site sewage treatment — septic tank design, RNPCP 2000 Appendix B
+// (Module 4).  Sizes a two-compartment septic tank from the drainage-fixture-
+// unit load and lays out the digestive (inlet) and leaching (outlet) chambers.
+//
+//   • Minimum liquid capacity — Table B-2 (by max DFU served); beyond 100 DFU
+//     add 94.6 L per extra fixture unit.
+//   • Two compartments: the inlet is ≥ 2/3 of the total capacity (and ≥ 2 m³),
+//     the secondary ≤ 1/3 (and ≥ 1 m³).
+//   • Liquid depth 0.6–1.8 m; side walls extend ≥ 228.6 mm above the liquid
+//     (freeboard); inlet ≥ 0.9 m wide × 1.5 m long.
+//
+// Units: capacity L (and m³); tank dimensions m; DFU dimensionless.
+// ─────────────────────────────────────────────────────────────────────────
+import { type FixtureCount, type Occupancy, totalDFU } from './plumbingFixtures'
+import { type SolutionStep, sn0, sn2 } from '../lib/solution'
+
+/** Side-wall freeboard above the liquid level (Appendix B), m. */
+export const FREEBOARD_M = 0.2286      // 228.6 mm
+export const MIN_LIQUID_DEPTH = 0.6
+export const MAX_LIQUID_DEPTH = 1.8
+export const MIN_INLET_WIDTH = 0.9
+export const MIN_INLET_LENGTH = 1.5
+export const MIN_INLET_VOL = 2.0       // m³
+export const MIN_SECONDARY_VOL = 1.0   // m³
+
+// ── Table B-2 — capacity of septic tanks by max DFU served ──────────────────
+export interface SepticRow { maxDfu: number; gallons: number; liters: number }
+export const SEPTIC_TABLE_B2: SepticRow[] = [
+  { maxDfu: 15, gallons: 750, liters: 2838.0 },
+  { maxDfu: 20, gallons: 1000, liters: 3785.0 },
+  { maxDfu: 25, gallons: 1200, liters: 4542.0 },
+  { maxDfu: 33, gallons: 1500, liters: 5677.5 },
+  { maxDfu: 45, gallons: 2000, liters: 7570.0 },
+  { maxDfu: 55, gallons: 2250, liters: 8516.3 },
+  { maxDfu: 60, gallons: 2500, liters: 9462.5 },
+  { maxDfu: 70, gallons: 2750, liters: 10408.8 },
+  { maxDfu: 80, gallons: 3000, liters: 11355.0 },
+  { maxDfu: 90, gallons: 3250, liters: 12301.3 },
+  { maxDfu: 100, gallons: 3500, liters: 13247.5 },
+]
+/** Extra capacity per fixture unit above 100 DFU (Table B-2 note), L. */
+export const L_PER_DFU_OVER_100 = 94.6
+
+/** Minimum septic-tank liquid capacity (L) for a drainage fixture-unit load. */
+export function septicCapacity(dfu: number): number {
+  const last = SEPTIC_TABLE_B2[SEPTIC_TABLE_B2.length - 1]
+  if (dfu > last.maxDfu) return last.liters + (dfu - last.maxDfu) * L_PER_DFU_OVER_100
+  return (SEPTIC_TABLE_B2.find((r) => dfu <= r.maxDfu) ?? SEPTIC_TABLE_B2[0]).liters
+}
+
+// ── Tank design ─────────────────────────────────────────────────────────────
+export interface SepticResult {
+  dfu: number
+  capacityL: number          // required minimum (Table B-2)
+  width: number; liquidDepth: number
+  length: number             // rounded up to 0.1 m
+  totalHeight: number        // liquidDepth + freeboard, rounded up to 0.1 m
+  inletLength: number        // digestive chamber, 2/3
+  outletLength: number       // leaching chamber, 1/3
+  providedVol: number        // m³ liquid volume at the rounded length
+  inletVol: number; outletVol: number
+  depthOK: boolean           // 0.6–1.8 m
+  capacityOK: boolean        // provided ≥ required
+  inletVolOK: boolean; outletVolOK: boolean; inletDimOK: boolean
+  ok: boolean
+}
+
+const ceil1 = (x: number) => Math.ceil(x * 10) / 10   // round up to 0.1 m
+
+/** Two-compartment septic-tank layout for a DFU load, given the plan width and
+ *  liquid depth (Appendix B design steps). */
+export function designSepticTank(p: { dfu: number; width: number; liquidDepth: number }): SepticResult {
+  const capacityL = septicCapacity(p.dfu)
+  const capacityM3 = capacityL / 1000
+  const rawLength = capacityM3 / (p.width * p.liquidDepth)
+  const length = ceil1(rawLength)
+  const totalHeight = ceil1(p.liquidDepth + FREEBOARD_M)
+  const inletLength = ceil1((2 / 3) * length)
+  const outletLength = Math.max(0, length - inletLength)
+  const providedVol = p.width * length * p.liquidDepth
+  const inletVol = p.width * inletLength * p.liquidDepth
+  const outletVol = p.width * outletLength * p.liquidDepth
+  const depthOK = p.liquidDepth >= MIN_LIQUID_DEPTH && p.liquidDepth <= MAX_LIQUID_DEPTH
+  const capacityOK = providedVol * 1000 >= capacityL - 1e-6
+  const inletVolOK = inletVol >= MIN_INLET_VOL - 1e-6
+  const outletVolOK = outletVol >= MIN_SECONDARY_VOL - 1e-6
+  const inletDimOK = p.width >= MIN_INLET_WIDTH && inletLength >= MIN_INLET_LENGTH
+  return {
+    dfu: p.dfu, capacityL, width: p.width, liquidDepth: p.liquidDepth,
+    length, totalHeight, inletLength, outletLength, providedVol, inletVol, outletVol,
+    depthOK, capacityOK, inletVolOK, outletVolOK, inletDimOK,
+    ok: depthOK && capacityOK && inletVolOK && outletVolOK && inletDimOK,
+  }
+}
+
+/** Convenience: total DFU from a fixture schedule, then design the tank. */
+export function designSepticFromSchedule(p: {
+  items: FixtureCount[]; occupancy: Occupancy; width: number; liquidDepth: number
+}): SepticResult {
+  return designSepticTank({ dfu: totalDFU(p.items, p.occupancy), width: p.width, liquidDepth: p.liquidDepth })
+}
+
+// ── Worked solution ────────────────────────────────────────────────────────
+export function septicSolution(r: SepticResult): SolutionStep[] {
+  return [
+    {
+      title: 'Minimum capacity', clause: 'RNPCP Table B-2',
+      lines: [
+        { text: `Σ DFU = ${sn0(r.dfu)} → minimum liquid capacity = ${sn0(r.capacityL)} L (${sn2(r.capacityL / 1000)} m³).` },
+      ],
+    },
+    {
+      title: 'Plan length', clause: 'Appendix B, step 4',
+      lines: [
+        { tex: `L = \\dfrac{V}{w\\,d} = \\dfrac{${sn2(r.capacityL / 1000)}}{${sn2(r.width)}\\times ${sn2(r.liquidDepth)}} = ${sn2(r.capacityL / 1000 / (r.width * r.liquidDepth))}\\ \\text{m} \\to ${sn2(r.length)}\\ \\text{m}` },
+        { text: `Provided liquid volume = ${sn2(r.width)}×${sn2(r.length)}×${sn2(r.liquidDepth)} = ${sn2(r.providedVol)} m³ ≥ ${sn2(r.capacityL / 1000)} m³.` },
+      ],
+      pass: r.capacityOK,
+    },
+    {
+      title: 'Two compartments (2/3 · 1/3)', clause: 'Appendix B',
+      lines: [
+        { tex: `L_{inlet} = \\tfrac{2}{3}L = ${sn2(r.inletLength)}\\ \\text{m}\\ (${sn2(r.inletVol)}\\ \\text{m}^3);\\quad L_{outlet} = \\tfrac{1}{3}L = ${sn2(r.outletLength)}\\ \\text{m}\\ (${sn2(r.outletVol)}\\ \\text{m}^3)` },
+        { text: `Inlet ≥ 2 m³ & ≥ 2/3 total ${r.inletVolOK ? '✓' : '✗'}; secondary ≥ 1 m³ ${r.outletVolOK ? '✓' : '✗'}; inlet ≥ 0.9 m × 1.5 m ${r.inletDimOK ? '✓' : '✗'}.` },
+      ],
+      pass: r.inletVolOK && r.outletVolOK && r.inletDimOK,
+    },
+    {
+      title: 'Overall height', clause: 'Appendix B (freeboard 228.6 mm)',
+      lines: [
+        { tex: `H = d + ${sn2(FREEBOARD_M)} = ${sn2(r.liquidDepth)} + ${sn2(FREEBOARD_M)} = ${sn2(r.liquidDepth + FREEBOARD_M)} \\to ${sn2(r.totalHeight)}\\ \\text{m}` },
+        { text: `Digestive chamber ${sn2(r.width)}×${sn2(r.inletLength)}×${sn2(r.totalHeight)} m; leaching chamber ${sn2(r.width)}×${sn2(r.outletLength)}×${sn2(r.totalHeight)} m.` },
+      ],
+      pass: r.depthOK,
+      note: 'Liquid depth must be 0.6–1.8 m. Provide two 508 mm manholes (inlet & outlet); inlet/outlet baffles 101.6 mm above / 304.8 mm below the liquid.',
+    },
+  ]
+}

--- a/webapp/src/engine/validation.ts
+++ b/webapp/src/engine/validation.ts
@@ -26,6 +26,7 @@ import { boltGeomFromPositions, outOfPlaneBoltGroup, pryingAction } from './stee
 import { columnStabilityFactor, beamStabilityFactor, getWoodRef } from './woodDesign'
 import { velocity, hazenWilliamsHead, gpmToLps } from './waterSupply'
 import { designDrainage } from './drainage'
+import { designSepticTank } from './septicTank'
 import type { RectSection } from './model'
 
 export interface ValidationCase {
@@ -244,6 +245,11 @@ const plumbDrain = (() => {
   return { manual: 76, software: r.drainMm }
 })()
 
+const plumbSeptic = (() => {
+  // Module 4: 78 DFU, 2.0 m wide, 1.2 m liquid depth → 4.8 m plan length.
+  return { manual: 4.8, software: designSepticTank({ dfu: 78, width: 2.0, liquidDepth: 1.2 }).length }
+})()
+
 export const VALIDATION_CASES: ValidationCase[] = [
   {
     id: 'rc-beam-mn', category: 'RC', title: 'Singly-reinforced beam — nominal moment',
@@ -379,5 +385,10 @@ export const VALIDATION_CASES: ValidationCase[] = [
     id: 'plumb-drain', category: 'Plumbing', title: 'Sanitary drain size (14 DFU)',
     reference: 'RNPCP Table 7-5 / Module 3', formula: '14 DFU (incl. WC) → 76 mm soil drain',
     manual: plumbDrain.manual, software: plumbDrain.software, unit: 'mm', tol: 1e-9,
+  },
+  {
+    id: 'plumb-septic', category: 'Plumbing', title: 'Septic tank plan length (78 DFU)',
+    reference: 'RNPCP Table B-2 / Module 4', formula: 'L = V/(w·d) = 11.355/(2.0·1.2) → 4.8 m',
+    manual: plumbSeptic.manual, software: plumbSeptic.software, unit: 'm', tol: 1e-9,
   },
 ]

--- a/webapp/src/pages/PlumbingDesign.tsx
+++ b/webapp/src/pages/PlumbingDesign.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import { FIXTURE_LIST, type FixtureCount, type Occupancy, totalWSFU, totalDFU } from '../engine/plumbingFixtures'
 import { designWaterSupply, waterSupplySolution, HAZEN_C, type HunterSystem, type WaterSupplyInput } from '../engine/waterSupply'
 import { designDrainage, drainageSolution } from '../engine/drainage'
+import { designSepticTank, septicSolution } from '../engine/septicTank'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { ReportControls } from '../components/ReportControls'
 
@@ -71,6 +72,12 @@ export default function PlumbingDesign() {
   const [slopePct, setSlopePct] = useState(2)
   const drainage = useMemo(() => designDrainage({ items, occupancy: occ, slopePct }), [items, occ, slopePct])
   const drainageSteps = useMemo(() => drainageSolution({ items, occupancy: occ }, drainage), [items, occ, drainage])
+
+  // Septic tank (OSST) tab inputs.
+  const [tankWidth, setTankWidth] = useState(2.0)
+  const [liquidDepth, setLiquidDepth] = useState(1.2)
+  const septic = useMemo(() => designSepticTank({ dfu, width: tankWidth, liquidDepth }), [dfu, tankWidth, liquidDepth])
+  const septicSteps = useMemo(() => septicSolution(septic), [septic])
 
   const tabBtn = (id: Tab, label: string) => (
     <button type="button" onClick={() => setTab(id)}
@@ -209,12 +216,30 @@ export default function PlumbingDesign() {
         </>
       )}
       {tab === 'septic' && (
-        <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-          <p className="text-sm text-slate-500">
-            Septic-tank / on-site sewage treatment sizing (RNPCP Appendix B) from the drainage fixture units
-            above ({f0(dfu)} DFU). This module ships in an upcoming update.
-          </p>
-        </section>
+        <>
+          <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Tank geometry</h2>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <Field label="Plan width" unit="m" value={tankWidth} onChange={setTankWidth} step="0.1" hint="≥ 0.9 m" />
+              <Field label="Liquid depth" unit="m" value={liquidDepth} onChange={setLiquidDepth} step="0.1" hint="0.6–1.8 m" />
+            </div>
+          </section>
+          <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Results</h2>
+            <Out label="Drainage fixture units" value={`${f0(septic.dfu)} DFU`} />
+            <Out label="Min capacity (Table B-2)" value={`${f0(septic.capacityL)} L · ${f2(septic.capacityL / 1000)} m³`} />
+            <Out label="Plan length" value={`${f2(septic.length)} m`} ok={septic.capacityOK} />
+            <Out label="Overall height" value={`${f2(septic.totalHeight)} m (liquid ${f1(septic.liquidDepth)} + 0.23 freeboard)`} ok={septic.depthOK} />
+            <Out label="Digestive chamber (2/3)" value={`${f2(tankWidth)} × ${f2(septic.inletLength)} × ${f2(septic.totalHeight)} m · ${f2(septic.inletVol)} m³`} ok={septic.inletVolOK && septic.inletDimOK} />
+            <Out label="Leaching chamber (1/3)" value={`${f2(tankWidth)} × ${f2(septic.outletLength)} × ${f2(septic.totalHeight)} m · ${f2(septic.outletVol)} m³`} ok={septic.outletVolOK} />
+            <Out label="Provided liquid volume" value={`${f2(septic.providedVol)} m³`} ok={septic.capacityOK} />
+            <p className="mt-2 text-[10px] text-slate-500">
+              Capacity from Table B-2 (by DFU). L = V/(w·d); inlet 2/3 (≥ 2 m³ &amp; ≥ 2/3 total), secondary 1/3
+              (≥ 1 m³). Liquid depth 0.6–1.8 m; side walls 228.6 mm above liquid. Two 508 mm manholes required.
+            </p>
+          </section>
+          <div className="no-print">{septicSteps.length > 0 && <WorkedSolution steps={septicSteps} />}</div>
+        </>
       )}
     </main>
   )


### PR DESCRIPTION
## What & why

Final phase of the **Plumbing System Design** feature (after [#381](https://github.com/BitLess246/civilEngineering/pull/381), [#382](https://github.com/BitLess246/civilEngineering/pull/382)) — the **Septic Tank** tab, sizing a two-compartment on-site septic tank from the shared fixture schedule's DFU load. Module 4. This completes the water-supply / drainage / septic trio on one page.

## Engine (L7) — `septicTank.ts`
- **Minimum liquid capacity** from RNPCP **Table B-2** (by max DFU served; **+94.6 L** per fixture unit beyond 100 DFU).
- **Appendix B two-chamber layout:** plan length `L = V/(w·d)`; digestive (inlet) **2/3** (≥ 2 m³ & ≥ 2/3 total), leaching (outlet) **1/3** (≥ 1 m³); overall height = liquid depth + **228.6 mm** freeboard; liquid depth clamped to 0.6–1.8 m; inlet ≥ 0.9 m × 1.5 m.
- Worked-solution output.

## Page
The **Septic** tab takes plan width + liquid depth and shows capacity, plan length, overall height, both chamber dimensions/volumes, and the worked solution.

## Validation (L9)
`plumb-septic` case (78 DFU → 4.8 m plan length) + a septic coverage row in `docs/ValidationMap.md`.

## Tests & verification
- `septicTank.test.ts` — Table B-2 lookup + over-100 extension, the Module 4 worked example (**78 DFU → 11,355 L → 2.0 × 4.8 × 1.5 m, chambers 3.2 / 1.6 m**), depth limits, schedule-driven sizing.
- **In-browser (verified):** the Module 4 example reproduces exactly — 78 DFU → 11,355 L, 4.80 m length, 1.50 m height, digestive 7.68 m³ / leaching 3.84 m³.

```
tsc -b     → clean
vitest run → 95 files, 1200 tests pass
```

The plumbing feature (Modules 2–4) is now complete: one `/plumbing` page, three tabs, a shared fixture schedule, four new engines, and eight validation benchmarks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)