### PR TITLE
Direct-integration MDOF time-history with Rayleigh damping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,8 +170,10 @@ Ordered: correctness first, then code completeness, then new capability.
    Φ-modified `kLocal` + per-family shear areas in the bridge (opt-in
    `shearDeformation`, UI default on). FEMs stay Euler; modal/pushover/
    buckling still run the Euler element (follow-up if needed).
-6. **Direct-integration time-history** on the full MDOF system with Rayleigh
-   damping (currently modal superposition only) — prerequisite for nonlinear TH.
+6. ~~**Direct-integration time-history** on the full MDOF system with Rayleigh
+   damping~~ — ✔ shipped (#432): `directTimeHistory.ts` — Newmark-β on the full
+   free-DOF system with `C = αM + βK`, K̂ LU-factored once and reused per step;
+   `rayleighCoeffs` inverts the two-anchor ζ(ω) curve. Unblocks nonlinear TH.
 7. Tension-only / compression-only members (braces, uplift springs);
    consistent-mass option beside lumped.
 8. Irregularity auto-flags (torsional, soft-storey, mass — NSCP Table 208-9/10).

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -692,8 +692,16 @@ complete. New disciplines landed too: **timber wood-frame** (#379–#386),
 **Still genuinely missing** (verified absent from the engine):
 
 _Analysis completeness (P3):_
-- **Direct-integration MDOF time-history** with Rayleigh damping — `timeHistory.ts`
-  is modal-superposition only (no full-system Newmark); prerequisite for nonlinear TH.
+- ~~**Direct-integration MDOF time-history** with Rayleigh damping~~ — ✔ shipped
+  (#432): `engine/directTimeHistory.ts` — Newmark-β on the FULL free-DOF system
+  `M ü + C u̇ + K u = P(t)` with `C = αM + βK`; the effective stiffness
+  `K̂ = K + a₀M + a₁C` is constant for fixed dt so it is LU-factored **once** and
+  reused every step (same shared-factorization discipline as the static solver).
+  `rayleighCoeffs(ω₁,ζ₁,ω₂,ζ₂)` inverts the two-anchor curve; the model driver
+  anchors to two modal frequencies. No mode truncation and damping need not be
+  modally diagonalizable — the prerequisite for **nonlinear TH**. Validated by
+  reproducing mode-by-mode superposition to 1e-9 on a 2-DOF shear building.
+  Diaphragm constraints are not applied on this path (same as `modal.ts`).
 - **Tension-only / compression-only members** (braces, uplift springs) and a
   **consistent-mass** option beside lumped — neither exists anywhere.
 - ~~**Irregularity auto-flags** — NSCP Table 208-9/10 (torsional, soft-storey,

--- a/docs/ValidationMap.md
+++ b/docs/ValidationMap.md
@@ -103,6 +103,7 @@ asserted by that file; all run in CI.
 | Structural irregularities | `irregularity.test.ts` | NSCP Table 208-9/10 thresholds as hand calcs — P1 torsional δmax/δavg (1.2/1.4), V1 soft-storey (0.7/0.6 of above, 0.8/0.7 of avg-3), V2 mass (1.5), V3 vertical-geometric (1.3); real bridge+solver integration (symmetric grid ⇒ regular); `validation.ts` `torsional-irregularity` |
 | Load combinations | `loadCombinations.test.ts`, `pipeline.test.ts` | NSCP 203 factor sets as data; Ev = 0.5·Ca·I·D shifts (1.42D/0.68D) |
 | Time history | `timeHistory.test.ts`, `timeHistoryModel.test.ts`, `accelerogram.test.ts` | Newmark SDOF vs analytical free/forced responses; modal superposition |
+| Direct-integration TH (Rayleigh) | `directTimeHistory.test.ts` | full-MDOF Newmark ≡ mode-by-mode superposition to 1e-9 on a 2-DOF shear building (Rayleigh C is diagonalized by the modes, so the two paths are algebraically identical); 1-DOF ≡ `newmarkSDOF` to 1e-10; free-vibration log decrement exp(−2πζ/√(1−ζ²)); Rayleigh α/β inversion hits both target ζ exactly, sags between anchors; `validation.ts` `direct-th-decay` |
 | Buckling | `buckling.test.ts` | linearized Pcr vs Euler closed forms (cantilever, fixed-fixed) |
 | Pushover | `pushover.test.ts`, `pushoverModel.test.ts` | event-to-event capacity curve vs hand-tracked hinge sequence (review-problem anchors) |
 | Floor vibration | `floorVibration.test.ts` | AISC DG11 fn = 0.18√(g/Δ) + tolerance thresholds |

--- a/webapp/src/engine/directTimeHistory.test.ts
+++ b/webapp/src/engine/directTimeHistory.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest'
+import {
+  rayleighCoeffs, rayleighZeta, newmarkDirect, directTimeHistory,
+} from './directTimeHistory'
+import { newmarkSDOF, modalTimeHistory, type GroundMotion } from './timeHistory'
+import { jacobiEigen } from './modal'
+import { generateGridModel } from './modelBuilder'
+import type { RectSection } from './model'
+
+// ── Rayleigh coefficients ───────────────────────────────────────────────
+describe('directTimeHistory — Rayleigh damping model', () => {
+  it('reproduces the two target damping ratios exactly', () => {
+    const w1 = 2.0, w2 = 9.0, z1 = 0.05, z2 = 0.05
+    const c = rayleighCoeffs(w1, z1, w2, z2)
+    expect(rayleighZeta(c, w1)).toBeCloseTo(z1, 12)
+    expect(rayleighZeta(c, w2)).toBeCloseTo(z2, 12)
+  })
+
+  it('supports unequal anchor ratios', () => {
+    const c = rayleighCoeffs(3, 0.02, 20, 0.07)
+    expect(rayleighZeta(c, 3)).toBeCloseTo(0.02, 12)
+    expect(rayleighZeta(c, 20)).toBeCloseTo(0.07, 12)
+  })
+
+  it('dips below the target between the anchors and rises outside them', () => {
+    const c = rayleighCoeffs(2, 0.05, 10, 0.05)
+    expect(rayleighZeta(c, 5)).toBeLessThan(0.05)        // classic Rayleigh sag
+    expect(rayleighZeta(c, 25)).toBeGreaterThan(0.05)    // stiff modes over-damped
+    expect(rayleighZeta(c, 0.5)).toBeGreaterThan(0.05)   // soft modes over-damped
+  })
+
+  it('α alone gives mass-proportional damping ζ = α/2ω', () => {
+    const c = { alpha: 0.4, beta: 0 }
+    expect(rayleighZeta(c, 4)).toBeCloseTo(0.05, 12)
+  })
+})
+
+// ── the pure integrator vs the validated SDOF routine ───────────────────
+describe('directTimeHistory — newmarkDirect on a 1-DOF system', () => {
+  const omega = 3.0, zeta = 0.05, dt = 0.01, n = 400
+  const p = Array.from({ length: n }, (_, i) => Math.sin(2.0 * i * dt))
+
+  it('matches newmarkSDOF step for step', () => {
+    const r = newmarkDirect([[1]], [[2 * zeta * omega]], [[omega * omega]], p.map((x) => [x]), dt)!
+    const s = newmarkSDOF(omega, zeta, p, dt)
+    expect(r.steps).toBe(n)
+    for (let i = 0; i < n; i += 25) expect(r.u[i][0]).toBeCloseTo(s.u[i], 10)
+    expect(r.u[n - 1][0]).toBeCloseTo(s.u[n - 1], 10)
+  })
+
+  it('free vibration decays at the logarithmic decrement of ζ', () => {
+    // released from u0 = 1 with no forcing: peaks decay by exp(−ζ·ω·T)
+    const zeros = Array.from({ length: 3000 }, () => [0])
+    const r = newmarkDirect([[1]], [[2 * zeta * omega]], [[omega * omega]], zeros, 0.002, { u0: [1] })!
+    const T = (2 * Math.PI) / omega
+    const idx = Math.round(T / 0.002)
+    // one full cycle later the amplitude is exp(−2πζ/√(1−ζ²)) of the start
+    const expected = Math.exp((-2 * Math.PI * zeta) / Math.sqrt(1 - zeta * zeta))
+    expect(r.u[idx][0]).toBeCloseTo(expected, 3)
+  })
+
+  it('returns null when the effective stiffness is singular', () => {
+    expect(newmarkDirect([[0]], [[0]], [[0]], [[1], [1]], 0.01)).toBeNull()
+  })
+})
+
+// ── the decisive check: direct ≡ modal superposition under Rayleigh ─────
+// With C = αM + βK the mode shapes diagonalize M, C and K simultaneously, and
+// Newmark is a linear one-step method — so integrating the coupled system must
+// reproduce the mode-by-mode SDOF integration to roundoff.
+describe('directTimeHistory — direct integration ≡ modal superposition (2-DOF)', () => {
+  // 2-storey shear building: m = 1 each, k = 1 each
+  const M = [[1, 0], [0, 1]]
+  const K = [[2, -1], [-1, 1]]
+  const zeta = 0.04, dt = 0.01, n = 1200
+  const ag = Array.from({ length: n }, (_, i) => Math.sin(1.3 * i * dt) * Math.exp(-0.3 * i * dt))
+
+  // exact modes (M = I ⇒ standard eigenproblem); ω² = (3∓√5)/2
+  const { values, vectors } = jacobiEigen(K)
+  const order = values.map((_, i) => i).sort((a, b) => values[a] - values[b])
+  const omegas = order.map((i) => Math.sqrt(values[i]))
+  const phis = order.map((i) => vectors[i])   // jacobiEigen returns modes as ROWS
+
+  it('the eigen-solution matches the golden-ratio closed form', () => {
+    expect(omegas[0]).toBeCloseTo(Math.sqrt((3 - Math.sqrt(5)) / 2), 10)
+    expect(omegas[1]).toBeCloseTo(Math.sqrt((3 + Math.sqrt(5)) / 2), 10)
+  })
+
+  const ray = rayleighCoeffs(omegas[0], zeta, omegas[1], zeta)
+
+  it('Rayleigh gives exactly ζ in BOTH modes (so the two paths are comparable)', () => {
+    expect(rayleighZeta(ray, omegas[0])).toBeCloseTo(zeta, 12)
+    expect(rayleighZeta(ray, omegas[1])).toBeCloseTo(zeta, 12)
+  })
+
+  it('agrees with mode-by-mode superposition to roundoff', () => {
+    const C = [[ray.alpha * 1 + ray.beta * K[0][0], ray.beta * K[0][1]],
+      [ray.beta * K[1][0], ray.alpha * 1 + ray.beta * K[1][1]]]
+    const iota = [1, 1]
+    const P = ag.map((g) => [-M[0][0] * iota[0] * g, -M[1][1] * iota[1] * g])
+    const direct = newmarkDirect(M, C, K, P, dt)!
+
+    // modal: q_r = Γ_r·D_r with D̈+2ζωḊ+ω²D = −a_g
+    const p = ag.map((g) => -g)
+    const modalU: number[][] = Array.from({ length: n }, () => [0, 0])
+    for (let r = 0; r < 2; r++) {
+      const phi = phis[r]
+      const Mstar = phi[0] * phi[0] + phi[1] * phi[1]
+      const L = phi[0] * iota[0] + phi[1] * iota[1]
+      const G = L / Mstar
+      const { u: D } = newmarkSDOF(omegas[r], zeta, p, dt)
+      for (let i = 0; i < n; i++) {
+        modalU[i][0] += phi[0] * G * D[i]
+        modalU[i][1] += phi[1] * G * D[i]
+      }
+    }
+
+    let peak = 0
+    for (const row of modalU) peak = Math.max(peak, Math.abs(row[0]), Math.abs(row[1]))
+    expect(peak).toBeGreaterThan(0.01)                 // the record actually excites it
+    for (let i = 0; i < n; i += 17) {
+      expect(direct.u[i][0]).toBeCloseTo(modalU[i][0], 9)
+      expect(direct.u[i][1]).toBeCloseTo(modalU[i][1], 9)
+    }
+  })
+})
+
+// ── model-level driver ──────────────────────────────────────────────────
+describe('directTimeHistory — model level', () => {
+  const section: RectSection = { id: 'S1', name: '400×400', b: 400, h: 400, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
+  const model = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3, 3], section, slabThickness: 150 })
+  const n = 500, dt = 0.02
+  const gm: GroundMotion = {
+    dt, dir: 0,
+    ag: Array.from({ length: n }, (_, i) => 2.0 * Math.sin(6.0 * i * dt) * Math.exp(-0.15 * i * dt)),
+  }
+
+  it('runs the full free-DOF system and reports the Rayleigh anchors', () => {
+    const r = directTimeHistory(model, gm, { zeta: 0.05, anchorModes: [1, 2] })!
+    expect(r).toBeTruthy()
+    expect(r.ndof).toBeGreaterThan(6)                    // full MDOF, not a modal subset
+    expect(r.t).toHaveLength(n)
+    expect(r.anchors).toHaveLength(2)
+    for (const a of r.anchors) expect(a.zeta).toBeCloseTo(0.05, 10)
+    expect(r.rayleigh.alpha).toBeGreaterThan(0)
+    expect(r.rayleigh.beta).toBeGreaterThan(0)
+  })
+
+  it('produces finite peaks and a non-trivial base-shear history', () => {
+    const r = directTimeHistory(model, gm, { zeta: 0.05 })!
+    expect(Number.isFinite(r.peakNodeDisp)).toBe(true)
+    expect(r.peakNodeDisp).toBeGreaterThan(0)
+    expect(r.peakNode).toBeTruthy()
+    expect(r.peakBaseShear).toBeGreaterThan(0)
+    expect(r.baseShear).toHaveLength(n)
+    expect(r.baseShear.every((v) => Number.isFinite(v))).toBe(true)
+  })
+
+  it('lands in the same ballpark as modal superposition', () => {
+    const d = directTimeHistory(model, gm, { zeta: 0.05, anchorModes: [1, 2] })!
+    const m = modalTimeHistory(model, gm, { zeta: 0.05, nModes: 12 })!
+    // different damping models (Rayleigh ζ(ω) vs constant modal ζ) + mode
+    // truncation ⇒ not identical, but the same order of magnitude
+    expect(d.peakNodeDisp).toBeGreaterThan(0.2 * m.peakNodeDisp)
+    expect(d.peakNodeDisp).toBeLessThan(5 * m.peakNodeDisp)
+  })
+
+  it('returns the requested node displacement history', () => {
+    const top = model.nodes.reduce((b, nd) => (nd.y > b.y ? nd : b))
+    const r = directTimeHistory(model, gm, { zeta: 0.05, historyNode: top.id })!
+    expect(r.nodeHistory?.node).toBe(top.id)
+    expect(r.nodeHistory?.u).toHaveLength(n)
+    const peakX = Math.max(...r.nodeHistory!.u.map((u) => Math.abs(u[0])))
+    expect(peakX).toBeCloseTo(r.peakDisp[top.id][0], 12)
+  })
+
+  it('heavier damping reduces the peak response', () => {
+    const light = directTimeHistory(model, gm, { zeta: 0.02 })!
+    const heavy = directTimeHistory(model, gm, { zeta: 0.15 })!
+    expect(heavy.peakNodeDisp).toBeLessThan(light.peakNodeDisp)
+  })
+
+  it('returns null for an empty record', () => {
+    expect(directTimeHistory(model, { dt: 0.02, dir: 0, ag: [] })).toBeNull()
+  })
+})

--- a/webapp/src/engine/directTimeHistory.ts
+++ b/webapp/src/engine/directTimeHistory.ts
@@ -1,0 +1,300 @@
+// ─────────────────────────────────────────────────────────────────────────
+// DIRECT-INTEGRATION time-history analysis on the full MDOF system with
+// RAYLEIGH damping — the companion to the modal-superposition path in
+// `timeHistory.ts` (which decouples the system and can only carry a constant
+// modal ζ). Layer L5.
+//
+//   M ü + C u̇ + K u = P(t),      C = α·M + β·K      (Rayleigh)
+//
+// integrated step-by-step with Newmark-β (average acceleration β=¼, γ=½ →
+// unconditionally stable). The effective stiffness
+//   K̂ = K + a0·M + a1·C,   a0 = 1/(β·dt²),  a1 = γ/(β·dt)
+// is CONSTANT for a fixed dt, so it is LU-factored ONCE and reused for every
+// step — the same shared-factorization discipline the static solver uses.
+//
+// Why this and not modal superposition:
+//   • no mode truncation — every free DOF participates,
+//   • damping need not be diagonalizable by the modes (prerequisite for
+//     nonlinear time-history, where modes stop existing),
+//   • frequency-dependent ζ(ω) = α/(2ω) + β·ω/2 is the physical Rayleigh model.
+//
+// Mass model: LUMPED translational (same source as modal.ts — `buildSeismicMass`).
+// Rotational DOFs carry no mass, so M is singular; that is harmless here because
+// K̂ = (1+a1·β)·K + (a0+a1·α)·M stays non-singular whenever K is.
+//
+// Diaphragm constraints are NOT applied on this path (same as `modal.ts`, which
+// also calls `precomputeFrame` without diaphragm groups).
+//
+// Units: mass tonnes, K kN/m, a_g m/s², u m, base shear kN (t·m/s² = kN), dt s.
+// Refs: Newmark (1959); Chopra, Dynamics of Structures §16.
+// ─────────────────────────────────────────────────────────────────────────
+import type { StructuralModel } from './model'
+import { precomputeFrame } from './frame3d'
+import { modelToFrame3D } from './modelBridge'
+import { luFactor, luSolve, matVec } from './fem'
+import { buildSeismicMass, modalAnalysis } from './modal'
+import { validateMesh, hasMeshErrors } from './meshValidation'
+import type { GroundMotion } from './timeHistory'
+
+// ── Rayleigh damping ─────────────────────────────────────────────────────
+
+export interface RayleighCoeffs { alpha: number; beta: number }
+
+/**
+ * Rayleigh coefficients that produce damping ratios ζ₁ at ω₁ and ζ₂ at ω₂:
+ *   ζ(ω) = α/(2ω) + β·ω/2
+ *   α = 2·ω₁·ω₂·(ζ₁·ω₂ − ζ₂·ω₁)/(ω₂² − ω₁²)
+ *   β = 2·(ζ₂·ω₂ − ζ₁·ω₁)/(ω₂² − ω₁²)
+ * ω₁ ≠ ω₂ required (returns mass-proportional-only when they coincide).
+ */
+export function rayleighCoeffs(w1: number, z1: number, w2: number, z2: number): RayleighCoeffs {
+  const d = w2 * w2 - w1 * w1
+  if (!(Math.abs(d) > 1e-12)) return { alpha: w1 > 0 ? 2 * z1 * w1 : 0, beta: 0 }
+  return {
+    alpha: (2 * w1 * w2 * (z1 * w2 - z2 * w1)) / d,
+    beta: (2 * (z2 * w2 - z1 * w1)) / d,
+  }
+}
+
+/** Damping ratio the Rayleigh model delivers at circular frequency ω. */
+export function rayleighZeta(c: RayleighCoeffs, omega: number): number {
+  return omega > 0 ? c.alpha / (2 * omega) + (c.beta * omega) / 2 : 0
+}
+
+// ── Newmark direct integration (pure matrix level) ───────────────────────
+
+export interface DirectNewmarkOpts {
+  beta?: number
+  gamma?: number
+  /** Initial displacement / velocity vectors (default zero). */
+  u0?: number[]
+  v0?: number[]
+  /**
+   * Per-step observer. The arrays passed are REUSED between steps — copy what
+   * you keep. Lets a caller track peaks without retaining the whole history.
+   */
+  onStep?: (step: number, u: number[], v: number[], a: number[]) => void
+  /** Collect the full u/v/a histories in the result (default true). */
+  collect?: boolean
+}
+
+export interface DirectResult {
+  /** Displacement history per step (empty when `collect: false`). */
+  u: number[][]
+  v: number[][]
+  a: number[][]
+  steps: number
+}
+
+/**
+ * Newmark-β direct integration of `M ü + C u̇ + K u = P(t)` for a linear MDOF
+ * system. `P` is either the full nStep×n forcing or a generator `P(step)`;
+ * `nSteps` is required with the generator form. Returns null when K̂ is
+ * singular (the LU pivot check fails).
+ */
+export function newmarkDirect(
+  M: number[][], C: number[][], K: number[][],
+  P: number[][] | ((step: number) => number[]),
+  dt: number, opts?: DirectNewmarkOpts & { nSteps?: number },
+): DirectResult | null {
+  const n = K.length
+  const isFn = typeof P === 'function'
+  const nSteps = isFn ? (opts?.nSteps ?? 0) : (P as number[][]).length
+  const pAt = isFn ? (P as (s: number) => number[]) : (s: number) => (P as number[][])[s]
+  const collect = opts?.collect !== false
+  if (n === 0 || nSteps === 0) return { u: [], v: [], a: [], steps: 0 }
+
+  const beta = opts?.beta ?? 0.25
+  const gamma = opts?.gamma ?? 0.5
+  // Newmark constants (Chopra Table 16.2.2)
+  const a0 = 1 / (beta * dt * dt), a1 = gamma / (beta * dt)
+  const a2 = 1 / (beta * dt), a3 = 1 / (2 * beta) - 1
+  const a4 = gamma / beta - 1, a5 = dt * (gamma / (2 * beta) - 1)
+
+  // K̂ = K + a0·M + a1·C — constant for fixed dt, factored once
+  const Khat: number[][] = Array.from({ length: n }, (_, i) => {
+    const row = new Array<number>(n)
+    for (let j = 0; j < n; j++) row[j] = K[i][j] + a0 * M[i][j] + a1 * C[i][j]
+    return row
+  })
+  const lu = luFactor(Khat)
+  if (!lu) return null
+
+  let u = opts?.u0 ? [...opts.u0] : new Array(n).fill(0)
+  let v = opts?.v0 ? [...opts.v0] : new Array(n).fill(0)
+  // a₀ = M⁻¹(P₀ − C·v₀ − K·u₀); M is singular on rotational DOFs, so seed the
+  // acceleration only where mass exists (zero elsewhere — those DOFs are
+  // stiffness-slaved and carry no inertia).
+  const p0 = pAt(0), Cv0 = matVec(C, v), Ku0 = matVec(K, u)
+  const a = new Array(n).fill(0)
+  for (let i = 0; i < n; i++) {
+    const mi = M[i][i]
+    if (mi > 0) a[i] = (p0[i] - Cv0[i] - Ku0[i]) / mi
+  }
+
+  const uH: number[][] = [], vH: number[][] = [], aH: number[][] = []
+  const push = () => { if (collect) { uH.push([...u]); vH.push([...v]); aH.push([...a]) } }
+  push()
+  opts?.onStep?.(0, u, v, a)
+
+  const rhs = new Array(n).fill(0)
+  for (let s = 1; s < nSteps; s++) {
+    const p = pAt(s)
+    // P̂ = P + M(a0·u + a2·v + a3·a) + C(a1·u + a4·v + a5·a)
+    const mTerm = matVec(M, u.map((ui, i) => a0 * ui + a2 * v[i] + a3 * a[i]))
+    const cTerm = matVec(C, u.map((ui, i) => a1 * ui + a4 * v[i] + a5 * a[i]))
+    for (let i = 0; i < n; i++) rhs[i] = p[i] + mTerm[i] + cTerm[i]
+
+    const uNext = luSolve(lu, rhs)
+    const aNext = new Array(n)
+    const vNext = new Array(n)
+    for (let i = 0; i < n; i++) {
+      aNext[i] = a0 * (uNext[i] - u[i]) - a2 * v[i] - a3 * a[i]
+      vNext[i] = v[i] + dt * (1 - gamma) * a[i] + dt * gamma * aNext[i]
+    }
+    u = uNext; v = vNext
+    for (let i = 0; i < n; i++) a[i] = aNext[i]
+    push()
+    opts?.onStep?.(s, u, v, a)
+  }
+  return { u: uH, v: vH, a: aH, steps: nSteps }
+}
+
+// ── Model-level driver ───────────────────────────────────────────────────
+
+export interface DirectTHOpts extends DirectNewmarkOpts {
+  /** Explicit Rayleigh coefficients. Takes precedence over the ζ/mode form. */
+  rayleigh?: RayleighCoeffs
+  /** Target damping ratio for the two anchor modes (default 0.05). */
+  zeta?: number
+  /** 1-based mode numbers the Rayleigh curve is anchored to (default 1 and 3). */
+  anchorModes?: [number, number]
+  /** Full displacement history of this node is returned in `nodeHistory`. */
+  historyNode?: string
+}
+
+export interface DirectTHResult {
+  t: number[]
+  dir: 0 | 1 | 2
+  /** Rayleigh coefficients actually used. */
+  rayleigh: RayleighCoeffs
+  /** ζ the Rayleigh curve delivers at each anchor frequency. */
+  anchors: { omega: number; zeta: number }[]
+  /** Free DOFs integrated (the full MDOF system size). */
+  ndof: number
+  /** Total base shear (inertia) history in the excitation direction, kN. */
+  baseShear: number[]
+  peakBaseShear: number
+  /** Peak |displacement| per node, per global direction [X,Y,Z], m. */
+  peakDisp: Record<string, [number, number, number]>
+  peakNode: string | null
+  peakNodeDisp: number
+  nodeHistory?: { node: string; u: [number, number, number][] }
+}
+
+/**
+ * Direct-integration time-history of a structural model under uniform ground
+ * acceleration, with Rayleigh damping anchored to two modes. Returns null when
+ * the mesh is invalid, K is singular, or the record is empty.
+ */
+export function directTimeHistory(
+  model: StructuralModel, gm: GroundMotion, opts?: DirectTHOpts,
+): DirectTHResult | null {
+  if (gm.ag.length === 0) return null
+  if (hasMeshErrors(validateMesh(model))) return null
+  const br = modelToFrame3D(model, { useShells: false })
+  const pre = precomputeFrame(br.nodes, br.members, br.supports)
+  const K = pre.Kff_raw
+  const nf = K.length
+  if (nf === 0) return null
+
+  // lumped mass on free translational DOFs (tonnes) — diagonal M
+  const massByNode = buildSeismicMass(model)
+  const mVec = new Array(nf).fill(0)
+  /** free-DOF position → [nodeId, direction] for the massive translational DOFs */
+  const dofNode: { fpos: number; node: string; dir: 0 | 1 | 2 }[] = []
+  for (const [nodeId, m] of massByNode) {
+    if (m <= 0) continue
+    const ni = pre.idx.get(nodeId)
+    if (ni === undefined) continue
+    for (let d = 0 as 0 | 1 | 2; d < 3; d = (d + 1) as 0 | 1 | 2) {
+      const fpos = pre.freeIdx.get(6 * ni + d)
+      if (fpos === undefined) continue
+      mVec[fpos] += m
+      dofNode.push({ fpos, node: nodeId, dir: d })
+    }
+  }
+  if (!mVec.some((m) => m > 0)) return null
+
+  // Rayleigh coefficients — explicit, or anchored to two modal frequencies
+  let ray = opts?.rayleigh
+  const anchors: { omega: number; zeta: number }[] = []
+  if (!ray) {
+    const zeta = opts?.zeta ?? 0.05
+    const [m1, m2] = opts?.anchorModes ?? [1, 3]
+    const modal = modalAnalysis(model, Math.max(m1, m2))
+    const w1 = modal?.modes[m1 - 1]?.omega
+    const w2 = modal?.modes[m2 - 1]?.omega
+    ray = w1 && w2 && Math.abs(w2 - w1) > 1e-9
+      ? rayleighCoeffs(w1, zeta, w2, zeta)
+      : { alpha: w1 ? 2 * zeta * w1 : 0, beta: 0 }   // single mode available
+    if (w1) anchors.push({ omega: w1, zeta: rayleighZeta(ray, w1) })
+    if (w2) anchors.push({ omega: w2, zeta: rayleighZeta(ray, w2) })
+  }
+
+  // M (diagonal) and C = αM + βK as dense matrices for the integrator
+  const M: number[][] = Array.from({ length: nf }, (_, i) => {
+    const row = new Array(nf).fill(0); row[i] = mVec[i]; return row
+  })
+  const C: number[][] = Array.from({ length: nf }, (_, i) => {
+    const row = new Array<number>(nf)
+    for (let j = 0; j < nf; j++) row[j] = ray!.beta * K[i][j] + (i === j ? ray!.alpha * mVec[i] : 0)
+    return row
+  })
+
+  // P(t) = −M·ι·a_g(t): influence vector ι is 1 on free translational DOFs in `dir`
+  const iota = new Array(nf).fill(0)
+  for (const d of dofNode) if (d.dir === gm.dir) iota[d.fpos] = 1
+  const mIota = mVec.map((m, i) => m * iota[i])
+  const nSteps = gm.ag.length
+  const pAt = (s: number): number[] => mIota.map((mi) => -mi * gm.ag[s])
+
+  // integrate, tracking peaks per node (never retaining the whole field)
+  const peakDisp: Record<string, [number, number, number]> = {}
+  for (const d of dofNode) if (!peakDisp[d.node]) peakDisp[d.node] = [0, 0, 0]
+  const baseShear = new Array(nSteps).fill(0)
+  const histNode = opts?.historyNode
+  const hist: [number, number, number][] | null =
+    histNode && peakDisp[histNode] ? Array.from({ length: nSteps }, () => [0, 0, 0] as [number, number, number]) : null
+
+  const res = newmarkDirect(M, C, K, pAt, gm.dt, {
+    ...opts, nSteps, collect: false,
+    onStep: (s, u, _v, acc) => {
+      let vb = 0
+      for (const d of dofNode) {
+        const ud = Math.abs(u[d.fpos])
+        if (ud > peakDisp[d.node][d.dir]) peakDisp[d.node][d.dir] = ud
+        if (hist && d.node === histNode) hist[s][d.dir] = u[d.fpos]
+        // total inertia force in the excitation direction = base shear
+        if (d.dir === gm.dir) vb += mVec[d.fpos] * (acc[d.fpos] + gm.ag[s])
+      }
+      baseShear[s] = vb
+    },
+  })
+  if (!res) return null
+
+  let peakBaseShear = 0
+  for (const vb of baseShear) peakBaseShear = Math.max(peakBaseShear, Math.abs(vb))
+  let peakNode: string | null = null, peakNodeDisp = 0
+  for (const [id, p] of Object.entries(peakDisp)) {
+    const mag = Math.hypot(p[0], p[1], p[2])
+    if (mag > peakNodeDisp) { peakNodeDisp = mag; peakNode = id }
+  }
+
+  return {
+    t: Array.from({ length: nSteps }, (_, i) => i * gm.dt),
+    dir: gm.dir, rayleigh: ray!, anchors, ndof: nf,
+    baseShear, peakBaseShear, peakDisp, peakNode, peakNodeDisp,
+    ...(hist ? { nodeHistory: { node: histNode!, u: hist } } : {}),
+  }
+}

--- a/webapp/src/engine/modal.ts
+++ b/webapp/src/engine/modal.ts
@@ -120,7 +120,8 @@ export function buildSeismicMass(model: StructuralModel): Map<string, number> {
 
 /**
  * Eigen-decomposition of a symmetric n×n matrix by cyclic Jacobi rotations.
- * Returns eigenvalues and eigenvectors (vectors[k] is the k-th column / mode).
+ * Returns eigenvalues and eigenvectors, where `vectors[k]` is the k-th mode as
+ * a ROW (i.e. `vectors[k][c]` is component c of mode k), paired with `values[k]`.
  */
 export function jacobiEigen(Ain: number[][], maxSweeps = 100): { values: number[]; vectors: number[][] } {
   const n = Ain.length

--- a/webapp/src/engine/validation.ts
+++ b/webapp/src/engine/validation.ts
@@ -16,6 +16,7 @@ import { shapeByName } from './aiscSections'
 import { designAxialColumn } from './columnDesign'
 import { activeThrust, rankineKa, bearingFactors, infiniteSlopeFS } from './geotech'
 import { felleniusFS, type Slice } from './slopeStability'
+import { newmarkDirect } from './directTimeHistory'
 import { computeSeismic } from './seismic'
 import { torsionalVerdict } from './irregularity'
 import { jacobiEigen } from './modal'
@@ -154,6 +155,21 @@ const slopeSlices = (() => {
   }
   const sl = [mk(-10, 100), mk(15, 150), mk(35, 120)]
   return { manual: 2.10205, software: felleniusFS(sl, { c: 10, phiDeg: 20, gamma: 18 }).FS }
+})()
+
+// ── 12. Direct-integration MDOF — free-vibration logarithmic decrement ───────
+// A damped oscillator released from u₀ = 1 returns, one damped period later, to
+// u/u₀ = exp(−2πζ/√(1−ζ²)). Integrated here through the FULL MDOF Newmark path
+// (1×1 system) with Rayleigh mass-proportional damping α = 2ζω.
+const directDecay = (() => {
+  const omega = 3.0, zeta = 0.05, dt = 0.001
+  const idx = Math.round((2 * Math.PI) / omega / dt)
+  const zeros = Array.from({ length: idx + 5 }, () => [0])
+  const r = newmarkDirect([[1]], [[2 * zeta * omega]], [[omega * omega]], zeros, dt, { u0: [1] })
+  return {
+    manual: Math.exp((-2 * Math.PI * zeta) / Math.sqrt(1 - zeta * zeta)),
+    software: r ? r.u[idx][0] : NaN,
+  }
 })()
 
 // ── Dynamics — eigen-solver & response spectrum ──────────────────────────────
@@ -379,6 +395,11 @@ export const VALIDATION_CASES: ValidationCase[] = [
     id: 'torsional-irregularity', category: 'Seismic', title: 'Torsional irregularity ratio',
     reference: 'NSCP Table 208-10 §1', formula: 'δmax/δavg, δavg = (δmax+δmin)/2  →  13/10',
     manual: 1.3, software: torsionalVerdict(13, 7).ratio, unit: '—', tol: 1e-9,
+  },
+  {
+    id: 'direct-th-decay', category: 'Dynamics', title: 'Direct-integration free-vibration decay',
+    reference: 'Chopra, Dynamics of Structures', formula: 'u(T)/u₀ = exp(−2πζ/√(1−ζ²))',
+    manual: directDecay.manual, software: directDecay.software, unit: '—', tol: 1e-3,
   },
   {
     id: 'eigen-jacobi', category: 'Dynamics', title: 'Jacobi eigenvalue of [[2,1],[1,2]]',


### PR DESCRIPTION
## Summary
Closes backlog **P3-6** (CLAUDE.md) — `timeHistory.ts` was modal-superposition only. Layer **L5**; no existing solver path changed.

**`engine/directTimeHistory.ts`** integrates the full free-DOF system

```
M ü + C u̇ + K u = P(t),      C = α·M + β·K      (Rayleigh)
```

with Newmark-β (average acceleration, unconditionally stable). The effective stiffness `K̂ = K + a₀·M + a₁·C` is **constant for a fixed dt**, so it is **LU-factored once and reused every step** — the same shared-factorization discipline the static solver uses. Lumped translational mass leaves `M` singular on rotational DOFs, which is harmless here: `K̂ = (1+a₁β)·K + (a₀+a₁α)·M` stays non-singular whenever `K` is.

**Why this over modal superposition:** no mode truncation, damping need not be diagonalizable by the modes (the prerequisite for **nonlinear TH**), and ζ(ω) = α/2ω + βω/2 is the physical Rayleigh model rather than a constant modal ζ.

- `rayleighCoeffs(ω₁, ζ₁, ω₂, ζ₂)` inverts the two-anchor curve; the model driver anchors it to two modal frequencies (default modes 1 and 3).
- `newmarkDirect(M, C, K, P, dt)` is the pure matrix-level core — array **or** generator forcing, plus an optional per-step observer so the driver tracks peaks without ever retaining the whole displacement field.
- `directTimeHistory(model, gm, opts)` reports base shear, per-node peaks and an optional node history, mirroring the modal result shape.

## Verification
**The decisive test:** with Rayleigh damping the mode shapes diagonalize `M`, `C` and `K` simultaneously, and Newmark is a linear one-step method — so integrating the *coupled* system must reproduce *mode-by-mode* SDOF integration to roundoff. On a 2-DOF shear building (golden-ratio closed-form ω checked first) the two paths agree to **1e-9**.

Also asserted (16 cases): 1-DOF ≡ the existing `newmarkSDOF` to 1e-10; free-vibration logarithmic decrement `exp(−2πζ/√(1−ζ²))`; Rayleigh hits both target ζ **exactly** and shows the characteristic sag between anchors / over-damping outside them; singular-K̂ returns null; model level — full `ndof` (not a modal subset), finite base shear, requested node history consistent with the reported peak, heavier damping ⇒ smaller peak, and same-order agreement with `modalTimeHistory`.

`validation.ts` `direct-th-decay` + a **ValidationMap** coverage row (L9 rule). **Full suite 1477 → 1493**, `npx tsc -b` clean, `npm run build` succeeds.

## Out-of-scope fix worth flagging
`modal.ts`'s `jacobiEigen` docstring said `vectors[k]` is the k-th **column**; it is actually the k-th mode as a **ROW** (which is how `modalAnalysis` itself consumes it). The column reading produces plausible-but-wrong results rather than an obvious failure — it cost a debugging round here, so I corrected the comment. **Comment only, no logic touched.**

## Known limitation (documented in the module header)
Diaphragm constraints are **not** applied on this path — identical to the existing `modal.ts`, which also calls `precomputeFrame` without diaphragm groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_