### PR TITLE
Plan renderer Phase 4: typical footing detail sheet (plan + Section A-A)

### DIFF
--- a/webapp/src/engine/footingDetail.test.ts
+++ b/webapp/src/engine/footingDetail.test.ts
@@ -30,11 +30,11 @@ describe('footingDetail — column-footing detail sheet', () => {
     expect(t.some((s) => s === '8-16mmØ VERT. BARS')).toBe(true)
   })
 
-  it('draws the bottom mat with END HOOKS (bars are polylines, not plain spans)', () => {
-    // each plan mat bar is a 3-segment hooked polyline → ≥ 3 rebar segments per bar,
-    // both ways ⇒ well over 2·bars rebar lines
-    const rebar = d.primitives.filter((p) => p.kind === 'line' && (p as { stroke?: string }).stroke === '#b45309')
-    expect(rebar.length).toBeGreaterThan(4 * base.bars)
+  it('draws each bar as an OUTLINE tube (closed rebar path), both ways', () => {
+    // every bar is one closed rebar-coloured path; plan has 2·bars (both ways)
+    const rebar = d.primitives.filter((p) => p.kind === 'path' && (p as { stroke?: string }).stroke === '#b45309')
+    expect(rebar.length).toBeGreaterThanOrEqual(2 * base.bars)
+    expect(rebar.every((p) => (p as { closed?: boolean }).closed)).toBe(true)
     // filled rebar circles = n section bar-ends + 4 plan column vertical bars
     const ends = d.primitives.filter((p) => p.kind === 'circle' && (p as { fill?: string }).fill === '#b45309')
     expect(ends.length).toBe(base.bars + 4)
@@ -58,8 +58,8 @@ describe('footingDetail — column-footing detail sheet', () => {
     const t = texts(d.primitives)
     expect(t).toContain('NATURAL GRADE LINE')
     expect(t).toContain('T.O.F. EL -1.05 m')
-    // gravel aggregate circles (unfilled, hatch stroke) under the footing
-    expect(d.primitives.some((p) => p.kind === 'circle' && (p as { stroke?: string }).stroke === '#94a3b8')).toBe(true)
+    // gravel aggregate stones (unfilled, stone stroke) under the footing
+    expect(d.primitives.some((p) => p.kind === 'circle' && (p as { stroke?: string }).stroke === '#64748b')).toBe(true)
   })
 
   it('bounds enclose everything and serialise to valid SVG', () => {

--- a/webapp/src/engine/footingDetail.test.ts
+++ b/webapp/src/engine/footingDetail.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { buildFootingDetail, type FootingDetailInput } from './footingDetail'
+import { planToSvg, type PlanPrimitive } from './planRenderer'
+
+const base: FootingDetailInput = {
+  mark: 'WF-1', B: 1.8, H: 0.4, cover: 75, barDia: 16, bars: 8, barSpacing: 200,
+  colB: 400, colH: 400, dowelDia: 20, foundingElev: -1.5,
+}
+const texts = (p: PlanPrimitive[]) => p.filter((x) => x.kind === 'text').map((x) => (x as { text: string }).text)
+
+describe('footingDetail — typical footing detail sheet', () => {
+  const d = buildFootingDetail(base, { detailNo: '1', sheetRef: 'S-05' })
+
+  it('draws both views (PLAN + SECTION A-A) and a titled detail tag', () => {
+    const t = texts(d.primitives)
+    expect(t).toContain('PLAN')
+    expect(t).toContain('SECTION A-A')
+    expect(t).toContain('A')                       // A-A cut flags
+    expect(d.title).toBe('TYPICAL FOOTING DETAIL — WF-1')
+    expect(t).toContain('S-05'); expect(t).toContain('NTS')
+  })
+
+  it('lays out the two views side by side (section to the right of the plan)', () => {
+    // plan is centred on x=0; the section sits entirely at positive x
+    const rects = d.primitives.filter((p) => p.kind === 'rect') as { x: number; w: number }[]
+    const planFooting = rects.find((r) => Math.abs(r.x + base.B / 2) < 1e-6)!   // x = -B/2
+    expect(planFooting).toBeTruthy()
+    const sectionFooting = rects.find((r) => r.x > base.B)!                     // shifted right by ≥ B
+    expect(sectionFooting.w).toBeCloseTo(base.B, 6)
+  })
+
+  it('lays the bottom mat both ways (n bars) with a matching note', () => {
+    // plan: n bars ∥x + n bars ∥y = 2n rebar lines
+    const rebar = d.primitives.filter((p) => p.kind === 'line' && (p as { stroke?: string }).stroke === '#b45309')
+    expect(rebar.length).toBeGreaterThanOrEqual(2 * base.bars)
+    // section: n perpendicular bar ends drawn as filled circles
+    const barEnds = d.primitives.filter((p) => p.kind === 'circle' && (p as { fill?: string }).fill === '#b45309')
+    expect(barEnds.length).toBe(base.bars)
+    expect(texts(d.primitives).some((s) => s.includes('⌀16') && s.includes('BOTH WAYS'))).toBe(true)
+  })
+
+  it('dimensions the footing width B and depth H in mm', () => {
+    const dims = d.primitives.filter((p) => p.kind === 'dim') as { text: string }[]
+    expect(dims.some((x) => x.text === '1800 mm')).toBe(true)   // B
+    expect(dims.some((x) => x.text === '400 mm')).toBe(true)    // H
+  })
+
+  it('shows column dowels and a top-of-footing elevation with units', () => {
+    const t = texts(d.primitives)
+    expect(t.some((s) => s.startsWith('DOWELS'))).toBe(true)
+    expect(t).toContain('T.O.F. EL -1.50 m')
+  })
+
+  it('bounds enclose everything and serialise to valid SVG', () => {
+    expect(d.bounds.maxX).toBeGreaterThan(d.bounds.minX)
+    const svg = planToSvg(d, 1200)
+    expect(svg.startsWith('<svg')).toBe(true)
+    expect(svg.trimEnd().endsWith('</svg>')).toBe(true)
+  })
+})

--- a/webapp/src/engine/footingDetail.test.ts
+++ b/webapp/src/engine/footingDetail.test.ts
@@ -55,8 +55,8 @@ describe('footingDetail — column-footing detail sheet', () => {
   it('mat bars are straight by default and hooked only when endHook="90"', () => {
     const straight = buildFootingDetail({ ...base, endHook: 'none' }, {})
     const hooked = buildFootingDetail({ ...base, endHook: '90' }, {})
-    // a hooked bar path has more vertices than the straight two-point run
-    const verts = (dw: typeof straight) => dw.primitives.filter((p) => p.kind === 'path').reduce((m, p) => Math.max(m, (p as { cmds: unknown[] }).cmds.length), 0)
+    // hooked mat bars add vertices → more total path vertices than straight runs
+    const verts = (dw: typeof straight) => dw.primitives.filter((p) => p.kind === 'path').reduce((m, p) => m + (p as { cmds: unknown[] }).cmds.length, 0)
     expect(verts(hooked)).toBeGreaterThan(verts(straight))
   })
 

--- a/webapp/src/engine/footingDetail.test.ts
+++ b/webapp/src/engine/footingDetail.test.ts
@@ -35,15 +35,24 @@ describe('footingDetail — column-footing detail sheet', () => {
     const rebar = d.primitives.filter((p) => p.kind === 'path' && (p as { stroke?: string }).stroke === '#b45309')
     expect(rebar.length).toBeGreaterThanOrEqual(2 * base.bars)
     expect(rebar.every((p) => (p as { closed?: boolean }).closed)).toBe(true)
-    // filled rebar circles = n section bar-ends + colBars plan vertical bars
     const ends = d.primitives.filter((p) => p.kind === 'circle' && (p as { fill?: string }).fill === '#b45309')
-    expect(ends.length).toBe(base.bars + (base.colBars ?? 8))
+    // plan column ring (colBars) + section bar-ends (n) + column-section inset ring (colBars)
+    expect(ends.length).toBe(base.bars + 2 * (base.colBars ?? 8))
   })
 
   it('shows the full ring of column vertical bars in plan (not just corners)', () => {
-    const ends = d.primitives.filter((p) => p.kind === 'circle' && (p as { fill?: string }).fill === '#b45309')
-    // colBars column dots + n section bar-ends; the column ring alone must be colBars
-    expect(ends.length - base.bars).toBe(base.colBars)
+    // the plan column dots cluster at the origin; section/inset dots sit far to the right
+    const planDots = d.primitives.filter((p) => p.kind === 'circle' && (p as { fill?: string }).fill === '#b45309'
+      && Math.abs((p as { cx: number }).cx) < base.colB / 1000)
+    expect(planDots.length).toBe(base.colBars)
+  })
+
+  it('draws a COLUMN SECTION inset with the tie wrap (perimeter tie + crossties)', () => {
+    const t = texts(d.primitives)
+    expect(t).toContain('COLUMN SECTION')
+    // the tie wrap is drawn as closed rebar paths that are NOT filled (outlines)
+    const tiePaths = d.primitives.filter((p) => p.kind === 'path' && (p as { stroke?: string; fill?: string }).stroke === '#b45309' && (p as { fill?: string }).fill === 'none' && (p as { closed?: boolean }).closed)
+    expect(tiePaths.length).toBeGreaterThan(0)
   })
 
   it('labels the column ties as LATERAL TIES with a spacing schedule', () => {

--- a/webapp/src/engine/footingDetail.test.ts
+++ b/webapp/src/engine/footingDetail.test.ts
@@ -35,24 +35,15 @@ describe('footingDetail — column-footing detail sheet', () => {
     const rebar = d.primitives.filter((p) => p.kind === 'path' && (p as { stroke?: string }).stroke === '#b45309')
     expect(rebar.length).toBeGreaterThanOrEqual(2 * base.bars)
     expect(rebar.every((p) => (p as { closed?: boolean }).closed)).toBe(true)
+    // filled rebar circles = n section bar-ends + colBars plan vertical bars
     const ends = d.primitives.filter((p) => p.kind === 'circle' && (p as { fill?: string }).fill === '#b45309')
-    // plan column ring (colBars) + section bar-ends (n) + column-section inset ring (colBars)
-    expect(ends.length).toBe(base.bars + 2 * (base.colBars ?? 8))
+    expect(ends.length).toBe(base.bars + (base.colBars ?? 8))
   })
 
   it('shows the full ring of column vertical bars in plan (not just corners)', () => {
-    // the plan column dots cluster at the origin; section/inset dots sit far to the right
-    const planDots = d.primitives.filter((p) => p.kind === 'circle' && (p as { fill?: string }).fill === '#b45309'
-      && Math.abs((p as { cx: number }).cx) < base.colB / 1000)
-    expect(planDots.length).toBe(base.colBars)
-  })
-
-  it('draws a COLUMN SECTION inset with the tie wrap (perimeter tie + crossties)', () => {
-    const t = texts(d.primitives)
-    expect(t).toContain('COLUMN SECTION')
-    // the tie wrap is drawn as closed rebar paths that are NOT filled (outlines)
-    const tiePaths = d.primitives.filter((p) => p.kind === 'path' && (p as { stroke?: string; fill?: string }).stroke === '#b45309' && (p as { fill?: string }).fill === 'none' && (p as { closed?: boolean }).closed)
-    expect(tiePaths.length).toBeGreaterThan(0)
+    const ends = d.primitives.filter((p) => p.kind === 'circle' && (p as { fill?: string }).fill === '#b45309')
+    // colBars column dots + n section bar-ends; the column ring alone must be colBars
+    expect(ends.length - base.bars).toBe(base.colBars)
   })
 
   it('labels the column ties as LATERAL TIES with a spacing schedule', () => {

--- a/webapp/src/engine/footingDetail.test.ts
+++ b/webapp/src/engine/footingDetail.test.ts
@@ -35,15 +35,29 @@ describe('footingDetail — column-footing detail sheet', () => {
     const rebar = d.primitives.filter((p) => p.kind === 'path' && (p as { stroke?: string }).stroke === '#b45309')
     expect(rebar.length).toBeGreaterThanOrEqual(2 * base.bars)
     expect(rebar.every((p) => (p as { closed?: boolean }).closed)).toBe(true)
-    // filled rebar circles = n section bar-ends + 4 plan column vertical bars
+    // filled rebar circles = n section bar-ends + colBars plan vertical bars
     const ends = d.primitives.filter((p) => p.kind === 'circle' && (p as { fill?: string }).fill === '#b45309')
-    expect(ends.length).toBe(base.bars + 4)
+    expect(ends.length).toBe(base.bars + (base.colBars ?? 8))
   })
 
-  it('shows a variable-spaced stirrup schedule callout', () => {
+  it('shows the full ring of column vertical bars in plan (not just corners)', () => {
+    const ends = d.primitives.filter((p) => p.kind === 'circle' && (p as { fill?: string }).fill === '#b45309')
+    // colBars column dots + n section bar-ends; the column ring alone must be colBars
+    expect(ends.length - base.bars).toBe(base.colBars)
+  })
+
+  it('labels the column ties as LATERAL TIES with a spacing schedule', () => {
     const t = texts(d.primitives)
-    expect(t.some((s) => s.startsWith('STIRRUPS = ⌀'))).toBe(true)
+    expect(t.some((s) => s.startsWith('LATERAL TIES = ⌀'))).toBe(true)
     expect(t.some((s) => s.includes('2@50'))).toBe(true)
+  })
+
+  it('mat bars are straight by default and hooked only when endHook="90"', () => {
+    const straight = buildFootingDetail({ ...base, endHook: 'none' }, {})
+    const hooked = buildFootingDetail({ ...base, endHook: '90' }, {})
+    // a hooked bar path has more vertices than the straight two-point run
+    const verts = (dw: typeof straight) => dw.primitives.filter((p) => p.kind === 'path').reduce((m, p) => Math.max(m, (p as { cmds: unknown[] }).cmds.length), 0)
+    expect(verts(hooked)).toBeGreaterThan(verts(straight))
   })
 
   it('chained sub-dimensions in plan and a depth chain in section (mm)', () => {

--- a/webapp/src/engine/footingDetail.test.ts
+++ b/webapp/src/engine/footingDetail.test.ts
@@ -3,52 +3,63 @@ import { buildFootingDetail, type FootingDetailInput } from './footingDetail'
 import { planToSvg, type PlanPrimitive } from './planRenderer'
 
 const base: FootingDetailInput = {
-  mark: 'WF-1', B: 1.8, H: 0.4, cover: 75, barDia: 16, bars: 8, barSpacing: 200,
-  colB: 400, colH: 400, dowelDia: 20, foundingElev: -1.5,
+  mark: 'WF-1', B: 1.2, H: 0.35, cover: 75, barDia: 16, bars: 8, barSpacing: 150,
+  colB: 300, colH: 300, colBars: 8, colBarDia: 16, foundingElev: -1.05,
 }
 const texts = (p: PlanPrimitive[]) => p.filter((x) => x.kind === 'text').map((x) => (x as { text: string }).text)
 
-describe('footingDetail — typical footing detail sheet', () => {
+describe('footingDetail — column-footing detail sheet', () => {
   const d = buildFootingDetail(base, { detailNo: '1', sheetRef: 'S-05' })
 
   it('draws both views (PLAN + SECTION A-A) and a titled detail tag', () => {
     const t = texts(d.primitives)
-    expect(t).toContain('PLAN')
-    expect(t).toContain('SECTION A-A')
-    expect(t).toContain('A')                       // A-A cut flags
-    expect(d.title).toBe('TYPICAL FOOTING DETAIL — WF-1')
-    expect(t).toContain('S-05'); expect(t).toContain('NTS')
+    expect(t).toContain('PLAN'); expect(t).toContain('SECTION A-A'); expect(t).toContain('A')
+    expect(d.title).toBe('COLUMN FOOTING DETAIL — WF-1')
+    expect(t).toContain('S-05'); expect(t).toContain('1:25 MTS')
   })
 
-  it('lays out the two views side by side (section to the right of the plan)', () => {
-    // plan is centred on x=0; the section sits entirely at positive x
+  it('lays the two views side by side (section right of the plan)', () => {
     const rects = d.primitives.filter((p) => p.kind === 'rect') as { x: number; w: number }[]
-    const planFooting = rects.find((r) => Math.abs(r.x + base.B / 2) < 1e-6)!   // x = -B/2
-    expect(planFooting).toBeTruthy()
-    const sectionFooting = rects.find((r) => r.x > base.B)!                     // shifted right by ≥ B
-    expect(sectionFooting.w).toBeCloseTo(base.B, 6)
+    expect(rects.some((r) => Math.abs(r.x + base.B / 2) < 1e-6)).toBe(true)   // plan footing at x=-B/2
+    expect(rects.some((r) => r.x > base.B && Math.abs(r.w - base.B) < 1e-6)).toBe(true)   // section footing shifted right
   })
 
-  it('lays the bottom mat both ways (n bars) with a matching note', () => {
-    // plan: n bars ∥x + n bars ∥y = 2n rebar lines
-    const rebar = d.primitives.filter((p) => p.kind === 'line' && (p as { stroke?: string }).stroke === '#b45309')
-    expect(rebar.length).toBeGreaterThanOrEqual(2 * base.bars)
-    // section: n perpendicular bar ends drawn as filled circles
-    const barEnds = d.primitives.filter((p) => p.kind === 'circle' && (p as { fill?: string }).fill === '#b45309')
-    expect(barEnds.length).toBe(base.bars)
-    expect(texts(d.primitives).some((s) => s.includes('⌀16') && s.includes('BOTH WAYS'))).toBe(true)
-  })
-
-  it('dimensions the footing width B and depth H in mm', () => {
-    const dims = d.primitives.filter((p) => p.kind === 'dim') as { text: string }[]
-    expect(dims.some((x) => x.text === '1800 mm')).toBe(true)   // B
-    expect(dims.some((x) => x.text === '400 mm')).toBe(true)    // H
-  })
-
-  it('shows column dowels and a top-of-footing elevation with units', () => {
+  it('labels reinforcement with count + diameter (Ø) both ways and vertical bars', () => {
     const t = texts(d.primitives)
-    expect(t.some((s) => s.startsWith('DOWELS'))).toBe(true)
-    expect(t).toContain('T.O.F. EL -1.50 m')
+    expect(t.some((s) => s === '8-16mmØ BOTHWAY')).toBe(true)
+    expect(t.some((s) => s === '8-16mmØ VERT. BARS')).toBe(true)
+  })
+
+  it('draws the bottom mat with END HOOKS (bars are polylines, not plain spans)', () => {
+    // each plan mat bar is a 3-segment hooked polyline → ≥ 3 rebar segments per bar,
+    // both ways ⇒ well over 2·bars rebar lines
+    const rebar = d.primitives.filter((p) => p.kind === 'line' && (p as { stroke?: string }).stroke === '#b45309')
+    expect(rebar.length).toBeGreaterThan(4 * base.bars)
+    // filled rebar circles = n section bar-ends + 4 plan column vertical bars
+    const ends = d.primitives.filter((p) => p.kind === 'circle' && (p as { fill?: string }).fill === '#b45309')
+    expect(ends.length).toBe(base.bars + 4)
+  })
+
+  it('shows a variable-spaced stirrup schedule callout', () => {
+    const t = texts(d.primitives)
+    expect(t.some((s) => s.startsWith('STIRRUPS = ⌀'))).toBe(true)
+    expect(t.some((s) => s.includes('2@50'))).toBe(true)
+  })
+
+  it('chained sub-dimensions in plan and a depth chain in section (mm)', () => {
+    const dims = d.primitives.filter((p) => p.kind === 'dim') as { text: string }[]
+    expect(dims.some((x) => x.text === '1200 mm')).toBe(true)   // overall B
+    expect(dims.some((x) => x.text === '300')).toBe(true)       // column sub-dim (col width)
+    expect(dims.some((x) => x.text === '450')).toBe(true)       // edge sub-dim (B−col)/2
+    expect(dims.some((x) => x.text === '350')).toBe(true)       // footing depth H
+  })
+
+  it('marks the natural grade, a gravel base and the T.O.F. elevation', () => {
+    const t = texts(d.primitives)
+    expect(t).toContain('NATURAL GRADE LINE')
+    expect(t).toContain('T.O.F. EL -1.05 m')
+    // gravel aggregate circles (unfilled, hatch stroke) under the footing
+    expect(d.primitives.some((p) => p.kind === 'circle' && (p as { stroke?: string }).stroke === '#94a3b8')).toBe(true)
   })
 
   it('bounds enclose everything and serialise to valid SVG', () => {

--- a/webapp/src/engine/footingDetail.ts
+++ b/webapp/src/engine/footingDetail.ts
@@ -290,48 +290,6 @@ export function buildFootingDetail(f: FootingDetailInput, opts: FootingDetailOpt
     P.push({ kind: 'text', x: secL, y: footTop - ts * 0.5, text: `T.O.F. EL ${f.foundingElev.toFixed(2)} m`, size: ts * 0.5, anchor: 'start', color: PANEL, weight: 600 })
   P.push({ kind: 'text', x: sx0, y: gravBot + ts * 2.4, text: 'SECTION A-A', size: ts * 0.85, anchor: 'middle', color: INK, weight: 700 })
 
-  // ══ COLUMN SECTION inset — enlarged column cross-section showing the exact
-  // tie wrap: a perimeter tie hugging the corner bars + interior crossties that
-  // hook 180° around the interior bars (mirrors the report / ColumnSchematic) ══
-  {
-    const side = Math.min(gap * 0.56, B * 0.55)   // drawn column size (enlarged)
-    const sc = side / cw
-    const cxI = hp + gap * 0.4, cyI = 0           // sit in the clear part of the gap, left of the section's dim chain
-    const halfW = side / 2, halfH = (cd / cw) * side / 2
-    const bx = (fx: number) => cxI + fx * sc
-    const by = (fy: number) => cyI + fy * sc
-    const br = Math.max((colBarDia / 2000) * sc, side * 0.03)
-    const rTt = Math.max((tieDia / 2000) * sc, side * 0.012)
-    const tx0 = bx(colX1), tx1 = bx(colX2), ty0 = by(colY1), ty1 = by(colY2)
-    // column concrete outline
-    P.push({ kind: 'rect', x: cxI - halfW, y: cyI - halfH, w: side, h: 2 * halfH, stroke: INK, fill: '#fff', width: 1.4 })
-    // perimeter tie — rounded rectangle around the corner bars
-    const rr = Math.min(tx1 - tx0, ty1 - ty0) * 0.26
-    P.push({ kind: 'path', stroke: REBAR, width: 1.4, fill: 'none', closed: true, cmds: [
-      { c: 'M', x: tx0 + rr, y: ty0 }, { c: 'L', x: tx1 - rr, y: ty0 }, { c: 'A', rx: rr, ry: rr, x: tx1, y: ty0 + rr, sweep: 1 },
-      { c: 'L', x: tx1, y: ty1 - rr }, { c: 'A', rx: rr, ry: rr, x: tx1 - rr, y: ty1, sweep: 1 },
-      { c: 'L', x: tx0 + rr, y: ty1 }, { c: 'A', rx: rr, ry: rr, x: tx0, y: ty1 - rr, sweep: 1 },
-      { c: 'L', x: tx0, y: ty0 + rr }, { c: 'A', rx: rr, ry: rr, x: tx0 + rr, y: ty0, sweep: 1 },
-    ] })
-    // crosstie: a stadium loop grabbing bars A and B with a 180° hook at each
-    const hookR = br + rTt * 1.2
-    const stadium = (ax: number, ay: number, bx2: number, by2: number, odx: number, ody: number) =>
-      P.push({ kind: 'path', stroke: REBAR, width: 1.1, fill: 'none', closed: true, cmds: [
-        { c: 'M', x: ax + odx * hookR, y: ay + ody * hookR },
-        { c: 'L', x: bx2 + odx * hookR, y: by2 + ody * hookR },
-        { c: 'A', rx: hookR, ry: hookR, x: bx2 - odx * hookR, y: by2 - ody * hookR, sweep: 1 },
-        { c: 'L', x: ax - odx * hookR, y: ay - ody * hookR },
-        { c: 'A', rx: hookR, ry: hookR, x: ax + odx * hookR, y: ay + ody * hookR, sweep: 1 },
-      ] })
-    for (const fx of rowFx.slice(1, -1)) stadium(bx(fx), ty0, bx(fx), ty1, 1, 0)   // interior top/bottom bars
-    for (const fy of sideFy) stadium(tx0, by(fy), tx1, by(fy), 0, 1)               // interior side bars
-    // vertical bars (dots)
-    for (const fx of rowFx) { P.push({ kind: 'circle', cx: bx(fx), cy: ty0, r: br, stroke: REBAR, fill: REBAR, width: 0.4 }); P.push({ kind: 'circle', cx: bx(fx), cy: ty1, r: br, stroke: REBAR, fill: REBAR, width: 0.4 }) }
-    for (const fy of sideFy) { P.push({ kind: 'circle', cx: tx0, cy: by(fy), r: br, stroke: REBAR, fill: REBAR, width: 0.4 }); P.push({ kind: 'circle', cx: tx1, cy: by(fy), r: br, stroke: REBAR, fill: REBAR, width: 0.4 }) }
-    P.push({ kind: 'text', x: cxI, y: cyI + halfH + ts * 1.0, text: 'COLUMN SECTION', size: ts * 0.6, anchor: 'middle', color: INK, weight: 700 })
-    P.push({ kind: 'text', x: cxI, y: cyI + halfH + ts * 1.8, text: `${colBars}-⌀${colBarDia} · TIES ⌀${tieDia}`, size: ts * 0.45, anchor: 'middle', color: REBAR, weight: 600 })
-  }
-
   // ══ detail-tag title block ═════════════════════════════════════════════
   const detailNo = opts.detailNo ?? '1', sheetRef = opts.sheetRef ?? 'S-05', scale = opts.scale ?? '1:25 MTS'
   const title = `COLUMN FOOTING DETAIL — ${f.mark}`

--- a/webapp/src/engine/footingDetail.ts
+++ b/webapp/src/engine/footingDetail.ts
@@ -47,11 +47,14 @@ export interface FootingDetailInput {
   /** Column vertical bars — count and diameter (default 8 × mat bar). */
   colBars?: number
   colBarDia?: number
-  /** Tie/stirrup diameter, mm (default 10). */
-  stirrupDia?: number
-  /** Tie set from the footing up: [count, spacing mm] groups, then rest @ … */
-  stirrupSchedule?: [number, number][]
-  stirrupRest?: number
+  /** Column LATERAL TIE diameter, mm (default 10). */
+  tieDia?: number
+  /** Lateral-tie set from the footing up: [count, spacing mm] groups, then rest @ … */
+  tieSchedule?: [number, number][]
+  tieRest?: number
+  /** Mat-bar end detail — '90' hook or 'none' (straight). Design-driven; only
+   *  hook footings whose design calls for it. Default 'none'. */
+  endHook?: '90' | 'none'
   /** Gravel/lean base thickness, m (default 0.1). */
   gravel?: number
   /** Column projection above natural grade, m (default 0.3). */
@@ -111,35 +114,47 @@ export function buildFootingDetail(f: FootingDetailInput, opts: FootingDetailOpt
   const barX = (i: number) => -hp + c + (inner * i) / (n - 1)
   const ts = B * 0.075
   const gap = B * 1.05
-  const hook = Math.min(0.12, B * 0.07)        // 90° hook leg length (m)
+  const hookLen = (f.endHook ?? 'none') === '90' ? Math.min(0.12, B * 0.07) : 0   // mat-bar end hook (0 = straight)
   const rMain = Math.max(bd / 2, B * 0.007)    // drawn bar radius (mat/dowels)
-  const rTie = Math.max((f.stirrupDia ?? 10) / 2000, B * 0.005)   // stirrups thinner
   const colBars = f.colBars ?? 8, colBarDia = f.colBarDia ?? f.barDia
-  const stDia = f.stirrupDia ?? 10
-  const stSched = f.stirrupSchedule ?? [[2, 50], [2, 75], [5, 100], [7, 150]]
-  const stRest = f.stirrupRest ?? 200
+  const tieDia = f.tieDia ?? 10
+  const rTie = Math.max(tieDia / 2000, B * 0.005)   // lateral ties thinner
+  const tieSched = f.tieSchedule ?? [[2, 50], [2, 75], [5, 100], [7, 150]]
+  const tieRest = f.tieRest ?? 200
   const hg = f.gravel ?? 0.1
   const aboveGrade = f.aboveGrade ?? 0.3
   const embed = f.foundingElev != null ? Math.abs(f.foundingElev) : Math.max(1.0, H * 3)
 
+  // Column bar layout — 4 corners + the rest split between the b/h faces in
+  // proportion to face length (mirrors ColumnSchematic / the engine's
+  // 'all-around' layers). Gives the plan its dots and the section its verticals.
+  const cInset = c + tieDia / 1000 + colBarDia / 2000   // cover + tie + ½bar, m
+  const N = Math.max(4, 2 * Math.round(colBars / 2))
+  const bwIn = Math.max(1e-3, cw - 2 * cInset), hIn = Math.max(1e-3, cd - 2 * cInset)
+  const nx = Math.max(2, Math.min(2 + Math.round(((N - 4) / 2) * (bwIn / (bwIn + hIn))), N / 2))
+  const ny = N / 2 + 2 - nx
+  const rowFx = Array.from({ length: nx }, (_, i) => (nx === 1 ? 0 : -cw / 2 + cInset + ((cw - 2 * cInset) * i) / (nx - 1)))   // bar x, column-local
+  const sideFy = Array.from({ length: Math.max(0, ny - 2) }, (_, i) => -cd / 2 + cInset + ((cd - 2 * cInset) * (i + 1)) / (ny - 1))
+
   // ══ PLAN (centred at origin) ═══════════════════════════════════════════
   P.push({ kind: 'rect', x: -hp, y: -hp, w: B, h: B, stroke: INK, fill: 'none', width: 1.4 })
-  // bottom mat, both ways, each bar hooked 90° toward the footing interior
+  // bottom mat, both ways — straight, or (when the design calls for it) with a
+  // 90° end hook that hugs the perpendicular perimeter bar
   const xo = -hp + c, xf = hp - c   // outermost mat-bar lines (= perimeter bars)
-  const hd = (p: number) => (p < 0 ? hook : -hook)   // 90° hook, turned toward the footing centre
+  const hd = (p: number) => (p < 0 ? hookLen : -hookLen)
   for (let i = 0; i < n; i++) {
     const p = barX(i)
-    // ∥x bar: straight run xo→xf, each end hooking along the perpendicular
-    // perimeter bar it meets (at xo and xf) — i.e. the hook hugs that bar
-    rod([[xo, p + hd(p)], [xo, p], [xf, p], [xf, p + hd(p)]], rMain)
-    rod([[p + hd(p), xo], [p, xo], [p, xf], [p + hd(p), xf]], rMain)   // ∥y bar, mirror
+    rod(hookLen ? [[xo, p + hd(p)], [xo, p], [xf, p], [xf, p + hd(p)]] : [[xo, p], [xf, p]], rMain)
+    rod(hookLen ? [[p + hd(p), xo], [p, xo], [p, xf], [p + hd(p), xf]] : [[p, xo], [p, xf]], rMain)
   }
-  // column footprint + vertical bars (corner circles) + a tie square
+  // column footprint + LATERAL TIE outline + the full ring of vertical bars
   P.push({ kind: 'rect', x: -cw / 2, y: -cd / 2, w: cw, h: cd, stroke: COL, fill: '#fff', width: 1.1 })
-  P.push({ kind: 'rect', x: -cw / 2 + c * 0.5, y: -cd / 2 + c * 0.5, w: cw - c, h: cd - c, stroke: REBAR, fill: 'none', width: 1.0 })
+  P.push({ kind: 'rect', x: -cw / 2 + cInset, y: -cd / 2 + cInset, w: cw - 2 * cInset, h: cd - 2 * cInset, stroke: REBAR, fill: 'none', width: 1.0 })
   const vr = Math.max(colBarDia / 2000, B * 0.008)
-  for (const sxp of [-1, 1]) for (const szp of [-1, 1])
-    P.push({ kind: 'circle', cx: sxp * (cw / 2 - c * 0.7), cy: szp * (cd / 2 - c * 0.7), r: vr, stroke: REBAR, fill: REBAR, width: 0.5 })
+  const colX1 = -cw / 2 + cInset, colX2 = cw / 2 - cInset, colY1 = -cd / 2 + cInset, colY2 = cd / 2 - cInset
+  const dot = (x: number, y: number) => P.push({ kind: 'circle', cx: x, cy: y, r: vr, stroke: REBAR, fill: REBAR, width: 0.5 })
+  for (const x of rowFx) { dot(x, colY1); dot(x, colY2) }   // top & bottom faces
+  for (const y of sideFy) { dot(colX1, y); dot(colX2, y) }  // interior side-face bars
   // A–A cut line through the centre
   const aExt = hp + ts * 1.6
   P.push({ kind: 'line', x1: -aExt, y1: 0, x2: aExt, y2: 0, stroke: INK, width: 0.6, dash: [0.12, 0.06, 0.03, 0.06] })
@@ -205,22 +220,28 @@ export function buildFootingDetail(f: FootingDetailInput, opts: FootingDetailOpt
   const zLong = H - c - rMain                       // in-plane bar centre (bottom layer, on cover)
   const rDot = rMain * 0.9
   const zPerp = zLong - rMain - rDot                 // perpendicular bars sit tangent on top
-  rod([[secL + c, zPerp - rDot], [secL + c, zLong], [secR - c, zLong], [secR - c, zPerp - rDot]], rMain)
+  const upHook = hookLen ? Math.min(hookLen, H * 0.45) : 0
+  rod(upHook ? [[secL + c, zLong - upHook], [secL + c, zLong], [secR - c, zLong], [secR - c, zLong - upHook]]
+             : [[secL + c, zLong], [secR - c, zLong]], rMain)
   for (let i = 0; i < n; i++)
     P.push({ kind: 'circle', cx: sx0 + barX(i), cy: zPerp, r: rDot, stroke: REBAR, fill: REBAR, width: 0.4 })
-  // column vertical bars / dowels — full height, footed out to rest on the mat
-  const vx = [cl + c, cr - c]
-  for (const dx of vx) {
+  // column vertical bars — one per bar x-position visible in the section (from
+  // the same layout as the plan); the two outer bars foot out onto the mat
+  const secVx = rowFx.map((fx) => sx0 + fx)
+  for (const dx of secVx) {
+    const outer = Math.abs(dx - sx0) > cw / 2 - cInset - 1e-6
     const dir = dx < sx0 ? -1 : 1
-    rod([[dx, colTop + c], [dx, zLong], [dx + dir * (cw * 0.42), zLong]], rMain)
+    rod(outer ? [[dx, colTop + c], [dx, zLong], [dx + dir * (cw * 0.3), zLong]]
+              : [[dx, colTop + c], [dx, zLong]], rMain)
   }
-  // stirrups up the column at the scheduled spacing (each a thin closed tube)
+  // lateral ties up the column at the scheduled spacing (each a thin closed tube)
   const stX0 = cl + c * 0.6, stX1 = cr - c * 0.6
   let z = 0
   const stopZ = -(embed + aboveGrade) + c
-  const drawStirrup = () => { if (-z > stopZ) rod([[stX0, -z], [stX1, -z]], rTie) }
-  for (const [count, sp] of stSched) for (let k = 0; k < count; k++) { z += sp / 1000; drawStirrup() }
-  while (-z > stopZ) { z += stRest / 1000; drawStirrup() }
+  const tieZs: number[] = []
+  const drawTie = () => { if (-z > stopZ) { rod([[stX0, -z], [stX1, -z]], rTie); tieZs.push(-z) } }
+  for (const [count, sp] of tieSched) for (let k = 0; k < count; k++) { z += sp / 1000; drawTie() }
+  while (-z > stopZ) { z += tieRest / 1000; drawTie() }
   // depth dimension chain (embedment / footing / gravel) + overall
   const dX = secL - ts * 1.4
   for (const [a, b] of [[gradeZ, footTop], [footTop, footBot], [footBot, gravBot]] as const)
@@ -232,15 +253,24 @@ export function buildFootingDetail(f: FootingDetailInput, opts: FootingDetailOpt
   for (const zb of [gradeZ, footTop, footBot, gravBot]) ext(dX, zb, secL, zb)
   for (const zb of [gradeZ, gravBot]) ext(dX - ts * 1.4, zb, dX, zb)
   for (const xb of [secL, secR]) ext(xb, gravBot + ts * 1.2, xb, gravBot)
-  // callouts with leaders
-  const lead = (x1: number, y1: number, x2: number, y2: number) => P.push({ kind: 'line', x1, y1, x2, y2, stroke: INK, width: 0.5 })
-  lead(cr, colTop * 0.75, secR + ts * 0.6, colTop * 0.75)
-  P.push({ kind: 'text', x: secR + ts * 0.8, y: colTop * 0.75, text: `${colBars}-${colBarDia}mmØ VERT. BARS`, size: ts * 0.55, anchor: 'start', color: REBAR, weight: 600 })
-  lead(cr, gradeZ * 0.55, secR + ts * 0.6, gradeZ * 0.55)
-  const stLines = [`STIRRUPS = ⌀${stDia} REBAR`, `${stSched.map(([cc, ss]) => `${cc}@${ss}`).join(', ')},`, `REST @ ${stRest} mm O.C.`]
-  stLines.forEach((s, i) => P.push({ kind: 'text', x: secR + ts * 0.8, y: gradeZ * 0.55 + i * ts * 0.72, text: s, size: ts * 0.5, anchor: 'start', color: INK, weight: 500 }))
-  lead(secR - c, zLong, secR + ts * 0.6, zLong + ts * 0.6)
-  P.push({ kind: 'text', x: secR + ts * 0.8, y: zLong + ts * 0.6, text: `${n}-${f.barDia}mmØ BOTHWAY`, size: ts * 0.55, anchor: 'start', color: REBAR, weight: 600 })
+  // callouts — each leader starts ON the element it names (a dot marks the tap)
+  const lead = (ex: number, ey: number, tx: number, ty: number) => {
+    P.push({ kind: 'line', x1: ex, y1: ey, x2: tx, y2: ty, stroke: INK, width: 0.5 })
+    P.push({ kind: 'circle', cx: ex, cy: ey, r: ts * 0.06, stroke: INK, fill: INK, width: 0.4 })
+  }
+  // → a column vertical bar
+  const rightVx = secVx.length ? Math.max(...secVx) : cr - c
+  const vy = colTop * 0.6
+  lead(rightVx, vy, secR + ts * 0.7, vy)
+  P.push({ kind: 'text', x: secR + ts * 0.9, y: vy, text: `${colBars}-${colBarDia}mmØ VERT. BARS`, size: ts * 0.55, anchor: 'start', color: REBAR, weight: 600 })
+  // → a lateral tie
+  const tieY = tieZs.length ? tieZs[Math.floor(tieZs.length * 0.55)] : gradeZ * 0.55
+  lead(stX1, tieY, secR + ts * 0.7, tieY)
+  const tieLines = [`LATERAL TIES = ⌀${tieDia}`, `${tieSched.map(([cc, ss]) => `${cc}@${ss}`).join(', ')},`, `REST @ ${tieRest} mm O.C.`]
+  tieLines.forEach((s, i) => P.push({ kind: 'text', x: secR + ts * 0.9, y: tieY + (i - 1) * ts * 0.72, text: s, size: ts * 0.5, anchor: 'start', color: INK, weight: 500 }))
+  // → the bottom mat bar
+  lead(secR - c, zLong, secR + ts * 0.7, zLong + ts * 0.7)
+  P.push({ kind: 'text', x: secR + ts * 0.9, y: zLong + ts * 0.7, text: `${n}-${f.barDia}mmØ BOTHWAY`, size: ts * 0.55, anchor: 'start', color: REBAR, weight: 600 })
   if (f.foundingElev != null)
     P.push({ kind: 'text', x: secL, y: footTop - ts * 0.5, text: `T.O.F. EL ${f.foundingElev.toFixed(2)} m`, size: ts * 0.5, anchor: 'start', color: PANEL, weight: 600 })
   P.push({ kind: 'text', x: sx0, y: gravBot + ts * 2.4, text: 'SECTION A-A', size: ts * 0.85, anchor: 'middle', color: INK, weight: 700 })

--- a/webapp/src/engine/footingDetail.ts
+++ b/webapp/src/engine/footingDetail.ts
@@ -1,17 +1,20 @@
 // ─────────────────────────────────────────────────────────────────────────
-// Footing detail sheet — a standalone CAD detail (bar-mat PLAN + SECTION A-A)
-// for one isolated square footing, built from its designed geometry. Emits the
-// same typed PlanPrimitive[] the plan renderer uses, so planToSvg paints it.
+// Column-footing detail sheet — a bar-mat PLAN + a reinforced SECTION for one
+// isolated square footing, built from its designed geometry. Emits the same
+// typed PlanPrimitive[] the plan renderer uses, so planToSvg paints it.
 //
-// Two views laid out side by side in world metres:
-//   • PLAN — footing outline, column footprint, the bottom reinforcing mat
-//     (bars both ways), and the A–A cut line.
-//   • SECTION A–A — footing depth, column stub with dowels + ties, the bottom
-//     mat shown in section, cover, and B/H dimensions.
-// A detail-tag title block sits below, per the "n / S-xx" convention.
+// The reinforcement is drawn as real bars with their end HOOKS/BENDS shown in
+// full (ACI 318-14 §25.3 standard hooks, §25.4 development, §13.3 footing bar
+// placement): the bottom mat hooks up at every end, the column dowels bend out
+// onto the mat, and the column carries a variable-spaced stirrup set.
 //
-// Units: geometry m; bar/column sizes mm.  Detailing follows ACI 318-14
-// §25.4 (development/hooks) and §13.3 (footing reinforcement placement).
+//   • PLAN — footing outline, chained sub-dimensions, the bottom mat both ways
+//     with end hooks, the column footprint + vertical bars.
+//   • SECTION — column with stirrups + vertical bars/dowels hooked onto the
+//     mat, footing on a gravel base, natural-grade line with soil hatch, and a
+//     chained depth dimension.
+//
+// Units: geometry m; bar/column sizes mm.
 // ─────────────────────────────────────────────────────────────────────────
 import type { PlanPrimitive, Drawing } from './planRenderer'
 
@@ -20,143 +23,193 @@ export interface FootingDetailInput {
   mark: string
   /** Plan side B, m. */
   B: number
-  /** Total footing depth H, m. */
+  /** Total footing depth (thickness) H, m. */
   H: number
   /** Clear cover, mm. */
   cover: number
-  /** Main mat bar diameter, mm. */
+  /** Bottom-mat bar diameter, mm, and count each way. */
   barDia: number
-  /** Bars each way (count). */
   bars: number
   /** Bar spacing, mm. */
   barSpacing: number
   /** Column width (x) and depth (y), mm. */
   colB: number
   colH?: number
-  /** Dowel (column vertical) bar diameter, mm — defaults to the mat bar. */
-  dowelDia?: number
-  /** Top-of-footing elevation, m (−down). */
+  /** Column vertical bars — count and diameter (default 8 × mat bar). */
+  colBars?: number
+  colBarDia?: number
+  /** Tie/stirrup diameter, mm (default 10). */
+  stirrupDia?: number
+  /** Tie set from the footing up: [count, spacing mm] groups, then rest @ … */
+  stirrupSchedule?: [number, number][]
+  stirrupRest?: number
+  /** Gravel/lean base thickness, m (default 0.1). */
+  gravel?: number
+  /** Column projection above natural grade, m (default 0.3). */
+  aboveGrade?: number
+  /** Top-of-footing elevation, m (−down); its magnitude is the embedment. */
   foundingElev?: number
 }
 
-export interface FootingDetailOptions {
-  detailNo?: string
-  sheetRef?: string
-  scale?: string
-}
-
+export interface FootingDetailOptions { detailNo?: string; sheetRef?: string; scale?: string }
 export interface DetailDrawing extends Drawing { title: string }
 
 const INK = '#1e293b', COL = '#1e293b', REBAR = '#b45309', HATCH = '#94a3b8', PANEL = '#0f766e'
+const RW = 2.4   // rebar line weight (px) — bars read as solid rod, not hairline
 
-/** Build a typical-footing detail (plan + section) from a designed footing. */
+/** Build a column-footing detail (plan + section) from a designed footing. */
 export function buildFootingDetail(f: FootingDetailInput, opts: FootingDetailOptions = {}): DetailDrawing {
   const P: PlanPrimitive[] = []
+  const bar = (pts: [number, number][], w = RW) => {   // bold rebar polyline
+    for (let i = 0; i < pts.length - 1; i++)
+      P.push({ kind: 'line', x1: pts[i][0], y1: pts[i][1], x2: pts[i + 1][0], y2: pts[i + 1][1], stroke: REBAR, width: w })
+  }
+
   const B = f.B, H = f.H
-  const c = f.cover / 1000                       // cover, m
-  const cw = f.colB / 1000, cd = (f.colH ?? f.colB) / 1000   // column, m
-  const bd = f.barDia / 1000                      // mat bar dia, m
+  const c = f.cover / 1000
+  const cw = f.colB / 1000, cd = (f.colH ?? f.colB) / 1000
+  const bd = f.barDia / 1000
   const n = Math.max(2, Math.round(f.bars))
   const hp = B / 2
-  const inner = B - 2 * c                          // mat clear span
-  const barX = (i: number) => -hp + c + (inner * i) / (n - 1)   // bar coord in [-hp+c, hp-c]
-  const ts = B * 0.09                              // base text height, m
-  const gap = B * 0.7                              // gap between the two views
+  const inner = B - 2 * c
+  const barX = (i: number) => -hp + c + (inner * i) / (n - 1)
+  const ts = B * 0.075
+  const gap = B * 1.05
+  const hook = Math.min(0.12, B * 0.07)        // 90° hook leg length (m)
+  const colBars = f.colBars ?? 8, colBarDia = f.colBarDia ?? f.barDia
+  const stDia = f.stirrupDia ?? 10
+  const stSched = f.stirrupSchedule ?? [[2, 50], [2, 75], [5, 100], [7, 150]]
+  const stRest = f.stirrupRest ?? 200
+  const hg = f.gravel ?? 0.1
+  const aboveGrade = f.aboveGrade ?? 0.3
+  const embed = f.foundingElev != null ? Math.abs(f.foundingElev) : Math.max(1.0, H * 3)
 
-  // ── PLAN view (centred at origin) ──────────────────────────────────────
-  P.push({ kind: 'rect', x: -hp, y: -hp, w: B, h: B, stroke: INK, fill: 'none', width: 1.5 })
-  // column footprint (dashed)
-  P.push({ kind: 'rect', x: -cw / 2, y: -cd / 2, w: cw, h: cd, stroke: COL, fill: 'none', width: 1.1, dash: [0.05, 0.035] })
-  // bottom mat — bars both ways
+  // ══ PLAN (centred at origin) ═══════════════════════════════════════════
+  P.push({ kind: 'rect', x: -hp, y: -hp, w: B, h: B, stroke: INK, fill: 'none', width: 1.4 })
+  // bottom mat, both ways, each bar hooked 90° toward the footing interior
   for (let i = 0; i < n; i++) {
     const p = barX(i)
-    P.push({ kind: 'line', x1: -hp + c, y1: p, x2: hp - c, y2: p, stroke: REBAR, width: 0.8 })   // bars ∥ x
-    P.push({ kind: 'line', x1: p, y1: -hp + c, x2: p, y2: hp - c, stroke: REBAR, width: 0.8 })   // bars ∥ y
+    const dz = p < 0 ? hook : -hook, dx = p < 0 ? hook : -hook
+    bar([[-hp + c, p + dz], [-hp + c, p], [hp - c, p], [hp - c, p + dz]])   // bar ∥ x
+    bar([[p + dx, -hp + c], [p, -hp + c], [p, hp - c], [p + dx, hp - c]])   // bar ∥ y
   }
-  // A–A cut line (horizontal, through the centre) with end flags
-  const aY = 0, aExt = hp + ts * 1.4
-  P.push({ kind: 'line', x1: -aExt, y1: aY, x2: aExt, y2: aY, stroke: INK, width: 0.7, dash: [0.12, 0.06, 0.03, 0.06] })
-  for (const sx of [-1, 1]) {
-    P.push({ kind: 'text', x: sx * aExt, y: aY - ts * 0.55, text: 'A', size: ts * 0.9, anchor: 'middle', color: INK, weight: 700 })
-    // arrow head toward the cut
-    P.push({ kind: 'line', x1: sx * aExt, y1: aY, x2: sx * (aExt - ts * 0.4), y2: aY - ts * 0.25, stroke: INK, width: 0.8 })
-    P.push({ kind: 'line', x1: sx * aExt, y1: aY, x2: sx * (aExt - ts * 0.4), y2: aY + ts * 0.25, stroke: INK, width: 0.8 })
+  // column footprint + vertical bars (corner circles) + a tie square
+  P.push({ kind: 'rect', x: -cw / 2, y: -cd / 2, w: cw, h: cd, stroke: COL, fill: '#fff', width: 1.1 })
+  P.push({ kind: 'rect', x: -cw / 2 + c * 0.5, y: -cd / 2 + c * 0.5, w: cw - c, h: cd - c, stroke: REBAR, fill: 'none', width: 1.0 })
+  const vr = Math.max(colBarDia / 2000, B * 0.008)
+  for (const sxp of [-1, 1]) for (const szp of [-1, 1])
+    P.push({ kind: 'circle', cx: sxp * (cw / 2 - c * 0.7), cy: szp * (cd / 2 - c * 0.7), r: vr, stroke: REBAR, fill: REBAR, width: 0.5 })
+  // A–A cut line through the centre
+  const aExt = hp + ts * 1.6
+  P.push({ kind: 'line', x1: -aExt, y1: 0, x2: aExt, y2: 0, stroke: INK, width: 0.6, dash: [0.12, 0.06, 0.03, 0.06] })
+  for (const sxp of [-1, 1]) {
+    P.push({ kind: 'text', x: sxp * aExt, y: -ts * 0.6, text: 'A', size: ts * 0.9, anchor: 'middle', color: INK, weight: 700 })
+    P.push({ kind: 'line', x1: sxp * aExt, y1: 0, x2: sxp * (aExt - ts * 0.45), y2: -ts * 0.28, stroke: INK, width: 0.8 })
+    P.push({ kind: 'line', x1: sxp * aExt, y1: 0, x2: sxp * (aExt - ts * 0.45), y2: ts * 0.28, stroke: INK, width: 0.8 })
   }
-  // mat note + view label
-  P.push({ kind: 'text', x: 0, y: -hp - ts * 0.7, text: `${n}-⌀${f.barDia} @ ${Math.round(f.barSpacing)} mm BOTH WAYS`, size: ts * 0.62, anchor: 'middle', color: REBAR, weight: 600 })
-  // width dimension along the bottom
-  const pdY = hp + ts * 1.1
-  P.push({ kind: 'dim', x1: -hp, y1: pdY, x2: hp, y2: pdY, text: `${Math.round(B * 1000)} mm`, off: 0, size: ts * 0.7 })
-  P.push({ kind: 'text', x: 0, y: pdY + ts * 1.1, text: 'PLAN', size: ts * 0.85, anchor: 'middle', color: INK, weight: 700 })
+  // chained sub-dimensions: edge / column / edge, both ways, + overall
+  const edge = (B - cw) / 2
+  const pTop = -hp - ts * 1.2, pTop2 = -hp - ts * 2.6
+  const xseg = [[-hp, -cw / 2], [-cw / 2, cw / 2], [cw / 2, hp]] as const
+  for (const [a, b] of xseg)
+    P.push({ kind: 'dim', x1: a, y1: pTop, x2: b, y2: pTop, text: `${Math.round((b - a) * 1000)}`, off: 0, size: ts * 0.6 })
+  P.push({ kind: 'dim', x1: -hp, y1: pTop2, x2: hp, y2: pTop2, text: `${Math.round(B * 1000)} mm`, off: 0, size: ts * 0.7 })
+  const pL = -hp - ts * 1.2
+  const zseg = [[-hp, -cd / 2], [-cd / 2, cd / 2], [cd / 2, hp]] as const
+  for (const [a, b] of zseg)
+    P.push({ kind: 'dim', x1: pL, y1: a, x2: pL, y2: b, text: `${Math.round((b - a) * 1000)}`, off: 0, size: ts * 0.6 })
+  void edge
+  // labels
+  P.push({ kind: 'text', x: 0, y: hp + ts * 1.4, text: `${n}-${f.barDia}mmØ BOTHWAY`, size: ts * 0.7, anchor: 'middle', color: REBAR, weight: 700 })
+  P.push({ kind: 'text', x: 0, y: hp + ts * 2.5, text: 'PLAN', size: ts * 0.85, anchor: 'middle', color: INK, weight: 700 })
 
-  // ── SECTION A–A view (to the right) ────────────────────────────────────
-  const sx0 = hp + gap + hp          // section centre x
+  // ══ SECTION A–A (to the right) ═════════════════════════════════════════
+  const sx0 = hp + gap + hp
   const secL = sx0 - hp, secR = sx0 + hp
-  const zTop = 0, zBot = H
-  const stubH = Math.max(0.5, H * 1.4)   // column stub shown above the footing
-  // footing block + column stub
-  P.push({ kind: 'rect', x: secL, y: zTop, w: B, h: H, stroke: INK, fill: 'none', width: 1.5 })
-  P.push({ kind: 'rect', x: sx0 - cw / 2, y: -stubH, w: cw, h: stubH, stroke: INK, fill: 'none', width: 1.5 })
-  // ground line + soil hatch either side of the column at top of footing
-  for (const [lo, hi] of [[secL, sx0 - cw / 2], [sx0 + cw / 2, secR]] as const) {
-    P.push({ kind: 'line', x1: lo, y1: zTop, x2: hi, y2: zTop, stroke: HATCH, width: 0.8 })
-    const step = Math.max(0.08, (hi - lo) / 6)
+  const footTop = 0, footBot = H, gravBot = H + hg
+  const gradeZ = -embed, colTop = -(embed + aboveGrade)
+  const cl = sx0 - cw / 2, cr = sx0 + cw / 2
+  // natural-grade line (broken at the column) + soil hatch in the backfill band
+  for (const [lo, hi] of [[secL - ts, cl], [cr, secR + ts]] as const) {
+    P.push({ kind: 'line', x1: lo, y1: gradeZ, x2: hi, y2: gradeZ, stroke: HATCH, width: 0.9 })
+    const step = Math.max(0.13, B * 0.09)
     for (let x = lo; x < hi - 1e-6; x += step)
-      P.push({ kind: 'line', x1: x, y1: zTop, x2: x + step * 0.6, y2: zTop - step * 0.6, stroke: HATCH, width: 0.5 })
+      for (let z = gradeZ + step; z < footTop - 1e-6; z += step)
+        P.push({ kind: 'line', x1: x, y1: z, x2: x + step * 0.5, y2: z - step * 0.5, stroke: HATCH, width: 0.4 })
   }
-  // bottom mat in section: longitudinal bar + perpendicular bar ends (circles)
+  P.push({ kind: 'text', x: secL - ts, y: gradeZ - ts * 0.5, text: 'NATURAL GRADE LINE', size: ts * 0.5, anchor: 'start', color: INK, weight: 600 })
+  // footing + gravel base + column
+  P.push({ kind: 'rect', x: secL, y: footTop, w: B, h: H, stroke: INK, fill: 'none', width: 1.5 })
+  P.push({ kind: 'rect', x: secL, y: footBot, w: B, h: hg, stroke: HATCH, fill: 'none', width: 0.9 })
+  for (let x = secL + hg * 0.6; x < secR; x += hg * 1.1)
+    P.push({ kind: 'circle', cx: x, cy: footBot + hg / 2, r: hg * 0.28, stroke: HATCH, fill: 'none', width: 0.5 })
+  P.push({ kind: 'rect', x: cl, y: colTop, w: cw, h: -colTop, stroke: INK, fill: 'none', width: 1.5 })
+  // bottom mat — longitudinal bar hooked up at both ends + transverse bar ends
   const matZ = H - c - bd / 2
-  P.push({ kind: 'line', x1: secL + c, y1: matZ, x2: secR - c, y2: matZ, stroke: REBAR, width: 1.0 })
+  const hs = Math.min(H * 0.55, 0.22)
+  bar([[secL + c, matZ - hs], [secL + c, matZ], [secR - c, matZ], [secR - c, matZ - hs]])
   for (let i = 0; i < n; i++)
-    P.push({ kind: 'circle', cx: secL + hp + barX(i), cy: matZ, r: Math.max(bd / 2, B * 0.008), stroke: REBAR, fill: REBAR, width: 0.5 })
-  // column dowels — vertical bars hooked onto the mat, lapping up the stub
-  const dd = (f.dowelDia ?? f.barDia) / 1000
-  const dowelX = [sx0 - cw / 2 + c, sx0 + cw / 2 - c]
-  for (const dx of dowelX) {
-    P.push({ kind: 'line', x1: dx, y1: -stubH * 0.55, x2: dx, y2: H - c - dd, stroke: REBAR, width: 1.0 })
-    // 90° hook toward the footing centre onto the mat
-    const dir = dx < sx0 ? 1 : -1
-    P.push({ kind: 'line', x1: dx, y1: H - c - dd, x2: dx + dir * cw * 0.35, y2: H - c - dd, stroke: REBAR, width: 1.0 })
+    P.push({ kind: 'circle', cx: sx0 + barX(i), cy: matZ, r: Math.max(bd / 2, B * 0.009), stroke: REBAR, fill: REBAR, width: 0.5 })
+  // column vertical bars / dowels — full height, bent out onto the mat
+  const vx = [cl + c, cr - c]
+  for (const dx of vx) {
+    const dir = dx < sx0 ? -1 : 1
+    bar([[dx, colTop + c], [dx, matZ], [dx + dir * (cw * 0.42), matZ]])
   }
-  // column ties (short horizontals in the stub)
-  for (let k = 1; k <= 3; k++) {
-    const ty = -stubH * (0.15 + 0.2 * k)
-    P.push({ kind: 'line', x1: sx0 - cw / 2 + c, y1: ty, x2: sx0 + cw / 2 - c, y2: ty, stroke: REBAR, width: 0.7 })
-  }
-  // dimensions: width B (bottom) and depth H (right)
-  const sdY = H + ts * 1.1
-  P.push({ kind: 'dim', x1: secL, y1: sdY, x2: secR, y2: sdY, text: `${Math.round(B * 1000)} mm`, off: 0, size: ts * 0.7 })
-  const sdX = secR + ts * 1.2
-  P.push({ kind: 'dim', x1: sdX, y1: zTop, x2: sdX, y2: zBot, text: `${Math.round(H * 1000)} mm`, off: 0, size: ts * 0.7 })
-  // callouts
-  P.push({ kind: 'text', x: sx0, y: matZ + ts * 0.75, text: `${n}-⌀${f.barDia} E.W. BOTT.`, size: ts * 0.55, anchor: 'middle', color: REBAR, weight: 600 })
-  P.push({ kind: 'text', x: sx0 + cw * 0.5 + ts * 0.3, y: -stubH * 0.6, text: `DOWELS ⌀${f.dowelDia ?? f.barDia}`, size: ts * 0.5, anchor: 'start', color: REBAR, weight: 600 })
+  // stirrups up the column at the scheduled spacing
+  const stX0 = cl + c * 0.6, stX1 = cr - c * 0.6
+  let z = 0
+  const stopZ = -(embed + aboveGrade) + c
+  const drawStirrup = () => { if (-z > stopZ) P.push({ kind: 'line', x1: stX0, y1: -z, x2: stX1, y2: -z, stroke: REBAR, width: 1.1 }) }
+  for (const [count, sp] of stSched) for (let k = 0; k < count; k++) { z += sp / 1000; drawStirrup() }
+  while (-z > stopZ) { z += stRest / 1000; drawStirrup() }
+  // depth dimension chain (embedment / footing / gravel) + overall
+  const dX = secL - ts * 1.4
+  for (const [a, b] of [[gradeZ, footTop], [footTop, footBot], [footBot, gravBot]] as const)
+    P.push({ kind: 'dim', x1: dX, y1: a, x2: dX, y2: b, text: `${Math.round((b - a) * 1000)}`, off: 0, size: ts * 0.6 })
+  P.push({ kind: 'dim', x1: dX - ts * 1.4, y1: gradeZ, x2: dX - ts * 1.4, y2: gravBot, text: `${Math.round((gravBot - gradeZ) * 1000)} mm`, off: 0, size: ts * 0.7 })
+  // width dimension below the gravel
+  P.push({ kind: 'dim', x1: secL, y1: gravBot + ts * 1.2, x2: secR, y2: gravBot + ts * 1.2, text: `${Math.round(B * 1000)} mm`, off: 0, size: ts * 0.7 })
+  // callouts with leaders
+  const lead = (x1: number, y1: number, x2: number, y2: number) => P.push({ kind: 'line', x1, y1, x2, y2, stroke: INK, width: 0.5 })
+  lead(cr, colTop * 0.75, secR + ts * 0.6, colTop * 0.75)
+  P.push({ kind: 'text', x: secR + ts * 0.8, y: colTop * 0.75, text: `${colBars}-${colBarDia}mmØ VERT. BARS`, size: ts * 0.55, anchor: 'start', color: REBAR, weight: 600 })
+  lead(cr, gradeZ * 0.55, secR + ts * 0.6, gradeZ * 0.55)
+  const stLines = [`STIRRUPS = ⌀${stDia} REBAR`, `${stSched.map(([cc, ss]) => `${cc}@${ss}`).join(', ')},`, `REST @ ${stRest} mm O.C.`]
+  stLines.forEach((s, i) => P.push({ kind: 'text', x: secR + ts * 0.8, y: gradeZ * 0.55 + i * ts * 0.72, text: s, size: ts * 0.5, anchor: 'start', color: INK, weight: 500 }))
+  lead(secR - c, matZ, secR + ts * 0.6, matZ + ts * 0.6)
+  P.push({ kind: 'text', x: secR + ts * 0.8, y: matZ + ts * 0.6, text: `${n}-${f.barDia}mmØ BOTHWAY`, size: ts * 0.55, anchor: 'start', color: REBAR, weight: 600 })
   if (f.foundingElev != null)
-    P.push({ kind: 'text', x: secL, y: zTop - ts * 0.5, text: `T.O.F. EL ${f.foundingElev.toFixed(2)} m`, size: ts * 0.5, anchor: 'start', color: PANEL, weight: 600 })
-  P.push({ kind: 'text', x: sx0, y: sdY + ts * 1.1, text: 'SECTION A-A', size: ts * 0.85, anchor: 'middle', color: INK, weight: 700 })
+    P.push({ kind: 'text', x: secL, y: footTop - ts * 0.5, text: `T.O.F. EL ${f.foundingElev.toFixed(2)} m`, size: ts * 0.5, anchor: 'start', color: PANEL, weight: 600 })
+  P.push({ kind: 'text', x: sx0, y: gravBot + ts * 2.4, text: 'SECTION A-A', size: ts * 0.85, anchor: 'middle', color: INK, weight: 700 })
 
-  // ── detail-tag title block below both views ────────────────────────────
-  const detailNo = opts.detailNo ?? '1', sheetRef = opts.sheetRef ?? 'S-05', scale = opts.scale ?? 'NTS'
-  const title = `TYPICAL FOOTING DETAIL — ${f.mark}`
-  const tbR = ts * 1.15, tbY = Math.max(pdY, sdY) + ts * 3.2, tbX = -hp
+  // ══ detail-tag title block ═════════════════════════════════════════════
+  const detailNo = opts.detailNo ?? '1', sheetRef = opts.sheetRef ?? 'S-05', scale = opts.scale ?? '1:25 MTS'
+  const title = `COLUMN FOOTING DETAIL — ${f.mark}`
+  // title sits below BOTH views (the plan runs deeper than the section here)
+  const tbR = ts * 1.2, tbY = Math.max(hp + ts * 2.5, gravBot + ts * 2.4) + ts * 2.6, tbX = -hp
   P.push({ kind: 'circle', cx: tbX + tbR, cy: tbY, r: tbR, stroke: INK, fill: '#fff', width: 1 })
   P.push({ kind: 'line', x1: tbX, y1: tbY, x2: tbX + 2 * tbR, y2: tbY, stroke: INK, width: 1 })
-  P.push({ kind: 'text', x: tbX + tbR, y: tbY - tbR * 0.5, text: detailNo, size: tbR * 0.75, anchor: 'middle', color: INK, weight: 700 })
-  P.push({ kind: 'text', x: tbX + tbR, y: tbY + tbR * 0.5, text: sheetRef, size: tbR * 0.6, anchor: 'middle', color: INK, weight: 700 })
+  P.push({ kind: 'text', x: tbX + tbR, y: tbY - tbR * 0.5, text: detailNo, size: tbR * 0.72, anchor: 'middle', color: INK, weight: 700 })
+  P.push({ kind: 'text', x: tbX + tbR, y: tbY + tbR * 0.5, text: sheetRef, size: tbR * 0.58, anchor: 'middle', color: INK, weight: 700 })
   const lnX0 = tbX + 2 * tbR + ts * 0.3, lnX1 = secR
   P.push({ kind: 'line', x1: lnX0, y1: tbY, x2: lnX1, y2: tbY, stroke: INK, width: 1.4 })
-  P.push({ kind: 'text', x: lnX0 + ts * 0.15, y: tbY - tbR * 0.55, text: title, size: tbR * 0.8, anchor: 'start', color: INK, weight: 700 })
+  P.push({ kind: 'text', x: lnX0 + ts * 0.15, y: tbY - tbR * 0.55, text: title, size: tbR * 0.75, anchor: 'start', color: INK, weight: 700 })
   P.push({ kind: 'text', x: lnX0 + ts * 0.15, y: tbY + tbR * 0.55, text: 'SCALE', size: tbR * 0.4, anchor: 'start', color: INK, weight: 600 })
   P.push({ kind: 'text', x: lnX1 - ts * 0.3, y: tbY + tbR * 0.55, text: scale, size: tbR * 0.4, anchor: 'end', color: INK, weight: 600 })
 
-  // ── bounds ──
+  // ══ bounds ══
   let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
   const acc = (x: number, y: number) => { minX = Math.min(minX, x); minY = Math.min(minY, y); maxX = Math.max(maxX, x); maxY = Math.max(maxY, y) }
   for (const pr of P) {
     if (pr.kind === 'line' || pr.kind === 'dim') { acc(pr.x1, pr.y1); acc(pr.x2, pr.y2) }
     else if (pr.kind === 'rect') { acc(pr.x, pr.y); acc(pr.x + pr.w, pr.y + pr.h) }
     else if (pr.kind === 'circle') { acc(pr.cx - pr.r, pr.cy - pr.r); acc(pr.cx + pr.r, pr.cy + pr.r) }
-    else acc(pr.x, pr.y)
+    else {   // text: include the rendered extent so labels aren't clipped
+      const w = pr.text.length * pr.size * 0.58, a = pr.anchor ?? 'start'
+      acc(a === 'start' ? pr.x : a === 'end' ? pr.x - w : pr.x - w / 2, pr.y - pr.size * 0.6)
+      acc(a === 'start' ? pr.x + w : a === 'end' ? pr.x : pr.x + w / 2, pr.y + pr.size * 0.6)
+    }
   }
   return { primitives: P, bounds: { minX, minY, maxX, maxY }, title }
 }

--- a/webapp/src/engine/footingDetail.ts
+++ b/webapp/src/engine/footingDetail.ts
@@ -76,7 +76,7 @@ export function buildFootingDetail(f: FootingDetailInput, opts: FootingDetailOpt
   // about the centreline `pts`): offset both sides with mitred corners and cap
   // the two free ends with a semicircle — so the bar reads as a rod of real
   // diameter with rounded (hooked) ends, not a single centreline.
-  const rod = (pts: Pt[], r: number) => {
+  const rod = (pts: Pt[], r: number, fill: string = 'none') => {
     const ns = pts.length - 1
     const nrm: Pt[] = []
     for (let i = 0; i < ns; i++) {
@@ -99,7 +99,7 @@ export function buildFootingDetail(f: FootingDetailInput, opts: FootingDetailOpt
     cmds.push({ c: 'A', rx: r, ry: r, x: R[R.length - 1][0], y: R[R.length - 1][1], sweep: 1 })
     for (let i = R.length - 2; i >= 0; i--) cmds.push({ c: 'L', x: R[i][0], y: R[i][1] })
     cmds.push({ c: 'A', rx: r, ry: r, x: L[0][0], y: L[0][1], sweep: 1 })
-    P.push({ kind: 'path', cmds, stroke: REBAR, width: RW, fill: 'none', closed: true })
+    P.push({ kind: 'path', cmds, stroke: REBAR, width: RW, fill, closed: true })
   }
   const ext = (x1: number, y1: number, x2: number, y2: number) =>   // dashed dimension extension line
     P.push({ kind: 'line', x1, y1, x2, y2, stroke: GRID, width: 0.6, dash: [0.05, 0.04] })
@@ -138,14 +138,23 @@ export function buildFootingDetail(f: FootingDetailInput, opts: FootingDetailOpt
 
   // ══ PLAN (centred at origin) ═══════════════════════════════════════════
   P.push({ kind: 'rect', x: -hp, y: -hp, w: B, h: B, stroke: INK, fill: 'none', width: 1.4 })
-  // bottom mat, both ways — straight, or (when the design calls for it) with a
-  // 90° end hook that hugs the perpendicular perimeter bar
+  // bottom mat, both ways.  Layering (matches the section): the ∥y bars sit ON
+  // TOP of the ∥x bars, so the ∥x bars are drawn first (hollow) and the ∥y bars
+  // over them WHITE-FILLED — masking the ∥x lines at each crossing so the
+  // over/under reads correctly (the under-bar is trimmed where the top bar crosses).
   const xo = -hp + c, xf = hp - c   // outermost mat-bar lines (= perimeter bars)
   const hd = (p: number) => (p < 0 ? hookLen : -hookLen)
-  for (let i = 0; i < n; i++) {
-    const p = barX(i)
+  // guard: when hooked, nudge the outermost transverse bar inward so an end hook
+  // wraps AROUND it instead of landing on top of it
+  const guard = hookLen ? rMain * 2.8 : 0
+  const matPos = (i: number) => (i === 0 ? barX(0) + guard : i === n - 1 ? barX(n - 1) - guard : barX(i))
+  for (let i = 0; i < n; i++) {   // ∥x bars — bottom layer (hollow)
+    const p = matPos(i)
     rod(hookLen ? [[xo, p + hd(p)], [xo, p], [xf, p], [xf, p + hd(p)]] : [[xo, p], [xf, p]], rMain)
-    rod(hookLen ? [[p + hd(p), xo], [p, xo], [p, xf], [p + hd(p), xf]] : [[p, xo], [p, xf]], rMain)
+  }
+  for (let i = 0; i < n; i++) {   // ∥y bars — top layer (white-filled → masks the ∥x lines under it)
+    const p = matPos(i)
+    rod(hookLen ? [[p + hd(p), xo], [p, xo], [p, xf], [p + hd(p), xf]] : [[p, xo], [p, xf]], rMain, '#fff')
   }
   // column footprint + LATERAL TIE outline + the full ring of vertical bars
   P.push({ kind: 'rect', x: -cw / 2, y: -cd / 2, w: cw, h: cd, stroke: COL, fill: '#fff', width: 1.1 })
@@ -221,27 +230,33 @@ export function buildFootingDetail(f: FootingDetailInput, opts: FootingDetailOpt
   const rDot = rMain * 0.9
   const zPerp = zLong - rMain - rDot                 // perpendicular bars sit tangent on top
   const upHook = hookLen ? Math.min(hookLen, H * 0.45) : 0
+  // the longitudinal bar's hook clears (guards) the outer perpendicular bar
   rod(upHook ? [[secL + c, zLong - upHook], [secL + c, zLong], [secR - c, zLong], [secR - c, zLong - upHook]]
              : [[secL + c, zLong], [secR - c, zLong]], rMain)
   for (let i = 0; i < n; i++)
-    P.push({ kind: 'circle', cx: sx0 + barX(i), cy: zPerp, r: rDot, stroke: REBAR, fill: REBAR, width: 0.4 })
-  // column vertical bars — one per bar x-position visible in the section (from
-  // the same layout as the plan); the two outer bars foot out onto the mat
+    P.push({ kind: 'circle', cx: sx0 + matPos(i), cy: zPerp, r: rDot, stroke: REBAR, fill: REBAR, width: 0.4 })
+  // LATERAL TIES first (each a thin closed tube whose ends hook around the outer
+  // vertical bars) — then the vertical bars are drawn OVER them white-filled, so
+  // the ties read as wrapping around / passing behind the bars (as in the report)
   const secVx = rowFx.map((fx) => sx0 + fx)
+  const xL = secVx[0], xR = secVx[secVx.length - 1]
+  const g = rMain * 1.3      // tie reaches just OUTSIDE the corner bar…
+  const tw = rTie * 3.2      // …then hooks up around it (stays clear of the white-filled bar)
+  let z = 0
+  const stopZ = -(embed + aboveGrade) + c
+  const tieZs: number[] = []
+  const drawTie = () => { if (-z > stopZ) { rod([[xL - g, -z + tw], [xL - g, -z], [xR + g, -z], [xR + g, -z + tw]], rTie); tieZs.push(-z) } }
+  for (const [count, sp] of tieSched) for (let k = 0; k < count; k++) { z += sp / 1000; drawTie() }
+  while (-z > stopZ) { z += tieRest / 1000; drawTie() }
+  const stX1 = xR + g
+  // column vertical bars (white-filled, on top of the ties) — one per section
+  // x-position from the plan layout; the two outer bars foot out onto the mat
   for (const dx of secVx) {
     const outer = Math.abs(dx - sx0) > cw / 2 - cInset - 1e-6
     const dir = dx < sx0 ? -1 : 1
     rod(outer ? [[dx, colTop + c], [dx, zLong], [dx + dir * (cw * 0.3), zLong]]
-              : [[dx, colTop + c], [dx, zLong]], rMain)
+              : [[dx, colTop + c], [dx, zLong]], rMain, '#fff')
   }
-  // lateral ties up the column at the scheduled spacing (each a thin closed tube)
-  const stX0 = cl + c * 0.6, stX1 = cr - c * 0.6
-  let z = 0
-  const stopZ = -(embed + aboveGrade) + c
-  const tieZs: number[] = []
-  const drawTie = () => { if (-z > stopZ) { rod([[stX0, -z], [stX1, -z]], rTie); tieZs.push(-z) } }
-  for (const [count, sp] of tieSched) for (let k = 0; k < count; k++) { z += sp / 1000; drawTie() }
-  while (-z > stopZ) { z += tieRest / 1000; drawTie() }
   // depth dimension chain (embedment / footing / gravel) + overall
   const dX = secL - ts * 1.4
   for (const [a, b] of [[gradeZ, footTop], [footTop, footBot], [footBot, gravBot]] as const)

--- a/webapp/src/engine/footingDetail.ts
+++ b/webapp/src/engine/footingDetail.ts
@@ -290,6 +290,48 @@ export function buildFootingDetail(f: FootingDetailInput, opts: FootingDetailOpt
     P.push({ kind: 'text', x: secL, y: footTop - ts * 0.5, text: `T.O.F. EL ${f.foundingElev.toFixed(2)} m`, size: ts * 0.5, anchor: 'start', color: PANEL, weight: 600 })
   P.push({ kind: 'text', x: sx0, y: gravBot + ts * 2.4, text: 'SECTION A-A', size: ts * 0.85, anchor: 'middle', color: INK, weight: 700 })
 
+  // ══ COLUMN SECTION inset — enlarged column cross-section showing the exact
+  // tie wrap: a perimeter tie hugging the corner bars + interior crossties that
+  // hook 180° around the interior bars (mirrors the report / ColumnSchematic) ══
+  {
+    const side = Math.min(gap * 0.56, B * 0.55)   // drawn column size (enlarged)
+    const sc = side / cw
+    const cxI = hp + gap * 0.4, cyI = 0           // sit in the clear part of the gap, left of the section's dim chain
+    const halfW = side / 2, halfH = (cd / cw) * side / 2
+    const bx = (fx: number) => cxI + fx * sc
+    const by = (fy: number) => cyI + fy * sc
+    const br = Math.max((colBarDia / 2000) * sc, side * 0.03)
+    const rTt = Math.max((tieDia / 2000) * sc, side * 0.012)
+    const tx0 = bx(colX1), tx1 = bx(colX2), ty0 = by(colY1), ty1 = by(colY2)
+    // column concrete outline
+    P.push({ kind: 'rect', x: cxI - halfW, y: cyI - halfH, w: side, h: 2 * halfH, stroke: INK, fill: '#fff', width: 1.4 })
+    // perimeter tie — rounded rectangle around the corner bars
+    const rr = Math.min(tx1 - tx0, ty1 - ty0) * 0.26
+    P.push({ kind: 'path', stroke: REBAR, width: 1.4, fill: 'none', closed: true, cmds: [
+      { c: 'M', x: tx0 + rr, y: ty0 }, { c: 'L', x: tx1 - rr, y: ty0 }, { c: 'A', rx: rr, ry: rr, x: tx1, y: ty0 + rr, sweep: 1 },
+      { c: 'L', x: tx1, y: ty1 - rr }, { c: 'A', rx: rr, ry: rr, x: tx1 - rr, y: ty1, sweep: 1 },
+      { c: 'L', x: tx0 + rr, y: ty1 }, { c: 'A', rx: rr, ry: rr, x: tx0, y: ty1 - rr, sweep: 1 },
+      { c: 'L', x: tx0, y: ty0 + rr }, { c: 'A', rx: rr, ry: rr, x: tx0 + rr, y: ty0, sweep: 1 },
+    ] })
+    // crosstie: a stadium loop grabbing bars A and B with a 180° hook at each
+    const hookR = br + rTt * 1.2
+    const stadium = (ax: number, ay: number, bx2: number, by2: number, odx: number, ody: number) =>
+      P.push({ kind: 'path', stroke: REBAR, width: 1.1, fill: 'none', closed: true, cmds: [
+        { c: 'M', x: ax + odx * hookR, y: ay + ody * hookR },
+        { c: 'L', x: bx2 + odx * hookR, y: by2 + ody * hookR },
+        { c: 'A', rx: hookR, ry: hookR, x: bx2 - odx * hookR, y: by2 - ody * hookR, sweep: 1 },
+        { c: 'L', x: ax - odx * hookR, y: ay - ody * hookR },
+        { c: 'A', rx: hookR, ry: hookR, x: ax + odx * hookR, y: ay + ody * hookR, sweep: 1 },
+      ] })
+    for (const fx of rowFx.slice(1, -1)) stadium(bx(fx), ty0, bx(fx), ty1, 1, 0)   // interior top/bottom bars
+    for (const fy of sideFy) stadium(tx0, by(fy), tx1, by(fy), 0, 1)               // interior side bars
+    // vertical bars (dots)
+    for (const fx of rowFx) { P.push({ kind: 'circle', cx: bx(fx), cy: ty0, r: br, stroke: REBAR, fill: REBAR, width: 0.4 }); P.push({ kind: 'circle', cx: bx(fx), cy: ty1, r: br, stroke: REBAR, fill: REBAR, width: 0.4 }) }
+    for (const fy of sideFy) { P.push({ kind: 'circle', cx: tx0, cy: by(fy), r: br, stroke: REBAR, fill: REBAR, width: 0.4 }); P.push({ kind: 'circle', cx: tx1, cy: by(fy), r: br, stroke: REBAR, fill: REBAR, width: 0.4 }) }
+    P.push({ kind: 'text', x: cxI, y: cyI + halfH + ts * 1.0, text: 'COLUMN SECTION', size: ts * 0.6, anchor: 'middle', color: INK, weight: 700 })
+    P.push({ kind: 'text', x: cxI, y: cyI + halfH + ts * 1.8, text: `${colBars}-⌀${colBarDia} · TIES ⌀${tieDia}`, size: ts * 0.45, anchor: 'middle', color: REBAR, weight: 600 })
+  }
+
   // ══ detail-tag title block ═════════════════════════════════════════════
   const detailNo = opts.detailNo ?? '1', sheetRef = opts.sheetRef ?? 'S-05', scale = opts.scale ?? '1:25 MTS'
   const title = `COLUMN FOOTING DETAIL — ${f.mark}`

--- a/webapp/src/engine/footingDetail.ts
+++ b/webapp/src/engine/footingDetail.ts
@@ -1,0 +1,162 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Footing detail sheet — a standalone CAD detail (bar-mat PLAN + SECTION A-A)
+// for one isolated square footing, built from its designed geometry. Emits the
+// same typed PlanPrimitive[] the plan renderer uses, so planToSvg paints it.
+//
+// Two views laid out side by side in world metres:
+//   • PLAN — footing outline, column footprint, the bottom reinforcing mat
+//     (bars both ways), and the A–A cut line.
+//   • SECTION A–A — footing depth, column stub with dowels + ties, the bottom
+//     mat shown in section, cover, and B/H dimensions.
+// A detail-tag title block sits below, per the "n / S-xx" convention.
+//
+// Units: geometry m; bar/column sizes mm.  Detailing follows ACI 318-14
+// §25.4 (development/hooks) and §13.3 (footing reinforcement placement).
+// ─────────────────────────────────────────────────────────────────────────
+import type { PlanPrimitive, Drawing } from './planRenderer'
+
+export interface FootingDetailInput {
+  /** Footing mark (WF-1…). */
+  mark: string
+  /** Plan side B, m. */
+  B: number
+  /** Total footing depth H, m. */
+  H: number
+  /** Clear cover, mm. */
+  cover: number
+  /** Main mat bar diameter, mm. */
+  barDia: number
+  /** Bars each way (count). */
+  bars: number
+  /** Bar spacing, mm. */
+  barSpacing: number
+  /** Column width (x) and depth (y), mm. */
+  colB: number
+  colH?: number
+  /** Dowel (column vertical) bar diameter, mm — defaults to the mat bar. */
+  dowelDia?: number
+  /** Top-of-footing elevation, m (−down). */
+  foundingElev?: number
+}
+
+export interface FootingDetailOptions {
+  detailNo?: string
+  sheetRef?: string
+  scale?: string
+}
+
+export interface DetailDrawing extends Drawing { title: string }
+
+const INK = '#1e293b', COL = '#1e293b', REBAR = '#b45309', HATCH = '#94a3b8', PANEL = '#0f766e'
+
+/** Build a typical-footing detail (plan + section) from a designed footing. */
+export function buildFootingDetail(f: FootingDetailInput, opts: FootingDetailOptions = {}): DetailDrawing {
+  const P: PlanPrimitive[] = []
+  const B = f.B, H = f.H
+  const c = f.cover / 1000                       // cover, m
+  const cw = f.colB / 1000, cd = (f.colH ?? f.colB) / 1000   // column, m
+  const bd = f.barDia / 1000                      // mat bar dia, m
+  const n = Math.max(2, Math.round(f.bars))
+  const hp = B / 2
+  const inner = B - 2 * c                          // mat clear span
+  const barX = (i: number) => -hp + c + (inner * i) / (n - 1)   // bar coord in [-hp+c, hp-c]
+  const ts = B * 0.09                              // base text height, m
+  const gap = B * 0.7                              // gap between the two views
+
+  // ── PLAN view (centred at origin) ──────────────────────────────────────
+  P.push({ kind: 'rect', x: -hp, y: -hp, w: B, h: B, stroke: INK, fill: 'none', width: 1.5 })
+  // column footprint (dashed)
+  P.push({ kind: 'rect', x: -cw / 2, y: -cd / 2, w: cw, h: cd, stroke: COL, fill: 'none', width: 1.1, dash: [0.05, 0.035] })
+  // bottom mat — bars both ways
+  for (let i = 0; i < n; i++) {
+    const p = barX(i)
+    P.push({ kind: 'line', x1: -hp + c, y1: p, x2: hp - c, y2: p, stroke: REBAR, width: 0.8 })   // bars ∥ x
+    P.push({ kind: 'line', x1: p, y1: -hp + c, x2: p, y2: hp - c, stroke: REBAR, width: 0.8 })   // bars ∥ y
+  }
+  // A–A cut line (horizontal, through the centre) with end flags
+  const aY = 0, aExt = hp + ts * 1.4
+  P.push({ kind: 'line', x1: -aExt, y1: aY, x2: aExt, y2: aY, stroke: INK, width: 0.7, dash: [0.12, 0.06, 0.03, 0.06] })
+  for (const sx of [-1, 1]) {
+    P.push({ kind: 'text', x: sx * aExt, y: aY - ts * 0.55, text: 'A', size: ts * 0.9, anchor: 'middle', color: INK, weight: 700 })
+    // arrow head toward the cut
+    P.push({ kind: 'line', x1: sx * aExt, y1: aY, x2: sx * (aExt - ts * 0.4), y2: aY - ts * 0.25, stroke: INK, width: 0.8 })
+    P.push({ kind: 'line', x1: sx * aExt, y1: aY, x2: sx * (aExt - ts * 0.4), y2: aY + ts * 0.25, stroke: INK, width: 0.8 })
+  }
+  // mat note + view label
+  P.push({ kind: 'text', x: 0, y: -hp - ts * 0.7, text: `${n}-⌀${f.barDia} @ ${Math.round(f.barSpacing)} mm BOTH WAYS`, size: ts * 0.62, anchor: 'middle', color: REBAR, weight: 600 })
+  // width dimension along the bottom
+  const pdY = hp + ts * 1.1
+  P.push({ kind: 'dim', x1: -hp, y1: pdY, x2: hp, y2: pdY, text: `${Math.round(B * 1000)} mm`, off: 0, size: ts * 0.7 })
+  P.push({ kind: 'text', x: 0, y: pdY + ts * 1.1, text: 'PLAN', size: ts * 0.85, anchor: 'middle', color: INK, weight: 700 })
+
+  // ── SECTION A–A view (to the right) ────────────────────────────────────
+  const sx0 = hp + gap + hp          // section centre x
+  const secL = sx0 - hp, secR = sx0 + hp
+  const zTop = 0, zBot = H
+  const stubH = Math.max(0.5, H * 1.4)   // column stub shown above the footing
+  // footing block + column stub
+  P.push({ kind: 'rect', x: secL, y: zTop, w: B, h: H, stroke: INK, fill: 'none', width: 1.5 })
+  P.push({ kind: 'rect', x: sx0 - cw / 2, y: -stubH, w: cw, h: stubH, stroke: INK, fill: 'none', width: 1.5 })
+  // ground line + soil hatch either side of the column at top of footing
+  for (const [lo, hi] of [[secL, sx0 - cw / 2], [sx0 + cw / 2, secR]] as const) {
+    P.push({ kind: 'line', x1: lo, y1: zTop, x2: hi, y2: zTop, stroke: HATCH, width: 0.8 })
+    const step = Math.max(0.08, (hi - lo) / 6)
+    for (let x = lo; x < hi - 1e-6; x += step)
+      P.push({ kind: 'line', x1: x, y1: zTop, x2: x + step * 0.6, y2: zTop - step * 0.6, stroke: HATCH, width: 0.5 })
+  }
+  // bottom mat in section: longitudinal bar + perpendicular bar ends (circles)
+  const matZ = H - c - bd / 2
+  P.push({ kind: 'line', x1: secL + c, y1: matZ, x2: secR - c, y2: matZ, stroke: REBAR, width: 1.0 })
+  for (let i = 0; i < n; i++)
+    P.push({ kind: 'circle', cx: secL + hp + barX(i), cy: matZ, r: Math.max(bd / 2, B * 0.008), stroke: REBAR, fill: REBAR, width: 0.5 })
+  // column dowels — vertical bars hooked onto the mat, lapping up the stub
+  const dd = (f.dowelDia ?? f.barDia) / 1000
+  const dowelX = [sx0 - cw / 2 + c, sx0 + cw / 2 - c]
+  for (const dx of dowelX) {
+    P.push({ kind: 'line', x1: dx, y1: -stubH * 0.55, x2: dx, y2: H - c - dd, stroke: REBAR, width: 1.0 })
+    // 90° hook toward the footing centre onto the mat
+    const dir = dx < sx0 ? 1 : -1
+    P.push({ kind: 'line', x1: dx, y1: H - c - dd, x2: dx + dir * cw * 0.35, y2: H - c - dd, stroke: REBAR, width: 1.0 })
+  }
+  // column ties (short horizontals in the stub)
+  for (let k = 1; k <= 3; k++) {
+    const ty = -stubH * (0.15 + 0.2 * k)
+    P.push({ kind: 'line', x1: sx0 - cw / 2 + c, y1: ty, x2: sx0 + cw / 2 - c, y2: ty, stroke: REBAR, width: 0.7 })
+  }
+  // dimensions: width B (bottom) and depth H (right)
+  const sdY = H + ts * 1.1
+  P.push({ kind: 'dim', x1: secL, y1: sdY, x2: secR, y2: sdY, text: `${Math.round(B * 1000)} mm`, off: 0, size: ts * 0.7 })
+  const sdX = secR + ts * 1.2
+  P.push({ kind: 'dim', x1: sdX, y1: zTop, x2: sdX, y2: zBot, text: `${Math.round(H * 1000)} mm`, off: 0, size: ts * 0.7 })
+  // callouts
+  P.push({ kind: 'text', x: sx0, y: matZ + ts * 0.75, text: `${n}-⌀${f.barDia} E.W. BOTT.`, size: ts * 0.55, anchor: 'middle', color: REBAR, weight: 600 })
+  P.push({ kind: 'text', x: sx0 + cw * 0.5 + ts * 0.3, y: -stubH * 0.6, text: `DOWELS ⌀${f.dowelDia ?? f.barDia}`, size: ts * 0.5, anchor: 'start', color: REBAR, weight: 600 })
+  if (f.foundingElev != null)
+    P.push({ kind: 'text', x: secL, y: zTop - ts * 0.5, text: `T.O.F. EL ${f.foundingElev.toFixed(2)} m`, size: ts * 0.5, anchor: 'start', color: PANEL, weight: 600 })
+  P.push({ kind: 'text', x: sx0, y: sdY + ts * 1.1, text: 'SECTION A-A', size: ts * 0.85, anchor: 'middle', color: INK, weight: 700 })
+
+  // ── detail-tag title block below both views ────────────────────────────
+  const detailNo = opts.detailNo ?? '1', sheetRef = opts.sheetRef ?? 'S-05', scale = opts.scale ?? 'NTS'
+  const title = `TYPICAL FOOTING DETAIL — ${f.mark}`
+  const tbR = ts * 1.15, tbY = Math.max(pdY, sdY) + ts * 3.2, tbX = -hp
+  P.push({ kind: 'circle', cx: tbX + tbR, cy: tbY, r: tbR, stroke: INK, fill: '#fff', width: 1 })
+  P.push({ kind: 'line', x1: tbX, y1: tbY, x2: tbX + 2 * tbR, y2: tbY, stroke: INK, width: 1 })
+  P.push({ kind: 'text', x: tbX + tbR, y: tbY - tbR * 0.5, text: detailNo, size: tbR * 0.75, anchor: 'middle', color: INK, weight: 700 })
+  P.push({ kind: 'text', x: tbX + tbR, y: tbY + tbR * 0.5, text: sheetRef, size: tbR * 0.6, anchor: 'middle', color: INK, weight: 700 })
+  const lnX0 = tbX + 2 * tbR + ts * 0.3, lnX1 = secR
+  P.push({ kind: 'line', x1: lnX0, y1: tbY, x2: lnX1, y2: tbY, stroke: INK, width: 1.4 })
+  P.push({ kind: 'text', x: lnX0 + ts * 0.15, y: tbY - tbR * 0.55, text: title, size: tbR * 0.8, anchor: 'start', color: INK, weight: 700 })
+  P.push({ kind: 'text', x: lnX0 + ts * 0.15, y: tbY + tbR * 0.55, text: 'SCALE', size: tbR * 0.4, anchor: 'start', color: INK, weight: 600 })
+  P.push({ kind: 'text', x: lnX1 - ts * 0.3, y: tbY + tbR * 0.55, text: scale, size: tbR * 0.4, anchor: 'end', color: INK, weight: 600 })
+
+  // ── bounds ──
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+  const acc = (x: number, y: number) => { minX = Math.min(minX, x); minY = Math.min(minY, y); maxX = Math.max(maxX, x); maxY = Math.max(maxY, y) }
+  for (const pr of P) {
+    if (pr.kind === 'line' || pr.kind === 'dim') { acc(pr.x1, pr.y1); acc(pr.x2, pr.y2) }
+    else if (pr.kind === 'rect') { acc(pr.x, pr.y); acc(pr.x + pr.w, pr.y + pr.h) }
+    else if (pr.kind === 'circle') { acc(pr.cx - pr.r, pr.cy - pr.r); acc(pr.cx + pr.r, pr.cy + pr.r) }
+    else acc(pr.x, pr.y)
+  }
+  return { primitives: P, bounds: { minX, minY, maxX, maxY }, title }
+}

--- a/webapp/src/engine/footingDetail.ts
+++ b/webapp/src/engine/footingDetail.ts
@@ -16,7 +16,16 @@
 //
 // Units: geometry m; bar/column sizes mm.
 // ─────────────────────────────────────────────────────────────────────────
-import type { PlanPrimitive, Drawing } from './planRenderer'
+import type { PlanPrimitive, PathCmd, Drawing } from './planRenderer'
+
+type Pt = [number, number]
+/** Intersection of the infinite lines p1→p2 and p3→p4 (null if parallel). */
+function lineX(p1: Pt, p2: Pt, p3: Pt, p4: Pt): Pt | null {
+  const d = (p1[0] - p2[0]) * (p3[1] - p4[1]) - (p1[1] - p2[1]) * (p3[0] - p4[0])
+  if (Math.abs(d) < 1e-9) return null
+  const t = ((p1[0] - p3[0]) * (p3[1] - p4[1]) - (p1[1] - p3[1]) * (p3[0] - p4[0])) / d
+  return [p1[0] + t * (p2[0] - p1[0]), p1[1] + t * (p2[1] - p1[1])]
+}
 
 export interface FootingDetailInput {
   /** Footing mark (WF-1…). */
@@ -54,15 +63,40 @@ export interface FootingDetailInput {
 export interface FootingDetailOptions { detailNo?: string; sheetRef?: string; scale?: string }
 export interface DetailDrawing extends Drawing { title: string }
 
-const INK = '#1e293b', COL = '#1e293b', REBAR = '#b45309', HATCH = '#94a3b8', GRID = '#9aa5b5', PANEL = '#0f766e'
-const RW = 1.1   // rebar stroke weight (px) — a line, not a filled rod
+const INK = '#1e293b', COL = '#1e293b', REBAR = '#b45309', HATCH = '#94a3b8', GRID = '#9aa5b5', STONE = '#64748b', PANEL = '#0f766e'
+const RW = 0.8   // rebar outline stroke weight (px) — a thin tube edge, not a filled rod
 
 /** Build a column-footing detail (plan + section) from a designed footing. */
 export function buildFootingDetail(f: FootingDetailInput, opts: FootingDetailOptions = {}): DetailDrawing {
   const P: PlanPrimitive[] = []
-  const bar = (pts: [number, number][], w = RW) => {   // thin rebar polyline (stroke)
-    for (let i = 0; i < pts.length - 1; i++)
-      P.push({ kind: 'line', x1: pts[i][0], y1: pts[i][1], x2: pts[i + 1][0], y2: pts[i + 1][1], stroke: REBAR, width: w })
+  // Draw a reinforcing bar as its OUTLINE (a thin-stroked tube of radius `r`
+  // about the centreline `pts`): offset both sides with mitred corners and cap
+  // the two free ends with a semicircle — so the bar reads as a rod of real
+  // diameter with rounded (hooked) ends, not a single centreline.
+  const rod = (pts: Pt[], r: number) => {
+    const ns = pts.length - 1
+    const nrm: Pt[] = []
+    for (let i = 0; i < ns; i++) {
+      const dx = pts[i + 1][0] - pts[i][0], dy = pts[i + 1][1] - pts[i][1]
+      const l = Math.hypot(dx, dy) || 1
+      nrm.push([-dy / l, dx / l])   // left normal
+    }
+    const side = (s: number): Pt[] => pts.map((p, i) => {
+      if (i === 0) return [p[0] + s * r * nrm[0][0], p[1] + s * r * nrm[0][1]]
+      if (i === ns) return [p[0] + s * r * nrm[ns - 1][0], p[1] + s * r * nrm[ns - 1][1]]
+      const a0: Pt = [pts[i - 1][0] + s * r * nrm[i - 1][0], pts[i - 1][1] + s * r * nrm[i - 1][1]]
+      const a1: Pt = [p[0] + s * r * nrm[i - 1][0], p[1] + s * r * nrm[i - 1][1]]
+      const b0: Pt = [p[0] + s * r * nrm[i][0], p[1] + s * r * nrm[i][1]]
+      const b1: Pt = [pts[i + 1][0] + s * r * nrm[i][0], pts[i + 1][1] + s * r * nrm[i][1]]
+      return lineX(a0, a1, b0, b1) ?? b0
+    })
+    const L = side(1), R = side(-1)
+    const cmds: PathCmd[] = [{ c: 'M', x: L[0][0], y: L[0][1] }]
+    for (let i = 1; i < L.length; i++) cmds.push({ c: 'L', x: L[i][0], y: L[i][1] })
+    cmds.push({ c: 'A', rx: r, ry: r, x: R[R.length - 1][0], y: R[R.length - 1][1], sweep: 1 })
+    for (let i = R.length - 2; i >= 0; i--) cmds.push({ c: 'L', x: R[i][0], y: R[i][1] })
+    cmds.push({ c: 'A', rx: r, ry: r, x: L[0][0], y: L[0][1], sweep: 1 })
+    P.push({ kind: 'path', cmds, stroke: REBAR, width: RW, fill: 'none', closed: true })
   }
   const ext = (x1: number, y1: number, x2: number, y2: number) =>   // dashed dimension extension line
     P.push({ kind: 'line', x1, y1, x2, y2, stroke: GRID, width: 0.6, dash: [0.05, 0.04] })
@@ -78,6 +112,8 @@ export function buildFootingDetail(f: FootingDetailInput, opts: FootingDetailOpt
   const ts = B * 0.075
   const gap = B * 1.05
   const hook = Math.min(0.12, B * 0.07)        // 90° hook leg length (m)
+  const rMain = Math.max(bd / 2, B * 0.007)    // drawn bar radius (mat/dowels)
+  const rTie = Math.max((f.stirrupDia ?? 10) / 2000, B * 0.005)   // stirrups thinner
   const colBars = f.colBars ?? 8, colBarDia = f.colBarDia ?? f.barDia
   const stDia = f.stirrupDia ?? 10
   const stSched = f.stirrupSchedule ?? [[2, 50], [2, 75], [5, 100], [7, 150]]
@@ -95,8 +131,8 @@ export function buildFootingDetail(f: FootingDetailInput, opts: FootingDetailOpt
     const p = barX(i)
     // ∥x bar: straight run xo→xf, each end hooking along the perpendicular
     // perimeter bar it meets (at xo and xf) — i.e. the hook hugs that bar
-    bar([[xo, p + hd(p)], [xo, p], [xf, p], [xf, p + hd(p)]])
-    bar([[p + hd(p), xo], [p, xo], [p, xf], [p + hd(p), xf]])   // ∥y bar, mirror
+    rod([[xo, p + hd(p)], [xo, p], [xf, p], [xf, p + hd(p)]], rMain)
+    rod([[p + hd(p), xo], [p, xo], [p, xf], [p + hd(p), xf]], rMain)   // ∥y bar, mirror
   }
   // column footprint + vertical bars (corner circles) + a tie square
   P.push({ kind: 'rect', x: -cw / 2, y: -cd / 2, w: cw, h: cd, stroke: COL, fill: '#fff', width: 1.1 })
@@ -147,33 +183,42 @@ export function buildFootingDetail(f: FootingDetailInput, opts: FootingDetailOpt
         P.push({ kind: 'line', x1: x, y1: z, x2: x + step * 0.5, y2: z - step * 0.5, stroke: HATCH, width: 0.4 })
   }
   P.push({ kind: 'text', x: secL - ts, y: gradeZ - ts * 0.5, text: 'NATURAL GRADE LINE', size: ts * 0.5, anchor: 'start', color: INK, weight: 600 })
-  // footing + gravel base + column
+  // footing + column
   P.push({ kind: 'rect', x: secL, y: footTop, w: B, h: H, stroke: INK, fill: 'none', width: 1.5 })
-  P.push({ kind: 'rect', x: secL, y: footBot, w: B, h: hg, stroke: HATCH, fill: 'none', width: 0.9 })
-  for (let x = secL + hg * 0.6; x < secR; x += hg * 1.1)
-    P.push({ kind: 'circle', cx: x, cy: footBot + hg / 2, r: hg * 0.28, stroke: HATCH, fill: 'none', width: 0.5 })
   P.push({ kind: 'rect', x: cl, y: colTop, w: cw, h: -colTop, stroke: INK, fill: 'none', width: 1.5 })
-  // bottom mat in TWO stacked layers (bars can't pass through one another):
-  // the in-plane bar (continuous line) sits at the bottom; the perpendicular
-  // bars (into the page → circles) rest ON TOP of it.  The bottom bar's end
-  // hook turns up and HUGS the outermost perpendicular bar above it.
-  const rv = Math.max(bd / 2, B * 0.009)          // drawn bar radius
-  const zLong = H - c - rv                          // in-plane bar (bottom layer)
-  const zPerp = zLong - 2.6 * rv                    // perpendicular bars, stacked clearly on top
-  bar([[secL + c, zPerp - rv * 1.6], [secL + c, zLong], [secR - c, zLong], [secR - c, zPerp - rv * 1.6]])
+  // gravel bedding — packed aggregate between two lines (two staggered rows of
+  // rounded stones of mixed size, so it can't be mistaken for reinforcement)
+  P.push({ kind: 'line', x1: secL, y1: footBot, x2: secR, y2: footBot, stroke: INK, width: 0.9 })
+  P.push({ kind: 'line', x1: secL, y1: gravBot, x2: secR, y2: gravBot, stroke: INK, width: 0.9 })
+  const gs = hg * 0.42
+  let gi = 0
+  for (let x = secL + gs * 0.8; x < secR - gs * 0.4; x += gs * 1.15, gi++) {
+    const rTop = gs * (0.42 + 0.16 * ((gi % 3) - 1))
+    const rBot = gs * (0.5 - 0.14 * ((gi % 2)))
+    P.push({ kind: 'circle', cx: x, cy: footBot + gs * 0.72, r: rTop, stroke: STONE, fill: 'none', width: 0.5 })
+    P.push({ kind: 'circle', cx: x + gs * 0.55, cy: gravBot - gs * 0.72, r: rBot, stroke: STONE, fill: 'none', width: 0.5 })
+  }
+  // bottom mat in TWO stacked layers (bars cannot pass through one another):
+  // the in-plane bar runs at the BOTTOM (on the cover); the perpendicular bars
+  // (into the page → dots) REST ON TOP of it, touching. The bottom bar's end
+  // hooks up and around, hugging the outer perpendicular bar above it.
+  const zLong = H - c - rMain                       // in-plane bar centre (bottom layer, on cover)
+  const rDot = rMain * 0.9
+  const zPerp = zLong - rMain - rDot                 // perpendicular bars sit tangent on top
+  rod([[secL + c, zPerp - rDot], [secL + c, zLong], [secR - c, zLong], [secR - c, zPerp - rDot]], rMain)
   for (let i = 0; i < n; i++)
-    P.push({ kind: 'circle', cx: sx0 + barX(i), cy: zPerp, r: rv, stroke: REBAR, fill: REBAR, width: 0.5 })
-  // column vertical bars / dowels — full height, bent out onto the mat
+    P.push({ kind: 'circle', cx: sx0 + barX(i), cy: zPerp, r: rDot, stroke: REBAR, fill: REBAR, width: 0.4 })
+  // column vertical bars / dowels — full height, footed out to rest on the mat
   const vx = [cl + c, cr - c]
   for (const dx of vx) {
     const dir = dx < sx0 ? -1 : 1
-    bar([[dx, colTop + c], [dx, zLong], [dx + dir * (cw * 0.42), zLong]])
+    rod([[dx, colTop + c], [dx, zLong], [dx + dir * (cw * 0.42), zLong]], rMain)
   }
-  // stirrups up the column at the scheduled spacing
+  // stirrups up the column at the scheduled spacing (each a thin closed tube)
   const stX0 = cl + c * 0.6, stX1 = cr - c * 0.6
   let z = 0
   const stopZ = -(embed + aboveGrade) + c
-  const drawStirrup = () => { if (-z > stopZ) P.push({ kind: 'line', x1: stX0, y1: -z, x2: stX1, y2: -z, stroke: REBAR, width: 1.1 }) }
+  const drawStirrup = () => { if (-z > stopZ) rod([[stX0, -z], [stX1, -z]], rTie) }
   for (const [count, sp] of stSched) for (let k = 0; k < count; k++) { z += sp / 1000; drawStirrup() }
   while (-z > stopZ) { z += stRest / 1000; drawStirrup() }
   // depth dimension chain (embedment / footing / gravel) + overall
@@ -222,6 +267,7 @@ export function buildFootingDetail(f: FootingDetailInput, opts: FootingDetailOpt
     if (pr.kind === 'line' || pr.kind === 'dim') { acc(pr.x1, pr.y1); acc(pr.x2, pr.y2) }
     else if (pr.kind === 'rect') { acc(pr.x, pr.y); acc(pr.x + pr.w, pr.y + pr.h) }
     else if (pr.kind === 'circle') { acc(pr.cx - pr.r, pr.cy - pr.r); acc(pr.cx + pr.r, pr.cy + pr.r) }
+    else if (pr.kind === 'path') { for (const cmd of pr.cmds) acc(cmd.x, cmd.y) }
     else {   // text: include the rendered extent so labels aren't clipped
       const w = pr.text.length * pr.size * 0.58, a = pr.anchor ?? 'start'
       acc(a === 'start' ? pr.x : a === 'end' ? pr.x - w : pr.x - w / 2, pr.y - pr.size * 0.6)

--- a/webapp/src/engine/footingDetail.ts
+++ b/webapp/src/engine/footingDetail.ts
@@ -54,16 +54,18 @@ export interface FootingDetailInput {
 export interface FootingDetailOptions { detailNo?: string; sheetRef?: string; scale?: string }
 export interface DetailDrawing extends Drawing { title: string }
 
-const INK = '#1e293b', COL = '#1e293b', REBAR = '#b45309', HATCH = '#94a3b8', PANEL = '#0f766e'
-const RW = 2.4   // rebar line weight (px) — bars read as solid rod, not hairline
+const INK = '#1e293b', COL = '#1e293b', REBAR = '#b45309', HATCH = '#94a3b8', GRID = '#9aa5b5', PANEL = '#0f766e'
+const RW = 1.1   // rebar stroke weight (px) — a line, not a filled rod
 
 /** Build a column-footing detail (plan + section) from a designed footing. */
 export function buildFootingDetail(f: FootingDetailInput, opts: FootingDetailOptions = {}): DetailDrawing {
   const P: PlanPrimitive[] = []
-  const bar = (pts: [number, number][], w = RW) => {   // bold rebar polyline
+  const bar = (pts: [number, number][], w = RW) => {   // thin rebar polyline (stroke)
     for (let i = 0; i < pts.length - 1; i++)
       P.push({ kind: 'line', x1: pts[i][0], y1: pts[i][1], x2: pts[i + 1][0], y2: pts[i + 1][1], stroke: REBAR, width: w })
   }
+  const ext = (x1: number, y1: number, x2: number, y2: number) =>   // dashed dimension extension line
+    P.push({ kind: 'line', x1, y1, x2, y2, stroke: GRID, width: 0.6, dash: [0.05, 0.04] })
 
   const B = f.B, H = f.H
   const c = f.cover / 1000
@@ -87,11 +89,14 @@ export function buildFootingDetail(f: FootingDetailInput, opts: FootingDetailOpt
   // ══ PLAN (centred at origin) ═══════════════════════════════════════════
   P.push({ kind: 'rect', x: -hp, y: -hp, w: B, h: B, stroke: INK, fill: 'none', width: 1.4 })
   // bottom mat, both ways, each bar hooked 90° toward the footing interior
+  const xo = -hp + c, xf = hp - c   // outermost mat-bar lines (= perimeter bars)
+  const hd = (p: number) => (p < 0 ? hook : -hook)   // 90° hook, turned toward the footing centre
   for (let i = 0; i < n; i++) {
     const p = barX(i)
-    const dz = p < 0 ? hook : -hook, dx = p < 0 ? hook : -hook
-    bar([[-hp + c, p + dz], [-hp + c, p], [hp - c, p], [hp - c, p + dz]])   // bar ∥ x
-    bar([[p + dx, -hp + c], [p, -hp + c], [p, hp - c], [p + dx, hp - c]])   // bar ∥ y
+    // ∥x bar: straight run xo→xf, each end hooking along the perpendicular
+    // perimeter bar it meets (at xo and xf) — i.e. the hook hugs that bar
+    bar([[xo, p + hd(p)], [xo, p], [xf, p], [xf, p + hd(p)]])
+    bar([[p + hd(p), xo], [p, xo], [p, xf], [p + hd(p), xf]])   // ∥y bar, mirror
   }
   // column footprint + vertical bars (corner circles) + a tie square
   P.push({ kind: 'rect', x: -cw / 2, y: -cd / 2, w: cw, h: cd, stroke: COL, fill: '#fff', width: 1.1 })
@@ -118,6 +123,10 @@ export function buildFootingDetail(f: FootingDetailInput, opts: FootingDetailOpt
   const zseg = [[-hp, -cd / 2], [-cd / 2, cd / 2], [cd / 2, hp]] as const
   for (const [a, b] of zseg)
     P.push({ kind: 'dim', x1: pL, y1: a, x2: pL, y2: b, text: `${Math.round((b - a) * 1000)}`, off: 0, size: ts * 0.6 })
+  // dashed extension lines at every dimension boundary
+  for (const x of [-hp, -cw / 2, cw / 2, hp]) ext(x, pTop, x, -hp)
+  for (const x of [-hp, hp]) ext(x, pTop2, x, pTop)
+  for (const z of [-hp, -cd / 2, cd / 2, hp]) ext(pL, z, -hp, z)
   void edge
   // labels
   P.push({ kind: 'text', x: 0, y: hp + ts * 1.4, text: `${n}-${f.barDia}mmØ BOTHWAY`, size: ts * 0.7, anchor: 'middle', color: REBAR, weight: 700 })
@@ -144,17 +153,21 @@ export function buildFootingDetail(f: FootingDetailInput, opts: FootingDetailOpt
   for (let x = secL + hg * 0.6; x < secR; x += hg * 1.1)
     P.push({ kind: 'circle', cx: x, cy: footBot + hg / 2, r: hg * 0.28, stroke: HATCH, fill: 'none', width: 0.5 })
   P.push({ kind: 'rect', x: cl, y: colTop, w: cw, h: -colTop, stroke: INK, fill: 'none', width: 1.5 })
-  // bottom mat — longitudinal bar hooked up at both ends + transverse bar ends
-  const matZ = H - c - bd / 2
-  const hs = Math.min(H * 0.55, 0.22)
-  bar([[secL + c, matZ - hs], [secL + c, matZ], [secR - c, matZ], [secR - c, matZ - hs]])
+  // bottom mat in TWO stacked layers (bars can't pass through one another):
+  // the in-plane bar (continuous line) sits at the bottom; the perpendicular
+  // bars (into the page → circles) rest ON TOP of it.  The bottom bar's end
+  // hook turns up and HUGS the outermost perpendicular bar above it.
+  const rv = Math.max(bd / 2, B * 0.009)          // drawn bar radius
+  const zLong = H - c - rv                          // in-plane bar (bottom layer)
+  const zPerp = zLong - 2.6 * rv                    // perpendicular bars, stacked clearly on top
+  bar([[secL + c, zPerp - rv * 1.6], [secL + c, zLong], [secR - c, zLong], [secR - c, zPerp - rv * 1.6]])
   for (let i = 0; i < n; i++)
-    P.push({ kind: 'circle', cx: sx0 + barX(i), cy: matZ, r: Math.max(bd / 2, B * 0.009), stroke: REBAR, fill: REBAR, width: 0.5 })
+    P.push({ kind: 'circle', cx: sx0 + barX(i), cy: zPerp, r: rv, stroke: REBAR, fill: REBAR, width: 0.5 })
   // column vertical bars / dowels — full height, bent out onto the mat
   const vx = [cl + c, cr - c]
   for (const dx of vx) {
     const dir = dx < sx0 ? -1 : 1
-    bar([[dx, colTop + c], [dx, matZ], [dx + dir * (cw * 0.42), matZ]])
+    bar([[dx, colTop + c], [dx, zLong], [dx + dir * (cw * 0.42), zLong]])
   }
   // stirrups up the column at the scheduled spacing
   const stX0 = cl + c * 0.6, stX1 = cr - c * 0.6
@@ -170,6 +183,10 @@ export function buildFootingDetail(f: FootingDetailInput, opts: FootingDetailOpt
   P.push({ kind: 'dim', x1: dX - ts * 1.4, y1: gradeZ, x2: dX - ts * 1.4, y2: gravBot, text: `${Math.round((gravBot - gradeZ) * 1000)} mm`, off: 0, size: ts * 0.7 })
   // width dimension below the gravel
   P.push({ kind: 'dim', x1: secL, y1: gravBot + ts * 1.2, x2: secR, y2: gravBot + ts * 1.2, text: `${Math.round(B * 1000)} mm`, off: 0, size: ts * 0.7 })
+  // dashed extension lines at every section dimension boundary
+  for (const zb of [gradeZ, footTop, footBot, gravBot]) ext(dX, zb, secL, zb)
+  for (const zb of [gradeZ, gravBot]) ext(dX - ts * 1.4, zb, dX, zb)
+  for (const xb of [secL, secR]) ext(xb, gravBot + ts * 1.2, xb, gravBot)
   // callouts with leaders
   const lead = (x1: number, y1: number, x2: number, y2: number) => P.push({ kind: 'line', x1, y1, x2, y2, stroke: INK, width: 0.5 })
   lead(cr, colTop * 0.75, secR + ts * 0.6, colTop * 0.75)
@@ -177,8 +194,8 @@ export function buildFootingDetail(f: FootingDetailInput, opts: FootingDetailOpt
   lead(cr, gradeZ * 0.55, secR + ts * 0.6, gradeZ * 0.55)
   const stLines = [`STIRRUPS = ⌀${stDia} REBAR`, `${stSched.map(([cc, ss]) => `${cc}@${ss}`).join(', ')},`, `REST @ ${stRest} mm O.C.`]
   stLines.forEach((s, i) => P.push({ kind: 'text', x: secR + ts * 0.8, y: gradeZ * 0.55 + i * ts * 0.72, text: s, size: ts * 0.5, anchor: 'start', color: INK, weight: 500 }))
-  lead(secR - c, matZ, secR + ts * 0.6, matZ + ts * 0.6)
-  P.push({ kind: 'text', x: secR + ts * 0.8, y: matZ + ts * 0.6, text: `${n}-${f.barDia}mmØ BOTHWAY`, size: ts * 0.55, anchor: 'start', color: REBAR, weight: 600 })
+  lead(secR - c, zLong, secR + ts * 0.6, zLong + ts * 0.6)
+  P.push({ kind: 'text', x: secR + ts * 0.8, y: zLong + ts * 0.6, text: `${n}-${f.barDia}mmØ BOTHWAY`, size: ts * 0.55, anchor: 'start', color: REBAR, weight: 600 })
   if (f.foundingElev != null)
     P.push({ kind: 'text', x: secL, y: footTop - ts * 0.5, text: `T.O.F. EL ${f.foundingElev.toFixed(2)} m`, size: ts * 0.5, anchor: 'start', color: PANEL, weight: 600 })
   P.push({ kind: 'text', x: sx0, y: gravBot + ts * 2.4, text: 'SECTION A-A', size: ts * 0.85, anchor: 'middle', color: INK, weight: 700 })

--- a/webapp/src/engine/planRenderer.ts
+++ b/webapp/src/engine/planRenderer.ts
@@ -30,9 +30,14 @@ export interface ColumnScheduleRow { mark: string; size: string; notes: string }
  *  from the design pipeline. Geometry in m; thickness/spacing in mm. */
 export interface PlanFooting { node: string; B: number; Dc: number; bars: number; barSpacing: number; barDia?: number }
 
-export interface PlanDrawing {
+/** Anything the serializer can paint: typed primitives + their world bounds.
+ *  Both plan drawings and standalone details satisfy this. */
+export interface Drawing {
   primitives: PlanPrimitive[]
   bounds: { minX: number; minY: number; maxX: number; maxY: number }
+}
+
+export interface PlanDrawing extends Drawing {
   title: string
   beamSchedule: BeamScheduleRow[]
   footingSchedule: FootingScheduleRow[]
@@ -306,8 +311,9 @@ export function buildPlan(model: StructuralModel, opts: PlanOptions = {}): PlanD
 
 const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 
-/** Serialise a plan drawing to an SVG string (world metres → px, Y downward). */
-export function planToSvg(d: PlanDrawing, pxWidth = 1100): string {
+/** Serialise a drawing (plan or detail) to an SVG string (world metres → px,
+ *  Y downward). Only `primitives` + `bounds` are read. */
+export function planToSvg(d: Drawing, pxWidth = 1100): string {
   const wW = Math.max(0.001, d.bounds.maxX - d.bounds.minX)
   const wH = Math.max(0.001, d.bounds.maxY - d.bounds.minY)
   const pad = 24

--- a/webapp/src/engine/planRenderer.ts
+++ b/webapp/src/engine/planRenderer.ts
@@ -14,12 +14,18 @@
 // ─────────────────────────────────────────────────────────────────────────
 import type { StructuralModel, RectSection } from './model'
 
+export type PathCmd =
+  | { c: 'M' | 'L'; x: number; y: number }
+  | { c: 'A'; rx: number; ry: number; x: number; y: number; large?: 0 | 1; sweep?: 0 | 1 }
+
 export type PlanPrimitive =
   | { kind: 'line'; x1: number; y1: number; x2: number; y2: number; stroke: string; width?: number; dash?: number[] }
   | { kind: 'rect'; x: number; y: number; w: number; h: number; stroke?: string; fill?: string; width?: number; dash?: number[] }
   | { kind: 'circle'; cx: number; cy: number; r: number; stroke?: string; fill?: string; width?: number }
   | { kind: 'text'; x: number; y: number; text: string; size: number; anchor?: 'start' | 'middle' | 'end'; rotate?: number; color?: string; weight?: number }
   | { kind: 'dim'; x1: number; y1: number; x2: number; y2: number; text: string; off: number; size: number }
+  // world-space path (coords in m, arc radii in m) — used for outlined rebar tubes
+  | { kind: 'path'; cmds: PathCmd[]; stroke?: string; fill?: string; width?: number; dash?: number[]; closed?: boolean }
 
 export interface BeamScheduleRow { mark: string; size: string }
 export interface FootingScheduleRow { mark: string; size: string; thk: string; reinf: string }
@@ -297,6 +303,7 @@ export function buildPlan(model: StructuralModel, opts: PlanOptions = {}): PlanD
     if (pr.kind === 'line' || pr.kind === 'dim') { acc(pr.x1, pr.y1); acc(pr.x2, pr.y2) }
     else if (pr.kind === 'rect') { acc(pr.x, pr.y); acc(pr.x + pr.w, pr.y + pr.h) }
     else if (pr.kind === 'circle') { acc(pr.cx - pr.r, pr.cy - pr.r); acc(pr.cx + pr.r, pr.cy + pr.r) }
+    else if (pr.kind === 'path') { for (const cmd of pr.cmds) acc(cmd.x, cmd.y) }
     else acc(pr.x, pr.y)
   }
   return {
@@ -349,6 +356,11 @@ export function planToSvg(d: Drawing, pxWidth = 1100): string {
       const vertical = Math.abs(y2 - y1) > Math.abs(x2 - x1)
       const rot = vertical ? ` transform="rotate(-90 ${mx.toFixed(1)} ${my.toFixed(1)})"` : ''
       out.push(`<text x="${mx.toFixed(1)}" y="${(my - fs * 0.35).toFixed(1)}" font-size="${fs.toFixed(1)}" text-anchor="middle" fill="${INK}"${rot}>${esc(p.text)}</text>`)
+    } else if (p.kind === 'path') {
+      const d = p.cmds.map((cmd) => cmd.c === 'A'
+        ? `A ${L(cmd.rx).toFixed(1)} ${L(cmd.ry).toFixed(1)} 0 ${cmd.large ?? 0} ${cmd.sweep ?? 0} ${X(cmd.x).toFixed(1)} ${Y(cmd.y).toFixed(1)}`
+        : `${cmd.c} ${X(cmd.x).toFixed(1)} ${Y(cmd.y).toFixed(1)}`).join(' ') + (p.closed ? ' Z' : '')
+      out.push(`<path d="${d}" fill="${p.fill ?? 'none'}" stroke="${p.stroke ?? 'none'}" stroke-width="${p.width ?? 1}"${p.dash ? ` stroke-dasharray="${p.dash.map((v) => L(v).toFixed(1)).join(',')}"` : ''}/>`)
     }
   }
   out.push('</svg>')


### PR DESCRIPTION
## Summary
Phase 4 adds a standalone **typical footing detail sheet** — a bar-mat **PLAN** plus a **SECTION A-A** — for one designed footing. New module `footingDetail.ts` emits the same `PlanPrimitive[]` the plan renderer uses; `planToSvg` now takes a minimal `Drawing` shape (`{ primitives, bounds }`), so plans and details share one serializer.

Engine layer: drawing/output module (designed footing → detail). No solver/pipeline changes. Detailing follows **ACI 318-14 §25.4** (hooks/development) and **§13.3** (footing reinforcement placement).

## What it draws
- **PLAN** — footing outline, dashed column footprint, the bottom reinforcing mat drawn **both ways** at the design spacing, the **A-A cut line** with end flags/arrows, a `<n>-⌀<db> @ <spacing> BOTH WAYS` note, and the width dimension.
- **SECTION A-A** — footing depth with the **column stub + ties**, **column dowels** hooked onto the mat, the bottom mat in section (longitudinal bar + perpendicular bar-ends), soil hatch, **T.O.F. elevation**, and **B / H** dimensions in mm.
- **Detail-tag title block** — `n / S-xx  TYPICAL FOOTING DETAIL — <mark>  NTS`.

The input is a small `FootingDetailInput` (`mark, B, H, cover, barDia, bars, barSpacing, colB/colH, dowelDia?, foundingElev?`), so a caller maps a `SquareFootingResult` + column section into it — the module stays decoupled from the pipeline.

## Verification
- `webapp/src/engine/footingDetail.test.ts` — 6 cases (both views + tag, side-by-side layout, mat both ways + section bar-ends, B/H dims, dowels + elevation, valid SVG).
- **Full suite green: 1432 tests**, `npx tsc -b` clean.
- Rendered and rasterised via headless Chromium for visual review.

## Next phase
- **Phase 5** — "Plans" tab in Model Space: framing + foundation plans and per-footing detail sheets, wiring `design.footings` → `PlanFooting` / `FootingDetailInput`, with SVG/PDF export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_