### PR TITLE
feat: optimizer fixes failing timber members and deck joists

### DIFF
--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -375,6 +375,33 @@ describe('optimizeStructure', () => {
     expect(col.h).toBeLessThanOrEqual(500)
     expect(designOK(r.design)).toBe(true)
   })
+
+  it('wood frame with failing timber members and deck → optimizer grows both to pass', () => {
+    const woodSec: RectSection = {
+      id: 'W', name: '150×200', b: 150, h: 200, material: 'wood', woodSpecies: 'DFL-2', woodKind: 'sawn',
+      fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40,
+    }
+    const m = generateGridModel({ baysX: [5], baysZ: [4], storeyH: [3], section: woodSec, slabThickness: 150 })
+    m.loads = m.plates.flatMap((p) => [
+      { kind: 'area' as const, plate: p.id, q: 2.0, cat: 'D' as const },
+      { kind: 'area' as const, plate: p.id, q: 1.9, cat: 'L' as const },
+    ])
+    // undersized timber decks on every floor panel
+    m.plates = m.plates.map((p) => p.role === 'wall' ? p : { ...p, deck: {
+      joistSpecies: 'DFL-2', joistKind: 'sawn' as const, joistB: 50, joistD: 150, joistSpacing: 400,
+      deckMaterial: 'plank' as const, deckThickness: 20,
+    } })
+    const first = designStructure(m, soil)!
+    expect(designOK(first)).toBe(false)
+    expect(first.woodSlabs.length).toBeGreaterThan(0)
+    const r = optimizeStructure(m, soil)!
+    expect(r.converged).toBe(true)
+    expect(designOK(r.design)).toBe(true)
+    // the timber members grew, and the deck joists grew past their undersized start
+    expect(r.model.sections.some((s) => s.material === 'wood' && (s.h > 200 || s.b > 150))).toBe(true)
+    const grownDeck = r.model.plates.find((p) => p.deck)?.deck
+    expect(grownDeck && grownDeck.joistD).toBeGreaterThan(150)
+  })
 })
 
 describe('RC serviceability — NSCP Table 409.3.1.1 minimum thickness gate', () => {

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -7,7 +7,7 @@
 //   factored reactions → isolated footing) → concrete totals.
 // Every stage reuses the existing engines unchanged.
 // ─────────────────────────────────────────────────────────────────────────
-import type { StructuralModel, RectSection, ModelLoad, Member } from './model'
+import type { StructuralModel, RectSection, ModelLoad, Member, WoodDeck } from './model'
 import { enforceSectionHierarchy, refreshSelfWeight, barContinuityGroups } from './modelBuilder'
 import { modelToFrame3D } from './modelBridge'
 import { precomputeFrame, solveWithGeometry, applyF3Combo, serializePrecomp, type F3Result, type F3MemberResult, type F3Load } from './frame3d'
@@ -1163,7 +1163,7 @@ export async function optimizeStructureAsync(
         const u = act.utils.get(s.id)
         return [s.id, u !== undefined ? jumpSection(s, u, secRole.get(s.id) ?? '') : s]
       }))
-      const grown = settle(withWallThickness(withPlateThickness(withSizes(work, sizes), act.plates, soil.gammaConc), act.walls))
+      const grown = settle(withDecks(withWallThickness(withPlateThickness(withSizes(work, sizes), act.plates, soil.gammaConc), act.walls), act.decks))
       if (!sectionsChanged(work, grown)) {     // nothing can grow (catalog top / unsupported shape)
         stopReason = stopReasonFor(design, 'no failing section can grow any further (top of the W catalog, an unsupported shape family, or the cast-in-place size limit)')
         break
@@ -1464,6 +1464,10 @@ const sectionsChanged = (a: StructuralModel, b: StructuralModel): boolean =>
     return s.b !== t.b || s.h !== t.h || s.shape !== t.shape
   })
   || a.plates.some((p, i) => p.thickness !== b.plates[i]?.thickness)
+  || a.plates.some((p, i) => {
+    const q = b.plates[i]?.deck
+    return p.deck?.joistD !== q?.joistD || p.deck?.joistSpacing !== q?.joistSpacing || p.deck?.deckThickness !== q?.deckThickness
+  })
   || (a.walls ?? []).some((w, i) => w.thickness !== (b.walls ?? [])[i]?.thickness)
 
 /** Re-thickness plates and shift each panel's area-D load by Δt·γc — the slab
@@ -1491,7 +1495,7 @@ const withWallThickness = (model: StructuralModel, t: Map<string, number>): Stru
 /** Everything the grow phase can change in one iteration: member-section
  *  demand/capacity ratios (incl. SCWB column bumps), slab thickness targets
  *  and shear-wall thickness targets. n = number of distinct actions. */
