### PR TITLE
feat: on-screen timber schedules + auto-timber slabs for a wood frame

### DIFF
--- a/webapp/src/lib/modelReport.ts
+++ b/webapp/src/lib/modelReport.ts
@@ -7,10 +7,10 @@ import type { StructuralModel, RectSection, Node } from '../engine/model'
 import type {
   StructureDesign, SoilOptions,
   SteelBeamScheduleRow, SteelColumnScheduleRow,
-  WoodBeamScheduleRow, WoodColumnScheduleRow, WoodSlabScheduleRow,
 } from '../engine/pipeline'
 import { designOK } from '../engine/pipeline'
-import { beamSectionSolution, columnRowSolution, footingRowSolution, combinedRowSolution } from './modelSpaceSolutions'
+import { beamSectionSolution, columnRowSolution, footingRowSolution, combinedRowSolution,
+  woodBeamRowSolution, woodColumnRowSolution, woodSlabRowSolution } from './modelSpaceSolutions'
 import { connectionRowSolution } from './connectionSolution'
 import { buildPrestressedSolution } from './prestressedSolution'
 import type { SolutionStep, SolutionLine } from './solution'
@@ -90,62 +90,6 @@ export function steelColumnRowSolution(r: SteelColumnScheduleRow): SolutionStep[
     { title: 'Combined axial + flexure', clause: 'AISC 360-16 §H1-1', pass: r.ok, lines: [
       txt(`Mu = ${f1(r.Mu)} kN·m · φMn = ${f1(r.phiMn)} kN·m · equation ${r.equation}`),
       txt(`Interaction ratio = ${f2(r.ratio)} ≤ 1.00 ${r.ok ? '✓' : '✗'}`),
-    ] },
-  ]
-}
-
-// ── Timber worked "solutions" from the stored row detail (NDS §3 / NSCP §6) ───
-// The wood schedule rows carry the LRFD-adjusted stresses and stability factors;
-// these steps narrate them (no re-calculation), mirroring the steel builders.
-export function woodBeamRowSolution(r: WoodBeamScheduleRow): SolutionStep[] {
-  return [
-    { title: `Section ${f0(r.b)}×${f0(r.d)} mm — ${r.species || 'timber'} (${r.kind})`, clause: 'NDS 2018 §3 / NSCP §6', lines: [
-      txt(`b = ${f0(r.b)} mm · d = ${f0(r.d)} mm · L = ${f2(r.L)} m · role ${r.role}`),
-    ] },
-    { title: 'Flexure — bending with beam stability', clause: 'NDS §3.3', pass: r.utilM <= 1, lines: [
-      txt(`f_b = M/S = ${f2(r.fb)} MPa · C_L = ${f2(r.CL)} → F′b = ${f2(r.FbPrime)} MPa`),
-      txt(`Mu = ${f1(r.Mu)} kN·m → util f_b/F′b = ${f2(r.utilM)} ${r.utilM <= 1 ? '✓' : '✗'}`),
-    ] },
-    { title: 'Horizontal shear', clause: 'NDS §3.4', pass: r.utilV <= 1, lines: [
-      txt(`f_v = 1.5V/A = ${f2(r.fv)} MPa ≤ F′v = ${f2(r.FvPrime)} MPa`),
-      txt(`Vu = ${f1(r.Vu)} kN → util f_v/F′v = ${f2(r.utilV)} ${r.utilV <= 1 ? '✓' : '✗'}`),
-    ] },
-  ]
-}
-
-export function woodColumnRowSolution(r: WoodColumnScheduleRow): SolutionStep[] {
-  return [
-    { title: `Section ${f0(r.b)}×${f0(r.d)} mm — ${r.species || 'timber'} (${r.kind})`, clause: 'NDS 2018 §3 / NSCP §6', lines: [
-      txt(`b = ${f0(r.b)} mm · d = ${f0(r.d)} mm · L = ${f2(r.L)} m`),
-    ] },
-    { title: 'Axial compression with column stability', clause: 'NDS §3.7', pass: r.fc <= r.FcPrime, lines: [
-      txt(`slenderness le/d = ${f1(r.slenderness)} → C_P = ${f2(r.CP)} · F′c = ${f2(r.FcPrime)} MPa`),
-      txt(`f_c = P/A = ${f2(r.fc)} MPa · Pu = ${f1(r.Pu)} kN ${r.fc <= r.FcPrime ? '✓' : '✗'}`),
-    ] },
-    { title: 'Combined axial + flexure', clause: 'NDS §3.9.2', pass: r.ok, lines: [
-      txt(`Mu = ${f1(r.Mu)} kN·m → governing ratio = ${f2(r.ratio)} ≤ 1.00 ${r.ok ? '✓' : '✗'}`),
-    ] },
-  ]
-}
-
-// ── Timber deck (wood slab) worked solution from the stored row detail ────────
-export function woodSlabRowSolution(r: WoodSlabScheduleRow): SolutionStep[] {
-  const d = r.design, tk = d.takeoff
-  const chk = (label: string, c: typeof d.joist): SolutionStep => ({
-    title: label, clause: 'NDS §3.3–§3.4 / NSCP §6', pass: c.ok, lines: [
-      txt(`${f0(c.b)}×${f0(c.d)} mm · span ${f2(c.span)} m · w = ${f2(c.w)} kN/m → M = ${f2(c.M)} kN·m, V = ${f2(c.V)} kN`),
-      txt(`bending f_b/F′b = ${f2(c.fb)}/${f2(c.FbPrime)} (util ${f2(c.bendingRatio)}) · shear f_v/F′v = ${f2(c.fv)}/${f2(c.FvPrime)} (util ${f2(c.shearRatio)})`),
-      txt(`Δ live ${f2(c.deflLive)}/${f2(c.deflLiveAllow)} mm · Δ total ${f2(c.deflTotal)}/${f2(c.deflTotalAllow)} mm ${c.ok ? '✓' : '✗'}`),
-    ],
-  })
-  return [
-    { title: 'Loads', clause: 'NSCP §203', lines: [
-      txt(`superimposed dead ${f2(d.loads.deadKpa)} kPa · live ${f2(d.loads.liveKpa)} kPa · deck self ${f2(d.loads.deckSelfKpa)} · joist self ${f2(d.loads.joistSelfKpa)} → total ${f2(d.loads.totalKpa)} kPa`),
-    ] },
-    chk('Decking', d.deck),
-    chk('Joist', d.joist),
-    { title: 'Take-off (board feet)', clause: 'BOM', lines: [
-      txt(`${f0(tk.joistCount)} joists · ${f2(tk.joistLengthM)} m · ${f0(tk.joistBoardFeet)} bd·ft · deck ${f2(tk.deckAreaM2)} m² · ${f0(tk.deckBoardFeet)} bd·ft${tk.bambooSlatCount != null ? ` · ${f0(tk.bambooSlatCount)} bamboo slats` : ''}`),
     ] },
   ]
 }

