### PR TITLE
docs: reconcile priority backlog with the shipped engine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,10 +146,11 @@ mm, forces kN, stress MPa) and state them at module boundaries.
 Ordered: correctness first, then code completeness, then new capability.
 
 ## P1 — results correctness
-1. **Cracked-section stiffness modifiers** (ACI 318-14 §6.6.3.1.1: 0.35Ig
-   beams, 0.70Ig columns, 0.25Ig walls/flat plates). The frame runs on gross
-   EI → drifts and P-Δ are unconservative. Implement as per-role factors in
-   `modelBridge` section props (opt-out toggle), not inside `frame3d`.
+1. ~~**Cracked-section stiffness modifiers** (ACI 318-14 §6.6.3.1.1: 0.35Ig
+   beams, 0.70Ig columns, 0.25Ig walls/flat plates)~~ — ✔ shipped (#327):
+   per-role factors via `BridgeOpts.crackedSections` in `modelBridge` section
+   props (ON in the Model Space UI, OFF at the API level so closed-form
+   benchmarks stay gross-section) — never inside `frame3d`.
 2. ~~**Accidental torsion, 5% eccentricity** (NSCP §208.7.2.7)~~ — ✔ shipped:
    `accidentalTorsionLoads` applies ±0.05·L⊥ storey torques as mass-weighted
    node-force couples (works with and without the diaphragm).
@@ -176,8 +177,9 @@ Ordered: correctness first, then code completeness, then new capability.
 8. Irregularity auto-flags (torsional, soft-storey, mass — NSCP Table 208-9/10).
 
 ## P4 — design & geotech capability
-9. Steel **moment connections, shear tabs, block shear, prying** (HANDOFF
-   already flags connections + Lb bracing inputs).
+9. ~~Steel **moment connections, shear tabs, block shear, prying**~~ — ✔ shipped:
+   `steelConnections.ts` (shear-tab, moment-flange-weld, moment-web-plate) +
+   `steelDesign.ts` block shear §J4.3 (`shearTabBlockShear`) and prying §J3.9.
 10. Thread cracked deflection (`beamDeflection`/`slabDeflection`) into
     model-space serviceability results.
 11. **Slope stability by method of slices** (Bishop simplified / Janbu) —

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -607,3 +607,44 @@ each as **Problem → Reference solution → Software output → Error % → PAS
 Surface the pass counts on the `/validation` page and a public "Validation"
 section. This is the highest-leverage next body of work; treat each chapter as
 its own PR (engine benchmark test + a `docs/validation/*.md` write-up).
+
+## Verified backlog (code-vs-docs reconciliation, July 2026)
+
+An audit of the actual engine (`webapp/src/engine/`) against the CLAUDE.md
+priority backlog. **Already shipped** (docs lagged the code): cracked-section
+modifiers (#327, `modelBridge` role factors), accidental torsion, orthogonal
+100 %+30 % & vertical `Ev`, Timoshenko shear, and steel **block shear (§J4.3)**
++ **prying (§J3.9)** + shear-tab / moment connections (`steelDesign.ts`,
+`steelConnections.ts`) — so the old P4 "steel connections" item is effectively
+complete. New disciplines landed too: **timber wood-frame** (#379–#386),
+**plumbing RNPCP** (#381–#383), **project scheduling CPM/PERT** (#387–#390).
+
+**Still genuinely missing** (verified absent from the engine):
+
+_Analysis completeness (P3):_
+- **Direct-integration MDOF time-history** with Rayleigh damping — `timeHistory.ts`
+  is modal-superposition only (no full-system Newmark); prerequisite for nonlinear TH.
+- **Tension-only / compression-only members** (braces, uplift springs) and a
+  **consistent-mass** option beside lumped — neither exists anywhere.
+- **Irregularity auto-flags** — NSCP Table 208-9/10 (torsional, soft-storey,
+  mass) are not detected/reported. *(Smallest, high-value: pure checks off the
+  existing modal/drift results.)*
+
+_Geotech / foundations (P4):_
+- **Slope stability by method of slices** (Bishop / Janbu) — `geotech.ts` has only
+  `infiniteSlopeFS`; no global slope stability.
+- **Settlement** (immediate + consolidation) and **laterally loaded piles**
+  (Broms / p-y) — absent.
+- **Offset framing / beam-on-girder-flange bearing** (seat detail, AISC §J10) —
+  still blocked on the model supporting vertically offset framing.
+
+_v1.0 gate:_
+- **Formal validation manual** (`docs/validation/`, one file per case:
+  Problem → Reference → Software output → Error % → PASS) + the external-tool
+  cross-checks (ETABS/STAAD/PCA/Excel — open items X001–X004). The unit suite is
+  the seed; it is not yet assembled into a documented manual.
+
+_Minor / partial:_
+- Cracked-section deflection (`beamDeflection`/`slabDeflection` exist standalone)
+  is not clearly threaded into Model-Space serviceability results.
+- Pressure grouting — intentionally skipped (empirical).


### PR DESCRIPTION
## What

Docs-only reconciliation of the priority backlog against the actual engine code (no functional changes).

- **Marks as shipped** (the docs had lagged the code):
  - Cracked-section stiffness modifiers — #327, `BridgeOpts.crackedSections` in `modelBridge`.
  - Steel connections — shear-tab / moment-flange-weld / moment-web-plate (`steelConnections.ts`) plus **block shear §J4.3** and **prying §J3.9** (`steelDesign.ts`).
- **Adds a "Verified backlog" section to `HANDOFF.md`** listing what is genuinely still missing, checked against `engine/`:
  - Direct-integration MDOF time-history (Rayleigh) — `timeHistory.ts` is modal-only.
  - Tension-only / compression-only members + consistent-mass option.
  - Irregularity auto-flags (NSCP Table 208-9/10).
  - Slope stability by method of slices (Bishop / Janbu).
  - Settlement (immediate + consolidation), laterally loaded piles (Broms / p-y).
  - Offset framing / beam-on-girder-flange bearing (AISC §J10).
  - Formal validation manual + external-tool cross-checks (X001–X004).
- Also notes the newly-landed disciplines (timber wood-frame, plumbing RNPCP, project scheduling CPM/PERT).

## Files

`HANDOFF.md`, `CLAUDE.md` — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_