### PR TITLE
Framing plan: combined per-floor sheet + slab span symbols

### DIFF
--- a/webapp/src/components/PlansPanel.tsx
+++ b/webapp/src/components/PlansPanel.tsx
@@ -5,6 +5,10 @@ import { buildPlan, planToSvg } from '../engine/planRenderer'
 import { buildFootingDetail } from '../engine/footingDetail'
 import { footingsForPlan, footingDetailBundles, type SoilInput } from '../lib/planDetails'
 
+const FLOOR_ORD = ['Ground', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth', 'Seventh', 'Eighth', 'Ninth', 'Tenth', 'Eleventh', 'Twelfth']
+/** Framed-level ordinal (1 = first floor above the base) → floor name. */
+function floorName(k: number): string { return `${FLOOR_ORD[k - 1] ?? `${k}th`} Floor` }
+
 /** Render a trusted, engine-generated SVG string. */
 function RawSvg({ svg, className }: { svg: string; className?: string }): JSX.Element {
   return <div className={className} dangerouslySetInnerHTML={{ __html: svg }} />
@@ -38,31 +42,17 @@ function Sheet({ title, svg, file }: { title: string; svg: string; file: string 
 export function PlansPanel({ model, design, soil }: { model: StructuralModel; design: StructureDesign | null; soil: SoilInput }): JSX.Element {
   const [hooked, setHooked] = useState(false)
 
-  // per floor: a BEAM framing plan and a COLUMN framing plan (split sheets);
-  // level index = the node-y ordinal above the base
+  // one framing plan per framed floor, named 'Ground/Second/… Floor Framing Plan'
   const framings = useMemo(() => {
     const ys = [...new Set(model.nodes.map((n) => Math.round(n.y * 100) / 100))].sort((a, b) => a - b)
     const floors = ys.slice(1)   // skip the base (foundation)
-    const idxs = floors.length ? floors.map((_, i) => i + 1) : [ys.length > 1 ? 1 : 0]
-    const out: { heading: string; file: string; svg: string }[] = []
-    let sheet = 2
-    for (const level of idxs) {
-      const y = ys[level] ?? ys[ys.length - 1]
-      const single = floors.length <= 1
-      const suffix = single ? '' : ` — Level ${level} · EL +${y.toFixed(2)} m`
-      const label = single ? undefined : `L${level} (EL +${y.toFixed(2)} m)`
-      const tag = single ? '' : `-L${level}`
-      for (const layer of ['beam', 'column'] as const) {
-        const d = buildPlan(model, { kind: 'framing', layer, level, detailNo: '1', sheetRef: `S-${sheet++}`, label })
-        if (!d) continue
-        out.push({
-          heading: `${layer === 'beam' ? 'Beam framing plan' : 'Column framing plan'}${suffix}`,
-          file: `${layer}-framing${tag}.svg`,
-          svg: planToSvg(d),
-        })
-      }
-    }
-    return out
+    const idxs = floors.length ? floors.map((_, i) => i + 1) : [1]
+    return idxs.map((level, i) => {
+      const name = floorName(level)
+      const d = buildPlan(model, { kind: 'framing', level, detailNo: '1', sheetRef: `S-${2 + i}`, title: `${name} FRAMING PLAN`.toUpperCase() })
+      if (!d) return null
+      return { heading: `${name} framing plan`, file: `framing-${name.toLowerCase().replace(/\s+/g, '-')}.svg`, svg: planToSvg(d) }
+    }).filter((x): x is { heading: string; file: string; svg: string } => x != null)
   }, [model])
 
   const foundation = useMemo(() => {

--- a/webapp/src/engine/planRenderer.test.ts
+++ b/webapp/src/engine/planRenderer.test.ts
@@ -62,32 +62,23 @@ describe('planRenderer — framing plan geometry', () => {
     expect(f.primitives.some((p) => p.kind === 'rect' && (p as { dash?: number[] }).dash)).toBe(true)
   })
 
-  it('draws a per-floor framing plan for each level, titled with a label', () => {
+  it('draws a per-floor framing plan for each level with a title override', () => {
     const twoStorey = generateGridModel({ baysX: [6, 6], baysZ: [5], storeyH: [3, 3], section, slabThickness: 150 })
-    const l1 = buildPlan(twoStorey, { kind: 'framing', level: 1, label: 'L1 (EL +3.00 m)' })!
-    const l2 = buildPlan(twoStorey, { kind: 'framing', level: 2, label: 'L2 (EL +6.00 m)' })!
-    expect(l1.title).toBe('FRAMING PLAN — L1 (EL +3.00 m)')
-    expect(l2.title).toBe('FRAMING PLAN — L2 (EL +6.00 m)')
+    const l1 = buildPlan(twoStorey, { kind: 'framing', level: 1, title: 'GROUND FLOOR FRAMING PLAN' })!
+    const l2 = buildPlan(twoStorey, { kind: 'framing', level: 2, title: 'SECOND FLOOR FRAMING PLAN' })!
+    expect(l1.title).toBe('GROUND FLOOR FRAMING PLAN')
+    expect(l2.title).toBe('SECOND FLOOR FRAMING PLAN')
     expect(l1.beamSchedule.length).toBeGreaterThan(0)
     expect(l2.beamSchedule.length).toBeGreaterThan(0)
   })
 
-  it('splits framing into a BEAM sheet (beams + schedule, no column marks) and a COLUMN sheet (columns + schedule, no beams)', () => {
-    const beam = buildPlan(model, { kind: 'framing', layer: 'beam' })!
-    const col = buildPlan(model, { kind: 'framing', layer: 'column' })!
-    expect(beam.title).toBe('BEAM FRAMING PLAN')
-    expect(col.title).toBe('COLUMN FRAMING PLAN')
-    // beam sheet: has beam centrelines (BEAM stroke) + BEAM SCHEDULE, no C-marks
-    expect(beam.primitives.some((p) => p.kind === 'line' && (p as { stroke?: string }).stroke === '#0f4c92')).toBe(true)
-    expect(texts(beam.primitives)).toContain('BEAM SCHEDULE')
-    expect(texts(beam.primitives).some((t) => /^C\d+$/.test(t))).toBe(false)
-    // beam sheet: columns are a light dashed reference outline (no solid fill)
-    expect(beam.primitives.some((p) => p.kind === 'rect' && (p as { fill?: string }).fill === '#1e293b')).toBe(false)
-    // column sheet: solid column squares + C-marks + COLUMN SCHEDULE, no beams
-    expect(col.primitives.some((p) => p.kind === 'rect' && (p as { fill?: string }).fill === '#1e293b')).toBe(true)
-    expect(texts(col.primitives).some((t) => /^C\d+$/.test(t))).toBe(true)
-    expect(texts(col.primitives)).toContain('COLUMN SCHEDULE')
-    expect(col.primitives.some((p) => p.kind === 'line' && (p as { stroke?: string }).stroke === '#0f4c92')).toBe(false)
+  it('framing plan draws solid black columns + beams (both), with a beam schedule', () => {
+    const f = buildPlan(model, { kind: 'framing' })!
+    expect(f.title).toBe('FRAMING PLAN')
+    // solid black column squares AND beam centrelines both present
+    expect(f.primitives.filter((p) => p.kind === 'rect' && (p as { fill?: string }).fill === '#1e293b').length).toBe(6)
+    expect(f.primitives.some((p) => p.kind === 'line' && (p as { stroke?: string }).stroke === '#0f4c92')).toBe(true)
+    expect(texts(f.primitives)).toContain('BEAM SCHEDULE')
   })
 })
 

--- a/webapp/src/engine/planRenderer.test.ts
+++ b/webapp/src/engine/planRenderer.test.ts
@@ -28,8 +28,11 @@ describe('planRenderer — framing plan geometry', () => {
     expect(texts(plan.primitives)).toContain('BEAM SCHEDULE')
   })
 
-  it('labels slab panels with a thickness carrying units (h=150 mm)', () => {
-    expect(texts(plan.primitives)).toContain('h=150 mm')
+  it('marks slab panels with a slab number (S1) + a SLAB SCHEDULE, not h=…', () => {
+    expect(texts(plan.primitives)).toContain('S1')
+    expect(texts(plan.primitives)).toContain('SLAB SCHEDULE')
+    expect(texts(plan.primitives).some((t) => t.startsWith('h='))).toBe(false)
+    expect(plan.slabSchedule[0]).toMatchObject({ mark: 'S1' })
   })
 
   it('emits a title block with the sheet title, detail tag and scale', () => {

--- a/webapp/src/engine/planRenderer.ts
+++ b/webapp/src/engine/planRenderer.ts
@@ -30,6 +30,7 @@ export type PlanPrimitive =
 export interface BeamScheduleRow { mark: string; size: string }
 export interface FootingScheduleRow { mark: string; size: string; thk: string; reinf: string }
 export interface ColumnScheduleRow { mark: string; size: string; notes: string }
+export interface SlabScheduleRow { mark: string; thk: string; type: string }
 
 /** Minimal per-footing shape the foundation plan needs — mapped from the
  *  pipeline's `design.footings` by the caller, so this module stays decoupled
@@ -48,6 +49,7 @@ export interface PlanDrawing extends Drawing {
   beamSchedule: BeamScheduleRow[]
   footingSchedule: FootingScheduleRow[]
   columnSchedule: ColumnScheduleRow[]
+  slabSchedule: SlabScheduleRow[]
 }
 
 export interface PlanOptions {
@@ -136,6 +138,15 @@ export function buildPlan(model: StructuralModel, opts: PlanOptions = {}): PlanD
     const key = `${sec.b}×${sec.h}|${sec.fc}|${sec.fy}`   // identical columns share a mark
     let mk = colMarkBySec.get(key)
     if (!mk) { mk = `C${colMarkBySec.size + 1}`; colMarkBySec.set(key, mk); columnSchedule.push({ mark: mk, size: `${sec.b}×${sec.h}`, notes: `f'c=${sec.fc} MPa` }) }
+    return mk
+  }
+  // slab marks (S1, S2…) group by thickness × span type
+  const slabMarkByKey = new Map<string, string>()
+  const slabSchedule: SlabScheduleRow[] = []
+  const slabMarkFor = (thk: number, type: string): string => {
+    const key = `${thk}|${type}`
+    let mk = slabMarkByKey.get(key)
+    if (!mk) { mk = `S${slabMarkByKey.size + 1}`; slabMarkByKey.set(key, mk); slabSchedule.push({ mark: mk, thk: `${thk}`, type }) }
     return mk
   }
   // footing marks (WF-1, WF-2…) group by side × thickness
@@ -234,18 +245,51 @@ export function buildPlan(model: StructuralModel, opts: PlanOptions = {}): PlanD
     P.push({ kind: 'rect', x: node.x - cw / 2, y: node.z - ch / 2, w: cw, h: ch, stroke: COL, fill: outline ? 'none' : COL, width: 1.2, dash: outline ? [0.2, 0.15] : undefined })
   }
 
-  // ── slab panels at the level (outline + thickness label) ──
-  for (const p of model.plates) {
-    if (p.role === 'wall') continue
-    const c = p.corners.map((id) => nm.get(id)); if (c.some((q) => !q)) continue
-    const cc = c as { x: number; y: number; z: number }[]
-    if (!cc.every((q) => near(q.y, levelY))) continue
-    for (let i = 0; i < 4; i++) {
-      const u = cc[i], v = cc[(i + 1) % 4]
-      P.push({ kind: 'line', x1: u.x, y1: u.z, x2: v.x, y2: v.z, stroke: PANEL, width: 0.5, dash: [0.15, 0.12] })
+  // ── slab panels at the level: outline + a span-direction symbol (double
+  // arrows = two-way, a single pair = one-way) and the slab mark (S1, S2…) ──
+  const ah = r * 0.22                       // arrowhead size
+  const arrowHead = (ex: number, ez: number, ux: number, uz: number) => {
+    const px = -uz, pz = ux
+    P.push({ kind: 'line', x1: ex, y1: ez, x2: ex - ux * ah + px * ah * 0.5, y2: ez - uz * ah + pz * ah * 0.5, stroke: PANEL, width: 0.7 })
+    P.push({ kind: 'line', x1: ex, y1: ez, x2: ex - ux * ah - px * ah * 0.5, y2: ez - uz * ah - pz * ah * 0.5, stroke: PANEL, width: 0.7 })
+  }
+  const spanArm = (mx: number, mz: number, ux: number, uz: number, gap: number, sh: number) => {
+    P.push({ kind: 'line', x1: mx + ux * gap, y1: mz + uz * gap, x2: mx + ux * sh, y2: mz + uz * sh, stroke: PANEL, width: 0.7 })
+    arrowHead(mx + ux * sh, mz + uz * sh, ux, uz)
+  }
+  const platesOnLevel = model.plates
+    .filter((p) => p.role !== 'wall')
+    .map((p) => ({ p, cc: p.corners.map((id) => nm.get(id)) }))
+    .filter((x): x is { p: typeof x.p; cc: NonNullable<(typeof x.cc)[number]>[] } => x.cc.every((q) => q != null) && x.cc.every((q) => near(q!.y, levelY)))
+    .map(({ p, cc }) => {
+      const xsp = cc.map((q) => q.x), zsp = cc.map((q) => q.z)
+      return { p, minX: Math.min(...xsp), maxX: Math.max(...xsp), minZ: Math.min(...zsp), maxZ: Math.max(...zsp) }
+    })
+  for (const { p, minX, maxX, minZ, maxZ } of platesOnLevel) {
+    const cs: [number, number][] = [[minX, minZ], [maxX, minZ], [maxX, maxZ], [minX, maxZ]]
+    for (let i = 0; i < 4; i++)
+      P.push({ kind: 'line', x1: cs[i][0], y1: cs[i][1], x2: cs[(i + 1) % 4][0], y2: cs[(i + 1) % 4][1], stroke: PANEL, width: 0.5, dash: [0.15, 0.12] })
+    const lx = maxX - minX, ly = maxZ - minZ
+    const mx = (minX + maxX) / 2, mz = (minZ + maxZ) / 2
+    const twoWay = Math.max(lx, ly) / Math.max(1e-6, Math.min(lx, ly)) <= 2
+    const mk = slabMarkFor(Math.round(p.thickness), twoWay ? 'Two-way' : 'One-way')
+    const gap = r * 0.55, sh = Math.min(lx, ly) * 0.32
+    const dirs: [number, number][] = twoWay ? [[1, 0], [-1, 0], [0, 1], [0, -1]]
+      : lx <= ly ? [[1, 0], [-1, 0]] : [[0, 1], [0, -1]]   // one-way spans the SHORT direction
+    for (const [ux, uz] of dirs) spanArm(mx, mz, ux, uz, gap, sh)
+    P.push({ kind: 'text', x: mx, y: mz, text: mk, size: r * 0.55, anchor: 'middle', color: PANEL, weight: 700 })
+  }
+
+  // ── grid bays with NO slab → an X from corner to corner ──
+  if (!foundation) {
+    for (let i = 0; i < xs.length - 1; i++) for (let j = 0; j < zs.length - 1; j++) {
+      const bx0 = xs[i], bx1 = xs[i + 1], bz0 = zs[j], bz1 = zs[j + 1]
+      const cx = (bx0 + bx1) / 2, cz = (bz0 + bz1) / 2
+      const covered = platesOnLevel.some((s) => cx >= s.minX - 0.05 && cx <= s.maxX + 0.05 && cz >= s.minZ - 0.05 && cz <= s.maxZ + 0.05)
+      if (covered) continue
+      P.push({ kind: 'line', x1: bx0, y1: bz0, x2: bx1, y2: bz1, stroke: GRID, width: 0.7 })
+      P.push({ kind: 'line', x1: bx1, y1: bz0, x2: bx0, y2: bz1, stroke: GRID, width: 0.7 })
     }
-    const mx = (cc[0].x + cc[2].x) / 2, mz = (cc[0].z + cc[2].z) / 2
-    P.push({ kind: 'text', x: mx, y: mz, text: `h=${Math.round(p.thickness)} mm`, size: r * 0.5, anchor: 'middle', color: PANEL, weight: 600 })
   }
 
   // ── chained grid dimensions — placed INSIDE the bubbles (between the bubble
@@ -300,9 +344,16 @@ export function buildPlan(model: StructuralModel, opts: PlanOptions = {}): PlanD
       const rows = [['MARK', 'SIZE', 'REMARKS'], ...columnSchedule.map((c) => [c.mark, withUnit(c.size), c.notes])]
       drawTable(tbX, y, 'COLUMN SCHEDULE', COL, [r * 1.6, r * 3.4, r * 4.4], rows)
     }
-  } else if (schedule.length) {
-    const rows = [['MARK', 'SIZE'], ...schedule.map((s) => [s.mark, withUnit(s.size)])]
-    drawTable(tbX, tblY0, 'BEAM SCHEDULE', BEAM, [r * 1.6, r * 3.6], rows)
+  } else {
+    let y = tblY0
+    if (schedule.length) {
+      const rows = [['MARK', 'SIZE'], ...schedule.map((s) => [s.mark, withUnit(s.size)])]
+      y = drawTable(tbX, y, 'BEAM SCHEDULE', BEAM, [r * 1.6, r * 3.6], rows) + r * 1.4
+    }
+    if (slabSchedule.length) {
+      const rows = [['MARK', 'THK', 'TYPE'], ...slabSchedule.map((s) => [s.mark, withUnit(s.thk), s.type])]
+      drawTable(tbX, y, 'SLAB SCHEDULE', PANEL, [r * 1.6, r * 2.2, r * 3.6], rows)
+    }
   }
 
   // ── bounds = span of every primitive coordinate ──
@@ -326,6 +377,7 @@ export function buildPlan(model: StructuralModel, opts: PlanOptions = {}): PlanD
     beamSchedule: schedule,
     footingSchedule,
     columnSchedule,
+    slabSchedule,
   }
 }
 

--- a/webapp/src/engine/planRenderer.ts
+++ b/webapp/src/engine/planRenderer.ts
@@ -282,7 +282,7 @@ export function buildPlan(model: StructuralModel, opts: PlanOptions = {}): PlanD
     // two-way → one span arrow per axis (crossing); one-way → a single arrow in
     // the SHORT direction; each spans ~60% of its panel dimension
     const axes: [number, number][] = twoWay ? [[1, 0], [0, 1]] : lx <= ly ? [[1, 0]] : [[0, 1]]
-    for (const [ux, uz] of axes) spanSymbol(mx, mz, ux, uz, (ux ? lx : ly) * 0.3)
+    for (const [ux, uz] of axes) spanSymbol(mx, mz, ux, uz, (ux ? lx : ly) * 0.15)
     // slab mark tucked into the upper-left quadrant, clear of the crossing arrows
     const q = Math.min(lx, ly) * 0.18
     P.push({ kind: 'text', x: mx - q, y: mz - q, text: mk, size: r * 0.55, anchor: 'middle', color: PANEL, weight: 700 })

--- a/webapp/src/engine/planRenderer.ts
+++ b/webapp/src/engine/planRenderer.ts
@@ -52,9 +52,6 @@ export interface PlanDrawing extends Drawing {
 
 export interface PlanOptions {
   kind?: 'framing' | 'foundation'
-  /** Framing sub-sheet: 'beam' (beams + slab, columns as reference) or 'column'
-   *  (columns + schedule only). Omit for the combined framing plan. */
-  layer?: 'beam' | 'column'
   /** Storey level index (1 = first floor above base). Default: first framed level. */
   level?: number
   /** Title-block detail number, sheet reference and scale note. */
@@ -65,8 +62,8 @@ export interface PlanOptions {
   footings?: PlanFooting[]
   /** Foundation plan: top-of-footing elevation (m, −down) for per-footing ELEV tags. */
   foundingElev?: number
-  /** Extra title suffix, e.g. a floor label — 'FRAMING PLAN — L2 (EL +6.00 m)'. */
-  label?: string
+  /** Full sheet title override, e.g. 'GROUND FLOOR FRAMING PLAN'. */
+  title?: string
 }
 
 const INK = '#1e293b', GRID = '#94a3b8', BEAM = '#0f4c92', COL = '#1e293b', PANEL = '#0f766e'
@@ -95,7 +92,6 @@ export function buildPlan(model: StructuralModel, opts: PlanOptions = {}): PlanD
 
   // level to draw: default the first framed level above the base (or the base for foundation)
   const foundation = opts.kind === 'foundation'
-  const layer = foundation ? undefined : opts.layer   // 'beam' | 'column' | undefined (both)
   const levelY = foundation ? ys[0] : (opts.level != null ? ys[opts.level] : (ys[1] ?? ys[0]))
 
   const P: PlanPrimitive[] = []
@@ -158,7 +154,6 @@ export function buildPlan(model: StructuralModel, opts: PlanOptions = {}): PlanD
     return mk
   }
   for (const mem of model.members) {
-    if (layer === 'column') break   // column layout sheet — no beams
     if (mem.role === 'column') continue
     const a = nm.get(mem.i), b = nm.get(mem.j); if (!a || !b) continue
     if (!(near(a.y, levelY) && near(b.y, levelY))) continue   // only members on this level
@@ -233,20 +228,14 @@ export function buildPlan(model: StructuralModel, opts: PlanOptions = {}): PlanD
     drawn.add(key)
     const sec = secOf(mem.id)
     const cw = (sec?.b ?? 400) / 1000, ch = (sec?.h ?? 400) / 1000
-    const mk = sec ? colMarkFor(sec) : ''   // collect the column schedule (marks shown in the table)
-    // on the foundation plan a designed footing sits under the stub → draw the
-    // stub solid so it reads inside the dashed pad; on the BEAM sheet columns are
-    // drawn as a light reference outline; on the COLUMN sheet they are solid + marked
-    const footed = foundation && !!opts.footings?.length
-    const outline = (foundation && !footed) || layer === 'beam'
-    P.push({ kind: 'rect', x: node.x - cw / 2, y: node.z - ch / 2, w: cw, h: ch, stroke: layer === 'beam' ? GRID : COL, fill: outline ? 'none' : COL, width: layer === 'beam' ? 0.8 : 1.2, dash: outline ? [0.2, 0.15] : undefined })
-    if (layer === 'column' && sec)
-      P.push({ kind: 'text', x: node.x + cw / 2 + r * 0.25, y: node.z - ch / 2 - r * 0.25, text: mk, size: r * 0.55, anchor: 'start', color: COL, weight: 700 })
+    if (sec) colMarkFor(sec)   // collect the column schedule (shown on the foundation plan)
+    // framing: solid black column section; foundation without a footing: dashed outline
+    const outline = foundation && !opts.footings?.length
+    P.push({ kind: 'rect', x: node.x - cw / 2, y: node.z - ch / 2, w: cw, h: ch, stroke: COL, fill: outline ? 'none' : COL, width: 1.2, dash: outline ? [0.2, 0.15] : undefined })
   }
 
   // ── slab panels at the level (outline + thickness label) ──
   for (const p of model.plates) {
-    if (layer === 'column') break   // column layout sheet — no slab panels
     if (p.role === 'wall') continue
     const c = p.corners.map((id) => nm.get(id)); if (c.some((q) => !q)) continue
     const cc = c as { x: number; y: number; z: number }[]
@@ -270,15 +259,15 @@ export function buildPlan(model: StructuralModel, opts: PlanOptions = {}): PlanD
 
   // ── title block (detail tag) + beam schedule, below the plan ──
   const detailNo = opts.detailNo ?? '1', sheetRef = opts.sheetRef ?? 'S-1', scale = opts.scale ?? 'NTS'
-  const baseTitle = foundation ? 'FOUNDATION PLAN' : layer === 'beam' ? 'BEAM FRAMING PLAN' : layer === 'column' ? 'COLUMN FRAMING PLAN' : 'FRAMING PLAN'
-  const title = `${baseTitle}${opts.label ? ` — ${opts.label}` : ''}`
+  const title = opts.title ?? (foundation ? 'FOUNDATION PLAN' : 'FRAMING PLAN')
   const tbR = r * 1.15, tbY = z1 + ext + r * 2, tbX = x0 - ext
-  P.push({ kind: 'circle', cx: tbX + tbR, cy: tbY, r: tbR, stroke: INK, fill: '#fff', width: 1 })
-  P.push({ kind: 'line', x1: tbX, y1: tbY, x2: tbX + 2 * tbR, y2: tbY, stroke: INK, width: 1 })
+  const lnX1 = x1 + ext, lnX0 = tbX + 2 * tbR + r * 0.3
+  // one continuous divider line — it bisects the tag circle AND runs under the
+  // sheet title (title above, scale below), so the circle chord is a continuation
+  P.push({ kind: 'line', x1: tbX, y1: tbY, x2: lnX1, y2: tbY, stroke: INK, width: 1.2 })
+  P.push({ kind: 'circle', cx: tbX + tbR, cy: tbY, r: tbR, stroke: INK, fill: 'none', width: 1 })
   P.push({ kind: 'text', x: tbX + tbR, y: tbY - tbR * 0.5, text: detailNo, size: tbR * 0.75, anchor: 'middle', color: INK, weight: 700 })
   P.push({ kind: 'text', x: tbX + tbR, y: tbY + tbR * 0.5, text: sheetRef, size: tbR * 0.6, anchor: 'middle', color: INK, weight: 700 })
-  const lnX0 = tbX + 2 * tbR + r * 0.3, lnX1 = x1 + ext
-  P.push({ kind: 'line', x1: lnX0, y1: tbY, x2: lnX1, y2: tbY, stroke: INK, width: 1.4 })
   P.push({ kind: 'text', x: lnX0 + r * 0.15, y: tbY - tbR * 0.55, text: title, size: tbR * 0.95, anchor: 'start', color: INK, weight: 700 })
   P.push({ kind: 'text', x: lnX0 + r * 0.15, y: tbY + tbR * 0.55, text: 'SCALE', size: tbR * 0.4, anchor: 'start', color: INK, weight: 600 })
   P.push({ kind: 'text', x: lnX1 - r * 0.3, y: tbY + tbR * 0.55, text: scale, size: tbR * 0.4, anchor: 'end', color: INK, weight: 600 })
@@ -300,7 +289,6 @@ export function buildPlan(model: StructuralModel, opts: PlanOptions = {}): PlanD
     return tY + rows.length * rowH
   }
   const withUnit = (v: string, u = 'mm') => `${v} ${u}`   // units on every schedule value
-  const colRows = () => [['MARK', 'SIZE', 'REMARKS'], ...columnSchedule.map((c) => [c.mark, withUnit(c.size), c.notes])]
   const tblY0 = tbY + tbR + r * 1.2
   if (foundation) {
     let y = tblY0
@@ -308,9 +296,10 @@ export function buildPlan(model: StructuralModel, opts: PlanOptions = {}): PlanD
       const rows = [['MARK', 'SIZE', 'THK', 'REINF.'], ...footingSchedule.map((f) => [f.mark, withUnit(f.size), withUnit(f.thk), f.reinf])]
       y = drawTable(tbX, y, 'FOOTING SCHEDULE', BEAM, [r * 1.9, r * 3.4, r * 2.0, r * 5.4], rows) + r * 1.4
     }
-    if (columnSchedule.length) drawTable(tbX, y, 'COLUMN SCHEDULE', COL, [r * 1.6, r * 3.4, r * 4.4], colRows())
-  } else if (layer === 'column') {
-    if (columnSchedule.length) drawTable(tbX, tblY0, 'COLUMN SCHEDULE', COL, [r * 1.6, r * 3.4, r * 4.4], colRows())
+    if (columnSchedule.length) {
+      const rows = [['MARK', 'SIZE', 'REMARKS'], ...columnSchedule.map((c) => [c.mark, withUnit(c.size), c.notes])]
+      drawTable(tbX, y, 'COLUMN SCHEDULE', COL, [r * 1.6, r * 3.4, r * 4.4], rows)
+    }
   } else if (schedule.length) {
     const rows = [['MARK', 'SIZE'], ...schedule.map((s) => [s.mark, withUnit(s.size)])]
     drawTable(tbX, tblY0, 'BEAM SCHEDULE', BEAM, [r * 1.6, r * 3.6], rows)
@@ -324,7 +313,11 @@ export function buildPlan(model: StructuralModel, opts: PlanOptions = {}): PlanD
     else if (pr.kind === 'rect') { acc(pr.x, pr.y); acc(pr.x + pr.w, pr.y + pr.h) }
     else if (pr.kind === 'circle') { acc(pr.cx - pr.r, pr.cy - pr.r); acc(pr.cx + pr.r, pr.cy + pr.r) }
     else if (pr.kind === 'path') { for (const cmd of pr.cmds) acc(cmd.x, cmd.y) }
-    else acc(pr.x, pr.y)
+    else if (pr.kind === 'text' && !pr.rotate) {   // include rendered width so long titles aren't clipped
+      const w = pr.text.length * pr.size * 0.58, a = pr.anchor ?? 'start'
+      acc(a === 'start' ? pr.x : a === 'end' ? pr.x - w : pr.x - w / 2, pr.y)
+      acc(a === 'start' ? pr.x + w : a === 'end' ? pr.x : pr.x + w / 2, pr.y)
+    } else acc(pr.x, pr.y)
   }
   return {
     primitives: P,

--- a/webapp/src/engine/planRenderer.ts
+++ b/webapp/src/engine/planRenderer.ts
@@ -253,9 +253,20 @@ export function buildPlan(model: StructuralModel, opts: PlanOptions = {}): PlanD
     P.push({ kind: 'line', x1: ex, y1: ez, x2: ex - ux * ah + px * ah * 0.5, y2: ez - uz * ah + pz * ah * 0.5, stroke: PANEL, width: 0.7 })
     P.push({ kind: 'line', x1: ex, y1: ez, x2: ex - ux * ah - px * ah * 0.5, y2: ez - uz * ah - pz * ah * 0.5, stroke: PANEL, width: 0.7 })
   }
-  const spanArm = (mx: number, mz: number, ux: number, uz: number, gap: number, sh: number) => {
-    P.push({ kind: 'line', x1: mx + ux * gap, y1: mz + uz * gap, x2: mx + ux * sh, y2: mz + uz * sh, stroke: PANEL, width: 0.7 })
-    arrowHead(mx + ux * sh, mz + uz * sh, ux, uz)
+  // a double-headed span arrow with a Z-crank in the middle, centred at (mx,mz),
+  // running ±half along (ux,uz) — the standard slab span-direction symbol
+  const spanSymbol = (mx: number, mz: number, ux: number, uz: number, half: number) => {
+    const px = -uz, pz = ux                            // unit perpendicular
+    const off = Math.min(half * 0.18, r * 0.55)        // crank perpendicular offset
+    const g = half * 0.22                              // half-length of the crank diagonal
+    const a = [mx - ux * half + px * off, mz - uz * half + pz * off]   // raised end (arrow out)
+    const b = [mx - ux * g + px * off, mz - uz * g + pz * off]
+    const c = [mx + ux * g - px * off, mz + uz * g - pz * off]
+    const d = [mx + ux * half - px * off, mz + uz * half - pz * off]   // lowered end (arrow out)
+    for (const [p0, p1] of [[a, b], [b, c], [c, d]])
+      P.push({ kind: 'line', x1: p0[0], y1: p0[1], x2: p1[0], y2: p1[1], stroke: PANEL, width: 0.8 })
+    arrowHead(a[0], a[1], -ux, -uz)
+    arrowHead(d[0], d[1], ux, uz)
   }
   const platesOnLevel = model.plates
     .filter((p) => p.role !== 'wall')
@@ -273,11 +284,13 @@ export function buildPlan(model: StructuralModel, opts: PlanOptions = {}): PlanD
     const mx = (minX + maxX) / 2, mz = (minZ + maxZ) / 2
     const twoWay = Math.max(lx, ly) / Math.max(1e-6, Math.min(lx, ly)) <= 2
     const mk = slabMarkFor(Math.round(p.thickness), twoWay ? 'Two-way' : 'One-way')
-    const gap = r * 0.55, sh = Math.min(lx, ly) * 0.32
-    const dirs: [number, number][] = twoWay ? [[1, 0], [-1, 0], [0, 1], [0, -1]]
-      : lx <= ly ? [[1, 0], [-1, 0]] : [[0, 1], [0, -1]]   // one-way spans the SHORT direction
-    for (const [ux, uz] of dirs) spanArm(mx, mz, ux, uz, gap, sh)
-    P.push({ kind: 'text', x: mx, y: mz, text: mk, size: r * 0.55, anchor: 'middle', color: PANEL, weight: 700 })
+    // two-way → one span arrow per axis (crossing); one-way → a single arrow in
+    // the SHORT direction; each spans ~60% of its panel dimension
+    const axes: [number, number][] = twoWay ? [[1, 0], [0, 1]] : lx <= ly ? [[1, 0]] : [[0, 1]]
+    for (const [ux, uz] of axes) spanSymbol(mx, mz, ux, uz, (ux ? lx : ly) * 0.3)
+    // slab mark tucked into the upper-left quadrant, clear of the crossing arrows
+    const q = Math.min(lx, ly) * 0.18
+    P.push({ kind: 'text', x: mx - q, y: mz - q, text: mk, size: r * 0.55, anchor: 'middle', color: PANEL, weight: 700 })
   }
 
   // ── grid bays with NO slab → an X from corner to corner ──

--- a/webapp/src/engine/planRenderer.ts
+++ b/webapp/src/engine/planRenderer.ts
@@ -247,26 +247,21 @@ export function buildPlan(model: StructuralModel, opts: PlanOptions = {}): PlanD
 
   // ── slab panels at the level: outline + a span-direction symbol (double
   // arrows = two-way, a single pair = one-way) and the slab mark (S1, S2…) ──
-  const ah = r * 0.22                       // arrowhead size
-  const arrowHead = (ex: number, ez: number, ux: number, uz: number) => {
-    const px = -uz, pz = ux
-    P.push({ kind: 'line', x1: ex, y1: ez, x2: ex - ux * ah + px * ah * 0.5, y2: ez - uz * ah + pz * ah * 0.5, stroke: PANEL, width: 0.7 })
-    P.push({ kind: 'line', x1: ex, y1: ez, x2: ex - ux * ah - px * ah * 0.5, y2: ez - uz * ah - pz * ah * 0.5, stroke: PANEL, width: 0.7 })
+  const ah = r * 0.28                       // half-arrow barb length
+  // a single barb at tip (tx,tz), pointing outward (ox,oz), on one perpendicular side
+  const halfArrow = (tx: number, tz: number, ox: number, oz: number, side: number) => {
+    const px = -oz, pz = ox
+    P.push({ kind: 'line', x1: tx, y1: tz, x2: tx - ox * ah + px * ah * side, y2: tz - oz * ah + pz * ah * side, stroke: PANEL, width: 0.8 })
   }
-  // a double-headed span arrow with a Z-crank in the middle, centred at (mx,mz),
-  // running ±half along (ux,uz) — the standard slab span-direction symbol
+  // the standard slab span symbol: a STRAIGHT line centred at (mx,mz) running
+  // ±half along (ux,uz), with a half-arrow (single barb) at each end, on
+  // opposite sides
   const spanSymbol = (mx: number, mz: number, ux: number, uz: number, half: number) => {
-    const px = -uz, pz = ux                            // unit perpendicular
-    const off = Math.min(half * 0.18, r * 0.55)        // crank perpendicular offset
-    const g = half * 0.22                              // half-length of the crank diagonal
-    const a = [mx - ux * half + px * off, mz - uz * half + pz * off]   // raised end (arrow out)
-    const b = [mx - ux * g + px * off, mz - uz * g + pz * off]
-    const c = [mx + ux * g - px * off, mz + uz * g - pz * off]
-    const d = [mx + ux * half - px * off, mz + uz * half - pz * off]   // lowered end (arrow out)
-    for (const [p0, p1] of [[a, b], [b, c], [c, d]])
-      P.push({ kind: 'line', x1: p0[0], y1: p0[1], x2: p1[0], y2: p1[1], stroke: PANEL, width: 0.8 })
-    arrowHead(a[0], a[1], -ux, -uz)
-    arrowHead(d[0], d[1], ux, uz)
+    const ax = mx - ux * half, az = mz - uz * half
+    const bx = mx + ux * half, bz = mz + uz * half
+    P.push({ kind: 'line', x1: ax, y1: az, x2: bx, y2: bz, stroke: PANEL, width: 0.8 })
+    halfArrow(ax, az, -ux, -uz, +1)
+    halfArrow(bx, bz, ux, uz, +1)
   }
   const platesOnLevel = model.plates
     .filter((p) => p.role !== 'wall')


### PR DESCRIPTION
## Summary
Follow-up to the plans work merged in #424 (which shipped the earlier beam/column-split version). This reverts that split and adds slab span-direction symbols.

- **Revert the beam/column split** — one **combined** framing plan per floor again (beams + solid-black columns + slab + beam schedule), named by floor (`GROUND FLOOR FRAMING PLAN`, `SECOND FLOOR FRAMING PLAN`, …) via a `PlanOptions.title` override; `PlansPanel` derives floor names from the model's node elevations.
- **Beams drawn to their real width** — each beam/girder is a band sized from the section width `b`, not a single centreline. Units on every dimension and schedule value.
- **Title block** — one continuous divider that bisects the (unfilled) detail-tag circle and runs under the sheet title.
- **Slab span symbols (new)** — the `h=… mm` slab label is replaced by:
  - a **span-direction symbol**: a straight line with a half-arrow (single barb) at each end, on opposite sides. **Two-way** (long/short span ratio ≤ 2, ACI) draws a perpendicular copy so the two lines cross as a `+`; **one-way** draws a single line in the **short** direction.
  - a **slab mark** (`S1`, `S2`…) pooled by (thickness, type) into a new **SLAB SCHEDULE** (MARK / THK / TYPE), tucked into the panel's upper-left quadrant.
  - grid bays with **no slab** get a corner-to-corner **X**.

## Verification
- `planRenderer.test.ts` — slab marks `S1` + `SLAB SCHEDULE` (no `h=`), per-floor title override, combined framing (solid-black columns + beam centrelines + beam schedule).
- **Full suite green: 1446**, `npx tsc -b` clean, `npm run build` succeeds.
- Rendered one-way and two-way panels headless and reviewed (span symbol, empty-bay X, schedules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_