### PR TITLE
feat: project scheduling — CPM + PERT engine core (Phase 1)

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -1,0 +1,116 @@
+# Project Scheduling module — PERT / CPM & progress tracking
+
+A Primavera/MS-Project-style planning module for the civil-engineering webapp:
+Work-Breakdown-Structure, activities with FS/FF/SS/SF dependencies, Critical
+Path Method, PERT probabilistic analysis, progress tracking, earned value,
+resource loading, Gantt / network diagrams, and reports.
+
+## Architecture note — this is a client-side module
+
+The original brief specified Next.js + Prisma + PostgreSQL + API routes. **This
+repository has none of those.** It is a **Vite + React 19 + TypeScript**
+single-page app; every calculator is a *pure, typed engine module* under
+`webapp/src/engine/` with a matching `*.test.ts`, rendered by a page under
+`webapp/src/pages/`, and persisted in the browser (localStorage / file
+import-export). The scheduling module follows the same architecture rather than
+introducing a backend:
+
+| Brief asked for        | Delivered here (existing stack)                          |
+|------------------------|----------------------------------------------------------|
+| Prisma / PostgreSQL    | JSON-serialisable `ScheduleProject`, localStorage + import/export |
+| Next.js API routes     | Pure in-browser engine functions (no network round-trip) |
+| Server scheduling job  | Synchronous engines (fast; can move to a worker if needed) |
+| PDF / Excel export     | `jspdf` + `jspdf-autotable` / `exceljs` (already deps)    |
+
+This keeps the module consistent with the other 30+ tools, deployable as static
+files, and offline-capable — the same reasons the structural engines are pure.
+
+## Engine layers
+
+```
+webapp/src/engine/schedule/
+  model.ts        # types: Activity, Dependency, WbsNode, WorkingCalendar,
+                  #        Resource, Baseline, ScheduleProject (all JSON-safe)
+  calendar.ts     # working-day date arithmetic (workweek + holidays)
+  cpm.ts          # Critical Path Method: topo-order, forward/backward, floats
+  pert.ts         # PERT: TE/variance + normal-approx completion probability
+  *.test.ts       # hand-calc-verified vitest coverage for each engine
+```
+
+Everything the engines produce is on an **abstract working-day axis** (offset 0 =
+project start). `calendar.ts` projects those offsets onto real dates, skipping
+non-working weekdays and holidays. Separating the numeric solve from calendar
+mapping keeps CPM exactly testable against textbook hand calculations.
+
+## CPM algorithm (`cpm.ts`)
+
+Activity-on-node network. For a predecessor **P** and successor **Q** with lag
+**L** (working units; negative = lead), the four relations impose:
+
+| Relation | Forward-pass lower bound        | Backward-pass upper bound        |
+|----------|---------------------------------|----------------------------------|
+| FS       | `ES(Q) ≥ EF(P) + L`             | `LF(P) ≤ LS(Q) − L`              |
+| SS       | `ES(Q) ≥ ES(P) + L`             | `LS(P) ≤ LS(Q) − L`              |
+| FF       | `EF(Q) ≥ EF(P) + L`             | `LF(P) ≤ LF(Q) − L`              |
+| SF       | `EF(Q) ≥ ES(P) + L`             | `LS(P) ≤ LF(Q) − L`              |
+
+1. **Topological order** — Kahn's algorithm; a cycle raises `ScheduleCycleError`
+   (with the offending loop, from a DFS back-edge trace). `wouldCreateCycle()`
+   lets the UI reject an illegal link *before* it is committed.
+2. **Forward pass** (topo order) → `ES`, `EF = ES + duration`. Early start is
+   floored at the project start (a lead cannot precede day 0). Project duration =
+   `max EF`.
+3. **Backward pass** (reverse topo order) → `LF`, `LS = LF − duration`,
+   initialised to the project finish (computed `max EF`, or an imposed target).
+4. **Floats** — Total `TF = LS − ES = LF − EF`; Free float from the minimum
+   successor gap (early-date based, so independent of the imposed finish).
+5. **Critical path** — activities with `TF ≤ ε`. An imposed finish tighter than
+   the computed duration drives floats negative (an accelerated / infeasible
+   target) rather than hiding the conflict.
+
+Milestones are simply zero-duration activities (`EF = ES`).
+
+## PERT algorithm (`pert.ts`)
+
+Per activity, from the three-point estimate (Optimistic, Most-likely,
+Pessimistic):
+
+```
+TE = (O + 4M + P) / 6          σ² = ((P − O) / 6)²          σ = (P − O) / 6
+```
+
+The network is scheduled with each `TE` as its CPM duration. Project expected
+duration = the resulting critical-path length; project variance = Σσ² of the
+activities on the critical path; `σ = √Σσ²`. Completion probability for a target
+`T` uses the normal approximation `P[finish ≤ T] = Φ((T − TE)/σ)` with a
+high-accuracy `erf` (A&S 7.1.26) and inverse `Φ⁻¹` (Acklam) so we can also
+answer "what date carries 90 % confidence?" (`durationForProbability`).
+
+## Roadmap (one PR per phase)
+
+- **Phase 1 — engine core** *(this PR)*: model, calendar, CPM, PERT + 50 tests.
+- **Phase 2 — progress & earned value**: %-complete roll-up, status derivation,
+  PV/EV/AC → SPI/CPI/SV/CV/BAC/EAC/VAC, baseline capture + variance.
+- **Phase 3 — persistence**: `ScheduleProject` store (localStorage, schema
+  version), JSON import/export, sample projects.
+- **Phase 4 — WBS + activity grid UI**: add/edit/delete/reorder/collapse, live
+  CPM recompute, dependency editor with cycle prevention.
+- **Phase 5 — Gantt chart**: baseline/actual/forecast bars, critical highlight,
+  zoom (day→year), milestones, dependency arrows.
+- **Phase 6 — AON network diagram**: draggable nodes, critical-path styling.
+- **Phase 7 — dashboard**: progress vs plan, SPI/CPI, variance, EAC, EVM charts.
+- **Phase 8 — resource loading**: labor/equipment/material, over-allocation.
+- **Phase 9 — reports**: schedule / critical-path / EVM / progress / resource →
+  PDF, Excel, CSV.
+- **Phase 10 — daily-report integration & delay analysis** + user docs.
+
+## Known limitations / future extensions
+
+- CPM solves in whole working days on one project calendar; per-activity
+  calendars and hour-granular durations map through `hoursPerDay` in a later
+  phase. Lags are measured in working units, not calendar-spanning.
+- PERT project variance is summed over the flagged critical path — exact for a
+  single dominant chain, conservative when parallel critical chains exist (a
+  full probabilistic path merge is a future refinement).
+- Activity date/imposed constraints (SNET/FNLT/MSO) are modelled at the project
+  level (imposed finish) for now; per-activity constraints come with the UI.

