### PR TITLE
fix: de-circularize the wood-slab-joist validation benchmark (from #393 review)

### DIFF
--- a/webapp/src/engine/validation.ts
+++ b/webapp/src/engine/validation.ts
@@ -239,6 +239,8 @@ const woodSlabJoist = (() => {
   //   f_b = (w·L²/8)·1e6 / (b·d²/6) = 3.571 MPa
   const ref = getWoodRef('DFL-2')!.ref
   const gamma = ref.G * 9.81                                   // kN/m³ (= woodUnitWeight)
+  // Plank deck ⇒ deckRef defaults to joistRef, so deck and joist share γ here.
+  // (A bamboo-slat deck would use BAMBOO_SLAT_REF.G = 0.65 for the deck self-weight.)
   const deckSelf = gamma * (25 / 1000)                        // kPa
   const joistSelf = gamma * ((50 * 200) / 1e6)               // kN/m
   const w = (0.5 + deckSelf + 1.9) * (400 / 1000) + joistSelf // kN/m ≈ 1.0581

--- a/webapp/src/engine/validation.ts
+++ b/webapp/src/engine/validation.ts
@@ -228,15 +228,28 @@ const woodCL = (() => {
 })()
 
 const woodSlabJoist = (() => {
-  // DFL-No.2 joist 50 × 200 mm @ 400 mm o.c., 3.0 m simple span; deck 25 mm plank.
-  // Closed form: f_b = M/S with the assembled UDL M = wL²/8.
-  const r = designWoodSlab({
-    Lx: 3.0, Ly: 3.6, joistRef: getWoodRef('DFL-2')!.ref, joistB: 50, joistD: 200,
+  // DFL-No.2 joist 50 × 200 mm @ 400 mm o.c., 3.0 m simple span; 25 mm plank deck.
+  // INDEPENDENT hand assembly of the joist line load and f_b — the manual side
+  // rebuilds the whole load path from the inputs (it does NOT reuse the engine's
+  // w), so a wrong tributary width, missing/duplicated self-weight or wrong UDL
+  // coefficient would break the check:
+  //   γ = G·9.81 = 4.905 kN/m³; deck self = γ·0.025 = 0.1226 kPa;
+  //   joist self = γ·(0.05·0.20) = 0.04905 kN/m; tributary = 0.40 m spacing →
+  //   w = (0.5 + 0.1226 + 1.9)·0.40 + 0.04905 = 1.0581 kN/m
+  //   f_b = (w·L²/8)·1e6 / (b·d²/6) = 3.571 MPa
+  const ref = getWoodRef('DFL-2')!.ref
+  const gamma = ref.G * 9.81                                   // kN/m³ (= woodUnitWeight)
+  const deckSelf = gamma * (25 / 1000)                        // kPa
+  const joistSelf = gamma * ((50 * 200) / 1e6)               // kN/m
+  const w = (0.5 + deckSelf + 1.9) * (400 / 1000) + joistSelf // kN/m ≈ 1.0581
+  const S = (50 * 200 * 200) / 6                              // mm³
+  const manual = ((w * 3.0 * 3.0) / 8) * 1e6 / S             // MPa ≈ 3.571
+  const software = designWoodSlab({
+    Lx: 3.0, Ly: 3.6, joistRef: ref, joistB: 50, joistD: 200,
     joistSpacing: 400, joistSupport: 'simple', deckMaterial: 'plank', deckThickness: 25,
     deckWidth: 140, deckSupport: 'continuous', deadKpa: 0.5, liveKpa: 1.9,
-  })
-  const S = (50 * 200 * 200) / 6
-  return { manual: ((r.joist.w * 3.0 * 3.0) / 8) * 1e6 / S, software: r.joist.fb }
+  }).joist.fb
+  return { manual, software }
 })()
 
 // ── Plumbing (RNPCP 2000) — water-supply hydraulics ─────────────────────────

--- a/webapp/src/engine/woodSlab.test.ts
+++ b/webapp/src/engine/woodSlab.test.ts
@@ -13,6 +13,18 @@ const base: WoodSlabInput = {
 }
 
 describe('designWoodSlab — flexural demands (NSCP/ACI UDL coefficients)', () => {
+  it('assembles the joist line load and f_b to an independent hand value', () => {
+    const r = designWoodSlab(base)
+    // Independent of the engine's own w. DFL-2: γ = G·9.81 = 0.5·9.81 = 4.905 kN/m³.
+    //   deck self  = γ·0.025               = 0.12263 kPa
+    //   joist self = γ·(0.05·0.20)         = 0.04905 kN/m
+    //   tributary  = 0.40 m spacing →
+    //   w  = (0.5 + 0.12263 + 1.9)·0.40 + 0.04905 = 1.0581 kN/m
+    //   fb = (w·3²/8)·1e6 / (50·200²/6)           = 3.571 MPa
+    expect(r.joist.w).toBeCloseTo(1.0581, 3)     // pins the tributary + self-weight assembly
+    expect(r.joist.fb).toBeCloseTo(3.571, 2)     // pins f_b = M/S from that load
+  })
+
   it('joist moment & shear follow the simple-span coefficients wL²/8, wL/2', () => {
     const r = designWoodSlab(base)
     const L = base.Lx


### PR DESCRIPTION
## What

Fix a **circular validation benchmark** surfaced by the two-subagent code + peer review of the wood-slab engine (#393, already merged).

The `wood-slab-joist` row in `validation.ts` computed its `manual` side from the engine's own assembled line load `w` (`manual = (r.joist.w·L²/8)·1e6/S`, `software = r.joist.fb`). Since both derive from the same `w` and `S`, `manual == software` by construction and the row **could never fail** (tol 1e-9). That violates the repo's L9 rule that a `/validation` benchmark be a *real independent check* — a wrong tributary width, missing/duplicated self-weight, or wrong UDL coefficient would have gone undetected.

## Change (test/validation-quality only — no engine change)
- **`validation.ts`** — the `manual` side now rebuilds the joist line load independently from the inputs: `γ = G·9.81`; deck self `γ·0.025`; joist self `γ·(0.05·0.20)`; tributary = the 0.40 m joist spacing → `w = (0.5 + deckSelf + 1.9)·0.40 + joistSelf`; then `M = wL²/8`, `f_b = M/S`. It no longer reads any engine intermediate.
- **`woodSlab.test.ts`** — new hand-calc anchor pinning `r.joist.w ≈ 1.058 kN/m` and `r.joist.fb ≈ 3.571 MPa` to literals, so the load-path magnitudes are independently pinned.

Both reviews hand-verified the **engine physics was already correct** (base case: `w = 1.0581 kN/m`, `f_b = 3.571 MPa`), so no engine output changes — the benchmark still passes, but now because the independent hand value genuinely matches, not by construction.

## Verification
- `woodSlab.test.ts` + `validation.test.ts` green; full suite **1335 passing (107 files)**; `npx tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)