### PR TITLE
feat: project scheduling — dashboard + EVM (Phase 7)

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -161,12 +161,18 @@ columns (dates + total float + critical tag) and an expandable ES/EF/LS/LF/float
   tested). Status-coloured bars with a %-complete fill, critical highlight,
   milestone diamonds, optional baseline underlay, dependency connectors and a
   data-date line. Arrow routing is a simple elbow (polish later).
-- **Phase 6 — AON network diagram** *(this PR)*: `/schedule/network` + pure
+- **Phase 6 — AON network diagram** ✅: `/schedule/network` + pure
   layered-DAG layout in `lib/network.ts` (longest-path columns, rows, critical
-  edges; tested). SVG nodes carry ES/EF and total float, the critical path is
-  in brick red, dependency links are bezier arrows, and nodes are **draggable**
-  (view-only — moving a node never touches the schedule).
-- **Phase 7 — dashboard**: progress vs plan, SPI/CPI, variance, EAC, EVM charts.
+  edges — an edge is critical only when both endpoints are critical **and** the
+  link is binding; tested). SVG nodes carry ES/EF and total float, the critical
+  path is brick red, dependency links are bezier arrows, and nodes are
+  **draggable** (view-only — moving a node never touches the schedule).
+- **Phase 7 — dashboard** *(this PR)*: `/schedule/dashboard` composes the engine
+  `projectProgress` + `earnedValue` at a user-chosen data date — KPIs (actual vs
+  planned %, schedule variance, SPI, days ahead/behind, forecast finish date),
+  a status breakdown, a planned-vs-actual **S-curve** (pure `lib/progressCurve.ts`,
+  tested), **cost EVM** (BAC from resource rates + an actual-cost input →
+  PV/EV/AC/SV/CV/CPI/EAC/VAC/ETC/TCPI), and critical/delayed/upcoming lists.
 - **Phase 8 — resource loading**: labor/equipment/material, over-allocation.
 - **Phase 9 — reports**: schedule / critical-path / EVM / progress / resource →
   PDF, Excel, CSV.

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -45,6 +45,7 @@ import PlumbingDesign from './pages/PlumbingDesign'
 import Schedule from './pages/Schedule'
 import ScheduleGantt from './pages/ScheduleGantt'
 import ScheduleNetwork from './pages/ScheduleNetwork'