--- a/webapp/src/lib/modelSpaceSolutions.ts
+++ b/webapp/src/lib/modelSpaceSolutions.ts
@@ -2,14 +2,15 @@
 // schedules from the design rows, reusing the same builders the standalone
 // calculator pages use (beam / column / isolated footing).
 import type { RectSection } from '../engine/model'
-import type { BeamSectionDesign, ColumnScheduleRow, FootingScheduleRow, CombinedScheduleRow, SoilOptions } from '../engine/pipeline'
+import type { BeamSectionDesign, ColumnScheduleRow, FootingScheduleRow, CombinedScheduleRow, SoilOptions,
+  WoodBeamScheduleRow, WoodColumnScheduleRow, WoodSlabScheduleRow } from '../engine/pipeline'
 import type { CombinedFootingInput } from '../engine/combinedFooting'
 import { designAxialColumn, interaction, capacityAtEccentricity } from '../engine/columnDesign'
 import { buildBeamSolution } from './beamSolution'
 import { axialColumnSolution, eccentricColumnSolution, type SeismicTieOverride } from './columnSolution'
 import { buildFoundationSolution, type SolutionCtx } from './foundationSolution'
 import { buildCombinedFootingSolution } from './combinedFootingSolution'
-import type { SolutionStep } from './solution'
+import type { SolutionStep, SolutionLine } from './solution'
 
 /** Worked solution for one beam/girder critical section. */
 export function beamSectionSolution(sec: RectSection, s: BeamSectionDesign): SolutionStep[] {
@@ -80,4 +81,63 @@ export function combinedRowSolution(secA: RectSection, secB: RectSection, soil: 
     surcharge: 0, H: soil.H, barDia: secA.barDia, cover: 75,
   }
   return buildCombinedFootingSolution(input, row.design)
+}
+
+// ── Timber worked "solutions" (NDS §3 / NSCP §6) — narrate the stored LRFD
+// stresses and stability factors; shared by the on-screen schedules and the PDF. ──
+const wf0 = (v: number) => v.toFixed(0)
+const wf1 = (v: number) => v.toFixed(1)
+const wf2 = (v: number) => v.toFixed(2)
+const wtxt = (text: string): SolutionLine => ({ text })
+
+export function woodBeamRowSolution(r: WoodBeamScheduleRow): SolutionStep[] {
+  return [
+    { title: `Section ${wf0(r.b)}×${wf0(r.d)} mm — ${r.species || 'timber'} (${r.kind})`, clause: 'NDS 2018 §3 / NSCP §6', lines: [
+      wtxt(`b = ${wf0(r.b)} mm · d = ${wf0(r.d)} mm · L = ${wf2(r.L)} m · role ${r.role}`),
+    ] },
+    { title: 'Flexure — bending with beam stability', clause: 'NDS §3.3', pass: r.utilM <= 1, lines: [
+      wtxt(`f_b = M/S = ${wf2(r.fb)} MPa · C_L = ${wf2(r.CL)} → F′b = ${wf2(r.FbPrime)} MPa`),
+      wtxt(`Mu = ${wf1(r.Mu)} kN·m → util f_b/F′b = ${wf2(r.utilM)} ${r.utilM <= 1 ? '✓' : '✗'}`),
+    ] },
+    { title: 'Horizontal shear', clause: 'NDS §3.4', pass: r.utilV <= 1, lines: [
+      wtxt(`f_v = 1.5V/A = ${wf2(r.fv)} MPa ≤ F′v = ${wf2(r.FvPrime)} MPa`),
+      wtxt(`Vu = ${wf1(r.Vu)} kN → util f_v/F′v = ${wf2(r.utilV)} ${r.utilV <= 1 ? '✓' : '✗'}`),
+    ] },
+  ]
+}
+
+export function woodColumnRowSolution(r: WoodColumnScheduleRow): SolutionStep[] {
+  return [
+    { title: `Section ${wf0(r.b)}×${wf0(r.d)} mm — ${r.species || 'timber'} (${r.kind})`, clause: 'NDS 2018 §3 / NSCP §6', lines: [
+      wtxt(`b = ${wf0(r.b)} mm · d = ${wf0(r.d)} mm · L = ${wf2(r.L)} m`),
+    ] },
+    { title: 'Axial compression with column stability', clause: 'NDS §3.7', pass: r.fc <= r.FcPrime, lines: [
+      wtxt(`slenderness le/d = ${wf1(r.slenderness)} → C_P = ${wf2(r.CP)} · F′c = ${wf2(r.FcPrime)} MPa`),
+      wtxt(`f_c = P/A = ${wf2(r.fc)} MPa · Pu = ${wf1(r.Pu)} kN ${r.fc <= r.FcPrime ? '✓' : '✗'}`),
+    ] },
+    { title: 'Combined axial + flexure', clause: 'NDS §3.9.2', pass: r.ok, lines: [
+      wtxt(`Mu = ${wf1(r.Mu)} kN·m → governing ratio = ${wf2(r.ratio)} ≤ 1.00 ${r.ok ? '✓' : '✗'}`),
+    ] },
+  ]
+}
+
+export function woodSlabRowSolution(r: WoodSlabScheduleRow): SolutionStep[] {
+  const d = r.design, tk = d.takeoff
+  const chk = (label: string, c: typeof d.joist): SolutionStep => ({
+    title: label, clause: 'NDS §3.3–§3.4 / NSCP §6', pass: c.ok, lines: [
+      wtxt(`${wf0(c.b)}×${wf0(c.d)} mm · span ${wf2(c.span)} m · w = ${wf2(c.w)} kN/m → M = ${wf2(c.M)} kN·m, V = ${wf2(c.V)} kN`),
+      wtxt(`bending f_b/F′b = ${wf2(c.fb)}/${wf2(c.FbPrime)} (util ${wf2(c.bendingRatio)}) · shear f_v/F′v = ${wf2(c.fv)}/${wf2(c.FvPrime)} (util ${wf2(c.shearRatio)})`),
+      wtxt(`Δ live ${wf2(c.deflLive)}/${wf2(c.deflLiveAllow)} mm · Δ total ${wf2(c.deflTotal)}/${wf2(c.deflTotalAllow)} mm ${c.ok ? '✓' : '✗'}`),
+    ],
+  })
+  return [
+    { title: 'Loads', clause: 'NSCP §203', lines: [
+      wtxt(`superimposed dead ${wf2(d.loads.deadKpa)} kPa · live ${wf2(d.loads.liveKpa)} kPa · deck self ${wf2(d.loads.deckSelfKpa)} · joist self ${wf2(d.loads.joistSelfKpa)} → total ${wf2(d.loads.totalKpa)} kPa`),
+    ] },
+    chk('Decking', d.deck),
+    chk('Joist', d.joist),
+    { title: 'Take-off (board feet)', clause: 'BOM', lines: [
+      wtxt(`${wf0(tk.joistCount)} joists · ${wf2(tk.joistLengthM)} m · ${wf0(tk.joistBoardFeet)} bd·ft · deck ${wf2(tk.deckAreaM2)} m² · ${wf0(tk.deckBoardFeet)} bd·ft${tk.bambooSlatCount != null ? ` · ${wf0(tk.bambooSlatCount)} bamboo slats` : ''}`),
+    ] },
+  ]
 }

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -32,7 +32,8 @@ import { JointConnections3D } from '../components/JointConnections3D'
 import { ConnectionDetail2D } from '../components/ConnectionDetail2D'
 import { connectionRowSolution } from '../lib/connectionSolution'
 import { WorkedSolution } from '../components/WorkedSolution'
