### PR TITLE
feat: timber in the 3D Model Space material take-off & bill of quantities

### DIFF
--- a/webapp/src/engine/takeoff.test.ts
+++ b/webapp/src/engine/takeoff.test.ts
@@ -186,3 +186,47 @@ describe('structural steel — per-shape unit weight + costed BOM line items (A2
     expect(beamRow.amount).toBeCloseTo(beamRow.qty * 120, 6)
   })
 })
+
+describe('timber (wood-frame) take-off', () => {
+  const woodSec = (id: string, name: string, b: number, h: number): RectSection =>
+    ({ id, name, b, h, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40, material: 'wood', woodSpecies: 'DFL-2', woodKind: 'sawn' })
+  const woodModel = (): StructuralModel => {
+    const m = generateGridModel({
+      baysX: [6], baysZ: [5], storeyH: [3],
+      column: woodSec('C', '400×400', 400, 400), girder: woodSec('G', '300×500', 300, 500),
+      beam: woodSec('B', '250×450', 250, 450), slabThickness: 200,
+    })
+    m.loads = buildGravityLoads(m, 4.8, 2.4)
+    return m
+  }
+  const design = designStructure(woodModel(), soil)!
+  const t = estimateTakeoff(woodModel(), design)
+
+  it('reports timber volume + board feet by section size, excluded from concrete', () => {
+    expect(t.timberM3).toBeGreaterThan(0)
+    expect(t.timberBoardFeet).toBeCloseTo(t.timberM3 * 423.776, 4)
+    expect(t.timberBySize.reduce((s, x) => s + x.m3, 0)).toBeCloseTo(t.timberM3, 6)
+    expect(t.timberBySize.every((x) => x.species === 'DFL-2' && x.kind === 'sawn' && x.count > 0)).toBe(true)
+    // the three role sizes appear
+    expect(t.timberBySize.map((x) => x.name).sort()).toEqual(['250×450', '300×500', '400×400'])
+    // wood not double-counted as concrete members (only the concrete slabs remain)
+    expect(t.byElement.filter((e) => e.kind === 'Beam' || e.kind === 'Column')).toHaveLength(0)
+  })
+
+  it('adds timber lines to the BOQ and prices them per board foot', () => {
+    expect(t.boq.some((r) => r.item.startsWith('Timber — ') && r.unit === 'm³')).toBe(true)
+    const bill = costBill(t, {
+      cementBag: 260, sandM3: 1500, gravelM3: 1600, steelKg: 65, tieWireRoll: 2500, plywoodSheet: 700, lumberM: 25, timberBdFt: 60,
+    })
+    const timberRows = bill.rows.filter((r) => r.item.startsWith('Timber — '))
+    expect(timberRows.length).toBe(t.timberBySize.length)
+    expect(timberRows.every((r) => r.unit === 'bd·ft' && r.unitPrice === 60 && r.priceKey === 'timberBdFt')).toBe(true)
+    const timberSubtotal = timberRows.reduce((s, r) => s + r.amount, 0)
+    expect(timberSubtotal).toBeCloseTo(t.timberBoardFeet * 60, 2)
+  })
+
+  it('defaults the timber rate to ₱55 / board foot', () => {
+    const bill = costBill(t, { cementBag: 260, sandM3: 1500, gravelM3: 1600, steelKg: 65, tieWireRoll: 2500, plywoodSheet: 700, lumberM: 25 })
+    expect(bill.rows.find((r) => r.item.startsWith('Timber — '))!.unitPrice).toBe(55)
+  })
+})

--- a/webapp/src/engine/takeoff.ts
+++ b/webapp/src/engine/takeoff.ts
@@ -69,6 +69,17 @@ export interface BoqRow { item: string; unit: string; qty: number }
 
 export interface SteelShapeQty { shape: string; kg: number; L: number; kgPerM: number }
 