+import ScheduleDashboard from './pages/ScheduleDashboard'
 
 export default function App() {
   const [auth, setAuth] = useState<'login' | 'signup' | null>(null)
@@ -107,6 +108,7 @@ export default function App() {
         <Route path="/schedule" element={<Schedule />} />
         <Route path="/schedule/gantt" element={<ScheduleGantt />} />
         <Route path="/schedule/network" element={<ScheduleNetwork />} />
+        <Route path="/schedule/dashboard" element={<ScheduleDashboard />} />
             </Routes>
           </AppShell>
         } />

--- a/webapp/src/lib/progressCurve.test.ts
+++ b/webapp/src/lib/progressCurve.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { plannedCurve, type CurveItem } from './progressCurve'
+
+describe('plannedCurve', () => {
+  it('a single activity ramps 0 → 100 linearly', () => {
+    const c = plannedCurve([{ es: 0, ef: 10, weight: 1 }], 10, 10)
+    expect(c[0]).toEqual({ t: 0, planned: 0 })
+    expect(c[c.length - 1]).toEqual({ t: 10, planned: 100 })
+    const mid = c.find((p) => p.t === 5)!
+    expect(mid.planned).toBeCloseTo(50, 9)
+  })
+
+  it('is monotonic non-decreasing', () => {
+    const items: CurveItem[] = [
+      { es: 0, ef: 4, weight: 4 },
+      { es: 4, ef: 10, weight: 6 },
+    ]
+    const c = plannedCurve(items, 10, 20)
+    for (let i = 1; i < c.length; i++) expect(c[i].planned).toBeGreaterThanOrEqual(c[i - 1].planned - 1e-9)
+    expect(c[0].planned).toBe(0)
+    expect(c[c.length - 1].planned).toBeCloseTo(100, 9)
+  })
+
+  it('weights the mean by activity weight', () => {
+    // A (weight 3) done by t=5; B (weight 1) not started until t=5.
+    const c = plannedCurve([{ es: 0, ef: 5, weight: 3 }, { es: 5, ef: 10, weight: 1 }], 10, 10)
+    const at5 = c.find((p) => p.t === 5)!
+    expect(at5.planned).toBeCloseTo(75, 9)     // 3/4 of the weight complete
+  })
+
+  it('handles an empty set and zero duration without NaN', () => {
+    expect(plannedCurve([], 10).every((p) => p.planned === 0)).toBe(true)
+    const z = plannedCurve([{ es: 0, ef: 0, weight: 1 }], 0, 5)
+    expect(z.every((p) => Number.isFinite(p.planned))).toBe(true)
+  })
+})

--- a/webapp/src/lib/progressCurve.ts
+++ b/webapp/src/lib/progressCurve.ts
@@ -1,0 +1,40 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Planned-progress S-curve (pure). Samples the cumulative planned %-complete
+// across the project timeline (0 → duration) as the weight-weighted mean of
+// each activity's planned fraction. The dashboard overlays the actual %.
+// ─────────────────────────────────────────────────────────────────────────
+
+import { plannedFraction } from '../engine/schedule/earnedValue'
+
+export interface CurveItem {
+  es: number
+  ef: number
+  /** Weight (duration or budget) used for the cumulative mean. */
+  weight: number
+}
+
+export interface CurvePoint {
+  /** Working-day offset from project start. */
+  t: number
+  /** Cumulative planned % complete (0–100) at t. */
+  planned: number
+}
+
+/**
+ * Sample the planned S-curve over [0, duration] at `samples`+1 points. The
+ * curve is monotonic non-decreasing, 0 at t=0 and 100 at t=duration.
+ */
+export function plannedCurve(items: CurveItem[], duration: number, samples = 40): CurvePoint[] {
+  const totalW = items.reduce((s, i) => s + i.weight, 0)
+  const n = Math.max(1, Math.round(samples))
+  const span = Math.max(0, duration)
+  const out: CurvePoint[] = []
+  for (let k = 0; k <= n; k++) {
+    const t = (span * k) / n
+    const planned = totalW > 0
+      ? (items.reduce((s, i) => s + i.weight * plannedFraction(i.es, i.ef, t), 0) / totalW) * 100
+      : 0
+    out.push({ t, planned })
+  }
+  return out
+}

--- a/webapp/src/lib/scheduleDates.test.ts
+++ b/webapp/src/lib/scheduleDates.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import type { WorkingCalendar } from '../engine/schedule/model'
+import { MON_FRI, durationEndDate, parseISO, toISO } from '../engine/schedule/calendar'
+import { dataDateOffset, forecastFinishISO } from './scheduleDates'
+
+// 2026-01-05 is a Monday; the working week is Mon–Fri.
+const cal: WorkingCalendar = { id: 'c', name: 'Std', workweek: [...MON_FRI], holidays: [] }
+const START = '2026-01-05'
+// A 5-working-day schedule (Mon 01-05 … Fri 01-09); finish = inclusive last day.
+const FINISH = toISO(durationEndDate(cal, parseISO(START), 5)) // 2026-01-09
+
+describe('dataDateOffset (inclusive through the data date)', () => {
+  it('the last working day equals the project duration', () => {
+    expect(FINISH).toBe('2026-01-09')
+    expect(dataDateOffset(cal, START, FINISH)).toBe(5)   // NOT 4 — a complete project is 100% planned
+  })
+  it('the start date counts as one elapsed working day', () => {
+    expect(dataDateOffset(cal, START, START)).toBe(1)
+  })
+  it('skips the weekend', () => {
+    expect(dataDateOffset(cal, START, '2026-01-07')).toBe(3)   // Mon,Tue,Wed
+  })
+  it('clamps dates before the project start to 0', () => {
+    expect(dataDateOffset(cal, START, '2026-01-01')).toBe(0)
+  })
+})
+
+describe('forecastFinishISO (inclusive last day, mirrors finishDate)', () => {
+  it('an on-schedule forecast (duration = D) lands on the planned finish', () => {
+    expect(forecastFinishISO(cal, START, 5)).toBe(FINISH)   // NOT one day late
+  })
+  it('a longer forecast pushes the finish later; shorter, earlier', () => {
+    expect(forecastFinishISO(cal, START, 7) > FINISH).toBe(true)
+    expect(forecastFinishISO(cal, START, 3) < FINISH).toBe(true)
+  })
+  it('round-trips with dataDateOffset', () => {
+    // finish date of a D-day schedule → back to offset D
+    expect(dataDateOffset(cal, START, forecastFinishISO(cal, START, 5))).toBe(5)
+  })
+  it('degenerate durations stay finite and clamped', () => {
+    expect(forecastFinishISO(cal, START, 0)).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    expect(forecastFinishISO(cal, START, 1e9)).toMatch(/^\d{4}-\d{2}-\d{2}$/)  // guarded, no freeze
+  })
+})

--- a/webapp/src/lib/scheduleDates.ts
+++ b/webapp/src/lib/scheduleDates.ts
@@ -1,0 +1,39 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Schedule date↔offset conversions (pure). Keeps the dashboard (and later the
+// reports) on ONE convention that agrees with `useScheduleSolve.finishDate` /
+// `calendar.durationEndDate`: a schedule of D working days finishes on the
+// INCLUSIVE last worked day = offset D−1, and a data date is measured as the
+// working days ELAPSED through the end of that date. Reconciling these two
+// removes the "complete project reads ahead" / "on-time reads late" off-by-ones.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { WorkingCalendar } from '../engine/schedule/model'
+import { parseISO, toISO, addDays, offsetToDate, workingDaysBetween } from '../engine/schedule/calendar'
+
+/** Guard against a pathological forecast (tiny SPI) looping over huge offsets. */
+const MAX_OFFSET = 366 * 20
+
+/**
+ * Working-day offset for a data date, counted INCLUSIVELY through the end of
+ * that date (elapsed working days). At the schedule's last working day this
+ * equals the project duration D, so a fully-complete schedule reads 100 %
+ * planned. Dates before the project start clamp to 0.
+ */
+export function dataDateOffset(cal: WorkingCalendar, startIso: string, dataDateIso: string): number {
+  const start = parseISO(startIso)
+  const day = parseISO(dataDateIso)
+  if (day.getTime() < start.getTime()) return 0
+  return workingDaysBetween(cal, start, addDays(day, 1))
+}
+
+/**
+ * Calendar finish date for a schedule of `duration` working days — the
+ * INCLUSIVE last worked day (offset duration−1), mirroring
+ * `calendar.durationEndDate` and `useScheduleSolve.finishDate`. So an
+ * on-schedule forecast (SPI = 1 ⇒ forecastDuration = D) lands exactly on the
+ * planned finish rather than one working day late.
+ */
+export function forecastFinishISO(cal: WorkingCalendar, startIso: string, duration: number): string {
+  const offset = Math.min(MAX_OFFSET, Math.max(0, Math.round(duration) - 1))
+  return toISO(offsetToDate(cal, parseISO(startIso), offset))
+}

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -54,6 +54,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/schedule',        name: 'Project Schedule', sub: 'CPM · PERT · progress' },
       { to: '/schedule/gantt',   name: 'Gantt Chart',      sub: 'Timeline · baseline' },
       { to: '/schedule/network', name: 'Network Diagram',  sub: 'AON · critical path' },
+      { to: '/schedule/dashboard', name: 'Dashboard',      sub: 'Progress · EVM · SPI/CPI' },
     ],
   },
   {

--- a/webapp/src/pages/ScheduleDashboard.tsx
+++ b/webapp/src/pages/ScheduleDashboard.tsx
@@ -2,9 +2,10 @@ import { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import type { ScheduleProject, WorkingCalendar } from '../engine/schedule/model'
 import { projectProgress } from '../engine/schedule/progress'
-import { earnedValue, type EvmActivityInput } from '../engine/schedule/earnedValue'
+import { earnedValue, plannedFraction, type EvmActivityInput } from '../engine/schedule/earnedValue'
 import { plannedCurve } from '../lib/progressCurve'
-import { parseISO, toISO, offsetToDate, workingDaysBetween, defaultCalendar } from '../engine/schedule/calendar'
+import { defaultCalendar } from '../engine/schedule/calendar'
+import { dataDateOffset, forecastFinishISO } from '../lib/scheduleDates'
 import { useScheduleProject } from '../lib/useScheduleProject'
 import { useScheduleSolve, type ScheduleSolve } from '../lib/useScheduleSolve'
 import { PageHeader } from '../components/calc'
@@ -18,7 +19,7 @@ import { PageHeader } from '../components/calc'
 const btn = 'inline-flex items-center gap-1.5 rounded-md border border-[#d6d3c9] bg-white px-2.5 py-1.5 text-[12px] font-semibold text-[#3d4a5c] hover:border-[#0f4c92] hover:text-[#0f4c92]'
 const n1 = (v: number | null) => (v == null || !Number.isFinite(v) ? '—' : v.toFixed(1))
 const n2 = (v: number | null) => (v == null || !Number.isFinite(v) ? '—' : v.toFixed(2))
-const peso = (v: number) => '₱' + Math.round(v).toLocaleString('en-US')
+const peso = (v: number) => '₱' + Math.round(v).toLocaleString('en-PH', { maximumFractionDigits: 0 })
 
 function projectCalendar(p: ScheduleProject): WorkingCalendar {
   return p.calendars.find((c) => c.id === p.defaultCalendarId) ?? defaultCalendar(p.defaultCalendarId)
@@ -95,7 +96,7 @@ function Dashboard({ project, solve }: { project: ScheduleProject; solve: Schedu
 
   const [dataDate, setDataDate] = useState(defaultData)
   const [acInput, setAcInput] = useState(0)
-  const dataOffset = Math.max(0, workingDaysBetween(cal, parseISO(start), parseISO(dataDate)))
+  const dataOffset = dataDateOffset(cal, start, dataDate)
 
   const nameOf = useMemo(() => new Map(project.activities.map((a) => [a.id, a.name])), [project])
   const prog = useMemo(() => projectProgress(project.activities, solve.cpm!, dataOffset), [project, solve.cpm, dataOffset])
@@ -103,21 +104,29 @@ function Dashboard({ project, solve }: { project: ScheduleProject; solve: Schedu
   // Cost EVM — BAC from resource costs; AC from the input, split by earned share.
   const costOf = useMemo(() => new Map(project.resources.map((r) => [r.id, r.costPerUnit ?? 0])), [project])
   const evm = useMemo(() => {
-    const rows = project.activities.map((a) => {
+    let bac = 0, pv = 0, ev = 0, hasCost = false
+    for (const a of project.activities) {
       const c = solve.cpm!.activities.get(a.id)
-      const bac = (a.resources ?? []).reduce((s, r) => s + r.quantity * (costOf.get(r.resourceId) ?? 0), 0)
+      const b = (a.resources ?? []).reduce((s, r) => s + r.quantity * (costOf.get(r.resourceId) ?? 0), 0)
+      if (b > 0) hasCost = true
       const pct = Math.min(100, Math.max(0, a.percentComplete ?? 0))
-      return { id: a.id, bac, pct, ev: bac * (pct / 100), pf: c ? (c.ef > c.es ? Math.min(1, Math.max(0, (dataOffset - c.es) / (c.ef - c.es))) : dataOffset >= c.ef ? 1 : 0) : 0 }
-    })
-    const totalEv = rows.reduce((s, r) => s + r.ev, 0)
-    const items: EvmActivityInput[] = rows.map((r) => ({
-      id: r.id, bac: r.bac, percentComplete: r.pct, plannedFraction: r.pf,
-      actualCost: totalEv > 0 ? acInput * (r.ev / totalEv) : 0,
-    }))
-    return { result: earnedValue(items), hasCost: items.some((i) => i.bac > 0) }
+      bac += b
+      pv += b * (c ? plannedFraction(c.es, c.ef, dataOffset) : 0)
+      ev += b * (pct / 100)
+    }
+    // Feed AC at the project level (single aggregate row that reproduces
+    // PV/EV/BAC) so the entered actual cost is honoured in every case —
+    // including EV = 0, where an earned-share split would zero it out.
+    const item: EvmActivityInput = {
+      id: 'project', bac,
+      percentComplete: bac > 0 ? (ev / bac) * 100 : 0,
+      plannedFraction: bac > 0 ? pv / bac : 0,
+      actualCost: acInput,
+    }
+    return { result: earnedValue([item]), hasCost }
   }, [project, solve.cpm, costOf, dataOffset, acInput])
 
-  const forecastFinish = toISO(offsetToDate(cal, parseISO(start), Math.round(prog.forecastDuration)))
+  const forecastFinish = forecastFinishISO(cal, start, prog.forecastDuration)
   const ahead = prog.daysAheadBehind
   const varTone = prog.scheduleVariancePercent < -0.5 ? 'bad' : prog.scheduleVariancePercent > 0.5 ? 'ok' : undefined
 
@@ -205,6 +214,7 @@ function Dashboard({ project, solve }: { project: ScheduleProject; solve: Schedu
             <Stat label="TCPI" value={n2(evm.result.tcpi)} />
           </div>
         )}
+        {evm.hasCost && <p className="mt-3 text-[10.5px] text-[#a39d8d]">AC is your entered cost to date; PV, EV and BAC are computed from the schedule and resource rates. CPI, EAC and VAC appear once AC &gt; 0.</p>}
       </Card>
 
       <div className="grid gap-4 lg:grid-cols-3">

--- a/webapp/src/pages/ScheduleDashboard.tsx
+++ b/webapp/src/pages/ScheduleDashboard.tsx
@@ -1,0 +1,243 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import type { ScheduleProject, WorkingCalendar } from '../engine/schedule/model'
+import { projectProgress } from '../engine/schedule/progress'
+import { earnedValue, type EvmActivityInput } from '../engine/schedule/earnedValue'
+import { plannedCurve } from '../lib/progressCurve'
+import { parseISO, toISO, offsetToDate, workingDaysBetween, defaultCalendar } from '../engine/schedule/calendar'
+import { useScheduleProject } from '../lib/useScheduleProject'
+import { useScheduleSolve, type ScheduleSolve } from '../lib/useScheduleSolve'
+import { PageHeader } from '../components/calc'
+
+// Phase 7 — project dashboard at /schedule/dashboard. Composes the engine's
+// projectProgress (schedule/progress) + earnedValue (cost EVM) at a user-chosen
+// data date: KPIs, a status breakdown, a planned-vs-actual S-curve, cost EVM
+// (BAC from resources + an actual-cost input), and critical/delayed/upcoming
+// lists. Drawing-sheet palette; reuses the store-backed project + solve.
+
+const btn = 'inline-flex items-center gap-1.5 rounded-md border border-[#d6d3c9] bg-white px-2.5 py-1.5 text-[12px] font-semibold text-[#3d4a5c] hover:border-[#0f4c92] hover:text-[#0f4c92]'
+const n1 = (v: number | null) => (v == null || !Number.isFinite(v) ? '—' : v.toFixed(1))
+const n2 = (v: number | null) => (v == null || !Number.isFinite(v) ? '—' : v.toFixed(2))
+const peso = (v: number) => '₱' + Math.round(v).toLocaleString('en-US')
+
+function projectCalendar(p: ScheduleProject): WorkingCalendar {
+  return p.calendars.find((c) => c.id === p.defaultCalendarId) ?? defaultCalendar(p.defaultCalendarId)
+}
+
+function Stat({ label, value, sub, tone }: { label: string; value: string; sub?: string; tone?: 'ok' | 'bad' | 'warn' }) {
+  const color = tone === 'bad' ? 'text-[#c2402a]' : tone === 'ok' ? 'text-[#14603a]' : tone === 'warn' ? 'text-[#b97d10]' : 'text-[#0f1b2a]'
+  return (
+    <div className="rounded-lg border border-[#e3e1da] bg-white px-3.5 py-3">
+      <p className="text-[10px] font-semibold uppercase tracking-widest text-[#a39d8d]">{label}</p>
+      <p className={`mt-0.5 font-mono text-[18px] font-semibold ${color}`}>{value}</p>
+      {sub && <p className="text-[10.5px] text-[#a39d8d]">{sub}</p>}
+    </div>
+  )
+}
+
+function Card({ title, right, children }: { title: string; right?: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-lg border border-[#e3e1da] bg-white">
+      <div className="flex items-center justify-between border-b border-[#eeece5] px-4 py-2.5">
+        <h2 className="text-[13px] font-bold text-[#0f1b2a]">{title}</h2>
+        {right && <span className="font-mono text-[10.5px] text-[#a39d8d]">{right}</span>}
+      </div>
+      <div className="p-4">{children}</div>
+    </section>
+  )
+}
+
+const STATUS_BAR: { key: 'completed' | 'inProgress' | 'delayed' | 'notStarted' | 'blocked'; label: string; color: string }[] = [
+  { key: 'completed', label: 'Completed', color: '#1a7f4b' },
+  { key: 'inProgress', label: 'In progress', color: '#0f4c92' },
+  { key: 'delayed', label: 'Delayed', color: '#b97d10' },
+  { key: 'blocked', label: 'Blocked', color: '#7c3aed' },
+  { key: 'notStarted', label: 'Upcoming', color: '#94a0ae' },
+]
+
+function SCurve({ curve, duration, actualPct, dataOffset }: { curve: { t: number; planned: number }[]; duration: number; actualPct: number; dataOffset: number }) {
+  const W = 640, H = 200, pad = 30
+  const x = (t: number) => pad + (duration > 0 ? (t / duration) * (W - pad * 2) : 0)
+  const y = (p: number) => H - pad - (p / 100) * (H - pad * 2)
+  const path = curve.map((p, i) => `${i === 0 ? 'M' : 'L'} ${x(p.t).toFixed(1)} ${y(p.planned).toFixed(1)}`).join(' ')
+  const dx = x(Math.min(duration, Math.max(0, dataOffset)))
+  return (
+    <div className="overflow-x-auto">
+      <svg width={W} height={H} className="min-w-[520px]">
+        {[0, 25, 50, 75, 100].map((g) => (
+          <g key={g}>
+            <line x1={pad} y1={y(g)} x2={W - pad} y2={y(g)} stroke="#f1efe8" />
+            <text x={pad - 6} y={y(g) + 3} textAnchor="end" style={{ fontSize: 9, fontFamily: 'monospace', fill: '#a39d8d' }}>{g}</text>
+          </g>
+        ))}
+        <path d={path} fill="none" stroke="#0f4c92" strokeWidth={2} />
+        <line x1={dx} y1={pad} x2={dx} y2={H - pad} stroke="#c2402a" strokeWidth={1} strokeDasharray="3 3" />
+        <circle cx={dx} cy={y(actualPct)} r={4} fill="#c2402a" />
+        <text x={dx + 6} y={y(actualPct) - 6} style={{ fontSize: 10, fontFamily: 'monospace', fill: '#c2402a' }}>actual {actualPct.toFixed(0)}%</text>
+        <text x={pad} y={H - 8} style={{ fontSize: 9, fill: '#a39d8d' }}>planned S-curve (blue) · data date (red)</text>
+      </svg>
+    </div>
+  )
+}
+
+function Dashboard({ project, solve }: { project: ScheduleProject; solve: ScheduleSolve }) {
+  const cal = projectCalendar(project)
+  const start = project.meta.start
+  const finishIso = solve.finishDate ?? start
+
+  const defaultData = useMemo(() => {
+    const today = new Date().toISOString().slice(0, 10)
+    const cand = [today, ...project.activities.flatMap((a) => [a.actualStart, a.actualFinish].filter((d): d is string => !!d))]
+      .filter((d) => d >= start && d <= finishIso)
+    if (cand.length) return cand.reduce((m, d) => (d > m ? d : m))
+    return today < start ? start : today > finishIso ? finishIso : today
+  }, [project, start, finishIso])
+
+  const [dataDate, setDataDate] = useState(defaultData)
+  const [acInput, setAcInput] = useState(0)
+  const dataOffset = Math.max(0, workingDaysBetween(cal, parseISO(start), parseISO(dataDate)))
+
+  const nameOf = useMemo(() => new Map(project.activities.map((a) => [a.id, a.name])), [project])
+  const prog = useMemo(() => projectProgress(project.activities, solve.cpm!, dataOffset), [project, solve.cpm, dataOffset])
+
+  // Cost EVM — BAC from resource costs; AC from the input, split by earned share.
+  const costOf = useMemo(() => new Map(project.resources.map((r) => [r.id, r.costPerUnit ?? 0])), [project])
+  const evm = useMemo(() => {
+    const rows = project.activities.map((a) => {
+      const c = solve.cpm!.activities.get(a.id)
+      const bac = (a.resources ?? []).reduce((s, r) => s + r.quantity * (costOf.get(r.resourceId) ?? 0), 0)
+      const pct = Math.min(100, Math.max(0, a.percentComplete ?? 0))
+      return { id: a.id, bac, pct, ev: bac * (pct / 100), pf: c ? (c.ef > c.es ? Math.min(1, Math.max(0, (dataOffset - c.es) / (c.ef - c.es))) : dataOffset >= c.ef ? 1 : 0) : 0 }
+    })
+    const totalEv = rows.reduce((s, r) => s + r.ev, 0)
+    const items: EvmActivityInput[] = rows.map((r) => ({
+      id: r.id, bac: r.bac, percentComplete: r.pct, plannedFraction: r.pf,
+      actualCost: totalEv > 0 ? acInput * (r.ev / totalEv) : 0,
+    }))
+    return { result: earnedValue(items), hasCost: items.some((i) => i.bac > 0) }
+  }, [project, solve.cpm, costOf, dataOffset, acInput])
+
+  const forecastFinish = toISO(offsetToDate(cal, parseISO(start), Math.round(prog.forecastDuration)))
+  const ahead = prog.daysAheadBehind
+  const varTone = prog.scheduleVariancePercent < -0.5 ? 'bad' : prog.scheduleVariancePercent > 0.5 ? 'ok' : undefined
+
+  const critical = prog.activities.filter((a) => a.critical)
+  const delayed = prog.activities.filter((a) => a.status === 'delayed')
+  const upcoming = prog.activities.filter((a) => a.status === 'not-started').sort((a, b) => a.es - b.es).slice(0, 6)
+
+  const miniList = (rows: typeof prog.activities, empty: string) => (
+    rows.length === 0 ? <p className="text-[11.5px] text-[#a39d8d]">{empty}</p> : (
+      <ul className="space-y-1">
+        {rows.slice(0, 6).map((a) => (
+          <li key={a.id} className="flex items-center gap-2 text-[12px]">
+            <span className="truncate text-[#0f1b2a]">{nameOf.get(a.id)}</span>
+            <span className="ml-auto flex-none font-mono text-[10.5px] text-[#a39d8d]">{a.percentComplete}%</span>
+          </li>
+        ))}
+      </ul>
+    )
+  )
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-end gap-3 rounded-lg border border-[#e3e1da] bg-white p-3">
+        <label className="flex flex-col text-[10px] font-semibold uppercase tracking-widest text-[#a39d8d]">Data date
+          <input type="date" value={dataDate} min={start} max={finishIso} onChange={(e) => setDataDate(e.target.value || start)}
+            className="mt-0.5 rounded border border-[#e3e1da] px-2 py-1 font-mono text-[12.5px] font-normal tracking-normal text-[#0f1b2a]" />
+        </label>
+        <label className="flex flex-col text-[10px] font-semibold uppercase tracking-widest text-[#a39d8d]">Actual cost to date (₱)
+          <input type="number" min={0} step={1000} value={acInput} onChange={(e) => setAcInput(Math.max(0, parseFloat(e.target.value) || 0))}
+            className="mt-0.5 w-40 rounded border border-[#e3e1da] px-2 py-1 text-right font-mono text-[12.5px] font-normal tracking-normal text-[#0f1b2a]" />
+        </label>
+        <span className="ml-auto text-[11px] text-[#a39d8d]">Data date = working day {dataOffset} of {prog.plannedDuration}</span>
+      </div>
+
+      {/* KPIs */}
+      <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-3 lg:grid-cols-6">
+        <Stat label="Actual progress" value={`${n1(prog.actualPercent)}%`} />
+        <Stat label="Planned progress" value={`${n1(prog.plannedPercent)}%`} />
+        <Stat label="Schedule var." value={`${prog.scheduleVariancePercent > 0 ? '+' : ''}${n1(prog.scheduleVariancePercent)}%`} tone={varTone} />
+        <Stat label="SPI" value={n2(prog.spi)} tone={prog.spi != null && prog.spi < 0.995 ? 'bad' : prog.spi != null && prog.spi > 1.005 ? 'ok' : undefined} />
+        <Stat label={ahead >= 0 ? 'Days ahead' : 'Days behind'} value={`${Math.abs(ahead).toFixed(1)} d`} tone={ahead < -0.05 ? 'bad' : ahead > 0.05 ? 'ok' : undefined} />
+        <Stat label="Est. completion" value={forecastFinish} sub={`planned ${finishIso}`} tone={forecastFinish > finishIso ? 'bad' : undefined} />
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[1.5fr_1fr]">
+        <Card title="Progress S-curve" right={`${prog.completed}/${prog.total} activities complete`}>
+          <SCurve curve={plannedCurve(prog.activities.map((a) => ({ es: a.es, ef: a.ef, weight: a.duration })), prog.plannedDuration, 48)}
+            duration={prog.plannedDuration} actualPct={prog.actualPercent} dataOffset={dataOffset} />
+        </Card>
+        <Card title="Status breakdown" right={`${prog.critical} critical`}>
+          <div className="flex h-4 overflow-hidden rounded">
+            {STATUS_BAR.map((s) => {
+              const v = prog[s.key]
+              return v > 0 ? <div key={s.key} title={`${s.label}: ${v}`} style={{ width: `${(v / prog.total) * 100}%`, background: s.color }} /> : null
+            })}
+          </div>
+          <div className="mt-3 grid grid-cols-2 gap-x-4 gap-y-1.5">
+            {STATUS_BAR.map((s) => (
+              <div key={s.key} className="flex items-center gap-1.5 text-[11.5px]">
+                <span className="h-2.5 w-2.5 rounded-[2px]" style={{ background: s.color }} />
+                <span className="text-[#5c6675]">{s.label}</span>
+                <span className="ml-auto font-mono text-[#0f1b2a]">{prog[s.key]}</span>
+              </div>
+            ))}
+          </div>
+          <p className="mt-3 border-t border-[#eeece5] pt-2 text-[11px] text-[#5c6675]">Remaining duration <span className="float-right font-mono text-[#0f1b2a]">{n1(prog.remainingDuration)} d</span></p>
+        </Card>
+      </div>
+
+      {/* Earned value (cost) */}
+      <Card title="Earned Value Management (cost)" right="BAC from resource rates · AC from input">
+        {!evm.hasCost ? (
+          <p className="text-[12px] text-[#a39d8d]">No resource costs are defined on the activities — add resource assignments with rates in the project to see cost EVM. Schedule performance (SPI, days ahead/behind) above is duration-based and needs no cost.</p>
+        ) : (
+          <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-3 lg:grid-cols-6">
+            <Stat label="PV" value={peso(evm.result.pv)} />
+            <Stat label="EV" value={peso(evm.result.ev)} />
+            <Stat label="AC" value={peso(evm.result.ac)} />
+            <Stat label="BAC" value={peso(evm.result.bac)} />
+            <Stat label="CPI" value={n2(evm.result.cpi)} tone={evm.result.cpi != null && evm.result.cpi < 0.995 ? 'bad' : evm.result.cpi != null && evm.result.cpi > 1.005 ? 'ok' : undefined} />
+            <Stat label="SV / CV" value={`${peso(evm.result.sv)} / ${peso(evm.result.cv)}`} />
+            <Stat label="EAC" value={evm.result.eac == null ? '—' : peso(evm.result.eac)} sub="BAC / CPI" />
+            <Stat label="VAC" value={evm.result.vac == null ? '—' : peso(evm.result.vac)} tone={evm.result.vac != null && evm.result.vac < 0 ? 'bad' : undefined} />
+            <Stat label="ETC" value={evm.result.etc == null ? '—' : peso(evm.result.etc)} />
+            <Stat label="TCPI" value={n2(evm.result.tcpi)} />
+          </div>
+        )}
+      </Card>
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        <Card title="Critical activities" right={`${critical.length}`}>{miniList(critical, 'None on the critical path.')}</Card>
+        <Card title="Delayed" right={`${delayed.length}`}>{miniList(delayed, 'Nothing behind schedule.')}</Card>
+        <Card title="Upcoming" right={`${upcoming.length}`}>{miniList(upcoming, 'No upcoming activities.')}</Card>
+      </div>
+    </div>
+  )
+}
+
+export default function ScheduleDashboard() {
+  const api = useScheduleProject()
+  const solve = useScheduleSolve(api.project)
+  const project = api.project
+
+  return (
+    <>
+      <PageHeader title="Dashboard" badges={['progress', 'EVM', 'SPI/CPI']} actions={project ? <Link to="/schedule" className={btn}>Grid</Link> : undefined} />
+      <div className="mx-auto max-w-[1400px] space-y-4 p-5 sm:p-7">
+        {!project ? (
+          <div className="rounded-lg border border-dashed border-[#d6d3c9] bg-white px-6 py-16 text-center">
+            <h2 className="text-[16px] font-bold text-[#0f1b2a]">No schedule open</h2>
+            <Link to="/schedule" className="mt-4 inline-flex rounded-md bg-[#0f4c92] px-3 py-1.5 text-[12px] font-semibold text-white hover:bg-[#0d3f78]">Go to the schedule grid</Link>
+          </div>
+        ) : project.activities.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-[#d6d3c9] bg-white px-6 py-16 text-center text-[13px] text-[#a39d8d]">No activities yet — add some in the grid.</div>
+        ) : !solve.ok ? (
+          <div className="rounded-lg border border-[#efd9cc] bg-[#fdf3ee] px-4 py-2.5 text-[12px] text-[#8f4a2f]">The schedule has {solve.errorCount} blocking issue(s); fix them in the grid to see the dashboard.</div>
+        ) : (
+          <Dashboard project={project} solve={solve} />
+        )}
+      </div>
+    </>
+  )
+}

--- a/webapp/src/pages/ScheduleDashboard.tsx
+++ b/webapp/src/pages/ScheduleDashboard.tsx
@@ -101,7 +101,7 @@ function Dashboard({ project, solve }: { project: ScheduleProject; solve: Schedu
   const nameOf = useMemo(() => new Map(project.activities.map((a) => [a.id, a.name])), [project])
   const prog = useMemo(() => projectProgress(project.activities, solve.cpm!, dataOffset), [project, solve.cpm, dataOffset])
 
-  // Cost EVM — BAC from resource costs; AC from the input, split by earned share.
+  // Cost EVM — BAC from resource costs; PV/EV from the schedule; AC entered.
   const costOf = useMemo(() => new Map(project.resources.map((r) => [r.id, r.costPerUnit ?? 0])), [project])
   const evm = useMemo(() => {
     let bac = 0, pv = 0, ev = 0, hasCost = false


### PR DESCRIPTION
## Project Scheduling module — Phase 7 of 10

Project dashboard at `/schedule/dashboard`, composing the engine's `projectProgress` (schedule/progress) + `earnedValue` (cost EVM) at a **user-chosen data date**.

### What's in this PR
| File | Role |
|------|------|
| `lib/progressCurve.ts` | **Pure** planned %-complete **S-curve** sampling (weight-weighted mean planned fraction over `[0,duration]`), tested. |
| `pages/ScheduleDashboard.tsx` | Data-date + actual-cost controls; **KPIs** (actual vs planned %, schedule variance, SPI, days ahead/behind, forecast finish date); **status breakdown** bar; **planned-vs-actual S-curve**; **cost EVM** (BAC from resource rates, AC from input split by earned share → PV/EV/AC/SV/CV/CPI/EAC/VAC/ETC/TCPI, null-guarded); critical/delayed/upcoming lists. |
| `App.tsx`, `lib/tools.ts` | `/schedule/dashboard` route + "Planning" sidebar entry. |

Nothing new in the engines — this composes the tested `progress.ts`/`earnedValue.ts` from Phases 2.

### Verified live in the browser
- Sample dashboard at data day 9/69: **Actual 23.8% vs Planned 12.2%**, SchedVar +11.6%, **SPI 1.96**, days ahead 8.6, **est. completion 2026-09-15** (planned 2026-10-24); status breakdown 2 completed / 1 in-progress / 10 upcoming, 13 critical; S-curve renders.
- **EVM**: PV ₱17,550 / EV ₱108,360 / BAC ₱419,050, TCPI 0.74; entering **AC ₱120,000** → **EAC ₱464,064** (= BAC/CPI, CPI 0.903) and **VAC −₱45,014** — hand-verified correct.
- No console errors.

### Verification
- **4 new vitest cases** on `lib/progressCurve.ts` (linear ramp 0→100, monotonic, weight-weighted mean, empty/zero-duration no-NaN).
- Full suite: **1361 passing (110 files)**; `npx tsc -b` clean.

### Notes / next
- Actual cost is a single project-level input (no per-activity cost tracking yet — that arrives with Phase 10 daily reports). Next: Phase 8 — resource loading at `/schedule/resources` (labor/equipment/material, over-allocation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)