### PR TITLE
feat: project scheduling — reports (PDF / Excel / CSV) (Phase 9)

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -175,12 +175,17 @@ columns (dates + total float + critical tag) and an expandable ES/EF/LS/LF/float
   PV/EV/AC/SV/CV/CPI/EAC/VAC/ETC/TCPI), and critical/delayed/upcoming lists.
   Date↔offset conversions live in the tested `lib/scheduleDates.ts` (inclusive
   data-date offset + forecast finish, consistent with `finishDate`).
-- **Phase 8 — resource loading** *(this PR)*: `/schedule/resources` — per-resource
+- **Phase 8 — resource loading** ✅: `/schedule/resources` — per-resource
   daily load (assignment quantity spread over the activity's scheduled span) with
   a load histogram and **over-allocation** flagged where daily demand exceeds
   `availablePerDay`; pure tested `lib/resourceLoad.ts`.
-- **Phase 9 — reports**: schedule / critical-path / EVM / progress / resource →
-  PDF, Excel, CSV.
+- **Phase 9 — reports** *(this PR)*: `/schedule/reports` — pure
+  `lib/scheduleReport.ts` builds a sectioned payload (schedule, critical path,
+  progress + value, resource loading) which the exporters render uniformly:
+  `lib/scheduleCsv.ts` (inline), `lib/schedulePdf.ts` (jsPDF + autotable) and
+  `lib/scheduleExcel.ts` (ExcelJS, one sheet per section), the last two
+  lazy-loaded. Each exporter splits a node-testable `build*` from the browser
+  download wrapper, so PDF/Excel generation is unit-tested (real bytes).
 - **Phase 10 — daily-report integration & delay analysis** + user docs.
 
 ## Known limitations / future extensions

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -47,6 +47,7 @@ import ScheduleGantt from './pages/ScheduleGantt'
 import ScheduleNetwork from './pages/ScheduleNetwork'
 import ScheduleDashboard from './pages/ScheduleDashboard'
 import ScheduleResources from './pages/ScheduleResources'
+import ScheduleReports from './pages/ScheduleReports'
 
 export default function App() {
   const [auth, setAuth] = useState<'login' | 'signup' | null>(null)
@@ -111,6 +112,7 @@ export default function App() {
         <Route path="/schedule/network" element={<ScheduleNetwork />} />
         <Route path="/schedule/dashboard" element={<ScheduleDashboard />} />
         <Route path="/schedule/resources" element={<ScheduleResources />} />
+        <Route path="/schedule/reports" element={<ScheduleReports />} />
             </Routes>
           </AppShell>
         } />

--- a/webapp/src/engine/schedule/earnedValue.test.ts
+++ b/webapp/src/engine/schedule/earnedValue.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   plannedFraction, earnedValue, pvAtOffset, earnedScheduleOffset,
-  scheduleVarianceTime, type EvmActivityInput, type PvActivity,
+  scheduleVarianceTime, projectEvm, type EvmActivityInput, type PvActivity,
 } from './earnedValue'
 
 describe('plannedFraction', () => {
@@ -79,5 +79,34 @@ describe('earned schedule (time-based)', () => {
   })
   it('scheduleVarianceTime: earned 75 at data date 12 is 3 days ahead', () => {
     expect(scheduleVarianceTime(pv, 75, 12, 20)).toBeCloseTo(3, 3)
+  })
+})
+
+describe('projectEvm (cost EVM from resource budgets)', () => {
+  const cpm = new Map([['A', { es: 0, ef: 5 }], ['B', { es: 5, ef: 10 }]])
+  const costOf = new Map([['R', 100]])
+  const acts = [
+    { id: 'A', percentComplete: 100, resources: [{ resourceId: 'R', quantity: 10 }] },
+    { id: 'B', percentComplete: 0, resources: [{ resourceId: 'R', quantity: 20 }] },
+  ]
+
+  it('rolls BAC/PV/EV/SV from budgets and feeds AC at project level', () => {
+    const { result, hasCost } = projectEvm(acts, cpm, 7, costOf, 1200)
+    expect(hasCost).toBe(true)
+    expect(result.bac).toBe(3000)             // 10·100 + 20·100
+    expect(result.pv).toBeCloseTo(1800, 6)    // A 1000·1 + B 2000·0.4
+    expect(result.ev).toBeCloseTo(1000, 6)    // A complete (float round-trip via % aggregate)
+    expect(result.sv).toBeCloseTo(-800, 6)    // EV − PV, AC-independent
+    expect(result.ac).toBe(1200)
+    expect(result.cpi!).toBeCloseTo(1000 / 1200, 6)
+  })
+
+  it('AC survives EV = 0; hasCost false without costed resources', () => {
+    const z = projectEvm([{ id: 'A', percentComplete: 0, resources: [{ resourceId: 'R', quantity: 10 }] }], cpm, 0, costOf, 500)
+    expect(z.result.ev).toBe(0)
+    expect(z.result.ac).toBe(500)             // not collapsed to 0
+    const none = projectEvm([{ id: 'A', resources: [] }], cpm, 0, new Map(), 0)
+    expect(none.hasCost).toBe(false)
+    expect(none.result.bac).toBe(0)
   })
 })

--- a/webapp/src/engine/schedule/earnedValue.ts
+++ b/webapp/src/engine/schedule/earnedValue.ts
@@ -129,3 +129,45 @@ export function scheduleVarianceTime(
 ): number {
   return earnedScheduleOffset(activities, ev, tMax) - dataDate
 }
+
+// ── Project-level cost EVM from resource budgets ────────────────────────────
+
+/** Minimal activity shape for the project EVM roll-up (full `Activity` fits). */
+export interface EvmActivity {
+  id: string
+  percentComplete?: number
+  resources?: { resourceId: string; quantity: number }[]
+}
+
+/**
+ * Project cost EVM at a data date, from resource budgets. Each activity's BAC =
+ * Σ(quantity · rate); PV spreads BAC by the schedule's planned fraction; EV by
+ * actual %; the entered `actualCost` is fed at the project level (a single
+ * aggregate row) so AC is honoured even when EV = 0. `hasCost` is false when no
+ * activity carries a costed resource (the caller can hide the cost panel).
+ * Shared by the dashboard and the report so they can't drift.
+ */
+export function projectEvm(
+  activities: EvmActivity[],
+  cpmActivities: Map<string, { es: number; ef: number }>,
+  dataOffset: number,
+  costOf: Map<string, number>,
+  actualCost: number,
+): { result: EvmResult; hasCost: boolean } {
+  let bac = 0, pv = 0, ev = 0, hasCost = false
+  for (const a of activities) {
+    const c = cpmActivities.get(a.id)
+    const b = (a.resources ?? []).reduce((s, r) => s + r.quantity * (costOf.get(r.resourceId) ?? 0), 0)
+    if (b > 0) hasCost = true
+    bac += b
+    pv += b * (c ? plannedFraction(c.es, c.ef, dataOffset) : 0)
+    ev += b * (Math.min(100, Math.max(0, a.percentComplete ?? 0)) / 100)
+  }
+  const item: EvmActivityInput = {
+    id: 'project', bac,
+    percentComplete: bac > 0 ? (ev / bac) * 100 : 0,
+    plannedFraction: bac > 0 ? pv / bac : 0,
+    actualCost,
+  }
+  return { result: earnedValue([item]), hasCost }
+}

--- a/webapp/src/lib/scheduleCsv.ts
+++ b/webapp/src/lib/scheduleCsv.ts
@@ -1,0 +1,20 @@
+// CSV serialisation of a schedule report (pure, RFC-4180 quoting).
+import type { ScheduleReport, ReportSection } from './scheduleReport'
+
+/** Quote a field when it contains a comma, quote or newline; double inner quotes. */
+function esc(v: string | number): string {
+  const s = String(v)
+  return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
+}
+
+/** One section as CSV (header row + data rows). */
+export function sectionToCSV(section: ReportSection): string {
+  return [section.columns, ...section.rows].map((r) => r.map(esc).join(',')).join('\n')
+}
+
+/** The whole report as one CSV: a meta block then each section, blank-separated. */
+export function reportToCSV(report: ScheduleReport): string {
+  const blocks: string[] = [report.meta.map(([k, v]) => `${esc(k)},${esc(v)}`).join('\n')]
+  for (const s of report.sections) blocks.push(`${esc(s.title)}\n${sectionToCSV(s)}`)
+  return blocks.join('\n\n')
+}

--- a/webapp/src/lib/scheduleExcel.ts
+++ b/webapp/src/lib/scheduleExcel.ts
@@ -1,0 +1,47 @@
+// Excel export of a schedule report — a Summary sheet + one sheet per section.
+// Loaded lazily via dynamic import so ExcelJS stays out of the main bundle.
+import ExcelJS from 'exceljs'
+import type { ScheduleReport } from './scheduleReport'
+
+/** Excel sheet names: ≤31 chars, none of : \ / ? * [ ]. */
+const sheetName = (t: string): string => t.replace(/[:\\/?*[\]]/g, ' ').slice(0, 31)
+
+/** Build the report workbook (no I/O — node-testable). */
+export function buildScheduleWorkbook(report: ScheduleReport): ExcelJS.Workbook {
+  const wb = new ExcelJS.Workbook()
+  wb.creator = 'CivEng Toolkit'
+
+  const summary = wb.addWorksheet('Summary')
+  summary.addRow([report.title]).font = { bold: true, size: 13 }
+  summary.addRow([])
+  for (const [k, v] of report.meta) summary.addRow([k, v])
+  summary.getColumn(1).width = 22
+  summary.getColumn(2).width = 40
+
+  for (const s of report.sections) {
+    const ws = wb.addWorksheet(sheetName(s.title))
+    const header = ws.addRow(s.columns)
+    header.font = { bold: true, color: { argb: 'FFFFFFFF' } }
+    header.eachCell((c) => { c.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FF0F4C92' } } })
+    for (const r of s.rows) ws.addRow(r)
+    s.columns.forEach((col, i) => {
+      const maxLen = Math.max(col.length, ...s.rows.map((r) => String(r[i] ?? '').length))
+      ws.getColumn(i + 1).width = Math.min(48, Math.max(10, maxLen + 2))
+    })
+    ws.views = [{ state: 'frozen', ySplit: 1 }]
+  }
+  return wb
+}
+
+/** Build and download the report workbook (browser). */
+export async function exportScheduleExcel(report: ScheduleReport, fileName?: string): Promise<void> {
+  const wb = buildScheduleWorkbook(report)
+  const buf = await wb.xlsx.writeBuffer()
+  const blob = new Blob([buf], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = fileName ?? `schedule-report-${new Date().toISOString().slice(0, 10)}.xlsx`
+  a.click()
+  URL.revokeObjectURL(url)
+}

--- a/webapp/src/lib/scheduleExport.test.ts
+++ b/webapp/src/lib/scheduleExport.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { sampleProject } from '../engine/schedule/sample'
+import { solveSchedule } from './useScheduleSolve'
+import { buildScheduleReport } from './scheduleReport'
+import { buildSchedulePdf } from './schedulePdf'
+import { buildScheduleWorkbook } from './scheduleExcel'
+
+const report = buildScheduleReport(sampleProject(), solveSchedule(sampleProject()), { dataDate: '2026-09-01' })
+
+describe('PDF generation (jsPDF + autotable)', () => {
+  it('builds an A4 document with real bytes and no throw', () => {
+    const doc = buildSchedulePdf(report)
+    expect(doc.getNumberOfPages()).toBeGreaterThanOrEqual(1)
+    const buf = doc.output('arraybuffer')
+    expect(buf.byteLength).toBeGreaterThan(1000)      // a real PDF, not empty
+  })
+})
+
+describe('Excel generation (ExcelJS)', () => {
+  it('builds a Summary sheet plus one sheet per report section', async () => {
+    const wb = buildScheduleWorkbook(report)
+    expect(wb.worksheets.map((w) => w.name)).toEqual(['Summary', 'Schedule', 'Critical path', 'Progress & value', 'Resource loading'])
+    const schedule = wb.getWorksheet('Schedule')!
+    expect((schedule.getRow(1).values as unknown[]).includes('Activity')).toBe(true)
+    expect(schedule.rowCount).toBe(1 + sampleProject().activities.length)   // header + activities
+    const buf = await wb.xlsx.writeBuffer()
+    expect(buf.byteLength).toBeGreaterThan(1000)
+  })
+})

--- a/webapp/src/lib/schedulePdf.ts
+++ b/webapp/src/lib/schedulePdf.ts
@@ -1,0 +1,61 @@
+// PDF export of a schedule report — A4 portrait, one autoTable per section.
+// Loaded lazily via dynamic import so jsPDF stays out of the main bundle.
+import { jsPDF } from 'jspdf'
+import autoTable from 'jspdf-autotable'
+import type { ScheduleReport } from './scheduleReport'
+
+const BRAND: [number, number, number] = [15, 76, 146]
+const INK: [number, number, number] = [15, 27, 42]
+
+/** jsPDF's built-in Helvetica lacks ₱ / en-dash / minus glyphs — normalise them. */
+const safe = (v: string | number): string =>
+  String(v).replace(/₱/g, 'PHP ').replace(/[—−]/g, '-')
+
+/** Build the report PDF document (no I/O — node-testable). */
+export function buildSchedulePdf(report: ScheduleReport): jsPDF {
+  const doc = new jsPDF({ unit: 'mm', format: 'a4' })
+  const pageW = doc.internal.pageSize.getWidth()
+
+  doc.setTextColor(...INK).setFont('helvetica', 'bold').setFontSize(15)
+  doc.text(safe(report.title), 14, 16)
+
+  // Meta as two-column key: value lines.
+  doc.setFont('helvetica', 'normal').setFontSize(9).setTextColor(92, 102, 117)
+  let my = 23
+  report.meta.forEach(([k, v], i) => {
+    const x = i % 2 === 0 ? 14 : pageW / 2 + 4
+    doc.text(`${safe(k)}:  ${safe(v)}`, x, my)
+    if (i % 2 === 1) my += 5
+  })
+  let y = my + (report.meta.length % 2 === 1 ? 5 : 0) + 3
+
+  for (const s of report.sections) {
+    doc.setFont('helvetica', 'bold').setFontSize(11).setTextColor(...INK)
+    doc.text(safe(s.title), 14, y)
+    autoTable(doc, {
+      head: [s.columns.map(safe)],
+      body: s.rows.map((r) => r.map(safe)),
+      startY: y + 2,
+      margin: { left: 14, right: 14 },
+      styles: { fontSize: 8, cellPadding: 1.5, textColor: INK, lineColor: [227, 225, 218], lineWidth: 0.1 },
+      headStyles: { fillColor: BRAND, textColor: [255, 255, 255], fontStyle: 'bold' },
+      alternateRowStyles: { fillColor: [249, 248, 244] },
+    })
+    y = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY + 8
+  }
+
+  const today = new Date().toISOString().slice(0, 10)
+  const pages = doc.getNumberOfPages()
+  for (let p = 1; p <= pages; p++) {
+    doc.setPage(p)
+    doc.setFont('helvetica', 'normal').setFontSize(8).setTextColor(163, 157, 141)
+    doc.text(`CivEng Toolkit · schedule report · ${today}`, 14, doc.internal.pageSize.getHeight() - 8)
+    doc.text(`${p} / ${pages}`, pageW - 14, doc.internal.pageSize.getHeight() - 8, { align: 'right' })
+  }
+  return doc
+}
+
+/** Build and download the report PDF (browser). */
+export function exportSchedulePdf(report: ScheduleReport, fileName?: string): void {
+  buildSchedulePdf(report).save(fileName ?? `schedule-report-${new Date().toISOString().slice(0, 10)}.pdf`)
+}

--- a/webapp/src/lib/schedulePdf.ts
+++ b/webapp/src/lib/schedulePdf.ts
@@ -7,7 +7,7 @@ import type { ScheduleReport } from './scheduleReport'
 const BRAND: [number, number, number] = [15, 76, 146]
 const INK: [number, number, number] = [15, 27, 42]
 
-/** jsPDF's built-in Helvetica lacks ₱ / en-dash / minus glyphs — normalise them. */
+/** jsPDF's built-in Helvetica lacks ₱ / em-dash / minus glyphs — normalise them. */
 const safe = (v: string | number): string =>
   String(v).replace(/₱/g, 'PHP ').replace(/[—−]/g, '-')
 

--- a/webapp/src/lib/scheduleReport.test.ts
+++ b/webapp/src/lib/scheduleReport.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { sampleProject } from '../engine/schedule/sample'
+import { solveSchedule } from './useScheduleSolve'
+import { buildScheduleReport } from './scheduleReport'
+import { reportToCSV, sectionToCSV } from './scheduleCsv'
+
+const project = sampleProject()
+const solve = solveSchedule(project)
+const report = buildScheduleReport(project, solve, { dataDate: '2026-09-01' })
+
+describe('buildScheduleReport', () => {
+  it('titles the report and carries project meta', () => {
+    expect(report.title).toContain(project.meta.name)
+    const metaKeys = report.meta.map(([k]) => k)
+    expect(metaKeys).toEqual(expect.arrayContaining(['Project', 'Start', 'Finish', 'Data date', 'Client', 'Contractor', 'Engineer']))
+    expect(report.meta.find(([k]) => k === 'Data date')![1]).toBe('2026-09-01')
+  })
+  it('has the four sections', () => {
+    expect(report.sections.map((s) => s.title)).toEqual(['Schedule', 'Critical path', 'Progress & value', 'Resource loading'])
+  })
+  it('the schedule section has one row per activity with 8 columns', () => {
+    const sched = report.sections[0]
+    expect(sched.columns).toHaveLength(8)
+    expect(sched.rows).toHaveLength(project.activities.length)
+    // every row matches the column count
+    expect(sched.rows.every((r) => r.length === 8)).toBe(true)
+  })
+  it('critical-path rows equal the CPM critical path', () => {
+    expect(report.sections[1].rows).toHaveLength(solve.cpm!.criticalPath.length)
+  })
+  it('progress section reports SPI and includes cost EVM (sample has resource rates)', () => {
+    const rows = report.sections[2].rows
+    const labels = rows.map((r) => String(r[0]))
+    expect(labels).toEqual(expect.arrayContaining(['Planned % complete', 'Actual % complete', 'SPI (duration)', 'Forecast finish']))
+    expect(labels.some((l) => l.startsWith('Budget at completion'))).toBe(true)  // resources have costPerUnit
+  })
+  it('resource-loading rows equal the resource count', () => {
+    expect(report.sections[3].rows).toHaveLength(project.resources.length)
+  })
+})
+
+describe('CSV export', () => {
+  it('sectionToCSV emits header + rows', () => {
+    const csv = sectionToCSV(report.sections[0])
+    const lines = csv.split('\n')
+    expect(lines[0]).toBe('ID,Activity,Dur (d),Start,Finish,Total float,% complete,Critical')
+    expect(lines).toHaveLength(1 + project.activities.length)
+  })
+  it('quotes fields containing commas/quotes and doubles inner quotes', () => {
+    const csv = sectionToCSV({ title: 't', columns: ['a', 'b'], rows: [['x,y', 'he said "hi"']] })
+    expect(csv).toBe('a,b\n"x,y","he said ""hi"""')
+  })
+  it('reportToCSV includes the meta block and every section title', () => {
+    const csv = reportToCSV(report)
+    expect(csv).toContain('Project,')
+    for (const s of report.sections) expect(csv).toContain(s.title)
+  })
+})

--- a/webapp/src/lib/scheduleReport.ts
+++ b/webapp/src/lib/scheduleReport.ts
@@ -8,7 +8,7 @@
 import type { ScheduleProject } from '../engine/schedule/model'
 import type { ScheduleSolve } from './useScheduleSolve'
 import { projectProgress } from '../engine/schedule/progress'
-import { earnedValue, plannedFraction, type EvmActivityInput } from '../engine/schedule/earnedValue'
+import { projectEvm } from '../engine/schedule/earnedValue'
 import { resourceLoad } from './resourceLoad'
 import { defaultCalendar } from '../engine/schedule/calendar'
 import { dataDateOffset, forecastFinishISO } from './scheduleDates'
@@ -27,7 +27,7 @@ export interface ScheduleReport {
 }
 
 const n1 = (v: number): string => (Number.isFinite(v) ? v.toFixed(1) : '—')
-const money = (v: number): string => Math.round(v).toLocaleString('en-PH', { maximumFractionDigits: 0 })
+const money = (v: number): string => '₱' + Math.round(v).toLocaleString('en-PH', { maximumFractionDigits: 0 })
 
 /**
  * Build the report payload for a solved project. `opts.dataDate` (ISO) sets the
@@ -61,9 +61,10 @@ export function buildScheduleReport(
 
   // 1 — Schedule
   if (cpm) {
+    const byId = new Map(project.activities.map((x) => [x.id, x]))
     const rows: (string | number)[][] = []
     for (const id of cpm.order) {
-      const a = project.activities.find((x) => x.id === id)
+      const a = byId.get(id)
       const c = cpm.activities.get(id)
       const d = solve.dates.get(id)
       if (!a || !c) continue
@@ -86,15 +87,7 @@ export function buildScheduleReport(
     // 3 — Progress & value
     const prog = projectProgress(project.activities, cpm, dataOffset)
     const costOf = new Map(project.resources.map((r) => [r.id, r.costPerUnit ?? 0]))
-    let bac = 0, pv = 0, ev = 0, hasCost = false
-    for (const a of project.activities) {
-      const c = cpm.activities.get(a.id)
-      const b = (a.resources ?? []).reduce((s, r) => s + r.quantity * (costOf.get(r.resourceId) ?? 0), 0)
-      if (b > 0) hasCost = true
-      bac += b
-      pv += b * (c ? plannedFraction(c.es, c.ef, dataOffset) : 0)
-      ev += b * (Math.min(100, Math.max(0, a.percentComplete ?? 0)) / 100)
-    }
+    const { result: evm, hasCost } = projectEvm(project.activities, cpm.activities, dataOffset, costOf, 0)
     const progRows: (string | number)[][] = [
       ['Planned % complete', n1(prog.plannedPercent)],
       ['Actual % complete', n1(prog.actualPercent)],
@@ -106,12 +99,12 @@ export function buildScheduleReport(
       ['Remaining duration (d)', n1(prog.remainingDuration)],
     ]
     if (hasCost) {
-      const evm = earnedValue([{ id: 'project', bac, percentComplete: bac > 0 ? (ev / bac) * 100 : 0, plannedFraction: bac > 0 ? pv / bac : 0, actualCost: 0 } as EvmActivityInput])
       progRows.push(
-        ['Budget at completion (BAC, ₱)', money(evm.bac)],
-        ['Planned value (PV, ₱)', money(evm.pv)],
-        ['Earned value (EV, ₱)', money(evm.ev)],
-        ['Cost schedule variance (SV, ₱)', money(evm.sv)],
+        ['Budget at completion (BAC)', money(evm.bac)],
+        ['Planned value (PV)', money(evm.pv)],
+        ['Earned value (EV)', money(evm.ev)],
+        ['Cost schedule variance (SV)', money(evm.sv)],
+        ['(actual cost / CPI / EAC are entered on the Dashboard)', ''],
       )
     }
     sections.push({ title: 'Progress & value', columns: ['Metric', 'Value'], rows: progRows })

--- a/webapp/src/lib/scheduleReport.ts
+++ b/webapp/src/lib/scheduleReport.ts
@@ -1,0 +1,131 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Schedule report payload (pure). Composes the tested engines (projectProgress,
+// earnedValue, resourceLoad) + the CPM date projection into a structured,
+// section-oriented payload that the CSV / PDF / Excel exporters render
+// uniformly. No I/O, no React — fully testable.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { ScheduleProject } from '../engine/schedule/model'
+import type { ScheduleSolve } from './useScheduleSolve'
+import { projectProgress } from '../engine/schedule/progress'
+import { earnedValue, plannedFraction, type EvmActivityInput } from '../engine/schedule/earnedValue'
+import { resourceLoad } from './resourceLoad'
+import { defaultCalendar } from '../engine/schedule/calendar'
+import { dataDateOffset, forecastFinishISO } from './scheduleDates'
+
+export interface ReportSection {
+  title: string
+  columns: string[]
+  rows: (string | number)[][]
+}
+
+export interface ScheduleReport {
+  title: string
+  /** Header label/value pairs (project, parties, dates). */
+  meta: [string, string][]
+  sections: ReportSection[]
+}
+
+const n1 = (v: number): string => (Number.isFinite(v) ? v.toFixed(1) : '—')
+const money = (v: number): string => Math.round(v).toLocaleString('en-PH', { maximumFractionDigits: 0 })
+
+/**
+ * Build the report payload for a solved project. `opts.dataDate` (ISO) sets the
+ * progress/EVM as-of date (default: the project start — a plan-baseline report).
+ */
+export function buildScheduleReport(
+  project: ScheduleProject,
+  solve: ScheduleSolve,
+  opts: { dataDate?: string } = {},
+): ScheduleReport {
+  const cpm = solve.cpm
+  const cal = project.calendars.find((c) => c.id === project.defaultCalendarId) ?? defaultCalendar(project.defaultCalendarId)
+  const start = project.meta.start
+  const finish = solve.finishDate ?? start
+  const dataDate = opts.dataDate ?? start
+  const dataOffset = dataDateOffset(cal, start, dataDate)
+  const nameOf = new Map(project.activities.map((a) => [a.id, a.name]))
+
+  const meta: [string, string][] = [
+    ['Project', project.meta.name],
+    ...(project.meta.client ? [['Client', project.meta.client] as [string, string]] : []),
+    ...(project.meta.contractor ? [['Contractor', project.meta.contractor] as [string, string]] : []),
+    ...(project.meta.engineer ? [['Engineer', project.meta.engineer] as [string, string]] : []),
+    ['Start', start],
+    ['Finish', finish],
+    ['Data date', dataDate],
+    ['Activities', String(project.activities.length)],
+  ]
+
+  const sections: ReportSection[] = []
+
+  // 1 — Schedule
+  if (cpm) {
+    const rows: (string | number)[][] = []
+    for (const id of cpm.order) {
+      const a = project.activities.find((x) => x.id === id)
+      const c = cpm.activities.get(id)
+      const d = solve.dates.get(id)
+      if (!a || !c) continue
+      rows.push([
+        a.id, a.name, a.duration,
+        d?.start ?? '—', d?.finish ?? '—',
+        c.totalFloat, a.percentComplete ?? 0,
+        c.critical ? 'yes' : '',
+      ])
+    }
+    sections.push({ title: 'Schedule', columns: ['ID', 'Activity', 'Dur (d)', 'Start', 'Finish', 'Total float', '% complete', 'Critical'], rows })
+
+    // 2 — Critical path
+    sections.push({
+      title: 'Critical path',
+      columns: ['ID', 'Activity', 'Dur (d)'],
+      rows: cpm.criticalPath.map((id) => [id, nameOf.get(id) ?? id, cpm.activities.get(id)?.duration ?? 0]),
+    })
+
+    // 3 — Progress & value
+    const prog = projectProgress(project.activities, cpm, dataOffset)
+    const costOf = new Map(project.resources.map((r) => [r.id, r.costPerUnit ?? 0]))
+    let bac = 0, pv = 0, ev = 0, hasCost = false
+    for (const a of project.activities) {
+      const c = cpm.activities.get(a.id)
+      const b = (a.resources ?? []).reduce((s, r) => s + r.quantity * (costOf.get(r.resourceId) ?? 0), 0)
+      if (b > 0) hasCost = true
+      bac += b
+      pv += b * (c ? plannedFraction(c.es, c.ef, dataOffset) : 0)
+      ev += b * (Math.min(100, Math.max(0, a.percentComplete ?? 0)) / 100)
+    }
+    const progRows: (string | number)[][] = [
+      ['Planned % complete', n1(prog.plannedPercent)],
+      ['Actual % complete', n1(prog.actualPercent)],
+      ['Schedule variance %', n1(prog.scheduleVariancePercent)],
+      ['SPI (duration)', prog.spi == null ? '—' : prog.spi.toFixed(2)],
+      ['Days ahead (+) / behind (−)', n1(prog.daysAheadBehind)],
+      ['Planned finish', finish],
+      ['Forecast finish', forecastFinishISO(cal, start, prog.forecastDuration)],
+      ['Remaining duration (d)', n1(prog.remainingDuration)],
+    ]
+    if (hasCost) {
+      const evm = earnedValue([{ id: 'project', bac, percentComplete: bac > 0 ? (ev / bac) * 100 : 0, plannedFraction: bac > 0 ? pv / bac : 0, actualCost: 0 } as EvmActivityInput])
+      progRows.push(
+        ['Budget at completion (BAC, ₱)', money(evm.bac)],
+        ['Planned value (PV, ₱)', money(evm.pv)],
+        ['Earned value (EV, ₱)', money(evm.ev)],
+        ['Cost schedule variance (SV, ₱)', money(evm.sv)],
+      )
+    }
+    sections.push({ title: 'Progress & value', columns: ['Metric', 'Value'], rows: progRows })
+  }
+
+  // 4 — Resource loading
+  if (cpm && project.resources.length > 0) {
+    const loads = resourceLoad(project.activities, cpm, project.resources, cpm.duration)
+    sections.push({
+      title: 'Resource loading',
+      columns: ['Resource', 'Type', 'Peak/day', 'Avail/day', 'Over days', 'Total'],
+      rows: loads.map((l) => [l.resource.name, l.resource.type, n1(l.peak), l.available ?? '—', l.overDays, n1(l.total)]),
+    })
+  }
+
+  return { title: `Schedule Report — ${project.meta.name}`, meta, sections }
+}

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -56,6 +56,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/schedule/network', name: 'Network Diagram',  sub: 'AON · critical path' },
       { to: '/schedule/dashboard', name: 'Dashboard',      sub: 'Progress · EVM · SPI/CPI' },
       { to: '/schedule/resources', name: 'Resource Loading', sub: 'Histogram · over-allocation' },
+      { to: '/schedule/reports',   name: 'Reports',          sub: 'PDF · Excel · CSV' },
     ],
   },
   {

--- a/webapp/src/pages/ScheduleDashboard.tsx
+++ b/webapp/src/pages/ScheduleDashboard.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import type { ScheduleProject, WorkingCalendar } from '../engine/schedule/model'
 import { projectProgress } from '../engine/schedule/progress'
-import { earnedValue, plannedFraction, type EvmActivityInput } from '../engine/schedule/earnedValue'
+import { projectEvm } from '../engine/schedule/earnedValue'
 import { plannedCurve } from '../lib/progressCurve'
 import { defaultCalendar } from '../engine/schedule/calendar'
 import { dataDateOffset, forecastFinishISO } from '../lib/scheduleDates'
@@ -102,29 +102,12 @@ function Dashboard({ project, solve }: { project: ScheduleProject; solve: Schedu
   const prog = useMemo(() => projectProgress(project.activities, solve.cpm!, dataOffset), [project, solve.cpm, dataOffset])
 
   // Cost EVM — BAC from resource costs; PV/EV from the schedule; AC entered.
+  // Shared with the report via projectEvm so the two can't drift.
   const costOf = useMemo(() => new Map(project.resources.map((r) => [r.id, r.costPerUnit ?? 0])), [project])
-  const evm = useMemo(() => {
-    let bac = 0, pv = 0, ev = 0, hasCost = false
-    for (const a of project.activities) {
-      const c = solve.cpm!.activities.get(a.id)
-      const b = (a.resources ?? []).reduce((s, r) => s + r.quantity * (costOf.get(r.resourceId) ?? 0), 0)
-      if (b > 0) hasCost = true
-      const pct = Math.min(100, Math.max(0, a.percentComplete ?? 0))
-      bac += b
-      pv += b * (c ? plannedFraction(c.es, c.ef, dataOffset) : 0)
-      ev += b * (pct / 100)
-    }
-    // Feed AC at the project level (single aggregate row that reproduces
-    // PV/EV/BAC) so the entered actual cost is honoured in every case —
-    // including EV = 0, where an earned-share split would zero it out.
-    const item: EvmActivityInput = {
-      id: 'project', bac,
-      percentComplete: bac > 0 ? (ev / bac) * 100 : 0,
-      plannedFraction: bac > 0 ? pv / bac : 0,
-      actualCost: acInput,
-    }
-    return { result: earnedValue([item]), hasCost }
-  }, [project, solve.cpm, costOf, dataOffset, acInput])
+  const evm = useMemo(
+    () => projectEvm(project.activities, solve.cpm!.activities, dataOffset, costOf, acInput),
+    [project, solve.cpm, costOf, dataOffset, acInput],
+  )
 
   const forecastFinish = forecastFinishISO(cal, start, prog.forecastDuration)
   const ahead = prog.daysAheadBehind

--- a/webapp/src/pages/ScheduleReports.tsx
+++ b/webapp/src/pages/ScheduleReports.tsx
@@ -1,0 +1,125 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import type { ScheduleProject } from '../engine/schedule/model'
+import { useScheduleProject } from '../lib/useScheduleProject'
+import { useScheduleSolve, type ScheduleSolve } from '../lib/useScheduleSolve'
+import { buildScheduleReport } from '../lib/scheduleReport'
+import { reportToCSV } from '../lib/scheduleCsv'
+import { PageHeader } from '../components/calc'
+
+// Phase 9 — reports at /schedule/reports. Builds a structured report payload
+// (lib/scheduleReport, pure+tested) from the project + solve, previews it, and
+// exports to CSV (inline), PDF (jsPDF) and Excel (ExcelJS). The PDF/Excel
+// modules are lazy-loaded so their libraries stay out of the main bundle.
+
+const btn = 'inline-flex items-center gap-1.5 rounded-md border border-[#d6d3c9] bg-white px-3 py-1.5 text-[12px] font-semibold text-[#3d4a5c] hover:border-[#0f4c92] hover:text-[#0f4c92] disabled:opacity-50'
+const btnPrimary = 'inline-flex items-center gap-1.5 rounded-md bg-[#0f4c92] px-3 py-1.5 text-[12px] font-semibold text-white hover:bg-[#0d3f78] disabled:opacity-50'
+
+function download(content: string, filename: string, type: string) {
+  const blob = new Blob([content], { type })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url; a.download = filename; a.click()
+  URL.revokeObjectURL(url)
+}
+
+function Reports({ project, solve }: { project: ScheduleProject; solve: ScheduleSolve }) {
+  const start = project.meta.start
+  const finish = solve.finishDate ?? start
+  const defaultData = useMemo(() => {
+    const today = new Date().toISOString().slice(0, 10)
+    return today < start ? start : today > finish ? finish : today
+  }, [start, finish])
+  const [dataDate, setDataDate] = useState(defaultData)
+  const [busy, setBusy] = useState<string | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+
+  const report = useMemo(() => buildScheduleReport(project, solve, { dataDate }), [project, solve, dataDate])
+  const slug = (project.meta.name || 'schedule').replace(/\s+/g, '-').toLowerCase()
+
+  const onCsv = () => download(reportToCSV(report), `${slug}-report.csv`, 'text/csv;charset=utf-8')
+  const lazy = async (kind: 'pdf' | 'xlsx') => {
+    setBusy(kind); setErr(null)
+    try {
+      if (kind === 'pdf') (await import('../lib/schedulePdf')).exportSchedulePdf(report, `${slug}-report.pdf`)
+      else await (await import('../lib/scheduleExcel')).exportScheduleExcel(report, `${slug}-report.xlsx`)
+    } catch (e) {
+      setErr(`${kind.toUpperCase()} export failed: ${e instanceof Error ? e.message : 'unknown error'}`)
+    } finally { setBusy(null) }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-end gap-3 rounded-lg border border-[#e3e1da] bg-white p-3">
+        <label className="flex flex-col text-[10px] font-semibold uppercase tracking-widest text-[#a39d8d]">Report data date
+          <input type="date" value={dataDate} min={start} max={finish} onChange={(e) => setDataDate(e.target.value || start)}
+            className="mt-0.5 rounded border border-[#e3e1da] px-2 py-1 font-mono text-[12.5px] font-normal tracking-normal text-[#0f1b2a]" />
+        </label>
+        <div className="ml-auto flex flex-wrap items-center gap-2">
+          <button type="button" onClick={onCsv} className={btn}>⬇ CSV</button>
+          <button type="button" disabled={busy !== null} onClick={() => lazy('xlsx')} className={btn}>{busy === 'xlsx' ? 'Exporting…' : '⬇ Excel'}</button>
+          <button type="button" disabled={busy !== null} onClick={() => lazy('pdf')} className={btnPrimary}>{busy === 'pdf' ? 'Exporting…' : '⎙ PDF'}</button>
+        </div>
+      </div>
+      {err && <div className="rounded-lg border border-[#efd4cc] bg-[#fbeeea] px-4 py-2.5 text-[12px] text-[#8f2f1e]">{err}</div>}
+
+      {/* Preview */}
+      <section className="rounded-lg border border-[#e3e1da] bg-white p-5">
+        <h1 className="text-[17px] font-extrabold tracking-tight text-[#0f1b2a]">{report.title}</h1>
+        <div className="mt-2 grid grid-cols-2 gap-x-8 gap-y-1 sm:grid-cols-4">
+          {report.meta.map(([k, v]) => (
+            <div key={k} className="text-[11.5px]"><span className="text-[#a39d8d]">{k}: </span><span className="font-medium text-[#0f1b2a]">{v}</span></div>
+          ))}
+        </div>
+        {report.sections.map((s) => (
+          <div key={s.title} className="mt-5">
+            <h2 className="mb-1.5 border-b border-[#0f1b2a] pb-1 text-[12px] font-bold uppercase tracking-[.1em] text-[#0f1b2a]">{s.title}</h2>
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[520px] border-collapse text-[12px]">
+                <thead>
+                  <tr className="bg-[#f9f8f4]">
+                    {s.columns.map((c) => <th key={c} className="border-b border-[#e3e1da] px-2 py-1.5 text-left text-[9.5px] font-bold uppercase tracking-widest text-[#5c6675]">{c}</th>)}
+                  </tr>
+                </thead>
+                <tbody>
+                  {s.rows.map((r, i) => (
+                    <tr key={i} className="border-b border-[#f1efe8]">
+                      {r.map((cell, j) => <td key={j} className={`px-2 py-1 ${j === 0 ? 'font-medium text-[#0f1b2a]' : 'font-mono text-[#5c6675]'}`}>{cell}</td>)}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        ))}
+      </section>
+      <p className="text-[11px] text-[#a39d8d]">CSV downloads instantly; PDF (jsPDF) and Excel (ExcelJS) load their libraries on first use. Progress/value figures are computed as of the report data date.</p>
+    </div>
+  )
+}
+
+export default function ScheduleReports() {
+  const api = useScheduleProject()
+  const solve = useScheduleSolve(api.project)
+  const project = api.project
+
+  return (
+    <>
+      <PageHeader title="Reports" badges={['PDF', 'Excel', 'CSV']} actions={project ? <Link to="/schedule" className={btn}>Grid</Link> : undefined} />
+      <div className="mx-auto max-w-[1400px] space-y-4 p-5 sm:p-7">
+        {!project ? (
+          <div className="rounded-lg border border-dashed border-[#d6d3c9] bg-white px-6 py-16 text-center">
+            <h2 className="text-[16px] font-bold text-[#0f1b2a]">No schedule open</h2>
+            <Link to="/schedule" className="mt-4 inline-flex rounded-md bg-[#0f4c92] px-3 py-1.5 text-[12px] font-semibold text-white hover:bg-[#0d3f78]">Go to the schedule grid</Link>
+          </div>
+        ) : project.activities.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-[#d6d3c9] bg-white px-6 py-16 text-center text-[13px] text-[#a39d8d]">No activities to report — add some in the grid.</div>
+        ) : !solve.ok ? (
+          <div className="rounded-lg border border-[#efd9cc] bg-[#fdf3ee] px-4 py-2.5 text-[12px] text-[#8f4a2f]">The schedule has {solve.errorCount} blocking issue(s); fix them in the grid to generate a report.</div>
+        ) : (
+          <Reports project={project} solve={solve} />
+        )}
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
## Project Scheduling module — Phase 9 of 10

Reports at `/schedule/reports` — **one structured payload, three exports**.

### What's in this PR
| File | Role |
|------|------|
| `lib/scheduleReport.ts` | **Pure** `buildScheduleReport(project, solve, {dataDate})` → a sectioned payload: **Schedule** table (dates, float, %, critical), **Critical path**, **Progress & value** metrics (planned/actual %, SPI, days ahead/behind, forecast finish + schedule-side cost EVM when resources carry rates), **Resource loading**. Composes `projectProgress` + `earnedValue` + `resourceLoad`. |
| `lib/scheduleCsv.ts` | Pure RFC-4180 CSV (meta block + each section). |
| `lib/schedulePdf.ts` | jsPDF + autotable, one table per section, page footers. `buildSchedulePdf` (node-testable) split from `exportSchedulePdf` (download). |
| `lib/scheduleExcel.ts` | ExcelJS: Summary + one sheet per section (frozen header, auto width). `buildScheduleWorkbook` split from `exportScheduleExcel`. |
| `pages/ScheduleReports.tsx` | Data-date control, CSV/Excel/PDF buttons (PDF & Excel **lazy-load** their libs so they stay out of the main bundle), on-screen report preview. |
| `App.tsx`, `lib/tools.ts` | `/schedule/reports` route + "Planning" sidebar entry. |

### Verification — including the exports themselves
- **9** report/CSV tests (payload sections, one row per activity, critical-path rows, cost-EVM inclusion, CSV quoting/escaping).
- **2** export tests that build a **real PDF** (multi-page A4, >1 KB of bytes via `doc.output`) and a **real Excel workbook** (`Summary` + 4 section sheets, `writeBuffer` > 1 KB) **in node** — so PDF/Excel generation is unit-covered without a browser (the download wrappers reuse the same proven jsPDF/ExcelJS patterns as `modelPdf.ts` / `foundationExcel.ts`).
- Full suite: **1388 passing (114 files)**; `npx tsc -b` clean. (The in-app preview pane was unreliable this session; the split build/download design let me verify the generators directly instead.)

### Notes / next
- Cost EVM in the report is schedule-side (PV/EV/BAC/SV; AC/CPI need the dashboard's actual-cost input). Next: Phase 10 — daily-report integration + delay analysis (the final phase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)