### PR TITLE
feat: non-linear construction schedule — split trades, overlaps & parallel branches

### DIFF
--- a/webapp/src/components/ConstructionSchedule.tsx
+++ b/webapp/src/components/ConstructionSchedule.tsx
@@ -4,7 +4,7 @@ import type { StructureDesign } from '../engine/pipeline'
 import { buildModelSchedule, type Trade } from '../engine/modelSchedule'
 
 const TRADE_COLOR: Record<Trade, string> = {
-  sitework: '#a3792e', foundation: '#6b7280', columns: '#0f4c92', floor: '#0f766e',
+  sitework: '#a3792e', foundation: '#6b7280', columns: '#0f4c92', floor: '#0f766e', finishes: '#9333ea',
 }
 const f1 = (v: number) => v.toFixed(1)
 
@@ -97,7 +97,7 @@ export function ConstructionSchedule({ model, design }: { model: StructuralModel
                   <td className="py-1 pr-2 font-semibold">{a.id}</td>
                   <td className="py-1 pr-2 font-sans text-slate-700">{a.name}</td>
                   <td className="py-1 pr-2 text-slate-500">{a.quantity} {a.unit}</td>
-                  <td className="py-1 pr-2 text-slate-500">{a.predecessors.join(', ') || '—'}</td>
+                  <td className="py-1 pr-2 text-slate-500">{a.predecessors.map((l) => `${l.id} ${l.type}${l.lag ? `+${l.lag}` : ''}`).join(', ') || '—'}</td>
                   <td className="py-1 pr-2 text-right">{a.o}/{a.m}/{a.p}</td>
                   <td className="py-1 pr-2 text-right font-semibold">{f1(te)}</td>
                   <td className="py-1 pr-2 text-right">{c.es}</td>

--- a/webapp/src/engine/modelSchedule.test.ts
+++ b/webapp/src/engine/modelSchedule.test.ts
@@ -16,57 +16,64 @@ function twoStorey() {
   return m
 }
 
-describe('buildModelSchedule — auto CPM/PERT from the model', () => {
+describe('buildModelSchedule — non-linear CPM/PERT from the model', () => {
   const model = twoStorey()
   const design = designStructure(model, soil)!
   const sch = buildModelSchedule(model, design)!
+  const by = new Map(sch.activities.map((a) => [a.id, a]))
 
-  it('derives the excavation → footings → per-storey columns/floors sequence', () => {
-    const ids = sch.activities.map((a) => a.id)
-    expect(ids.slice(0, 2)).toEqual(['EXCAV', 'FOUND'])
-    // two storeys → COL1, FLR1, COL2, FLR2
-    expect(ids).toEqual(['EXCAV', 'FOUND', 'COL1', 'FLR1', 'COL2', 'FLR2'])
+  it('splits each concrete phase into its trades (form/rebar/pour)', () => {
+    // foundation split + per-storey column and floor sub-trades
+    for (const id of ['EXCAV', 'FTGF', 'FTGP', 'BACK', 'CF1', 'CP1', 'FF1', 'FR1', 'FP1', 'CF2', 'FP2', 'FIN1']) {
+      expect(by.has(id)).toBe(true)
+    }
+    expect(sch.activities.length).toBeGreaterThanOrEqual(15)   // far more than the old 2-per-storey
   })
 
-  it('chains finish-to-start: each lift waits on the floor below', () => {
-    const by = new Map(sch.activities.map((a) => [a.id, a]))
-    expect(by.get('FOUND')!.predecessors).toEqual(['EXCAV'])
-    expect(by.get('COL1')!.predecessors).toEqual(['FOUND'])
-    expect(by.get('FLR1')!.predecessors).toEqual(['COL1'])
-    expect(by.get('COL2')!.predecessors).toEqual(['FLR1'])
+  it('uses overlapping (SS) and finish-to-start (FS) relations with lag', () => {
+    // rebar starts a lag after formwork begins (overlap), not after it finishes
+    const fr1 = by.get('FR1')!.predecessors.find((p) => p.id === 'FF1')!
+    expect(fr1.type).toBe('SS')
+    expect(fr1.lag).toBeGreaterThan(0)
+    // the pour waits for rebar to finish
+    expect(by.get('FP1')!.predecessors.some((p) => p.id === 'FR1' && p.type === 'FS')).toBe(true)
   })
 
-  it('every activity carries a positive duration and a three-point estimate O ≤ M ≤ P', () => {
+  it('has parallel branches — backfill and finishes run off the critical path', () => {
+    const cpm = sch.pert.cpm.activities
+    // BACK and CF1 both depend on FTGP → they overlap in time
+    expect(by.get('BACK')!.predecessors[0].id).toBe('FTGP')
+    expect(by.get('CF1')!.predecessors[0].id).toBe('FTGP')
+    expect(cpm.get('BACK')!.totalFloat).toBeGreaterThan(0)     // parallel, not critical
+    expect(cpm.get('FIN1')!.totalFloat).toBeGreaterThan(0)
+    // FR1 overlaps FF1 on the timeline (starts before FF1 finishes)
+    expect(cpm.get('FR1')!.es).toBeLessThan(cpm.get('FF1')!.ef)
+  })
+
+  it('durations vary across activities and every activity has a positive TE', () => {
+    const durs = new Set(sch.activities.map((a) => a.duration))
+    expect(durs.size).toBeGreaterThan(1)                       // not one uniform duration
     for (const a of sch.activities) {
       expect(a.duration).toBeGreaterThan(0)
       expect(a.o).toBeLessThanOrEqual(a.m)
       expect(a.m).toBeLessThanOrEqual(a.p)
-      expect(a.quantity).toBeGreaterThanOrEqual(0)
     }
   })
 
-  it('solves the CPM: a linear chain makes every activity critical', () => {
+  it('solves the CPM: critical path is a subset shorter than the full activity list', () => {
     expect(sch.projectDays).toBeGreaterThan(0)
-    // pure FS chain (no parallelism) → the whole sequence is the critical path
-    expect(sch.criticalPath).toEqual(['EXCAV', 'FOUND', 'COL1', 'FLR1', 'COL2', 'FLR2'])
-    // project duration = Σ expected times
-    const sumTe = sch.activities.reduce((s, a) => s + (a.o + 4 * a.m + a.p) / 6, 0)
-    expect(sch.projectDays).toBeCloseTo(sumTe, 6)
     expect(sch.projectSd).toBeGreaterThan(0)
+    expect(sch.criticalPath.length).toBeGreaterThan(0)
+    expect(sch.criticalPath.length).toBeLessThan(sch.activities.length)   // parallelism ⇒ not everything is critical
   })
 
-  it('reports the frame material and reflects it in the activity units', () => {
-    expect(sch.frame).toBe('concrete')
-    expect(sch.activities.find((a) => a.id === 'COL1')!.unit).toContain('concrete')
-  })
-
-  it('a steel frame schedules by tonnage', () => {
+  it('a steel frame schedules by erection tonnage & deck area', () => {
     const steelSec: RectSection = { ...section, material: 'steel', shape: 'W310x79', name: 'W310x79', steelFy: 345, steelFu: 448 }
     const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section: steelSec, slabThickness: 150 })
     m.loads = m.plates.flatMap((p): ModelLoad[] => [{ kind: 'area', plate: p.id, q: 4.0, cat: 'D' }, { kind: 'area', plate: p.id, q: 2.4, cat: 'L' }])
     const d = designStructure(m, soil)!
     const s = buildModelSchedule(m, d)!
-    expect(s.frame === 'steel' || s.frame === 'mixed').toBe(true)
-    expect(s.activities.find((a) => a.id === 'COL1')!.unit).toContain('steel')
+    expect(s.activities.some((a) => a.id === 'CE1' && a.unit.includes('steel'))).toBe(true)
+    expect(s.activities.some((a) => a.id === 'DK1')).toBe(true)
   })
 })

--- a/webapp/src/engine/modelSchedule.ts
+++ b/webapp/src/engine/modelSchedule.ts
@@ -1,34 +1,46 @@
 // ─────────────────────────────────────────────────────────────────────────
 // Automatic construction schedule (CPM + PERT) from the 3D model.
 //
-// Turns the designed structure into a buildable activity network — excavation →
-// footings → then, storey by storey, columns → floor (beams/girders + slab) —
-// deriving each activity's WORK QUANTITY from the model geometry + design and its
-// DURATION from crew-productivity rates.  Activities chain finish-to-start (a lift
-// can't start until the floor below is cast); the network is solved with the
-// existing CPM/PERT engine so the critical path and expected duration fall out.
+// Turns the designed structure into a REALISTIC, non-linear activity network and
+// solves it with the existing CPM/PERT engine.  Each storey is split into its
+// trades (formwork → rebar → pour → cure, or erect → deck → pour by material),
+// and the trades overlap and branch:
+//   · rebar/deck START-TO-START a lag after formwork/erection begins (overlap);
+//   · the next lift starts finish-to-start after the floor below is cast;
+//   · backfill runs in PARALLEL with the ground-floor columns;
+//   · trailing finishes/MEP run in PARALLEL with the structure going up above.
+// so the critical path threads the governing trades while the rest carry float.
 //
-// Durations are working days.  Rates are typical mid-rise building crew outputs
-// and are documented constants — adjust for a specific project.
+// Work quantities come from the model geometry + design; durations from documented
+// crew-productivity rates.  Durations are working days.
 // ─────────────────────────────────────────────────────────────────────────
 import type { StructuralModel, RectSection } from './model'
 import type { StructureDesign } from './pipeline'
 import { computePert, type PertResult } from './schedule/pert'
+import type { RelationType } from './schedule/model'
 import { shapeByName } from './aiscSections'
 
 /** Crew-productivity rates (working days from a work quantity). */
 export const SCHEDULE_RATES = {
-  excavationM3PerDay: 40,      // machine excavation
-  concretePourM3PerDay: 15,    // form + rebar + pour crew throughput
-  formworkRebarDays: 3,        // fixed prep before a concrete pour
-  slabCureDays: 4,             // stripping/cure before the next lift
-  steelErectTonPerDay: 5,      // bolt-up erection
-  timberM3PerDay: 8,           // framing
-  minDays: 2,
+  excavationM3PerDay: 40,
+  backfillM3PerDay: 50,
+  formworkM2PerDay: 25,
+  rebarTonPerDay: 1.5,
+  rebarRatioTPerM3: 0.10,     // ~100 kg reinforcing per m³ of RC
+  concretePourM3PerDay: 20,
+  cureDays: 5,                // strip/cure before the next lift is loaded
+  steelErectTonPerDay: 5,
+  deckM2PerDay: 60,           // metal deck + shear studs / timber sheathing
+  timberFrameM3PerDay: 8,
+  finishesM2PerDay: 30,       // trailing MEP rough-in + partitions
+  overlapLag: 1,              // SS lag between overlapping trades (days)
+  minDays: 1,
 }
 
-export type Trade = 'sitework' | 'foundation' | 'columns' | 'floor'
+export type Trade = 'sitework' | 'foundation' | 'columns' | 'floor' | 'finishes'
 export type FrameMaterial = 'concrete' | 'steel' | 'wood' | 'mixed'
+
+export interface ActivityLink { id: string; type: RelationType; lag: number }
 
 export interface ModelActivity {
   id: string
@@ -39,14 +51,14 @@ export interface ModelActivity {
   unit: string
   duration: number        // most-likely working days
   o: number; m: number; p: number   // PERT three-point (days)
-  predecessors: string[]  // finish-to-start
+  predecessors: ActivityLink[]
 }
 
 export interface ModelSchedule {
   activities: ModelActivity[]
   pert: PertResult                    // .cpm carries ES/EF/LS/LF/float/critical
-  projectDays: number                 // expected duration (Σ TE on the critical path)
-  projectSd: number                   // std-dev of the project duration
+  projectDays: number
+  projectSd: number
   criticalPath: string[]
   frame: FrameMaterial
 }
@@ -56,17 +68,13 @@ const uniqSorted = (v: number[]): number[] => {
   for (const x of [...v].sort((a, b) => a - b)) if (!out.length || Math.abs(x - out[out.length - 1]) > 0.05) out.push(x)
   return out
 }
-
-const durConcrete = (m3: number, cure = 0): number =>
-  m3 > 0 ? Math.max(SCHEDULE_RATES.minDays, Math.ceil(m3 / SCHEDULE_RATES.concretePourM3PerDay) + SCHEDULE_RATES.formworkRebarDays + cure) : 0
-const durSteel = (ton: number): number =>
-  ton > 0 ? Math.max(SCHEDULE_RATES.minDays, Math.ceil(ton / SCHEDULE_RATES.steelErectTonPerDay)) : 0
-const durWood = (m3: number): number =>
-  m3 > 0 ? Math.max(SCHEDULE_RATES.minDays, Math.ceil(m3 / SCHEDULE_RATES.timberM3PerDay)) : 0
-
+const dur = (q: number, rate: number): number => Math.max(SCHEDULE_RATES.minDays, Math.ceil(Math.max(0, q) / rate))
 const round1 = (v: number) => Math.round(v * 10) / 10
+const FS = (id: string, lag = 0): ActivityLink => ({ id, type: 'FS', lag })
+const SS = (id: string, lag = 0): ActivityLink => ({ id, type: 'SS', lag })
 
-/** Build the model's construction schedule and solve CPM + PERT. */
+/** Build the model's construction schedule (split trades, overlaps, parallel
+ *  branches) and solve CPM + PERT. */
 export function buildModelSchedule(model: StructuralModel, design: StructureDesign): ModelSchedule | null {
   if (!model.nodes.length || !model.members.length) return null
   const nm = new Map(model.nodes.map((n) => [n.id, n]))
@@ -75,32 +83,35 @@ export function buildModelSchedule(model: StructuralModel, design: StructureDesi
     const mem = model.members.find((x) => x.id === memberId)
     return mem ? secById.get(mem.section) : undefined
   }
-  const levels = uniqSorted(model.nodes.map((n) => n.y))        // [base, L1, L2, …]
+  const levels = uniqSorted(model.nodes.map((n) => n.y))
   const nStoreys = Math.max(1, levels.length - 1)
   const levelIndex = (y: number): number => {
     let bi = 0, bd = Infinity
     levels.forEach((lv, i) => { const d = Math.abs(lv - y); if (d < bd) { bd = d; bi = i } })
     return bi
   }
-
-  // per-storey work quantities: columns[s] and floor[s] (beams/girders + slab)
-  const colConc = Array(nStoreys).fill(0), colSteel = Array(nStoreys).fill(0), colWood = Array(nStoreys).fill(0)
-  const flrConc = Array(nStoreys).fill(0), flrSteel = Array(nStoreys).fill(0), flrWood = Array(nStoreys).fill(0)
+  const zero = () => Array(nStoreys).fill(0)
+  // per-storey work quantities
+  const colConc = zero(), colForm = zero(), colTon = zero(), colWood = zero()
+  const flrConc = zero(), flrForm = zero(), flrTon = zero(), flrWood = zero()
+  const slabConc = zero(), slabArea = zero()
   let hasConc = false, hasSteel = false, hasWood = false
-  const add = (cArr: number[], sArr: number[], wArr: number[], idx: number, sec: RectSection, L: number) => {
-    if (idx < 0 || idx >= nStoreys) return
-    if (sec.material === 'steel') { const sh = sec.shape ? shapeByName(sec.shape) : undefined; if (sh) { sArr[idx] += (sh.A / 1e6) * L * 7.85; hasSteel = true } }
-    else if (sec.material === 'wood') { wArr[idx] += (sec.b / 1000) * (sec.h / 1000) * L; hasWood = true }
-    else { cArr[idx] += (sec.b / 1000) * (sec.h / 1000) * L; hasConc = true }
+
+  const formworkArea = (sec: RectSection, L: number, isColumn: boolean): number => {
+    const b = sec.b / 1000, h = sec.h / 1000
+    return isColumn ? 2 * (b + h) * L : (b + 2 * h) * L   // column perimeter · L ; beam bottom + 2 sides
   }
   for (const mem of model.members) {
     const a = nm.get(mem.i), b = nm.get(mem.j); if (!a || !b) continue
     const sec = secOf(mem.id); if (!sec) continue
     const L = Math.hypot(b.x - a.x, b.y - a.y, b.z - a.z)
-    if (mem.role === 'column') add(colConc, colSteel, colWood, levelIndex(Math.max(a.y, b.y)) - 1, sec, L)
-    else add(flrConc, flrSteel, flrWood, levelIndex((a.y + b.y) / 2) - 1, sec, L)   // beams/girders sit at a level
+    const isCol = mem.role === 'column'
+    const si = (isCol ? levelIndex(Math.max(a.y, b.y)) : levelIndex((a.y + b.y) / 2)) - 1
+    if (si < 0 || si >= nStoreys) continue
+    if (sec.material === 'steel') { const sh = sec.shape ? shapeByName(sec.shape) : undefined; if (sh) { (isCol ? colTon : flrTon)[si] += (sh.A / 1e6) * L * 7.85; hasSteel = true } }
+    else if (sec.material === 'wood') { (isCol ? colWood : flrWood)[si] += (sec.b / 1000) * (sec.h / 1000) * L; hasWood = true }
+    else { (isCol ? colConc : flrConc)[si] += (sec.b / 1000) * (sec.h / 1000) * L; (isCol ? colForm : flrForm)[si] += formworkArea(sec, L, isCol); hasConc = true }
   }
-  // slabs / timber decks → the floor of their level
   const woodSlabByPlate = new Map(design.woodSlabs.map((s) => [s.plate, s]))
   for (const p of model.plates) {
     if (p.role === 'wall') continue
@@ -108,47 +119,73 @@ export function buildModelSchedule(model: StructuralModel, design: StructureDesi
     const cc = c as { x: number; y: number; z: number }[]
     const si = levelIndex((cc[0].y + cc[2].y) / 2) - 1
     if (si < 0 || si >= nStoreys) continue
+    const area = Math.hypot(cc[1].x - cc[0].x, cc[1].z - cc[0].z) * Math.hypot(cc[3].x - cc[0].x, cc[3].z - cc[0].z)
+    slabArea[si] += area
     const ws = woodSlabByPlate.get(p.id)
     if (ws) { flrWood[si] += ws.design.takeoff.joistM3 + ws.design.takeoff.deckM3; hasWood = true }
-    else {
-      const lx = Math.hypot(cc[1].x - cc[0].x, cc[1].z - cc[0].z), lz = Math.hypot(cc[3].x - cc[0].x, cc[3].z - cc[0].z)
-      flrConc[si] += lx * lz * (p.thickness / 1000); hasConc = true
-    }
+    else { slabConc[si] += area * (p.thickness / 1000); hasConc = true }
   }
 
-  // foundation: footing concrete + excavation from the designed footing sizes
+  // foundation quantities
   let footConc = 0, excav = 0
   for (const f of design.footings) { const B = f.design.B; footConc += B * B * (f.design.Dc / 1000); excav += B * B * 1.5 }
   for (const cf of design.combined) { footConc += cf.design.Bx * cf.design.By * (cf.design.Dc / 1000); excav += cf.design.Bx * cf.design.By * 1.5 }
-  if (excav === 0) excav = model.members.filter((m) => m.role === 'column').length * 3   // no footings designed yet
-
-  const dominant = (conc: number, steel: number, wood: number): { quantity: number; unit: string } =>
-    steel > 0 ? { quantity: round1(steel), unit: 't steel' }
-      : wood > 0 ? { quantity: round1(wood), unit: 'm³ timber' }
-        : { quantity: round1(conc), unit: 'm³ concrete' }
+  if (excav === 0) excav = model.members.filter((m) => m.role === 'column').length * 3
 
   const acts: ModelActivity[] = []
-  const push = (id: string, name: string, trade: Trade, q: { quantity: number; unit: string }, duration: number, predecessors: string[], storey?: number) => {
-    acts.push({ id, name, trade, storey, quantity: q.quantity, unit: q.unit, duration, o: Math.max(1, Math.round(duration * 0.8)), m: Math.max(1, Math.round(duration)), p: Math.max(1, Math.round(duration * 1.5)), predecessors })
+  const push = (id: string, name: string, trade: Trade, quantity: number, unit: string, duration: number, predecessors: ActivityLink[], storey?: number) => {
+    const d = Math.max(SCHEDULE_RATES.minDays, Math.round(duration))
+    acts.push({ id, name, trade, storey, quantity: round1(quantity), unit, duration: d, o: Math.max(1, Math.round(d * 0.8)), m: d, p: Math.max(1, Math.round(d * 1.5)), predecessors })
   }
 
-  push('EXCAV', 'Excavation & site preparation', 'sitework', { quantity: round1(excav), unit: 'm³ soil' }, Math.max(SCHEDULE_RATES.minDays, Math.ceil(excav / SCHEDULE_RATES.excavationM3PerDay)), [])
-  push('FOUND', 'Footings — rebar, formwork & pour', 'foundation', { quantity: round1(footConc), unit: 'm³ concrete' }, durConcrete(footConc) || SCHEDULE_RATES.minDays, ['EXCAV'])
+  // ── Foundation (excavation → footing form+rebar (overlapped) → pour → backfill ∥) ──
+  push('EXCAV', 'Excavation & site preparation', 'sitework', excav, 'm³ soil', dur(excav, SCHEDULE_RATES.excavationM3PerDay), [])
+  push('FTGF', 'Footings — formwork & rebar', 'foundation', footConc, 'm³ (RC)', dur(footConc * 3, SCHEDULE_RATES.formworkM2PerDay) + dur(footConc * SCHEDULE_RATES.rebarRatioTPerM3, SCHEDULE_RATES.rebarTonPerDay), [SS('EXCAV', SCHEDULE_RATES.overlapLag)])
+  push('FTGP', 'Footings — concrete pour', 'foundation', footConc, 'm³ concrete', dur(footConc, SCHEDULE_RATES.concretePourM3PerDay), [FS('FTGF')])
+  push('BACK', 'Backfill & compaction', 'foundation', excav * 0.6, 'm³ fill', dur(excav * 0.6, SCHEDULE_RATES.backfillM3PerDay), [FS('FTGP')])   // parallel branch (has float)
 
-  let prev = 'FOUND'
+  let prevExit = 'FTGP'
   for (let s = 0; s < nStoreys; s++) {
-    const colDur = durConcrete(colConc[s]) + durSteel(colSteel[s]) + durWood(colWood[s]) || SCHEDULE_RATES.minDays
-    const colId = `COL${s + 1}`
-    push(colId, `Columns — level ${s + 1}`, 'columns', dominant(colConc[s], colSteel[s], colWood[s]), colDur, [prev], s + 1)
-    const flrDur = durConcrete(flrConc[s], SCHEDULE_RATES.slabCureDays) + durSteel(flrSteel[s]) + durWood(flrWood[s]) || SCHEDULE_RATES.minDays
-    const flrId = `FLR${s + 1}`
-    push(flrId, `Floor ${s + 1} — beams, girders & slab`, 'floor', dominant(flrConc[s], flrSteel[s], flrWood[s]), flrDur, [colId], s + 1)
-    prev = flrId
+    const lvl = s + 1
+    const mat: FrameMaterial = colTon[s] > 0 ? 'steel' : colWood[s] > 0 ? 'wood' : 'concrete'
+    const lag = SCHEDULE_RATES.overlapLag
+    let exit: string
+
+    if (mat === 'steel') {
+      const ce = `CE${lvl}`, be = `BE${lvl}`, dk = `DK${lvl}`, sp = `SP${lvl}`
+      push(ce, `Columns L${lvl} — steel erection`, 'columns', colTon[s], 't steel', dur(colTon[s], SCHEDULE_RATES.steelErectTonPerDay), [FS(prevExit)], lvl)
+      push(be, `Floor ${lvl} — beam/girder erection`, 'floor', flrTon[s], 't steel', dur(flrTon[s], SCHEDULE_RATES.steelErectTonPerDay), [FS(ce)], lvl)
+      push(dk, `Floor ${lvl} — metal deck & shear studs`, 'floor', slabArea[s], 'm²', dur(slabArea[s], SCHEDULE_RATES.deckM2PerDay), [SS(be, lag)], lvl)
+      push(sp, `Floor ${lvl} — slab pour & cure`, 'floor', slabConc[s], 'm³ concrete', dur(slabConc[s], SCHEDULE_RATES.concretePourM3PerDay) + SCHEDULE_RATES.cureDays, [FS(dk)], lvl)
+      exit = sp
+    } else if (mat === 'wood') {
+      const pf = `PF${lvl}`, jf = `JF${lvl}`, sh = `SH${lvl}`, fa = `FA${lvl}`
+      push(pf, `Level ${lvl} — post/column framing`, 'columns', colWood[s], 'm³ timber', dur(colWood[s], SCHEDULE_RATES.timberFrameM3PerDay), [FS(prevExit)], lvl)
+      push(jf, `Floor ${lvl} — joist & beam framing`, 'floor', flrWood[s], 'm³ timber', dur(flrWood[s], SCHEDULE_RATES.timberFrameM3PerDay), [FS(pf)], lvl)
+      push(sh, `Floor ${lvl} — deck sheathing`, 'floor', slabArea[s], 'm²', dur(slabArea[s], SCHEDULE_RATES.deckM2PerDay), [SS(jf, lag)], lvl)
+      push(fa, `Floor ${lvl} — fastening & blocking`, 'floor', slabArea[s], 'm²', dur(slabArea[s], SCHEDULE_RATES.finishesM2PerDay), [FS(sh)], lvl)
+      exit = fa
+    } else {
+      const cf = `CF${lvl}`, cp = `CP${lvl}`, ff = `FF${lvl}`, fr = `FR${lvl}`, fp = `FP${lvl}`
+      const floorConc = flrConc[s] + slabConc[s]
+      const floorForm = flrForm[s] + slabArea[s]
+      push(cf, `Columns L${lvl} — formwork & rebar`, 'columns', colForm[s], 'm² form', dur(colForm[s], SCHEDULE_RATES.formworkM2PerDay) + dur(colConc[s] * SCHEDULE_RATES.rebarRatioTPerM3, SCHEDULE_RATES.rebarTonPerDay), [FS(prevExit)], lvl)
+      push(cp, `Columns L${lvl} — concrete pour`, 'columns', colConc[s], 'm³ concrete', dur(colConc[s], SCHEDULE_RATES.concretePourM3PerDay), [FS(cf)], lvl)
+      push(ff, `Floor ${lvl} — formwork & shoring`, 'floor', floorForm, 'm² form', dur(floorForm, SCHEDULE_RATES.formworkM2PerDay), [FS(cp)], lvl)
+      push(fr, `Floor ${lvl} — rebar & MEP rough-in`, 'floor', floorConc * SCHEDULE_RATES.rebarRatioTPerM3, 't rebar', dur(floorConc * SCHEDULE_RATES.rebarRatioTPerM3, SCHEDULE_RATES.rebarTonPerDay), [SS(ff, lag)], lvl)
+      push(fp, `Floor ${lvl} — concrete pour & cure`, 'floor', floorConc, 'm³ concrete', dur(floorConc, SCHEDULE_RATES.concretePourM3PerDay) + SCHEDULE_RATES.cureDays, [FS(fr), FS(cp)], lvl)
+      exit = fp
+    }
+
+    // trailing finishes / MEP for this floor — starts after the pour, runs in
+    // PARALLEL with the storey above (carries float, off the critical path).
+    push(`FIN${lvl}`, `Floor ${lvl} — finishes & MEP`, 'finishes', slabArea[s], 'm²', dur(slabArea[s], SCHEDULE_RATES.finishesM2PerDay), [SS(exit, SCHEDULE_RATES.cureDays)], lvl)
+    prevExit = exit
   }
 
   const pert = computePert(acts.map((a) => ({
     id: a.id, optimistic: a.o, mostLikely: a.m, pessimistic: a.p,
-    predecessors: a.predecessors.map((pr) => ({ predecessor: pr, type: 'FS' as const, lag: 0 })),
+    predecessors: a.predecessors.map((l) => ({ predecessor: l.id, type: l.type, lag: l.lag })),
   })))
 
   const frame: FrameMaterial = [hasConc, hasSteel, hasWood].filter(Boolean).length > 1 ? 'mixed'


### PR DESCRIPTION
## What

Reworks the auto construction schedule from a single finish-to-start **linear chain** into a realistic **non-linear network** with parallel work, overlapping trades and finer activities — addressing all four points.

### Split further
Each phase is broken into its trades:
- **Foundation** → Excavation · Footing formwork & rebar · Footing pour · Backfill.
- **Concrete storey** → Columns (formwork+rebar, pour) · Floor (formwork+shoring, rebar+MEP, pour+cure).
- **Steel storey** → Column erection · Beam erection · Metal deck & studs · Slab pour.
- **Wood storey** → Post framing · Joist/beam framing · Sheathing · Fastening.
- Plus trailing **Finishes & MEP** per floor.

(A two-storey grid goes from ~6 activities to ~18.)

### Simultaneous activities + start/stop relations
Uses the CPM engine's real precedence relations with lead/lag:
- **Start-to-start (SS) + lag** — rebar/deck begin a lag *after formwork/erection starts*, so trades **overlap** instead of queuing.
- **Finish-to-start (FS)** — pours wait for rebar to finish; the next lift waits on the floor below.
- **Parallel branches with float** — **backfill** runs alongside the ground-floor columns; **finishes/MEP** for each floor run alongside the structure rising above. These carry float and sit off the critical path.

### Different durations
Every activity's duration is derived from **its own** quantity — formwork m², rebar tonnes, pour m³, erection tonnes, deck m² — at documented crew rates, so durations vary across the network.

The `ConstructionSchedule` tab shows each predecessor with its **relation type + lag** (e.g. `FF1 SS+1`), and the mini-Gantt now shows bars that genuinely overlap.

## Verification

- New tests assert the trade split, SS-overlap + FS relations, **parallel branches carry float** (`BACK`, `FIN1`), `FR1` overlaps `FF1` on the timeline, durations vary, and the critical path is a proper subset (not everything is critical).
- `tsc -b` clean, `npm run build` OK, full suite **1408 passing**.

## Note
Durations still use generic crew rates and a nominal 100 kg/m³ rebar ratio — good for a planning-grade programme; a contractual schedule needs your crew sizes, procurement lead times and a working calendar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_