### PR TITLE
docs: record the plan-renderer / drawing-sheets status in HANDOFF

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -29,6 +29,43 @@ store-backed `ScheduleProject`.
   delay-report export, photos, resource levelling, per-activity calendars/
   constraints) are listed in `docs/scheduling.md`.
 
+## Structural plan renderer / drawing sheets (PRs #419–#422 — COMPLETE)
+CAD-style structural **drawings generated from the 3D model + design**, emitted as
+scalable **SVG** and surfaced in a **"Plans" tab** in Model Space (`/model`). Pure
+engine + a thin React panel; every sheet exports to SVG.
+
+- **Engine** (pure, tested): `webapp/src/engine/`
+  - `planRenderer.ts` — `buildPlan(model, opts)` → typed `PlanPrimitive[]` in world
+    metres + bounds; `planToSvg(drawing, pxWidth)` serialises (Y-down). Draws the
+    **framing plan** (grid + bubbles, chained dims w/ units, framing beams with
+    grouped marks FB1/FB2… + a BEAM SCHEDULE, column squares, slab panels, detail-tag
+    title block) and the **foundation plan** (dashed footing pads sized from
+    `design.footings`, WF-n marks + FOOTING SCHEDULE, FTB tie beams, per-pad EL
+    elevation tags, COLUMN SCHEDULE). Primitive kinds: line/rect/circle/text/dim +
+    **`path`** (world-space M/L/A with fill-rule, opacity, join/cap) for outlined rebar.
+  - `footingDetail.ts` — `buildFootingDetail(input, opts)` → a column-footing detail
+    sheet: **bar-mat PLAN + SECTION A-A**. Rebar drawn as **outline tubes** (`rod()`),
+    design-driven **90° end hooks** (`endHook`, default straight) that hug the
+    perpendicular bar with a guard, **stacked mat layers** (over/under at crossings via
+    white-filled top bars; §13.3), column dowels + variable-spaced **lateral ties**,
+    **packed-gravel** bedding, natural-grade line + soil hatch, chained depth dims,
+    element-anchored leaders. ACI 318-14 §25.3/§25.4/§13.3.
+  - `columnSection.ts` — `columnSectionPrimitives(P, cx, cy, side, p, colors, sw)`: an
+    engine port of the report's `<ColumnSchematic>` (tied) — rounded concrete square,
+    perimeter tie + interior 180° crossties, full bar ring, and a **135° corner tie
+    hook drawn as two lines tangent to the corner bar**. Colour-parameterised; the
+    footing sheet draws it **as the column IN the plan** (orange/white), reusing the
+    all-around bar-layout math shared with `ColumnSchematic`.
+- **UI**: `components/PlansPanel.tsx` (+ `lib/planDetails.ts`, pure/tested — maps a
+  `StructureDesign` to `PlanFooting[]` and one `FootingDetailInput` per distinct
+  footing type WF-n, recovering the footing bar Ø from the designed steel area);
+  new **`plans`** right-panel tab in `pages/ModelSpace.tsx`.
+- Phases → PRs: **#419** framing (P1–2), **#420** foundation (P3), **#421** footing
+  detail sheet (P4), **#422** "Plans" tab + engine column section (P5). Suite **1444**.
+- **Follow-ups** (not built): SVG→PDF sheet export/print layout; beam/column
+  **schedule detail sheets** and a tie-bend detail; slab reinforcement plans;
+  wiring the plan-renderer drawings into the direct PDF report (`lib/modelPdf.ts`).
+
 ## Continue from your phone / cloud (PC off)
 The local terminal session needs your PC on. To keep working without it:
 1. Open **claude.ai/code** (mobile browser) or the **Claude app**, same account.


### PR DESCRIPTION
## Summary
Adds a **"Structural plan renderer / drawing sheets (PRs #419–#422 — COMPLETE)"** section to `HANDOFF.md`, placed next to the Scheduling module as a peer feature, so a fresh session picks up the drawing work instantly.

Documents:
- the three engine modules — `planRenderer.ts` (framing + foundation plans + the `path` primitive + `planToSvg`), `footingDetail.ts` (bar-mat plan + Section A-A, outline-tube rebar, design-driven 90° hooks, stacked mat layers, lateral ties, packed gravel), `columnSection.ts` (engine port of `ColumnSchematic`, drawn as the column in the plan, tangent two-line tie hook);
- the UI wiring (`components/PlansPanel.tsx`, pure `lib/planDetails.ts`, new `plans` tab in `ModelSpace`);
- the phase→PR map (#419 framing, #420 foundation, #421 footing detail, #422 Plans tab), suite at **1444**;
- the not-yet-built follow-ups (SVG→PDF sheet export, beam/column schedule detail sheets, tie-bend detail, plan drawings into the direct PDF report).

Docs-only — no code, no test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_