### PR TITLE
Irregularity auto-flags (NSCP Table 208-9/10) — engine (Phase 1)

### DIFF
--- a/webapp/src/engine/irregularity.test.ts
+++ b/webapp/src/engine/irregularity.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest'
+import {
+  torsionalVerdict, softStoreyVerdicts, massVerdicts, geometricVerdicts, assessIrregularities,
+} from './irregularity'
+import { emptyModel, type StructuralModel, type Node, type Member, type RectSection, type Storey } from './model'
+
+// ── pure checks vs NSCP thresholds ──────────────────────────────────────
+describe('irregularity — torsional (Table 208-10 Type 1a/1b)', () => {
+  it('regular when both ends drift equally', () => {
+    expect(torsionalVerdict(10, 10).verdict).toBe('none')          // ratio 1.0
+  })
+  it('irregular above 1.2× the average', () => {
+    // δmax=13, δmin=7 → avg=10 → 1.3 > 1.2
+    const r = torsionalVerdict(13, 7); expect(r.verdict).toBe('irregular'); expect(r.ratio).toBeCloseTo(1.3, 6)
+  })
+  it('extreme above 1.4× the average', () => {
+    // δmax=15, δmin=5 → avg=10 → 1.5 > 1.4
+    expect(torsionalVerdict(15, 5).verdict).toBe('extreme')
+  })
+  it('just below 1.2 stays regular', () => {
+    expect(torsionalVerdict(11.9, 10.1).verdict).toBe('none')      // 1.081
+  })
+})
+
+describe('irregularity — soft storey (Table 208-9 Type 1a/1b)', () => {
+  // k ordered bottom→top
+  it('regular when stiffness is uniform', () => {
+    expect(softStoreyVerdicts([100, 100, 100, 100]).every((v) => v.verdict === 'none')).toBe(true)
+  })
+  it('flags a storey below 70% of the one above', () => {
+    // k0/above = 65/100 = 0.65 (<0.70, >0.60) ⇒ irregular via the 'above' clause;
+    // the softer storeys further up keep avg-of-3 = 73.3 so that clause stays OK.
+    const v = softStoreyVerdicts([65, 100, 60, 60])[0]
+    expect(v.basis).toBe('above'); expect(v.verdict).toBe('irregular'); expect(v.ratio).toBeCloseTo(0.65, 6)
+  })
+  it('extreme below 60% of the one above', () => {
+    const v = softStoreyVerdicts([55, 100, 100, 100])[0]
+    expect(v.verdict).toBe('extreme')
+  })
+  it('flags below 80% of the average of the three above', () => {
+    // k0=77, three above avg=100 → 0.77 < 0.80 but 0.77 > 0.70 of above(100)=OK on the above clause
+    const v = softStoreyVerdicts([77, 100, 100, 100])[0]
+    expect(v.basis).toBe('avg3'); expect(v.verdict).toBe('irregular')
+  })
+  it('never flags the top storey (no storey above)', () => {
+    expect(softStoreyVerdicts([100, 100]).length).toBe(1)          // only the bottom storey is checked
+  })
+})
+
+describe('irregularity — mass (Table 208-9 Type 2)', () => {
+  it('regular when weights are similar', () => {
+    expect(massVerdicts([100, 100, 100]).every((v) => v.verdict === 'none')).toBe(true)
+  })
+  it('flags a storey over 150% of an adjacent storey', () => {
+    const v = massVerdicts([100, 160, 100])       // middle 160 vs 100 → 1.6 > 1.5
+    expect(v[1].verdict).toBe('irregular'); expect(v[1].ratio).toBeCloseTo(1.6, 6)
+  })
+  it('a heavier lower floor does not falsely flag a light roof', () => {
+    // roof(top) lighter than floor below → roof ratio 0.5 ⇒ none; floor below ratio vs roof = 2.0>1.5 flags the floor
+    const v = massVerdicts([100, 200, 100])
+    expect(v[2].verdict).toBe('none')             // the light roof itself is not flagged
+  })
+})
+
+describe('irregularity — vertical geometric (Table 208-9 Type 3)', () => {
+  it('flags a storey wider than 130% of an adjacent storey', () => {
+    const v = geometricVerdicts([10, 14, 10])     // 14/10 = 1.4 > 1.3
+    expect(v[1].verdict).toBe('irregular')
+  })
+  it('regular within 130%', () => {
+    expect(geometricVerdicts([10, 12, 10]).every((v) => v.verdict === 'none')).toBe(true)  // 1.2
+  })
+})
+
+// ── model adapter: a 2-storey, 4-column frame with a crafted E displacement ──
+function twoStoreyModel(): StructuralModel {
+  const m = emptyModel('irreg-test')
+  const sec: RectSection = { id: 'C', name: '400×400', b: 400, h: 400, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
+  m.sections = [sec]
+  // a 6×6 m bay, columns at the four corners, two storeys of 3 m
+  const xs = [0, 6], zs = [0, 6], ys = [0, 3, 6]
+  const nodes: Node[] = []
+  for (const y of ys) for (const x of xs) for (const z of zs) nodes.push({ id: `n_${x}_${y}_${z}`, x, y, z })
+  m.nodes = nodes
+  const members: Member[] = []
+  for (let l = 0; l < ys.length - 1; l++) for (const x of xs) for (const z of zs)
+    members.push({ id: `c_${x}_${ys[l]}_${z}`, i: `n_${x}_${ys[l]}_${z}`, j: `n_${x}_${ys[l + 1]}_${z}`, role: 'column', section: 'C' })
+  m.members = members
+  m.storeys = [{ id: 's1', name: 'L1', elevation: 3 }, { id: 's2', name: 'L2', elevation: 6 }] as Storey[]
+  return m
+}
+
+describe('irregularity — model adapter', () => {
+  const model = twoStoreyModel()
+  // nodeOrder = model.nodes; craft displacements so the +Z edge (z=6) racks
+  // much more than the −Z edge (z=0) at level 1 → torsional irregularity in X.
+  const nodeOrder = model.nodes.map((n) => ({ id: n.id, y: n.y }))
+  const uX = (n: Node): number => {
+    if (n.y === 0) return 0
+    const base = n.y === 3 ? 0.010 : 0.020            // m, uniform part
+    const twist = (n.z === 6 ? 1 : -1) * (n.y === 3 ? 0.006 : 0.012)  // ± edge twist
+    return base + twist
+  }
+  const d: number[] = []
+  for (const n of nodeOrder) {
+    const nd = model.nodes.find((q) => q.id === n.id)!
+    d.push(uX(nd), 0, 0, 0, 0, 0)                     // only the X component matters
+  }
+  const storeyForce = [{ elevation: 3, F: 50 }, { elevation: 6, F: 50 }]
+
+  it('flags torsional irregularity from the crafted twist', () => {
+    const flags = assessIrregularities(model, { nodeOrder, d, storeyForce, dir: 'x' })
+    const tor = flags.find((f) => f.code.startsWith('P1'))
+    expect(tor).toBeTruthy()
+    expect(tor!.table).toBe('Table 208-10')
+    expect(tor!.dir).toBe('x')
+    // level-1 drift: +edge 16 mm, −edge 4 mm → avg 10 → ratio 1.6 ⇒ extreme
+    expect(tor!.ratio).toBeGreaterThan(1.4)
+    expect(tor!.verdict).toBe('extreme')
+  })
+
+  it('a uniform (untwisted) field trips no torsional flag', () => {
+    const dU: number[] = []
+    for (const n of nodeOrder) dU.push(n.y === 0 ? 0 : n.y === 3 ? 0.010 : 0.020, 0, 0, 0, 0, 0)
+    const flags = assessIrregularities(model, { nodeOrder, d: dU, storeyForce, dir: 'x' })
+    expect(flags.some((f) => f.code.startsWith('P1'))).toBe(false)
+  })
+})

--- a/webapp/src/engine/irregularity.ts
+++ b/webapp/src/engine/irregularity.ts
@@ -1,0 +1,267 @@
+// ─────────────────────────────────────────────────────────────────────────
+// NSCP 2015 structural-irregularity auto-flags — Table 208-9 (vertical) and
+// Table 208-10 (plan/horizontal). Pure post-processing of results the model
+// already produces (the E-case displacement field + storey weights); no solver
+// change. Layer L5 (dynamics/seismic).
+//
+// Implemented (the four checks derivable from the existing modal/drift data):
+//   P1  Torsional irregularity        (208-10 Type 1a/1b): max storey drift at
+//        one end > 1.2× (1a) / 1.4× (1b) the average of the two ends.
+//   V1  Stiffness — soft storey        (208-9  Type 1a/1b): storey stiffness
+//        k = Vstorey/Δstorey < 70% (1a) / 60% (1b) of the storey above, OR
+//        < 80% (1a) / 70% (1b) of the average of the three storeys above.
+//   V2  Weight (mass) irregularity     (208-9  Type 2): storey seismic weight
+//        > 150% of an adjacent storey (a roof lighter than the floor below is
+//        exempt).
+//   V3  Vertical geometric             (208-9  Type 3): horizontal dimension of
+//        the LFRS in a storey > 130% of that in an adjacent storey.
+//
+// Not covered here (need capacity, plan-shape polygon, or offset topology the
+// analysis model doesn't yet carry): 208-9 Types 4 (in-plane discontinuity) &
+// 5 (weak storey), 208-10 Types 2 (re-entrant corners), 3 (diaphragm
+// discontinuity), 4 (out-of-plane offsets), 5 (non-parallel systems).
+//
+// Units: geometry m; displacements taken from the frame3d DOF vector in m and
+// reported as mm; weights kN. Ratios are unitless so the verdicts are
+// unit-independent.
+// ─────────────────────────────────────────────────────────────────────────
+import type { StructuralModel } from './model'
+import { storeyWeights } from './seismic'
+
+export type IrregVerdict = 'none' | 'irregular' | 'extreme'
+
+export interface IrregularityFlag {
+  /** NSCP designation: 'P1a'|'P1b' (Table 208-10) / 'V1a'|'V1b'|'V2'|'V3' (208-9). */
+  code: string
+  /** Human name of the irregularity type. */
+  name: string
+  /** Which NSCP table it comes from. */
+  table: 'Table 208-9' | 'Table 208-10'
+  /** Load direction the check was evaluated in (torsion/stiffness are directional). */
+  dir?: 'x' | 'z'
+  /** Storey (top elevation, m) where the governing ratio occurs. */
+  elevation?: number
+  /** Governing ratio (see `detail` for its definition). */
+  ratio: number
+  /** The threshold the ratio crossed. */
+  limit: number
+  verdict: IrregVerdict
+  /** One-line explanation with the numbers. */
+  detail: string
+}
+
+const near = (a: number, b: number, tol = 1e-6) => Math.abs(a - b) < tol
+const r2 = (v: number) => Math.round(v * 100) / 100
+
+// ── P1 · Torsional irregularity (Table 208-10 Type 1a/1b) ────────────────
+/**
+ * Verdict from the two extreme-end storey drifts (δmax, δmin ≥ 0):
+ * ratio = δmax / δavg, δavg = (δmax + δmin)/2 → > 1.4 extreme, > 1.2 irregular.
+ */
+export function torsionalVerdict(driftMax: number, driftMin: number): { ratio: number; verdict: IrregVerdict } {
+  const avg = (driftMax + driftMin) / 2
+  if (!(avg > 1e-12)) return { ratio: 1, verdict: 'none' }
+  const ratio = driftMax / avg
+  return { ratio, verdict: ratio > 1.4 ? 'extreme' : ratio > 1.2 ? 'irregular' : 'none' }
+}
+
+// ── V1 · Stiffness / soft storey (Table 208-9 Type 1a/1b) ────────────────
+/**
+ * Per-storey soft-storey verdict. `k[]` is storey lateral stiffness ordered
+ * BOTTOM→TOP (k[i] = Vstorey_i / Δstorey_i). A storey is soft when its
+ * stiffness drops below 70%/60% of the storey directly above, or 80%/70% of
+ * the mean of the three storeys above. The top storey (no storey above) is
+ * never flagged. Returns one entry per storey index, verdict 'none' where OK.
+ */
+export function softStoreyVerdicts(k: number[]): { i: number; ratio: number; verdict: IrregVerdict; basis: 'above' | 'avg3' }[] {
+  const sev = (v: IrregVerdict) => (v === 'extreme' ? 2 : v === 'irregular' ? 1 : 0)
+  const out: { i: number; ratio: number; verdict: IrregVerdict; basis: 'above' | 'avg3' }[] = []
+  for (let i = 0; i < k.length - 1; i++) {
+    const above = k[i + 1]
+    const rAbove = above > 1e-12 ? k[i] / above : Infinity
+    // three storeys above, when they exist
+    const three = k.slice(i + 1, i + 4)
+    const avg3 = three.length === 3 ? three.reduce((s, v) => s + v, 0) / 3 : NaN
+    const rAvg3 = Number.isFinite(avg3) && avg3 > 1e-12 ? k[i] / avg3 : Infinity
+    // each clause is scored independently; the storey takes the more severe.
+    // 1a soft: < 70% of above OR < 80% of avg-of-3; 1b extreme: < 60% / < 70%.
+    const vAbove: IrregVerdict = rAbove < 0.6 ? 'extreme' : rAbove < 0.7 ? 'irregular' : 'none'
+    const vAvg3: IrregVerdict = rAvg3 < 0.7 ? 'extreme' : rAvg3 < 0.8 ? 'irregular' : 'none'
+    const basis: 'above' | 'avg3' = sev(vAvg3) > sev(vAbove) ? 'avg3' : 'above'
+    out.push({ i, ratio: basis === 'above' ? rAbove : rAvg3, verdict: sev(vAvg3) > sev(vAbove) ? vAvg3 : vAbove, basis })
+  }
+  return out
+}
+
+// ── V2 · Weight (mass) irregularity (Table 208-9 Type 2) ─────────────────
+/**
+ * `w[]` = storey seismic weight ordered BOTTOM→TOP. A storey whose weight
+ * exceeds 150% of an adjacent storey is irregular; a roof (top storey) lighter
+ * than the floor below is exempt (§ note to Table 208-9). Returns per-storey
+ * governing ratio (w_i / lighter-neighbour) and verdict.
+ */
+export function massVerdicts(w: number[]): { i: number; ratio: number; verdict: IrregVerdict }[] {
+  const out: { i: number; ratio: number; verdict: IrregVerdict }[] = []
+  for (let i = 0; i < w.length; i++) {
+    const neigh: number[] = []
+    if (i > 0) neigh.push(w[i - 1])
+    if (i < w.length - 1) neigh.push(w[i + 1])
+    // exceeds 150% of ANY adjacent storey ⇒ compare to the lighter neighbour
+    const minN = neigh.length ? Math.min(...neigh) : Infinity
+    const ratio = minN > 1e-12 ? w[i] / minN : 1
+    out.push({ i, ratio, verdict: ratio > 1.5 ? 'irregular' : 'none' })
+  }
+  return out
+}
+
+// ── V3 · Vertical geometric irregularity (Table 208-9 Type 3) ────────────
+/**
+ * `dim[]` = LFRS horizontal dimension per storey (m), BOTTOM→TOP. A storey
+ * whose dimension exceeds 130% of an adjacent storey is irregular.
+ */
+export function geometricVerdicts(dim: number[]): { i: number; ratio: number; verdict: IrregVerdict }[] {
+  const out: { i: number; ratio: number; verdict: IrregVerdict }[] = []
+  for (let i = 0; i < dim.length; i++) {
+    const neigh: number[] = []
+    if (i > 0) neigh.push(dim[i - 1])
+    if (i < dim.length - 1) neigh.push(dim[i + 1])
+    const minN = neigh.length ? Math.min(...neigh) : Infinity
+    const ratio = minN > 1e-12 ? dim[i] / minN : 1
+    out.push({ i, ratio, verdict: ratio > 1.3 ? 'irregular' : 'none' })
+  }
+  return out
+}
+
+// ── Model adapter ────────────────────────────────────────────────────────
+export interface IrregularityInput {
+  /** DOF ordering of `d` (6 DOFs/node), matching the frame3d solution. */
+  nodeOrder: { id: string; y: number }[]
+  /** Global displacement vector of the E-case solve (metres). */
+  d: number[]
+  /** Applied lateral storey force per level in `dir` (kN) — for storey shear. */
+  storeyForce: { elevation: number; F: number }[]
+  /** Load direction the E-case was solved in. */
+  dir: 'x' | 'z'
+}
+
+/**
+ * Assemble the NSCP irregularity flags for one E-case run. The torsional (P1)
+ * and stiffness (V1) checks use the direction of the run; the mass (V2) and
+ * geometric (V3) checks are direction-independent (computed once).
+ *
+ * Only irregularities that trip (verdict ≠ 'none') are returned, most-severe
+ * first. An empty array means the structure is regular by these four checks.
+ */
+export function assessIrregularities(model: StructuralModel, input: IrregularityInput): IrregularityFlag[] {
+  const { nodeOrder, d, storeyForce, dir } = input
+  const nm = new Map(model.nodes.map((n) => [n.id, n]))
+  const comp = dir === 'x' ? 0 : 2
+  // levels bottom→top, including the base
+  const levels = [0, ...[...new Set(model.storeys.map((s) => s.elevation))].sort((a, b) => a - b)]
+    .filter((e, i, a) => a.indexOf(e) === i)
+    .sort((a, b) => a - b)
+
+  // per-level lateral displacement keyed by plan line (x,z) — mm
+  const key = (x: number, z: number) => `${Math.round(x * 1e3)},${Math.round(z * 1e3)}`
+  const uByLevel = levels.map(() => new Map<string, number>())
+  const levelOf = (y: number) => levels.findIndex((e) => near(e, y))
+  nodeOrder.forEach((n, i) => {
+    const li = levelOf(n.y)
+    const nd = nm.get(n.id)
+    if (li < 0 || !nd) return
+    uByLevel[li].set(key(nd.x, nd.z), d[6 * i + comp] * 1000)
+  })
+
+  const flags: IrregularityFlag[] = []
+  const dirTag = dir.toUpperCase()
+
+  // storey drift arrays (index s = storey between levels[s] and levels[s+1])
+  const nStorey = levels.length - 1
+  const driftMaxRep: number[] = []   // representative (max end) storey drift, mm
+  for (let s = 0; s < nStorey; s++) {
+    const below = uByLevel[s], above = uByLevel[s + 1]
+    const lineDrifts: number[] = []
+    for (const [ln, uTop] of above) {
+      if (below.has(ln)) lineDrifts.push(Math.abs(uTop - (below.get(ln) as number)))
+    }
+    if (lineDrifts.length === 0) { driftMaxRep.push(0); continue }
+    const dMax = Math.max(...lineDrifts), dMin = Math.min(...lineDrifts)
+    driftMaxRep.push(dMax)
+    // P1 torsional — needs at least two distinct ends
+    if (lineDrifts.length >= 2) {
+      const { ratio, verdict } = torsionalVerdict(dMax, dMin)
+      if (verdict !== 'none') flags.push({
+        code: verdict === 'extreme' ? 'P1b' : 'P1a',
+        name: verdict === 'extreme' ? 'Extreme torsional irregularity' : 'Torsional irregularity',
+        table: 'Table 208-10', dir, elevation: levels[s + 1], ratio, limit: verdict === 'extreme' ? 1.4 : 1.2,
+        verdict, detail: `${dirTag}: δmax/δavg = ${r2(ratio)} > ${verdict === 'extreme' ? 1.4 : 1.2} (δmax ${r2(dMax)} mm, δmin ${r2(dMin)} mm)`,
+      })
+    }
+  }
+
+  // V1 soft storey — k = storeyShear / storeyDrift, bottom→top
+  const shearByLevel = new Map(storeyForce.map((s) => [s.elevation, s.F]))
+  const k: number[] = []
+  for (let s = 0; s < nStorey; s++) {
+    // storey shear = Σ applied force at levels at/above the top of this storey
+    let V = 0
+    for (let t = s + 1; t < levels.length; t++) V += shearByLevel.get(levels[t]) ?? 0
+    const drift = driftMaxRep[s]
+    k.push(drift > 1e-9 ? Math.abs(V) / drift : Infinity)
+  }
+  if (k.every((v) => Number.isFinite(v))) {
+    for (const sv of softStoreyVerdicts(k)) {
+      if (sv.verdict === 'none') continue
+      const soft = sv.verdict === 'extreme'
+      flags.push({
+        code: soft ? 'V1b' : 'V1a',
+        name: soft ? 'Extreme soft storey (stiffness)' : 'Soft storey (stiffness)',
+        table: 'Table 208-9', dir, elevation: levels[sv.i + 1], ratio: sv.ratio,
+        limit: sv.basis === 'above' ? (soft ? 0.6 : 0.7) : (soft ? 0.7 : 0.8), verdict: sv.verdict,
+        detail: `${dirTag}: k/${sv.basis === 'above' ? 'k(above)' : 'avg k(3 above)'} = ${r2(sv.ratio)} < ${sv.basis === 'above' ? (soft ? 0.6 : 0.7) : (soft ? 0.7 : 0.8)}`,
+      })
+    }
+  }
+
+  // V2 mass — storey seismic weights bottom→top (exclude the base level 0)
+  const sw = storeyWeights(model)
+  const wByElev = new Map(sw.map((s) => [s.elevation, s.w]))
+  const elevs = levels.slice(1)                     // framed levels
+  const w = elevs.map((e) => wByElev.get(e) ?? 0)
+  if (w.length >= 2 && w.every((v) => v > 0)) {
+    for (const mv of massVerdicts(w)) {
+      if (mv.verdict === 'none') continue
+      // roof (top) lighter than the floor below is exempt — only heavier trips, so already fine
+      flags.push({
+        code: 'V2', name: 'Weight (mass) irregularity', table: 'Table 208-9', elevation: elevs[mv.i],
+        ratio: mv.ratio, limit: 1.5, verdict: mv.verdict,
+        detail: `W/W(adjacent) = ${r2(mv.ratio)} > 1.5 (W = ${Math.round(w[mv.i])} kN)`,
+      })
+    }
+  }
+
+  // V3 vertical geometric — LFRS plan dimension per framed level (max of X/Z extent)
+  const colNodeIds = new Set<string>()
+  for (const m of model.members) if (m.role === 'column') { colNodeIds.add(m.i); colNodeIds.add(m.j) }
+  const dimAt = (e: number): number => {
+    const ns = model.nodes.filter((n) => near(n.y, e) && colNodeIds.has(n.id))
+    if (ns.length < 2) return 0
+    const xs = ns.map((n) => n.x), zs = ns.map((n) => n.z)
+    return Math.max(Math.max(...xs) - Math.min(...xs), Math.max(...zs) - Math.min(...zs))
+  }
+  const dim = elevs.map(dimAt)
+  if (dim.length >= 2 && dim.every((v) => v > 0)) {
+    for (const gv of geometricVerdicts(dim)) {
+      if (gv.verdict === 'none') continue
+      flags.push({
+        code: 'V3', name: 'Vertical geometric irregularity', table: 'Table 208-9', elevation: elevs[gv.i],
+        ratio: gv.ratio, limit: 1.3, verdict: gv.verdict,
+        detail: `LFRS dim ratio = ${r2(gv.ratio)} > 1.3 (${r2(dim[gv.i])} m vs adjacent)`,
+      })
+    }
+  }
+
+  // most-severe first (extreme before irregular), then by code
+  const sev = (v: IrregVerdict) => (v === 'extreme' ? 0 : v === 'irregular' ? 1 : 2)
+  return flags.sort((a, b) => sev(a.verdict) - sev(b.verdict) || a.code.localeCompare(b.code))
+}


### PR DESCRIPTION
## Summary
First phase of NSCP 2015 **structural-irregularity auto-flags** — the smallest, highest-value item left on the analysis-completeness backlog. Pure post-processing of results the model already produces (the E-case displacement field + storey weights); **no solver change**. Layer **L5** (dynamics/seismic).

**`engine/irregularity.ts`** implements the four checks derivable from the existing modal/drift data:

| Code | Check | NSCP | Trips when |
| --- | --- | --- | --- |
| **P1a/P1b** | Torsional | Table 208-10 Type 1a/1b | max storey drift at one end > **1.2×** (irregular) / **1.4×** (extreme) the average of the two ends |
| **V1a/V1b** | Soft storey (stiffness) | Table 208-9 Type 1a/1b | storey stiffness `k = Vstorey/Δstorey` < **70%/60%** of the storey above **or** < **80%/70%** of the mean of the three above |
| **V2** | Weight (mass) | Table 208-9 Type 2 | storey seismic weight > **150%** of an adjacent storey (light-roof exemption falls out for free) |
| **V3** | Vertical geometric | Table 208-9 Type 3 | LFRS plan dimension > **130%** of an adjacent storey |

- `assessIrregularities(model, { nodeOrder, d, storeyForce, dir })` assembles the flags from a `frame3d` E-case solve — torsional/stiffness are directional, mass/geometric direction-independent — and returns only tripped flags, most-severe first.
- The two stiffness clauses (vs the storey above, vs the mean of three above) are scored **independently** and the storey takes the more severe verdict, so a "70%-of-avg-of-3" extreme is never masked by a milder "70%-of-above" reading.

Not covered (need capacity, a plan-shape polygon, or offset topology the analysis model doesn't yet carry): 208-9 Types 4/5, 208-10 Types 2–5 — noted in the module header.

## Verification
- `irregularity.test.ts` — threshold hand calcs for each pure check (1.2/1.4 torsional, 0.7/0.6 & 0.8/0.7 soft storey via each clause, 1.5 mass w/ light-roof case, 1.3 geometric) + a crafted two-storey twist that trips **extreme torsional** and stays regular under a uniform field.
- **Full suite 1446 → 1462**, `npx tsc -b` clean, `npm run build` succeeds.

## Next (Phase 2)
Wire `assessIrregularities` into `solverWorker` beside the storey-drift check (it already has `sol.d`, `br.nodes`, and the E-loads), surface an **Irregularities** panel in the Model Space Analysis tab, and fold the flags into the direct PDF report + a `/validation` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_