+/** Timber members aggregated by section size × species (solid-rectangle b×h). */
+export interface TimberSizeQty {
+  name: string             // section name, e.g. '400×400'
+  species: string          // woodSpecies id/label
+  kind: string             // 'sawn' | 'glulam'
+  count: number            // number of members of this size
+  L: number                // total length, m
+  m3: number               // volume, m³
+  boardFeet: number        // 1 m³ = 423.776 bd·ft
+}
+
 export interface TakeoffResult {
   byElement: ElementQty[]
   cutList: CutItem[]
@@ -83,13 +94,20 @@ export interface TakeoffResult {
   slabSteelDDM: boolean                   // slab steel from the DDM strip layout
   structuralSteelKg: number               // W-shape structural steel, net kg
   steelByShape: SteelShapeQty[]           // per W-shape breakdown
+  timberM3: number                        // timber (wood-frame) volume, m³
+  timberBoardFeet: number                 // = timberM3 × 423.776
+  timberBySize: TimberSizeQty[]           // per section-size × species breakdown
 }
+
+/** Board feet per cubic metre (1 bd·ft = 1/12 ft³). */
+export const BDFT_PER_M3 = 423.776
 
 // ── Pricing — turn the take-off into a costed Bill of Materials ──
 export interface PriceList {
   cementBag: number; sandM3: number; gravelM3: number; steelKg: number
   tieWireRoll: number; plywoodSheet: number; lumberM: number
   structuralSteelKg?: number              // W-shape sections, default ₱120/kg
+  timberBdFt?: number                     // structural timber, default ₱55 / board foot
 }
 export interface BillRow {
   item: string; qty: number; unit: string; unitPrice: number; amount: number
@@ -116,6 +134,10 @@ export function costBill(t: TakeoffResult, p: PriceList): CostedBill {
   const steelRate = p.structuralSteelKg ?? 120
   for (const s of [...t.steelByShape].sort((a, b) => a.shape.localeCompare(b.shape)))
     rows.push(row(`Structural steel — ${s.shape}`, s.kg, 'kg', steelRate, 'structuralSteelKg'))
+  // Timber — one costed line per section size, priced per board foot (PH commercial unit).
+  const timberRate = p.timberBdFt ?? 55
+  for (const t2 of [...t.timberBySize].sort((a, b) => a.name.localeCompare(b.name)))
+    rows.push(row(`Timber — ${t2.name} (${t2.species})`, t2.boardFeet, 'bd·ft', timberRate, 'timberBdFt'))
   return { rows, total: rows.reduce((s, r) => s + r.amount, 0) }
 }
 
@@ -335,6 +357,25 @@ export function estimateTakeoff(
     shapeMap.set(sec.shape, { kg: prev.kg + kg, L: prev.L + L, kgPerM: wKgM })
     boq.push({ item: `Structural steel — ${sec.shape}`, unit: 'm', qty: L })
   }
+
+  // ── Timber members (wood frame): volume + board feet by section size × species ──
+  const timberMap = new Map<string, TimberSizeQty>()
+  let timberM3 = 0
+  for (const mem of model.members) {
+    const sec = secById.get(memSecId.get(mem.id) ?? '')
+    if (sec?.material !== 'wood') continue
+    const ni = nodeXYZ.get(mem.i), nj = nodeXYZ.get(mem.j); if (!ni || !nj) continue
+    const L = Math.hypot(nj.x - ni.x, nj.y - ni.y, nj.z - ni.z)
+    const vol = (sec.b / 1000) * (sec.h / 1000) * L
+    timberM3 += vol
+    const species = sec.woodSpecies ?? '—', kind = sec.woodKind ?? 'sawn'
+    const key = `${sec.name}|${species}|${kind}`
+    const prev = timberMap.get(key) ?? { name: sec.name, species, kind, count: 0, L: 0, m3: 0, boardFeet: 0 }
+    timberMap.set(key, { ...prev, count: prev.count + 1, L: prev.L + L, m3: prev.m3 + vol, boardFeet: prev.boardFeet + vol * BDFT_PER_M3 })
+  }
+  const timberBySize = [...timberMap.values()]
+  const timberBoardFeet = timberM3 * BDFT_PER_M3
+  for (const t of timberBySize) boq.push({ item: `Timber — ${t.name} (${t.species})`, unit: 'm³', qty: t.m3 })
   // consolidate duplicate BOQ shape entries
   const shapeBoq = new Map<string, number>()
   for (const r of boq.filter((r) => r.item.startsWith('Structural steel — '))) {
@@ -350,5 +391,6 @@ export function estimateTakeoff(
     totalSteelNetKg, totalSteelPurchasedKg, totalConcreteM3, boq: boqFinal, slabSteelDDM,
     structuralSteelKg,
     steelByShape: [...shapeMap.entries()].map(([shape, v]) => ({ shape, ...v })),
+    timberM3, timberBoardFeet, timberBySize,
   }
 }

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -62,7 +62,7 @@ import { MaterialLibrary } from '../components/MaterialLibrary'
 import { loadCustomMaterials, saveCustomMaterials, type CustomMaterial } from '../lib/materialLibrary'
 import { buildSectionShapes } from '../lib/sectionShapes3d'
 import { SectionShape } from '../components/SectionShape'
-import { f1, f2 } from '../lib/format'
+import { f0, f1, f2 } from '../lib/format'
 
 const AUTOSAVE_KEY = 'model-space-autosave'
 const INPUTS_KEY = 'model-space-inputs'
@@ -960,7 +960,7 @@ export default function ModelSpace() {
   const [ioMenu, setIoMenu] = useState(false)                     // Import/Export dropdown
   const [concreteClass, setConcreteClass] = useState<ConcreteClass>((si.concreteClass as ConcreteClass) ?? 'A')   // mix class for the take-off
   const [prices, setPrices] = useState<PriceList>((si.prices as PriceList) ?? {   // unit prices for the costed bill (PHP)
-    cementBag: 260, sandM3: 1500, gravelM3: 1600, steelKg: 65, tieWireRoll: 2500, plywoodSheet: 700, lumberM: 25, structuralSteelKg: 120,
+    cementBag: 260, sandM3: 1500, gravelM3: 1600, steelKg: 65, tieWireRoll: 2500, plywoodSheet: 700, lumberM: 25, structuralSteelKg: 120, timberBdFt: 55,
   })
   const [sdlDraft, setSdlDraft] = useState<SdlItem[]>([])          // NSCP-204 SDL composition being built
   const [sdlMatId, setSdlMatId] = useState(TABLE_204_2[0].id)      // 204-2 material add-row
@@ -4788,6 +4788,8 @@ export default function ModelSpace() {
               takeoff.totalSteelPurchasedKg > 0 && ['Rebar (bought)', `${f1(takeoff.totalSteelPurchasedKg)} kg`],
               takeoff.tieWire.rolls > 0 && ['Tie wire', `${takeoff.tieWire.rolls} roll${takeoff.tieWire.rolls === 1 ? '' : 's'}`],
               takeoff.structuralSteelKg > 0 && ['Structural steel', `${(takeoff.structuralSteelKg / 1000).toFixed(2)} t`],
+              takeoff.timberM3 > 0 && ['Timber', `${f2(takeoff.timberM3)} m³`],
+              takeoff.timberM3 > 0 && ['Timber (bd·ft)', `${f0(takeoff.timberBoardFeet)}`],
             ].filter(Boolean as unknown as (v: unknown) => v is [string, string]).map(([k, v]) => (
               <div key={k} className="rounded-lg border border-slate-200 bg-white p-2 text-center shadow-sm">
                 <div className="text-[11px] uppercase tracking-wide text-slate-500">{k}</div>
@@ -4844,7 +4846,7 @@ export default function ModelSpace() {
               </table>
               <p className="mt-1 text-[11px] text-slate-500">
                 Edit the unit prices to your local rates (PHP). Steel priced on the purchased (6 m-bar) weight incl. lap/waste;
-                concrete via cement/sand/gravel. Labour, hauling and contingencies not included.
+                concrete via cement/sand/gravel; timber per board foot. Labour, hauling and contingencies not included.
               </p>
             </div>
           )}
@@ -4944,6 +4946,47 @@ export default function ModelSpace() {
                 </tbody>
               </table>
               <p className="mt-1 text-[11px] text-slate-500">Net mass: ρ = 7 850 kg/m³ · A (mm²) × L (m). Connections, base plates and field splices not included.</p>
+            </div>
+          )}
+
+          {/* Timber by section size — only when a wood frame is present */}
+          {takeoff.timberM3 > 0 && (
+            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Timber by size</h3>
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="text-left uppercase tracking-wide text-slate-500">
+                    <th className="py-1 pr-2 font-semibold">Size (mm)</th>
+                    <th className="py-1 pr-2 font-semibold">Species</th>
+                    <th className="py-1 pr-2 font-semibold">Kind</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Pcs</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Length (m)</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Volume (m³)</th>
+                    <th className="py-1 text-right font-semibold">Board feet</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {[...takeoff.timberBySize].sort((a, b) => a.name.localeCompare(b.name)).map((s) => (
+                    <tr key={`${s.name}-${s.species}-${s.kind}`} className="border-t border-slate-100">
+                      <td className="py-0.5 pr-2 font-medium">{s.name}</td>
+                      <td className="py-0.5 pr-2" title={WOOD_SPECIES[s.species]?.label ?? s.species}>{s.species}</td>
+                      <td className="py-0.5 pr-2">{s.kind}</td>
+                      <td className="py-0.5 pr-2 text-right">{s.count}</td>
+                      <td className="py-0.5 pr-2 text-right">{f1(s.L)}</td>
+                      <td className="py-0.5 pr-2 text-right">{f2(s.m3)}</td>
+                      <td className="py-0.5 text-right">{f0(s.boardFeet)}</td>
+                    </tr>
+                  ))}
+                  <tr className="border-t border-slate-200 font-semibold">
+                    <td className="py-1 pr-2">Total</td>
+                    <td className="py-1 pr-2" colSpan={3} />
+                    <td className="py-1 pr-2 text-right">{f1(takeoff.timberBySize.reduce((s, r) => s + r.L, 0))}</td>
+                    <td className="py-1 pr-2 text-right">{f2(takeoff.timberM3)}</td>
+                    <td className="py-1 text-right">{f0(takeoff.timberBoardFeet)}</td>
+                  </tr>
+                </tbody>
+              </table>
+              <p className="mt-1 text-[11px] text-slate-500">Solid-rectangle volume b×h×L; board feet = m³ × 423.776 (1 bd·ft = 1/12 ft³). Priced per board foot in the Bill of Materials. Connections and wastage/off-cuts not included.</p>
             </div>
           )}
 


### PR DESCRIPTION
## What & why

Wood-frame members were designed and shown in the timber schedules, but they never reached the **Material Take-off / Bill of Quantities** — the take-off's concrete BOM naturally skips them (they live in the timber schedules, not `design.beams`/`columns`). This adds **timber as a first-class take-off material**, mirroring how structural steel is aggregated separately from the concrete `byElement` list.

## `engine/takeoff.ts`
- `estimateTakeoff` aggregates wood members **by section size × species** → `TimberSizeQty` (count, length, volume m³, board feet), plus totals `timberM3` / `timberBoardFeet`. Board feet = m³ × 423.776 (1 bd·ft = 1/12 ft³).
- **BOQ** gains a per-size timber line (m³).
- **`costBill`** gains a per-size timber line priced **per board foot** (`PriceList.timberBdFt`, default ₱55) — the PH commercial lumber unit, editable in the Bill of Materials.

## Take-off UI (`ModelSpace`)
- Summary metrics add **Timber (m³)** and **Timber (board feet)**.
- New **"Timber by size"** table (size · species · kind · pcs · length · volume · board feet), shown only when a wood frame is present — mirrors "Structural steel by shape".
- The **BOQ** and **priced Bill of Materials** pick up the timber lines automatically; the timber rate is editable like the other prices.

## Tests & verification
- `takeoff.test.ts` — a wood-frame take-off asserts volume/board-feet by size, **exclusion from the concrete totals**, BOQ lines, and board-foot pricing (default ₱55).
- **In-browser on the attached 74-member wood model:** Timber **24.75 m³ / 10,488 bd·ft**, broken down 250×450 / 300×500 / 400×400 (DFL-2), priced into the Bill of Materials (**grand total ₱744,743**). Fresh-tab load has **no console errors**.

```
tsc -b     → clean
vitest run → 96 files, 1220 tests pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)