### PR TITLE
Irregularity auto-flags — PDF report + validation fold (Phase 3)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -697,12 +697,15 @@ _Analysis completeness (P3):_
 - **Tension-only / compression-only members** (braces, uplift springs) and a
   **consistent-mass** option beside lumped — neither exists anywhere.
 - ~~**Irregularity auto-flags** — NSCP Table 208-9/10 (torsional, soft-storey,
-  mass)~~ — ✔ shipped (#427 engine, #428 wiring/UI): `engine/irregularity.ts`
-  flags P1 torsional (208-10 §1a/1b), V1 soft-storey, V2 mass, V3
-  vertical-geometric as pure post-processing of the E-case drift field + storey
-  weights; `solverWorker` runs `assessIrregularities` beside the drift check and
-  the Model Space Analysis tab shows an **Irregularities** panel. Not
-  auto-checked (need capacity/plan-shape/offset topology): 208-9 Types 4/5,
+  mass)~~ — ✔ shipped (#427 engine, #428 wiring/UI, #429 report/validation):
+  `engine/irregularity.ts` flags P1 torsional (208-10 §1a/1b), V1 soft-storey,
+  V2 mass, V3 vertical-geometric as pure post-processing of the E-case drift
+  field + storey weights; `solverWorker` runs `assessIrregularities` beside the
+  drift check and the Model Space Analysis tab shows an **Irregularities** panel.
+  The flags also fold into the direct **PDF report** (advisory regularity check +
+  a "Structural irregularities" table, does not gate `designOK`) and carry a
+  `/validation` row (`torsional-irregularity`) + a ValidationMap coverage entry.
+  Not auto-checked (need capacity/plan-shape/offset topology): 208-9 Types 4/5,
   208-10 Types 2–5.
 
 _Geotech / foundations (P4):_

--- a/docs/ValidationMap.md
+++ b/docs/ValidationMap.md
@@ -100,6 +100,7 @@ asserted by that file; all run in CI.
 |------|--------------|-------|
 | NSCP §208 static seismic | `seismic.test.ts`, `nscpSeismic.test.ts` | every V branch (208-9/10/11) + Ft + w·h distribution vs hand formulas; Method-B caps 1.3/1.4·Ta; accidental-torsion couple statics (ΣΔF = 0, ΣΔF·d = 0.05·L⊥·F); `validation.ts` `seismic-period`/`seismic-base-shear` |
 | RSA → design loads | `responseSpectrum.test.ts` | equivalent-load base shear ≡ CQC/SRSS combination (1e-9), single-mode Sa·effMass hand calc, §208.6.4.2 floor scaling |
+| Structural irregularities | `irregularity.test.ts` | NSCP Table 208-9/10 thresholds as hand calcs — P1 torsional δmax/δavg (1.2/1.4), V1 soft-storey (0.7/0.6 of above, 0.8/0.7 of avg-3), V2 mass (1.5), V3 vertical-geometric (1.3); real bridge+solver integration (symmetric grid ⇒ regular); `validation.ts` `torsional-irregularity` |
 | Load combinations | `loadCombinations.test.ts`, `pipeline.test.ts` | NSCP 203 factor sets as data; Ev = 0.5·Ca·I·D shifts (1.42D/0.68D) |
 | Time history | `timeHistory.test.ts`, `timeHistoryModel.test.ts`, `accelerogram.test.ts` | Newmark SDOF vs analytical free/forced responses; modal superposition |
 | Buckling | `buckling.test.ts` | linearized Pcr vs Euler closed forms (cantilever, fixed-fixed) |

--- a/webapp/src/engine/validation.ts
+++ b/webapp/src/engine/validation.ts
@@ -16,6 +16,7 @@ import { shapeByName } from './aiscSections'
 import { designAxialColumn } from './columnDesign'
 import { activeThrust, rankineKa, bearingFactors, infiniteSlopeFS } from './geotech'
 import { computeSeismic } from './seismic'
+import { torsionalVerdict } from './irregularity'
 import { jacobiEigen } from './modal'
 import { elasticResponseSpectrum } from './accelSpectrum'
 import { generateGridModel } from './modelBuilder'
@@ -353,6 +354,11 @@ export const VALIDATION_CASES: ValidationCase[] = [
     id: 'seismic-base-shear', category: 'Seismic', title: 'NSCP 208 static base shear',
     reference: 'NSCP 208.5.2.1', formula: 'V = Cv·I·W / (R·T)',
     manual: seismic.baseShear.manual, software: seismic.baseShear.software, unit: 'kN', tol: 1e-6,
+  },
+  {
+    id: 'torsional-irregularity', category: 'Seismic', title: 'Torsional irregularity ratio',
+    reference: 'NSCP Table 208-10 §1', formula: 'δmax/δavg, δavg = (δmax+δmin)/2  →  13/10',
+    manual: 1.3, software: torsionalVerdict(13, 7).ratio, unit: '—', tol: 1e-9,
   },
   {
     id: 'eigen-jacobi', category: 'Dynamics', title: 'Jacobi eigenvalue of [[2,1],[1,2]]',

--- a/webapp/src/lib/modelReport.test.ts
+++ b/webapp/src/lib/modelReport.test.ts
@@ -4,6 +4,7 @@ import { designStructure, designOK } from '../engine/pipeline'
 import type { RectSection } from '../engine/model'
 import { buildModelReport } from './modelReport'
 import { texToPlain } from './texText'
+import type { IrregularityFlag } from '../engine/irregularity'
 
 // The PDF payload assembler must mirror the pipeline results 1:1: same member
 // counts, same verdict, a worked solution for EVERY designed member (the
@@ -88,6 +89,40 @@ describe('buildModelReport', () => {
               expect(plain).not.toContain('{')
             }
           }
+  })
+})
+
+describe('buildModelReport — seismic irregularities', () => {
+  const model = makeModel()
+  const design = designStructure(model, soil)!
+
+  it('omits the regularity check when no seismic run is supplied', () => {
+    const rpt = buildModelReport(model, design, [], soil)
+    expect(rpt.checks.some((c) => c.name.startsWith('Seismic regularity'))).toBe(false)
+    expect(rpt.tables.some((t) => t.title.startsWith('Structural irregularities'))).toBe(false)
+  })
+
+  it('reports a passing regularity check for a regular structure (empty flags)', () => {
+    const rpt = buildModelReport(model, design, [], soil, [])
+    const chk = rpt.checks.find((c) => c.name.startsWith('Seismic regularity'))!
+    expect(chk.ok).toBe(true)
+    expect(rpt.tables.some((t) => t.title.startsWith('Structural irregularities'))).toBe(false)  // no rows ⇒ no table
+  })
+
+  it('folds flags into a not-ok check + an irregularities table without gating the overall verdict', () => {
+    const flags: IrregularityFlag[] = [
+      { code: 'P1b', name: 'Extreme torsional irregularity', table: 'Table 208-10', dir: 'x', elevation: 3, ratio: 1.6, limit: 1.4, verdict: 'extreme', detail: 'X: δmax/δavg = 1.6 > 1.4' },
+      { code: 'V2', name: 'Weight (mass) irregularity', table: 'Table 208-9', elevation: 6, ratio: 1.7, limit: 1.5, verdict: 'irregular', detail: 'W/W(adjacent) = 1.7 > 1.5' },
+    ]
+    const rpt = buildModelReport(model, design, [], soil, flags)
+    const chk = rpt.checks.find((c) => c.name.startsWith('Seismic regularity'))!
+    expect(chk.ok).toBe(false)
+    expect(chk.detail).toContain('P1b')
+    expect(rpt.ok).toBe(designOK(design))            // advisory only — does not flip the verdict
+    const t = rpt.tables.find((x) => x.title.startsWith('Structural irregularities'))!
+    expect(t.rows).toHaveLength(2)
+    for (const r of t.rows) expect(r).toHaveLength(t.head.length)
+    expect(t.rows[0][0]).toBe('P1b')
   })
 })
 

