### PR TITLE
feat: connect the wood-slab take-off to the wood-frame bill of materials

### DIFF
--- a/webapp/src/engine/takeoff.ts
+++ b/webapp/src/engine/takeoff.ts
@@ -135,10 +135,18 @@ export function costBill(t: TakeoffResult, p: PriceList): CostedBill {
   for (const s of [...t.steelByShape].sort((a, b) => a.shape.localeCompare(b.shape)))
     rows.push(row(`Structural steel — ${s.shape}`, s.kg, 'kg', steelRate, 'structuralSteelKg'))
   // Timber — one costed line per section size, priced per board foot (PH commercial unit).
-  const timberRate = p.timberBdFt ?? 55
-  for (const t2 of [...t.timberBySize].sort((a, b) => a.name.localeCompare(b.name)))
-    rows.push(row(`Timber — ${t2.name} (${t2.species})`, t2.boardFeet, 'bd·ft', timberRate, 'timberBdFt'))
+  rows.push(...costTimberRows(t.timberBySize, p.timberBdFt ?? 55))
   return { rows, total: rows.reduce((s, r) => s + r.amount, 0) }
+}
+
+/** Cost a set of timber sizes at ₱/board-foot — shared by the model wood-frame
+ *  BOM (costBill) and any standalone timber bill (e.g. the wood slab), so both
+ *  price timber identically. */
+export function costTimberRows(sizes: TimberSizeQty[], ratePerBdFt = 55): BillRow[] {
+  return [...sizes].sort((a, b) => a.name.localeCompare(b.name)).map((t) => ({
+    item: `Timber — ${t.name} (${t.species})`, qty: t.boardFeet, unit: 'bd·ft',
+    unitPrice: ratePerBdFt, amount: t.boardFeet * ratePerBdFt, priceKey: 'timberBdFt' as const,
+  }))
 }
 
 export interface TakeoffOptions {

--- a/webapp/src/engine/woodSlab.test.ts
+++ b/webapp/src/engine/woodSlab.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { designWoodSlab, BAMBOO_SLAT_REF, type WoodSlabInput } from './woodSlab'
+import { designWoodSlab, woodSlabTimberSizes, BAMBOO_SLAT_REF, type WoodSlabInput } from './woodSlab'
 import { getWoodRef, woodSectionProps, woodAdjusted } from './woodDesign'
-import { BDFT_PER_M3 } from './takeoff'
+import { BDFT_PER_M3, costTimberRows } from './takeoff'
 
 const DFL2 = getWoodRef('DFL-2')!.ref
 
@@ -86,5 +86,36 @@ describe('designWoodSlab — take-off / bill of materials', () => {
   it('bamboo reference values are the conservative preliminary set', () => {
     expect(BAMBOO_SLAT_REF.Fb).toBe(12)
     expect(BAMBOO_SLAT_REF.Emin).toBeLessThan(BAMBOO_SLAT_REF.E)
+  })
+})
+
+describe('woodSlabTimberSizes — wood-frame BOM connection', () => {
+  it('emits joist + deck rows in the TimberSizeQty vocabulary with matching board feet', () => {
+    const r = designWoodSlab(base)
+    const sizes = woodSlabTimberSizes(base, r, { joist: 'DFL No.2', deck: 'DFL No.2' })
+    expect(sizes).toHaveLength(2)
+    const [joist, deck] = sizes
+    expect(joist.name).toBe('50×200')
+    expect(joist.boardFeet).toBeCloseTo(r.takeoff.joistBoardFeet, 6)
+    expect(joist.count).toBe(r.takeoff.joistCount)
+    expect(deck.boardFeet).toBeCloseTo(r.takeoff.deckBoardFeet, 6)
+    // deck linear metres × width × thickness = deck volume
+    expect(deck.L * (140 / 1000) * (25 / 1000)).toBeCloseTo(r.takeoff.deckM3, 9)
+  })
+
+  it('costs through the shared costTimberRows at ₱/board-foot', () => {
+    const r = designWoodSlab(base)
+    const sizes = woodSlabTimberSizes(base, r)
+    const rows = costTimberRows(sizes, 55)
+    expect(rows).toHaveLength(2)
+    expect(rows.every((x) => x.unit === 'bd·ft' && x.priceKey === 'timberBdFt')).toBe(true)
+    const total = rows.reduce((s, x) => s + x.amount, 0)
+    expect(total).toBeCloseTo((r.takeoff.joistBoardFeet + r.takeoff.deckBoardFeet) * 55, 4)
+  })
+
+  it('labels a bamboo deck as bamboo', () => {
+    const r = designWoodSlab({ ...base, deckMaterial: 'bamboo-slat', deckWidth: 50 })
+    const [, deck] = woodSlabTimberSizes({ ...base, deckMaterial: 'bamboo-slat', deckWidth: 50 }, r)
+    expect(deck.species).toBe('bamboo')
   })
 })

--- a/webapp/src/engine/woodSlab.ts
+++ b/webapp/src/engine/woodSlab.ts
@@ -25,7 +25,7 @@ import {
   type WoodRefValues, type WoodKind, type WoodAdjustOpts,
   woodAdjusted, woodSectionProps, woodUnitWeight, checkWoodBeam,
 } from './woodDesign'
-import { BDFT_PER_M3 } from './takeoff'
+import { BDFT_PER_M3, type TimberSizeQty } from './takeoff'
 
 /** Indicative ASD allowable stresses for flattened / laminated STRUCTURAL BAMBOO
  *  (e.g. Guadua, Bambusa / kawayan).  NOT an NDS-tabulated species — these are
@@ -212,4 +212,26 @@ export function designWoodSlab(i: WoodSlabInput): WoodSlabResult {
     takeoff, ratio, ok: ratio <= 1,
     clause: 'NDS §3.3–§3.4 / NSCP §6 (ASD)',
   }
+}
+
+/** Express a wood-slab take-off as wood-frame BOM rows (TimberSizeQty, board-feet
+ *  by size × species), so the slab's joists and decking aggregate into — and cost
+ *  through the same `costTimberRows` as — the wood-frame bill of materials. */
+export function woodSlabTimberSizes(
+  i: WoodSlabInput, r: WoodSlabResult, labels: { joist?: string; deck?: string } = {},
+): TimberSizeQty[] {
+  const bamboo = i.deckMaterial === 'bamboo-slat'
+  const deckWidth = i.deckWidth ?? (bamboo ? 50 : 140)
+  const deckLenM = r.takeoff.deckM3 / ((deckWidth / 1000) * (i.deckThickness / 1000))  // total board linear metres
+  return [
+    {
+      name: `${i.joistB}×${i.joistD}`, species: labels.joist ?? '—', kind: i.joistKind ?? 'sawn',
+      count: r.takeoff.joistCount, L: r.takeoff.joistLengthM, m3: r.takeoff.joistM3, boardFeet: r.takeoff.joistBoardFeet,
+    },
+    {
+      name: `deck ${deckWidth}×${i.deckThickness}`, species: labels.deck ?? (bamboo ? 'bamboo' : labels.joist ?? '—'),
+      kind: 'sawn', count: r.takeoff.bambooSlatCount ?? Math.ceil(i.Lx / (deckWidth / 1000)),
+      L: deckLenM, m3: r.takeoff.deckM3, boardFeet: r.takeoff.deckBoardFeet,
+    },
+  ]
 }

--- a/webapp/src/pages/WoodSlab.tsx
+++ b/webapp/src/pages/WoodSlab.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
-import { designWoodSlab, type DeckMaterial, type SlabSupport } from '../engine/woodSlab'
+import { designWoodSlab, woodSlabTimberSizes, type DeckMaterial, type SlabSupport } from '../engine/woodSlab'
 import { speciesList, gradesOf, resolveWoodSpecies } from '../engine/woodDesign'
 import type { LoadDuration } from '../engine/woodDesign'
+import { costTimberRows } from '../engine/takeoff'
 import { ReportControls } from '../components/ReportControls'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
@@ -77,6 +78,7 @@ export default function WoodSlab() {
   // options
   const [duration, setDuration] = useState<LoadDuration>('ten-year')
   const [wet, setWet] = useState(false)
+  const [timberRate, setTimberRate] = useState(55)   // ₱ / board-foot (shared wood-frame rate)
 
   const sp = resolveWoodSpecies(species, grade)
   const joistRef = sp?.ref
@@ -204,37 +206,61 @@ export default function WoodSlab() {
             <CheckCard title="Joist" sub={`${f0(joistB)}×${f0(joistD)} over ${f2(Lx)} m`} c={r.joist} />
           </div>
 
-          <h3 className="mb-1 mt-5 text-sm font-bold text-slate-700">Bill of materials</h3>
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-slate-200 text-left text-slate-500">
-                  <th className="py-1 pr-3 font-medium">Item</th>
-                  <th className="py-1 pr-3 font-medium">Qty</th>
-                  <th className="py-1 font-medium">Board feet</th>
-                </tr>
-              </thead>
-              <tbody className="font-mono">
-                <tr className="border-b border-slate-100">
-                  <td className="py-1 pr-3">Joists {f0(joistB)}×{f0(joistD)} ({sp?.label})</td>
-                  <td className="py-1 pr-3">{f0(r.takeoff.joistCount)} pc · {f2(r.takeoff.joistLengthM)} m · {f3(r.takeoff.joistM3)} m³</td>
-                  <td className="py-1">{f0(r.takeoff.joistBoardFeet)}</td>
-                </tr>
-                <tr className="border-b border-slate-100">
-                  <td className="py-1 pr-3">Decking — {deckMaterial === 'bamboo-slat' ? 'bamboo slats' : 'planks'} ({f0(deckThickness)} mm)</td>
-                  <td className="py-1 pr-3">
-                    {f2(r.takeoff.deckAreaM2)} m² · {f3(r.takeoff.deckM3)} m³
-                    {r.takeoff.bambooSlatCount != null ? ` · ${f0(r.takeoff.bambooSlatCount)} slats` : ''}
-                  </td>
-                  <td className="py-1">{f0(r.takeoff.deckBoardFeet)}</td>
-                </tr>
-              </tbody>
-            </table>
+          <div className="mb-1 mt-5 flex items-baseline justify-between">
+            <h3 className="text-sm font-bold text-slate-700">Bill of materials <span className="font-normal text-slate-400">— wood-frame timber costing</span></h3>
+            <label className="no-print flex items-center gap-1 text-xs text-slate-500">
+              ₱/bd·ft
+              <input type="number" step="any" value={timberRate} onChange={(e) => setTimberRate(num(e.target.value, 55))}
+                className="w-16 rounded border border-slate-300 px-1.5 py-0.5 text-right font-mono" />
+            </label>
           </div>
+          {(() => {
+            const sizes = woodSlabTimberSizes(
+              { Lx, Ly, joistRef: joistRef!, joistKind: sp!.kind, joistB, joistD, joistSpacing, joistSupport, deckMaterial, deckThickness, deckWidth, deckSupport, deadKpa, liveKpa },
+              r, { joist: sp?.label, deck: deckMaterial === 'bamboo-slat' ? 'bamboo' : sp?.label },
+            )
+            const rows = costTimberRows(sizes, timberRate)
+            const total = rows.reduce((s, x) => s + x.amount, 0)
+            return (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-slate-200 text-left text-slate-500">
+                      <th className="py-1 pr-3 font-medium">Item</th>
+                      <th className="py-1 pr-3 text-right font-medium">Board feet</th>
+                      <th className="py-1 text-right font-medium">Amount (₱)</th>
+                    </tr>
+                  </thead>
+                  <tbody className="font-mono">
+                    {rows.map((row, k) => (
+                      <tr key={k} className="border-b border-slate-100">
+                        <td className="py-1 pr-3">
+                          {row.item}
+                          <span className="ml-1 text-[11px] text-slate-400">
+                            {k === 0
+                              ? `${f0(sizes[0].count)} pc · ${f2(sizes[0].L)} m · ${f3(sizes[0].m3)} m³`
+                              : `${f2(r.takeoff.deckAreaM2)} m² · ${f3(sizes[1].m3)} m³${r.takeoff.bambooSlatCount != null ? ` · ${f0(r.takeoff.bambooSlatCount)} slats` : ''}`}
+                          </span>
+                        </td>
+                        <td className="py-1 pr-3 text-right">{f0(row.qty)}</td>
+                        <td className="py-1 text-right">{row.amount.toLocaleString(undefined, { maximumFractionDigits: 0 })}</td>
+                      </tr>
+                    ))}
+                    <tr className="font-semibold text-slate-700">
+                      <td className="py-1 pr-3">Timber sub-total</td>
+                      <td className="py-1 pr-3 text-right">{f0(sizes.reduce((s, x) => s + x.boardFeet, 0))}</td>
+                      <td className="py-1 text-right">{total.toLocaleString(undefined, { maximumFractionDigits: 0 })}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            )
+          })()}
           <p className="mt-2 text-[10px] text-slate-500">
             Demands wL²/8 (simple) or wL²/10 (continuous ≥3 spans); deflection on the service modulus E′.
-            Board feet = m³ × {`423.776`}. Verify joist-to-support bearing, fastener schedule and diaphragm
-            action separately.
+            Board feet = m³ × 423.776, priced with the same <code>costTimberRows</code> (₱/board-foot) as the
+            wood-frame model bill of materials. Verify joist-to-support bearing, fastener schedule and
+            diaphragm action separately.
           </p>
         </section>
       )}


### PR DESCRIPTION
## What

Final wooden-slab phase — wires the slab take-off into the **wood-frame bill of materials** so both price timber through one code path.

- **`costTimberRows(sizes, ratePerBdFt)`** extracted from `costBill` in `takeoff.ts` (costBill now calls it). Single ₱/board-foot costing path shared by the model wood-frame BOM and any standalone timber bill.
- **`woodSlabTimberSizes(input, result, labels)`** in `woodSlab.ts` expresses the slab's **joists** and **decking** as wood-frame `TimberSizeQty` rows (board-feet by size × species) — so a slab aggregates into, and prices identically to, the model's `timberBySize` bill.
- The **wood-slab page** now renders a **costed BOM** (board-feet + ₱ amounts + timber sub-total) via `costTimberRows`, with an editable ₱/board-foot rate (defaults to the wood-frame ₱55).

## Layer

L7/L9 + take-off (`quantities`). Pure refactor of `costBill` (behaviour-preserving) + one new connector; page renders it.

## Verification

- New tests: board-feet **parity** between `woodSlabTimberSizes` and the slab take-off; `costTimberRows` total = Σ board-feet × rate; bamboo deck labelled `bamboo`; deck linear-m × width × t = deck m³.
- Existing `takeoff.test.ts` still green (costBill unchanged in behaviour).
- Full suite **1334 passing**, `tsc -b` clean, `npm run build` OK.

## Series recap (wooden slab)
1. #393 — engine (`woodSlab.ts`, deck-on-joist, planks / bamboo slats).
2. #394 — page (`/wood-slab`).
3. **this** — wood-frame BOM connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_