### PR TITLE
refactor: timber material model — species/grade split + property struct on section

### DIFF
--- a/webapp/src/engine/model.ts
+++ b/webapp/src/engine/model.ts
@@ -7,6 +7,7 @@
 import type { LoadCategory } from './beamAnalysis'
 import type { SdlItem } from './deadLoads'
 import type { LiveItem } from './liveLoads'
+import type { WoodRefValues } from './woodDesign'
 
 export interface Node { id: string; x: number; y: number; z: number }
 
@@ -25,9 +26,16 @@ export interface RectSection {
   /** Steel grade yield/ultimate (steel only). Defaults: Fy 248, Fu 400 (A36). */
   steelFy?: number
   steelFu?: number
-  /** Timber species/grade id (wood only), key into WOOD_SPECIES (woodDesign.ts),
-   *  e.g. 'DFL-2'. Resolves the ASD/LRFD reference design values. */
+  /** Timber material id (wood only): a built-in library id (`${species}-${grade}`,
+   *  e.g. 'DFL-2') or a custom-material id. Resolves the reference design values
+   *  via WOOD_SPECIES when `woodRef` is absent. */
   woodSpecies?: string
+  /** Grade key within the species (wood only), e.g. '2' for No.2 — UI metadata. */
+  woodGrade?: string
+  /** Resolved ASD/LRFD reference design values (wood only). When present these
+   *  are authoritative (a custom material's values travel with the model); the
+   *  engine falls back to the library id otherwise. JSON-serialisable. */
+  woodRef?: WoodRefValues
   /** Solid-sawn ('sawn') or glued-laminated ('glulam') timber (wood only).
    *  Absent ⇒ 'sawn'. */
   woodKind?: 'sawn' | 'glulam'

--- a/webapp/src/engine/modelBridge.ts
+++ b/webapp/src/engine/modelBridge.ts
@@ -13,7 +13,7 @@ import { distributePanel, type AreaLoad } from './tributary'
 import type { BeamLoad } from './beamAnalysis'
 import { shapeByName, torsionJ, type AiscShape } from './aiscSections'
 import { deriveWSection, E_STEEL } from './steelDesign'
-import { getWoodRef } from './woodDesign'
+import { woodRefOf } from './woodDesign'
 
 export interface BridgeResult {
   nodes: F3Node[]
@@ -58,7 +58,7 @@ function plateShells(plate: Plate, mat: { E: number; nu: number }): F3Shell[] {
  *  shear modulus G ≈ E/16 (NDS solid-sawn), solid-rectangle I/J and κ = 5/6 shear
  *  areas. Falls back to a mid-range softwood E if the species is unset/unknown. */
 function woodSectionProps(s: RectSection) {
-  const ref = (s.woodSpecies ? getWoodRef(s.woodSpecies) : undefined)?.ref
+  const ref = woodRefOf(s)
   const cmE = s.woodWet ? (s.woodKind === 'glulam' ? 0.833 : 0.9) : 1
   const E = (ref?.E ?? 9500) * cmE
   const G = E / 16

--- a/webapp/src/engine/modelBuilder.ts
+++ b/webapp/src/engine/modelBuilder.ts
@@ -9,12 +9,12 @@
 import type { StructuralModel, RectSection, Node, Member, Plate, NodeSupport, MemberRole } from './model'
 import { sdlTotal } from './deadLoads'
 import { shapeByName } from './aiscSections'
-import { getWoodRef, woodUnitWeight } from './woodDesign'
+import { woodRefOf, woodUnitWeight } from './woodDesign'
 
-/** Timber self-weight line load basis (kN/m³) from the section's species (γ ≈
- *  G·9.81); fallback G = 0.5 (~4.9 kN/m³) when the species is unset/unknown. */
+/** Timber self-weight line load basis (kN/m³) from the section's material (γ ≈
+ *  G·9.81); fallback G = 0.5 (~4.9 kN/m³) when the material is unset/unknown. */
 const woodGamma = (sec: RectSection): number =>
-  woodUnitWeight((sec.woodSpecies ? getWoodRef(sec.woodSpecies) : undefined)?.ref.G ?? 0.5)
+  woodUnitWeight(woodRefOf(sec)?.G ?? 0.5)
 
 export interface GridSpec {
   baysX: number[]      // bay widths along x, m

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -27,7 +27,7 @@ import { designShearWall, type ShearWallResult } from './shearWallDesign'
 import { checkModelSCWB, type SCWBJointRow } from './scwb'
 import { shapeByName, nextHeavierW, nextLighterW, type AiscShape } from './aiscSections'
 import { deriveWSection, beamFlexure, beamShear, columnAxial, combinedLoading } from './steelDesign'
-import { getWoodRef, checkWoodBeam, checkWoodColumn } from './woodDesign'
+import { woodRefOf, checkWoodBeam, checkWoodColumn } from './woodDesign'
 import { designBasePlate, adoptPlateThickness, type BasePlateResult } from './baseplate'
 import { designSteelJoints, designBeamBeamJoints, type SteelJoint, type BeamBeamJoint } from './steelConnections'
 
@@ -360,7 +360,7 @@ function timeEffectFactor(comboName: string): number {
 function designWoodBeamRow(
   mr: F3MemberResult, role: string, sec: RectSection, lambda: number, lu?: number,
 ): WoodBeamScheduleRow | null {
-  const ref = (sec.woodSpecies ? getWoodRef(sec.woodSpecies) : undefined)?.ref
+  const ref = woodRefOf(sec)
   if (!ref) return null
   const kind = sec.woodKind === 'glulam' ? 'glulam' : 'sawn'
   const r = checkWoodBeam({
@@ -378,7 +378,7 @@ function designWoodBeamRow(
 /** Design a timber column from a member result: axial (governing-plane CP) +
  *  §3.9.2 beam-column interaction with the peak bending. */
 function designWoodColumnRow(mr: F3MemberResult, sec: RectSection, lambda: number): WoodColumnScheduleRow | null {
-  const ref = (sec.woodSpecies ? getWoodRef(sec.woodSpecies) : undefined)?.ref
+  const ref = woodRefOf(sec)
   if (!ref) return null
   const kind = sec.woodKind === 'glulam' ? 'glulam' : 'sawn'
   const Pu = Math.max(0, -Math.min(...mr.N))   // compression (N < 0)

--- a/webapp/src/engine/woodDesign.test.ts
+++ b/webapp/src/engine/woodDesign.test.ts
@@ -3,6 +3,7 @@ import {
   WOOD_SPECIES, getWoodRef, loadDurationFactor, sizeFactorTimber, volumeFactorGlulam,
   effectiveBendingLength, beamStabilityFactor, columnStabilityFactor, woodSectionProps,
   woodAdjusted, checkWoodBeam, checkWoodColumn, woodUnitWeight,
+  speciesList, gradesOf, resolveWoodSpecies, woodRefOf, validateWoodRef,
 } from './woodDesign'
 
 describe('reference value library', () => {
@@ -19,6 +20,53 @@ describe('reference value library', () => {
       for (const v of Object.values(s.ref)) expect(v).toBeGreaterThan(0)
       expect(s.ref.Emin).toBeLessThan(s.ref.E)   // stability modulus < mean E
     }
+  })
+})
+
+describe('structured library — species / grade separation', () => {
+  it('keeps the stable flat ids for back-compatibility', () => {
+    for (const id of ['DFL-SS', 'DFL-1', 'DFL-2', 'HF-2', 'SPF-2', 'SP-2', 'GLULAM-24F'])
+      expect(getWoodRef(id), id).toBeTruthy()
+  })
+  it('speciesList returns the distinct species (DFL first, 5 total)', () => {
+    const sp = speciesList()
+    expect(sp.map((s) => s.species)).toEqual(['DFL', 'HF', 'SPF', 'SP', 'GLULAM'])
+    expect(sp[0].label).toBe('Douglas Fir-Larch')
+  })
+  it('gradesOf lists the grades within a species', () => {
+    expect(gradesOf('DFL').map((g) => g.grade)).toEqual(['SS', '1', '2'])
+    expect(gradesOf('HF')).toHaveLength(1)
+  })
+  it('resolveWoodSpecies composes the id from species + grade', () => {
+    expect(resolveWoodSpecies('DFL', '2')!.id).toBe('DFL-2')
+    expect(resolveWoodSpecies('DFL', 'nope')).toBeUndefined()
+  })
+})
+
+describe('woodRefOf — the section → reference-values contract', () => {
+  const custom = { Fb: 30, Ft: 20, Fv: 4, FcPerp: 8, Fc: 18, E: 15000, Emin: 5200, G: 0.75 }
+  it('an explicit woodRef (custom material) wins over the library id', () => {
+    expect(woodRefOf({ woodSpecies: 'DFL-2', woodRef: custom })).toBe(custom)
+  })
+  it('falls back to the library id when no woodRef is stored', () => {
+    expect(woodRefOf({ woodSpecies: 'DFL-2' })).toBe(getWoodRef('DFL-2')!.ref)
+  })
+  it('returns undefined when neither is available', () => {
+    expect(woodRefOf({})).toBeUndefined()
+    expect(woodRefOf({ woodSpecies: 'not-a-species' })).toBeUndefined()
+  })
+})
+
+describe('validateWoodRef — guards the custom-material path', () => {
+  it('accepts a sound reference set', () => {
+    expect(validateWoodRef({ Fb: 24, Ft: 16, Fv: 2.5, FcPerp: 6, Fc: 16, E: 16000, Emin: 5500, G: 0.8 })).toEqual([])
+  })
+  it('rejects non-positive stresses', () => {
+    expect(validateWoodRef({ Fb: 0, Ft: 16, Fv: 2.5, FcPerp: 6, Fc: 16, E: 16000, Emin: 5500, G: 0.8 })).not.toHaveLength(0)
+  })
+  it('requires Emin < E and G ≤ 1.4', () => {
+    expect(validateWoodRef({ Fb: 24, Ft: 16, Fv: 2.5, FcPerp: 6, Fc: 16, E: 16000, Emin: 16000, G: 0.8 }).some((e) => /Emin/.test(e))).toBe(true)
+    expect(validateWoodRef({ Fb: 24, Ft: 16, Fv: 2.5, FcPerp: 6, Fc: 16, E: 16000, Emin: 5500, G: 1.6 }).some((e) => /gravity/.test(e))).toBe(true)
   })
 })
 

--- a/webapp/src/engine/woodDesign.ts
+++ b/webapp/src/engine/woodDesign.ts
@@ -27,39 +27,105 @@ export interface WoodRefValues {
 
 export type WoodKind = 'sawn' | 'glulam'
 
+/** One material entry (species × grade) resolved to a flat lookup.  The
+ *  analysis/design engine only ever consumes `ref` (WoodRefValues) — species,
+ *  grade and origin are UI/provenance metadata so the library is code- and
+ *  country-agnostic (add any species by supplying its ref). */
 export interface WoodSpecies {
-  id: string
-  label: string
+  id: string                 // composite `${species}-${grade}`
+  label: string              // "<species> — <grade>"
   kind: WoodKind
   ref: WoodRefValues
+  species: string            // grouping key for the species dropdown
+  speciesLabel: string
+  grade: string              // key within a species (grade dropdown)
+  gradeLabel: string
+  origin: string             // provenance badge: 'NDS' | 'NSCP' | 'custom' | …
 }
 
 // psi → MPa
 const K = 0.00689476
 const mpa = (psi: number) => psi * K
 
-// ── Reference design value library ────────────────────────────────────────
+// ── Built-in reference-value library, structured species → grades ──────────
 // Sawn: NDS Supplement Table 4A (visually-graded dimension lumber / timbers).
 // Glulam: NDS Supplement Table 5A (bending combinations, Δ = tension zone).
-export const WOOD_SPECIES: Record<string, WoodSpecies> = {
-  'DFL-SS': { id: 'DFL-SS', label: 'Douglas Fir-Larch — Select Structural', kind: 'sawn',
-    ref: { Fb: mpa(1500), Ft: mpa(1000), Fv: mpa(180), FcPerp: mpa(625), Fc: mpa(1700), E: mpa(1_900_000), Emin: mpa(690_000), G: 0.50 } },
-  'DFL-1': { id: 'DFL-1', label: 'Douglas Fir-Larch — No.1', kind: 'sawn',
-    ref: { Fb: mpa(1000), Ft: mpa(675), Fv: mpa(180), FcPerp: mpa(625), Fc: mpa(1500), E: mpa(1_700_000), Emin: mpa(620_000), G: 0.50 } },
-  'DFL-2': { id: 'DFL-2', label: 'Douglas Fir-Larch — No.2', kind: 'sawn',
-    ref: { Fb: mpa(900), Ft: mpa(575), Fv: mpa(180), FcPerp: mpa(625), Fc: mpa(1350), E: mpa(1_600_000), Emin: mpa(580_000), G: 0.50 } },
-  'HF-2': { id: 'HF-2', label: 'Hem-Fir — No.2', kind: 'sawn',
-    ref: { Fb: mpa(850), Ft: mpa(525), Fv: mpa(150), FcPerp: mpa(405), Fc: mpa(1300), E: mpa(1_300_000), Emin: mpa(470_000), G: 0.43 } },
-  'SPF-2': { id: 'SPF-2', label: 'Spruce-Pine-Fir — No.2', kind: 'sawn',
-    ref: { Fb: mpa(875), Ft: mpa(450), Fv: mpa(135), FcPerp: mpa(425), Fc: mpa(1150), E: mpa(1_400_000), Emin: mpa(510_000), G: 0.42 } },
-  'SP-2': { id: 'SP-2', label: 'Southern Pine — No.2', kind: 'sawn',
-    ref: { Fb: mpa(1050), Ft: mpa(650), Fv: mpa(175), FcPerp: mpa(565), Fc: mpa(1700), E: mpa(1_600_000), Emin: mpa(580_000), G: 0.55 } },
-  'GLULAM-24F': { id: 'GLULAM-24F', label: 'Glulam 24F-1.8E (24F-V4 DF)', kind: 'glulam',
-    ref: { Fb: mpa(2400), Ft: mpa(1100), Fv: mpa(265), FcPerp: mpa(650), Fc: mpa(1650), E: mpa(1_800_000), Emin: mpa(950_000), G: 0.50 } },
-}
+// Philippine species (Yakal, Ipil, Molave, Tanguile …) share this shape and can
+// be added here — or supplied as custom materials — once their NSCP §6 / PWCM /
+// FPRDI allowable stresses are available.
+interface GradeSpec { grade: string; gradeLabel: string; ref: WoodRefValues }
+interface SpeciesSpec { species: string; speciesLabel: string; kind: WoodKind; origin: string; grades: GradeSpec[] }
+
+const LIBRARY_SPEC: SpeciesSpec[] = [
+  { species: 'DFL', speciesLabel: 'Douglas Fir-Larch', kind: 'sawn', origin: 'NDS', grades: [
+    { grade: 'SS', gradeLabel: 'Select Structural', ref: { Fb: mpa(1500), Ft: mpa(1000), Fv: mpa(180), FcPerp: mpa(625), Fc: mpa(1700), E: mpa(1_900_000), Emin: mpa(690_000), G: 0.50 } },
+    { grade: '1', gradeLabel: 'No.1', ref: { Fb: mpa(1000), Ft: mpa(675), Fv: mpa(180), FcPerp: mpa(625), Fc: mpa(1500), E: mpa(1_700_000), Emin: mpa(620_000), G: 0.50 } },
+    { grade: '2', gradeLabel: 'No.2', ref: { Fb: mpa(900), Ft: mpa(575), Fv: mpa(180), FcPerp: mpa(625), Fc: mpa(1350), E: mpa(1_600_000), Emin: mpa(580_000), G: 0.50 } },
+  ] },
+  { species: 'HF', speciesLabel: 'Hem-Fir', kind: 'sawn', origin: 'NDS', grades: [
+    { grade: '2', gradeLabel: 'No.2', ref: { Fb: mpa(850), Ft: mpa(525), Fv: mpa(150), FcPerp: mpa(405), Fc: mpa(1300), E: mpa(1_300_000), Emin: mpa(470_000), G: 0.43 } },
+  ] },
+  { species: 'SPF', speciesLabel: 'Spruce-Pine-Fir', kind: 'sawn', origin: 'NDS', grades: [
+    { grade: '2', gradeLabel: 'No.2', ref: { Fb: mpa(875), Ft: mpa(450), Fv: mpa(135), FcPerp: mpa(425), Fc: mpa(1150), E: mpa(1_400_000), Emin: mpa(510_000), G: 0.42 } },
+  ] },
+  { species: 'SP', speciesLabel: 'Southern Pine', kind: 'sawn', origin: 'NDS', grades: [
+    { grade: '2', gradeLabel: 'No.2', ref: { Fb: mpa(1050), Ft: mpa(650), Fv: mpa(175), FcPerp: mpa(565), Fc: mpa(1700), E: mpa(1_600_000), Emin: mpa(580_000), G: 0.55 } },
+  ] },
+  { species: 'GLULAM', speciesLabel: 'Glulam — Douglas Fir', kind: 'glulam', origin: 'NDS', grades: [
+    { grade: '24F', gradeLabel: '24F-1.8E (24F-V4)', ref: { Fb: mpa(2400), Ft: mpa(1100), Fv: mpa(265), FcPerp: mpa(650), Fc: mpa(1650), E: mpa(1_800_000), Emin: mpa(950_000), G: 0.50 } },
+  ] },
+]
+
+/** Flat id → material lookup (id = `${species}-${grade}`), derived from the
+ *  structured spec.  Ids are stable ('DFL-SS', 'HF-2', 'GLULAM-24F', …). */
+export const WOOD_SPECIES: Record<string, WoodSpecies> = Object.fromEntries(
+  LIBRARY_SPEC.flatMap((s) => s.grades.map((g): [string, WoodSpecies] => {
+    const id = `${s.species}-${g.grade}`
+    return [id, {
+      id, label: `${s.speciesLabel} — ${g.gradeLabel}`, kind: s.kind, ref: g.ref,
+      species: s.species, speciesLabel: s.speciesLabel, grade: g.grade, gradeLabel: g.gradeLabel, origin: s.origin,
+    }]
+  })),
+)
 
 export function getWoodRef(id: string): WoodSpecies | undefined {
   return WOOD_SPECIES[id]
+}
+
+/** Distinct species for the species dropdown (first-seen order). */
+export function speciesList(): { species: string; label: string; kind: WoodKind; origin: string }[] {
+  const seen = new Map<string, { species: string; label: string; kind: WoodKind; origin: string }>()
+  for (const e of Object.values(WOOD_SPECIES))
+    if (!seen.has(e.species)) seen.set(e.species, { species: e.species, label: e.speciesLabel, kind: e.kind, origin: e.origin })
+  return [...seen.values()]
+}
+
+/** Grades available for a species (the dependent grade dropdown). */
+export function gradesOf(species: string): WoodSpecies[] {
+  return Object.values(WOOD_SPECIES).filter((e) => e.species === species)
+}
+
+/** Resolve a (species, grade) pair to its material entry. */
+export function resolveWoodSpecies(species: string, grade: string): WoodSpecies | undefined {
+  return WOOD_SPECIES[`${species}-${grade}`]
+}
+
+/** The reference design values a wood section actually uses: an explicit
+ *  `woodRef` (custom material — travels with the model) wins over the built-in
+ *  library id.  Keeps the pure engine independent of any material registry. */
+export function woodRefOf(sec: { woodSpecies?: string; woodRef?: WoodRefValues }): WoodRefValues | undefined {
+  return sec.woodRef ?? (sec.woodSpecies ? getWoodRef(sec.woodSpecies)?.ref : undefined)
+}
+
+/** Validate a (possibly user-entered) reference-value set; returns human-
+ *  readable errors, empty when usable.  Guards the custom-material path. */
+export function validateWoodRef(r: Partial<WoodRefValues>): string[] {
+  const errs: string[] = []
+  const pos = (k: keyof WoodRefValues) => { const v = r[k]; if (!(typeof v === 'number' && Number.isFinite(v) && v > 0)) errs.push(`${k} must be a positive number`) }
+  ;(['Fb', 'Ft', 'Fv', 'FcPerp', 'Fc', 'E', 'Emin', 'G'] as (keyof WoodRefValues)[]).forEach(pos)
+  if (typeof r.E === 'number' && typeof r.Emin === 'number' && r.Emin >= r.E) errs.push('Emin (5th-percentile stability modulus) must be less than E')
+  if (typeof r.G === 'number' && (r.G <= 0 || r.G > 1.4)) errs.push('specific gravity G must be within (0, 1.4]')
+  return errs
 }
 
 // ── Load-duration factor CD (NDS Table 2.3.2) ──────────────────────────────

--- a/webapp/src/engine/woodFrame.test.ts
+++ b/webapp/src/engine/woodFrame.test.ts
@@ -39,6 +39,22 @@ describe('bridge — timber member stiffness', () => {
   })
 })
 
+describe('bridge — custom material (woodRef on the section)', () => {
+  it('uses an explicit woodRef even with no library species (custom material travels with the model)', () => {
+    const customRef = { Fb: 30, Ft: 20, Fv: 4, FcPerp: 8, Fc: 18, E: 16500, Emin: 5800, G: 0.85 }
+    const sec: RectSection = { id: 'S', name: '200×400', b: 200, h: 400, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40, material: 'wood', woodRef: customRef }
+    const model: StructuralModel = {
+      ...emptyModel('t'),
+      nodes: [{ id: 'a', x: 0, y: 0, z: 0 }, { id: 'b', x: 4, y: 0, z: 0 }],
+      sections: [sec], members: [{ id: 'm', i: 'a', j: 'b', role: 'beam', section: 'S' }],
+      supports: [{ node: 'a', fixity: 'fixed' }],
+    }
+    const m = modelToFrame3D(model).members.find((x) => x.id === 'm')!
+    expect(m.E).toBeCloseTo(customRef.E, 3)      // the custom E, not a library value
+    expect(m.G).toBeCloseTo(customRef.E / 16, 3)
+  })
+})
+
 describe('self-weight — timber density', () => {
   it('a wood member self-weight uses γ ≈ G·9.81, much lighter than concrete', () => {
     const model = woodModel()

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -57,7 +57,7 @@ import { HintButton, SeismicHint, WindHint } from '../components/LoadHints'
 import { Num, Pick, Row } from '../components/qty'
 import { FitView } from '../components/FitView'
 import { shapeByName, shapesOf, effectiveSection, sectionBoundingBox, FAMILIES, type SectionFamily } from '../engine/aiscSections'
-import { WOOD_SPECIES } from '../engine/woodDesign'
+import { WOOD_SPECIES, speciesList, gradesOf, resolveWoodSpecies, type WoodSpecies } from '../engine/woodDesign'
 import { buildSectionShapes } from '../lib/sectionShapes3d'
 import { SectionShape } from '../components/SectionShape'
 import { f1, f2 } from '../lib/format'
@@ -837,9 +837,13 @@ export default function ModelSpace() {
   // Material: 'concrete' (RC), 'steel' (AISC W-shapes) or 'wood' (timber) for the frame members.
   const [material, setMaterial] = useState<'concrete' | 'steel' | 'wood'>((si.material as 'concrete' | 'steel' | 'wood') ?? 'concrete')
   // Timber (wood frame): species/grade, sawn vs glulam, wet service.
-  const [woodSpecies, setWoodSpecies] = useState(s('woodSpecies', 'DFL-2'))
-  const [woodKind, setWoodKind] = useState<'sawn' | 'glulam'>((s('woodKind', 'sawn')) as 'sawn' | 'glulam')
+  // Timber material as separate species + grade (migrating any legacy composite id).
+  const legacyWood = WOOD_SPECIES[s('woodSpecies', 'DFL-2')]
+  const [woodSpeciesId, setWoodSpeciesId] = useState(s('woodSpeciesId', legacyWood?.species ?? 'DFL'))
+  const [woodGrade, setWoodGrade] = useState(s('woodGrade', legacyWood?.grade ?? '2'))
   const [woodWet, setWoodWet] = useState(b('woodWet', false))
+  const woodSel: WoodSpecies = resolveWoodSpecies(woodSpeciesId, woodGrade) ?? gradesOf(woodSpeciesId)[0] ?? WOOD_SPECIES['DFL-2']
+  const woodKind = woodSel.kind
   const [colFam, setColFam] = useState<SectionFamily>((s('colFam', 'W')) as SectionFamily)
   const [girFam, setGirFam] = useState<SectionFamily>((s('girFam', 'W')) as SectionFamily)
   const [beaFam, setBeaFam] = useState<SectionFamily>((s('beaFam', 'W')) as SectionFamily)
@@ -991,7 +995,7 @@ export default function ModelSpace() {
         Vw, expo, Kzt, wDirs, assembly, pDelta, cracked, shearDef, tryBars,
         concreteClass, prices, planSel,
         material, colFam, girFam, beaFam, colShape, girShape, beaShape, steelFy, steelFu,
-        woodSpecies, woodKind, woodWet,
+        woodSpeciesId, woodGrade, woodWet,
       }))
     } catch { /* quota — ignore */ }
   }, [baysX, baysZ, storeyH, colB, colH, girB, girH, beaB, beaH,
@@ -1000,7 +1004,7 @@ export default function ModelSpace() {
     Vw, expo, Kzt, wDirs, assembly, pDelta, cracked, shearDef, tryBars,
     concreteClass, prices, planSel,
     material, colFam, girFam, beaFam, colShape, girShape, beaShape, steelFy, steelFu,
-    woodSpecies, woodKind, woodWet])
+    woodSpeciesId, woodGrade, woodWet])
 
   const save = (m: StructuralModel | null) => {
     setModel(m)
@@ -1499,7 +1503,7 @@ export default function ModelSpace() {
     return map
   }, [govRes])
 
-  const generate = (matOverride?: 'concrete' | 'steel' | 'wood') => {
+  const generate = (matOverride?: 'concrete' | 'steel' | 'wood', woodOverride?: { sel?: WoodSpecies; wet?: boolean }) => {
     const mat = { fc, fy, barDia, tieDia, cover }
     const role = (b: number, h: number, id: string): RectSection => ({ id, name: `${b}×${h}`, b, h, ...mat })
     // steel role: bounding box b = bf, h = d from the chosen AISC shape, tagged
@@ -1509,10 +1513,15 @@ export default function ModelSpace() {
       const { b, h } = sh ? sectionBoundingBox(sh) : { b: 200, h: 300 }
       return { id, name: shapeName, b, h, ...mat, material: 'steel', shape: shapeName, steelFy, steelFu }
     }
-    // wood role: solid-rectangle b × d tagged with the timber species/grade so
-    // the bridge (E), pipeline (NDS §3 design) and take-off pick it up.
+    // wood role: solid-rectangle b × d tagged with the resolved timber material —
+    // both the library id and the reference values travel with the section so
+    // the bridge (E), pipeline (NDS §3 design) and take-off pick it up. Fresh
+    // selection passed via woodOverride to avoid a same-tick stale-state read.
+    const wsel = woodOverride?.sel ?? woodSel
+    const wet = woodOverride?.wet ?? woodWet
     const woodRole = (b: number, h: number, id: string): RectSection =>
-      ({ id, name: `${b}×${h}`, b, h, ...mat, material: 'wood', woodSpecies, woodKind, woodWet })
+      ({ id, name: `${b}×${h}`, b, h, ...mat, material: 'wood',
+         woodSpecies: wsel.id, woodGrade: wsel.grade, woodRef: wsel.ref, woodKind: wsel.kind, woodWet: wet })
     const chosen = matOverride ?? material
     const steel = chosen === 'steel', wood = chosen === 'wood'
     const m = generateGridModel({
@@ -2378,13 +2387,18 @@ export default function ModelSpace() {
                 </Sec>
               ) : material === 'wood' ? (
                 <Sec title="Timber (wood frame)">
-                  <Pick label="Species / grade" value={woodSpecies} onChange={(v) => {
-                    setWoodSpecies(v); setWoodKind(WOOD_SPECIES[v]?.kind ?? 'sawn')
-                    if (model) generate('wood')
-                  }} options={Object.values(WOOD_SPECIES).map((sp) => [sp.id, sp.label])} />
+                  <Pick label="Species" value={woodSpeciesId} onChange={(v) => {
+                    const g = gradesOf(v)[0]?.grade ?? '2'
+                    setWoodSpeciesId(v); setWoodGrade(g)
+                    if (model) generate('wood', { sel: resolveWoodSpecies(v, g) })
+                  }} options={speciesList().map((sp) => [sp.species, sp.label])} />
+                  <Pick label="Grade" value={woodGrade} onChange={(v) => {
+                    setWoodGrade(v)
+                    if (model) generate('wood', { sel: resolveWoodSpecies(woodSpeciesId, v) })
+                  }} options={gradesOf(woodSpeciesId).map((g) => [g.grade, g.gradeLabel])} />
                   <label className="col-span-full flex items-center gap-2 text-sm">
                     <input type="checkbox" checked={woodWet}
-                      onChange={(e) => { setWoodWet(e.target.checked); if (model) generate('wood') }} />
+                      onChange={(e) => { setWoodWet(e.target.checked); if (model) generate('wood', { wet: e.target.checked }) }} />
                     Wet service — MC &gt; 19% sawn / 16% glulam (applies C<sub>M</sub>)
                   </label>
                   <p className="col-span-full -mb-1 text-[11px] text-slate-500">
@@ -2399,7 +2413,7 @@ export default function ModelSpace() {
                   <Num label="Beam d" unit="mm" value={beaH} onChange={setBeaH} />
                   <Num label="Slab thickness" unit="mm" value={slabThk} onChange={setSlabThk} />
                   <p className="col-span-full text-[11px] text-slate-500">
-                    Designed to NDS §3 / NSCP §6: reference values ({WOOD_SPECIES[woodSpecies]?.kind === 'glulam' ? 'glulam' : 'sawn'})
+                    Designed to NDS §3 / NSCP §6: reference values ({woodKind === 'glulam' ? 'glulam' : 'sawn'}, {woodSel.origin})
                     adjusted by C<sub>D</sub>/C<sub>M</sub>/C<sub>F</sub>/C<sub>V</sub>, beam stability C<sub>L</sub> and column
                     stability C<sub>P</sub>; factored demands checked LRFD (Appendix N, K<sub>F</sub>·φ·λ). Slabs/footings stay reinforced concrete.
                   </p>


### PR DESCRIPTION
## What & why

You were right that the timber layer shouldn't hard-code species — and the good news is the **analysis engine already doesn't** (it consumes `WoodRefValues`, not species names). This PR delivers the **material-model** half of your proposal (the *editable library* follows next), restructuring the data + UI layer so it's code- and country-agnostic and ready for user-defined materials — **no solver change**.

Chosen approach from our discussion: **structure now, data later** + **material model first**.

## `woodDesign.ts`
- The built-in library is now **structured species → grades**, with the flat `id → entry` lookup **derived** from it. Ids stay stable (`DFL-SS`, `HF-2`, `GLULAM-24F`, …), so `getWoodRef` and every existing caller/test are untouched.
- Each entry carries `species` / `grade` / `origin` metadata for **dependent dropdowns**.
- New helpers:
  - `speciesList()`, `gradesOf(species)`, `resolveWoodSpecies(species, grade)` — the dropdown data.
  - **`woodRefOf(section)`** — the section → reference-values contract: an explicit `woodRef` wins over the library id, so a **custom material's values travel with the model** and the pure engine needs no material registry.
  - **`validateWoodRef()`** — guards user input (positive stresses, `Emin < E`, `G ≤ 1.4`). This is the "flag unverified custom values" safeguard I flagged in the analysis.

## Model (L1)
`RectSection` gains `woodGrade` + `woodRef` (JSON-serialisable). `modelBridge`, `modelBuilder`, and `pipeline` resolve via `woodRefOf(sec)` — prefer the stored ref, fall back to the library id. **Back-compatible** with existing saved models.

## UI (`ModelSpace`)
The single "species/grade" dropdown becomes **dependent Species + Grade selects**; generated sections store the resolved id + grade + `woodRef`. Also fixes a **latent same-tick stale-state bug** — species/grade/wet changes now take effect immediately (the fresh selection is passed into `generate()`).

## Notes on your proposal (carried into the design)
- Kept **`Emin`** (your interface omitted it — it's required for `CL`/`CP` buckling).
- **Load-duration stays off the material** (it's a load-combination property; already handled per combo).
- **`poisson` omitted** — unused (the solver uses `G ≈ E/16` directly; timber is orthotropic).

## Tests & verification
- `woodDesign.test.ts` — library structure, helpers, `woodRefOf` precedence, `validateWoodRef`; `woodFrame.test.ts` — a **custom `woodRef` with no library species** flows through to the frame `E`.
- **In-browser:** Species (DFL/HF/SPF/SP/GLULAM) + dependent Grade selects; GLULAM collapses Grade to `24F`; a regenerated **DFL-SS** section carries `woodRef {Fb 10.34, E 13100}`.

```
tsc -b     → clean
vitest run → 95 files, 1211 tests pass
```

## Next PR
User-editable **custom-material library** — new / copy / edit / CSV import-export + localStorage, surfaced in the Species dropdown as `origin: custom`. Then (separately) Philippine species data once sourced, and Bamboo as its own material + engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)