### PR TITLE
feat: edit schedule dependencies (links, FS/SS/FF/SF, lead/lag)

### DIFF
--- a/webapp/src/components/ConstructionSchedule.tsx
+++ b/webapp/src/components/ConstructionSchedule.tsx
@@ -1,8 +1,12 @@
 import { useMemo, useState, type JSX } from 'react'
 import type { StructuralModel } from '../engine/model'
 import type { StructureDesign } from '../engine/pipeline'
-import { buildModelActivities, solveModelSchedule, withDuration, type Trade } from '../engine/modelSchedule'
+import { buildModelActivities, solveModelSchedule, withDuration, type Trade, type ActivityLink } from '../engine/modelSchedule'
+import { findCycle } from '../engine/schedule/cpm'
+import type { RelationType } from '../engine/schedule/model'
 import { CriticalPathDiagram } from './CriticalPathDiagram'
+
+const REL_TYPES: RelationType[] = ['FS', 'SS', 'FF', 'SF']
 
 const TRADE_COLOR: Record<Trade, string> = {
   sitework: '#a3792e', foundation: '#6b7280', columns: '#0f4c92', floor: '#0f766e', finishes: '#9333ea',
@@ -16,10 +20,16 @@ const f1 = (v: number) => v.toFixed(1)
 export function ConstructionSchedule({ model, design }: { model: StructuralModel; design: StructureDesign }): JSX.Element {
   const base = useMemo(() => buildModelActivities(model, design), [model, design])
   const [durOverride, setDurOverride] = useState<Record<string, number>>({})
+  const [depOverride, setDepOverride] = useState<Record<string, ActivityLink[]>>({})
+  const [depErr, setDepErr] = useState<string | null>(null)
 
   const activities = useMemo(() =>
-    (base?.activities ?? []).map((a) => (durOverride[a.id] != null ? withDuration(a, durOverride[a.id]) : a)),
-    [base, durOverride])
+    (base?.activities ?? []).map((a) => {
+      const links = depOverride[a.id] ?? a.predecessors
+      const withDeps = links === a.predecessors ? a : { ...a, predecessors: links }
+      return durOverride[a.id] != null ? withDuration(withDeps, durOverride[a.id]) : withDeps
+    }),
+    [base, durOverride, depOverride])
   const solved = useMemo(() => (activities.length ? solveModelSchedule(activities) : null), [activities])
 
   if (!base || !solved) return <p className="text-sm text-slate-500">Add members to the model to generate a construction schedule.</p>
@@ -27,8 +37,23 @@ export function ConstructionSchedule({ model, design }: { model: StructuralModel
   const cpm = solved.pert.cpm.activities
   const span = Math.max(1, solved.pert.cpm.duration)
   const crit = new Set(solved.criticalPath)
-  const edited = Object.keys(durOverride).length > 0
+  const edited = Object.keys(durOverride).length > 0 || Object.keys(depOverride).length > 0
   const setDuration = (id: string, d: number) => setDurOverride((o) => ({ ...o, [id]: d }))
+  const resetAll = () => { setDurOverride({}); setDepOverride({}); setDepErr(null) }
+
+  /** Commit a new predecessor list for `id`, unless it creates a cycle. */
+  const setLinks = (id: string, links: ActivityLink[]) => {
+    const cand = activities.map((a) => (a.id === id ? { ...a, predecessors: links } : a))
+    const cyc = findCycle(cand.map((a) => ({ id: a.id, duration: a.duration, predecessors: a.predecessors.map((l) => ({ predecessor: l.id, type: l.type, lag: l.lag })) })))
+    if (cyc) { setDepErr(`That link would create a cycle: ${cyc.join(' → ')}`); return }
+    setDepErr(null)
+    setDepOverride((o) => ({ ...o, [id]: links }))
+  }
+  const addLink = (id: string, predId: string) => setLinks(id, [...(activities.find((a) => a.id === id)?.predecessors ?? []), { id: predId, type: 'FS', lag: 0 }])
+  const patchLink = (id: string, predId: string, patch: Partial<ActivityLink>) =>
+    setLinks(id, (activities.find((a) => a.id === id)?.predecessors ?? []).map((l) => (l.id === predId ? { ...l, ...patch } : l)))
+  const removeLink = (id: string, predId: string) =>
+    setLinks(id, (activities.find((a) => a.id === id)?.predecessors ?? []).filter((l) => l.id !== predId))
 
   return (
     <div className="mt-6 space-y-4 break-before-page">
@@ -36,8 +61,8 @@ export function ConstructionSchedule({ model, design }: { model: StructuralModel
         <h2 className="text-xl font-extrabold tracking-tight text-[#0f4c92]">Construction schedule — CPM / PERT</h2>
         <span className="flex items-center gap-3 text-sm text-slate-500">
           <span>auto-derived from the model · {base.frame} frame</span>
-          {edited && <button type="button" onClick={() => setDurOverride({})}
-            className="no-print rounded border border-slate-300 px-2 py-0.5 text-xs font-semibold text-[#0f4c92] hover:bg-blue-50">↺ reset durations</button>}
+          {edited && <button type="button" onClick={resetAll}
+            className="no-print rounded border border-slate-300 px-2 py-0.5 text-xs font-semibold text-[#0f4c92] hover:bg-blue-50">↺ reset edits</button>}
         </span>
       </div>
 
@@ -88,6 +113,7 @@ export function ConstructionSchedule({ model, design }: { model: StructuralModel
       {/* Activity table — editable duration */}
       <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
         <h3 className="mb-2 text-[1.02rem] font-bold text-[#0f4c92]">Activity network (CPM / PERT)</h3>
+        {depErr && <p className="no-print mb-2 rounded border border-red-300 bg-red-50 px-2 py-1 text-[11px] font-semibold text-red-700">{depErr}</p>}
         <table className="w-full border-collapse text-xs">
           <thead>
             <tr className="text-left uppercase tracking-wide text-slate-500">
@@ -113,7 +139,29 @@ export function ConstructionSchedule({ model, design }: { model: StructuralModel
                   <td className="py-1 pr-2 font-semibold">{a.id}</td>
                   <td className="py-1 pr-2 font-sans text-slate-700">{a.name}</td>
                   <td className="py-1 pr-2 text-slate-500">{a.quantity} {a.unit}</td>
-                  <td className="py-1 pr-2 text-slate-500">{a.predecessors.map((l) => `${l.id} ${l.type}${l.lag ? `+${l.lag}` : ''}`).join(', ') || '—'}</td>
+                  <td className="py-1 pr-2 align-top">
+                    <div className="flex flex-col gap-0.5">
+                      {a.predecessors.map((l) => (
+                        <div key={l.id} className="flex items-center gap-1">
+                          <span className="w-12 font-semibold text-slate-600">{l.id}</span>
+                          <select value={l.type} onChange={(e) => patchLink(a.id, l.id, { type: e.target.value as RelationType })}
+                            className="rounded border border-slate-200 px-0.5 py-px text-[10px]">
+                            {REL_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
+                          </select>
+                          <input type="number" value={l.lag} title="lead/lag (days)"
+                            onChange={(e) => patchLink(a.id, l.id, { lag: Math.round(+e.target.value || 0) })}
+                            className="w-9 rounded border border-slate-200 px-0.5 py-px text-right text-[10px]" />
+                          <button type="button" onClick={() => removeLink(a.id, l.id)} title="remove link"
+                            className="no-print px-0.5 text-red-500 hover:text-red-700">×</button>
+                        </div>
+                      ))}
+                      <select value="" onChange={(e) => { if (e.target.value) addLink(a.id, e.target.value) }}
+                        className="no-print w-24 rounded border border-dashed border-slate-300 px-0.5 py-px text-[10px] text-slate-500">
+                        <option value="">+ add…</option>
+                        {activities.filter((x) => x.id !== a.id && !a.predecessors.some((l) => l.id === x.id)).map((x) => <option key={x.id} value={x.id}>{x.id}</option>)}
+                      </select>
+                    </div>
+                  </td>
                   <td className="py-1 pr-1 text-right">
                     <input type="number" min={1} value={a.duration}
                       onChange={(e) => setDuration(a.id, Math.max(1, Math.round(+e.target.value || 1)))}
@@ -132,7 +180,8 @@ export function ConstructionSchedule({ model, design }: { model: StructuralModel
         </table>
         <p className="mt-2 text-[11px] text-slate-500">
           Durations start from crew-productivity rates on the model quantities; edit any <b>Dur</b> (here or on the
-          diagram) to re-solve the network. ES/EF/LS/LF/float from the CPM passes; expected project duration
+          diagram), or add/remove <b>predecessors</b> and change their <b>relation (FS/SS/FF/SF)</b> and <b>lag</b> to
+          re-solve the network. ES/EF/LS/LF/float from the CPM passes; expected project duration
           {' '}{f1(solved.projectDays)} days (σ {f1(solved.projectSd)}). Verify crew sizes, procurement and a working calendar for a contractual programme.
         </p>
       </div>


### PR DESCRIPTION
## What

Makes the schedule **dependencies editable** (first half of the request; "push into /schedule" is the next PR).

The activity table's **Predecessors** column is now an editor:
- each link shows a **relation-type** dropdown (**FS / SS / FF / SF**) and a **lead/lag** input, with a **×** to remove it
- an **"+ add…"** picker adds a predecessor from the other activities
- edits **re-solve the CPM/PERT**, so the diagram, mini-Gantt and table all update together (as with duration edits)
- a link that would create a **cycle is rejected** with the offending loop shown (`findCycle`)
- **↺ reset edits** clears both duration and dependency overrides

## Layer

UI only (`ConstructionSchedule.tsx`), reusing the schedule engine's `findCycle` and relation types.

## Verification

- `tsc -b` clean, `npm run build` OK, full suite **1409 passing**.

## Next PR
"Open in Scheduler" — convert the edited network into a `ScheduleProject`, save it to the schedule store, and jump to `/schedule` so a calendar, resources, baselines and exports apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_