### PR TITLE
feat: project scheduling — AON network diagram (Phase 6)

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -156,12 +156,16 @@ columns (dates + total float + critical tag) and an expandable ES/EF/LS/LF/float
   WBS-group collapse, live CPM recompute, cycle-prevented dependency editor,
   project new/sample/import/export. Drag-and-drop reorder is a later polish
   (up/down buttons ship now).
-- **Phase 5 — Gantt chart** *(this PR)*: `/schedule/gantt` + pure timeline
+- **Phase 5 — Gantt chart** ✅: `/schedule/gantt` + pure timeline
   geometry in `lib/gantt.ts` (zoom day→year, date→pixel, ticks, bar widths;
   tested). Status-coloured bars with a %-complete fill, critical highlight,
   milestone diamonds, optional baseline underlay, dependency connectors and a
   data-date line. Arrow routing is a simple elbow (polish later).
-- **Phase 6 — AON network diagram**: draggable nodes, critical-path styling.
+- **Phase 6 — AON network diagram** *(this PR)*: `/schedule/network` + pure
+  layered-DAG layout in `lib/network.ts` (longest-path columns, rows, critical
+  edges; tested). SVG nodes carry ES/EF and total float, the critical path is
+  in brick red, dependency links are bezier arrows, and nodes are **draggable**
+  (view-only — moving a node never touches the schedule).
 - **Phase 7 — dashboard**: progress vs plan, SPI/CPI, variance, EAC, EVM charts.
 - **Phase 8 — resource loading**: labor/equipment/material, over-allocation.
 - **Phase 9 — reports**: schedule / critical-path / EVM / progress / resource →

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -44,6 +44,7 @@ import LoadCombinations from './pages/LoadCombinations'
 import PlumbingDesign from './pages/PlumbingDesign'
 import Schedule from './pages/Schedule'
 import ScheduleGantt from './pages/ScheduleGantt'
+import ScheduleNetwork from './pages/ScheduleNetwork'
 
 export default function App() {
   const [auth, setAuth] = useState<'login' | 'signup' | null>(null)
@@ -105,6 +106,7 @@ export default function App() {
         <Route path="/plumbing" element={<PlumbingDesign />} />
         <Route path="/schedule" element={<Schedule />} />
         <Route path="/schedule/gantt" element={<ScheduleGantt />} />
+        <Route path="/schedule/network" element={<ScheduleNetwork />} />
             </Routes>
           </AppShell>
         } />

--- a/webapp/src/lib/network.test.ts
+++ b/webapp/src/lib/network.test.ts
@@ -66,3 +66,47 @@ describe('layoutNetwork', () => {
     expect(L.height).toBeGreaterThan(0)
   })
 })
+
+describe('critical edges require a binding link (diamond of equal-length paths)', () => {
+  // A(5)→P(5)→S(10); A→R(10); Q(5) after P and R. Two equal 20-day paths
+  // A-P-S and A-R-Q ⇒ A,P,R,S,Q all critical, but P→Q is slack (R drives Q).
+  const acts: NetActivity[] = [
+    { id: 'A', name: 'A', predecessors: [] },
+    { id: 'P', name: 'P', predecessors: [dep('A')] },
+    { id: 'R', name: 'R', predecessors: [dep('A')] },
+    { id: 'S', name: 'S', predecessors: [dep('P')] },
+    { id: 'Q', name: 'Q', predecessors: [dep('P'), dep('R')] },
+  ]
+  const cpm = computeCPM([
+    { id: 'A', duration: 5, predecessors: [] },
+    { id: 'P', duration: 5, predecessors: [dep('A')] },
+    { id: 'R', duration: 10, predecessors: [dep('A')] },
+    { id: 'S', duration: 10, predecessors: [dep('P')] },
+    { id: 'Q', duration: 5, predecessors: [dep('P'), dep('R')] },
+  ])
+  const L = layoutNetwork(acts, cpm)
+  const edge = (from: string, to: string) => L.edges.find((e) => e.from === from && e.to === to)!
+  const node = (id: string) => L.nodes.find((n) => n.id === id)!
+
+  it('all five activities are critical (zero float)', () => {
+    for (const id of ['A', 'P', 'R', 'S', 'Q']) expect(node(id).critical).toBe(true)
+  })
+  it('binding critical links are red; the slack P→Q link is not', () => {
+    expect(edge('A', 'P').critical).toBe(true)
+    expect(edge('A', 'R').critical).toBe(true)
+    expect(edge('P', 'S').critical).toBe(true)
+    expect(edge('R', 'Q').critical).toBe(true)   // R drives Q (EF 15 = ES(Q) 15)
+    expect(edge('P', 'Q').critical).toBe(false)  // both critical, but P (EF 10) does not drive Q
+  })
+})
+
+describe('empty project', () => {
+  it('lays out with no nodes/edges and positive dimensions (no Math.max(-Infinity))', () => {
+    const L = layoutNetwork([], computeCPM([]))
+    expect(L.nodes).toHaveLength(0)
+    expect(L.edges).toHaveLength(0)
+    expect(L.cols).toBe(0)
+    expect(L.width).toBeGreaterThan(0)
+    expect(L.height).toBeGreaterThan(0)
+  })
+})