--- a/webapp/src/engine/schedule/calendar.test.ts
+++ b/webapp/src/engine/schedule/calendar.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+import type { WorkingCalendar } from './model'
+import {
+  MON_FRI, MON_SAT, parseISO, toISO, addDays, calendarDaysBetween,
+  isWorkingDay, nextWorkingDay, prevWorkingDay, addWorkingDays,
+  workingDaysBetween, offsetToDate, durationEndDate, defaultCalendar,
+} from './calendar'
+
+// 2026-01-01 is a Thursday; 01-03 Sat, 01-04 Sun, 01-05 Mon, 01-06 Tue.
+const cal: WorkingCalendar = { id: 'c', name: 'Std', workweek: [...MON_FRI], holidays: [] }
+
+describe('date primitives', () => {
+  it('parses / formats ISO at UTC midnight (round-trip)', () => {
+    const d = parseISO('2026-01-01')
+    expect(d.getUTCFullYear()).toBe(2026)
+    expect(d.getUTCDay()).toBe(4)                 // Thursday
+    expect(toISO(d)).toBe('2026-01-01')
+  })
+  it('addDays and calendarDaysBetween are inverse', () => {
+    const a = parseISO('2026-01-01')
+    expect(toISO(addDays(a, 7))).toBe('2026-01-08')
+    expect(calendarDaysBetween(a, parseISO('2026-01-08'))).toBe(7)
+    expect(calendarDaysBetween(parseISO('2026-01-08'), a)).toBe(-7)
+  })
+})
+
+describe('isWorkingDay', () => {
+  it('honours the Mon–Fri workweek', () => {
+    expect(isWorkingDay(cal, parseISO('2026-01-02'))).toBe(true)   // Fri
+    expect(isWorkingDay(cal, parseISO('2026-01-03'))).toBe(false)  // Sat
+    expect(isWorkingDay(cal, parseISO('2026-01-04'))).toBe(false)  // Sun
+  })
+  it('excludes holidays', () => {
+    const h: WorkingCalendar = { ...cal, holidays: ['2026-01-05'] }
+    expect(isWorkingDay(h, parseISO('2026-01-05'))).toBe(false)    // Mon holiday
+  })
+})
+
+describe('next / prev working day', () => {
+  it('nextWorkingDay skips the weekend', () => {
+    expect(toISO(nextWorkingDay(cal, parseISO('2026-01-03')))).toBe('2026-01-05') // Sat→Mon
+    expect(toISO(nextWorkingDay(cal, parseISO('2026-01-02')))).toBe('2026-01-02') // Fri→Fri
+  })
+  it('nextWorkingDay skips a holiday too', () => {
+    const h: WorkingCalendar = { ...cal, holidays: ['2026-01-05'] }
+    expect(toISO(nextWorkingDay(h, parseISO('2026-01-03')))).toBe('2026-01-06') // Sat/Sun/Mon-holiday → Tue
+  })
+  it('prevWorkingDay walks backward past the weekend', () => {
+    expect(toISO(prevWorkingDay(cal, parseISO('2026-01-04')))).toBe('2026-01-02') // Sun→Fri
+  })
+})
+
+describe('addWorkingDays', () => {
+  it('day-0 is the (snapped) start day itself', () => {
+    expect(toISO(addWorkingDays(cal, parseISO('2026-01-02'), 0))).toBe('2026-01-02') // Fri
+    expect(toISO(addWorkingDays(cal, parseISO('2026-01-03'), 0))).toBe('2026-01-05') // Sat snaps to Mon
+  })
+  it('steps across the weekend', () => {
+    // Thu(01) +3 working days → Fri(02), Mon(05), Tue(06)
+    expect(toISO(addWorkingDays(cal, parseISO('2026-01-01'), 3))).toBe('2026-01-06')
+    // Fri(02) +1 → Mon(05)
+    expect(toISO(addWorkingDays(cal, parseISO('2026-01-02'), 1))).toBe('2026-01-05')
+  })
+  it('a Mon–Sat calendar counts Saturday', () => {
+    const six: WorkingCalendar = { ...cal, workweek: [...MON_SAT] }
+    // Fri(02) +1 → Sat(03) because Saturday is worked
+    expect(toISO(addWorkingDays(six, parseISO('2026-01-02'), 1))).toBe('2026-01-03')
+  })
+  it('rejects a negative count', () => {
+    expect(() => addWorkingDays(cal, parseISO('2026-01-01'), -1)).toThrow()
+  })
+})
+
+describe('workingDaysBetween', () => {
+  it('counts working days in [from, to)', () => {
+    // 01Thu,02Fri,(03,04 weekend),05Mon,06Tue,07Wed → 5 working days before the 8th
+    expect(workingDaysBetween(cal, parseISO('2026-01-01'), parseISO('2026-01-08'))).toBe(5)
+  })
+  it('is zero for an empty / reversed interval', () => {
+    expect(workingDaysBetween(cal, parseISO('2026-01-08'), parseISO('2026-01-01'))).toBe(0)
+    expect(workingDaysBetween(cal, parseISO('2026-01-01'), parseISO('2026-01-01'))).toBe(0)
+  })
+})
+
+describe('offset → date projection', () => {
+  it('offset 0 is the first working day on/after project start', () => {
+    expect(toISO(offsetToDate(cal, parseISO('2026-01-03'), 0))).toBe('2026-01-05') // Sat start → Mon
+    expect(toISO(offsetToDate(cal, parseISO('2026-01-01'), 2))).toBe('2026-01-05') // Thu +2 → Mon
+  })
+  it('durationEndDate is the inclusive last working day', () => {
+    // start Thu(01), 3 working days → Thu, Fri, Mon → ends 01-05
+    expect(toISO(durationEndDate(cal, parseISO('2026-01-01'), 3))).toBe('2026-01-05')
+  })
+  it('a milestone (duration 0) resolves to its snapped day', () => {
+    expect(toISO(durationEndDate(cal, parseISO('2026-01-03'), 0))).toBe('2026-01-05')
+  })
+})
+
+describe('guards', () => {
+  it('defaultCalendar is Mon–Fri with 8h days', () => {
+    const d = defaultCalendar()
+    expect(d.workweek).toEqual(MON_FRI)
+    expect(d.hoursPerDay).toBe(8)
+  })
+  it('throws on a calendar with no working weekdays', () => {
+    const dead: WorkingCalendar = { id: 'x', name: 'None', workweek: [false, false, false, false, false, false, false], holidays: [] }
+    expect(() => nextWorkingDay(dead, parseISO('2026-01-01'))).toThrow()
+  })
+})

