### PR TITLE
feat: timber deck on model plates — designed + folded into the export

### DIFF
--- a/webapp/src/engine/meshValidation.ts
+++ b/webapp/src/engine/meshValidation.ts
@@ -163,6 +163,17 @@ export function validateMesh(model: StructuralModel): MeshIssue[] {
       issues.push({ severity: 'error', code: 'WOOD_DIMS', message: `section ${sec.id}: timber b and d must be positive`, refs: [sec.id] })
   }
 
+  // ── timber deck sanity (L1 rule for Plate.deck / wood slab) ─────────────
+  for (const p of model.plates) {
+    const d = p.deck; if (!d) continue
+    if (d.joistSpecies && !WOOD_SPECIES[d.joistSpecies] && !d.joistRef)
+      issues.push({ severity: 'error', code: 'DECK_SPECIES', message: `plate ${p.id}: unknown timber species "${d.joistSpecies}" — not in the WOOD_SPECIES library`, refs: [p.id] })
+    if (!(d.joistB > 0) || !(d.joistD > 0) || !(d.joistSpacing > 0))
+      issues.push({ severity: 'error', code: 'DECK_JOIST', message: `plate ${p.id}: deck joist b, d and spacing must be positive`, refs: [p.id] })
+    if (!(d.deckThickness > 0))
+      issues.push({ severity: 'error', code: 'DECK_THICKNESS', message: `plate ${p.id}: deck thickness must be positive`, refs: [p.id] })
+  }
+
   // ── prestressing sanity (L1 rule for RectSection.ps) ────────────────────
   for (const sec of model.sections) {
     if (!sec.ps) continue

--- a/webapp/src/engine/model.ts
+++ b/webapp/src/engine/model.ts
@@ -109,6 +109,27 @@ export interface Plate {
   sdlItems?: SdlItem[]
   /** Per-slab live load from NSCP Table 205-1 occupancy (overrides global LL). */
   live?: LiveItem
+  /** Timber deck-on-joist floor (wood slab). When present the panel is designed
+   *  by the woodSlab engine (NDS §3 / NSCP §6) instead of the RC Direct Design
+   *  Method: plan span/width come from the plate geometry, D/L from its area
+   *  loads (superimposed — the deck adds its own self weight). */
+  deck?: WoodDeck
+}
+
+/** A timber deck-on-joist floor carried by a plate. JSON-serialisable. */
+export interface WoodDeck {
+  joistSpecies?: string          // wood-library id ('DFL-2', …) — resolves joistRef when absent
+  joistRef?: WoodRefValues       // explicit reference values (custom material; travels with the model)
+  joistKind?: 'sawn' | 'glulam'
+  joistB: number                 // mm
+  joistD: number                 // mm
+  joistSpacing: number           // mm c/c
+  joistSupport?: 'simple' | 'continuous'
+  deckMaterial: 'plank' | 'bamboo-slat'
+  deckThickness: number          // mm
+  deckWidth?: number             // mm (board / slat face width)
+  deckSupport?: 'simple' | 'continuous'
+  wet?: boolean                  // wet-service C_M
 }
 
 /** A wall sitting on a member: its self-weight is applied to that member as a

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -27,7 +27,8 @@ import { designShearWall, type ShearWallResult } from './shearWallDesign'
 import { checkModelSCWB, type SCWBJointRow } from './scwb'
 import { shapeByName, nextHeavierW, nextLighterW, type AiscShape } from './aiscSections'
 import { deriveWSection, beamFlexure, beamShear, columnAxial, combinedLoading } from './steelDesign'
-import { woodRefOf, checkWoodBeam, checkWoodColumn } from './woodDesign'
+import { woodRefOf, checkWoodBeam, checkWoodColumn, getWoodRef } from './woodDesign'
+import { designWoodSlab, type WoodSlabResult } from './woodSlab'
 import { designBasePlate, adoptPlateThickness, type BasePlateResult } from './baseplate'
 import { designSteelJoints, designBeamBeamJoints, type SteelJoint, type BeamBeamJoint } from './steelConnections'
 
@@ -137,6 +138,15 @@ export interface SlabScheduleRow {
   design: SlabDesignResult
   ok: boolean
 }
+/** A plate carrying a timber deck-on-joist floor, designed by the woodSlab
+ *  engine (NDS §3 / NSCP §6) rather than the RC DDM. */
+export interface WoodSlabScheduleRow {
+  plate: string
+  lx: number; ly: number
+  species: string
+  design: WoodSlabResult
+  ok: boolean
+}
 export interface WallScheduleRow {
   id: string
   member: string
@@ -243,6 +253,8 @@ export interface StructureDesign {
   /** Beam-to-beam fin plates: beams framing into a girder web (steel only). */
   beamJoints: BeamBeamJoint[]
   slabs: SlabScheduleRow[]
+  /** Plates carrying a timber deck (Plate.deck), designed by the woodSlab engine. */
+  woodSlabs: WoodSlabScheduleRow[]
   walls: WallScheduleRow[]
   footings: FootingScheduleRow[]
   combined: CombinedScheduleRow[]
@@ -268,7 +280,7 @@ export function designOK(d: StructureDesign): boolean {
     && d.woodBeams.every((b) => b.ok) && d.woodColumns.every((c) => c.ok)
     && d.basePlates.every((p) => p.ok)
     && d.footings.every((f) => f.ok) && d.combined.every((c) => c.ok)
-    && d.slabs.every((s) => s.ok) && d.walls.every((w) => w.ok)
+    && d.slabs.every((s) => s.ok) && d.woodSlabs.every((s) => s.ok) && d.walls.every((w) => w.ok)
     && d.joints.every((j) => j.ok) && d.beamJoints.every((j) => j.ok) && d.scwb.every((j) => j.ok)
     && d.unchecked.length === 0
     && d.pDeltaIssues.length === 0
@@ -905,6 +917,7 @@ function designFromRuns(
   }
   let concreteSlabs = 0
   for (const p of model.plates) {
+    if (p.deck) continue                                 // timber deck — no concrete
     const c = p.corners.map((id) => nm.get(id))
     if (c.some((q) => !q)) continue
     const [c0, c1, , c3] = c as { x: number; y: number; z: number }[]
@@ -917,6 +930,7 @@ function designFromRuns(
   const xMin = Math.min(...model.nodes.map((n) => n.x)), xMax = Math.max(...model.nodes.map((n) => n.x))
   const zMin = Math.min(...model.nodes.map((n) => n.z)), zMax = Math.max(...model.nodes.map((n) => n.z))
   const slabs: SlabScheduleRow[] = []
+  const woodSlabs: WoodSlabScheduleRow[] = []
   for (const p of model.plates) {
     if (p.role === 'wall') continue
     const c = p.corners.map((id) => nm.get(id)); if (c.some((q) => !q)) continue
@@ -927,6 +941,25 @@ function designFromRuns(
     const areaD = model.loads.filter((l) => l.kind === 'area' && l.plate === p.id && l.cat === 'D').reduce((s, l) => s + (l as { q: number }).q, 0)
     const areaL = model.loads.filter((l) => l.kind === 'area' && l.plate === p.id && l.cat === 'L').reduce((s, l) => s + (l as { q: number }).q, 0)
     if (areaD + areaL < 1e-9) continue
+    // Timber deck: design the wood slab (joists span the shorter dimension) and
+    // skip the RC Direct Design Method for this panel. D/L are superimposed —
+    // the deck engine adds its own deck + joist self weight.
+    if (p.deck) {
+      const ref = p.deck.joistRef ?? (p.deck.joistSpecies ? getWoodRef(p.deck.joistSpecies)?.ref : undefined)
+      if (ref) {
+        const span = Math.min(lx, lz), across = Math.max(lx, lz)
+        const design = designWoodSlab({
+          Lx: span, Ly: across, joistRef: ref, joistKind: p.deck.joistKind,
+          joistB: p.deck.joistB, joistD: p.deck.joistD, joistSpacing: p.deck.joistSpacing,
+          joistSupport: p.deck.joistSupport, deckMaterial: p.deck.deckMaterial,
+          deckThickness: p.deck.deckThickness, deckWidth: p.deck.deckWidth,
+          deckSupport: p.deck.deckSupport, deadKpa: areaD, liveKpa: areaL,
+          opts: { wet: p.deck.wet },
+        })
+        woodSlabs.push({ plate: p.id, lx: span, ly: across, species: p.deck.joistSpecies ?? 'custom', design, ok: design.ok })
+        continue
+      }
+    }
     const cs = footSec(p.corners[0])
     const extX = cc.some((q) => Math.abs(q.x - xMin) < 1e-4) || cc.some((q) => Math.abs(q.x - xMax) < 1e-4)
     const extZ = cc.some((q) => Math.abs(q.z - zMin) < 1e-4) || cc.some((q) => Math.abs(q.z - zMax) < 1e-4)
@@ -945,6 +978,8 @@ function designFromRuns(
         && design.deflection.liveOK && design.deflection.totalOK,
     })
   }
+  // timber-deck panels add their joist + decking volume to the timber total
+  for (const s of woodSlabs) woodVolume += s.design.takeoff.joistM3 + s.design.takeoff.deckM3
 
   // ── Shear walls — in-plane reinforcement ──
   // The bridge models each shear wall as an X of two diagonal struts
@@ -983,7 +1018,7 @@ function designFromRuns(
     beams, prestressed, columns, steelBeams, steelColumns, woodBeams, woodColumns, basePlates,
     joints: [] as SteelJoint[],
     beamJoints: [] as BeamBeamJoint[],
-    slabs, walls, footings, combined,
+    slabs, woodSlabs, walls, footings, combined,
     scwb: [] as SCWBJointRow[],
     totals: { concreteMembers, concreteSlabs, concrete: concreteMembers + concreteSlabs, steelKg, woodVolume },
     orphanEdges: br.orphanEdges.length,

--- a/webapp/src/engine/takeoff.test.ts
+++ b/webapp/src/engine/takeoff.test.ts
@@ -116,7 +116,7 @@ describe('structural steel — per-shape unit weight + costed BOM line items (A2
   const emptyDesign: StructureDesign = {
     govName: '', cases: [], beams: [], prestressed: [], columns: [], steelBeams: [], steelColumns: [],
     woodBeams: [], woodColumns: [],
-    basePlates: [], joints: [], beamJoints: [], slabs: [], walls: [], footings: [], combined: [], scwb: [],
+    basePlates: [], joints: [], beamJoints: [], slabs: [], woodSlabs: [], walls: [], footings: [], combined: [], scwb: [],
     totals: { concreteMembers: 0, concreteSlabs: 0, concrete: 0, steelKg: 0, woodVolume: 0 }, orphanEdges: 0,
     unchecked: [], pDeltaIssues: [],
   }

--- a/webapp/src/lib/modelReport.test.ts
+++ b/webapp/src/lib/modelReport.test.ts
@@ -140,3 +140,32 @@ describe('buildModelReport — timber members', () => {
     expect(rpt.stats.some((s) => s.label === 'Timber' && s.unit === 'm³')).toBe(true)
   })
 })
+
+describe('buildModelReport — timber deck (wood slab on a plate)', () => {
+  const model = (() => {
+    const m = makeModel()   // concrete frame + area D/L loads on the plate
+    m.plates[0].deck = {
+      joistSpecies: 'DFL-2', joistKind: 'sawn', joistB: 50, joistD: 200, joistSpacing: 400,
+      joistSupport: 'simple', deckMaterial: 'plank', deckThickness: 25, deckSupport: 'continuous',
+    }
+    return m
+  })()
+  const design = designStructure(model, soil)!
+  const rpt = buildModelReport(model, design, [], soil)
+
+  it('the deck plate is designed as a wood slab, not an RC DDM slab', () => {
+    expect(design.woodSlabs.length).toBe(1)
+    expect(design.slabs.some((s) => s.plate === model.plates[0].id)).toBe(false)
+    expect(design.totals.woodVolume).toBeGreaterThan(0)
+  })
+
+  it('the wood slab appears in checks, schedule table and worked-solution groups', () => {
+    expect(rpt.checks.map((c) => c.name)).toContain('Timber deck slabs (NDS §3)')
+    const t = rpt.tables.find((x) => x.title.startsWith('Timber deck slab'))!
+    expect(t.rows).toHaveLength(1)
+    for (const r of t.rows) expect(r).toHaveLength(t.head.length)
+    const grp = rpt.groups.find((g) => g.title === 'Timber deck slabs')!
+    expect(grp.items).toHaveLength(1)
+    expect(grp.items[0].steps.length).toBeGreaterThan(0)
+  })
+})

--- a/webapp/src/lib/modelReport.ts
+++ b/webapp/src/lib/modelReport.ts
@@ -7,7 +7,7 @@ import type { StructuralModel, RectSection, Node } from '../engine/model'
 import type {
   StructureDesign, SoilOptions,
   SteelBeamScheduleRow, SteelColumnScheduleRow,
-  WoodBeamScheduleRow, WoodColumnScheduleRow,
+  WoodBeamScheduleRow, WoodColumnScheduleRow, WoodSlabScheduleRow,
 } from '../engine/pipeline'
 import { designOK } from '../engine/pipeline'
 import { beamSectionSolution, columnRowSolution, footingRowSolution, combinedRowSolution } from './modelSpaceSolutions'
@@ -128,6 +128,28 @@ export function woodColumnRowSolution(r: WoodColumnScheduleRow): SolutionStep[] 
   ]
 }
 
+// ── Timber deck (wood slab) worked solution from the stored row detail ────────
+export function woodSlabRowSolution(r: WoodSlabScheduleRow): SolutionStep[] {
+  const d = r.design, tk = d.takeoff
+  const chk = (label: string, c: typeof d.joist): SolutionStep => ({
+    title: label, clause: 'NDS §3.3–§3.4 / NSCP §6', pass: c.ok, lines: [
+      txt(`${f0(c.b)}×${f0(c.d)} mm · span ${f2(c.span)} m · w = ${f2(c.w)} kN/m → M = ${f2(c.M)} kN·m, V = ${f2(c.V)} kN`),
+      txt(`bending f_b/F′b = ${f2(c.fb)}/${f2(c.FbPrime)} (util ${f2(c.bendingRatio)}) · shear f_v/F′v = ${f2(c.fv)}/${f2(c.FvPrime)} (util ${f2(c.shearRatio)})`),
+      txt(`Δ live ${f2(c.deflLive)}/${f2(c.deflLiveAllow)} mm · Δ total ${f2(c.deflTotal)}/${f2(c.deflTotalAllow)} mm ${c.ok ? '✓' : '✗'}`),
+    ],
+  })
+  return [
+    { title: 'Loads', clause: 'NSCP §203', lines: [
+      txt(`superimposed dead ${f2(d.loads.deadKpa)} kPa · live ${f2(d.loads.liveKpa)} kPa · deck self ${f2(d.loads.deckSelfKpa)} · joist self ${f2(d.loads.joistSelfKpa)} → total ${f2(d.loads.totalKpa)} kPa`),
+    ] },
+    chk('Decking', d.deck),
+    chk('Joist', d.joist),
+    { title: 'Take-off (board feet)', clause: 'BOM', lines: [
+      txt(`${f0(tk.joistCount)} joists · ${f2(tk.joistLengthM)} m · ${f0(tk.joistBoardFeet)} bd·ft · deck ${f2(tk.deckAreaM2)} m² · ${f0(tk.deckBoardFeet)} bd·ft${tk.bambooSlatCount != null ? ` · ${f0(tk.bambooSlatCount)} bamboo slats` : ''}`),
+    ] },
+  ]
+}
+
 // ── Payload assembly ──────────────────────────────────────────────────────────
 export function buildModelReport(
   model: StructuralModel, design: StructureDesign, props: [string, string][], soil: SoilOptions,
@@ -193,6 +215,10 @@ export function buildModelReport(
   }
   if (design.slabs.length)
     checks.push({ name: 'Slabs (DDM)', detail: `${design.slabs.length} panels`, ratio: null, ok: design.slabs.every((s) => s.ok) })
+  if (design.woodSlabs.length) {
+    const w = worst(design.woodSlabs, (s) => s.design.ratio)!
+    checks.push({ name: 'Timber deck slabs (NDS §3)', detail: `${design.woodSlabs.length} panels · governing ${w.row.plate}`, ratio: w.r, ok: design.woodSlabs.every((s) => s.ok) })
+  }
   if (design.walls.length) {
     const w = worst(design.walls, (x) => (x.design.phiVn > 0 ? x.Vu / x.design.phiVn : 99))!
     checks.push({ name: 'Shear walls', detail: `${design.walls.length} walls · governing ${w.row.id}`, ratio: w.r, ok: design.walls.every((x) => x.ok) })
@@ -303,6 +329,15 @@ export function buildModelReport(
     right: [2, 3],
     rows: design.slabs.map((s) => [s.plate, `${f2(s.lx)} × ${f2(s.ly)}`, f0(s.design.h), f2(s.design.wu),
       s.design.twoWay ? 'two-way' : 'one-way', s.ok ? 'PASS' : 'FAIL']),
+  })
+  if (design.woodSlabs.length) tables.push({
+    title: 'Timber deck slab schedule (NDS §3 / NSCP §6)',
+    head: ['Panel', 'Span (m)', 'Species', 'Joists', 'Deck t (mm)', 'Deck util', 'Joist util', 'Bd·ft', 'Status'],
+    right: [1, 4, 5, 6, 7],
+    rows: design.woodSlabs.map((s) => [s.plate, f2(s.design.joist.span), s.species,
+      `${s.design.takeoff.joistCount}·${f0(s.design.joist.b)}×${f0(s.design.joist.d)}`, f0(s.design.deck.d),
+      f2(s.design.deck.ratio), f2(s.design.joist.ratio),
+      f0(s.design.takeoff.joistBoardFeet + s.design.takeoff.deckBoardFeet), s.ok ? 'PASS' : 'FAIL']),
   })
   if (design.walls.length) tables.push({
     title: 'Shear wall schedule',
@@ -446,6 +481,10 @@ export function buildModelReport(
   if (design.woodColumns.length) groups.push({
     title: 'Timber columns',
     items: design.woodColumns.map((c) => ({ title: c.id, sub: `${f0(c.b)}×${f0(c.d)} mm · ${c.species || 'timber'} · L = ${f2(c.L)} m · ${c.gov ?? ''}`, steps: woodColumnRowSolution(c) })),
+  })
+  if (design.woodSlabs.length) groups.push({
+    title: 'Timber deck slabs',
+    items: design.woodSlabs.map((s) => ({ title: s.plate, sub: `${f2(s.lx)} × ${f2(s.ly)} m · ${s.species} · deck-on-joist`, steps: woodSlabRowSolution(s) })),
   })
   const connItems: ReportSolution[] = [
     ...design.joints.flatMap((j) => j.connections.map((c) => ({


### PR DESCRIPTION
## What

Adds a **timber deck** to Model Space plates and **folds the resulting wood slab into the exported report** (engine + report). The plate-editor UI is the follow-up phase.

### Model (L1)
- `Plate.deck` (`WoodDeck`) — joist species/section/spacing, deck material (plank / bamboo slat), thickness, supports, wet-service. JSON-serialisable.
- `meshValidation` rule: positive joist b/d/spacing + deck thickness, and a known timber species (unless a custom `joistRef` is supplied).

### Pipeline
- A plate carrying a deck is designed by the **`woodSlab` engine** (joists span the shorter plan dimension; area D/L are treated as **superimposed** — the deck adds its own deck + joist self weight) into a new **`StructureDesign.woodSlabs`**, and **skips the RC Direct Design Method** for that panel.
- Its joist + decking volume counts as **timber, not concrete** in the totals; `woodSlabs` gate `designOK`.

### Report (fold into export)
The wood slab now reports **just like reinforced concrete**:
- **Summary check** — "Timber deck slabs (NDS §3)" with governing utilisation.
- **Schedule table** — span, species, joists, deck thickness, deck & joist utilisation, board-feet, status.
- **Worked solution** per panel — loads → deck check → joist check → board-feet take-off.

All flow through `modelPdf.ts`'s generic renderer, so the exported PDF picks it up.

## Layer

L1 (schema + meshValidation), L6 (pipeline consumes the L7 woodSlab engine), report. No solver changes.

## Verification

- New tests: a deck plate designs as a wood slab (not DDM), adds timber volume, and surfaces in the report checks/tables/groups.
- Full suite **1383 passing**, `tsc -b` clean, `npm run build` OK.

## Note / next phase
Deck **self-weight**: the panel's area **D is treated as superimposed** dead (the woodSlab engine computes deck + joist self weight itself). If the model's load generator auto-adds an RC-slab self-weight for deck panels, that should be suppressed in a follow-up. **Next PR**: the ModelSpace plate editor to add/configure a timber deck interactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_