### PR TITLE
Slope stability — /slope page (Phase 2)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -709,15 +709,16 @@ _Analysis completeness (P3):_
   208-10 Types 2–5.
 
 _Geotech / foundations (P4):_
-- **Slope stability by method of slices** (Bishop / Janbu) — engine ✔ shipped
-  (#430, Phase 1): `engine/slopeStability.ts` — vertical-slice discretisation of
-  a circular surface + Fellenius/OMS, Bishop's simplified (iterative mα), and
-  Janbu's simplified (f0 correction), with a grid search for the critical
-  (min-Bishop-FS) circle; ru / piezometric-line pore pressure; orientation-
-  agnostic driving. Tests vs a 3-slice hand calc + Bishop ≥ Fellenius +
-  monotonic steeper→lower; `validation.ts` `slope-slices-fellenius`. **Phase 2
-  (TODO): the `/slope` page** (geometry input, worked solution, slip-circle
-  drawing, PDF).
+- ~~**Slope stability by method of slices** (Bishop / Janbu)~~ — ✔ shipped
+  (#430 engine, #431 page): `engine/slopeStability.ts` — vertical-slice
+  discretisation of a circular surface + Fellenius/OMS, Bishop's simplified
+  (iterative mα), and Janbu's simplified (f0 correction), with a grid search for
+  the critical (min-Bishop-FS) circle; ru / piezometric-line pore pressure;
+  orientation-agnostic driving. **`/slope` page** (`pages/SlopeStability.tsx`):
+  slope-geometry + soil + ru inputs, the three-method FS on the critical circle,
+  a vector slope + slip-circle + slices drawing, a slice table, and the print
+  report. Tests vs a 3-slice hand calc + Bishop ≥ Fellenius + monotonic
+  steeper→lower; `validation.ts` `slope-slices-fellenius`.
 - **Settlement** (immediate + consolidation) and **laterally loaded piles**
   (Broms / p-y) — absent.
 - **Offset framing / beam-on-girder-flange bearing** (seat detail, AISC §J10) —

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -29,6 +29,7 @@ import SoilNail from './pages/SoilNail'
 import StairDesign from './pages/StairDesign'
 import WoodSlab from './pages/WoodSlab'
 import Micropile from './pages/Micropile'
+import SlopeStability from './pages/SlopeStability'
 import RockAnchor from './pages/RockAnchor'
 import SeismicWizard from './pages/SeismicWizard'
 import WaterTank from './pages/WaterTank'
@@ -95,6 +96,7 @@ export default function App() {
         <Route path="/stair" element={<StairDesign />} />
         <Route path="/wood-slab" element={<WoodSlab />} />
         <Route path="/micropile" element={<Micropile />} />
+        <Route path="/slope" element={<SlopeStability />} />
         <Route path="/rock-anchor" element={<RockAnchor />} />
         <Route path="/seismic-wizard" element={<SeismicWizard />} />
         <Route path="/water-tank" element={<WaterTank />} />

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -42,6 +42,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/micropile',        name: 'Micropile',        sub: 'FHWA · structural · bond', group: 'Geotechnical' },
       { to: '/rock-anchor',      name: 'Rock Anchor',      sub: 'PTI · tendon · bond',      group: 'Geotechnical' },
       { to: '/shotcrete-facing', name: 'Shotcrete Facing', sub: 'FHWA · flexure · punching', group: 'Geotechnical' },
+      { to: '/slope',            name: 'Slope Stability',  sub: 'Slices · Bishop/Fellenius/Janbu', group: 'Geotechnical' },
       { to: '/seismic-wizard',   name: 'Seismic Wizard',   sub: 'NSCP 208 Ca/Cv/I/R',       group: 'Seismic & Loads' },
       { to: '/load-combinations', name: 'Load Combinations', sub: 'NSCP 2015 §203.3 LRFD',  group: 'Seismic & Loads' },
       { to: '/wood-slab',        name: 'Wood Slab',        sub: 'Deck-on-joist · NDS §3 / NSCP §6', group: 'Timber' },

--- a/webapp/src/pages/SlopeStability.tsx
+++ b/webapp/src/pages/SlopeStability.tsx
@@ -1,0 +1,204 @@
+import { useMemo, useState } from 'react'
+import { ReportControls } from '../components/ReportControls'
+import {
+  searchCriticalCircle, surfaceY,
+  type Pt, type SlopeSoil, type WaterModel, type CircleResult,
+} from '../engine/slopeStability'
+
+function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
+const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
+const f0 = (n: number) => (Number.isFinite(n) ? Math.round(n).toString() : '—')
+
+function Field({ label, value, onChange, unit, step = 'any' }: {
+  label: string; value: number; onChange: (v: number) => void; unit?: string; step?: string
+}) {
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="mb-1 font-medium text-slate-600">{label}{unit ? ` (${unit})` : ''}</span>
+      <input type="number" step={step} value={value} onChange={(e) => onChange(num(e.target.value))}
+        className="rounded-md border border-slate-300 px-2.5 py-1.5" />
+    </label>
+  )
+}
+
+function Out({ label, value, ok }: { label: string; value: string; ok?: boolean }) {
+  return (
+    <div className="flex items-baseline justify-between border-t border-slate-100 py-1 text-sm">
+      <span className="text-slate-500">{label}</span>
+      <span className={`font-mono font-medium ${ok === undefined ? 'text-slate-800' : ok ? 'text-emerald-600' : 'text-red-600'}`}>{value}</span>
+    </div>
+  )
+}
+
+/** Build the ground polyline (left→right) from a simple slope geometry:
+ *  crest plateau at height H, a face at angle β, then a toe plateau. */
+function groundOf(H: number, betaDeg: number, crestW: number, toeW: number): Pt[] {
+  const run = betaDeg > 0 && betaDeg < 90 ? H / Math.tan((betaDeg * Math.PI) / 180) : H
+  return [{ x: 0, y: H }, { x: crestW, y: H }, { x: crestW + run, y: 0 }, { x: crestW + run + toeW, y: 0 }]
+}
+
+/** Vector slope + critical-circle drawing (world m → px, y up). */
+function SlopeSvg({ ground, res, water }: { ground: Pt[]; res: CircleResult | null; water?: Pt[] }) {
+  const W = 640, Hpx = 320, pad = 30
+  const xs = ground.map((p) => p.x), ys = ground.map((p) => p.y)
+  let minX = Math.min(...xs), maxX = Math.max(...xs), minY = Math.min(...ys), maxY = Math.max(...ys)
+  if (res) { minY = Math.min(minY, res.circle.yc - res.circle.R); maxY = Math.max(maxY, res.circle.yc) }
+  const sx = (W - 2 * pad) / Math.max(1e-6, maxX - minX)
+  const sy = (Hpx - 2 * pad) / Math.max(1e-6, maxY - minY)
+  const s = Math.min(sx, sy)
+  const X = (x: number) => pad + (x - minX) * s
+  const Y = (y: number) => Hpx - pad - (y - minY) * s
+
+  const groundPath = ground.map((p, i) => `${i ? 'L' : 'M'}${X(p.x).toFixed(1)},${Y(p.y).toFixed(1)}`).join(' ')
+  let arcPath = '', slicePts: string[] = [], massPath = '', center = null as null | { cx: number; cy: number }
+  if (res) {
+    const sl = res.slices, { xc, yc, R } = res.circle
+    const yArc = (x: number) => yc - Math.sqrt(Math.max(0, R * R - (x - xc) ** 2))
+    const x0 = sl[0].x - sl[0].b / 2, x1 = sl[sl.length - 1].x + sl[sl.length - 1].b / 2
+    const nSample = 60
+    const arc: Pt[] = []
+    for (let i = 0; i <= nSample; i++) { const x = x0 + ((x1 - x0) * i) / nSample; arc.push({ x, y: yArc(x) }) }
+    arcPath = arc.map((p, i) => `${i ? 'L' : 'M'}${X(p.x).toFixed(1)},${Y(p.y).toFixed(1)}`).join(' ')
+    // sliding mass = ground surface (x0→x1) then back along the arc
+    const top: Pt[] = arc.map((p) => ({ x: p.x, y: surfaceY(ground, p.x) }))
+    massPath = 'M' + top.map((p) => `${X(p.x).toFixed(1)},${Y(p.y).toFixed(1)}`).join(' L') +
+      ' L' + [...arc].reverse().map((p) => `${X(p.x).toFixed(1)},${Y(p.y).toFixed(1)}`).join(' L') + ' Z'
+    // interior slice boundaries
+    for (let i = 1; i < sl.length; i++) {
+      const xb = sl[i].x - sl[i].b / 2
+      slicePts.push(`M${X(xb).toFixed(1)},${Y(surfaceY(ground, xb)).toFixed(1)} L${X(xb).toFixed(1)},${Y(yArc(xb)).toFixed(1)}`)
+    }
+    center = { cx: X(xc), cy: Y(yc) }
+  }
+  const waterPath = water && water.length > 1
+    ? water.map((p, i) => `${i ? 'L' : 'M'}${X(p.x).toFixed(1)},${Y(p.y).toFixed(1)}`).join(' ') : ''
+
+  return (
+    <svg viewBox={`0 0 ${W} ${Hpx}`} className="w-full rounded-lg border border-slate-200 bg-white" style={{ maxHeight: 340 }}>
+      <rect x={0} y={0} width={W} height={Hpx} fill="#fff" />
+      {massPath && <path d={massPath} fill="#fca5a5" fillOpacity={0.28} stroke="none" />}
+      {slicePts.map((d, i) => <path key={i} d={d} stroke="#94a3b8" strokeWidth={0.5} fill="none" />)}
+      <path d={groundPath} stroke="#78350f" strokeWidth={2} fill="none" />
+      {arcPath && <path d={arcPath} stroke="#dc2626" strokeWidth={2} fill="none" />}
+      {waterPath && <path d={waterPath} stroke="#0ea5e9" strokeWidth={1.2} strokeDasharray="5,3" fill="none" />}
+      {center && <>
+        <line x1={center.cx} y1={center.cy} x2={X(res!.circle.xc + res!.circle.R)} y2={center.cy} stroke="#dc2626" strokeWidth={0.6} strokeDasharray="3,3" />
+        <circle cx={center.cx} cy={center.cy} r={3} fill="#dc2626" />
+      </>}
+    </svg>
+  )
+}
+
+export default function SlopeStability() {
+  const [H, setH] = useState(10)
+  const [beta, setBeta] = useState(30)
+  const [crestW, setCrestW] = useState(8)
+  const [toeW, setToeW] = useState(12)
+  const [c, setC] = useState(20)
+  const [phi, setPhi] = useState(25)
+  const [gamma, setGamma] = useState(18)
+  const [ru, setRu] = useState(0)
+  const [method, setMethod] = useState<'bishop' | 'fellenius' | 'janbu'>('bishop')
+
+  const ground = useMemo(() => groundOf(H, beta, crestW, toeW), [H, beta, crestW, toeW])
+  const soil: SlopeSoil = { c, phiDeg: phi, gamma }
+  const water: WaterModel | undefined = ru > 0 ? { ru } : undefined
+
+  const res = useMemo(() => searchCriticalCircle(ground, soil, { water, n: 30 }),
+    [ground, c, phi, gamma, ru]) // eslint-disable-line react-hooks/exhaustive-deps
+  const crit = res?.critical ?? null
+  const FS = crit ? { bishop: crit.bishop.FS, fellenius: crit.fellenius.FS, janbu: crit.janbu.FS }[method] : NaN
+  const govOK = FS >= 1.5
+
+  return (
+    <main className="mx-auto max-w-3xl px-5 py-10">
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
+      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Slope stability — method of slices</h1>
+      <ReportControls title="Slope Stability Report" badges={['Bishop', 'Fellenius', 'Janbu']} />
+      <p className="mt-2 text-sm text-slate-600">
+        Circular-failure factor of safety by the method of slices — Fellenius/OMS, Bishop&rsquo;s simplified and
+        Janbu&rsquo;s simplified — with a grid search for the critical (minimum-FS) circle. Pore pressure via ru.
+      </p>
+
+      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Slope geometry</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Field label="Height H" unit="m" value={H} onChange={setH} />
+          <Field label="Face angle β" unit="°" value={beta} onChange={setBeta} />
+          <Field label="Crest width" unit="m" value={crestW} onChange={setCrestW} />
+          <Field label="Toe width" unit="m" value={toeW} onChange={setToeW} />
+        </div>
+        <h2 className="mb-3 mt-5 text-[1.05rem] font-bold text-[#0056b3]">Soil &amp; water</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Field label="Cohesion c′" unit="kPa" value={c} onChange={setC} />
+          <Field label="Friction φ′" unit="°" value={phi} onChange={setPhi} />
+          <Field label="Unit weight γ" unit="kN/m³" value={gamma} onChange={setGamma} />
+          <Field label="Pore ratio ru" value={ru} onChange={setRu} step="0.05" />
+        </div>
+      </section>
+
+      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="mb-2 flex items-center justify-between">
+          <h2 className="text-[1.05rem] font-bold text-[#0056b3]">Critical circle</h2>
+          <label className="flex items-center gap-2 text-sm">
+            <span className="text-slate-500">Governing method</span>
+            <select value={method} onChange={(e) => setMethod(e.target.value as typeof method)}
+              className="rounded-md border border-slate-300 px-2 py-1">
+              <option value="bishop">Bishop simplified</option>
+              <option value="fellenius">Fellenius / OMS</option>
+              <option value="janbu">Janbu simplified</option>
+            </select>
+          </label>
+        </div>
+        <SlopeSvg ground={ground} res={crit} />
+        {crit ? (
+          <div className="mt-3">
+            <Out label={`Factor of safety — ${method}`} value={f2(FS)} ok={govOK} />
+            <Out label="FS — Bishop / Fellenius / Janbu" value={`${f2(crit.bishop.FS)} / ${f2(crit.fellenius.FS)} / ${f2(crit.janbu.FS)}`} />
+            <Out label="Critical circle (xc, yc, R)" value={`(${f2(crit.circle.xc)}, ${f2(crit.circle.yc)}, ${f2(crit.circle.R)}) m`} />
+            <Out label="Janbu correction f₀ · slices" value={`${f2(crit.f0)} · ${crit.slices.length}`} />
+            <Out label="Σ driving / Σ resisting (Bishop)" value={`${f0(crit.bishop.driving)} / ${f0(crit.bishop.resisting)} kN·m/m`} />
+            <p className="mt-2 text-[11px] text-slate-500">
+              FS &lt; 1.5 (static) is generally inadequate for a permanent slope; check the target FS for your load
+              case. Search covers a centre/radius grid — refine the geometry for site-specific circles.
+            </p>
+          </div>
+        ) : (
+          <p className="mt-3 rounded-lg border border-dashed border-slate-200 px-3 py-4 text-center text-xs text-slate-400">
+            No valid slip circle found for this geometry — check the slope height, angle and plateau widths.
+          </p>
+        )}
+      </section>
+
+      {crit && (
+        <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 className="mb-2 text-[1.05rem] font-bold text-[#0056b3]">Slices (critical circle)</h2>
+          <div className="overflow-x-auto">
+            <table className="w-full text-right text-[12px]">
+              <thead className="text-slate-500">
+                <tr className="border-b border-slate-200">
+                  <th className="py-1 pr-3 text-left">#</th><th className="py-1 pr-3">x (m)</th><th className="py-1 pr-3">b (m)</th>
+                  <th className="py-1 pr-3">h (m)</th><th className="py-1 pr-3">α (°)</th><th className="py-1 pr-3">W (kN/m)</th><th className="py-1 pr-3">u (kPa)</th>
+                </tr>
+              </thead>
+              <tbody className="font-mono">
+                {crit.slices.map((sl, i) => (
+                  <tr key={i} className="border-b border-slate-100">
+                    <td className="py-0.5 pr-3 text-left">{i + 1}</td>
+                    <td className="py-0.5 pr-3">{f2(sl.x)}</td><td className="py-0.5 pr-3">{f2(sl.b)}</td>
+                    <td className="py-0.5 pr-3">{f2(sl.h)}</td><td className="py-0.5 pr-3">{f2((sl.alpha * 180) / Math.PI)}</td>
+                    <td className="py-0.5 pr-3">{f0(sl.W)}</td><td className="py-0.5 pr-3">{f0(sl.u)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p className="mt-2 text-[10px] text-slate-500">
+            Bishop: FS = Σ[(c·b + (W − u·b)·tanφ)/mα] / Σ[W·sinα], mα = cosα + sinα·tanφ/FS (iterated).
+            Fellenius drops the inter-slice terms; Janbu uses force equilibrium × f₀.
+          </p>
+        </section>
+      )}
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
Phase 2 of slope stability — the **`/slope` page** over the engine merged in #430. Presentation layer only (no engine change).

- **`pages/SlopeStability.tsx`** — a standalone geotech calculator:
  - Inputs: slope geometry (height H, face angle β, crest/toe plateau widths), soil (c′, φ′, γ), and pore-pressure ratio ru.
  - Runs `searchCriticalCircle` and reports the **Fellenius / Bishop / Janbu** FS on the governing circle, with a selectable governing method (default Bishop) and a PASS threshold at FS ≥ 1.5.
  - A **vector drawing** (`SlopeSvg`): ground profile, critical slip arc, translucent sliding-mass fill, interior slice boundaries, and the circle centre + radius.
  - A **per-slice table** (x, b, h, α, W, u) for the critical circle, plus the method formulas.
  - Prints through the shared `ReportControls` letterhead.
- **Route `/slope`** + a **"Slope Stability"** tile in the Geotechnical group (`lib/tools.ts`).

## Verification
- **Full suite 1477** (unchanged — this is the presentation layer over the already-tested engine), `npx tsc -b` clean, `npm run build` succeeds.
- Confirmed the **default inputs** (H 10 m, β 30°, c 20 kPa, φ 25°, γ 18) resolve to a valid critical circle — Bishop **2.04** / Fellenius **1.89** / Janbu **2.03** (Bishop > Fellenius as expected) — so the page renders results on load, not the empty state.
- ⚠️ **UI not browser-verified** — this cloud session has no preview/screenshot tooling. The page reuses the established standalone-page pattern (`Field`/`Out`/`ReportControls`, same as `/micropile` et al.) and the drawing is generated from the tested engine geometry.

Completes the slope-stability backlog item (engine → page). HANDOFF updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_