--- a/webapp/src/lib/modelReport.ts
+++ b/webapp/src/lib/modelReport.ts
@@ -9,6 +9,7 @@ import type {
   SteelBeamScheduleRow, SteelColumnScheduleRow,
 } from '../engine/pipeline'
 import { designOK } from '../engine/pipeline'
+import type { IrregularityFlag } from '../engine/irregularity'
 import { beamSectionSolution, columnRowSolution, footingRowSolution, combinedRowSolution,
   woodBeamRowSolution, woodColumnRowSolution, woodSlabRowSolution } from './modelSpaceSolutions'
 import { connectionRowSolution } from './connectionSolution'
@@ -97,6 +98,7 @@ export function steelColumnRowSolution(r: SteelColumnScheduleRow): SolutionStep[
 // ── Payload assembly ──────────────────────────────────────────────────────────
 export function buildModelReport(
   model: StructuralModel, design: StructureDesign, props: [string, string][], soil: SoilOptions,
+  irregular?: IrregularityFlag[] | null,
 ): ModelReport {
   const sectionFor = (memberId: string): RectSection | undefined => {
     const m = model.members.find((x) => x.id === memberId)
@@ -203,6 +205,16 @@ export function buildModelReport(
     checks.push({ name: 'Unchecked members', detail: design.unchecked.map((u) => `${u.id} (${u.shape})`).join(', '), ratio: null, ok: false })
   if (design.pDeltaIssues.length)
     checks.push({ name: 'P-Δ convergence', detail: `failed: ${design.pDeltaIssues.join(', ')}`, ratio: null, ok: false })
+  // seismic regularity (advisory — does not gate designOK; irregular structures
+  // are permitted but trigger the code's added detailing/analysis requirements)
+  if (irregular)
+    checks.push({
+      name: 'Seismic regularity (NSCP 208-9/10)',
+      detail: irregular.length === 0
+        ? 'Regular — torsional, soft-storey, mass & vertical-geometric checks all pass'
+        : irregular.map((f) => `${f.code} ${f.name.toLowerCase()}${f.elevation != null ? ` @ EL ${f2(f.elevation)} m` : ''}`).join('; '),
+      ratio: null, ok: irregular.length === 0,
+    })
 
   const ok = designOK(design)
   const withRatio = checks.filter((c) => c.ratio !== null)
@@ -356,6 +368,15 @@ export function buildModelReport(
     rows: design.combined.map((c) => [c.nodes.join(' + '), c.design.shape, f2(c.spacing), f2(c.design.Bx),
       c.design.shape === 'Trapezoidal (CTF)' ? `${f2(c.design.By1)}/${f2(c.design.By2)}` : f2(c.design.By),
       f0(c.design.Dc), c.ok ? 'PASS' : 'FAIL']),
+  })
+  if (irregular && irregular.length) tables.push({
+    title: 'Structural irregularities (NSCP Table 208-9/10)',
+    head: ['Code', 'Type', 'Location', 'Ratio', 'Limit', 'Classification'],
+    right: [3, 4],
+    rows: irregular.map((f) => [
+      f.code, f.name, f.elevation != null ? `EL ${f2(f.elevation)} m${f.dir ? ` · ${f.dir.toUpperCase()}` : ''}` : (f.dir ? f.dir.toUpperCase() : '—'),
+      f2(f.ratio), f2(f.limit), f.verdict === 'extreme' ? 'Extreme' : 'Irregular',
+    ]),
   })
 
   // ── Worked solutions — every member (user-selected depth) ──

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -1455,7 +1455,7 @@ export default function ModelSpace() {
         ...(design.woodBeams.length || design.woodColumns.length ? ['NDS §3 / NSCP §6'] : [])]
       await generateModelPdf({
         lh, modelImg: img, badges,
-        report: buildModelReport(model, design, reportProps(design), soil),
+        report: buildModelReport(model, design, reportProps(design), soil, irregular),
         fileName: `structure-report${lh.sheet ? '-' + lh.sheet.split('·')[0].trim() : ''}.pdf`,
       })
     } catch (e) {


### PR DESCRIPTION
## Summary
Final phase of the NSCP irregularity auto-flags — folds the flags into the direct PDF report and the `/validation` benchmark set. No new engine check logic.

- **`modelReport` (`buildModelReport`)** — takes the optional E-case irregularity flags and adds:
  - an advisory **"Seismic regularity (NSCP 208-9/10)"** summary check — passes when the structure is regular, fails to surface flags — but it **does not gate `designOK`** (irregular structures are permitted; the flag just triggers the code's added detailing/analysis requirements).
  - a **"Structural irregularities"** table (`Code / Type / Location / Ratio / Limit / Classification`) rendered only when something trips.
  - `ModelSpace` threads its analysis `irregular` state into the export call.
- **`validation`** — new `torsional-irregularity` benchmark: δmax/δavg = 13/10 = **1.3** vs the Table 208-10 §1 definition (closed-form check of the ratio). Picked up by the existing "every case within tolerance" test.
- **`docs/ValidationMap.md`** — Structural-irregularities coverage row (L9 rule: the map must not lag the code).

## Verification
- **`modelReport.test.ts`** — three fold cases: the regularity check is **omitted** without a seismic run, **passes** for a regular structure (empty flags, no table), and for supplied flags produces a **not-ok** check + a 2-row table while leaving `rpt.ok === designOK(design)` (advisory, non-gating).
- **`validation.test.ts`** auto-covers the new case (0 % diff, tol 1e-9).
- **Full suite 1463 → 1466**, `npx tsc -b` clean, `npm run build` succeeds, Vercel preview built green on the prior phases.

Completes the irregularity backlog item end-to-end (engine → worker/UI → report/validation). HANDOFF updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_