-interface GrowActions { utils: Map<string, number>; plates: Map<string, number>; walls: Map<string, number>; n: number }
+interface GrowActions { utils: Map<string, number>; plates: Map<string, number>; walls: Map<string, number>; decks: Map<string, WoodDeck>; n: number }
 
 function buildGrowActions(design: StructureDesign, model: StructuralModel, memSecId: Map<string, string>): GrowActions {
   const utils = buildUtilMap(design, memSecId)
@@ -1524,7 +1528,33 @@ function buildGrowActions(design: StructureDesign, model: StructuralModel, memSe
   // Shear walls: in-plane shear failure → thicken the panel one step per iteration.
   const walls = new Map<string, number>()
   for (const w of design.walls) if (!w.ok) walls.set(w.id, w.thickness + 25)
-  return { utils, plates, walls, n: utils.size + plates.size + walls.size }
+  // Timber deck slabs: grow the joist depth (bending ∝ d², deflection ∝ d³); if the
+  // joist is capped and still short, tighten spacing; thicken the deck board if it
+  // governs. 50-mm joist / 5-mm board steps, capped like the section jump.
+  const decks = new Map<string, WoodDeck>()
+  const plateById = new Map(model.plates.map((p) => [p.id, p]))
+  for (const s of design.woodSlabs) {
+    if (s.ok) continue
+    const deck = plateById.get(s.plate)?.deck
+    if (!deck) continue
+    const nd: WoodDeck = { ...deck }
+    const jUtil = s.design.joist.ratio, dUtil = s.design.deck.ratio
+    if (jUtil > 1) {
+      const steps = Math.max(1, Math.min(8, Math.ceil((Math.sqrt(jUtil) - 1) * deck.joistD / 50)))
+      nd.joistD = Math.min(600, deck.joistD + 50 * steps)
+      if (nd.joistD >= 600 && jUtil > 1.5) nd.joistSpacing = Math.max(200, deck.joistSpacing - 50)
+    }
+    if (dUtil > 1) nd.deckThickness = Math.min(75, deck.deckThickness + 5)
+    if (nd.joistD !== deck.joistD || nd.joistSpacing !== deck.joistSpacing || nd.deckThickness !== deck.deckThickness)
+      decks.set(s.plate, nd)
+  }
+  return { utils, plates, walls, decks, n: utils.size + plates.size + walls.size + decks.size }
+}
+
+/** Apply grown timber decks back onto their plates (optimizer). */
+function withDecks(model: StructuralModel, decks: Map<string, WoodDeck>): StructuralModel {
+  if (decks.size === 0) return model
+  return { ...model, plates: model.plates.map((p) => (decks.has(p.id) ? { ...p, deck: decks.get(p.id) } : p)) }
 }
 
 /** Copy shape geometry into the section's bounding-box fields so metadata stays consistent. */
@@ -1553,6 +1583,8 @@ function buildUtilMap(
   for (const c of design.columns)      if (!c.ok) bump(memSecId.get(c.id), Math.max(2, c.util))
   for (const b of design.steelBeams)   if (!b.ok) bump(memSecId.get(b.id), Math.max(2, b.utilM, b.utilV, b.deflLim > 0 ? b.defl / b.deflLim : 2))
   for (const c of design.steelColumns) if (!c.ok) bump(memSecId.get(c.id), Math.max(2, c.ratio))
+  for (const b of design.woodBeams)    if (!b.ok) bump(memSecId.get(b.id), Math.max(2, b.utilM, b.utilV))
+  for (const c of design.woodColumns)  if (!c.ok) bump(memSecId.get(c.id), Math.max(2, c.ratio))
   return out
 }
 
@@ -1572,6 +1604,8 @@ function sectionUtilMap(design: StructureDesign, memSecId: Map<string, string>):
   for (const c of design.columns)      bump(memSecId.get(c.id), c.util)
   for (const b of design.steelBeams)   bump(memSecId.get(b.id), Math.max(b.utilM, b.utilV, b.deflLim > 0 ? b.defl / b.deflLim : 0))
   for (const c of design.steelColumns) bump(memSecId.get(c.id), c.ratio)
+  for (const b of design.woodBeams)    bump(memSecId.get(b.id), Math.max(b.utilM, b.utilV))
+  for (const c of design.woodColumns)  bump(memSecId.get(c.id), c.ratio)
   return out
 }
 
@@ -1681,7 +1715,7 @@ export function optimizeStructure(
       const u = act.utils.get(s.id)
       return [s.id, u !== undefined ? jumpSection(s, u, secRole.get(s.id) ?? '') : s]
     }))
-    const grown = settle(withWallThickness(withPlateThickness(withSizes(work, sizes), act.plates, soil.gammaConc), act.walls))
+    const grown = settle(withDecks(withWallThickness(withPlateThickness(withSizes(work, sizes), act.plates, soil.gammaConc), act.walls), act.decks))
     if (!sectionsChanged(work, grown)) {       // nothing can grow (catalog top / unsupported shape)
       stopReason = stopReasonFor(design, 'no failing section can grow any further (top of the W catalog, an unsupported shape family, or the cast-in-place size limit)')
       break


### PR DESCRIPTION
## What

Answers your third question — **yes, the optimizer now fixes the timber fails.** It previously ignored timber entirely: its utilisation maps only scored RC and steel members, so failing wood beams/columns and the timber deck slabs (the 159% columns and 580% joists you saw) were never grown.

- **Timber members** — add wood beams/columns to both the grow driver (`buildUtilMap`) and the trim guard (`sectionUtilMap`). `jumpSection` already grows a solid `b×d` section, so timber members now upsize until they pass and trim back when slack (same as RC).
- **Timber deck slabs** — a new grow action. `buildGrowActions` upsizes the **joist depth** (bending ∝ d², deflection ∝ d³, stepped by how far over it is), **tightens the spacing** when the joist caps at 600 mm, and **thickens the deck board** when it governs. `withDecks` writes the grown decks back, and `sectionsChanged` now detects deck changes so the loop doesn't stall on a deck-only fix.

## Layer

L6 optimizer (`pipeline.ts`). No solver/engine-formula changes.

## Verification

- New test: a wood frame with undersized members **and** an undersized deck fails `designOK`, then `optimizeStructure` **converges** — asserting both the timber members and the deck joists grew.
- `tsc -b` clean, full suite **1384 passing**, build OK.

So now: build a wood frame → the decks default in → hit **Optimize**, and the failing columns and deck joists grow until everything passes (rather than staying red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_