### PR TITLE
feat: user-editable custom timber material library (localStorage + CSV)

### DIFF
--- a/webapp/src/components/MaterialLibrary.tsx
+++ b/webapp/src/components/MaterialLibrary.tsx
@@ -1,0 +1,122 @@
+import { useRef, useState } from 'react'
+import { validateWoodRef, WOOD_SPECIES, speciesList, gradesOf, type WoodKind, type WoodRefValues } from '../engine/woodDesign'
+import {
+  materialsToCsv, csvToMaterials, slugId, upsertMaterial, deleteMaterial, type CustomMaterial,
+} from '../lib/materialLibrary'
+
+const REF_FIELDS: { k: keyof WoodRefValues; label: string; unit: string }[] = [
+  { k: 'Fb', label: 'Fb bending', unit: 'MPa' }, { k: 'Ft', label: 'Ft tension', unit: 'MPa' },
+  { k: 'Fv', label: 'Fv shear', unit: 'MPa' }, { k: 'FcPerp', label: 'Fc⊥ bearing', unit: 'MPa' },
+  { k: 'Fc', label: 'Fc∥ compr.', unit: 'MPa' }, { k: 'E', label: 'E', unit: 'MPa' },
+  { k: 'Emin', label: 'Emin (stability)', unit: 'MPa' }, { k: 'G', label: 'G (sp. gravity)', unit: '' },
+]
+const DEFAULT_REF = (): WoodRefValues => ({ ...WOOD_SPECIES['DFL-2'].ref })
+
+/** User-defined timber material library: select a custom material, or create /
+ *  copy / edit / delete one, with CSV import-export. Values validated before
+ *  save so an unusable material can't reach the solver. */
+export function MaterialLibrary({ materials, selectedId, onSelect, onChange }: {
+  materials: CustomMaterial[]
+  selectedId: string
+  /** Selection changed. `material` is the resolved entry (undefined = none) so
+   *  the parent never has to look it up from its own (possibly stale) state. */
+  onSelect: (id: string, material?: CustomMaterial) => void
+  onChange: (list: CustomMaterial[]) => void
+}) {
+  const [draft, setDraft] = useState<CustomMaterial | null>(null)
+  const [importErr, setImportErr] = useState('')
+  const fileRef = useRef<HTMLInputElement>(null)
+  const errors = draft ? validateWoodRef(draft.ref) : []
+
+  const startNew = () => { setImportErr(''); setDraft({ id: '', name: '', kind: 'sawn', ref: DEFAULT_REF() }) }
+  const startEdit = () => { const m = materials.find((x) => x.id === selectedId); if (m) { setImportErr(''); setDraft({ ...m, ref: { ...m.ref } }) } }
+  const save = () => {
+    if (!draft || errors.length || !draft.name.trim()) return
+    const id = draft.id || slugId(draft.name, materials.map((m) => m.id))
+    const m = { ...draft, id }
+    onChange(upsertMaterial(materials, m))
+    onSelect(id, m); setDraft(null)               // pass the fresh material
+  }
+  const del = () => { if (selectedId) { onChange(deleteMaterial(materials, selectedId)); onSelect('') } }
+  const exportCsv = () => {
+    const a = document.createElement('a')
+    a.href = URL.createObjectURL(new Blob([materialsToCsv(materials)], { type: 'text/csv' }))
+    a.download = 'timber-materials.csv'; a.click(); URL.revokeObjectURL(a.href)
+  }
+  const importCsv = (file: File) => {
+    setImportErr('')
+    file.text().then((t) => {
+      const { materials: imp, errors: errs } = csvToMaterials(t, materials.map((m) => m.id))
+      if (imp.length) { onChange([...materials, ...imp]); onSelect(imp[0].id, imp[0]) }
+      if (errs.length) setImportErr(errs.join(' · '))
+    })
+  }
+  const btn = 'rounded-md border border-slate-300 px-2 py-1 text-[11px] font-medium text-slate-600 hover:bg-slate-50'
+
+  return (
+    <div className="col-span-full">
+      <div className="flex flex-wrap items-center gap-2">
+        <select value={selectedId} onChange={(e) => onSelect(e.target.value, materials.find((m) => m.id === e.target.value))}
+          className="min-w-[10rem] flex-1 rounded-md border border-slate-300 px-2 py-1 text-sm">
+          <option value="">— select a custom material —</option>
+          {materials.map((m) => <option key={m.id} value={m.id}>{m.name}{m.kind === 'glulam' ? ' (GL)' : ''}</option>)}
+        </select>
+        <button type="button" className={btn} onClick={startNew}>＋ New</button>
+        <button type="button" className={btn} onClick={startEdit} disabled={!selectedId}>Edit</button>
+        <button type="button" className={btn} onClick={del} disabled={!selectedId}>Delete</button>
+        <button type="button" className={btn} onClick={exportCsv} disabled={!materials.length}>Export CSV</button>
+        <button type="button" className={btn} onClick={() => fileRef.current?.click()}>Import CSV</button>
+        <input ref={fileRef} type="file" accept=".csv,text/csv" className="hidden"
+          onChange={(e) => { const f = e.target.files?.[0]; if (f) importCsv(f); e.target.value = '' }} />
+      </div>
+      {importErr && <p className="mt-1 text-[11px] text-red-600">{importErr}</p>}
+
+      {draft && (
+        <div className="mt-3 rounded-lg border border-slate-200 bg-slate-50 p-3">
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+            <label className="col-span-2 flex flex-col text-[11px] sm:col-span-2">
+              <span className="mb-0.5 font-medium text-slate-600">Name</span>
+              <input value={draft.name} onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+                className="rounded-md border border-slate-300 px-2 py-1" placeholder="e.g. Apitong (80% grade)" />
+            </label>
+            <label className="flex flex-col text-[11px]">
+              <span className="mb-0.5 font-medium text-slate-600">Kind</span>
+              <select value={draft.kind} onChange={(e) => setDraft({ ...draft, kind: e.target.value as WoodKind })}
+                className="rounded-md border border-slate-300 px-2 py-1">
+                <option value="sawn">Sawn</option><option value="glulam">Glulam</option>
+              </select>
+            </label>
+            <label className="flex flex-col text-[11px]">
+              <span className="mb-0.5 font-medium text-slate-600">Seed from</span>
+              <select value="" onChange={(e) => { const g = e.target.value; if (g) setDraft({ ...draft, ref: { ...WOOD_SPECIES[g].ref }, kind: WOOD_SPECIES[g].kind }) }}
+                className="rounded-md border border-slate-300 px-2 py-1">
+                <option value="">library…</option>
+                {speciesList().flatMap((sp) => gradesOf(sp.species).map((gr) => <option key={gr.id} value={gr.id}>{gr.label}</option>))}
+              </select>
+            </label>
+            {REF_FIELDS.map(({ k, label, unit }) => (
+              <label key={k} className="flex flex-col text-[11px]">
+                <span className="mb-0.5 font-medium text-slate-600">{label}{unit ? ` (${unit})` : ''}</span>
+                <input type="number" step="any" value={draft.ref[k]}
+                  onChange={(e) => setDraft({ ...draft, ref: { ...draft.ref, [k]: parseFloat(e.target.value) } })}
+                  className="rounded-md border border-slate-300 px-2 py-1" />
+              </label>
+            ))}
+            <label className="col-span-2 flex flex-col text-[11px] sm:col-span-4">
+              <span className="mb-0.5 font-medium text-slate-600">Note / source (optional)</span>
+              <input value={draft.note ?? ''} onChange={(e) => setDraft({ ...draft, note: e.target.value })}
+                className="rounded-md border border-slate-300 px-2 py-1" placeholder="e.g. FPRDI Technical Note, air-dry" />
+            </label>
+          </div>
+          {errors.length > 0 && <p className="mt-2 text-[11px] text-red-600">{errors.join(' · ')}</p>}
+          <p className="mt-2 text-[10px] text-amber-600">User-defined values are unverified — you are responsible for their source and validity.</p>
+          <div className="mt-2 flex gap-2">
+            <button type="button" className="rounded-md bg-[#0056b3] px-3 py-1 text-[11px] font-semibold text-white disabled:opacity-40"
+              onClick={save} disabled={errors.length > 0 || !draft.name.trim()}>Save</button>
+            <button type="button" className={btn} onClick={() => setDraft(null)}>Cancel</button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/webapp/src/lib/materialLibrary.test.ts
+++ b/webapp/src/lib/materialLibrary.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import {
+  slugId, upsertMaterial, deleteMaterial, materialsToCsv, csvToMaterials, CSV_HEADER,
+  type CustomMaterial,
+} from './materialLibrary'
+
+const apitong: CustomMaterial = {
+  id: 'custom-apitong', name: 'Apitong (80% grade)', kind: 'sawn', note: 'FPRDI, air-dry',
+  ref: { Fb: 24.5, Ft: 14.0, Fv: 2.49, FcPerp: 6.15, Fc: 15.8, E: 13800, Emin: 5000, G: 0.72 },
+}
+
+describe('slugId', () => {
+  it('slugifies the name and avoids collisions', () => {
+    expect(slugId('Apitong (80% grade)', [])).toBe('custom-apitong-80-grade')
+    expect(slugId('Yakal', ['custom-yakal'])).toBe('custom-yakal-2')
+  })
+})
+
+describe('upsert / delete', () => {
+  it('adds, replaces by id, and removes', () => {
+    let list = upsertMaterial([], apitong)
+    expect(list).toHaveLength(1)
+    list = upsertMaterial(list, { ...apitong, name: 'Apitong v2' })
+    expect(list).toHaveLength(1)
+    expect(list[0].name).toBe('Apitong v2')
+    expect(deleteMaterial(list, apitong.id)).toHaveLength(0)
+  })
+})
+
+describe('CSV round-trip', () => {
+  it('exports a header + row and re-imports identical engineering values', () => {
+    const csv = materialsToCsv([apitong])
+    expect(csv.split('\n')[0]).toBe(CSV_HEADER.join(','))
+    const { materials, errors } = csvToMaterials(csv)
+    expect(errors).toEqual([])
+    expect(materials).toHaveLength(1)
+    expect(materials[0].name).toBe(apitong.name)
+    expect(materials[0].kind).toBe('sawn')
+    expect(materials[0].ref).toEqual(apitong.ref)
+    expect(materials[0].note).toBe('FPRDI, air-dry')
+  })
+  it('quotes names containing commas and restores them', () => {
+    const m = { ...apitong, name: 'Yakal, Guijo blend' }
+    const back = csvToMaterials(materialsToCsv([m])).materials[0]
+    expect(back.name).toBe('Yakal, Guijo blend')
+  })
+})
+
+describe('CSV import validation', () => {
+  it('rejects a row with bad engineering values but keeps good ones', () => {
+    const csv = [
+      CSV_HEADER.join(','),
+      'Good,sawn,24,16,2.5,6,16,16000,5500,0.8,ok',
+      'Bad,sawn,-5,16,2.5,6,16,16000,5500,0.8,negative Fb',   // Fb < 0
+      'BadEmin,sawn,24,16,2.5,6,16,16000,16000,0.8,Emin>=E',  // Emin ≥ E
+    ].join('\n')
+    const { materials, errors } = csvToMaterials(csv)
+    expect(materials).toHaveLength(1)
+    expect(materials[0].name).toBe('Good')
+    expect(errors).toHaveLength(2)
+  })
+  it('errors on a header missing required columns', () => {
+    const { materials, errors } = csvToMaterials('name,kind\nX,sawn')
+    expect(materials).toHaveLength(0)
+    expect(errors[0]).toMatch(/header must include/)
+  })
+})

--- a/webapp/src/lib/materialLibrary.ts
+++ b/webapp/src/lib/materialLibrary.ts
@@ -1,0 +1,107 @@
+// ─────────────────────────────────────────────────────────────────────────
+// User-defined timber material library — persistence + CSV interchange.
+//
+// A custom material is just a name + kind + WoodRefValues (the same struct the
+// analysis/design engine already consumes), so a user can define proprietary
+// glulam, engineered wood, or a locally tested species and it flows through the
+// solver unchanged.  Stored in localStorage; import/export as CSV so libraries
+// can be shared. The pure transforms (CSV ↔ materials, id, validation) are
+// separated from the storage I/O so they're testable without a browser.
+// ─────────────────────────────────────────────────────────────────────────
+import { validateWoodRef, type WoodKind, type WoodRefValues } from '../engine/woodDesign'
+
+export interface CustomMaterial {
+  id: string
+  name: string
+  kind: WoodKind
+  ref: WoodRefValues
+  note?: string
+}
+
+const STORAGE_KEY = 'wood-custom-materials'
+const FIELDS: (keyof WoodRefValues)[] = ['Fb', 'Ft', 'Fv', 'FcPerp', 'Fc', 'E', 'Emin', 'G']
+export const CSV_HEADER = ['name', 'kind', ...FIELDS, 'note']
+
+// ── Storage I/O (thin localStorage wrappers) ────────────────────────────────
+export function loadCustomMaterials(): CustomMaterial[] {
+  try {
+    const v = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]')
+    return Array.isArray(v) ? (v as CustomMaterial[]) : []
+  } catch { return [] }
+}
+export function saveCustomMaterials(list: CustomMaterial[]): void {
+  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(list)) } catch { /* quota — ignore */ }
+}
+
+// ── Pure helpers ────────────────────────────────────────────────────────────
+/** A stable, collision-free id derived from the material name. */
+export function slugId(name: string, existing: string[]): string {
+  const base = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'material'
+  let id = `custom-${base}`, i = 2
+  while (existing.includes(id)) id = `custom-${base}-${i++}`
+  return id
+}
+
+/** Insert or replace a material by id, returning a new list. */
+export function upsertMaterial(list: CustomMaterial[], m: CustomMaterial): CustomMaterial[] {
+  const i = list.findIndex((x) => x.id === m.id)
+  if (i < 0) return [...list, m]
+  const next = list.slice(); next[i] = m; return next
+}
+export function deleteMaterial(list: CustomMaterial[], id: string): CustomMaterial[] {
+  return list.filter((x) => x.id !== id)
+}
+
+const esc = (s: string) => (/[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s)
+
+/** Serialise materials to CSV (header + one row each). */
+export function materialsToCsv(list: CustomMaterial[]): string {
+  const rows = [CSV_HEADER.join(',')]
+  for (const m of list) rows.push([esc(m.name), m.kind, ...FIELDS.map((f) => String(m.ref[f])), esc(m.note ?? '')].join(','))
+  return rows.join('\n')
+}
+
+/** Split one CSV line into fields, honouring double-quoted values. */
+function parseLine(line: string): string[] {
+  const out: string[] = []
+  let cur = '', q = false
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i]
+    if (q) {
+      if (c === '"' && line[i + 1] === '"') { cur += '"'; i++ }
+      else if (c === '"') q = false
+      else cur += c
+    } else if (c === '"') q = true
+    else if (c === ',') { out.push(cur); cur = '' }
+    else cur += c
+  }
+  out.push(cur)
+  return out.map((s) => s.trim())
+}
+
+/** Parse a CSV back into materials, validating each row's engineering values.
+ *  Returns the accepted materials and a list of per-row errors. */
+export function csvToMaterials(text: string, existingIds: string[] = []): { materials: CustomMaterial[]; errors: string[] } {
+  const lines = text.split(/\r?\n/).filter((l) => l.trim().length > 0)
+  const errors: string[] = []
+  const materials: CustomMaterial[] = []
+  if (lines.length === 0) return { materials, errors: ['empty file'] }
+  const header = parseLine(lines[0]).map((h) => h.toLowerCase())
+  const col = (name: string) => header.indexOf(name.toLowerCase())
+  if (col('name') < 0 || FIELDS.some((f) => col(f) < 0)) {
+    return { materials, errors: [`header must include: ${CSV_HEADER.join(', ')}`] }
+  }
+  const ids = [...existingIds]
+  for (let r = 1; r < lines.length; r++) {
+    const cells = parseLine(lines[r])
+    const name = cells[col('name')] || `Material ${r}`
+    const kind: WoodKind = cells[col('kind')] === 'glulam' ? 'glulam' : 'sawn'
+    const ref = Object.fromEntries(FIELDS.map((f) => [f, Number(cells[col(f)])])) as unknown as WoodRefValues
+    const errs = validateWoodRef(ref)
+    if (errs.length) { errors.push(`row ${r} (${name}): ${errs.join('; ')}`); continue }
+    const id = slugId(name, ids); ids.push(id)
+    const noteIdx = col('note')
+    materials.push({ id, name, kind, ref, note: noteIdx >= 0 ? cells[noteIdx] || undefined : undefined })
+  }
+  return { materials, errors }
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -58,6 +58,8 @@ import { Num, Pick, Row } from '../components/qty'
 import { FitView } from '../components/FitView'
 import { shapeByName, shapesOf, effectiveSection, sectionBoundingBox, FAMILIES, type SectionFamily } from '../engine/aiscSections'
 import { WOOD_SPECIES, speciesList, gradesOf, resolveWoodSpecies, type WoodSpecies } from '../engine/woodDesign'
+import { MaterialLibrary } from '../components/MaterialLibrary'
+import { loadCustomMaterials, saveCustomMaterials, type CustomMaterial } from '../lib/materialLibrary'
 import { buildSectionShapes } from '../lib/sectionShapes3d'
 import { SectionShape } from '../components/SectionShape'
 import { f1, f2 } from '../lib/format'
@@ -843,7 +845,15 @@ export default function ModelSpace() {
   const [woodGrade, setWoodGrade] = useState(s('woodGrade', legacyWood?.grade ?? '2'))
   const [woodWet, setWoodWet] = useState(b('woodWet', false))
   const woodSel: WoodSpecies = resolveWoodSpecies(woodSpeciesId, woodGrade) ?? gradesOf(woodSpeciesId)[0] ?? WOOD_SPECIES['DFL-2']
-  const woodKind = woodSel.kind
+  // Timber material source: built-in library vs a user-defined custom material.
+  const [matSource, setMatSource] = useState<'library' | 'custom'>((s('matSource', 'library')) as 'library' | 'custom')
+  const [customId, setCustomId] = useState(s('customId', ''))
+  const [customMaterials, setCustomMaterials] = useState<CustomMaterial[]>(() => loadCustomMaterials())
+  const customAsSpecies = (cm: CustomMaterial): WoodSpecies =>
+    ({ id: cm.id, label: cm.name, kind: cm.kind, ref: cm.ref, species: cm.id, speciesLabel: cm.name, grade: 'custom', gradeLabel: 'Custom', origin: 'custom' })
+  const selectedCustom = customMaterials.find((m) => m.id === customId)
+  const activeWood: WoodSpecies = matSource === 'custom' && selectedCustom ? customAsSpecies(selectedCustom) : woodSel
+  const woodKind = activeWood.kind
   const [colFam, setColFam] = useState<SectionFamily>((s('colFam', 'W')) as SectionFamily)
   const [girFam, setGirFam] = useState<SectionFamily>((s('girFam', 'W')) as SectionFamily)
   const [beaFam, setBeaFam] = useState<SectionFamily>((s('beaFam', 'W')) as SectionFamily)
@@ -995,7 +1005,7 @@ export default function ModelSpace() {
         Vw, expo, Kzt, wDirs, assembly, pDelta, cracked, shearDef, tryBars,
         concreteClass, prices, planSel,
         material, colFam, girFam, beaFam, colShape, girShape, beaShape, steelFy, steelFu,
-        woodSpeciesId, woodGrade, woodWet,
+        woodSpeciesId, woodGrade, woodWet, matSource, customId,
       }))
     } catch { /* quota — ignore */ }
   }, [baysX, baysZ, storeyH, colB, colH, girB, girH, beaB, beaH,
@@ -1004,7 +1014,7 @@ export default function ModelSpace() {
     Vw, expo, Kzt, wDirs, assembly, pDelta, cracked, shearDef, tryBars,
     concreteClass, prices, planSel,
     material, colFam, girFam, beaFam, colShape, girShape, beaShape, steelFy, steelFu,
-    woodSpeciesId, woodGrade, woodWet])
+    woodSpeciesId, woodGrade, woodWet, matSource, customId])
 
   const save = (m: StructuralModel | null) => {
     setModel(m)
@@ -1517,7 +1527,7 @@ export default function ModelSpace() {
     // both the library id and the reference values travel with the section so
     // the bridge (E), pipeline (NDS §3 design) and take-off pick it up. Fresh
     // selection passed via woodOverride to avoid a same-tick stale-state read.
-    const wsel = woodOverride?.sel ?? woodSel
+    const wsel = woodOverride?.sel ?? activeWood
     const wet = woodOverride?.wet ?? woodWet
     const woodRole = (b: number, h: number, id: string): RectSection =>
       ({ id, name: `${b}×${h}`, b, h, ...mat, material: 'wood',
@@ -2387,15 +2397,30 @@ export default function ModelSpace() {
                 </Sec>
               ) : material === 'wood' ? (
                 <Sec title="Timber (wood frame)">
-                  <Pick label="Species" value={woodSpeciesId} onChange={(v) => {
-                    const g = gradesOf(v)[0]?.grade ?? '2'
-                    setWoodSpeciesId(v); setWoodGrade(g)
-                    if (model) generate('wood', { sel: resolveWoodSpecies(v, g) })
-                  }} options={speciesList().map((sp) => [sp.species, sp.label])} />
-                  <Pick label="Grade" value={woodGrade} onChange={(v) => {
-                    setWoodGrade(v)
-                    if (model) generate('wood', { sel: resolveWoodSpecies(woodSpeciesId, v) })
-                  }} options={gradesOf(woodSpeciesId).map((g) => [g.grade, g.gradeLabel])} />
+                  <Pick label="Material source" value={matSource} onChange={(v) => {
+                    const src = v as 'library' | 'custom'; setMatSource(src)
+                    if (model) generate('wood', { sel: src === 'custom' && selectedCustom ? customAsSpecies(selectedCustom) : woodSel })
+                  }} options={[['library', 'Built-in library'], ['custom', 'Custom material']]} />
+                  {matSource === 'library' ? (
+                    <>
+                      <Pick label="Species" value={woodSpeciesId} onChange={(v) => {
+                        const g = gradesOf(v)[0]?.grade ?? '2'
+                        setWoodSpeciesId(v); setWoodGrade(g)
+                        if (model) generate('wood', { sel: resolveWoodSpecies(v, g) })
+                      }} options={speciesList().map((sp) => [sp.species, sp.label])} />
+                      <Pick label="Grade" value={woodGrade} onChange={(v) => {
+                        setWoodGrade(v)
+                        if (model) generate('wood', { sel: resolveWoodSpecies(woodSpeciesId, v) })
+                      }} options={gradesOf(woodSpeciesId).map((g) => [g.grade, g.gradeLabel])} />
+                    </>
+                  ) : (
+                    <MaterialLibrary materials={customMaterials} selectedId={customId}
+                      onSelect={(id, cm) => {
+                        setCustomId(id)
+                        if (model) generate('wood', { sel: cm ? customAsSpecies(cm) : woodSel })
+                      }}
+                      onChange={(list) => { setCustomMaterials(list); saveCustomMaterials(list) }} />
+                  )}
                   <label className="col-span-full flex items-center gap-2 text-sm">
                     <input type="checkbox" checked={woodWet}
                       onChange={(e) => { setWoodWet(e.target.checked); if (model) generate('wood', { wet: e.target.checked }) }} />
@@ -2413,7 +2438,7 @@ export default function ModelSpace() {
                   <Num label="Beam d" unit="mm" value={beaH} onChange={setBeaH} />
                   <Num label="Slab thickness" unit="mm" value={slabThk} onChange={setSlabThk} />
                   <p className="col-span-full text-[11px] text-slate-500">
-                    Designed to NDS §3 / NSCP §6: reference values ({woodKind === 'glulam' ? 'glulam' : 'sawn'}, {woodSel.origin})
+                    Designed to NDS §3 / NSCP §6: reference values ({woodKind === 'glulam' ? 'glulam' : 'sawn'}, {activeWood.origin})
                     adjusted by C<sub>D</sub>/C<sub>M</sub>/C<sub>F</sub>/C<sub>V</sub>, beam stability C<sub>L</sub> and column
                     stability C<sub>P</sub>; factored demands checked LRFD (Appendix N, K<sub>F</sub>·φ·λ). Slabs/footings stay reinforced concrete.
                   </p>


### PR DESCRIPTION
## What & why

The standout feature from our material-model discussion, and the second half of the priority you picked: **engineers can define their own timber materials** — proprietary glulam, engineered wood, locally tested or NSCP/FPRDI species — and they flow through the solver unchanged. A custom material is just a name + kind + `WoodRefValues`, the exact struct the engine already consumes (PR [#384](https://github.com/BitLess246/civilEngineering/pull/384) laid the `woodRef`-on-section contract this builds on).

## `lib/materialLibrary.ts` (pure transforms + storage)
- `CustomMaterial` type; localStorage `load`/`save`; `upsert`/`delete`; `slugId`.
- **CSV export/import** (`materialsToCsv` / `csvToMaterials`) with quoted-field handling and **per-row validation** via `validateWoodRef` — a bad row is reported, not silently imported. I/O separated from the pure transforms so they're unit-tested without a browser.

## `components/MaterialLibrary.tsx`
- Select a custom material, or **New / Edit / Delete**; a **Seed-from-library** dropdown (copy an existing species' values as a starting point — your "Copy Existing"); **Import / Export CSV**.
- The editor **validates before Save** (positive stresses, `Emin < E`, `G ≤ 1.4`) and shows an *"unverified — you own the source/validity"* caveat, the safeguard I flagged in the analysis.

## `ModelSpace` Properties
A **Material-source** toggle (Built-in library vs Custom). The active material — library or custom — is written to generated sections as `woodRef`, so a custom material's values **travel with the model**. Also fixes a stale-closure bug by passing the resolved material into `onSelect` rather than re-looking-it-up from parent state (caught during in-browser verification).

## Tests & verification
- `materialLibrary.test.ts` — `slugId`, upsert/delete, **CSV round-trip** incl. comma-quoted names, and import validation (rejects bad rows + bad header).
- **In-browser, end-to-end:** created **"Yakal (80% grade)"** `{Fb 24.5, E 18000, G 0.9}` → persisted to localStorage → regenerated sections carry that `woodRef` (`woodSpecies: custom-yakal-80-grade`). Verified a fresh-tab load has **no console errors** (a transient warning seen earlier was an HMR-only deps-array artifact, absent on clean mount).

```
tsc -b     → clean
vitest run → 96 files, 1217 tests pass
```

## Follow-ups (from the discussion, when you're ready)
- **Philippine species data** once sourced from NSCP §6 / PWCM / FPRDI (structure is ready — they can be added to the built-in library or entered as custom materials today).
- **Bamboo** as its own material + round-hollow-section engine (ISO 22156).
- **Multi-code** design procedures (EC5 `kmod`/`γM`, AS 1720 `k`-factors) as sibling strategies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)