### PR TITLE
feat: project scheduling — progress tracking + earned value (Phase 2)

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -34,6 +34,9 @@ webapp/src/engine/schedule/
   calendar.ts     # working-day date arithmetic (workweek + holidays)
   cpm.ts          # Critical Path Method: topo-order, forward/backward, floats
   pert.ts         # PERT: TE/variance + normal-approx completion probability
+  earnedValue.ts  # EVM: PV/EV/AC → SPI/CPI/…/TCPI + earned-schedule time SV
+  progress.ts     # %-complete roll-up, status derivation, dashboard summary,
+                  #        baseline variance
   *.test.ts       # hand-calc-verified vitest coverage for each engine
 ```
 
@@ -86,11 +89,31 @@ activities on the critical path; `σ = √Σσ²`. Completion probability for a 
 high-accuracy `erf` (A&S 7.1.26) and inverse `Φ⁻¹` (Acklam) so we can also
 answer "what date carries 90 % confidence?" (`durationForProbability`).
 
+## Progress & earned value (`progress.ts`, `earnedValue.ts`)
+
+**EVM** at a data date, per PMBOK:
+
+```
+PV = Σ BACᵢ·plannedᵢ   EV = Σ BACᵢ·%compᵢ   AC = Σ ACᵢ
+SV = EV − PV   CV = EV − AC   SPI = EV/PV   CPI = EV/AC
+EAC = BAC/CPI   VAC = BAC − EAC   ETC = EAC − AC   TCPI = (BAC−EV)/(BAC−AC)
+```
+
+BAC/AC are unit-agnostic (currency, or duration/man-days for a cost-free
+schedule view). Ratios with a zero denominator are returned as `null`
+(undefined, not 0). Time-based schedule variance uses the **Earned Schedule**
+method: the project-time offset where the PV curve equals the current EV, minus
+the data date (>0 ⇒ ahead). `progress.ts` derives each activity's status
+(completed / in-progress / delayed / not-started, honouring an explicit
+`blocked`), rolls duration-weighted planned-vs-actual %, and reports SPI,
+forecast duration, remaining work, and baseline start/finish/duration variance.
+
 ## Roadmap (one PR per phase)
 
-- **Phase 1 — engine core** *(this PR)*: model, calendar, CPM, PERT + 50 tests.
-- **Phase 2 — progress & earned value**: %-complete roll-up, status derivation,
-  PV/EV/AC → SPI/CPI/SV/CV/BAC/EAC/VAC, baseline capture + variance.
+- **Phase 1 — engine core** ✅: model, calendar, CPM, PERT + 50 tests.
+- **Phase 2 — progress & earned value** *(this PR)*: %-complete roll-up, status
+  derivation, PV/EV/AC → SPI/CPI/SV/CV/BAC/EAC/VAC/ETC/TCPI, earned-schedule
+  time variance, baseline variance + 24 tests.
 - **Phase 3 — persistence**: `ScheduleProject` store (localStorage, schema
   version), JSON import/export, sample projects.
 - **Phase 4 — WBS + activity grid UI**: add/edit/delete/reorder/collapse, live

--- a/webapp/src/engine/schedule/earnedValue.test.ts
+++ b/webapp/src/engine/schedule/earnedValue.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import {
+  plannedFraction, earnedValue, pvAtOffset, earnedScheduleOffset,
+  scheduleVarianceTime, type EvmActivityInput, type PvActivity,
+} from './earnedValue'
+
+describe('plannedFraction', () => {
+  it('linear ramp between early start and finish', () => {
+    expect(plannedFraction(0, 10, 0)).toBe(0)
+    expect(plannedFraction(0, 10, 5)).toBe(0.5)
+    expect(plannedFraction(0, 10, 10)).toBe(1)
+    expect(plannedFraction(0, 10, 12)).toBe(1)     // clamped
+    expect(plannedFraction(0, 10, -3)).toBe(0)
+  })
+  it('a milestone steps at its date', () => {
+    expect(plannedFraction(5, 5, 4)).toBe(0)
+    expect(plannedFraction(5, 5, 5)).toBe(1)
+  })
+})
+
+describe('earnedValue roll-up', () => {
+  const acts: EvmActivityInput[] = [
+    { id: 'A', bac: 100, percentComplete: 100, actualCost: 90, plannedFraction: 1 },
+    { id: 'B', bac: 100, percentComplete: 50, actualCost: 60, plannedFraction: 0.75 },
+  ]
+  const r = earnedValue(acts)
+  it('PV / EV / AC / BAC', () => {
+    expect(r.pv).toBe(175)   // 100·1 + 100·0.75
+    expect(r.ev).toBe(150)   // 100·1 + 100·0.5
+    expect(r.ac).toBe(150)
+    expect(r.bac).toBe(200)
+  })
+  it('variances and indices', () => {
+    expect(r.sv).toBe(-25)
+    expect(r.cv).toBe(0)
+    expect(r.spi!).toBeCloseTo(150 / 175, 9)
+    expect(r.cpi!).toBe(1)
+  })
+  it('forecasts (EAC / VAC / ETC / TCPI)', () => {
+    expect(r.eac!).toBe(200)   // BAC / CPI
+    expect(r.vac!).toBe(0)
+    expect(r.etc!).toBe(50)    // EAC − AC
+    expect(r.tcpi!).toBe(1)    // (200−150)/(200−150)
+  })
+  it('clamps percent complete to 100', () => {
+    const over = earnedValue([{ id: 'X', bac: 50, percentComplete: 150, actualCost: 40, plannedFraction: 1 }])
+    expect(over.ev).toBe(50)
+  })
+  it('returns null indices when a denominator is zero', () => {
+    const empty = earnedValue([])
+    expect(empty.spi).toBeNull()
+    expect(empty.cpi).toBeNull()
+    expect(empty.eac).toBeNull()
+    expect(empty.tcpi).toBeNull()
+  })
+})
+
+describe('earned schedule (time-based)', () => {
+  // Series A[0,10] then B[10,20], each budget 50 → total PV 100.
+  const pv: PvActivity[] = [
+    { es: 0, ef: 10, bac: 50 },
+    { es: 10, ef: 20, bac: 50 },
+  ]
+  it('pv curve is the sum of ramps', () => {
+    expect(pvAtOffset(pv, 5)).toBe(25)
+    expect(pvAtOffset(pv, 10)).toBe(50)
+    expect(pvAtOffset(pv, 15)).toBe(75)
+    expect(pvAtOffset(pv, 20)).toBe(100)
+  })
+  it('earnedScheduleOffset inverts the pv curve', () => {
+    expect(earnedScheduleOffset(pv, 25, 20)).toBeCloseTo(5, 4)
+    expect(earnedScheduleOffset(pv, 75, 20)).toBeCloseTo(15, 4)
+    expect(earnedScheduleOffset(pv, 0, 20)).toBe(0)
+    expect(earnedScheduleOffset(pv, 100, 20)).toBe(20)   // ev ≥ max pv → tMax
+    expect(earnedScheduleOffset(pv, 130, 20)).toBe(20)
+  })
+  it('scheduleVarianceTime: earned 25 at data date 8 is 3 days behind', () => {
+    expect(scheduleVarianceTime(pv, 25, 8, 20)).toBeCloseTo(-3, 3)
+  })
+  it('scheduleVarianceTime: earned 75 at data date 12 is 3 days ahead', () => {
+    expect(scheduleVarianceTime(pv, 75, 12, 20)).toBeCloseTo(3, 3)
+  })
+})

--- a/webapp/src/engine/schedule/earnedValue.ts
+++ b/webapp/src/engine/schedule/earnedValue.ts
@@ -1,0 +1,131 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Earned Value Management (EVM) engine.
+//
+// The three primitives, at a data date:
+//   PV  Planned Value   — budget scheduled to be complete   (Σ BACᵢ · plannedᵢ)
+//   EV  Earned Value    — budget actually earned             (Σ BACᵢ · %compᵢ)
+//   AC  Actual Cost     — cost actually incurred             (Σ ACᵢ, input)
+// Derived (PMBOK):
+//   SV = EV − PV        CV = EV − AC
+//   SPI = EV / PV       CPI = EV / AC
+//   EAC = BAC / CPI     VAC = BAC − EAC     ETC = EAC − AC
+//   TCPI = (BAC − EV) / (BAC − AC)
+// Ratios whose denominator is zero are returned as `null` (undefined, not 0).
+//
+// BAC/AC are unit-agnostic: currency for cost EVM, or man-days / duration-units
+// for a cost-free schedule-performance view — the caller stays consistent.
+//
+// Time-based schedule performance uses the Earned Schedule method (Lipke): the
+// point in project time at which the planned-value curve equals the current EV.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Fraction (0–1) of an activity that should be complete at working-day
+ *  `dataDate`, given its early start/finish. Milestones (ef ≤ es) step at ef. */
+export function plannedFraction(es: number, ef: number, dataDate: number): number {
+  if (ef <= es) return dataDate >= ef ? 1 : 0
+  if (dataDate <= es) return 0
+  if (dataDate >= ef) return 1
+  return (dataDate - es) / (ef - es)
+}
+
+/** One activity's EVM inputs at the data date. */
+export interface EvmActivityInput {
+  id: string
+  /** Budget at completion for this activity (cost or work units). */
+  bac: number
+  /** Actual percent complete, 0–100. */
+  percentComplete: number
+  /** Actual cost incurred to date (same units as `bac`). */
+  actualCost: number
+  /** Fraction (0–1) of `bac` scheduled to be complete by the data date. */
+  plannedFraction: number
+}
+
+export interface EvmResult {
+  pv: number
+  ev: number
+  ac: number
+  bac: number
+  sv: number
+  cv: number
+  spi: number | null
+  cpi: number | null
+  /** Estimate at completion = BAC / CPI. */
+  eac: number | null
+  /** Estimate to complete = EAC − AC. */
+  etc: number | null
+  /** Variance at completion = BAC − EAC. */
+  vac: number | null
+  /** To-complete performance index = (BAC − EV) / (BAC − AC). */
+  tcpi: number | null
+}
+
+/** Roll up per-activity EVM inputs into project PV/EV/AC and the indices. */
+export function earnedValue(activities: EvmActivityInput[]): EvmResult {
+  let pv = 0, ev = 0, ac = 0, bac = 0
+  for (const a of activities) {
+    const pct = Math.min(100, Math.max(0, a.percentComplete)) / 100
+    pv += a.bac * a.plannedFraction
+    ev += a.bac * pct
+    ac += a.actualCost
+    bac += a.bac
+  }
+  const spi = pv > 0 ? ev / pv : null
+  const cpi = ac > 0 ? ev / ac : null
+  const eac = cpi != null && cpi !== 0 ? bac / cpi : null
+  const vac = eac != null ? bac - eac : null
+  const etc = eac != null ? eac - ac : null
+  const tcpi = bac - ac !== 0 ? (bac - ev) / (bac - ac) : null
+  return { pv, ev, ac, bac, sv: ev - pv, cv: ev - ac, spi, cpi, eac, etc, vac, tcpi }
+}
+
+// ── Earned Schedule (time-based) ────────────────────────────────────────────
+
+/** An activity's scheduled span and budget for building the PV curve. */
+export interface PvActivity {
+  es: number
+  ef: number
+  bac: number
+}
+
+/** Cumulative planned value at working-day offset `t` (monotonic in t). */
+export function pvAtOffset(activities: PvActivity[], t: number): number {
+  let pv = 0
+  for (const a of activities) pv += a.bac * plannedFraction(a.es, a.ef, t)
+  return pv
+}
+
+/**
+ * Earned Schedule: the project-time offset at which the planned-value curve
+ * first reaches the current `ev`. PV is monotonic non-decreasing in t, so a
+ * bounded bisection converges. Returns 0 for ev ≤ 0 and `tMax` if ev exceeds
+ * the total planned value at `tMax`.
+ */
+export function earnedScheduleOffset(
+  activities: PvActivity[],
+  ev: number,
+  tMax: number,
+): number {
+  if (ev <= 0) return 0
+  if (pvAtOffset(activities, tMax) <= ev) return tMax
+  let lo = 0, hi = tMax
+  for (let i = 0; i < 60; i++) {
+    const mid = (lo + hi) / 2
+    if (pvAtOffset(activities, mid) < ev) lo = mid
+    else hi = mid
+  }
+  return (lo + hi) / 2
+}
+
+/**
+ * Schedule variance in time units at the data date: Earned Schedule − data date.
+ * Positive ⇒ ahead of schedule, negative ⇒ behind.
+ */
+export function scheduleVarianceTime(
+  activities: PvActivity[],
+  ev: number,
+  dataDate: number,
+  tMax: number,
+): number {
+  return earnedScheduleOffset(activities, ev, tMax) - dataDate
+}

--- a/webapp/src/engine/schedule/progress.test.ts
+++ b/webapp/src/engine/schedule/progress.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import type { Activity } from './model'
+import { computeCPM } from './cpm'
+import {
+  activityRemainingDuration, plannedPercentComplete, rollupPercentComplete,
+  deriveStatus, projectProgress, baselineVariance,
+} from './progress'
+
+/** Minimal Activity factory. */
+const act = (id: string, duration: number, over: Partial<Activity> = {}): Activity => ({
+  id, name: id, duration, unit: 'days', predecessors: [], ...over,
+})
+
+describe('activity-level helpers', () => {
+  it('remaining duration = duration·(1 − %/100)', () => {
+    expect(activityRemainingDuration(10, 30)).toBeCloseTo(7, 9)
+    expect(activityRemainingDuration(10, undefined)).toBe(10)
+    expect(activityRemainingDuration(10, 150)).toBe(0)     // clamped
+  })
+  it('planned % complete from the schedule', () => {
+    expect(plannedPercentComplete(0, 10, 5)).toBe(50)
+    expect(plannedPercentComplete(0, 10, 0)).toBe(0)
+    expect(plannedPercentComplete(0, 10, 10)).toBe(100)
+  })
+  it('duration-weighted roll-up', () => {
+    expect(rollupPercentComplete([{ weight: 10, percentComplete: 100 }, { weight: 10, percentComplete: 0 }])).toBe(50)
+    expect(rollupPercentComplete([{ weight: 20, percentComplete: 50 }, { weight: 10, percentComplete: 100 }]))
+      .toBeCloseTo(200 / 3, 9)   // (1000+1000)/30
+  })
+})
+
+describe('deriveStatus', () => {
+  const ctx = { dataDate: 5, es: 0, ef: 10 }
+  it('completed when %≥100 or an actual finish exists', () => {
+    expect(deriveStatus(act('A', 10, { percentComplete: 100 }), ctx)).toBe('completed')
+    expect(deriveStatus(act('A', 10, { actualFinish: '2026-01-10' }), ctx)).toBe('completed')
+  })
+  it('preserves an explicit blocked flag', () => {
+    expect(deriveStatus(act('A', 10, { status: 'blocked', percentComplete: 40 }), ctx)).toBe('blocked')
+  })
+  it('in-progress when on or ahead of the planned curve', () => {
+    // planned at dataDate 5 = 50%; actual 50 ⇒ on track
+    expect(deriveStatus(act('A', 10, { percentComplete: 50 }), ctx)).toBe('in-progress')
+  })
+  it('delayed when behind the planned curve', () => {
+    expect(deriveStatus(act('A', 10, { percentComplete: 20 }), ctx)).toBe('delayed')
+  })
+  it('delayed when past its finish but unfinished', () => {
+    expect(deriveStatus(act('A', 10, { percentComplete: 50 }), { dataDate: 12, es: 0, ef: 10 })).toBe('delayed')
+  })
+  it('not-started before its planned start; delayed after it', () => {
+    expect(deriveStatus(act('A', 10, { percentComplete: 0 }), { dataDate: 0, es: 0, ef: 10 })).toBe('not-started')
+    expect(deriveStatus(act('A', 10, { percentComplete: 0 }), { dataDate: 5, es: 0, ef: 10 })).toBe('delayed')
+  })
+})
+
+describe('projectProgress roll-up', () => {
+  // A(4) → B(6): single critical chain, project duration 10.
+  const activities = [
+    act('A', 4, { percentComplete: 100 }),
+    act('B', 6, { percentComplete: 0, predecessors: [{ predecessor: 'A', type: 'FS', lag: 0 }] }),
+  ]
+  const cpm = computeCPM(activities)
+
+  it('on-plan at data date 4 (A done, B due to start)', () => {
+    const p = projectProgress(activities, cpm, 4)
+    expect(p.plannedPercent).toBeCloseTo(40, 6)   // 4 of 10 work-days planned
+    expect(p.actualPercent).toBeCloseTo(40, 6)
+    expect(p.scheduleVariancePercent).toBeCloseTo(0, 6)
+    expect(p.spi!).toBeCloseTo(1, 6)
+    expect(p.daysAheadBehind).toBeCloseTo(0, 3)
+    expect(p.completed).toBe(1)
+    expect(p.notStarted).toBe(1)
+    expect(p.critical).toBe(2)
+    expect(p.remainingDuration).toBe(6)
+    expect(p.plannedDuration).toBe(10)
+  })
+
+  it('behind schedule when B is late to start (data date 7)', () => {
+    const p = projectProgress(activities, cpm, 7)
+    expect(p.plannedPercent).toBeCloseTo(70, 6)   // 4 + 6·0.5
+    expect(p.actualPercent).toBeCloseTo(40, 6)
+    expect(p.scheduleVariancePercent).toBeCloseTo(-30, 6)
+    expect(p.spi!).toBeCloseTo(4 / 7, 6)
+    expect(p.daysAheadBehind).toBeCloseTo(-3, 3)  // earned schedule 4, data date 7
+    expect(p.delayed).toBe(1)                     // B should have started
+    expect(p.forecastDuration).toBeCloseTo(10 / (4 / 7), 4)
+  })
+
+  it('skips activities missing from the CPM result', () => {
+    const p = projectProgress([...activities, act('ghost', 5)], cpm, 4)
+    expect(p.total).toBe(2)
+  })
+})
+
+describe('baselineVariance', () => {
+  it('current − baseline (positive = slip)', () => {
+    const v = baselineVariance({ start: 2, finish: 12, duration: 10 }, { start: 0, finish: 10, duration: 10 })
+    expect(v).toEqual({ startVariance: 2, finishVariance: 2, durationVariance: 0 })
+  })
+})

--- a/webapp/src/engine/schedule/progress.ts
+++ b/webapp/src/engine/schedule/progress.ts
@@ -1,0 +1,193 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Progress-tracking engine.
+//
+// Turns per-activity %-complete + actuals + the CPM schedule into activity
+// status, a planned-vs-actual roll-up, schedule/forecast metrics and baseline
+// variance — the numbers the dashboard, Gantt shading and reports consume.
+//
+// "Progress" here is duration-weighted (a cost-free schedule-performance view).
+// When costs exist, `earnedValue.ts` gives the same shape in currency units.
+// All times are on the CPM working-day axis (offset 0 = project start).
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { Activity, ActivityStatus } from './model'
+import type { CpmResult } from './cpm'
+import { plannedFraction, scheduleVarianceTime, type PvActivity } from './earnedValue'
+
+const clampPct = (p: number | undefined): number => Math.min(100, Math.max(0, p ?? 0))
+
+/** Remaining duration = duration · (1 − %complete). */
+export function activityRemainingDuration(duration: number, percentComplete: number | undefined): number {
+  return duration * (1 - clampPct(percentComplete) / 100)
+}
+
+/** Percent an activity *should* be complete at `dataDate`, from its schedule. */
+export function plannedPercentComplete(es: number, ef: number, dataDate: number): number {
+  return plannedFraction(es, ef, dataDate) * 100
+}
+
+/** Duration- (or budget-) weighted mean percent complete. */
+export function rollupPercentComplete(items: { weight: number; percentComplete: number }[]): number {
+  let num = 0, den = 0
+  for (const it of items) { num += it.weight * clampPct(it.percentComplete); den += it.weight }
+  return den > 0 ? num / den : 0
+}
+
+/** Schedule context for status derivation (from the CPM solve). */
+export interface StatusContext {
+  dataDate: number
+  es: number
+  ef: number
+}
+
+/**
+ * Derive an activity's status from its actuals and the schedule. An explicit
+ * `blocked` flag is preserved (it cannot be inferred). Otherwise:
+ *   completed  — %≥100 or an actual finish is recorded
+ *   delayed    — behind: past its finish unfinished, started but under planned %,
+ *                or not started after its planned start
+ *   in-progress / not-started otherwise
+ */
+export function deriveStatus(activity: Activity, ctx: StatusContext): ActivityStatus {
+  if (activity.status === 'blocked') return 'blocked'
+  const pct = clampPct(activity.percentComplete)
+  if (pct >= 100 || activity.actualFinish) return 'completed'
+
+  const started = pct > 0 || !!activity.actualStart
+  const eps = 1e-6
+  if (started) {
+    if (ctx.dataDate > ctx.ef + eps) return 'delayed'          // should have finished
+    const planned = plannedPercentComplete(ctx.es, ctx.ef, ctx.dataDate)
+    return pct + eps < planned ? 'delayed' : 'in-progress'
+  }
+  return ctx.dataDate > ctx.es + eps ? 'delayed' : 'not-started'
+}
+
+/** Per-activity progress row (schedule + actual + derived status). */
+export interface ActivityProgress {
+  id: string
+  es: number
+  ef: number
+  duration: number
+  percentComplete: number
+  plannedPercent: number
+  remainingDuration: number
+  critical: boolean
+  status: ActivityStatus
+}
+
+/** Project-level dashboard summary. */
+export interface ProjectProgress {
+  /** Planned % complete at the data date (duration-weighted). */
+  plannedPercent: number
+  /** Actual % complete (duration-weighted). */
+  actualPercent: number
+  /** actualPercent − plannedPercent (>0 ahead). */
+  scheduleVariancePercent: number
+  /** Duration-based schedule performance index EV/PV (null when nothing planned). */
+  spi: number | null
+  /** Earned-schedule time variance at the data date, working days (>0 ahead). */
+  daysAheadBehind: number
+  /** Baseline (planned) project duration = CPM critical-path length. */
+  plannedDuration: number
+  /** SPI-forecast duration = plannedDuration / SPI. */
+  forecastDuration: number
+  /** Total remaining duration across activities. */
+  remainingDuration: number
+  total: number
+  completed: number
+  inProgress: number
+  notStarted: number
+  delayed: number
+  blocked: number
+  critical: number
+  activities: ActivityProgress[]
+}
+
+/**
+ * Roll activities + the CPM solve up into a dashboard summary at `dataDate`.
+ * Activities absent from the CPM result (unknown ids) are skipped.
+ */
+export function projectProgress(
+  activities: Activity[],
+  cpm: CpmResult,
+  dataDate: number,
+): ProjectProgress {
+  const rows: ActivityProgress[] = []
+  const pvActs: PvActivity[] = []
+  let plannedWork = 0, earnedWork = 0, totalWork = 0, remaining = 0
+  let completed = 0, inProgress = 0, notStarted = 0, delayed = 0, blocked = 0, critical = 0
+
+  for (const a of activities) {
+    const c = cpm.activities.get(a.id)
+    if (!c) continue
+    const pct = clampPct(a.percentComplete)
+    const planned = plannedPercentComplete(c.es, c.ef, dataDate)
+    const status = deriveStatus(a, { dataDate, es: c.es, ef: c.ef })
+    const rem = activityRemainingDuration(a.duration, pct)
+
+    rows.push({
+      id: a.id, es: c.es, ef: c.ef, duration: a.duration,
+      percentComplete: pct, plannedPercent: planned, remainingDuration: rem,
+      critical: c.critical, status,
+    })
+
+    const w = a.duration
+    plannedWork += w * (planned / 100)
+    earnedWork += w * (pct / 100)
+    totalWork += w
+    remaining += rem
+    pvActs.push({ es: c.es, ef: c.ef, bac: w })
+
+    if (c.critical) critical++
+    switch (status) {
+      case 'completed': completed++; break
+      case 'in-progress': inProgress++; break
+      case 'not-started': notStarted++; break
+      case 'delayed': delayed++; break
+      case 'blocked': blocked++; break
+    }
+  }
+
+  const plannedPercent = totalWork > 0 ? (plannedWork / totalWork) * 100 : 0
+  const actualPercent = totalWork > 0 ? (earnedWork / totalWork) * 100 : 0
+  const spi = plannedWork > 0 ? earnedWork / plannedWork : null
+  const forecastDuration = spi && spi > 0 ? cpm.duration / spi : cpm.duration
+  const daysAheadBehind = scheduleVarianceTime(pvActs, earnedWork, dataDate, cpm.duration)
+
+  return {
+    plannedPercent, actualPercent,
+    scheduleVariancePercent: actualPercent - plannedPercent,
+    spi, daysAheadBehind,
+    plannedDuration: cpm.duration, forecastDuration, remainingDuration: remaining,
+    total: rows.length, completed, inProgress, notStarted, delayed, blocked, critical,
+    activities: rows,
+  }
+}
+
+// ── Baseline variance ───────────────────────────────────────────────────────
+
+/** A start/finish/duration snapshot (working-day offsets, or day counts). */
+export interface ScheduleSnapshot {
+  start: number
+  finish: number
+  duration: number
+}
+
+export interface BaselineVariance {
+  /** current.start − baseline.start (>0 = starts later than baseline). */
+  startVariance: number
+  /** current.finish − baseline.finish (>0 = finishes later). */
+  finishVariance: number
+  /** current.duration − baseline.duration (>0 = longer). */
+  durationVariance: number
+}
+
+/** Compare a current snapshot against its baseline (current − baseline). */
+export function baselineVariance(current: ScheduleSnapshot, baseline: ScheduleSnapshot): BaselineVariance {
+  return {
+    startVariance: current.start - baseline.start,
+    finishVariance: current.finish - baseline.finish,
+    durationVariance: current.duration - baseline.duration,
+  }
+}


### PR DESCRIPTION
## Project Scheduling module — Phase 2 of 10

Progress tracking + Earned Value Management. Consumes the Phase 1 CPM schedule
and turns %-complete + actuals into the numbers the dashboard, Gantt shading and
reports will render.

> **Stacked on #387.** Base is `feature/schedule-cpm-pert-engine`; the diff is
> Phase 2 only. GitHub retargets this to `main` when #387 merges (or I'll rebase).

### What's in this PR (`webapp/src/engine/schedule/`)
| File | Role |
|------|------|
| `earnedValue.ts` | EVM: `PV = Σ BACᵢ·plannedᵢ`, `EV = Σ BACᵢ·%compᵢ`, `AC` → `SV, CV, SPI, CPI, EAC, VAC, ETC, TCPI` (zero-denominator ratios returned as `null`, not `0`). **Earned Schedule** (`pvAtOffset` + bisection) for a *time-based* schedule variance in working days. BAC/AC unit-agnostic (currency, or duration for a cost-free view). |
| `progress.ts` | Activity remaining duration, **status derivation** (completed / in-progress / delayed / not-started, preserving an explicit `blocked`), planned %, duration-weighted roll-up, `projectProgress` dashboard summary (planned vs actual %, SPI, days ahead/behind, forecast duration, counts), and `baselineVariance`. |

### Engineering accuracy
- EVM verified against a **PMBOK worked example** (PV 175 / EV 150 / AC 150 / BAC 200 → SV −25, SPI 0.857, CPI 1.0, EAC 200, TCPI 1.0).
- Earned Schedule verified by inverting a known PV curve (earned 25 at data date 8 ⇒ **3 days behind**; earned 75 at date 12 ⇒ **3 days ahead**).
- Every `deriveStatus` branch and the planned-vs-actual roll-up asserted on a 2-activity chain.

### Verification
- **24 new vitest cases**, all green.
- Full suite: **1294 passing (101 files)**; `npx tsc -b` clean.

### Next
Phase 3 — persistence (`ScheduleProject` localStorage store + JSON import/export), then the UI phases (WBS grid → Gantt → network diagram → dashboard). Roadmap in `docs/scheduling.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)