### PR TITLE
feat: editable critical-path (AON) diagram synced with Gantt & table

### DIFF
--- a/webapp/src/components/ConstructionSchedule.tsx
+++ b/webapp/src/components/ConstructionSchedule.tsx
@@ -1,38 +1,53 @@
-import { useMemo, type JSX } from 'react'
+import { useMemo, useState, type JSX } from 'react'
 import type { StructuralModel } from '../engine/model'
 import type { StructureDesign } from '../engine/pipeline'
-import { buildModelSchedule, type Trade } from '../engine/modelSchedule'
+import { buildModelActivities, solveModelSchedule, withDuration, type Trade } from '../engine/modelSchedule'
+import { CriticalPathDiagram } from './CriticalPathDiagram'
 
 const TRADE_COLOR: Record<Trade, string> = {
   sitework: '#a3792e', foundation: '#6b7280', columns: '#0f4c92', floor: '#0f766e', finishes: '#9333ea',
 }
 const f1 = (v: number) => v.toFixed(1)
 
-/** Auto CPM/PERT construction schedule derived from the designed 3D model:
- *  summary metrics, a mini-Gantt on the working-day axis, and the activity
- *  table (quantity, O/M/P, ES/EF, total float, critical). */
+/** Auto CPM/PERT construction schedule derived from the designed 3D model, with
+ *  a live-editable critical-path diagram. Editing an activity's duration (in the
+ *  diagram or the table) re-solves the network so the diagram, mini-Gantt and
+ *  activity table all update together. */
 export function ConstructionSchedule({ model, design }: { model: StructuralModel; design: StructureDesign }): JSX.Element {
-  const sch = useMemo(() => buildModelSchedule(model, design), [model, design])
-  if (!sch) return <p className="text-sm text-slate-500">Add members to the model to generate a construction schedule.</p>
+  const base = useMemo(() => buildModelActivities(model, design), [model, design])
+  const [durOverride, setDurOverride] = useState<Record<string, number>>({})
 
-  const cpm = sch.pert.cpm.activities
-  const span = Math.max(1, sch.pert.cpm.duration)
-  const crit = new Set(sch.criticalPath)
+  const activities = useMemo(() =>
+    (base?.activities ?? []).map((a) => (durOverride[a.id] != null ? withDuration(a, durOverride[a.id]) : a)),
+    [base, durOverride])
+  const solved = useMemo(() => (activities.length ? solveModelSchedule(activities) : null), [activities])
+
+  if (!base || !solved) return <p className="text-sm text-slate-500">Add members to the model to generate a construction schedule.</p>
+
+  const cpm = solved.pert.cpm.activities
+  const span = Math.max(1, solved.pert.cpm.duration)
+  const crit = new Set(solved.criticalPath)
+  const edited = Object.keys(durOverride).length > 0
+  const setDuration = (id: string, d: number) => setDurOverride((o) => ({ ...o, [id]: d }))
 
   return (
     <div className="mt-6 space-y-4 break-before-page">
       <div className="flex flex-wrap items-baseline justify-between gap-2">
         <h2 className="text-xl font-extrabold tracking-tight text-[#0f4c92]">Construction schedule — CPM / PERT</h2>
-        <span className="text-sm text-slate-500">auto-derived from the model · {sch.frame} frame</span>
+        <span className="flex items-center gap-3 text-sm text-slate-500">
+          <span>auto-derived from the model · {base.frame} frame</span>
+          {edited && <button type="button" onClick={() => setDurOverride({})}
+            className="no-print rounded border border-slate-300 px-2 py-0.5 text-xs font-semibold text-[#0f4c92] hover:bg-blue-50">↺ reset durations</button>}
+        </span>
       </div>
 
       {/* Summary metrics */}
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
         {[
-          ['Expected duration', `${f1(sch.projectDays)} days`],
-          ['Std deviation (σ)', `${f1(sch.projectSd)} days`],
-          ['P80 finish', `${f1(sch.projectDays + 0.842 * sch.projectSd)} days`],
-          ['Activities', `${sch.activities.length} · ${sch.criticalPath.length} critical`],
+          ['Expected duration', `${f1(solved.projectDays)} days`],
+          ['Std deviation (σ)', `${f1(solved.projectSd)} days`],
+          ['P80 finish', `${f1(solved.projectDays + 0.842 * solved.projectSd)} days`],
+          ['Activities', `${activities.length} · ${solved.criticalPath.length} critical`],
         ].map(([k, v]) => (
           <div key={k} className="rounded-lg border border-slate-200 bg-white p-3">
             <p className="text-[11px] font-medium uppercase tracking-wide text-slate-500">{k}</p>
@@ -41,18 +56,21 @@ export function ConstructionSchedule({ model, design }: { model: StructuralModel
         ))}
       </div>
 
+      {/* Editable critical-path (Activity-on-Node) diagram */}
+      <h3 className="text-[1.02rem] font-bold text-[#0f4c92]">Critical-path diagram <span className="font-normal text-slate-400">— editable</span></h3>
+      <CriticalPathDiagram activities={activities} cpm={cpm} critical={crit} onEditDuration={setDuration} />
+
       {/* Mini-Gantt on the working-day axis */}
       <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
         <h3 className="mb-3 text-[1.02rem] font-bold text-[#0f4c92]">Timeline (working days)</h3>
         <div className="space-y-1.5">
-          {sch.activities.map((a) => {
-            const c = cpm.get(a.id)
-            if (!c) return null
+          {activities.map((a) => {
+            const c = cpm.get(a.id); if (!c) return null
             const left = (c.es / span) * 100, width = Math.max(1.5, (c.duration / span) * 100)
             const isCrit = crit.has(a.id)
             return (
               <div key={a.id} className="flex items-center gap-2 text-[11px]">
-                <span className="w-40 shrink-0 truncate text-slate-600" title={a.name}>{a.name}</span>
+                <span className="w-44 shrink-0 truncate text-slate-600" title={a.name}>{a.name}</span>
                 <div className="relative h-4 flex-1 rounded bg-slate-50">
                   <div className="absolute top-0 h-4 rounded" style={{
                     left: `${left}%`, width: `${width}%`,
@@ -64,12 +82,10 @@ export function ConstructionSchedule({ model, design }: { model: StructuralModel
             )
           })}
         </div>
-        <p className="mt-2 text-[11px] text-slate-500">
-          Red = critical path (zero float). Bars run from early-start to early-finish on the working-day axis.
-        </p>
+        <p className="mt-2 text-[11px] text-slate-500">Red = critical path (zero float). Bars run early-start → early-finish; overlaps show parallel work.</p>
       </div>
 
-      {/* Activity table */}
+      {/* Activity table — editable duration */}
       <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
         <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Activity network (CPM / PERT)</h3>
         <table className="w-full border-collapse text-xs">
@@ -78,19 +94,19 @@ export function ConstructionSchedule({ model, design }: { model: StructuralModel
               <th className="py-1 pr-2 font-semibold">ID</th>
               <th className="py-1 pr-2 font-semibold">Activity</th>
               <th className="py-1 pr-2 font-semibold">Quantity</th>
-              <th className="py-1 pr-2 font-semibold">Pred.</th>
-              <th className="py-1 pr-2 text-right font-semibold">O / M / P</th>
-              <th className="py-1 pr-2 text-right font-semibold">TE</th>
+              <th className="py-1 pr-2 font-semibold">Predecessors</th>
+              <th className="py-1 pr-2 text-right font-semibold">Dur</th>
               <th className="py-1 pr-2 text-right font-semibold">ES</th>
               <th className="py-1 pr-2 text-right font-semibold">EF</th>
+              <th className="py-1 pr-2 text-right font-semibold">LS</th>
+              <th className="py-1 pr-2 text-right font-semibold">LF</th>
               <th className="py-1 pr-2 text-right font-semibold">Float</th>
               <th className="py-1 font-semibold">Critical</th>
             </tr>
           </thead>
           <tbody className="font-mono">
-            {sch.activities.map((a) => {
+            {activities.map((a) => {
               const c = cpm.get(a.id)!
-              const te = sch.pert.activities.get(a.id)!.te
               const isCrit = crit.has(a.id)
               return (
                 <tr key={a.id} className={`border-t border-slate-100 ${isCrit ? 'bg-red-50/60' : ''}`}>
@@ -98,10 +114,15 @@ export function ConstructionSchedule({ model, design }: { model: StructuralModel
                   <td className="py-1 pr-2 font-sans text-slate-700">{a.name}</td>
                   <td className="py-1 pr-2 text-slate-500">{a.quantity} {a.unit}</td>
                   <td className="py-1 pr-2 text-slate-500">{a.predecessors.map((l) => `${l.id} ${l.type}${l.lag ? `+${l.lag}` : ''}`).join(', ') || '—'}</td>
-                  <td className="py-1 pr-2 text-right">{a.o}/{a.m}/{a.p}</td>
-                  <td className="py-1 pr-2 text-right font-semibold">{f1(te)}</td>
+                  <td className="py-1 pr-1 text-right">
+                    <input type="number" min={1} value={a.duration}
+                      onChange={(e) => setDuration(a.id, Math.max(1, Math.round(+e.target.value || 1)))}
+                      className={`w-12 rounded border px-1 py-0.5 text-right ${durOverride[a.id] != null ? 'border-[#0f4c92] bg-blue-50 text-[#0f4c92]' : 'border-slate-200'}`} />
+                  </td>
                   <td className="py-1 pr-2 text-right">{c.es}</td>
                   <td className="py-1 pr-2 text-right">{c.ef}</td>
+                  <td className="py-1 pr-2 text-right">{c.ls}</td>
+                  <td className="py-1 pr-2 text-right">{c.lf}</td>
                   <td className="py-1 pr-2 text-right">{c.totalFloat}</td>
                   <td className={`py-1 font-semibold ${isCrit ? 'text-red-600' : 'text-slate-400'}`}>{isCrit ? '● yes' : 'no'}</td>
                 </tr>
@@ -110,9 +131,9 @@ export function ConstructionSchedule({ model, design }: { model: StructuralModel
           </tbody>
         </table>
         <p className="mt-2 text-[11px] text-slate-500">
-          Durations from crew-productivity rates on the model quantities; TE = (O + 4M + P)/6. ES/EF/float from the
-          CPM forward/backward pass; expected project duration {f1(sch.projectDays)} days (σ {f1(sch.projectSd)}).
-          Verify crew sizes, procurement lead times and calendar/holidays for a contractual programme.
+          Durations start from crew-productivity rates on the model quantities; edit any <b>Dur</b> (here or on the
+          diagram) to re-solve the network. ES/EF/LS/LF/float from the CPM passes; expected project duration
+          {' '}{f1(solved.projectDays)} days (σ {f1(solved.projectSd)}). Verify crew sizes, procurement and a working calendar for a contractual programme.
         </p>
       </div>
     </div>

--- a/webapp/src/components/CriticalPathDiagram.tsx
+++ b/webapp/src/components/CriticalPathDiagram.tsx
@@ -1,0 +1,111 @@
+import { useMemo, type JSX } from 'react'
+import type { ModelActivity } from '../engine/modelSchedule'
+import type { CpmActivity } from '../engine/schedule/cpm'
+
+const BOX_W = 148, BOX_H = 66, COL_W = 214, ROW_H = 108, PAD = 18
+
+/** Editable Activity-on-Node critical-path diagram: each activity is a node box
+ *  (ES | DUR | EF · name · LS | TF | LF) with arrows to its successors, the
+ *  critical path in red, and an editable DUR field.  Editing a duration calls
+ *  `onEditDuration`, which re-solves the schedule so this diagram, the Gantt and
+ *  the table all update together. */
+export function CriticalPathDiagram({ activities, cpm, critical, onEditDuration }: {
+  activities: ModelActivity[]
+  cpm: Map<string, CpmActivity>
+  critical: Set<string>
+  onEditDuration: (id: string, duration: number) => void
+}): JSX.Element {
+  const layout = useMemo(() => {
+    // longest-path rank → columns; order within a column by early start
+    const rank = new Map<string, number>()
+    for (const a of activities) rank.set(a.id, 0)
+    for (let pass = 0; pass < activities.length + 2; pass++) {
+      let changed = false
+      for (const a of activities) for (const l of a.predecessors) {
+        const r = (rank.get(l.id) ?? 0) + 1
+        if (r > (rank.get(a.id) ?? 0)) { rank.set(a.id, r); changed = true }
+      }
+      if (!changed) break
+    }
+    const cols = new Map<number, ModelActivity[]>()
+    for (const a of activities) { const r = rank.get(a.id)!; (cols.get(r) ?? cols.set(r, []).get(r)!).push(a) }
+    const pos = new Map<string, { x: number; y: number }>()
+    let maxRows = 0
+    for (const [r, list] of cols) {
+      list.sort((a, b) => (cpm.get(a.id)?.es ?? 0) - (cpm.get(b.id)?.es ?? 0))
+      list.forEach((a, i) => pos.set(a.id, { x: PAD + r * COL_W, y: PAD + i * ROW_H }))
+      maxRows = Math.max(maxRows, list.length)
+    }
+    const width = PAD * 2 + (Math.max(0, ...[...cols.keys()]) * COL_W) + BOX_W
+    const height = PAD * 2 + Math.max(1, maxRows) * ROW_H - (ROW_H - BOX_H)
+    return { pos, width, height }
+  }, [activities, cpm])
+
+  const cell = (v: number | string, cls: string) =>
+    <div className={`flex items-center justify-center text-[10.5px] font-semibold ${cls}`}>{v}</div>
+
+  return (
+    <div className="overflow-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="relative" style={{ width: layout.width, height: layout.height }}>
+        {/* arrows */}
+        <svg className="pointer-events-none absolute inset-0" width={layout.width} height={layout.height}>
+          <defs>
+            <marker id="cpd-arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+              <path d="M0,0 L8,4 L0,8 Z" fill="#334155" />
+            </marker>
+            <marker id="cpd-arrow-crit" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+              <path d="M0,0 L8,4 L0,8 Z" fill="#dc2626" />
+            </marker>
+          </defs>
+          {activities.flatMap((a) => {
+            const to = layout.pos.get(a.id); if (!to) return []
+            return a.predecessors.map((l) => {
+              const from = layout.pos.get(l.id); if (!from) return null
+              const x1 = from.x + BOX_W, y1 = from.y + BOX_H / 2, x2 = to.x, y2 = to.y + BOX_H / 2
+              const isCrit = critical.has(a.id) && critical.has(l.id)
+              const mx = (x1 + x2) / 2
+              return (
+                <path key={`${l.id}->${a.id}`} d={`M${x1},${y1} C${mx},${y1} ${mx},${y2} ${x2 - 2},${y2}`}
+                  fill="none" stroke={isCrit ? '#dc2626' : '#94a3b8'} strokeWidth={isCrit ? 2 : 1.3}
+                  markerEnd={`url(#${isCrit ? 'cpd-arrow-crit' : 'cpd-arrow'})`} />
+              )
+            })
+          })}
+        </svg>
+        {/* node boxes */}
+        {activities.map((a) => {
+          const c = cpm.get(a.id); if (!c) return null
+          const p = layout.pos.get(a.id)!
+          const isCrit = critical.has(a.id)
+          return (
+            <div key={a.id} className={`absolute rounded-md border-2 bg-white shadow-sm ${isCrit ? 'border-red-500' : 'border-slate-300'}`}
+              style={{ left: p.x, top: p.y, width: BOX_W, height: BOX_H }} title={a.name}>
+              <div className="grid h-[22px] grid-cols-3 divide-x divide-white overflow-hidden rounded-t">
+                {cell(c.es, 'bg-[#a5d76e] text-[#1e3a0f]')}
+                <div className="flex items-center justify-center bg-[#3f9a3f]">
+                  <input type="number" min={1} value={a.duration}
+                    onChange={(e) => onEditDuration(a.id, Math.max(1, Math.round(+e.target.value || 1)))}
+                    className="h-full w-full bg-transparent text-center text-[11px] font-bold text-white outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none" />
+                </div>
+                {cell(c.ef, 'bg-[#a5d76e] text-[#1e3a0f]')}
+              </div>
+              <div className="flex h-[22px] items-center justify-center truncate px-1 text-[10px] font-bold text-slate-700">
+                {a.id} · {a.name.replace(/^(Floor|Columns|Footings|Level) /, '').split(' — ')[0].slice(0, 16)}
+              </div>
+              <div className="grid h-[22px] grid-cols-3 divide-x divide-white overflow-hidden rounded-b">
+                {cell(c.ls, 'bg-[#57cbbf] text-[#0f3b36]')}
+                {cell(c.totalFloat, `${isCrit ? 'bg-red-500 text-white' : 'bg-slate-400 text-white'}`)}
+                {cell(c.lf, 'bg-[#57cbbf] text-[#0f3b36]')}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+      <div className="mt-2 flex flex-wrap items-center gap-4 text-[11px] text-slate-500">
+        <span><b>ES</b>·<b>DUR</b>·<b>EF</b> top, <b>LS</b>·<b>TF</b>·<b>LF</b> bottom</span>
+        <span className="text-red-600">red = critical path (TF = 0)</span>
+        <span>edit any <b>DUR</b> — the diagram, Gantt and table update together</span>
+      </div>
+    </div>
+  )
+}

--- a/webapp/src/engine/modelSchedule.test.ts
+++ b/webapp/src/engine/modelSchedule.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { generateGridModel } from './modelBuilder'
 import { designStructure } from './pipeline'
-import { buildModelSchedule } from './modelSchedule'
+import { buildModelSchedule, buildModelActivities, solveModelSchedule, withDuration } from './modelSchedule'
 import type { RectSection, ModelLoad } from './model'
 
 const section: RectSection = { id: 'S1', name: '400×400', b: 400, h: 400, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
@@ -65,6 +65,20 @@ describe('buildModelSchedule — non-linear CPM/PERT from the model', () => {
     expect(sch.projectSd).toBeGreaterThan(0)
     expect(sch.criticalPath.length).toBeGreaterThan(0)
     expect(sch.criticalPath.length).toBeLessThan(sch.activities.length)   // parallelism ⇒ not everything is critical
+  })
+
+  it('editing a critical activity re-solves the network (longer critical duration → longer project)', () => {
+    const b = buildModelActivities(model, design)!
+    const s0 = solveModelSchedule(b.activities)
+    const critId = s0.criticalPath[s0.criticalPath.length - 1]   // last critical activity → its finish is the project end
+    const before = b.activities.find((a) => a.id === critId)!.duration
+    const edited = b.activities.map((a) => (a.id === critId ? withDuration(a, before + 10) : a))
+    const s1 = solveModelSchedule(edited)
+    expect(s1.projectDays).toBeGreaterThan(s0.projectDays)
+    // a non-critical (parallel) activity has slack, so bumping it a little keeps the project length
+    const slackId = [...s0.pert.cpm.activities.values()].find((c) => c.totalFloat > 2)!.id
+    const edited2 = b.activities.map((a) => (a.id === slackId ? withDuration(a, a.duration + 1) : a))
+    expect(solveModelSchedule(edited2).projectDays).toBeCloseTo(s0.projectDays, 6)
   })
 
   it('a steel frame schedules by erection tonnage & deck area', () => {

--- a/webapp/src/engine/modelSchedule.ts
+++ b/webapp/src/engine/modelSchedule.ts
@@ -73,9 +73,26 @@ const round1 = (v: number) => Math.round(v * 10) / 10
 const FS = (id: string, lag = 0): ActivityLink => ({ id, type: 'FS', lag })
 const SS = (id: string, lag = 0): ActivityLink => ({ id, type: 'SS', lag })
 
-/** Build the model's construction schedule (split trades, overlaps, parallel
- *  branches) and solve CPM + PERT. */
-export function buildModelSchedule(model: StructuralModel, design: StructureDesign): ModelSchedule | null {
+/** Recompute the duration-derived PERT three-point (O/M/P) for an activity — used
+ *  when the user edits a duration in the schedule views. */
+export function withDuration(a: ModelActivity, duration: number): ModelActivity {
+  const d = Math.max(SCHEDULE_RATES.minDays, Math.round(duration))
+  return { ...a, duration: d, o: Math.max(1, Math.round(d * 0.8)), m: d, p: Math.max(1, Math.round(d * 1.5)) }
+}
+
+/** Solve CPM + PERT for a set of activities (base or user-edited). */
+export function solveModelSchedule(activities: ModelActivity[]): Omit<ModelSchedule, 'activities' | 'frame'> {
+  const pert = computePert(activities.map((a) => ({
+    id: a.id, optimistic: a.o, mostLikely: a.m, pessimistic: a.p,
+    predecessors: a.predecessors.map((l) => ({ predecessor: l.id, type: l.type, lag: l.lag })),
+  })))
+  return { pert, projectDays: pert.projectTe, projectSd: pert.projectSd, criticalPath: pert.cpm.criticalPath }
+}
+
+/** Derive the construction activities (split trades, overlaps, parallel branches)
+ *  from the model + design — before CPM/PERT is solved, so callers can edit the
+ *  activities and re-solve. */
+export function buildModelActivities(model: StructuralModel, design: StructureDesign): { activities: ModelActivity[]; frame: FrameMaterial } | null {
   if (!model.nodes.length || !model.members.length) return null
   const nm = new Map(model.nodes.map((n) => [n.id, n]))
   const secById = new Map(model.sections.map((s) => [s.id, s]))
@@ -183,13 +200,14 @@ export function buildModelSchedule(model: StructuralModel, design: StructureDesi
     prevExit = exit
   }
 
-  const pert = computePert(acts.map((a) => ({
-    id: a.id, optimistic: a.o, mostLikely: a.m, pessimistic: a.p,
-    predecessors: a.predecessors.map((l) => ({ predecessor: l.id, type: l.type, lag: l.lag })),
-  })))
-
   const frame: FrameMaterial = [hasConc, hasSteel, hasWood].filter(Boolean).length > 1 ? 'mixed'
     : hasSteel ? 'steel' : hasWood ? 'wood' : 'concrete'
+  return { activities: acts, frame }
+}
 
-  return { activities: acts, pert, projectDays: pert.projectTe, projectSd: pert.projectSd, criticalPath: pert.cpm.criticalPath, frame }
+/** Build the model's construction schedule and solve CPM + PERT (convenience). */
+export function buildModelSchedule(model: StructuralModel, design: StructureDesign): ModelSchedule | null {
+  const b = buildModelActivities(model, design)
+  if (!b) return null
+  return { activities: b.activities, frame: b.frame, ...solveModelSchedule(b.activities) }
 }


### PR DESCRIPTION
## What

Adds the **editable critical-path diagram** you asked for — a Primavera-style Activity-on-Node network in the Construction Schedule tab — and keeps it, the Gantt and the activity table **all in sync**: edit a duration in any of them and everything re-solves.

### The diagram
Each activity is a node box laid out by longest-path rank, matching the template:
- top row **ES | DUR | EF**, middle **ID · name**, bottom **LS | TF | LF**
- arrows to successors; the **critical path is red** (boxes and arrows)
- **DUR is an editable field**

### Two-way sync
`modelSchedule` is split into `buildModelActivities` (derivation) + `solveModelSchedule` (CPM/PERT) + `withDuration`, so the network can be re-solved from edited activities. `ConstructionSchedule` is now **stateful**: a duration edit — in the **diagram** *or* the **table** — is held as an override, the network is re-solved, and the **diagram, mini-Gantt and table all update together** (float, ES/EF/LS/LF, critical path, project duration/σ). A **↺ reset durations** button clears the edits and returns to the auto-derived schedule.

## Layer

UI + a pure engine refactor (`modelSchedule` split; no behaviour change to the derivation). New `CriticalPathDiagram.tsx`.

## Verification

- New test: editing the **last critical** activity lengthens the project; nudging a **slack** (parallel) activity within its float leaves the project length unchanged — confirming the re-solve honours float and the critical path.
- `tsc -b` clean, `npm run build` OK, full suite **1409 passing**.

Note: it correctly shows a real CPM subtlety — an activity headed by a start-to-start link (e.g. excavation, with footings overlapping it) can read TF = 0 yet not extend the project when *its own* duration grows, because SS ties starts, not finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_