### PR TITLE
Irregularity auto-flags — worker wiring + Analysis-tab panel (Phase 2)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -696,9 +696,14 @@ _Analysis completeness (P3):_
   is modal-superposition only (no full-system Newmark); prerequisite for nonlinear TH.
 - **Tension-only / compression-only members** (braces, uplift springs) and a
   **consistent-mass** option beside lumped — neither exists anywhere.
-- **Irregularity auto-flags** — NSCP Table 208-9/10 (torsional, soft-storey,
-  mass) are not detected/reported. *(Smallest, high-value: pure checks off the
-  existing modal/drift results.)*
+- ~~**Irregularity auto-flags** — NSCP Table 208-9/10 (torsional, soft-storey,
+  mass)~~ — ✔ shipped (#427 engine, #428 wiring/UI): `engine/irregularity.ts`
+  flags P1 torsional (208-10 §1a/1b), V1 soft-storey, V2 mass, V3
+  vertical-geometric as pure post-processing of the E-case drift field + storey
+  weights; `solverWorker` runs `assessIrregularities` beside the drift check and
+  the Model Space Analysis tab shows an **Irregularities** panel. Not
+  auto-checked (need capacity/plan-shape/offset topology): 208-9 Types 4/5,
+  208-10 Types 2–5.
 
 _Geotech / foundations (P4):_
 - **Slope stability by method of slices** (Bishop / Janbu) — `geotech.ts` has only

--- a/webapp/src/engine/irregularity.test.ts
+++ b/webapp/src/engine/irregularity.test.ts
@@ -3,6 +3,9 @@ import {
   torsionalVerdict, softStoreyVerdicts, massVerdicts, geometricVerdicts, assessIrregularities,
 } from './irregularity'
 import { emptyModel, type StructuralModel, type Node, type Member, type RectSection, type Storey } from './model'
+import { generateGridModel } from './modelBuilder'
+import { modelToFrame3D } from './modelBridge'
+import { solveFrame3D, applyF3Combo } from './frame3d'
 
 // ── pure checks vs NSCP thresholds ──────────────────────────────────────
 describe('irregularity — torsional (Table 208-10 Type 1a/1b)', () => {
@@ -124,5 +127,36 @@ describe('irregularity — model adapter', () => {
     for (const n of nodeOrder) dU.push(n.y === 0 ? 0 : n.y === 3 ? 0.010 : 0.020, 0, 0, 0, 0, 0)
     const flags = assessIrregularities(model, { nodeOrder, d: dU, storeyForce, dir: 'x' })
     expect(flags.some((f) => f.code.startsWith('P1'))).toBe(false)
+  })
+})
+
+// ── worker-path integration: a symmetric grid under uniform E is regular ──
+describe('irregularity — integration through the real bridge + solver', () => {
+  it('a symmetric 2×2-bay, 2-storey frame under uniform X shows no plan/mass/geometry flags', () => {
+    const section: RectSection = { id: 'C', name: '400×400', b: 400, h: 400, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
+    const m = generateGridModel({ baysX: [6, 6], baysZ: [6, 6], storeyH: [3, 3], section, slabThickness: 150 })
+    // uniform lateral E node loads on every framed node (symmetric ⇒ no twist)
+    for (const n of m.nodes) if (n.y > 1e-6) m.loads.push({ kind: 'node', node: n.id, Fx: 10, cat: 'E' })
+
+    const br = modelToFrame3D(m)
+    const eOnly = applyF3Combo(br.loads, { E: 1 })
+    const sol = solveFrame3D(br.nodes, br.members, br.supports, eOnly, {}, br.shells)
+    expect(sol).toBeTruthy()
+    if (!sol) return
+    // storey force per level (X), mirroring solverWorker
+    const yById = new Map(br.nodes.map((n) => [n.id, n.y]))
+    const fByLevel = new Map<number, number>()
+    for (const ld of eOnly) {
+      if (ld.kind !== 'node') continue
+      const y = yById.get(ld.node); if (y === undefined) continue
+      fByLevel.set(y, (fByLevel.get(y) ?? 0) + (ld.Fx ?? 0))
+    }
+    const storeyForce = [...fByLevel].map(([elevation, F]) => ({ elevation, F }))
+
+    const flags = assessIrregularities(m, { nodeOrder: br.nodes, d: sol.d, storeyForce, dir: 'x' })
+    // symmetric geometry/mass and an untwisted field ⇒ no torsional, mass, or geometric flags
+    expect(flags.some((f) => f.code.startsWith('P1'))).toBe(false)
+    expect(flags.some((f) => f.code === 'V2')).toBe(false)
+    expect(flags.some((f) => f.code === 'V3')).toBe(false)
   })
 })

--- a/webapp/src/engine/solverWorker.ts
+++ b/webapp/src/engine/solverWorker.ts
@@ -13,6 +13,7 @@ import { modalAnalysis } from './modal'
 import { runPushoverModel, type PushoverModelOpts } from './pushoverModel'
 import { runTimeHistoryModel, type TimeHistoryModelOpts } from './timeHistoryModel'
 import { driftCheck } from './seismic'
+import { assessIrregularities } from './irregularity'
 import { designStructureAsync, optimizeStructureAsync, selectBarDiameters, type SoilOptions, type FootingPlan, type AnalyzeOptions } from './pipeline'
 import type { SolveProgress } from './progress'
 
@@ -36,13 +37,27 @@ ctx.onmessage = async (e: MessageEvent<SolverRequest>) => {
       const br = modelToFrame3D(msg.model, { crackedSections: msg.crackedSections, shearDeformation: msg.shearDeformation })
       const analysis = analyzeFrame3D(br.nodes, br.members, br.supports, br.loads, msg.opts, onProgress, br.diaphragmGroups, br.shells)
       let drift = null
+      let irregularities = null
       if (msg.drift.hasSeis) {
         onProgress({ phase: 'Storey-drift check' })
         const eOnly = applyF3Combo(br.loads, { E: 1 })
         const sol = eOnly.length ? solveFrame3D(br.nodes, br.members, br.supports, eOnly, { pDelta: msg.drift.pDelta }, br.shells) : null
         drift = sol ? driftCheck(msg.model, br.nodes, sol.d, msg.drift.R, msg.drift.T, msg.drift.axis) : null
+        if (sol) {
+          // applied lateral storey force per level (E-case, run direction) → storey shear
+          const yById = new Map(br.nodes.map((n) => [n.id, n.y]))
+          const fByLevel = new Map<number, number>()
+          for (const ld of eOnly) {
+            if (ld.kind !== 'node') continue
+            const y = yById.get(ld.node); if (y === undefined) continue
+            const F = (msg.drift.axis === 'x' ? ld.Fx : ld.Fz) ?? 0
+            fByLevel.set(y, (fByLevel.get(y) ?? 0) + F)
+          }
+          const storeyForce = [...fByLevel].map(([elevation, F]) => ({ elevation, F }))
+          irregularities = assessIrregularities(msg.model, { nodeOrder: br.nodes, d: sol.d, storeyForce, dir: msg.drift.axis })
+        }
       }
-      ctx.postMessage({ id: msg.id, ok: true, result: { analysis, orphans: br.orphanEdges.length, drift } })
+      ctx.postMessage({ id: msg.id, ok: true, result: { analysis, orphans: br.orphanEdges.length, drift, irregularities } })
     } else if (msg.kind === 'modal') {
       onProgress({ phase: 'Modal analysis' })
       const modal = modalAnalysis(msg.model, msg.nModes)

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -22,6 +22,7 @@ import { TABLE_204_1, TABLE_204_2, sdlItemKPa, sdlTotal, type SdlItem } from '..
 import { TABLE_205_1, TABLE_206 } from '../engine/liveLoads'
 import type { ConcreteClass } from '../engine/quantities'
 import { computeSeismic, buildECases, type SeismicResult, type DriftRow } from '../engine/seismic'
+import type { IrregularityFlag } from '../engine/irregularity'
 import { columnKFactors, type ColumnK } from '../engine/effectiveLength'
 import { freqFromDeflection, dg11Walking, DG11_OCCUPANCY } from '../engine/floorVibration'
 import { buildSeismicMass, GRAVITY } from '../engine/modal'
@@ -927,6 +928,7 @@ export default function ModelSpace() {
   const [rsaRegular, setRsaRegular] = useState(b('rsaRegular', true)) // §208.6.4.2 floors: 0.9·V_B & 0.8·V_A vs 1.0·V_B
   const [rsaGen, setRsaGen] = useState<{ x: RsaLateralResult; z: RsaLateralResult } | null>(null)   // RSA-derived E cases
   const [drift, setDrift] = useState<DriftRow[] | null>(null)
+  const [irregular, setIrregular] = useState<IrregularityFlag[] | null>(null)
   // Wind (NSCP 207B directional procedure, MWFRS)
   const [Vw, setVw] = useState(n('Vw', 50)); const [expo, setExpo] = useState<'B' | 'C' | 'D'>((si.expo as 'B' | 'C' | 'D') ?? 'C')
   const [Kzt, setKzt] = useState(n('Kzt', 1.0))
@@ -1074,6 +1076,7 @@ export default function ModelSpace() {
     setOpt(null)
     setExpanded(null)
     setDrift(null)
+    setIrregular(null)
     try {
       if (m) sessionStorage.setItem(AUTOSAVE_KEY, JSON.stringify(m))
       else sessionStorage.removeItem(AUTOSAVE_KEY)
@@ -1090,6 +1093,7 @@ export default function ModelSpace() {
     setOpt(null)
     setExpanded(null)
     setDrift(null)
+    setIrregular(null)
     try { sessionStorage.setItem(AUTOSAVE_KEY, JSON.stringify(m)) } catch { /* quota — ignore */ }
   }
 
@@ -1112,10 +1116,11 @@ export default function ModelSpace() {
     run('analyze', {
       model, opts: anaOpts, drift: { hasSeis: !!seis, T: seis?.T ?? 0, R: Rw, axis: primAxis, pDelta }, crackedSections: cracked, shearDeformation: shearDef,
     }).then((r) => {
-      const res = r as { analysis: F3Analysis | null; orphans: number; drift: DriftRow[] | null }
+      const res = r as { analysis: F3Analysis | null; orphans: number; drift: DriftRow[] | null; irregularities: IrregularityFlag[] | null }
       setOrphans(res.orphans)
       setAnalysis(res.analysis)
       setDrift(res.drift)
+      setIrregular(res.irregularities)
     }).catch((e) => console.error('analyze failed', e))
   }
 
@@ -3412,6 +3417,23 @@ export default function ModelSpace() {
                   ))}
                   <p className="mt-1 text-[11px] text-slate-500">
                     Limit {seis.T < 0.7 ? '0.025' : '0.020'}·hs (T {seis.T < 0.7 ? '<' : '≥'} 0.7 s) — NSCP 208.5.10.
+                  </p>
+                </Sec>
+              )}
+
+              {irregular && seis && (
+                <Sec grid={false} title={`Structural irregularities — ${(eDirs[0] ?? '+X').replace(/[+-]/, '')}`}>
+                  {irregular.length === 0
+                    ? <Row label="NSCP Table 208-9 / 208-10" value="Regular ✓" sub="Torsional, soft-storey, mass & vertical-geometric checks all pass" />
+                    : irregular.map((f, i) => (
+                      <Row key={`${f.code}-${f.elevation ?? i}`} alert={f.verdict === 'extreme'}
+                        label={`${f.code} · ${f.name}`}
+                        value={`${f.verdict === 'extreme' ? '✗ extreme' : '△ irregular'}${f.elevation != null ? ` · EL ${f1(f.elevation)} m` : ''}`}
+                        sub={`${f.table} — ${f.detail}`} />
+                    ))}
+                  <p className="mt-1 text-[11px] text-slate-500">
+                    Auto-flags off the E-case drift field + storey weights: P1 torsional (208-10 §1a/1b),
+                    V1 soft-storey, V2 mass, V3 vertical-geometric (208-9 §1–3). Capacity/plan-shape types are not auto-checked.
                   </p>
                 </Sec>
               )}


### PR DESCRIPTION
## Summary
Phase 2 of the NSCP irregularity auto-flags — wires the engine from #427 into the analysis run and surfaces it in the UI. No new engine logic.

- **`solverWorker` (`analyze`)** — after the storey-drift solve (which already produces the E-case displacement field), derive the applied lateral storey force per level from the E-loads and run `assessIrregularities` on the same `sol.d` / `br.nodes`. The result is posted as `irregularities` alongside `drift`.
- **`ModelSpace`** — consume the new field (reset together with `drift` on model edits) and render a **"Structural irregularities"** panel in the Analysis tab, right below storey drift:
  - **Regular ✓** when nothing trips (all four checks pass), or
  - one row per flag — `△ irregular` / `✗ extreme` (extreme rows alert-styled) — with the NSCP table, storey elevation, and the governing ratio in the sub-line.
  - Gated identically to the drift panel (`irregular && seis`).

## Verification
- **`irregularity.test.ts`** — added an integration case that runs the **real bridge + solver** (`modelToFrame3D` → `solveFrame3D` → `assessIrregularities`) on a symmetric 2×2-bay, 2-storey frame under uniform X and asserts **no** torsional/mass/geometric flags, mirroring the worker's exact storey-force derivation. This covers the `nodeOrder ↔ sol.d` seam the pure adapter test can't.
- **Full suite 1462 → 1463**, `npx tsc -b` clean, `npm run build` succeeds.
- ⚠️ **UI not browser-verified** — this cloud session has no preview/screenshot tooling. The panel is simple JSX reusing the same `Sec`/`Row` components and gating as the working storey-drift panel; the data path it renders is covered by the integration test.

Completes the backlog item (HANDOFF updated to mark it shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_