-import { beamSectionSolution, columnRowSolution, footingRowSolution, combinedRowSolution } from '../lib/modelSpaceSolutions'
+import { beamSectionSolution, columnRowSolution, footingRowSolution, combinedRowSolution,
+  woodBeamRowSolution, woodColumnRowSolution, woodSlabRowSolution } from '../lib/modelSpaceSolutions'
 import { Diagram } from '../components/Diagram'
 import { MemberForcesTable } from '../components/MemberForcesTable'
 import { ReactionsPanel } from '../components/ReactionsPanel'
@@ -1599,6 +1600,11 @@ export default function ModelSpace() {
       beam: steel ? steelRole(beaShape, 'BEA') : wood ? woodRole(beaB, beaH, 'BEA') : role(beaB, beaH, 'BEA'),
       slabThickness: slabThk,
     })
+    // Wood frame → the floor slabs are timber decks too: give every floor panel a
+    // default deck-on-joist (joists in the chosen species) so it designs as a
+    // wood slab. Concrete/steel frames keep RC slabs.
+    if (wood) m.plates = m.plates.map((p) => p.role === 'wall' ? p
+      : { ...p, deck: { ...DEFAULT_DECK, joistSpecies: wsel.id, joistKind: wsel.kind, wet } })
     // gravity loads: member self-weight (D), slab self-weight + SDL (D), LL (L)
     m.loads = buildGravityLoads(m, qD, qL, gammaC)
     setSelected(null)
