### PR TITLE
feat: tabbed Model Space results + Construction Schedule (CPM/PERT) tab

### DIFF
--- a/webapp/src/components/ConstructionSchedule.tsx
+++ b/webapp/src/components/ConstructionSchedule.tsx
@@ -1,0 +1,120 @@
+import { useMemo, type JSX } from 'react'
+import type { StructuralModel } from '../engine/model'
+import type { StructureDesign } from '../engine/pipeline'
+import { buildModelSchedule, type Trade } from '../engine/modelSchedule'
+
+const TRADE_COLOR: Record<Trade, string> = {
+  sitework: '#a3792e', foundation: '#6b7280', columns: '#0f4c92', floor: '#0f766e',
+}
+const f1 = (v: number) => v.toFixed(1)
+
+/** Auto CPM/PERT construction schedule derived from the designed 3D model:
+ *  summary metrics, a mini-Gantt on the working-day axis, and the activity
+ *  table (quantity, O/M/P, ES/EF, total float, critical). */
+export function ConstructionSchedule({ model, design }: { model: StructuralModel; design: StructureDesign }): JSX.Element {
+  const sch = useMemo(() => buildModelSchedule(model, design), [model, design])
+  if (!sch) return <p className="text-sm text-slate-500">Add members to the model to generate a construction schedule.</p>
+
+  const cpm = sch.pert.cpm.activities
+  const span = Math.max(1, sch.pert.cpm.duration)
+  const crit = new Set(sch.criticalPath)
+
+  return (
+    <div className="mt-6 space-y-4 break-before-page">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h2 className="text-xl font-extrabold tracking-tight text-[#0f4c92]">Construction schedule — CPM / PERT</h2>
+        <span className="text-sm text-slate-500">auto-derived from the model · {sch.frame} frame</span>
+      </div>
+
+      {/* Summary metrics */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {[
+          ['Expected duration', `${f1(sch.projectDays)} days`],
+          ['Std deviation (σ)', `${f1(sch.projectSd)} days`],
+          ['P80 finish', `${f1(sch.projectDays + 0.842 * sch.projectSd)} days`],
+          ['Activities', `${sch.activities.length} · ${sch.criticalPath.length} critical`],
+        ].map(([k, v]) => (
+          <div key={k} className="rounded-lg border border-slate-200 bg-white p-3">
+            <p className="text-[11px] font-medium uppercase tracking-wide text-slate-500">{k}</p>
+            <p className="mt-0.5 font-mono text-[15px] font-bold text-[#0f1b2a]">{v}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Mini-Gantt on the working-day axis */}
+      <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+        <h3 className="mb-3 text-[1.02rem] font-bold text-[#0f4c92]">Timeline (working days)</h3>
+        <div className="space-y-1.5">
+          {sch.activities.map((a) => {
+            const c = cpm.get(a.id)
+            if (!c) return null
+            const left = (c.es / span) * 100, width = Math.max(1.5, (c.duration / span) * 100)
+            const isCrit = crit.has(a.id)
+            return (
+              <div key={a.id} className="flex items-center gap-2 text-[11px]">
+                <span className="w-40 shrink-0 truncate text-slate-600" title={a.name}>{a.name}</span>
+                <div className="relative h-4 flex-1 rounded bg-slate-50">
+                  <div className="absolute top-0 h-4 rounded" style={{
+                    left: `${left}%`, width: `${width}%`,
+                    background: isCrit ? '#c2402a' : TRADE_COLOR[a.trade], opacity: isCrit ? 0.95 : 0.8,
+                  }} title={`${a.name}: day ${c.es}–${c.ef}`} />
+                </div>
+                <span className="w-14 shrink-0 text-right font-mono text-slate-500">{c.es}–{c.ef}</span>
+              </div>
+            )
+          })}
+        </div>
+        <p className="mt-2 text-[11px] text-slate-500">
+          Red = critical path (zero float). Bars run from early-start to early-finish on the working-day axis.
+        </p>
+      </div>
+
+      {/* Activity table */}
+      <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+        <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Activity network (CPM / PERT)</h3>
+        <table className="w-full border-collapse text-xs">
+          <thead>
+            <tr className="text-left uppercase tracking-wide text-slate-500">
+              <th className="py-1 pr-2 font-semibold">ID</th>
+              <th className="py-1 pr-2 font-semibold">Activity</th>
+              <th className="py-1 pr-2 font-semibold">Quantity</th>
+              <th className="py-1 pr-2 font-semibold">Pred.</th>
+              <th className="py-1 pr-2 text-right font-semibold">O / M / P</th>
+              <th className="py-1 pr-2 text-right font-semibold">TE</th>
+              <th className="py-1 pr-2 text-right font-semibold">ES</th>
+              <th className="py-1 pr-2 text-right font-semibold">EF</th>
+              <th className="py-1 pr-2 text-right font-semibold">Float</th>
+              <th className="py-1 font-semibold">Critical</th>
+            </tr>
+          </thead>
+          <tbody className="font-mono">
+            {sch.activities.map((a) => {
+              const c = cpm.get(a.id)!
+              const te = sch.pert.activities.get(a.id)!.te
+              const isCrit = crit.has(a.id)
+              return (
+                <tr key={a.id} className={`border-t border-slate-100 ${isCrit ? 'bg-red-50/60' : ''}`}>
+                  <td className="py-1 pr-2 font-semibold">{a.id}</td>
+                  <td className="py-1 pr-2 font-sans text-slate-700">{a.name}</td>
+                  <td className="py-1 pr-2 text-slate-500">{a.quantity} {a.unit}</td>
+                  <td className="py-1 pr-2 text-slate-500">{a.predecessors.join(', ') || '—'}</td>
+                  <td className="py-1 pr-2 text-right">{a.o}/{a.m}/{a.p}</td>
+                  <td className="py-1 pr-2 text-right font-semibold">{f1(te)}</td>
+                  <td className="py-1 pr-2 text-right">{c.es}</td>
+                  <td className="py-1 pr-2 text-right">{c.ef}</td>
+                  <td className="py-1 pr-2 text-right">{c.totalFloat}</td>
+                  <td className={`py-1 font-semibold ${isCrit ? 'text-red-600' : 'text-slate-400'}`}>{isCrit ? '● yes' : 'no'}</td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+        <p className="mt-2 text-[11px] text-slate-500">
+          Durations from crew-productivity rates on the model quantities; TE = (O + 4M + P)/6. ES/EF/float from the
+          CPM forward/backward pass; expected project duration {f1(sch.projectDays)} days (σ {f1(sch.projectSd)}).
+          Verify crew sizes, procurement lead times and calendar/holidays for a contractual programme.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -32,6 +32,7 @@ import { JointConnections3D } from '../components/JointConnections3D'
 import { ConnectionDetail2D } from '../components/ConnectionDetail2D'
 import { connectionRowSolution } from '../lib/connectionSolution'
 import { WorkedSolution } from '../components/WorkedSolution'
+import { ConstructionSchedule } from '../components/ConstructionSchedule'
 import { beamSectionSolution, columnRowSolution, footingRowSolution, combinedRowSolution,
   woodBeamRowSolution, woodColumnRowSolution, woodSlabRowSolution } from '../lib/modelSpaceSolutions'
 import { Diagram } from '../components/Diagram'
@@ -998,7 +999,8 @@ export default function ModelSpace() {
   const [design, setDesign] = useState<StructureDesign | null>(null)
   const [opt, setOpt] = useState<OptimizeResult | null>(null)
   const [expanded, setExpanded] = useState<string | null>(null)   // open schedule-row solution
-  const [report, setReport] = useState<'' | 'schedules' | 'drawings' | 'solutions' | 'full' | 'sol-only' | 'draw-only'>('')  // consolidated report template
+  const [report] = useState<'' | 'schedules' | 'drawings' | 'solutions' | 'full' | 'sol-only' | 'draw-only'>('')  // consolidated report template (interactive on screen; PDF carries everything)
+  const [resultsTab, setResultsTab] = useState<'schedules' | 'boq' | 'schedule'>('schedules')  // results section tab
   const [modelImg, setModelImg] = useState<string | null>(null)   // 3D snapshot for the PDF report
   const [lh, setLh] = useState<LetterheadState>({ project: '', sheet: '', preparedBy: '' })
   const [exporting, setExporting] = useState(false)               // PDF build in flight
@@ -3835,30 +3837,24 @@ export default function ModelSpace() {
             </div>
           )}
           <LetterheadCard lh={lh} onChange={(p) => setLh((s) => ({ ...s, ...p }))} />
-          <div className="no-print flex flex-wrap items-center gap-2 rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
-            <span className="text-sm font-semibold text-[#0f4c92]">Schedule view</span>
-            <select value={report} onChange={(e) => setReport(e.target.value as typeof report)}
-              className="rounded-md border border-slate-300 px-2.5 py-1.5 text-sm">
-              <option value="">Interactive (click a row)</option>
-              <option value="schedules">Schedules only</option>
-              <option value="drawings">Schedules + drawings</option>
-              <option value="solutions">Schedules + solutions</option>
-              <option value="full">Full — solutions + drawings</option>
-              <option value="sol-only">Solutions only (no tables)</option>
-              <option value="draw-only">Drawing sections only (no tables)</option>
-            </select>
-            <span className="text-xs text-slate-500">
-              {report === '' ? 'rows expand one at a time' : 'every row expanded'}
-            </span>
+          {/* Results tabs — Schedules · Bill of Quantities · Construction Schedule */}
+          <div className="no-print flex flex-wrap items-center gap-1.5 border-b border-slate-200">
+            {([['schedules', 'Schedules'], ['boq', 'Bill of Quantities'], ['schedule', 'Construction Schedule']] as const).map(([id, label]) => (
+              <button key={id} type="button" onClick={() => setResultsTab(id)}
+                className={`rounded-t-md px-3.5 py-2 text-[13px] font-semibold ${resultsTab === id ? 'border-b-2 border-[#0f4c92] text-[#0f4c92]' : 'text-slate-500 hover:text-[#0f4c92]'}`}>
+                {label}
+              </button>
+            ))}
             <button type="button" onClick={() => void exportPdf()} disabled={exporting}
-              className="ml-auto rounded-md bg-[#0f4c92] px-4 py-2 text-[12.5px] font-bold text-white hover:bg-[#0d3f78] disabled:opacity-40">
+              className="mb-1 ml-auto rounded-md bg-[#0f4c92] px-4 py-2 text-[12.5px] font-bold text-white hover:bg-[#0d3f78] disabled:opacity-40">
               {exporting ? '⏳ Building PDF…' : '⎙ Export PDF report'}
             </button>
           </div>
-          <p className="-mt-3 text-xs text-slate-500">
+
+          {resultsTab === 'schedules' && (<>
+          <p className="text-xs text-slate-500">
             Envelope of <b>{design.cases.length}</b> load case{design.cases.length === 1 ? '' : 's'} (NSCP combinations × lateral directions).
-            Each element is designed for its own governing case, shown in the “Case” column.
-            <span className="no-print"> The PDF report carries the letterhead, design summary, schedules and every worked solution.</span>
+            Each element is designed for its own governing case, shown in the “Case” column. Click any row for its worked solution.
           </p>
 
           {/* PAGE 2+ — project & design inputs (every template) */}
@@ -4949,12 +4945,15 @@ export default function ModelSpace() {
             critical sections (SRRB/DRRB) → column P–M → base reactions → isolated footings. Open any standalone
             page for the full worked solution of a given element.
           </p>
+          </>)}
+
+          {resultsTab === 'schedule' && model && <ConstructionSchedule model={model} design={design} />}
         </div>
         )
       })()}
 
       {/* ── Material take-off — BOM / BOQ (full width) ── */}
-      {design && takeoff && (
+      {design && takeoff && resultsTab === 'boq' && (
         <div className="mt-6 space-y-4 break-before-page">
           <div className="flex flex-wrap items-center justify-between gap-2">
             <h2 className="text-xl font-extrabold tracking-tight text-[#0f4c92]">


### PR DESCRIPTION
## What

Second half of the request — the **results reorganization** and the **Construction Schedule** UI (the engine landed in #412).

- **Removed the "Schedule view" card** (the report-template selector + envelope note). Its Export PDF button moves into the new tab bar; on-screen schedules stay interactive (rows expand on click) and the exported PDF still carries the full report.
- **Tabbed results** — the results section now has three tabs: **Schedules · Bill of Quantities · Construction Schedule**. The design header, warnings and letterhead stay above the tabs; each tab shows its own content.
- **Construction Schedule tab** — renders the auto CPM/PERT schedule from the model (`buildModelSchedule`):
  - Summary tiles: expected duration, σ, **P80 finish**, activity / critical counts.
  - A **mini-Gantt** on the working-day axis (bars from ES→EF, critical path in red, trades colour-coded).
  - The **activity table**: quantity, O/M/P, TE, ES, EF, total float, critical flag.

So it "automatically designs the PERT/CPM of the 3D model" — build a frame, run Design, open the **Construction Schedule** tab.

## Layer

UI only (`ModelSpace.tsx` + new `ConstructionSchedule.tsx`). Consumes the #412 engine; no engine changes.

## Verification

- `tsc -b` clean, `npm run build` OK, full suite **1408 passing**.

## Note
The `report` template modes (inline solutions/drawings) are gone from the on-screen selector; on screen it's interactive (click a row) and the PDF export carries the complete report. If you want those inline-expand modes back as a small control, say so and I'll add a compact toggle in the Schedules tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_