### PR TITLE
fix: de-duplicate timber schedules + detailed KaTeX worked solutions

### DIFF
--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -27,7 +27,7 @@ import { designShearWall, type ShearWallResult } from './shearWallDesign'
 import { checkModelSCWB, type SCWBJointRow } from './scwb'
 import { shapeByName, nextHeavierW, nextLighterW, type AiscShape } from './aiscSections'
 import { deriveWSection, beamFlexure, beamShear, columnAxial, combinedLoading } from './steelDesign'
-import { woodRefOf, checkWoodBeam, checkWoodColumn, getWoodRef } from './woodDesign'
+import { woodRefOf, checkWoodBeam, checkWoodColumn, getWoodRef, woodAdjusted } from './woodDesign'
 import { designWoodSlab, type WoodSlabResult } from './woodSlab'
 import { designBasePlate, adoptPlateThickness, type BasePlateResult } from './baseplate'
 import { designSteelJoints, designBeamBeamJoints, type SteelJoint, type BeamBeamJoint } from './steelConnections'
@@ -215,6 +215,9 @@ export interface WoodBeamScheduleRow {
   utilM: number; utilV: number
   ok: boolean
   gov?: string
+  // worked-solution intermediates
+  S: number; A: number             // mm³, mm² (section modulus, area)
+  RB: number; Emin: number; FbStar: number   // beam slenderness, stability modulus, Fb* (pre-CL)
 }
 export interface WoodColumnScheduleRow {
   id: string; L: number
@@ -224,6 +227,8 @@ export interface WoodColumnScheduleRow {
   ratio: number                    // governing (axial or §3.9.2 interaction)
   ok: boolean
   gov?: string
+  // worked-solution intermediates
+  A: number; FcE: number; Emin: number; FcStar: number   // mm², Euler stress, stability modulus, Fc* (pre-CP)
 }
 
 /** Prestressed member check (sections with RectSection.ps): the pipeline
@@ -375,15 +380,17 @@ function designWoodBeamRow(
   const ref = woodRefOf(sec)
   if (!ref) return null
   const kind = sec.woodKind === 'glulam' ? 'glulam' : 'sawn'
+  const opts = { method: 'LRFD' as const, lambda, wet: sec.woodWet }
   const r = checkWoodBeam({
     ref, kind, b: sec.b, d: sec.h, length: mr.L * 1000,
-    M: mr.Mmax, V: mr.Vmax, lu: lu && lu > 0 ? lu * 1000 : undefined,
-    opts: { method: 'LRFD', lambda, wet: sec.woodWet },
+    M: mr.Mmax, V: mr.Vmax, lu: lu && lu > 0 ? lu * 1000 : undefined, opts,
   })
+  const adj = woodAdjusted(ref, kind, sec.h, opts)
   return {
     id: mr.id, role, L: mr.L, species: sec.woodSpecies ?? '', kind, b: sec.b, d: sec.h,
     Mu: mr.Mmax, Vu: mr.Vmax, fb: r.fb, FbPrime: r.FbPrime, CL: r.CL,
     fv: r.fv, FvPrime: r.FvPrime, utilM: r.bendingRatio, utilV: r.shearRatio, ok: r.ok,
+    S: r.S, A: r.A, RB: r.RB, Emin: adj.Emin, FbStar: adj.FbStar,
   }
 }
 
@@ -393,15 +400,17 @@ function designWoodColumnRow(mr: F3MemberResult, sec: RectSection, lambda: numbe
   const ref = woodRefOf(sec)
   if (!ref) return null
   const kind = sec.woodKind === 'glulam' ? 'glulam' : 'sawn'
+  const opts = { method: 'LRFD' as const, lambda, wet: sec.woodWet }
   const Pu = Math.max(0, -Math.min(...mr.N))   // compression (N < 0)
   const r = checkWoodColumn({
-    ref, kind, b: sec.b, d: sec.h, length: mr.L * 1000,
-    P: Pu, Mx: mr.Mmax, opts: { method: 'LRFD', lambda, wet: sec.woodWet },
+    ref, kind, b: sec.b, d: sec.h, length: mr.L * 1000, P: Pu, Mx: mr.Mmax, opts,
   })
+  const adj = woodAdjusted(ref, kind, sec.h, opts)
   return {
     id: mr.id, L: mr.L, species: sec.woodSpecies ?? '', kind, b: sec.b, d: sec.h,
     Pu, Mu: mr.Mmax, fc: r.fc, FcPrime: r.FcPrime, CP: r.CP, slenderness: r.slenderness,
     ratio: r.ratio, ok: r.ok,
+    A: r.A, FcE: r.FcE, Emin: adj.Emin, FcStar: adj.FcStar,
   }
 }
 

--- a/webapp/src/lib/modelSpaceSolutions.ts
+++ b/webapp/src/lib/modelSpaceSolutions.ts
@@ -10,7 +10,7 @@ import { buildBeamSolution } from './beamSolution'
 import { axialColumnSolution, eccentricColumnSolution, type SeismicTieOverride } from './columnSolution'
 import { buildFoundationSolution, type SolutionCtx } from './foundationSolution'
 import { buildCombinedFootingSolution } from './combinedFootingSolution'
-import type { SolutionStep, SolutionLine } from './solution'
+import type { SolutionStep } from './solution'
 
 /** Worked solution for one beam/girder critical section. */
 export function beamSectionSolution(sec: RectSection, s: BeamSectionDesign): SolutionStep[] {
@@ -83,61 +83,97 @@ export function combinedRowSolution(secA: RectSection, secB: RectSection, soil: 
   return buildCombinedFootingSolution(input, row.design)
 }
 
-// ── Timber worked "solutions" (NDS §3 / NSCP §6) — narrate the stored LRFD
-// stresses and stability factors; shared by the on-screen schedules and the PDF. ──
+// ── Timber worked solutions (NDS §3 / NSCP §6, LRFD via Appendix N) — a full
+// step-by-step in KaTeX, narrating the stored intermediates. Shared by the
+// on-screen schedules and the direct PDF. ──
 const wf0 = (v: number) => v.toFixed(0)
 const wf1 = (v: number) => v.toFixed(1)
 const wf2 = (v: number) => v.toFixed(2)
-const wtxt = (text: string): SolutionLine => ({ text })
+const e3 = (v: number) => `${(v / 1e3).toFixed(1)}\\times10^{3}`   // mm³/mm² compact form
+const chk = (u: number) => (u <= 1 ? '\\le 1\\ \\checkmark' : '> 1\\ \\Rightarrow \\text{overstressed}')
 
 export function woodBeamRowSolution(r: WoodBeamScheduleRow): SolutionStep[] {
+  const braced = r.RB <= 1e-9
+  const FbE = braced ? Infinity : (1.2 * r.Emin) / (r.RB * r.RB)
   return [
-    { title: `Section ${wf0(r.b)}×${wf0(r.d)} mm — ${r.species || 'timber'} (${r.kind})`, clause: 'NDS 2018 §3 / NSCP §6', lines: [
-      wtxt(`b = ${wf0(r.b)} mm · d = ${wf0(r.d)} mm · L = ${wf2(r.L)} m · role ${r.role}`),
+    { title: 'Section properties & factored demands', clause: 'NDS 2018 §3 / NSCP §6', lines: [
+      { text: `${r.species || 'Timber'} (${r.kind}) — ${r.role}, span L = ${wf2(r.L)} m.` },
+      { tex: `b\\times d = ${wf0(r.b)}\\times${wf0(r.d)}\\ \\text{mm}` },
+      { tex: `S = \\dfrac{b\\,d^{2}}{6} = \\dfrac{${wf0(r.b)}\\cdot ${wf0(r.d)}^{2}}{6} = ${e3(r.S)}\\ \\text{mm}^{3}` },
+      { tex: `A = b\\,d = ${e3(r.A)}\\ \\text{mm}^{2}` },
+      { tex: `M_u = ${wf1(r.Mu)}\\ \\text{kN·m}, \\quad V_u = ${wf1(r.Vu)}\\ \\text{kN}` },
     ] },
-    { title: 'Flexure — bending with beam stability', clause: 'NDS §3.3', pass: r.utilM <= 1, lines: [
-      wtxt(`f_b = M/S = ${wf2(r.fb)} MPa · C_L = ${wf2(r.CL)} → F′b = ${wf2(r.FbPrime)} MPa`),
-      wtxt(`Mu = ${wf1(r.Mu)} kN·m → util f_b/F′b = ${wf2(r.utilM)} ${r.utilM <= 1 ? '✓' : '✗'}`),
+    { title: 'Bending stress', clause: 'NDS §3.3', lines: [
+      { tex: `f_b = \\dfrac{M_u}{S} = \\dfrac{${wf1(r.Mu)}\\times10^{6}}{${e3(r.S)}} = ${wf2(r.fb)}\\ \\text{MPa}` },
+    ] },
+    { title: 'Beam stability factor C_L', clause: 'NDS §3.3.3', lines: braced
+      ? [ { text: 'Compression edge continuously braced (le = 0) ⇒ CL = 1.00.' } ]
+      : [
+          { tex: `R_B = \\sqrt{\\dfrac{\\ell_e\\,d}{b^{2}}} = ${wf2(r.RB)} \\quad(\\le 50)` },
+          { tex: `F_{bE} = \\dfrac{1.2\\,E'_{min}}{R_B^{2}} = \\dfrac{1.2\\times ${wf0(r.Emin)}}{${wf2(r.RB)}^{2}} = ${wf1(FbE)}\\ \\text{MPa}` },
+          { tex: `C_L = ${wf2(r.CL)} \\quad\\text{from } F_{bE}/F_b^{*}` },
+        ] },
+    { title: 'Adjusted bending value & check', clause: 'NDS §3.3 · Appendix N', pass: r.utilM <= 1, lines: [
+      { tex: `F'_b = F_b^{*}\\,C_L = ${wf2(r.FbStar)}\\times ${wf2(r.CL)} = ${wf2(r.FbPrime)}\\ \\text{MPa}` },
+      { tex: `\\dfrac{f_b}{F'_b} = \\dfrac{${wf2(r.fb)}}{${wf2(r.FbPrime)}} = ${wf2(r.utilM)}\\ ${chk(r.utilM)}` },
     ] },
     { title: 'Horizontal shear', clause: 'NDS §3.4', pass: r.utilV <= 1, lines: [
-      wtxt(`f_v = 1.5V/A = ${wf2(r.fv)} MPa ≤ F′v = ${wf2(r.FvPrime)} MPa`),
-      wtxt(`Vu = ${wf1(r.Vu)} kN → util f_v/F′v = ${wf2(r.utilV)} ${r.utilV <= 1 ? '✓' : '✗'}`),
+      { tex: `f_v = \\dfrac{1.5\\,V_u}{A} = \\dfrac{1.5\\times ${wf1(r.Vu)}\\times10^{3}}{${e3(r.A)}} = ${wf2(r.fv)}\\ \\text{MPa}` },
+      { tex: `\\dfrac{f_v}{F'_v} = \\dfrac{${wf2(r.fv)}}{${wf2(r.FvPrime)}} = ${wf2(r.utilV)}\\ ${chk(r.utilV)}` },
     ] },
   ]
 }
 
 export function woodColumnRowSolution(r: WoodColumnScheduleRow): SolutionStep[] {
-  return [
-    { title: `Section ${wf0(r.b)}×${wf0(r.d)} mm — ${r.species || 'timber'} (${r.kind})`, clause: 'NDS 2018 §3 / NSCP §6', lines: [
-      wtxt(`b = ${wf0(r.b)} mm · d = ${wf0(r.d)} mm · L = ${wf2(r.L)} m`),
+  const axial = r.fc / r.FcPrime
+  const steps: SolutionStep[] = [
+    { title: 'Section properties & factored demands', clause: 'NDS 2018 §3 / NSCP §6', lines: [
+      { text: `${r.species || 'Timber'} (${r.kind}) column, length L = ${wf2(r.L)} m.` },
+      { tex: `A = b\\,d = ${wf0(r.b)}\\times${wf0(r.d)} = ${e3(r.A)}\\ \\text{mm}^{2}` },
+      { tex: `P_u = ${wf1(r.Pu)}\\ \\text{kN}, \\quad M_u = ${wf1(r.Mu)}\\ \\text{kN·m}` },
     ] },
-    { title: 'Axial compression with column stability', clause: 'NDS §3.7', pass: r.fc <= r.FcPrime, lines: [
-      wtxt(`slenderness le/d = ${wf1(r.slenderness)} → C_P = ${wf2(r.CP)} · F′c = ${wf2(r.FcPrime)} MPa`),
-      wtxt(`f_c = P/A = ${wf2(r.fc)} MPa · Pu = ${wf1(r.Pu)} kN ${r.fc <= r.FcPrime ? '✓' : '✗'}`),
+    { title: 'Axial stress', clause: 'NDS §3.6', lines: [
+      { tex: `f_c = \\dfrac{P_u}{A} = \\dfrac{${wf1(r.Pu)}\\times10^{3}}{${e3(r.A)}} = ${wf2(r.fc)}\\ \\text{MPa}` },
     ] },
-    { title: 'Combined axial + flexure', clause: 'NDS §3.9.2', pass: r.ok, lines: [
-      wtxt(`Mu = ${wf1(r.Mu)} kN·m → governing ratio = ${wf2(r.ratio)} ≤ 1.00 ${r.ok ? '✓' : '✗'}`),
+    { title: 'Column stability factor C_P', clause: 'NDS §3.7.1', lines: [
+      { tex: `\\dfrac{\\ell_e}{d} = ${wf1(r.slenderness)} \\quad(\\le 50)` },
+      { tex: `F_{cE} = \\dfrac{0.822\\,E'_{min}}{(\\ell_e/d)^{2}} = \\dfrac{0.822\\times ${wf0(r.Emin)}}{${wf1(r.slenderness)}^{2}} = ${wf1(r.FcE)}\\ \\text{MPa}` },
+      { tex: `C_P = ${wf2(r.CP)} \\quad\\text{from } F_{cE}/F_c^{*}` },
+      { tex: `F'_c = F_c^{*}\\,C_P = ${wf2(r.FcStar)}\\times ${wf2(r.CP)} = ${wf2(r.FcPrime)}\\ \\text{MPa}` },
     ] },
   ]
+  if (r.Mu > 1e-6) {
+    steps.push({ title: 'Combined axial + flexure (beam-column)', clause: 'NDS §3.9.2', pass: r.ok, lines: [
+      { tex: `\\left(\\dfrac{f_c}{F'_c}\\right)^{2} + \\dfrac{f_b}{F'_b\\left(1-f_c/F_{cE}\\right)} = ${wf2(r.ratio)}\\ ${chk(r.ratio)}` },
+      { text: `Axial term f_c/F′c = ${wf2(axial)}; the §3.9.2 interaction governs at ${wf2(r.ratio)}.` },
+    ] })
+  } else {
+    steps.push({ title: 'Axial check', clause: 'NDS §3.7', pass: r.ok, lines: [
+      { tex: `\\dfrac{f_c}{F'_c} = \\dfrac{${wf2(r.fc)}}{${wf2(r.FcPrime)}} = ${wf2(r.ratio)}\\ ${chk(r.ratio)}` },
+    ] })
+  }
+  return steps
 }
 
 export function woodSlabRowSolution(r: WoodSlabScheduleRow): SolutionStep[] {
   const d = r.design, tk = d.takeoff
-  const chk = (label: string, c: typeof d.joist): SolutionStep => ({
-    title: label, clause: 'NDS §3.3–§3.4 / NSCP §6', pass: c.ok, lines: [
-      wtxt(`${wf0(c.b)}×${wf0(c.d)} mm · span ${wf2(c.span)} m · w = ${wf2(c.w)} kN/m → M = ${wf2(c.M)} kN·m, V = ${wf2(c.V)} kN`),
-      wtxt(`bending f_b/F′b = ${wf2(c.fb)}/${wf2(c.FbPrime)} (util ${wf2(c.bendingRatio)}) · shear f_v/F′v = ${wf2(c.fv)}/${wf2(c.FvPrime)} (util ${wf2(c.shearRatio)})`),
-      wtxt(`Δ live ${wf2(c.deflLive)}/${wf2(c.deflLiveAllow)} mm · Δ total ${wf2(c.deflTotal)}/${wf2(c.deflTotalAllow)} mm ${c.ok ? '✓' : '✗'}`),
+  const member = (label: string, clause: string, c: typeof d.joist): SolutionStep => ({
+    title: label, clause, pass: c.ok, lines: [
+      { tex: `${wf0(c.b)}\\times${wf0(c.d)}\\ \\text{mm}, \\quad \\text{span } L = ${wf2(c.span)}\\ \\text{m}, \\quad w = ${wf2(c.w)}\\ \\text{kN/m}` },
+      { tex: `M = ${wf2(c.M)}\\ \\text{kN·m}, \\quad V = ${wf2(c.V)}\\ \\text{kN}` },
+      { tex: `\\dfrac{f_b}{F'_b} = \\dfrac{${wf2(c.fb)}}{${wf2(c.FbPrime)}} = ${wf2(c.bendingRatio)}\\ ${chk(c.bendingRatio)}` },
+      { tex: `\\dfrac{f_v}{F'_v} = \\dfrac{${wf2(c.fv)}}{${wf2(c.FvPrime)}} = ${wf2(c.shearRatio)}\\ ${chk(c.shearRatio)}` },
+      { tex: `\\Delta_{L} = ${wf2(c.deflLive)}\\ \\text{mm} \\le \\dfrac{L}{360} = ${wf2(c.deflLiveAllow)}\\ \\text{mm}, \\quad \\Delta_{T} = ${wf2(c.deflTotal)} \\le \\dfrac{L}{240} = ${wf2(c.deflTotalAllow)}` },
     ],
   })
   return [
-    { title: 'Loads', clause: 'NSCP §203', lines: [
-      wtxt(`superimposed dead ${wf2(d.loads.deadKpa)} kPa · live ${wf2(d.loads.liveKpa)} kPa · deck self ${wf2(d.loads.deckSelfKpa)} · joist self ${wf2(d.loads.joistSelfKpa)} → total ${wf2(d.loads.totalKpa)} kPa`),
+    { title: 'Floor loads', clause: 'NSCP §203', lines: [
+      { tex: `w_{tot} = ${wf2(d.loads.deadKpa)}_{SDL} + ${wf2(d.loads.deckSelfKpa)}_{deck} + ${wf2(d.loads.joistSelfKpa)}_{joist} + ${wf2(d.loads.liveKpa)}_{L} = ${wf2(d.loads.totalKpa)}\\ \\text{kPa}` },
     ] },
-    chk('Decking', d.deck),
-    chk('Joist', d.joist),
-    { title: 'Take-off (board feet)', clause: 'BOM', lines: [
-      wtxt(`${wf0(tk.joistCount)} joists · ${wf2(tk.joistLengthM)} m · ${wf0(tk.joistBoardFeet)} bd·ft · deck ${wf2(tk.deckAreaM2)} m² · ${wf0(tk.deckBoardFeet)} bd·ft${tk.bambooSlatCount != null ? ` · ${wf0(tk.bambooSlatCount)} bamboo slats` : ''}`),
+    member('Decking — spans the joist spacing', 'NDS §3.3–§3.4', d.deck),
+    member('Joist — spans the panel', 'NDS §3.3–§3.4', d.joist),
+    { title: 'Take-off (bill of materials)', clause: 'BOM', lines: [
+      { text: `${wf0(tk.joistCount)} joists · ${wf2(tk.joistLengthM)} m total · ${wf0(tk.joistBoardFeet)} bd·ft; deck ${wf2(tk.deckAreaM2)} m² · ${wf0(tk.deckBoardFeet)} bd·ft${tk.bambooSlatCount != null ? ` · ${wf0(tk.bambooSlatCount)} bamboo slats` : ''}.` },
     ] },
   ]
 }

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -4283,19 +4283,30 @@ export default function ModelSpace() {
                   </tr>
                 </thead>
                 <tbody>
-                  {design.woodBeams.map((b) => (
-                    <tr key={b.id} className={`sched-row border-t border-slate-100 ${b.ok ? '' : 'bg-red-50 text-red-700'}`}>
-                      <td className="py-1 pr-2 font-medium">{b.id}</td>
-                      <td className="py-1 pr-2 font-mono">{b.b}×{b.d}</td>
-                      <td className="py-1 pr-2" title={WOOD_SPECIES[b.species]?.label ?? b.species}>{b.species}{b.kind === 'glulam' ? ' (GL)' : ''}</td>
-                      <td className="py-1 pr-2 text-right">{f1(b.Mu)}</td>
-                      <td className="py-1 pr-2 text-right">{b.FbPrime.toFixed(2)}</td>
-                      <td className="py-1 pr-2 text-right">{b.CL.toFixed(2)}</td>
-                      <td className={`py-1 pr-2 text-right font-semibold ${b.utilM > 1 ? 'text-red-600' : b.utilM > 0.9 ? 'text-amber-600' : 'text-green-700'}`}>{(b.utilM * 100).toFixed(0)}%</td>
-                      <td className={`py-1 pr-2 text-right font-semibold ${b.utilV > 1 ? 'text-red-600' : b.utilV > 0.9 ? 'text-amber-600' : 'text-green-700'}`}>{(b.utilV * 100).toFixed(0)}%</td>
-                      <td className="py-1 text-[11px] text-slate-500">{b.gov}</td>
-                    </tr>
-                  ))}
+                  {design.woodBeams.flatMap((b) => {
+                    const key = `wbeam:${b.id}`, open = expanded === key || reportOpen
+                    return [
+                      <tr key={key} onClick={() => setExpanded(expanded === key ? null : key)}
+                        className={`sched-row cursor-pointer border-t border-slate-100 hover:bg-blue-50/40 ${b.ok ? '' : 'bg-red-50 text-red-700'}`}>
+                        <td className="py-1 pr-2 font-medium">{open ? '▾' : '▸'} {b.id}</td>
+                        <td className="py-1 pr-2 font-mono">{b.b}×{b.d}</td>
+                        <td className="py-1 pr-2" title={WOOD_SPECIES[b.species]?.label ?? b.species}>{b.species}{b.kind === 'glulam' ? ' (GL)' : ''}</td>
+                        <td className="py-1 pr-2 text-right">{f1(b.Mu)}</td>
+                        <td className="py-1 pr-2 text-right">{b.FbPrime.toFixed(2)}</td>
+                        <td className="py-1 pr-2 text-right">{b.CL.toFixed(2)}</td>
+                        <td className={`py-1 pr-2 text-right font-semibold ${b.utilM > 1 ? 'text-red-600' : b.utilM > 0.9 ? 'text-amber-600' : 'text-green-700'}`}>{(b.utilM * 100).toFixed(0)}%</td>
+                        <td className={`py-1 pr-2 text-right font-semibold ${b.utilV > 1 ? 'text-red-600' : b.utilV > 0.9 ? 'text-amber-600' : 'text-green-700'}`}>{(b.utilV * 100).toFixed(0)}%</td>
+                        <td className="py-1 text-[11px] text-slate-500">{b.gov}</td>
+                      </tr>,
+                      open && wantSol && (
+                        <tr key={`${key}:sol`}>
+                          <td colSpan={9} className="bg-slate-50/60 px-2 pb-2">
+                            <WorkedSolution steps={woodBeamRowSolution(b)} title={`${b.id} — worked solution`} />
+                          </td>
+                        </tr>
+                      ),
+                    ]
+                  })}
                 </tbody>
               </table>
               <p className="mt-1 text-[11px] text-slate-500">
@@ -4324,20 +4335,31 @@ export default function ModelSpace() {
                   </tr>
                 </thead>
                 <tbody>
-                  {design.woodColumns.map((c) => (
-                    <tr key={c.id} className={`sched-row border-t border-slate-100 ${c.ok ? '' : 'bg-red-50 text-red-700'}`}>
-                      <td className="py-1 pr-2 font-medium">{c.id}</td>
-                      <td className="py-1 pr-2 font-mono">{c.b}×{c.d}</td>
-                      <td className="py-1 pr-2" title={WOOD_SPECIES[c.species]?.label ?? c.species}>{c.species}{c.kind === 'glulam' ? ' (GL)' : ''}</td>
-                      <td className="py-1 pr-2 text-right">{f1(c.Pu)}</td>
-                      <td className="py-1 pr-2 text-right">{f1(c.Mu)}</td>
-                      <td className="py-1 pr-2 text-right">{c.FcPrime.toFixed(2)}</td>
-                      <td className="py-1 pr-2 text-right">{c.CP.toFixed(2)}</td>
-                      <td className="py-1 pr-2 text-right">{c.slenderness.toFixed(0)}</td>
-                      <td className={`py-1 pr-2 text-right font-semibold ${c.ratio > 1 ? 'text-red-600' : c.ratio > 0.9 ? 'text-amber-600' : 'text-green-700'}`}>{(c.ratio * 100).toFixed(0)}%</td>
-                      <td className="py-1 text-[11px] text-slate-500">{c.gov}</td>
-                    </tr>
-                  ))}
+                  {design.woodColumns.flatMap((c) => {
+                    const key = `wcol:${c.id}`, open = expanded === key || reportOpen
+                    return [
+                      <tr key={key} onClick={() => setExpanded(expanded === key ? null : key)}
+                        className={`sched-row cursor-pointer border-t border-slate-100 hover:bg-blue-50/40 ${c.ok ? '' : 'bg-red-50 text-red-700'}`}>
+                        <td className="py-1 pr-2 font-medium">{open ? '▾' : '▸'} {c.id}</td>
+                        <td className="py-1 pr-2 font-mono">{c.b}×{c.d}</td>
+                        <td className="py-1 pr-2" title={WOOD_SPECIES[c.species]?.label ?? c.species}>{c.species}{c.kind === 'glulam' ? ' (GL)' : ''}</td>
+                        <td className="py-1 pr-2 text-right">{f1(c.Pu)}</td>
+                        <td className="py-1 pr-2 text-right">{f1(c.Mu)}</td>
+                        <td className="py-1 pr-2 text-right">{c.FcPrime.toFixed(2)}</td>
+                        <td className="py-1 pr-2 text-right">{c.CP.toFixed(2)}</td>
+                        <td className="py-1 pr-2 text-right">{c.slenderness.toFixed(0)}</td>
+                        <td className={`py-1 pr-2 text-right font-semibold ${c.ratio > 1 ? 'text-red-600' : c.ratio > 0.9 ? 'text-amber-600' : 'text-green-700'}`}>{(c.ratio * 100).toFixed(0)}%</td>
+                        <td className="py-1 text-[11px] text-slate-500">{c.gov}</td>
+                      </tr>,
+                      open && wantSol && (
+                        <tr key={`${key}:sol`}>
+                          <td colSpan={10} className="bg-slate-50/60 px-2 pb-2">
+                            <WorkedSolution steps={woodColumnRowSolution(c)} title={`${c.id} — worked solution`} />
+                          </td>
+                        </tr>
+                      ),
+                    ]
+                  })}
                 </tbody>
               </table>
               <p className="mt-1 text-[11px] text-slate-500">
@@ -4632,98 +4654,6 @@ export default function ModelSpace() {
                 t = ℓ√(2fp/(0.9Fy)); ℓ = max(m, n, n′). Uplift sizes anchor rods (φt·0.75·Fu).
                 Adopted t rounded to plate stock.
               </p>
-            </div>
-          )}
-
-          {/* Timber beam & girder schedule — NDS §3 / NSCP §6 */}
-          {design.woodBeams.length > 0 && (
-            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Timber beam &amp; girder schedule — NDS §3 / NSCP §6<SchedChip items={design.woodBeams} ok={(b) => b.ok} /></h3>
-              <table className="w-full border-collapse text-xs">
-                <thead>
-                  <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
-                    <th className="py-1 pr-2 font-semibold">Member</th>
-                    <th className="py-1 pr-2 font-semibold">Section</th>
-                    <th className="py-1 pr-2 font-semibold">Species</th>
-                    <th className="py-1 pr-2 text-right font-semibold">Mu (kN·m)</th>
-                    <th className="py-1 pr-2 text-right font-semibold">Vu (kN)</th>
-                    <th className="py-1 pr-2 text-right font-semibold">Util</th>
-                    <th className="py-1 font-semibold">Status</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {design.woodBeams.flatMap((b) => {
-                    const key = `wbeam:${b.id}`, open = expanded === key || reportOpen
-                    return [
-                      <tr key={key} onClick={() => setExpanded(expanded === key ? null : key)}
-                        className={`sched-row cursor-pointer border-t border-slate-100 hover:bg-blue-50/40 ${b.ok ? '' : 'bg-red-50 text-red-700'}`}>
-                        <td className="py-1 pr-2 font-medium">{open ? '▾' : '▸'} {b.id}</td>
-                        <td className="py-1 pr-2">{f0(b.b)}×{f0(b.d)}</td>
-                        <td className="py-1 pr-2">{b.species || '—'} ({b.kind})</td>
-                        <td className="py-1 pr-2 text-right">{f1(b.Mu)}</td>
-                        <td className="py-1 pr-2 text-right">{f1(b.Vu)}</td>
-                        <td className="py-1 pr-2 text-right">{(Math.max(b.utilM, b.utilV) * 100).toFixed(0)}%</td>
-                        <td className="py-1 text-slate-500">{b.ok ? '✓ OK' : '✗ check'}</td>
-                      </tr>,
-                      open && wantSol && (
-                        <tr key={`${key}:sol`}>
-                          <td colSpan={7} className="bg-slate-50/60 px-2 pb-2">
-                            <WorkedSolution steps={woodBeamRowSolution(b)} title={`${b.id} — worked solution`} />
-                          </td>
-                        </tr>
-                      ),
-                    ]
-                  })}
-                </tbody>
-              </table>
-              <p className="mt-1 text-[11px] text-slate-500">§3.3 bending with beam-stability C_L, §3.4 horizontal shear; factored demand vs LRFD-adjusted F′ (Appendix N K_F·φ·λ). Click a row for the worked solution.</p>
-            </div>
-          )}
-
-          {/* Timber column schedule — NDS §3.7 / §3.9 */}
-          {design.woodColumns.length > 0 && (
-            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-              <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Timber column schedule — NDS §3.7 / §3.9<SchedChip items={design.woodColumns} ok={(c) => c.ok} /></h3>
-              <table className="w-full border-collapse text-xs">
-                <thead>
-                  <tr className="sched-head text-left uppercase tracking-wide text-slate-500">
-                    <th className="py-1 pr-2 font-semibold">Column</th>
-                    <th className="py-1 pr-2 font-semibold">Section</th>
-                    <th className="py-1 pr-2 font-semibold">Species</th>
-                    <th className="py-1 pr-2 text-right font-semibold">Pu (kN)</th>
-                    <th className="py-1 pr-2 text-right font-semibold">Mu (kN·m)</th>
-                    <th className="py-1 pr-2 text-right font-semibold">C_P</th>
-                    <th className="py-1 pr-2 text-right font-semibold">Ratio</th>
-                    <th className="py-1 font-semibold">Status</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {design.woodColumns.flatMap((c) => {
-                    const key = `wcol:${c.id}`, open = expanded === key || reportOpen
-                    return [
-                      <tr key={key} onClick={() => setExpanded(expanded === key ? null : key)}
-                        className={`sched-row cursor-pointer border-t border-slate-100 hover:bg-blue-50/40 ${c.ok ? '' : 'bg-red-50 text-red-700'}`}>
-                        <td className="py-1 pr-2 font-medium">{open ? '▾' : '▸'} {c.id}</td>
-                        <td className="py-1 pr-2">{f0(c.b)}×{f0(c.d)}</td>
-                        <td className="py-1 pr-2">{c.species || '—'} ({c.kind})</td>
-                        <td className="py-1 pr-2 text-right">{f1(c.Pu)}</td>
-                        <td className="py-1 pr-2 text-right">{f1(c.Mu)}</td>
-                        <td className="py-1 pr-2 text-right">{f2(c.CP)}</td>
-                        <td className="py-1 pr-2 text-right">{(c.ratio * 100).toFixed(0)}%</td>
-                        <td className="py-1 text-slate-500">{c.ok ? '✓ OK' : '✗ check'}</td>
-                      </tr>,
-                      open && wantSol && (
-                        <tr key={`${key}:sol`}>
-                          <td colSpan={8} className="bg-slate-50/60 px-2 pb-2">
-                            <WorkedSolution steps={woodColumnRowSolution(c)} title={`${c.id} — worked solution`} />
-                          </td>
-                        </tr>
-                      ),
-                    ]
-                  })}
-                </tbody>
-              </table>
-              <p className="mt-1 text-[11px] text-slate-500">§3.7 axial with column-stability C_P; §3.9.2 combined axial + flexure interaction. Ratio ≤ 100% passes. Click a row for the worked solution.</p>
             </div>
           )}
 


### PR DESCRIPTION
## What

Fixes the duplicate schedules and the thin worked solutions you flagged.

### Two schedules for each → one, expandable
The Design tab already had detailed **Timber beam / girder** and **Timber column** schedules (with F′b, C_L, le/d, C_P, ratio). Last round I added plainer duplicates. This removes the duplicates and instead makes the **original tables' rows expand into a worked solution** on click. The **Timber deck-slab** schedule stays (it had no duplicate) and is likewise expandable.

### Worked solutions → detailed, multi-step KaTeX
The wood solutions were one-line plain text. Rewritten as proper **KaTeX** steps, mirroring the RC/steel format:
- **Beam** — section properties `S = bd²/6`, `A = bd`; `f_b = M_u/S`; the beam-stability derivation `R_B = √(ℓ_e d / b²)`, `F_bE = 1.2 E′min / R_B²`, `C_L`; adjusted `F′_b = F_b*·C_L` and the `f_b/F′_b` check; horizontal shear `f_v = 1.5V_u/A` and the `f_v/F′_v` check.
- **Column** — `f_c = P_u/A`; the column-stability derivation `ℓ_e/d`, `F_cE = 0.822 E′min/(ℓ_e/d)²`, `C_P`, `F′_c`; the §3.9.2 beam-column interaction `(f_c/F′_c)² + f_b/[F′_b(1 − f_c/F_cE)]`.
- **Deck slab** — floor-load build-up, then the decking and joist checks (bending, shear, live/total deflection) and the board-feet take-off.

Each step carries a PASS/FAIL chip. To narrate real numbers (not re-derivations), the extra intermediates (`S, A, R_B, E′min, F_b*, F_cE, F_c*`) are threaded onto the wood schedule rows in the pipeline.

## Verification

- `tsc -b` clean, full suite **1383 passing** — including the report test's **tex-cleanliness** check (every KaTeX line converts to plain text for the PDF with no residual LaTeX), and build OK.

## Still open (next PR)
Your third point — *can the design/optimize engine fix the timber fails?* — is a separate change (teach the optimizer to upsize failing timber members and deck joists). I'll do that next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_