### PR TITLE
fix: scale the column stub in the footing section drawing

### DIFF
--- a/webapp/src/components/FootingSchematic.tsx
+++ b/webapp/src/components/FootingSchematic.tsx
@@ -50,7 +50,9 @@ export function FootingSchematic({ Bx, By, Dc, columnWidth, H }: SchematicProps)
   const slabH = Math.max(8, (Dc / 1000) * sV)
   const slabY = gl + (Hpx - slabH)
   const baseY = gl + Hpx
-  const stubW = 28
+  // column stub scaled to the section's horizontal scale (sW px ≙ Bx m), so it
+  // matches the plan's column-to-footing proportion instead of a fixed width.
+  const stubW = Math.max(6, cm * (sW / Bx))
   const soilTicks: JSX.Element[] = []
   for (let x = slabX; x < slabX + sW; x += 12) {
     soilTicks.push(<line key={`s${x}`} x1={x} y1={gl} x2={x - 6} y2={gl + 6} stroke="#caa472" strokeWidth={0.8} />)


### PR DESCRIPTION
## What

Fixes the footing drawing where the **column width in the SECTION wasn't to scale**. The PLAN drew the column scaled to the footing (`cpx = columnWidth·s`), but the SECTION used a hard-coded **28 px** stub regardless of footing size — so the column read too thin and didn't match the plan.

Now the section stub is scaled to the section's horizontal scale (`sW` px ≙ `Bx` m):

```
stubW = max(6, (columnWidth/1000) · sW / Bx)
```

so the plan and section show the same column-to-footing proportion (e.g. a 0.4 m column in a 1.0 m footing draws at 40% of the footing width in both views).

## Layer

Presentation only (`FootingSchematic.tsx`, the shared on-screen footing drawing used by Foundation Design and the Model Space schedules). No engine changes.

## Verification

- `tsc -b` clean, full suite **1384 passing**, build OK.
- Proportion check: Bx = 1.0 m, column = 0.4 m → plan column 46/116 px = 0.40, section stub 108/270 px = 0.40 (was 28/270 = 0.10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_