--- a/webapp/src/lib/network.test.ts
+++ b/webapp/src/lib/network.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import type { Dependency } from '../engine/schedule/model'
+import { computeCPM } from '../engine/schedule/cpm'
+import { layoutNetwork, type NetActivity } from './network'
+
+const dep = (predecessor: string, type: Dependency['type'] = 'FS', lag = 0): Dependency => ({ predecessor, type, lag })
+
+// A(3)→B(4)→D(5)→F(4) critical; A→C(2)→{D,E(6)}→F.
+const acts: NetActivity[] = [
+  { id: 'A', name: 'A', predecessors: [] },
+  { id: 'B', name: 'B', predecessors: [dep('A')] },
+  { id: 'C', name: 'C', predecessors: [dep('A')] },
+  { id: 'D', name: 'D', predecessors: [dep('B'), dep('C')] },
+  { id: 'E', name: 'E', predecessors: [dep('C')] },
+  { id: 'F', name: 'F', predecessors: [dep('D'), dep('E')] },
+]
+const cpmInput = [
+  { id: 'A', duration: 3, predecessors: [] },
+  { id: 'B', duration: 4, predecessors: [dep('A')] },
+  { id: 'C', duration: 2, predecessors: [dep('A')] },
+  { id: 'D', duration: 5, predecessors: [dep('B'), dep('C')] },
+  { id: 'E', duration: 6, predecessors: [dep('C')] },
+  { id: 'F', duration: 4, predecessors: [dep('D'), dep('E')] },
+]
+
+describe('layoutNetwork', () => {
+  const cpm = computeCPM(cpmInput)
+  const L = layoutNetwork(acts, cpm)
+  const node = (id: string) => L.nodes.find((n) => n.id === id)!
+
+  it('columns follow the longest predecessor chain', () => {
+    expect(node('A').col).toBe(0)              // start
+    expect(node('B').col).toBe(1)              // after A
+    expect(node('C').col).toBe(1)              // after A
+    expect(node('D').col).toBe(2)              // after B and C
+    expect(node('E').col).toBe(2)              // after C
+    expect(node('F').col).toBe(3)              // after D and E
+    expect(L.cols).toBe(4)
+  })
+  it('nodes in a column get distinct rows and non-overlapping y', () => {
+    expect(node('B').row).not.toBe(node('C').row)
+    expect(node('B').y).not.toBe(node('C').y)
+  })
+  it('x increases with column', () => {
+    expect(node('A').x).toBeLessThan(node('B').x)
+    expect(node('B').x).toBeLessThan(node('D').x)
+  })
+  it('carries the CPM critical flag onto nodes and edges', () => {
+    expect(node('A').critical && node('B').critical && node('D').critical && node('F').critical).toBe(true)
+    expect(node('C').critical || node('E').critical).toBe(false)
+    const ab = L.edges.find((e) => e.from === 'A' && e.to === 'B')!
+    const ac = L.edges.find((e) => e.from === 'A' && e.to === 'C')!
+    expect(ab.critical).toBe(true)             // both endpoints critical
+    expect(ac.critical).toBe(false)            // C is not critical
+  })
+  it('emits one edge per dependency link', () => {
+    // A→B, A→C, B→D, C→D, C→E, D→F, E→F
+    expect(L.edges).toHaveLength(7)
+  })
+  it('node ES/EF/float come from the CPM result', () => {
+    expect([node('A').es, node('A').ef]).toEqual([0, 3])
+    expect(node('C').totalFloat).toBe(1)
+  })
+  it('has positive overall dimensions', () => {
+    expect(L.width).toBeGreaterThan(0)
+    expect(L.height).toBeGreaterThan(0)
+  })
+})