@@ -2426,7 +2432,7 @@ export default function ModelSpace() {
                   {material === 'steel'
                     ? 'Members become AISC W-shapes designed to AISC 360-16 LRFD (§F flexure, §G shear, §E/§H1 columns); base plates per §J8. Slabs/footings stay reinforced concrete.'
                     : material === 'wood'
-                      ? 'Members become solid-rectangular timber designed to NDS §3 / NSCP §6 (LRFD via Appendix N). Slabs/footings stay reinforced concrete.'
+                      ? 'Members become solid-rectangular timber designed to NDS §3 / NSCP §6 (LRFD via Appendix N). Floor slabs become timber deck-on-joist floors (wood slab); footings stay reinforced concrete.'
                       : 'Members are reinforced concrete designed to NSCP 2015 / ACI 318-14.'}
                 </p>
               </Sec>
@@ -2498,7 +2504,7 @@ export default function ModelSpace() {
                   <p className="col-span-full text-[11px] text-slate-500">
                     Designed to NDS §3 / NSCP §6: reference values ({woodKind === 'glulam' ? 'glulam' : 'sawn'}, {activeWood.origin})
                     adjusted by C<sub>D</sub>/C<sub>M</sub>/C<sub>F</sub>/C<sub>V</sub>, beam stability C<sub>L</sub> and column
-                    stability C<sub>P</sub>; factored demands checked LRFD (Appendix N, K<sub>F</sub>·φ·λ). Slabs/footings stay reinforced concrete.
+                    stability C<sub>P</sub>; factored demands checked LRFD (Appendix N, K<sub>F</sub>·φ·λ). Floor slabs become timber decks; footings stay reinforced concrete.
                   </p>
                 </Sec>
               ) : (
@@ -4626,6 +4632,148 @@ export default function ModelSpace() {
                 t = ℓ√(2fp/(0.9Fy)); ℓ = max(m, n, n′). Uplift sizes anchor rods (φt·0.75·Fu).
                 Adopted t rounded to plate stock.
               </p>
+            </div>
+          )}
+
+          {/* Timber beam & girder schedule — NDS §3 / NSCP §6 */}
+          {design.woodBeams.length > 0 && (
+            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Timber beam &amp; girder schedule — NDS §3 / NSCP §6<SchedChip items={design.woodBeams} ok={(b) => b.ok} /></h3>
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
+                    <th className="py-1 pr-2 font-semibold">Member</th>
+                    <th className="py-1 pr-2 font-semibold">Section</th>
+                    <th className="py-1 pr-2 font-semibold">Species</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Mu (kN·m)</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Vu (kN)</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Util</th>
+                    <th className="py-1 font-semibold">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {design.woodBeams.flatMap((b) => {
+                    const key = `wbeam:${b.id}`, open = expanded === key || reportOpen
+                    return [
+                      <tr key={key} onClick={() => setExpanded(expanded === key ? null : key)}
+                        className={`sched-row cursor-pointer border-t border-slate-100 hover:bg-blue-50/40 ${b.ok ? '' : 'bg-red-50 text-red-700'}`}>
+                        <td className="py-1 pr-2 font-medium">{open ? '▾' : '▸'} {b.id}</td>
+                        <td className="py-1 pr-2">{f0(b.b)}×{f0(b.d)}</td>
+                        <td className="py-1 pr-2">{b.species || '—'} ({b.kind})</td>
+                        <td className="py-1 pr-2 text-right">{f1(b.Mu)}</td>
+                        <td className="py-1 pr-2 text-right">{f1(b.Vu)}</td>
+                        <td className="py-1 pr-2 text-right">{(Math.max(b.utilM, b.utilV) * 100).toFixed(0)}%</td>
+                        <td className="py-1 text-slate-500">{b.ok ? '✓ OK' : '✗ check'}</td>
+                      </tr>,
+                      open && wantSol && (
+                        <tr key={`${key}:sol`}>
+                          <td colSpan={7} className="bg-slate-50/60 px-2 pb-2">
+                            <WorkedSolution steps={woodBeamRowSolution(b)} title={`${b.id} — worked solution`} />
+                          </td>
+                        </tr>
+                      ),
+                    ]
+                  })}
+                </tbody>
+              </table>
+              <p className="mt-1 text-[11px] text-slate-500">§3.3 bending with beam-stability C_L, §3.4 horizontal shear; factored demand vs LRFD-adjusted F′ (Appendix N K_F·φ·λ). Click a row for the worked solution.</p>
+            </div>
+          )}
+
+          {/* Timber column schedule — NDS §3.7 / §3.9 */}
+          {design.woodColumns.length > 0 && (
+            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Timber column schedule — NDS §3.7 / §3.9<SchedChip items={design.woodColumns} ok={(c) => c.ok} /></h3>
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
+                    <th className="py-1 pr-2 font-semibold">Column</th>
+                    <th className="py-1 pr-2 font-semibold">Section</th>
+                    <th className="py-1 pr-2 font-semibold">Species</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Pu (kN)</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Mu (kN·m)</th>
+                    <th className="py-1 pr-2 text-right font-semibold">C_P</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Ratio</th>
+                    <th className="py-1 font-semibold">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {design.woodColumns.flatMap((c) => {
+                    const key = `wcol:${c.id}`, open = expanded === key || reportOpen
+                    return [
+                      <tr key={key} onClick={() => setExpanded(expanded === key ? null : key)}
+                        className={`sched-row cursor-pointer border-t border-slate-100 hover:bg-blue-50/40 ${c.ok ? '' : 'bg-red-50 text-red-700'}`}>
+                        <td className="py-1 pr-2 font-medium">{open ? '▾' : '▸'} {c.id}</td>
+                        <td className="py-1 pr-2">{f0(c.b)}×{f0(c.d)}</td>
+                        <td className="py-1 pr-2">{c.species || '—'} ({c.kind})</td>
+                        <td className="py-1 pr-2 text-right">{f1(c.Pu)}</td>
+                        <td className="py-1 pr-2 text-right">{f1(c.Mu)}</td>
+                        <td className="py-1 pr-2 text-right">{f2(c.CP)}</td>
+                        <td className="py-1 pr-2 text-right">{(c.ratio * 100).toFixed(0)}%</td>
+                        <td className="py-1 text-slate-500">{c.ok ? '✓ OK' : '✗ check'}</td>
+                      </tr>,
+                      open && wantSol && (
+                        <tr key={`${key}:sol`}>
+                          <td colSpan={8} className="bg-slate-50/60 px-2 pb-2">
+                            <WorkedSolution steps={woodColumnRowSolution(c)} title={`${c.id} — worked solution`} />
+                          </td>
+                        </tr>
+                      ),
+                    ]
+                  })}
+                </tbody>
+              </table>
+              <p className="mt-1 text-[11px] text-slate-500">§3.7 axial with column-stability C_P; §3.9.2 combined axial + flexure interaction. Ratio ≤ 100% passes. Click a row for the worked solution.</p>
+            </div>
+          )}
+
+          {/* Timber deck slab schedule — NDS §3 / NSCP §6 */}
+          {design.woodSlabs.length > 0 && report !== 'draw-only' && (
+            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Timber deck slab schedule — NDS §3 / NSCP §6<SchedChip items={design.woodSlabs} ok={(s) => s.ok} /></h3>
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
+                    <th className="py-1 pr-2 font-semibold">Panel</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Span (m)</th>
+                    <th className="py-1 pr-2 font-semibold">Species</th>
+                    <th className="py-1 pr-2 font-semibold">Joists</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Deck t</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Deck util</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Joist util</th>
+                    <th className="py-1 pr-2 text-right font-semibold">Bd·ft</th>
+                    <th className="py-1 font-semibold">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {design.woodSlabs.flatMap((s) => {
+                    const key = `wslab:${s.plate}`, open = expanded === key || reportOpen
+                    const t = s.design.takeoff
+                    return [
+                      <tr key={key} onClick={() => setExpanded(expanded === key ? null : key)}
+                        className={`sched-row cursor-pointer border-t border-slate-100 hover:bg-blue-50/40 ${s.ok ? '' : 'bg-red-50 text-red-700'}`}>
+                        <td className="py-1 pr-2 font-medium">{open ? '▾' : '▸'} {s.plate}</td>
+                        <td className="py-1 pr-2 text-right">{f2(s.design.joist.span)}</td>
+                        <td className="py-1 pr-2">{s.species}</td>
+                        <td className="py-1 pr-2">{t.joistCount}·{f0(s.design.joist.b)}×{f0(s.design.joist.d)}</td>
+                        <td className="py-1 pr-2 text-right">{f0(s.design.deck.d)}</td>
+                        <td className="py-1 pr-2 text-right">{(s.design.deck.ratio * 100).toFixed(0)}%</td>
+                        <td className="py-1 pr-2 text-right">{(s.design.joist.ratio * 100).toFixed(0)}%</td>
+                        <td className="py-1 pr-2 text-right">{f0(t.joistBoardFeet + t.deckBoardFeet)}</td>
+                        <td className="py-1 text-slate-500">{s.ok ? '✓ OK' : '✗ check'}</td>
+                      </tr>,
+                      open && wantSol && (
+                        <tr key={`${key}:sol`}>
+                          <td colSpan={9} className="bg-slate-50/60 px-2 pb-2">
+                            <WorkedSolution steps={woodSlabRowSolution(s)} title={`${s.plate} — worked solution`} />
+                          </td>
+                        </tr>
+                      ),
+                    ]
+                  })}
+                </tbody>
+              </table>
+              <p className="mt-1 text-[11px] text-slate-500">Deck-on-joist: the deck board spans the joist spacing, the joist spans the panel; bending + shear + service deflection (L/360 live, L/240 total). Board feet by size. Click a row for the worked solution.</p>
             </div>
           )}
 


### PR DESCRIPTION
## What

Fixes the two things you hit: **no timber schedules/worked-solutions in the on-screen design view**, and **slabs not becoming timber when the frame is wood**.

### On-screen timber schedules
The on-screen **Design tab** rendered only RC and steel schedules (the earlier work only touched the **PDF export** payload). Added three schedule tables there, each with an expandable **worked solution** (same pattern as the RC/steel tables):
- **Timber beam & girder** — section, species, Mu, Vu, utilisation.
- **Timber column** — Pu, Mu, `C_P`, ratio.
- **Timber deck slab** — span, species, joists, deck t, deck & joist utilisation, board-feet.

The wood row-solution builders **moved from `modelReport` into `modelSpaceSolutions`** so the on-screen view and the PDF share one source (no duplication); `modelReport` now imports them from there.

### Wood frame → timber slabs (automatic)
`generate()` now gives **every floor panel a default timber deck** (joists in the chosen species) when the frame material is **wood**, so slabs design as wood slabs automatically — no per-panel toggling needed. Concrete/steel frames keep RC slabs. The frame-material help text is updated ("Floor slabs become timber deck-on-joist floors; footings stay reinforced concrete").

## Layer

UI + presentation. The wood design/report was already delivered (#402–#405); this surfaces it on screen and applies it by default for wood frames. No engine changes.

## Verification

- `tsc -b` clean, `npm run build` OK, full suite **1383 passing** (the moved builders are still exercised by `modelReport.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_