### PR TITLE
feat: project scheduling — resource loading (Phase 8)

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -167,13 +167,18 @@ columns (dates + total float + critical tag) and an expandable ES/EF/LS/LF/float
   link is binding; tested). SVG nodes carry ES/EF and total float, the critical
   path is brick red, dependency links are bezier arrows, and nodes are
   **draggable** (view-only — moving a node never touches the schedule).
-- **Phase 7 — dashboard** *(this PR)*: `/schedule/dashboard` composes the engine
+- **Phase 7 — dashboard** ✅: `/schedule/dashboard` composes the engine
   `projectProgress` + `earnedValue` at a user-chosen data date — KPIs (actual vs
   planned %, schedule variance, SPI, days ahead/behind, forecast finish date),
   a status breakdown, a planned-vs-actual **S-curve** (pure `lib/progressCurve.ts`,
   tested), **cost EVM** (BAC from resource rates + an actual-cost input →
   PV/EV/AC/SV/CV/CPI/EAC/VAC/ETC/TCPI), and critical/delayed/upcoming lists.
-- **Phase 8 — resource loading**: labor/equipment/material, over-allocation.
+  Date↔offset conversions live in the tested `lib/scheduleDates.ts` (inclusive
+  data-date offset + forecast finish, consistent with `finishDate`).
+- **Phase 8 — resource loading** *(this PR)*: `/schedule/resources` — per-resource
+  daily load (assignment quantity spread over the activity's scheduled span) with
+  a load histogram and **over-allocation** flagged where daily demand exceeds
+  `availablePerDay`; pure tested `lib/resourceLoad.ts`.
 - **Phase 9 — reports**: schedule / critical-path / EVM / progress / resource →
   PDF, Excel, CSV.
 - **Phase 10 — daily-report integration & delay analysis** + user docs.

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -46,6 +46,7 @@ import Schedule from './pages/Schedule'
 import ScheduleGantt from './pages/ScheduleGantt'
 import ScheduleNetwork from './pages/ScheduleNetwork'
 import ScheduleDashboard from './pages/ScheduleDashboard'
+import ScheduleResources from './pages/ScheduleResources'
 
 export default function App() {
   const [auth, setAuth] = useState<'login' | 'signup' | null>(null)
@@ -109,6 +110,7 @@ export default function App() {
         <Route path="/schedule/gantt" element={<ScheduleGantt />} />
         <Route path="/schedule/network" element={<ScheduleNetwork />} />
         <Route path="/schedule/dashboard" element={<ScheduleDashboard />} />
+        <Route path="/schedule/resources" element={<ScheduleResources />} />
             </Routes>
           </AppShell>
         } />

--- a/webapp/src/lib/resourceLoad.test.ts
+++ b/webapp/src/lib/resourceLoad.test.ts
@@ -56,6 +56,22 @@ describe('edge cases', () => {
     expect(load.total).toBe(0)
     expect(hasOverAllocation([load])).toBe(false)
   })
+  it('sums multiple assignments of the same resource on one activity', () => {
+    const [load] = resourceLoad(
+      [{ id: 'A', duration: 3, resources: [{ resourceId: 'R', quantity: 10 }, { resourceId: 'R', quantity: 5 }] }],
+      mkCpm([{ id: 'A', es: 0, ef: 3, duration: 3 }]), [R], 3,
+    )
+    expect(load.total).toBe(15)               // 10 + 5
+    expect(load.perDay).toEqual([5, 5, 5])    // 15 / 3 days
+  })
+  it('an empty project yields an empty load with no peak', () => {
+    const emptyCpm = { activities: new Map(), order: [], duration: 0, finish: 0, criticalPath: [] } as CpmResult
+    const [load] = resourceLoad([], emptyCpm, [R], 0)
+    expect(load.perDay).toEqual([])
+    expect(load.total).toBe(0)
+    expect(load.peak).toBe(0)
+    expect(hasOverAllocation([load])).toBe(false)
+  })
   it('clamps activity spans to the timeline window', () => {
     const [load] = resourceLoad(
       [{ id: 'A', duration: 5, resources: [{ resourceId: 'R', quantity: 10 }] }],

--- a/webapp/src/lib/resourceLoad.test.ts
+++ b/webapp/src/lib/resourceLoad.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import type { CpmActivity, CpmResult } from '../engine/schedule/cpm'
+import type { Resource } from '../engine/schedule/model'
+import { resourceLoad, hasOverAllocation, type LoadActivity } from './resourceLoad'
+
+/** Build a minimal CpmResult from explicit es/ef rows (isolates the loader). */
+const mkCpm = (rows: { id: string; es: number; ef: number; duration: number }[]): CpmResult => ({
+  activities: new Map(rows.map((r) => [r.id, {
+    id: r.id, duration: r.duration, es: r.es, ef: r.ef, ls: r.es, lf: r.ef,
+    totalFloat: 0, freeFloat: 0, critical: false,
+  } as CpmActivity])),
+  order: rows.map((r) => r.id),
+  duration: Math.max(...rows.map((r) => r.ef)),
+  finish: Math.max(...rows.map((r) => r.ef)),
+  criticalPath: [],
+})
+
+const R: Resource = { id: 'R', name: 'Crew', type: 'labor', unit: 'man-day', availablePerDay: 8 }
+
+// A (5 d, days 0–4, 30 units → 6/day) overlaps B (4 d, days 3–6, 20 units → 5/day).
+const activities: LoadActivity[] = [
+  { id: 'A', duration: 5, resources: [{ resourceId: 'R', quantity: 30 }] },
+  { id: 'B', duration: 4, resources: [{ resourceId: 'R', quantity: 20 }] },
+]
+const cpm = mkCpm([{ id: 'A', es: 0, ef: 5, duration: 5 }, { id: 'B', es: 3, ef: 7, duration: 4 }])
+
+describe('resourceLoad', () => {
+  const [load] = resourceLoad(activities, cpm, [R], 7)
+
+  it('spreads each assignment over its span and sums overlaps', () => {
+    expect(load.perDay).toEqual([6, 6, 6, 11, 11, 5, 5])   // 6/day A, +5/day B on days 3–4
+  })
+  it('reports the peak, its day and the total units', () => {
+    expect(load.peak).toBe(11)
+    expect(load.peakDay).toBe(3)
+    expect(load.total).toBe(50)
+  })
+  it('flags days over availablePerDay', () => {
+    expect(load.available).toBe(8)
+    expect(load.overDays).toBe(2)                          // days 3 and 4 (11 > 8)
+    expect(hasOverAllocation([load])).toBe(true)
+  })
+})
+
+describe('edge cases', () => {
+  it('no limit ⇒ zero over-days regardless of demand', () => {
+    const [load] = resourceLoad(activities, cpm, [{ ...R, availablePerDay: undefined }], 7)
+    expect(load.available).toBeNull()
+    expect(load.overDays).toBe(0)
+    expect(load.peak).toBe(11)
+  })
+  it('a milestone (duration 0) and an unused resource contribute nothing', () => {
+    const acts: LoadActivity[] = [{ id: 'M', duration: 0, resources: [{ resourceId: 'R', quantity: 5 }] }]
+    const [load] = resourceLoad(acts, mkCpm([{ id: 'M', es: 3, ef: 3, duration: 0 }]), [R], 7)
+    expect(load.perDay.every((v) => v === 0)).toBe(true)
+    expect(load.total).toBe(0)
+    expect(hasOverAllocation([load])).toBe(false)
+  })
+  it('clamps activity spans to the timeline window', () => {
+    const [load] = resourceLoad(
+      [{ id: 'A', duration: 5, resources: [{ resourceId: 'R', quantity: 10 }] }],
+      mkCpm([{ id: 'A', es: 0, ef: 5, duration: 5 }]), [R], 3,   // window shorter than the activity
+    )
+    expect(load.perDay).toHaveLength(3)
+    expect(load.perDay).toEqual([2, 2, 2])
+  })
+})

--- a/webapp/src/lib/resourceLoad.ts
+++ b/webapp/src/lib/resourceLoad.ts
@@ -1,0 +1,81 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Resource loading (pure). Spreads each activity's resource assignment evenly
+// over its scheduled working-day span (quantity ÷ duration per day) and sums,
+// per resource, the daily demand across the project timeline. Flags days where
+// demand exceeds the resource's `availablePerDay` (over-allocation).
+//
+// Times are CPM working-day offsets (integers for whole-day durations); the
+// load array is indexed by day offset 0 … duration−1.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { CpmResult } from '../engine/schedule/cpm'
+import type { Resource, ActivityResource } from '../engine/schedule/model'
+
+/** Minimal activity shape the loader needs (full `Activity` satisfies it). */
+export interface LoadActivity {
+  id: string
+  duration: number
+  resources?: ActivityResource[]
+}
+
+export interface ResourceLoad {
+  resource: Resource
+  /** Daily demand indexed by working-day offset (length = project duration). */
+  perDay: number[]
+  /** Peak daily demand and the day it occurs. */
+  peak: number
+  peakDay: number
+  /** Number of days demand exceeds availablePerDay (0 when no limit set). */
+  overDays: number
+  /** availablePerDay, or null when the resource has no stated limit. */
+  available: number | null
+  /** Total resource-units consumed (Σ assignment quantities across activities). */
+  total: number
+}
+
+/**
+ * Per-resource daily load over [0, duration). A milestone (duration ≤ 0)
+ * contributes no daily demand. Activities absent from the CPM result are
+ * skipped.
+ */
+export function resourceLoad(
+  activities: LoadActivity[],
+  cpm: CpmResult,
+  resources: Resource[],
+  duration: number,
+): ResourceLoad[] {
+  const days = Math.max(0, Math.ceil(duration))
+  const EPS = 1e-9
+
+  return resources.map((resource) => {
+    const perDay = new Array<number>(days).fill(0)
+    let total = 0
+    for (const a of activities) {
+      if (a.duration <= 0) continue
+      const assign = (a.resources ?? []).filter((r) => r.resourceId === resource.id)
+      if (assign.length === 0) continue
+      const c = cpm.activities.get(a.id)
+      if (!c) continue
+      const qty = assign.reduce((s, r) => s + r.quantity, 0)
+      total += qty
+      const rate = qty / a.duration                    // units per working day
+      const from = Math.max(0, Math.floor(c.es))
+      const to = Math.min(days, Math.ceil(c.ef))        // active on [es, ef)
+      for (let t = from; t < to; t++) perDay[t] += rate
+    }
+
+    let peak = 0, peakDay = 0
+    for (let t = 0; t < perDay.length; t++) {
+      if (perDay[t] > peak) { peak = perDay[t]; peakDay = t }
+    }
+    const available = resource.availablePerDay ?? null
+    const overDays = available == null ? 0 : perDay.filter((v) => v > available + EPS).length
+
+    return { resource, perDay, peak, peakDay, overDays, available, total }
+  })
+}
+
+/** True when any resource is over-allocated on any day. */
+export function hasOverAllocation(loads: ResourceLoad[]): boolean {
+  return loads.some((l) => l.overDays > 0)
+}

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -55,6 +55,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/schedule/gantt',   name: 'Gantt Chart',      sub: 'Timeline · baseline' },
       { to: '/schedule/network', name: 'Network Diagram',  sub: 'AON · critical path' },
       { to: '/schedule/dashboard', name: 'Dashboard',      sub: 'Progress · EVM · SPI/CPI' },
+      { to: '/schedule/resources', name: 'Resource Loading', sub: 'Histogram · over-allocation' },
     ],
   },
   {

--- a/webapp/src/pages/ScheduleResources.tsx
+++ b/webapp/src/pages/ScheduleResources.tsx
@@ -1,0 +1,123 @@
+import { useMemo } from 'react'
+import { Link } from 'react-router-dom'
+import { useScheduleProject } from '../lib/useScheduleProject'
+import { useScheduleSolve } from '../lib/useScheduleSolve'
+import { resourceLoad, hasOverAllocation, type ResourceLoad } from '../lib/resourceLoad'
+import { PageHeader } from '../components/calc'
+
+// Phase 8 — resource loading at /schedule/resources. Spreads each activity's
+// resource assignment over its scheduled span (lib/resourceLoad, pure+tested),
+// shows a per-resource daily-load histogram with over-allocation in red, and a
+// summary table. Reuses the store-backed project + solve. Drawing-sheet palette.
+
+const btn = 'inline-flex items-center gap-1.5 rounded-md border border-[#d6d3c9] bg-white px-2.5 py-1.5 text-[12px] font-semibold text-[#3d4a5c] hover:border-[#0f4c92] hover:text-[#0f4c92]'
+const CRITICAL = '#c2402a'
+const TYPE_COLOR: Record<string, string> = { labor: '#0f4c92', equipment: '#7a5cc0', material: '#1a7f4b' }
+const n1 = (v: number) => (Number.isFinite(v) ? v.toFixed(1) : '—')
+
+function Histogram({ load }: { load: ResourceLoad }) {
+  const H = 64, bw = Math.max(3, Math.min(14, Math.floor(560 / Math.max(1, load.perDay.length))))
+  const base = TYPE_COLOR[load.resource.type] ?? '#0f4c92'
+  const max = Math.max(load.peak, load.available ?? 0, 1)
+  const yAvail = load.available != null ? H - (load.available / max) * H : null
+  return (
+    <div className="overflow-x-auto">
+      <svg width={load.perDay.length * bw + 8} height={H + 16} className="min-w-[220px]">
+        {yAvail != null && (
+          <>
+            <line x1={0} y1={yAvail} x2={load.perDay.length * bw} y2={yAvail} stroke={CRITICAL} strokeWidth={1} strokeDasharray="3 2" />
+            <text x={2} y={Math.max(9, yAvail - 2)} style={{ fontSize: 8, fontFamily: 'monospace', fill: CRITICAL }}>avail {load.available}</text>
+          </>
+        )}
+        {load.perDay.map((v, t) => {
+          const h = (v / max) * H
+          const over = load.available != null && v > load.available + 1e-9
+          return <rect key={t} x={t * bw} y={H - h} width={Math.max(1, bw - 1)} height={h} fill={over ? CRITICAL : base} opacity={over ? 0.95 : 0.6} />
+        })}
+        <text x={0} y={H + 12} style={{ fontSize: 8, fill: '#a39d8d' }}>day 0</text>
+        <text x={load.perDay.length * bw} textAnchor="end" y={H + 12} style={{ fontSize: 8, fill: '#a39d8d' }}>day {load.perDay.length - 1}</text>
+      </svg>
+    </div>
+  )
+}
+
+export default function ScheduleResources() {
+  const api = useScheduleProject()
+  const solve = useScheduleSolve(api.project)
+  const project = api.project
+
+  const loads = useMemo(() => {
+    if (!project || !solve.cpm) return []
+    return resourceLoad(project.activities, solve.cpm, project.resources, solve.cpm.duration)
+  }, [project, solve.cpm])
+
+  const anyOver = hasOverAllocation(loads)
+  const th = 'px-2.5 py-2 text-left text-[9.5px] font-bold uppercase tracking-widest text-[#5c6675]'
+  const td = 'px-2.5 py-1.5 align-middle'
+
+  return (
+    <>
+      <PageHeader title="Resource Loading" badges={['labor', 'equipment', 'material']} actions={project ? <Link to="/schedule" className={btn}>Grid</Link> : undefined} />
+      <div className="mx-auto max-w-[1400px] space-y-4 p-5 sm:p-7">
+        {!project ? (
+          <div className="rounded-lg border border-dashed border-[#d6d3c9] bg-white px-6 py-16 text-center">
+            <h2 className="text-[16px] font-bold text-[#0f1b2a]">No schedule open</h2>
+            <Link to="/schedule" className="mt-4 inline-flex rounded-md bg-[#0f4c92] px-3 py-1.5 text-[12px] font-semibold text-white hover:bg-[#0d3f78]">Go to the schedule grid</Link>
+          </div>
+        ) : project.resources.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-[#d6d3c9] bg-white px-6 py-16 text-center text-[13px] text-[#a39d8d]">No resources defined. Add labor / equipment / material resources with per-day availability to see the loading.</div>
+        ) : !solve.ok ? (
+          <div className="rounded-lg border border-[#efd9cc] bg-[#fdf3ee] px-4 py-2.5 text-[12px] text-[#8f4a2f]">The schedule has {solve.errorCount} blocking issue(s); fix them in the grid to compute resource loading.</div>
+        ) : (
+          <>
+            <div className={`rounded-lg border px-4 py-2.5 text-[12px] ${anyOver ? 'border-[#efd4cc] bg-[#fbeeea] text-[#8f2f1e]' : 'border-[#d3e8da] bg-[#ecf6ef] text-[#14603a]'}`}>
+              {anyOver
+                ? <><b>Over-allocation detected.</b> {loads.filter((l) => l.overDays > 0).length} resource(s) exceed their daily availability on one or more days (shown in red below). Re-sequence or level to resolve.</>
+                : <>No over-allocation — every resource stays within its daily availability across the schedule.</>}
+            </div>
+
+            {/* Summary table */}
+            <div className="overflow-x-auto rounded-lg border border-[#e3e1da] bg-white">
+              <table className="w-full min-w-[640px] border-collapse text-[12.5px]">
+                <thead>
+                  <tr className="border-b-[1.5px] border-[#0f1b2a] bg-[#f9f8f4]">
+                    <th className={th}>Resource</th><th className={th}>Type</th>
+                    <th className={`${th} text-right`}>Peak/day</th><th className={`${th} text-right`}>Avail/day</th>
+                    <th className={`${th} text-right`}>Over days</th><th className={`${th} text-right`}>Total</th><th className={th}>Unit</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {loads.map((l) => (
+                    <tr key={l.resource.id} className={`border-b border-[#f1efe8] ${l.overDays > 0 ? 'bg-[#fdf3f0]' : ''}`}>
+                      <td className={`${td} font-semibold text-[#0f1b2a]`}>{l.resource.name}</td>
+                      <td className={td}><span className="rounded px-1.5 py-px text-[10px] font-semibold text-white" style={{ background: TYPE_COLOR[l.resource.type] ?? '#5c6675' }}>{l.resource.type}</span></td>
+                      <td className={`${td} text-right font-mono ${l.overDays > 0 ? 'font-semibold text-[#c2402a]' : 'text-[#0f1b2a]'}`}>{n1(l.peak)}</td>
+                      <td className={`${td} text-right font-mono text-[#5c6675]`}>{l.available ?? '—'}</td>
+                      <td className={`${td} text-right font-mono ${l.overDays > 0 ? 'font-semibold text-[#c2402a]' : 'text-[#a39d8d]'}`}>{l.overDays}</td>
+                      <td className={`${td} text-right font-mono text-[#5c6675]`}>{n1(l.total)}</td>
+                      <td className={`${td} text-[11px] text-[#a39d8d]`}>{l.resource.unit}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {/* Per-resource histograms */}
+            <div className="grid gap-4 lg:grid-cols-2">
+              {loads.map((l) => (
+                <section key={l.resource.id} className="rounded-lg border border-[#e3e1da] bg-white">
+                  <div className="flex items-center justify-between border-b border-[#eeece5] px-4 py-2.5">
+                    <h2 className="text-[13px] font-bold text-[#0f1b2a]">{l.resource.name}</h2>
+                    <span className="font-mono text-[10.5px] text-[#a39d8d]">peak {n1(l.peak)} / {l.available ?? '∞'} {l.resource.unit}{l.overDays > 0 && <span className="ml-2 text-[#c2402a]">· {l.overDays}d over</span>}</span>
+                  </div>
+                  <div className="p-4"><Histogram load={l} /></div>
+                </section>
+              ))}
+            </div>
+            <p className="text-[11px] text-[#a39d8d]">Daily load spreads each activity's assigned quantity evenly over its scheduled working days; bars above the dashed availability line (red) are over-allocated. Assignments and per-day availability are set on the project.</p>
+          </>
+        )}
+      </div>
+    </>
+  )
+}

--- a/webapp/src/pages/ScheduleResources.tsx
+++ b/webapp/src/pages/ScheduleResources.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useScheduleProject } from '../lib/useScheduleProject'
 import { useScheduleSolve } from '../lib/useScheduleSolve'
 import { resourceLoad, hasOverAllocation, type ResourceLoad } from '../lib/resourceLoad'
+import type { ResourceType } from '../engine/schedule/model'
 import { PageHeader } from '../components/calc'
 
 // Phase 8 — resource loading at /schedule/resources. Spreads each activity's
@@ -12,7 +13,7 @@ import { PageHeader } from '../components/calc'
 
 const btn = 'inline-flex items-center gap-1.5 rounded-md border border-[#d6d3c9] bg-white px-2.5 py-1.5 text-[12px] font-semibold text-[#3d4a5c] hover:border-[#0f4c92] hover:text-[#0f4c92]'
 const CRITICAL = '#c2402a'
-const TYPE_COLOR: Record<string, string> = { labor: '#0f4c92', equipment: '#7a5cc0', material: '#1a7f4b' }
+const TYPE_COLOR: Record<ResourceType, string> = { labor: '#0f4c92', equipment: '#7c3aed', material: '#1a7f4b' }
 const n1 = (v: number) => (Number.isFinite(v) ? v.toFixed(1) : '—')
 
 function Histogram({ load }: { load: ResourceLoad }) {
@@ -32,10 +33,16 @@ function Histogram({ load }: { load: ResourceLoad }) {
         {load.perDay.map((v, t) => {
           const h = (v / max) * H
           const over = load.available != null && v > load.available + 1e-9
-          return <rect key={t} x={t * bw} y={H - h} width={Math.max(1, bw - 1)} height={h} fill={over ? CRITICAL : base} opacity={over ? 0.95 : 0.6} />
+          return (
+            <rect key={t} x={t * bw} y={H - h} width={Math.max(1, bw - 1)} height={h} fill={over ? CRITICAL : base} opacity={over ? 0.95 : 0.6}>
+              <title>day {t}: {n1(v)} {load.resource.unit}{over ? ' (over)' : ''}</title>
+            </rect>
+          )
         })}
-        <text x={0} y={H + 12} style={{ fontSize: 8, fill: '#a39d8d' }}>day 0</text>
-        <text x={load.perDay.length * bw} textAnchor="end" y={H + 12} style={{ fontSize: 8, fill: '#a39d8d' }}>day {load.perDay.length - 1}</text>
+        {load.perDay.length > 0 && <>
+          <text x={0} y={H + 12} style={{ fontSize: 8, fill: '#a39d8d' }}>day 0</text>
+          <text x={load.perDay.length * bw} textAnchor="end" y={H + 12} style={{ fontSize: 8, fill: '#a39d8d' }}>day {load.perDay.length - 1}</text>
+        </>}
       </svg>
     </div>
   )
@@ -65,7 +72,7 @@ export default function ScheduleResources() {
             <Link to="/schedule" className="mt-4 inline-flex rounded-md bg-[#0f4c92] px-3 py-1.5 text-[12px] font-semibold text-white hover:bg-[#0d3f78]">Go to the schedule grid</Link>
           </div>
         ) : project.resources.length === 0 ? (
-          <div className="rounded-lg border border-dashed border-[#d6d3c9] bg-white px-6 py-16 text-center text-[13px] text-[#a39d8d]">No resources defined. Add labor / equipment / material resources with per-day availability to see the loading.</div>
+          <div className="rounded-lg border border-dashed border-[#d6d3c9] bg-white px-6 py-16 text-center text-[13px] text-[#a39d8d]">This project has no resources. Load the sample, or import a project whose activities carry resource assignments and per-day availability, to see the loading.</div>
         ) : !solve.ok ? (
           <div className="rounded-lg border border-[#efd9cc] bg-[#fdf3ee] px-4 py-2.5 text-[12px] text-[#8f4a2f]">The schedule has {solve.errorCount} blocking issue(s); fix them in the grid to compute resource loading.</div>
         ) : (


### PR DESCRIPTION
## Project Scheduling module — Phase 8 of 10

Resource loading at `/schedule/resources`, over the same store-backed project + CPM solve.

### What's in this PR
| File | Role |
|------|------|
| `lib/resourceLoad.ts` | **Pure** per-resource daily load — each activity's assigned quantity spread evenly over its scheduled working-day span (`quantity ÷ duration`), summed per day; `peak`/`peakDay`, `total`, and **over-allocated days** where daily demand exceeds `availablePerDay` (+ `hasOverAllocation`). |
| `pages/ScheduleResources.tsx` | Over-allocation banner; resource **summary table** (peak/day, avail/day, over-days, total — over-allocated rows tinted red); per-resource **daily-load histogram** with the availability threshold line and over-allocated bars in red. |
| `App.tsx`, `lib/tools.ts` | `/schedule/resources` route + "Planning" sidebar entry. |

### Verification
- **6 new vitest cases** on `lib/resourceLoad.ts` with hand-computed values: two overlapping assignments (A 6/day days 0–4, B 5/day days 3–6) → `perDay = [6,6,6,11,11,5,5]`, peak 11 @ day 3, total 50, **2 over-days** vs avail 8; no-limit ⇒ 0 over-days; milestone/unused ⇒ zero; window-clamp.
- Full suite: **1375 passing (112 files)**; `npx tsc -b` clean.
- **Note on browser verification:** the in-app preview pane hung repeatedly this session (an automation-infra stall — Vite served fine). This page is a *pure render* of the tested loader with **no interactive state**, so it's verified via the unit tests + `tsc` + the Vercel CI build (which compiles & deploys the page). Flagging honestly.

### Notes / next
- Load uses even spreading over the span (no front/back-loading curves) and whole-day granularity — reasonable for a first cut; resource *levelling* (auto re-sequencing) is a future enhancement. Next: Phase 9 — reports (schedule / critical-path / EVM / progress / resource → PDF, Excel, CSV).

🤖 Generated with [Claude Code](https://claude.com/claude-code)