--- a/webapp/src/lib/network.ts
+++ b/webapp/src/lib/network.ts
@@ -1,0 +1,127 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Activity-on-node (AON) network layout (pure). Places each activity in a
+// layered left→right DAG: the column is the longest dependency chain reaching
+// it, the row is its order within that column. Edges carry a `critical` flag.
+// No React — the page renders nodes/edges and lets the user drag nodes (a view
+// concern that does not touch scheduling).
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { Dependency } from '../engine/schedule/model'
+import type { CpmResult as Cpm } from '../engine/schedule/cpm'
+
+/** Minimal activity shape the layout needs. */
+export interface NetActivity {
+  id: string
+  name: string
+  predecessors: Dependency[]
+  milestone?: boolean
+}
+
+export interface NetNode {
+  id: string
+  name: string
+  milestone: boolean
+  col: number
+  row: number
+  x: number
+  y: number
+  w: number
+  h: number
+  critical: boolean
+  es: number
+  ef: number
+  totalFloat: number
+}
+
+export interface NetEdge {
+  from: string
+  to: string
+  type: Dependency['type']
+  critical: boolean
+}
+
+export interface NetworkLayout {
+  nodes: NetNode[]
+  edges: NetEdge[]
+  cols: number
+  width: number
+  height: number
+}
+
+export interface LayoutOpts {
+  nodeW?: number
+  nodeH?: number
+  hGap?: number
+  vGap?: number
+  pad?: number
+}
+
+/**
+ * Layer the network. Column = longest predecessor chain (0 for start nodes);
+ * row = insertion order within the column, following the CPM topological order
+ * so critical activities line up. An edge is critical when both endpoints are.
+ */
+export function layoutNetwork(activities: NetActivity[], cpm: Cpm, opts: LayoutOpts = {}): NetworkLayout {
+  const nodeW = opts.nodeW ?? 156
+  const nodeH = opts.nodeH ?? 56
+  const hGap = opts.hGap ?? 54
+  const vGap = opts.vGap ?? 22
+  const pad = opts.pad ?? 16
+
+  const byId = new Map(activities.map((a) => [a.id, a]))
+  const order = cpm.order.filter((id) => byId.has(id))
+
+  // Longest-path column via one pass in topological order.
+  const col = new Map<string, number>()
+  for (const id of order) {
+    let c = 0
+    for (const dep of byId.get(id)!.predecessors) {
+      if (col.has(dep.predecessor)) c = Math.max(c, col.get(dep.predecessor)! + 1)
+    }
+    col.set(id, c)
+  }
+
+  // Row = running count within each column, in topological order.
+  const rowOf = new Map<string, number>()
+  const rowCount = new Map<number, number>()
+  for (const id of order) {
+    const c = col.get(id) ?? 0
+    const r = rowCount.get(c) ?? 0
+    rowOf.set(id, r)
+    rowCount.set(c, r + 1)
+  }
+
+  const nodes: NetNode[] = order.map((id) => {
+    const a = byId.get(id)!
+    const c = col.get(id) ?? 0
+    const r = rowOf.get(id) ?? 0
+    const info = cpm.activities.get(id)
+    return {
+      id, name: a.name, milestone: !!a.milestone,
+      col: c, row: r,
+      x: pad + c * (nodeW + hGap),
+      y: pad + r * (nodeH + vGap),
+      w: nodeW, h: nodeH,
+      critical: info?.critical ?? false,
+      es: info?.es ?? 0, ef: info?.ef ?? 0, totalFloat: info?.totalFloat ?? 0,
+    }
+  })
+
+  const critical = new Set(nodes.filter((n) => n.critical).map((n) => n.id))
+  const edges: NetEdge[] = []
+  for (const a of activities) {
+    if (!byId.has(a.id)) continue
+    for (const dep of a.predecessors) {
+      if (!byId.has(dep.predecessor)) continue
+      edges.push({ from: dep.predecessor, to: a.id, type: dep.type, critical: critical.has(a.id) && critical.has(dep.predecessor) })
+    }
+  }
+
+  const cols = (rowCount.size ? Math.max(...col.values()) + 1 : 0)
+  const maxRow = rowCount.size ? Math.max(...rowCount.values()) : 0
+  return {
+    nodes, edges, cols,
+    width: pad * 2 + cols * nodeW + Math.max(0, cols - 1) * hGap,
+    height: pad * 2 + maxRow * nodeH + Math.max(0, maxRow - 1) * vGap,
+  }
+}