--- a/webapp/src/engine/schedule/calendar.ts
+++ b/webapp/src/engine/schedule/calendar.ts
@@ -1,0 +1,130 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Working-calendar date arithmetic for the scheduling engine.
+//
+// The CPM engine solves on an abstract working-day axis (offset 0 = the project
+// start). This module projects those integer offsets onto real calendar dates,
+// skipping non-working weekdays and holidays, and reports working days between
+// two dates (used by progress / earned-value math).
+//
+// All dates are handled at UTC midnight to stay free of timezone / DST drift;
+// a date is a pure calendar day. ISO strings are 'YYYY-MM-DD'.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { WorkingCalendar } from './model'
+
+/** Sun…Sat working flags for a Monday–Friday week. */
+export const MON_FRI: boolean[] = [false, true, true, true, true, true, false]
+/** Sun…Sat working flags for a Monday–Saturday week (common on site). */
+export const MON_SAT: boolean[] = [false, true, true, true, true, true, true]
+
+const MS_PER_DAY = 86_400_000
+/** Guard against an all-non-working calendar spinning forever. */
+const MAX_SCAN_DAYS = 366 * 20
+
+/** Parse an ISO 'YYYY-MM-DD' date to a UTC-midnight Date. */
+export function parseISO(iso: string): Date {
+  const [y, m, d] = iso.split('-').map(Number)
+  return new Date(Date.UTC(y, (m ?? 1) - 1, d ?? 1))
+}
+
+/** Format a UTC Date as ISO 'YYYY-MM-DD'. */
+export function toISO(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+/** A new Date `n` calendar days after `date` (n may be negative). */
+export function addDays(date: Date, n: number): Date {
+  return new Date(date.getTime() + n * MS_PER_DAY)
+}
+
+/** Whole calendar days from `from` to `to` (`to − from`), sign-preserving. */
+export function calendarDaysBetween(from: Date, to: Date): number {
+  return Math.round((to.getTime() - from.getTime()) / MS_PER_DAY)
+}
+
+/** True when `date` is a worked weekday and not a holiday on `cal`. */
+export function isWorkingDay(cal: WorkingCalendar, date: Date): boolean {
+  if (!cal.workweek[date.getUTCDay()]) return false
+  return !cal.holidays.includes(toISO(date))
+}
+
+function ensureWorkable(cal: WorkingCalendar): void {
+  if (!cal.workweek.some(Boolean)) {
+    throw new Error(`Calendar "${cal.name}" has no working weekdays.`)
+  }
+}
+
+/** The first working day on or after `date`. */
+export function nextWorkingDay(cal: WorkingCalendar, date: Date): Date {
+  ensureWorkable(cal)
+  let d = date
+  for (let i = 0; i < MAX_SCAN_DAYS; i++) {
+    if (isWorkingDay(cal, d)) return d
+    d = addDays(d, 1)
+  }
+  throw new Error(`Calendar "${cal.name}": no working day within ${MAX_SCAN_DAYS} days.`)
+}
+
+/** The first working day on or before `date`. */
+export function prevWorkingDay(cal: WorkingCalendar, date: Date): Date {
+  ensureWorkable(cal)
+  let d = date
+  for (let i = 0; i < MAX_SCAN_DAYS; i++) {
+    if (isWorkingDay(cal, d)) return d
+    d = addDays(d, -1)
+  }
+  throw new Error(`Calendar "${cal.name}": no working day within ${MAX_SCAN_DAYS} days.`)
+}
+
+/**
+ * The date `n` working days after `start`. `start` is first snapped forward to a
+ * working day, which counts as working-day 0; so `addWorkingDays(cal, w, 0)`
+ * returns `w` when `w` is a working day, and each unit steps to the next
+ * working day. `n` must be ≥ 0.
+ */
+export function addWorkingDays(cal: WorkingCalendar, start: Date, n: number): Date {
+  if (n < 0) throw new Error('addWorkingDays: n must be ≥ 0')
+  let d = nextWorkingDay(cal, start)
+  let remaining = Math.round(n)
+  while (remaining > 0) {
+    d = nextWorkingDay(cal, addDays(d, 1))
+    remaining--
+  }
+  return d
+}
+
+/** Count of working days in the half-open interval [from, to). Zero when to ≤ from. */
+export function workingDaysBetween(cal: WorkingCalendar, from: Date, to: Date): number {
+  if (to.getTime() <= from.getTime()) return 0
+  let count = 0
+  let d = from
+  for (let i = 0; i < MAX_SCAN_DAYS && d.getTime() < to.getTime(); i++) {
+    if (isWorkingDay(cal, d)) count++
+    d = addDays(d, 1)
+  }
+  return count
+}
+
+/**
+ * Map a CPM working-day `offset` (0 = project start) to a calendar date on
+ * `cal`. Offset 0 resolves to the first working day on or after `projectStart`.
+ */
+export function offsetToDate(cal: WorkingCalendar, projectStart: Date, offset: number): Date {
+  return addWorkingDays(cal, projectStart, Math.max(0, offset))
+}
+
+/**
+ * The inclusive last working day of an activity that starts on `startDate` and
+ * spans `duration` working days. A milestone (duration ≤ 0) returns the snapped
+ * start day itself.
+ */
+export function durationEndDate(cal: WorkingCalendar, startDate: Date, duration: number): Date {
+  const start = nextWorkingDay(cal, startDate)
+  if (duration <= 0) return start
+  return addWorkingDays(cal, start, Math.round(duration) - 1)
+}
+
+/** A default Mon–Fri calendar with no holidays. */
+export function defaultCalendar(id = 'default', name = 'Standard (Mon–Fri)'): WorkingCalendar {
+  return { id, name, workweek: [...MON_FRI], holidays: [], hoursPerDay: 8 }
+}

--- a/webapp/src/engine/schedule/cpm.test.ts
+++ b/webapp/src/engine/schedule/cpm.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest'
+import type { Dependency } from './model'
+import {
+  computeCPM, topoOrder, findCycle, wouldCreateCycle, ScheduleCycleError,
+  type CpmActivityInput,
+} from './cpm'
+
+const dep = (predecessor: string, type: Dependency['type'] = 'FS', lag = 0): Dependency =>
+  ({ predecessor, type, lag })
+
+// Classic AON network (all FS, lag 0). Hand-computed answers below.
+//   A(3) → B(4) → D(5) → F(4)          critical chain
+//   A(3) → C(2) → {D, E(6)} → F(4)
+const NETWORK: CpmActivityInput[] = [
+  { id: 'A', duration: 3, predecessors: [] },
+  { id: 'B', duration: 4, predecessors: [dep('A')] },
+  { id: 'C', duration: 2, predecessors: [dep('A')] },
+  { id: 'D', duration: 5, predecessors: [dep('B'), dep('C')] },
+  { id: 'E', duration: 6, predecessors: [dep('C')] },
+  { id: 'F', duration: 4, predecessors: [dep('D'), dep('E')] },
+]
+
+describe('topological order', () => {
+  it('places every predecessor before its successors', () => {
+    const order = topoOrder(NETWORK)
+    const pos = new Map(order.map((id, i) => [id, i]))
+    for (const a of NETWORK)
+      for (const d of a.predecessors ?? [])
+        expect(pos.get(d.predecessor)!).toBeLessThan(pos.get(a.id)!)
+  })
+})
+
+describe('CPM forward / backward pass (textbook AON)', () => {
+  const r = computeCPM(NETWORK)
+  const get = (id: string) => r.activities.get(id)!
+
+  it('project duration is the longest path (A→B→D→F = 16)', () => {
+    expect(r.duration).toBe(16)
+    expect(r.finish).toBe(16)
+  })
+  it('early start / finish match the hand calc', () => {
+    expect([get('A').es, get('A').ef]).toEqual([0, 3])
+    expect([get('B').es, get('B').ef]).toEqual([3, 7])
+    expect([get('C').es, get('C').ef]).toEqual([3, 5])
+    expect([get('D').es, get('D').ef]).toEqual([7, 12])
+    expect([get('E').es, get('E').ef]).toEqual([5, 11])
+    expect([get('F').es, get('F').ef]).toEqual([12, 16])
+  })
+  it('late start / finish match the hand calc', () => {
+    expect([get('A').ls, get('A').lf]).toEqual([0, 3])
+    expect([get('B').ls, get('B').lf]).toEqual([3, 7])
+    expect([get('C').ls, get('C').lf]).toEqual([4, 6])
+    expect([get('D').ls, get('D').lf]).toEqual([7, 12])
+    expect([get('E').ls, get('E').lf]).toEqual([6, 12])
+    expect([get('F').ls, get('F').lf]).toEqual([12, 16])
+  })
+  it('total float and critical flags', () => {
+    expect(get('A').totalFloat).toBe(0)
+    expect(get('B').totalFloat).toBe(0)
+    expect(get('C').totalFloat).toBe(1)
+    expect(get('D').totalFloat).toBe(0)
+    expect(get('E').totalFloat).toBe(1)
+    expect(get('F').totalFloat).toBe(0)
+    expect(r.criticalPath).toEqual(['A', 'B', 'D', 'F'])
+  })
+  it('free float (E can slip 1 without moving F)', () => {
+    expect(get('A').freeFloat).toBe(0)
+    expect(get('C').freeFloat).toBe(0)   // limited by E starting at 5
+    expect(get('E').freeFloat).toBe(1)
+    expect(get('F').freeFloat).toBe(0)
+  })
+  it('the critical path length equals the project duration', () => {
+    const len = r.criticalPath.reduce((s, id) => s + get(id).duration, 0)
+    expect(len).toBe(r.duration)
+  })
+})
+
+describe('lead / lag and relation types', () => {
+  it('FS with a positive lag delays the successor', () => {
+    const r = computeCPM([
+      { id: 'A', duration: 5, predecessors: [] },
+      { id: 'B', duration: 3, predecessors: [dep('A', 'FS', 2)] },
+    ])
+    expect([r.activities.get('B')!.es, r.activities.get('B')!.ef]).toEqual([7, 10])
+    expect(r.duration).toBe(10)
+  })
+  it('SS: successor starts lag units after the predecessor starts', () => {
+    const r = computeCPM([
+      { id: 'A', duration: 5, predecessors: [] },
+      { id: 'B', duration: 3, predecessors: [dep('A', 'SS', 1)] },
+    ])
+    expect([r.activities.get('B')!.es, r.activities.get('B')!.ef]).toEqual([1, 4])
+  })
+  it('FF: successor finishes lag units after the predecessor finishes', () => {
+    const r = computeCPM([
+      { id: 'A', duration: 5, predecessors: [] },
+      { id: 'B', duration: 3, predecessors: [dep('A', 'FF', 1)] },
+    ])
+    // EF(B) = EF(A) + 1 = 6 → ES(B) = 3
+    expect([r.activities.get('B')!.es, r.activities.get('B')!.ef]).toEqual([3, 6])
+  })
+  it('a negative lag (lead) is clamped at the project start', () => {
+    const r = computeCPM([
+      { id: 'A', duration: 5, predecessors: [] },
+      { id: 'B', duration: 3, predecessors: [dep('A', 'SS', -10)] },
+    ])
+    expect(r.activities.get('B')!.es).toBe(0)
+  })
+})
+
+describe('milestones', () => {
+  it('a zero-duration activity has EF = ES', () => {
+    const r = computeCPM([
+      { id: 'A', duration: 3, predecessors: [] },
+      { id: 'M', duration: 0, predecessors: [dep('A')] },
+    ])
+    const m = r.activities.get('M')!
+    expect(m.es).toBe(3)
+    expect(m.ef).toBe(3)
+  })
+})
+
+describe('imposed finish (accelerated target)', () => {
+  it('drives total float negative on the critical path', () => {
+    const r = computeCPM(NETWORK, { imposedFinish: 14 })   // 2 units early
+    expect(r.activities.get('A')!.totalFloat).toBe(-2)
+    expect(r.activities.get('F')!.totalFloat).toBe(-2)
+    // free float is derived from early dates only → unaffected by the target
+    expect(r.activities.get('E')!.freeFloat).toBe(1)
+  })
+})
+
+describe('circular-dependency detection', () => {
+  const cyclic: CpmActivityInput[] = [
+    { id: 'A', duration: 1, predecessors: [dep('B')] },
+    { id: 'B', duration: 1, predecessors: [dep('A')] },
+  ]
+  it('findCycle returns the offending loop', () => {
+    const cycle = findCycle(cyclic)
+    expect(cycle).not.toBeNull()
+    expect(cycle).toContain('A')
+    expect(cycle).toContain('B')
+  })
+  it('computeCPM throws ScheduleCycleError', () => {
+    expect(() => computeCPM(cyclic)).toThrow(ScheduleCycleError)
+  })
+  it('an acyclic network yields no cycle', () => {
+    expect(findCycle(NETWORK)).toBeNull()
+  })
+  it('wouldCreateCycle flags a link that closes a loop', () => {
+    // A→B exists; adding B as a predecessor of A (i.e. A→B→A) closes a loop.
+    expect(wouldCreateCycle(NETWORK, 'A', 'B')).toBe(true)
+    expect(wouldCreateCycle(NETWORK, 'X', 'X')).toBe(true)     // self-loop
+    expect(wouldCreateCycle(NETWORK, 'F', 'A')).toBe(false)    // A already upstream of F
+  })
+})
+
+describe('data-integrity guards', () => {
+  it('throws on an unknown predecessor id', () => {
+    expect(() => computeCPM([
+      { id: 'A', duration: 1, predecessors: [dep('ghost')] },
+    ])).toThrow(/unknown predecessor/i)
+  })
+})

--- a/webapp/src/engine/schedule/cpm.ts
+++ b/webapp/src/engine/schedule/cpm.ts
@@ -1,0 +1,294 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Critical Path Method (CPM) engine.
+//
+// Solves an activity-on-node (AON) precedence network on the abstract
+// working-day axis (offset 0 = project start). Supports all four precedence
+// relations (FS/FF/SS/SF) with lead/lag, multiple predecessors/successors and
+// milestones (zero-duration activities). Detects circular dependencies.
+//
+// Algorithm (standard CPM, exact — no heuristics):
+//   1. Topological order via Kahn's algorithm (cycle ⇒ ScheduleCycleError).
+//   2. Forward pass  → Early Start (ES), Early Finish (EF = ES + d).
+//   3. Backward pass → Late Finish (LF), Late Start (LS = LF − d).
+//   4. Total Float TF = LS − ES = LF − EF;  Free Float FF from successor gaps.
+//   5. Critical activities: TF ≤ ε.
+//
+// Relation lower bounds used in the forward pass (Q successor of P, lag L):
+//   FS: ES(Q) ≥ EF(P) + L        FF: EF(Q) ≥ EF(P) + L
+//   SS: ES(Q) ≥ ES(P) + L        SF: EF(Q) ≥ ES(P) + L
+// and their duals in the backward pass. See the per-branch comments below.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { Dependency, RelationType } from './model'
+
+/** Minimal activity shape the CPM engine needs; the full `Activity` satisfies it. */
+export interface CpmActivityInput {
+  id: string
+  /** Duration in working units (0 = milestone). */
+  duration: number
+  predecessors?: Dependency[]
+}
+
+/** Per-activity CPM result on the working-day axis. */
+export interface CpmActivity {
+  id: string
+  duration: number
+  es: number
+  ef: number
+  ls: number
+  lf: number
+  totalFloat: number
+  freeFloat: number
+  critical: boolean
+}
+
+export interface CpmResult {
+  activities: Map<string, CpmActivity>
+  /** Topological order used for the passes. */
+  order: string[]
+  /** Project duration = max EF (working units). */
+  duration: number
+  /** Imposed or computed project finish used for the backward pass. */
+  finish: number
+  /** Critical activities ordered by early start. */
+  criticalPath: string[]
+}
+
+export interface CpmOptions {
+  /**
+   * Imposed project finish (working units) for the backward pass. Defaults to
+   * the computed project duration (max EF). A value tighter than the computed
+   * duration drives total floats negative (an infeasible / accelerated target).
+   */
+  imposedFinish?: number
+  /** Float tolerance for the critical test (default 1e-6). */
+  epsilon?: number
+}
+
+/** Thrown by `computeCPM`/`topoOrder` when the network contains a cycle. */
+export class ScheduleCycleError extends Error {
+  cycle: string[]
+  constructor(cycle: string[]) {
+    super(`Circular dependency detected: ${cycle.join(' → ')}`)
+    this.name = 'ScheduleCycleError'
+    this.cycle = cycle
+  }
+}
+
+type Edge = { from: string; to: string; type: RelationType; lag: number }
+
+/** Collect precedence edges (predecessor → successor) from the activities. */
+function buildEdges(activities: CpmActivityInput[], ids: Set<string>): Edge[] {
+  const edges: Edge[] = []
+  for (const a of activities) {
+    for (const dep of a.predecessors ?? []) {
+      if (!ids.has(dep.predecessor)) {
+        throw new Error(`Activity "${a.id}" references unknown predecessor "${dep.predecessor}".`)
+      }
+      edges.push({ from: dep.predecessor, to: a.id, type: dep.type ?? 'FS', lag: dep.lag ?? 0 })
+    }
+  }
+  return edges
+}
+
+/**
+ * Return a cycle as an ordered id list if the precedence graph has one, else
+ * null. Uses DFS colouring and reconstructs the offending loop.
+ */
+export function findCycle(activities: CpmActivityInput[]): string[] | null {
+  const ids = new Set(activities.map((a) => a.id))
+  const succ = new Map<string, string[]>()
+  for (const a of activities) succ.set(a.id, [])
+  for (const e of buildEdges(activities, ids)) succ.get(e.from)!.push(e.to)
+
+  const WHITE = 0, GREY = 1, BLACK = 2
+  const color = new Map<string, number>()
+  const parent = new Map<string, string | null>()
+  for (const id of ids) { color.set(id, WHITE); parent.set(id, null) }
+
+  let cycle: string[] | null = null
+  const visit = (u: string): boolean => {
+    color.set(u, GREY)
+    for (const v of succ.get(u) ?? []) {
+      if (cycle) return true
+      if (color.get(v) === GREY) {
+        // Reconstruct u → … → v back-edge into an ordered loop.
+        const path = [v, u]
+        let p = parent.get(u)
+        while (p && p !== v) { path.push(p); p = parent.get(p) ?? null }
+        if (p === v) path.push(v)
+        cycle = path.reverse()
+        return true
+      }
+      if (color.get(v) === WHITE) {
+        parent.set(v, u)
+        if (visit(v)) return true
+      }
+    }
+    color.set(u, BLACK)
+    return false
+  }
+  for (const id of ids) {
+    if (color.get(id) === WHITE && visit(id)) break
+  }
+  return cycle
+}
+
+/**
+ * Would adding a `predecessor → successor` link close a cycle? Lets the UI
+ * reject an illegal dependency before it is committed.
+ */
+export function wouldCreateCycle(
+  activities: CpmActivityInput[],
+  successor: string,
+  predecessor: string,
+): boolean {
+  if (successor === predecessor) return true
+  const probe: CpmActivityInput[] = activities.map((a) =>
+    a.id === successor
+      ? { ...a, predecessors: [...(a.predecessors ?? []), { predecessor, type: 'FS', lag: 0 }] }
+      : a,
+  )
+  return findCycle(probe) !== null
+}
+
+/** Kahn topological order. Throws `ScheduleCycleError` on a cycle. */
+export function topoOrder(activities: CpmActivityInput[]): string[] {
+  const ids = new Set(activities.map((a) => a.id))
+  const edges = buildEdges(activities, ids)
+  const indeg = new Map<string, number>()
+  const succ = new Map<string, string[]>()
+  for (const a of activities) { indeg.set(a.id, 0); succ.set(a.id, []) }
+  for (const e of edges) {
+    indeg.set(e.to, (indeg.get(e.to) ?? 0) + 1)
+    succ.get(e.from)!.push(e.to)
+  }
+  // Seed with zero-in-degree nodes in input order for a stable result.
+  const queue = activities.filter((a) => (indeg.get(a.id) ?? 0) === 0).map((a) => a.id)
+  const order: string[] = []
+  while (queue.length) {
+    const u = queue.shift()!
+    order.push(u)
+    for (const v of succ.get(u) ?? []) {
+      const d = (indeg.get(v) ?? 0) - 1
+      indeg.set(v, d)
+      if (d === 0) queue.push(v)
+    }
+  }
+  if (order.length !== ids.size) {
+    const cycle = findCycle(activities) ?? [...ids].filter((id) => (indeg.get(id) ?? 0) > 0)
+    throw new ScheduleCycleError(cycle)
+  }
+  return order
+}
+
+/**
+ * Run the full CPM solve. Throws `ScheduleCycleError` if the network is cyclic
+ * and `Error` if an activity references an unknown predecessor.
+ */
+export function computeCPM(activities: CpmActivityInput[], opts: CpmOptions = {}): CpmResult {
+  const eps = opts.epsilon ?? 1e-6
+  const order = topoOrder(activities)
+  const byId = new Map(activities.map((a) => [a.id, a]))
+  const edges = buildEdges(activities, new Set(byId.keys()))
+
+  // Predecessor and successor incidence, keyed by activity id.
+  const preds = new Map<string, Edge[]>()
+  const succs = new Map<string, Edge[]>()
+  for (const id of byId.keys()) { preds.set(id, []); succs.set(id, []) }
+  for (const e of edges) { preds.get(e.to)!.push(e); succs.get(e.from)!.push(e) }
+
+  const es = new Map<string, number>()
+  const ef = new Map<string, number>()
+  const dur = (id: string) => byId.get(id)!.duration
+
+  // ── Forward pass: ES/EF in topological order ──
+  for (const id of order) {
+    const d = dur(id)
+    let start = 0
+    for (const e of preds.get(id)!) {
+      const pEs = es.get(e.from)!
+      const pEf = ef.get(e.from)!
+      let bound = 0
+      switch (e.type) {
+        case 'FS': bound = pEf + e.lag; break            // ES(Q) ≥ EF(P) + L
+        case 'SS': bound = pEs + e.lag; break            // ES(Q) ≥ ES(P) + L
+        case 'FF': bound = pEf + e.lag - d; break        // EF(Q) ≥ EF(P) + L
+        case 'SF': bound = pEs + e.lag - d; break        // EF(Q) ≥ ES(P) + L
+      }
+      if (bound > start) start = bound
+    }
+    if (start < 0) start = 0                             // cannot precede project start
+    es.set(id, start)
+    ef.set(id, start + d)
+  }
+
+  const computedFinish = order.reduce((m, id) => Math.max(m, ef.get(id) ?? 0), 0)
+  const finish = opts.imposedFinish ?? computedFinish
+
+  // ── Backward pass: LF/LS in reverse topological order ──
+  const lf = new Map<string, number>()
+  const ls = new Map<string, number>()
+  for (const id of byId.keys()) { lf.set(id, finish); ls.set(id, finish - dur(id)) }
+
+  for (let i = order.length - 1; i >= 0; i--) {
+    const id = order[i]
+    const d = dur(id)
+    let latestFinish = finish
+    for (const e of succs.get(id)!) {
+      const qLs = ls.get(e.to)!
+      const qLf = lf.get(e.to)!
+      let bound = 0
+      switch (e.type) {
+        case 'FS': bound = qLs - e.lag; break            // LF(P) ≤ LS(Q) − L
+        case 'FF': bound = qLf - e.lag; break            // LF(P) ≤ LF(Q) − L
+        case 'SS': bound = qLs - e.lag + d; break        // LS(P) ≤ LS(Q) − L
+        case 'SF': bound = qLf - e.lag + d; break        // LS(P) ≤ LF(Q) − L
+      }
+      if (bound < latestFinish) latestFinish = bound
+    }
+    lf.set(id, latestFinish)
+    ls.set(id, latestFinish - d)
+  }
+
+  // ── Floats + critical flag ──
+  const result = new Map<string, CpmActivity>()
+  for (const id of byId.keys()) {
+    const d = dur(id)
+    const aEs = es.get(id)!, aEf = ef.get(id)!, aLs = ls.get(id)!, aLf = lf.get(id)!
+    const totalFloat = aLs - aEs
+
+    // Free float = the slip absorbed before any successor's early start moves;
+    // computed from early dates only (independent of the imposed finish).
+    let freeFloat: number
+    const outEdges = succs.get(id)!
+    if (outEdges.length === 0) {
+      freeFloat = computedFinish - aEf                   // terminal: slack to project end
+    } else {
+      freeFloat = Infinity
+      for (const e of outEdges) {
+        const qEs = es.get(e.to)!, qEf = ef.get(e.to)!
+        let gap = 0
+        switch (e.type) {
+          case 'FS': gap = qEs - (aEf + e.lag); break
+          case 'SS': gap = qEs - (aEs + e.lag); break
+          case 'FF': gap = qEf - (aEf + e.lag); break
+          case 'SF': gap = qEf - (aEs + e.lag); break
+        }
+        if (gap < freeFloat) freeFloat = gap
+      }
+    }
+    if (freeFloat < 0) freeFloat = 0
+
+    result.set(id, {
+      id, duration: d,
+      es: aEs, ef: aEf, ls: aLs, lf: aLf,
+      totalFloat, freeFloat,
+      critical: totalFloat <= eps,
+    })
+  }
+
+  const criticalPath = order.filter((id) => result.get(id)!.critical)
+
+  return { activities: result, order, duration: computedFinish, finish, criticalPath }
+}

--- a/webapp/src/engine/schedule/model.ts
+++ b/webapp/src/engine/schedule/model.ts
@@ -1,0 +1,153 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Project-scheduling data model (PERT/CPM module).
+//
+// Pure, JSON-serialisable types shared by the scheduling engines (CPM, PERT,
+// earned-value, resources) and the UI. Dates are ISO 'YYYY-MM-DD' strings so a
+// whole project round-trips through `JSON.stringify` / localStorage unchanged.
+//
+// UNITS. Durations and lags live on an abstract *working-time* axis measured in
+// the activity's `unit` (default: whole working days). The CPM engine solves on
+// that numeric axis; the working-calendar layer (`calendar.ts`) projects the
+// resulting offsets onto real dates, skipping non-working days and holidays.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Precedence relation between a predecessor P and its successor Q.
+ *  FS finish-to-start · FF finish-to-finish · SS start-to-start · SF start-to-finish. */
+export type RelationType = 'FS' | 'FF' | 'SS' | 'SF'
+
+export type DurationUnit = 'days' | 'hours'
+
+export type ActivityStatus =
+  | 'not-started'
+  | 'in-progress'
+  | 'completed'
+  | 'delayed'
+  | 'blocked'
+
+export type ResourceType = 'labor' | 'equipment' | 'material'
+
+/** A single precedence link, stored on the *successor* activity.
+ *  `lag` is in working units; a negative lag is a lead. */
+export interface Dependency {
+  /** Activity id of the predecessor. */
+  predecessor: string
+  /** Relation type; FS if omitted by a caller. */
+  type: RelationType
+  /** Lead/lag in working units (default 0). */
+  lag: number
+}
+
+/** A resource definition in the project pool. */
+export interface Resource {
+  id: string
+  name: string
+  type: ResourceType
+  /** Unit of measure, e.g. 'man-day', 'hr', 'm³'. */
+  unit: string
+  /** Cost per `unit` (project currency); optional. */
+  costPerUnit?: number
+  /** Max units available per working day (for over-allocation checks); optional. */
+  availablePerDay?: number
+}
+
+/** A resource assigned to an activity. */
+export interface ActivityResource {
+  resourceId: string
+  /** Quantity of the resource consumed by the activity (in the resource's unit). */
+  quantity: number
+}
+
+/** A schedule activity (task). A milestone is an activity with `duration === 0`. */
+export interface Activity {
+  id: string
+  /** Owning WBS node id (optional; activities may sit at project root). */
+  wbsId?: string
+  name: string
+  description?: string
+  /** Planned duration in `unit` (0 = milestone). */
+  duration: number
+  unit: DurationUnit
+  /** Working-calendar id; falls back to the project default when omitted. */
+  calendarId?: string
+  /** Precedence links to predecessors. */
+  predecessors: Dependency[]
+  milestone?: boolean
+
+  // ── PERT three-point estimate (optional) ──
+  optimistic?: number
+  mostLikely?: number
+  pessimistic?: number
+
+  // ── Progress / actuals ──
+  actualStart?: string
+  actualFinish?: string
+  /** 0–100. */
+  percentComplete?: number
+  responsible?: string
+  status?: ActivityStatus
+  remarks?: string
+
+  // ── Resources ──
+  resources?: ActivityResource[]
+}
+
+/** A Work-Breakdown-Structure node. Unlimited hierarchy via `parentId`. */
+export interface WbsNode {
+  id: string
+  /** Outline code, e.g. '1.2.3' (may be derived; stored for stable display). */
+  code?: string
+  name: string
+  parentId?: string
+  /** Sibling ordering (ascending). */
+  order: number
+}
+
+/** A working calendar: which weekdays are worked plus explicit holiday dates. */
+export interface WorkingCalendar {
+  id: string
+  name: string
+  /** Seven flags indexed Sun(0)…Sat(6); true = a working day. */
+  workweek: boolean[]
+  /** Non-working ISO dates (holidays / shutdowns). */
+  holidays: string[]
+  /** Working hours per day — used only to convert 'hours' durations to days. */
+  hoursPerDay?: number
+}
+
+/** Header / contractual metadata for a project. */
+export interface ProjectMeta {
+  name: string
+  description?: string
+  client?: string
+  contractor?: string
+  engineer?: string
+  /** Project data date / start (ISO). */
+  start: string
+  /** Contractual planned finish (ISO), optional target. */
+  plannedFinish?: string
+}
+
+/** A frozen snapshot of the schedule for variance tracking. */
+export interface Baseline {
+  id: string
+  name: string
+  createdAt: string
+  /** Per-activity planned {start, finish} ISO dates and duration at capture. */
+  activities: Record<string, { start: string; finish: string; duration: number }>
+}
+
+/** The complete, serialisable scheduling project. */
+export interface ScheduleProject {
+  meta: ProjectMeta
+  calendars: WorkingCalendar[]
+  defaultCalendarId: string
+  wbs: WbsNode[]
+  activities: Activity[]
+  resources: Resource[]
+  baselines: Baseline[]
+}
+
+/** Convenience constructor for an FS dependency with no lag. */
+export function fs(predecessor: string): Dependency {
+  return { predecessor, type: 'FS', lag: 0 }
+}

--- a/webapp/src/engine/schedule/pert.test.ts
+++ b/webapp/src/engine/schedule/pert.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import type { Dependency } from './model'
+import {
+  pertExpected, pertVariance, pertStdDev, computePert,
+  erf, normalCdf, invNormalCdf, completionProbability, durationForProbability,
+  type PertActivityInput,
+} from './pert'
+
+const dep = (predecessor: string): Dependency => ({ predecessor, type: 'FS', lag: 0 })
+
+describe('three-point estimate', () => {
+  it('TE = (O + 4M + P)/6', () => {
+    expect(pertExpected(2, 4, 6)).toBeCloseTo(4, 12)
+    expect(pertExpected(3, 3, 9)).toBeCloseTo(4, 12)          // skew toward P
+  })
+  it('variance = ((P − O)/6)² and σ = (P − O)/6', () => {
+    expect(pertVariance(2, 6)).toBeCloseTo((4 / 6) ** 2, 12)  // 0.4444
+    expect(pertStdDev(2, 6)).toBeCloseTo(4 / 6, 12)
+    expect(pertVariance(5, 5)).toBe(0)                        // certain activity
+  })
+})
+
+// Three activities in series → all critical.
+const SERIES: PertActivityInput[] = [
+  { id: 'A', optimistic: 1, mostLikely: 2, pessimistic: 3, predecessors: [] },
+  { id: 'B', optimistic: 2, mostLikely: 4, pessimistic: 6, predecessors: [dep('A')] },
+  { id: 'C', optimistic: 3, mostLikely: 3, pessimistic: 9, predecessors: [dep('B')] },
+]
+
+describe('computePert on a series network', () => {
+  const pert = computePert(SERIES)
+  it('per-activity TE and variance', () => {
+    expect(pert.activities.get('A')!.te).toBeCloseTo(2, 9)
+    expect(pert.activities.get('B')!.te).toBeCloseTo(4, 9)
+    expect(pert.activities.get('C')!.te).toBeCloseTo(4, 9)
+    expect(pert.activities.get('C')!.variance).toBeCloseTo(1, 9)
+  })
+  it('project TE is the critical-path length', () => {
+    expect(pert.projectTe).toBeCloseTo(10, 9)
+  })
+  it('project variance is the sum along the critical path', () => {
+    expect(pert.projectVariance).toBeCloseTo(1 / 9 + 4 / 9 + 1, 9)   // ≈1.5556
+    expect(pert.projectSd).toBeCloseTo(Math.sqrt(1 / 9 + 4 / 9 + 1), 9)
+  })
+  it('completion probability at TE is 50%', () => {
+    expect(completionProbability(pert, 10)).toBeCloseTo(0.5, 6)
+  })
+  it('completion probability rises above TE', () => {
+    expect(completionProbability(pert, 12)).toBeCloseTo(0.9456, 3)
+  })
+  it('durationForProbability inverts completionProbability', () => {
+    expect(durationForProbability(pert, 0.5)).toBeCloseTo(10, 6)
+    const t90 = durationForProbability(pert, 0.9)
+    expect(completionProbability(pert, t90)).toBeCloseTo(0.9, 6)
+  })
+})
+
+describe('project variance uses only the critical path', () => {
+  // A→B→D critical; A→C→D with C off the critical path (and zero-variance).
+  const net: PertActivityInput[] = [
+    { id: 'A', optimistic: 1, mostLikely: 2, pessimistic: 3, predecessors: [] },
+    { id: 'B', optimistic: 3, mostLikely: 4, pessimistic: 5, predecessors: [dep('A')] },
+    { id: 'C', optimistic: 1, mostLikely: 1, pessimistic: 1, predecessors: [dep('A')] },
+    { id: 'D', optimistic: 2, mostLikely: 3, pessimistic: 4, predecessors: [dep('B'), dep('C')] },
+  ]
+  const pert = computePert(net)
+  it('critical path is A→B→D, duration 9', () => {
+    expect(pert.projectTe).toBeCloseTo(9, 9)
+    expect(pert.cpm.criticalPath).toEqual(['A', 'B', 'D'])
+  })
+  it('variance sums A, B, D only (C excluded)', () => {
+    expect(pert.projectVariance).toBeCloseTo(3 * (2 / 6) ** 2, 9)     // 3 × 0.1111
+  })
+})
+
+describe('deterministic fallback', () => {
+  it('uses `duration` and zero variance when O/M/P are absent', () => {
+    const pert = computePert([
+      { id: 'A', duration: 5, predecessors: [] },
+    ])
+    expect(pert.projectTe).toBe(5)
+    expect(pert.projectVariance).toBe(0)
+    expect(completionProbability(pert, 5)).toBe(1)     // zero-variance meets target
+    expect(completionProbability(pert, 4)).toBe(0)
+  })
+})
+
+describe('normal-distribution helpers', () => {
+  it('erf endpoints', () => {
+    expect(erf(0)).toBeCloseTo(0, 8)          // A&S 7.1.26 residual ≈1e-9 at 0
+    expect(erf(3)).toBeCloseTo(1, 3)
+    expect(erf(-1)).toBeCloseTo(-erf(1), 12)            // odd function
+  })
+  it('normalCdf at standard points', () => {
+    expect(normalCdf(0)).toBeCloseTo(0.5, 8)
+    expect(normalCdf(1.96)).toBeCloseTo(0.975, 3)
+    expect(normalCdf(-1)).toBeCloseTo(0.158655, 4)
+  })
+  it('invNormalCdf inverts normalCdf', () => {
+    expect(invNormalCdf(0.5)).toBeCloseTo(0, 9)
+    expect(invNormalCdf(0.975)).toBeCloseTo(1.959964, 4)
+    expect(normalCdf(invNormalCdf(0.9))).toBeCloseTo(0.9, 6)
+    expect(invNormalCdf(0)).toBe(-Infinity)
+    expect(invNormalCdf(1)).toBe(Infinity)
+  })
+})

--- a/webapp/src/engine/schedule/pert.ts
+++ b/webapp/src/engine/schedule/pert.ts
@@ -1,0 +1,173 @@
+// ─────────────────────────────────────────────────────────────────────────
+// PERT (Program Evaluation and Review Technique) engine.
+//
+//   Expected time   TE = (O + 4M + P) / 6          (beta-distribution mean)
+//   Variance        σ² = ((P − O) / 6)²
+//   Std deviation   σ  = (P − O) / 6
+//
+// The project is scheduled with each activity's TE as its CPM duration; the
+// project expected duration is the resulting critical-path length and the
+// project variance is the sum of variances of the activities on that path.
+// Completion probability for a target date T uses the normal approximation
+//   z = (T − TE_project) / σ_project ,  P[finish ≤ T] = Φ(z).
+//
+// LIMITATION: project variance is summed over the flagged critical activities.
+// For a single dominant critical chain this is exact; when parallel critical
+// chains exist it is conservative (a full probabilistic merge is a later
+// refinement). This matches standard PERT textbook practice.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { Dependency } from './model'
+import { computeCPM } from './cpm'
+import type { CpmResult } from './cpm'
+
+/** Activity with an optional three-point estimate. When O/M/P are all present
+ *  the beta estimate drives TE/variance; otherwise `duration` is used with zero
+ *  variance (a deterministic activity in an otherwise probabilistic network). */
+export interface PertActivityInput {
+  id: string
+  optimistic?: number
+  mostLikely?: number
+  pessimistic?: number
+  predecessors?: Dependency[]
+  /** Fallback deterministic duration when O/M/P are absent (variance 0). */
+  duration?: number
+}
+
+export interface PertActivityResult {
+  id: string
+  te: number
+  variance: number
+  sd: number
+}
+
+export interface PertResult {
+  activities: Map<string, PertActivityResult>
+  /** CPM solve using TE as each activity's duration. */
+  cpm: CpmResult
+  /** Project expected duration (= critical-path length in TE). */
+  projectTe: number
+  /** Sum of variances along the critical path. */
+  projectVariance: number
+  projectSd: number
+}
+
+/** Expected time TE = (O + 4M + P) / 6. */
+export function pertExpected(o: number, m: number, p: number): number {
+  return (o + 4 * m + p) / 6
+}
+
+/** Activity variance σ² = ((P − O) / 6)². */
+export function pertVariance(o: number, p: number): number {
+  return ((p - o) / 6) ** 2
+}
+
+/** Activity standard deviation σ = (P − O) / 6. */
+export function pertStdDev(o: number, p: number): number {
+  return (p - o) / 6
+}
+
+/**
+ * Solve the PERT network: TE/σ² per activity, a CPM pass on TE durations, and
+ * the project expected duration + variance along the critical path.
+ */
+export function computePert(activities: PertActivityInput[]): PertResult {
+  const results = new Map<string, PertActivityResult>()
+  const cpmInput = activities.map((a) => {
+    const { optimistic: o, mostLikely: m, pessimistic: p } = a
+    // Inline null checks so TypeScript narrows O/M/P to `number` in the branch.
+    const te = o != null && m != null && p != null ? pertExpected(o, m, p) : (a.duration ?? 0)
+    const variance = o != null && p != null ? pertVariance(o, p) : 0
+    results.set(a.id, { id: a.id, te, variance, sd: Math.sqrt(variance) })
+    return { id: a.id, duration: te, predecessors: a.predecessors }
+  })
+
+  const cpm = computeCPM(cpmInput)
+  const projectVariance = cpm.criticalPath.reduce(
+    (sum, id) => sum + (results.get(id)?.variance ?? 0),
+    0,
+  )
+
+  return {
+    activities: results,
+    cpm,
+    projectTe: cpm.duration,
+    projectVariance,
+    projectSd: Math.sqrt(projectVariance),
+  }
+}
+
+// ── Normal distribution helpers ─────────────────────────────────────────────
+
+/** Gauss error function (Abramowitz & Stegun 7.1.26, |error| ≤ 1.5e-7). */
+export function erf(x: number): number {
+  const sign = x < 0 ? -1 : 1
+  const ax = Math.abs(x)
+  const t = 1 / (1 + 0.3275911 * ax)
+  const y =
+    1 -
+    ((((1.061405429 * t - 1.453152027) * t + 1.421413741) * t - 0.284496736) * t +
+      0.254829592) *
+      t *
+      Math.exp(-ax * ax)
+  return sign * y
+}
+
+/** Standard-normal CDF Φ(z) = ½·(1 + erf(z/√2)). */
+export function normalCdf(z: number): number {
+  return 0.5 * (1 + erf(z / Math.SQRT2))
+}
+
+/**
+ * Inverse standard-normal CDF (Peter Acklam's rational approximation,
+ * relative error < 1.15e-9 across 0 < p < 1). Returns ±∞ at the limits.
+ */
+export function invNormalCdf(p: number): number {
+  if (p <= 0) return -Infinity
+  if (p >= 1) return Infinity
+
+  const a = [-3.969683028665376e1, 2.209460984245205e2, -2.759285104469687e2,
+    1.383577518672690e2, -3.066479806614716e1, 2.506628277459239]
+  const b = [-5.447609879822406e1, 1.615858368580409e2, -1.556989798598866e2,
+    6.680131188771972e1, -1.328068155288572e1]
+  const c = [-7.784894002430293e-3, -3.223964580411365e-1, -2.400758277161838,
+    -2.549732539343734, 4.374664141464968, 2.938163982698783]
+  const d = [7.784695709041462e-3, 3.224671290700398e-1, 2.445134137142996,
+    3.754408661907416]
+  const plow = 0.02425
+  const phigh = 1 - plow
+
+  let q: number, r: number
+  if (p < plow) {
+    q = Math.sqrt(-2 * Math.log(p))
+    return (((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) /
+      ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1)
+  }
+  if (p <= phigh) {
+    q = p - 0.5
+    r = q * q
+    return (((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]) * q /
+      (((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1)
+  }
+  q = Math.sqrt(-2 * Math.log(1 - p))
+  return -(((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) /
+    ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1)
+}
+
+/**
+ * Probability the project finishes on or before `targetDuration` (working
+ * units on the same axis as `projectTe`). Returns 1 for a zero-variance
+ * project that meets the target, 0 if it cannot.
+ */
+export function completionProbability(pert: PertResult, targetDuration: number): number {
+  if (pert.projectSd <= 0) return targetDuration >= pert.projectTe ? 1 : 0
+  return normalCdf((targetDuration - pert.projectTe) / pert.projectSd)
+}
+
+/**
+ * The project duration achievable at a given confidence `prob` (0–1):
+ *   T = TE_project + z(prob)·σ_project.
+ */
+export function durationForProbability(pert: PertResult, prob: number): number {
+  return pert.projectTe + invNormalCdf(prob) * pert.projectSd
+}


### PR DESCRIPTION
## Project Scheduling module — Phase 1 of 10

First phase of a Primavera/MS-Project-style **PERT/CPM & progress-tracking**
module. This PR ships the **calculation core**: the pure, typed engines the rest
of the module (WBS grid, Gantt, network diagram, dashboard, EVM, reports) will
consume.

### Stack reconciliation
The original brief specified **Next.js + Prisma + PostgreSQL + API routes** — none
of which exist in this repo. `civilEngineering/webapp` is a **Vite + React 19 +
TypeScript SPA** where every calculator is a pure engine under
`src/engine/` with a matching `*.test.ts`, persisted in-browser. This module
follows that architecture (no backend introduced); the mapping and rationale are
in [`docs/scheduling.md`](docs/scheduling.md).

### What's in this PR (`webapp/src/engine/schedule/`)
| File | Role |
|------|------|
| `model.ts` | JSON-serialisable model: `Activity`, `Dependency` (FS/FF/SS/SF + lead/lag), `WbsNode`, `WorkingCalendar`, `Resource`, `Baseline`, `ScheduleProject` |
| `calendar.ts` | Working-day date arithmetic — workweek + holidays, `offsetToDate`, `durationEndDate`, `workingDaysBetween` |
| `cpm.ts` | CPM: Kahn topo-order + DFS **cycle detection** (`findCycle`, `wouldCreateCycle`), forward/backward passes, **total & free float**, **critical path**; all four relations with lead/lag; milestones; imposed-finish (negative float) |
| `pert.ts` | PERT: `TE=(O+4M+P)/6`, `σ²=((P−O)/6)²`, project **completion probability** via normal approx (A&S `erf` + Acklam inverse Φ) |

### Engineering accuracy (no approximations in the CPM logic)
- CPM verified against a **hand-computed AON network** (ES/EF/LS/LF/TF/FF and the
  A→B→D→F critical path all asserted).
- Every relation type (FS/FF/SS/SF), lead/lag clamping, milestones, cycle
  detection, and unknown-predecessor guards covered.
- PERT verified against textbook three-point examples; `Φ`/`Φ⁻¹` checked at
  standard points and round-tripped.

### Verification
- **50 new vitest cases**, all green.
- Full suite: **1270 passing (99 files)**; `npx tsc -b` clean.

### Roadmap (one PR per phase)
Phase 2 progress + EVM · 3 persistence · 4 WBS/activity grid UI · 5 Gantt ·
6 AON network diagram · 7 dashboard · 8 resources · 9 reports (PDF/Excel/CSV) ·
10 daily-reports + delay analysis. Full list in `docs/scheduling.md`.

### Known limitations
Whole-working-day CPM on one project calendar (per-activity calendars / hour
granularity later); PERT variance summed over the critical path (conservative
with parallel critical chains); activity date-constraints modelled at project
level for now. All documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)