### PR TITLE
feat: link model schedule to one scheduler project (update, keep plan & actuals)

### DIFF
--- a/webapp/src/components/ConstructionSchedule.tsx
+++ b/webapp/src/components/ConstructionSchedule.tsx
@@ -6,10 +6,11 @@ import { buildModelActivities, solveModelSchedule, withDuration, type Trade, typ
 import { findCycle } from '../engine/schedule/cpm'
 import type { RelationType } from '../engine/schedule/model'
 import { createStore, defaultBackend } from '../engine/schedule/store'
-import { modelActivitiesToProject } from '../lib/modelToScheduleProject'
+import { modelActivitiesToProject, mergeModelIntoProject } from '../lib/modelToScheduleProject'
 import { CriticalPathDiagram } from './CriticalPathDiagram'
 
 const SCHEDULE_ACTIVE_KEY = 'schedule:active'   // mirrors useScheduleProject
+const SCHEDULE_LINK_KEY = 'schedule:model-link' // remembers the model's linked project
 
 const REL_TYPES: RelationType[] = ['FS', 'SS', 'FF', 'SF']
 
@@ -47,13 +48,25 @@ export function ConstructionSchedule({ model, design }: { model: StructuralModel
   const setDuration = (id: string, d: number) => setDurOverride((o) => ({ ...o, [id]: d }))
   const resetAll = () => { setDurOverride({}); setDepOverride({}); setDepErr(null) }
 
-  /** Push the (edited) network into the /schedule module as a new active project. */
+  /** Push the (edited) network into the /schedule module. Re-opening UPDATES the
+   *  same linked project — refreshing structure while keeping the scheduler-side
+   *  calendar, resources, baselines and per-activity actuals — instead of making
+   *  a new copy each time. */
+  const [linked, setLinked] = useState<boolean>(() => {
+    const id = defaultBackend().getItem(SCHEDULE_LINK_KEY)
+    return !!(id && createStore(defaultBackend()).exists(id))
+  })
   const openInScheduler = () => {
-    const project = modelActivitiesToProject(activities, { name: `${model.name || 'Model'} — construction schedule` })
     const backend = defaultBackend()
-    const id = `p_${Date.now().toString(36)}`
-    createStore(backend).save(id, project)
+    const store = createStore(backend)
+    const fresh = modelActivitiesToProject(activities, { name: `${model.name || 'Model'} — construction schedule` })
+    const linkedId = backend.getItem(SCHEDULE_LINK_KEY)
+    const existing = linkedId && store.exists(linkedId) ? store.load(linkedId) : null
+    const id = existing && linkedId ? linkedId : `p_${Date.now().toString(36)}`
+    store.save(id, existing ? mergeModelIntoProject(existing, fresh) : fresh)
+    backend.setItem(SCHEDULE_LINK_KEY, id)
     backend.setItem(SCHEDULE_ACTIVE_KEY, id)
+    setLinked(true)
     navigate('/schedule')
   }
 
@@ -79,8 +92,8 @@ export function ConstructionSchedule({ model, design }: { model: StructuralModel
           <span>auto-derived from the model · {base.frame} frame</span>
           {edited && <button type="button" onClick={resetAll}
             className="no-print rounded border border-slate-300 px-2 py-0.5 text-xs font-semibold text-[#0f4c92] hover:bg-blue-50">↺ reset edits</button>}
-          <button type="button" onClick={openInScheduler}
-            className="no-print rounded-md bg-[#0f4c92] px-3 py-1 text-xs font-bold text-white hover:bg-[#0d3f78]">Open in Scheduler →</button>
+          <button type="button" onClick={openInScheduler} title={linked ? 'Refresh the linked scheduler project (keeps calendar, resources, baselines & actuals)' : 'Create a scheduler project from this schedule'}
+            className="no-print rounded-md bg-[#0f4c92] px-3 py-1 text-xs font-bold text-white hover:bg-[#0d3f78]">{linked ? 'Update in Scheduler →' : 'Open in Scheduler →'}</button>
         </span>
       </div>
 

--- a/webapp/src/lib/modelToScheduleProject.test.ts
+++ b/webapp/src/lib/modelToScheduleProject.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { generateGridModel } from '../engine/modelBuilder'
 import { designStructure } from '../engine/pipeline'
 import { buildModelActivities } from '../engine/modelSchedule'
-import { modelActivitiesToProject } from './modelToScheduleProject'
+import { modelActivitiesToProject, mergeModelIntoProject } from './modelToScheduleProject'
 import { validateProject, isProjectValid } from '../engine/schedule/validate'
 import { computeCPM } from '../engine/schedule/cpm'
 import type { RectSection, ModelLoad } from '../engine/model'
@@ -52,5 +52,29 @@ describe('modelActivitiesToProject', () => {
     const cpm = computeCPM(project.activities.map((a) => ({ id: a.id, duration: a.duration, predecessors: a.predecessors })))
     expect(cpm.duration).toBeGreaterThan(0)
     expect(cpm.criticalPath.length).toBeGreaterThan(0)
+  })
+
+  it('merge keeps scheduler-side setup + actuals while taking the model structure', () => {
+    // a user has set up the scheduler side: resources, a baseline, and progress
+    const existing = {
+      ...project,
+      resources: [{ id: 'r1', name: 'Crew A', type: 'labor' as const, unit: 'man-day' }],
+      baselines: [{ id: 'b1', name: 'BL1', createdAt: '2026-01-01', activities: {} }],
+      meta: { ...project.meta, client: 'Acme' },
+      activities: project.activities.map((a) => (a.id === 'FP1' ? { ...a, percentComplete: 40, status: 'in-progress' as const, actualStart: '2026-02-01' } : a)),
+    }
+    // the model is re-derived with an edited duration on FP1
+    const edited = modelActivitiesToProject(
+      acts.map((a) => (a.id === 'FP1' ? { ...a, duration: a.duration + 9, m: a.m + 9 } : a)), { name: 'Test schedule' })
+    const merged = mergeModelIntoProject(existing, edited)
+
+    expect(merged.resources).toHaveLength(1)             // scheduler resources kept
+    expect(merged.baselines).toHaveLength(1)             // baseline kept
+    expect(merged.meta.client).toBe('Acme')             // scheduler meta kept
+    const fp1 = merged.activities.find((a) => a.id === 'FP1')!
+    expect(fp1.duration).toBe(acts.find((a) => a.id === 'FP1')!.duration + 9)   // model duration flows in
+    expect(fp1.percentComplete).toBe(40)                // actuals preserved
+    expect(fp1.actualStart).toBe('2026-02-01')
+    expect(fp1.status).toBe('in-progress')
   })
 })

--- a/webapp/src/lib/modelToScheduleProject.ts
+++ b/webapp/src/lib/modelToScheduleProject.ts
@@ -53,3 +53,22 @@ export function modelActivitiesToProject(activities: ModelActivity[], opts: Proj
     baselines: [],
   }
 }
+
+/** Refresh an existing linked project with the model's latest structure while
+ *  KEEPING the scheduler-side setup — calendars, resources, baselines, meta — and
+ *  each activity's progress/actuals/assignments (matched by id). Model edits
+ *  (durations, predecessors, three-point) flow in; the user's plan is preserved. */
+export function mergeModelIntoProject(existing: ScheduleProject, fresh: ScheduleProject): ScheduleProject {
+  const prev = new Map(existing.activities.map((a) => [a.id, a]))
+  const activities: Activity[] = fresh.activities.map((a) => {
+    const p = prev.get(a.id)
+    return p ? {
+      ...a,
+      calendarId: p.calendarId,
+      actualStart: p.actualStart, actualFinish: p.actualFinish,
+      percentComplete: p.percentComplete, status: p.status ?? a.status,
+      responsible: p.responsible, resources: p.resources,
+    } : a
+  })
+  return { ...existing, activities, wbs: fresh.wbs }
+}


### PR DESCRIPTION
## What

Follow-up on the caveat from #417: re-opening the model schedule in the scheduler now **updates the same linked project** instead of creating a new copy each time.

- The model remembers its **linked project id** (`schedule:model-link`); the button reads **"Open in Scheduler →"** first, then **"Update in Scheduler →"** once linked.
- **`mergeModelIntoProject`** refreshes the **activities + WBS** from the model (durations, predecessors, three-point estimate) while **keeping the scheduler-side setup** — calendars, resources, baselines, project meta — and each activity's **progress / actuals / assignments** (matched by id). So model edits flow in without wiping the plan the user built in the scheduler.
- Falls back to creating a fresh project if the link is missing or the linked project was deleted (`store.exists`).

## Layer

`lib/modelToScheduleProject.ts` (merge helper) + the button handler in `ConstructionSchedule.tsx`. No changes to the schedule engine/store.

## Verification

- New test: after a user adds resources, a baseline, meta and marks progress on an activity, `mergeModelIntoProject` **keeps** all of that and the **actuals**, while an **edited model duration flows through**.
- `tsc -b` clean, `npm run build` OK, full suite **1414 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_