--- a/webapp/src/lib/network.ts
+++ b/webapp/src/lib/network.ts
@@ -107,13 +107,30 @@ export function layoutNetwork(activities: NetActivity[], cpm: Cpm, opts: LayoutO
     }
   })
 
+  // An edge lies on the critical path only when both endpoints are critical AND
+  // the link is *binding* — the predecessor's constraint exactly sets the
+  // successor's driving date. (Two critical nodes can be joined by a slack link
+  // in a diamond with equal-length paths; that link is not critical.)
   const critical = new Set(nodes.filter((n) => n.critical).map((n) => n.id))
+  const EPS = 1e-6
+  const isBinding = (dep: Dependency, predId: string, succId: string): boolean => {
+    const p = cpm.activities.get(predId), s = cpm.activities.get(succId)
+    if (!p || !s) return false
+    const lag = dep.lag ?? 0
+    switch (dep.type) {
+      case 'FS': return Math.abs(p.ef + lag - s.es) < EPS
+      case 'SS': return Math.abs(p.es + lag - s.es) < EPS
+      case 'FF': return Math.abs(p.ef + lag - s.ef) < EPS
+      case 'SF': return Math.abs(p.es + lag - s.ef) < EPS
+    }
+  }
   const edges: NetEdge[] = []
   for (const a of activities) {
     if (!byId.has(a.id)) continue
     for (const dep of a.predecessors) {
       if (!byId.has(dep.predecessor)) continue
-      edges.push({ from: dep.predecessor, to: a.id, type: dep.type, critical: critical.has(a.id) && critical.has(dep.predecessor) })
+      const crit = critical.has(a.id) && critical.has(dep.predecessor) && isBinding(dep, dep.predecessor, a.id)
+      edges.push({ from: dep.predecessor, to: a.id, type: dep.type, critical: crit })
     }
   }
 

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -51,8 +51,9 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
   {
     label: 'Project Planning',
     tools: [
-      { to: '/schedule',       name: 'Project Schedule', sub: 'CPM · PERT · progress' },
-      { to: '/schedule/gantt',  name: 'Gantt Chart',      sub: 'Timeline · baseline' },
+      { to: '/schedule',        name: 'Project Schedule', sub: 'CPM · PERT · progress' },
+      { to: '/schedule/gantt',   name: 'Gantt Chart',      sub: 'Timeline · baseline' },
+      { to: '/schedule/network', name: 'Network Diagram',  sub: 'AON · critical path' },
     ],
   },
   {

--- a/webapp/src/pages/ScheduleNetwork.tsx
+++ b/webapp/src/pages/ScheduleNetwork.tsx
@@ -1,0 +1,139 @@
+import { useMemo, useRef, useState, type PointerEvent as ReactPointerEvent } from 'react'
+import { Link } from 'react-router-dom'
+import { useScheduleProject } from '../lib/useScheduleProject'
+import { useScheduleSolve } from '../lib/useScheduleSolve'
+import { layoutNetwork, type NetActivity, type NetNode } from '../lib/network'
+import { PageHeader } from '../components/calc'
+
+// Phase 6 — Activity-on-node network diagram at /schedule/network. Layered
+// left→right DAG (layout in lib/network.ts), status-neutral nodes with the CPM
+// figures, critical path in brick red, and draggable nodes (view-only: moving a
+// node never changes the schedule). Reuses the store-backed project + solve.
+
+const btn = 'inline-flex items-center gap-1.5 rounded-md border border-[#d6d3c9] bg-white px-2.5 py-1.5 text-[12px] font-semibold text-[#3d4a5c] hover:border-[#0f4c92] hover:text-[#0f4c92]'
+const CRITICAL = '#c2402a'
+const clip = (s: string, n = 20) => (s.length > n ? s.slice(0, n - 1) + '…' : s)
+
+function Diagram({ nodes, edges, width, height }: ReturnType<typeof layoutNetwork>) {
+  const [pos, setPos] = useState<Record<string, { x: number; y: number }>>({})
+  const drag = useRef<{ id: string; px: number; py: number; ox: number; oy: number } | null>(null)
+  const posOf = (n: NetNode) => pos[n.id] ?? { x: n.x, y: n.y }
+  const nodeById = useMemo(() => new Map(nodes.map((n) => [n.id, n])), [nodes])
+
+  const onDown = (e: ReactPointerEvent, n: NetNode) => {
+    const p = posOf(n)
+    drag.current = { id: n.id, px: e.clientX, py: e.clientY, ox: p.x, oy: p.y }
+    ;(e.currentTarget as Element).setPointerCapture?.(e.pointerId)
+  }
+  const onMove = (e: ReactPointerEvent) => {
+    const d = drag.current
+    if (!d) return
+    setPos((s) => ({ ...s, [d.id]: { x: d.ox + (e.clientX - d.px), y: d.oy + (e.clientY - d.py) } }))
+  }
+  const onUp = () => { drag.current = null }
+
+  // Bounding box (grows as nodes are dragged) so the canvas can scroll to them.
+  const w = Math.max(width, ...nodes.map((n) => posOf(n).x + n.w + 16))
+  const h = Math.max(height, ...nodes.map((n) => posOf(n).y + n.h + 16))
+
+  return (
+    <div className="overflow-auto rounded-lg border border-[#e3e1da] bg-white [background-image:linear-gradient(#f4f3ef_1px,transparent_1px),linear-gradient(90deg,#f4f3ef_1px,transparent_1px)] [background-size:24px_24px]" style={{ maxHeight: '70vh' }}>
+      <svg width={w} height={h} onPointerMove={onMove} onPointerUp={onUp} onPointerLeave={onUp} style={{ touchAction: 'none' }}>
+        <defs>
+          <marker id="net-arrow" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+            <path d="M0,0 L7,3 L0,6 Z" fill="#9aa3ad" />
+          </marker>
+          <marker id="net-arrow-crit" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+            <path d="M0,0 L7,3 L0,6 Z" fill={CRITICAL} />
+          </marker>
+        </defs>
+        {edges.map((e, i) => {
+          const a = nodeById.get(e.from), b = nodeById.get(e.to)
+          if (!a || !b) return null
+          const pa = posOf(a), pb = posOf(b)
+          const sx = pa.x + a.w, sy = pa.y + a.h / 2
+          const tx = pb.x, ty = pb.y + b.h / 2
+          const c = Math.max(30, (tx - sx) / 2)
+          return (
+            <path key={i} d={`M ${sx} ${sy} C ${sx + c} ${sy}, ${tx - c} ${ty}, ${tx} ${ty}`} fill="none"
+              stroke={e.critical ? CRITICAL : '#9aa3ad'} strokeWidth={e.critical ? 2 : 1}
+              markerEnd={`url(#${e.critical ? 'net-arrow-crit' : 'net-arrow'})`} />
+          )
+        })}
+        {nodes.map((n) => {
+          const p = posOf(n)
+          const fill = n.critical ? '#fdf3f0' : '#ffffff'
+          const stroke = n.critical ? CRITICAL : '#c9c3b4'
+          return (
+            <g key={n.id} transform={`translate(${p.x} ${p.y})`} onPointerDown={(e) => onDown(e, n)} style={{ cursor: 'grab' }}>
+              {n.milestone ? (
+                <>
+                  <rect width={n.w} height={n.h} rx={6} fill={fill} stroke={stroke} strokeWidth={n.critical ? 2 : 1} strokeDasharray="4 3" />
+                  <text x={10} y={20} className="fill-[#0f1b2a]" style={{ fontSize: 12, fontWeight: 700 }}>◆ {clip(n.name)}</text>
+                  <text x={10} y={40} className="fill-[#5c6675]" style={{ fontSize: 10, fontFamily: 'monospace' }}>milestone · day {n.es}</text>
+                </>
+              ) : (
+                <>
+                  <rect width={n.w} height={n.h} rx={6} fill={fill} stroke={stroke} strokeWidth={n.critical ? 2 : 1} />
+                  {n.critical && <rect width={4} height={n.h} rx={2} fill={CRITICAL} />}
+                  <text x={12} y={19} className="fill-[#0f1b2a]" style={{ fontSize: 12, fontWeight: 700 }}>{clip(n.name)}</text>
+                  <line x1={8} y1={28} x2={n.w - 8} y2={28} stroke="#eeece5" />
+                  <text x={12} y={44} className="fill-[#5c6675]" style={{ fontSize: 10, fontFamily: 'monospace' }}>ES {n.es} · EF {n.ef}</text>
+                  <text x={n.w - 12} y={44} textAnchor="end" style={{ fontSize: 10, fontFamily: 'monospace', fill: n.critical ? CRITICAL : '#a39d8d' }}>TF {n.totalFloat}</text>
+                </>
+              )}
+            </g>
+          )
+        })}
+      </svg>
+    </div>
+  )
+}
+
+export default function ScheduleNetwork() {
+  const api = useScheduleProject()
+  const solve = useScheduleSolve(api.project)
+  const [nonce, setNonce] = useState(0)   // bump to remount → reset drag positions
+  const project = api.project
+
+  const layout = useMemo(() => {
+    if (!project || !solve.cpm) return null
+    const acts: NetActivity[] = project.activities.map((a) => ({ id: a.id, name: a.name, predecessors: a.predecessors, milestone: a.milestone }))
+    return layoutNetwork(acts, solve.cpm)
+  }, [project, solve.cpm])
+
+  const actions = project && (
+    <div className="flex items-center gap-2">
+      <button type="button" onClick={() => setNonce((n) => n + 1)} className={btn}>Reset layout</button>
+      <Link to="/schedule" className={btn}>Grid</Link>
+    </div>
+  )
+
+  return (
+    <>
+      <PageHeader title="Network Diagram" badges={['AON', 'critical path']} actions={actions ?? undefined} />
+      <div className="mx-auto max-w-[1400px] space-y-4 p-5 sm:p-7">
+        {!project ? (
+          <div className="rounded-lg border border-dashed border-[#d6d3c9] bg-white px-6 py-16 text-center">
+            <h2 className="text-[16px] font-bold text-[#0f1b2a]">No schedule open</h2>
+            <Link to="/schedule" className="mt-4 inline-flex rounded-md bg-[#0f4c92] px-3 py-1.5 text-[12px] font-semibold text-white hover:bg-[#0d3f78]">Go to the schedule grid</Link>
+          </div>
+        ) : project.activities.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-[#d6d3c9] bg-white px-6 py-16 text-center text-[13px] text-[#a39d8d]">No activities to plot — add some in the grid.</div>
+        ) : !solve.ok || !layout ? (
+          <div className="rounded-lg border border-[#efd9cc] bg-[#fdf3ee] px-4 py-2.5 text-[12px] text-[#8f4a2f]">The schedule has {solve.errorCount} blocking issue(s); fix them in the grid to draw the network.</div>
+        ) : (
+          <>
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-[11px] text-[#5c6675]">
+              <span className="inline-flex items-center gap-1.5"><span className="h-3 w-4 rounded-[2px] border-2" style={{ borderColor: CRITICAL, background: '#fdf3f0' }} /> Critical activity</span>
+              <span className="inline-flex items-center gap-1.5"><span className="h-3 w-4 rounded-[2px] border border-[#c9c3b4] bg-white" /> Non-critical</span>
+              <span className="inline-flex items-center gap-1.5"><svg width="20" height="8"><line x1="0" y1="4" x2="20" y2="4" stroke={CRITICAL} strokeWidth="2" /></svg> Critical link</span>
+              <span>Nodes are draggable · ES/EF and total float are per the CPM solve.</span>
+            </div>
+            <Diagram key={nonce} {...layout} />
+          </>
+        )}
+      </div>
+    </>
+  )
+}

--- a/webapp/src/pages/ScheduleNetwork.tsx
+++ b/webapp/src/pages/ScheduleNetwork.tsx
@@ -41,7 +41,7 @@ function Diagram({ nodes, edges, width, height }: ReturnType<typeof layoutNetwor
       <svg width={w} height={h} onPointerMove={onMove} onPointerUp={onUp} onPointerLeave={onUp} style={{ touchAction: 'none' }}>
         <defs>
           <marker id="net-arrow" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
-            <path d="M0,0 L7,3 L0,6 Z" fill="#9aa3ad" />
+            <path d="M0,0 L7,3 L0,6 Z" fill="#b7b0a0" />
           </marker>
           <marker id="net-arrow-crit" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
             <path d="M0,0 L7,3 L0,6 Z" fill={CRITICAL} />
@@ -56,7 +56,7 @@ function Diagram({ nodes, edges, width, height }: ReturnType<typeof layoutNetwor
           const c = Math.max(30, (tx - sx) / 2)
           return (
             <path key={i} d={`M ${sx} ${sy} C ${sx + c} ${sy}, ${tx - c} ${ty}, ${tx} ${ty}`} fill="none"
-              stroke={e.critical ? CRITICAL : '#9aa3ad'} strokeWidth={e.critical ? 2 : 1}
+              stroke={e.critical ? CRITICAL : '#b7b0a0'} strokeWidth={e.critical ? 2 : 1}
               markerEnd={`url(#${e.critical ? 'net-arrow-crit' : 'net-arrow'})`} />
           )
         })}


### PR DESCRIPTION
## Project Scheduling module — Phase 6 of 10

Activity-on-node network diagram at `/schedule/network`, over the same store-backed project + CPM solve as the grid/Gantt.

### What's in this PR
| File | Role |
|------|------|
| `lib/network.ts` | **Pure layered-DAG layout** — column = longest dependency chain (0 for start nodes), row = order within the column (CPM topological order), node x/y positions, per-edge `critical` flag. |
| `pages/ScheduleNetwork.tsx` | SVG nodes carrying **ES/EF + total float**; the **critical path** in brick red (node border + left stripe, bezier links + arrowheads); **draggable nodes** (view-only pointer state — moving a node never changes the schedule); reset-layout + legend; milestone nodes dashed. |
| `App.tsx`, `lib/tools.ts` | `/schedule/network` route + "Planning" sidebar entry. |

### Verified live in the browser
- Sample renders **13 nodes + 13 dependency edges**, laid out left→right by longest-path column; ES/EF/TF correct per the CPM solve (Mobilization ES 0 EF 10 … Handover milestone day 69); this near-linear sample is all-critical, so every node/edge is red.
- **Drag works**: a synthetic pointer drag moved a node `translate(16 16) → translate(151 -92)` — exactly the +135/−108 delta — with no schedule change.
- No console errors.

### Verification
- **7 new vitest cases** on `lib/network.ts` (longest-path columns, distinct rows/non-overlapping y, x increases with column, critical flag on nodes **and** edges, one edge per link, ES/EF/float from CPM, positive dimensions).
- Full suite: **1354 passing (109 files)**; `npx tsc -b` clean.

### Notes / next
- Layout is a simple layered DAG (no crossing-minimisation); fine for small/medium projects. Next: Phase 7 — dashboard at `/schedule/dashboard` (progress vs plan, SPI/CPI, variance, EAC, EVM charts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)