### PR TITLE
docs: scheduling module complete (Phases 1–10)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -10,6 +10,25 @@ react-three-fiber) of structural-design tools and material take-off estimators
 to **NSCP 2015 / ACI 318-14**. Every tool computes live and prints a PDF report.
 App code lives in **`webapp/`**.
 
+## Project Scheduling module (Phases 1–10 — COMPLETE)
+A Primavera/MS-Project-style **PERT/CPM & progress-tracking** module, built
+**client-side** (pure engines + localStorage, no backend) — see
+[`docs/scheduling.md`](docs/scheduling.md) for the full architecture. Routes:
+`/schedule` (WBS + activity grid), `/schedule/gantt`, `/schedule/network` (AON),
+`/schedule/dashboard` (progress + EVM), `/schedule/resources`, `/schedule/reports`
+(PDF/Excel/CSV), `/schedule/daily` (actuals + delay analysis) — all sharing one
+store-backed `ScheduleProject`.
+- **Engines** (pure, tested): `webapp/src/engine/schedule/` — `model`, `calendar`,
+  `cpm` (FS/FF/SS/SF + lead/lag, floats, critical path, cycle detection), `pert`,
+  `earnedValue` (+ `projectEvm`), `progress`, `validate`, `baseline`, `sample`.
+- **View/support** (pure, tested): `webapp/src/lib/` — `gantt`, `network`,
+  `resourceLoad`, `progressCurve`, `scheduleDates`, `scheduleReport`(+`Csv`/`Pdf`/
+  `Excel`), `delayAnalysis`; hooks `useScheduleProject`/`useScheduleSolve`.
+- Merged in PRs #387/#389/#390/#392/#397/#398/#399/#400/#401/#410; each passed a
+  two-subagent code+peer review gate. Deferred items (delay classification,
+  delay-report export, photos, resource levelling, per-activity calendars/
+  constraints) are listed in `docs/scheduling.md`.
+
 ## Continue from your phone / cloud (PC off)
 The local terminal session needs your PC on. To keep working without it:
 1. Open **claude.ai/code** (mobile browser) or the **Claude app**, same account.

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -187,13 +187,20 @@ columns (dates + total float + critical tag) and an expandable ES/EF/LS/LF/float
   lazy-loaded. Each exporter splits a node-testable `build*` from the browser
   download wrapper, so PDF/Excel generation is unit-tested (real bytes). The
   project cost-EVM roll-up is shared with the dashboard via `earnedValue.projectEvm`.
-- **Phase 10 — daily-report integration & delay analysis** *(this PR)*:
+- **Phase 10 — daily-report integration & delay analysis** ✅:
   `/schedule/daily` — capture/restore baselines, a per-activity daily-progress
   log (% complete, actual start/finish, remarks) that updates the schedule's
   actuals and recomputes live, and **delay analysis** (pure tested
   `lib/delayAnalysis.ts`): per-activity finish slip vs the baseline, **critical
   delays** flagged when a slipped activity is on the critical path, and a
-  project-slip summary.
+  project-slip summary (current − baseline project finish).
+
+**The 10-phase module is complete** — routes `/schedule`, `/schedule/gantt`,
+`/schedule/network`, `/schedule/dashboard`, `/schedule/resources`,
+`/schedule/reports`, `/schedule/daily`, all sharing one store-backed
+`ScheduleProject`. Merged in PRs #387, #389, #390, #392, #397, #398, #399, #400,
+#401, #410. Each phase passed a two-subagent (code + peer) review gate before
+merge.
 
 ## Known limitations / future extensions
 


### PR DESCRIPTION
Marks the PERT/CPM scheduling module complete: `docs/scheduling.md` Phase 10 → ✅ with a module-complete summary, and a new **Project Scheduling module (Phases 1–10)** section in `HANDOFF.md` (routes, pure engines, merged PRs #387…#410, deferred follow-ups).

Docs-only. Full suite / `tsc` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)