### PR TITLE
Engine audit: fix lint debt, split hysteresis tests, add equilibrium invariant

### DIFF
--- a/webapp/src/engine/axialOnly.test.ts
+++ b/webapp/src/engine/axialOnly.test.ts
@@ -85,6 +85,29 @@ describe('axialOnly — active-set solve', () => {
     expect(axialOf(r.result, kept)).toBeLessThan(0)   // the survivor is in compression
   })
 
+  it('equilibrium still holds after members deactivate (ΣR = ΣF)', () => {
+    // the invariant that matters most: dropping a member must not leave
+    // unbalanced force. Checked in both load directions and at two magnitudes.
+    for (const P of [50, -50, 120]) {
+      const r = solveActiveSet(nodes, members, supports, push(P), tensionOnly)!
+      const R = r.result.reactions.reduce(
+        (acc, q) => [acc[0] + q.F[0], acc[1] + q.F[1], acc[2] + q.F[2]], [0, 0, 0])
+      expect(r.inactive).toHaveLength(1)          // a member really did drop out
+      expect(R[0]).toBeCloseTo(-P, 9)             // reactions balance the push
+      expect(R[1]).toBeCloseTo(0, 9)
+      expect(R[2]).toBeCloseTo(0, 9)
+    }
+  })
+
+  it('response scales linearly while the active set is unchanged', () => {
+    // within one active set the problem is linear again — a useful guard that
+    // the iteration is not injecting spurious state between solves
+    const a = solveActiveSet(nodes, members, supports, push(50), tensionOnly)!
+    const b = solveActiveSet(nodes, members, supports, push(120), tensionOnly)!
+    expect(b.inactive).toEqual(a.inactive)
+    expect(axialOf(b.result, 'd14') / axialOf(a.result, 'd14')).toBeCloseTo(120 / 50, 9)
+  })
+
   it('converges in a handful of iterations', () => {
     const r = solveActiveSet(nodes, members, supports, push(50), tensionOnly)!
     expect(r.iterations).toBeGreaterThan(0)

--- a/webapp/src/engine/hysteresis.test.ts
+++ b/webapp/src/engine/hysteresis.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import {
+  bilinearPath, bilinearProbe, bilinearCommit, bilinearCycleEnergy, newBilinearState,
+  type BilinearParams,
+} from './hysteresis'
+
+// ── the hysteretic material ─────────────────────────────────────────────
+describe('hysteresis — bilinear kinematic hardening', () => {
+  const epp: BilinearParams = { k0: 100, Fy: 10 }          // u_y = 0.1
+  const hard: BilinearParams = { k0: 100, Fy: 10, b: 0.05 }
+
+  it('is linear below yield and caps at Fy (elastic-perfectly-plastic)', () => {
+    expect(bilinearProbe(0.05, newBilinearState(), epp).f).toBeCloseTo(5, 12)
+    expect(bilinearProbe(0.10, newBilinearState(), epp).f).toBeCloseTo(10, 12)   // exactly at yield
+    expect(bilinearProbe(0.50, newBilinearState(), epp).f).toBeCloseTo(10, 12)   // plateau
+    expect(bilinearProbe(0.50, newBilinearState(), epp).yielding).toBe(true)
+  })
+
+  it('hardens on the post-yield branch at b·k₀', () => {
+    const f1 = bilinearProbe(0.2, newBilinearState(), hard).f
+    const f2 = bilinearProbe(0.3, newBilinearState(), hard).f
+    expect(bilinearProbe(0.1, newBilinearState(), hard).f).toBeCloseTo(10, 12)   // still Fy at u_y
+    expect((f2 - f1) / 0.1).toBeCloseTo(0.05 * 100, 10)                          // slope = b·k₀
+  })
+
+  it('unloads elastically at k₀ after yielding (the thing pushover cannot do)', () => {
+    // push to u = 0.3 (plastic), then unload to 0.25
+    const { f } = bilinearPath([0.3, 0.25], epp)
+    expect(f[0]).toBeCloseTo(10, 12)
+    expect(f[1]).toBeCloseTo(10 - 100 * 0.05, 10)     // k₀ unloading ⇒ 5
+  })
+
+  it('yields in the reverse direction after a full reversal', () => {
+    const { f } = bilinearPath([0.3, -0.3], epp)
+    expect(f[0]).toBeCloseTo(10, 12)
+    expect(f[1]).toBeCloseTo(-10, 12)
+  })
+
+  it('dissipates the closed-form loop energy 4·Fy·(A − u_y) per steady-state cycle', () => {
+    const A = 0.4
+    const seg = (pts: number[], from: number, to: number) => {
+      for (let i = 1; i <= 200; i++) pts.push(from + ((to - from) * i) / 200)
+    }
+    // virgin loading 0→A alone dissipates only Fy·(A−u_y); the closed form is the
+    // STEADY-STATE loop, so difference out that first half-excursion.
+    const first: number[] = []; seg(first, 0, A)
+    const plusCycle = [...first]; seg(plusCycle, A, -A); seg(plusCycle, -A, A)
+
+    const e1 = bilinearPath(first, epp).state.dissipated
+    const e2 = bilinearPath(plusCycle, epp).state.dissipated
+    expect(e1).toBeCloseTo(10 * (A - 0.1), 6)                     // = 3, the virgin leg
+    expect(e2 - e1).toBeCloseTo(bilinearCycleEnergy(A, epp), 6)   // = 12, the loop
+    expect(bilinearCycleEnergy(A, epp)).toBeCloseTo(4 * 10 * (0.4 - 0.1), 12)
+  })
+
+  it('dissipates nothing while the response stays elastic', () => {
+    const { state } = bilinearPath([0.05, -0.05, 0.05, 0], epp)
+    expect(state.dissipated).toBe(0)
+    expect(state.cumPlastic).toBe(0)
+  })
+
+  it('an infinite Fy is a plain linear spring', () => {
+    const lin: BilinearParams = { k0: 100, Fy: Infinity }
+    expect(bilinearProbe(5, newBilinearState(), lin).f).toBeCloseTo(500, 12)
+    expect(bilinearProbe(5, newBilinearState(), lin).yielding).toBe(false)
+    expect(bilinearCommit(5, 0, newBilinearState(), lin).state.dissipated).toBe(0)
+  })
+})

--- a/webapp/src/engine/nonlinearTimeHistory.test.ts
+++ b/webapp/src/engine/nonlinearTimeHistory.test.ts
@@ -1,75 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import {
-  bilinearPath, bilinearProbe, bilinearCommit, bilinearCycleEnergy, newBilinearState,
-  type BilinearParams,
-} from './hysteresis'
-import {
   nonlinearTimeHistory, assembleK0, groundMotionForcing, type HystSpring,
 } from './nonlinearTimeHistory'
 import { newmarkDirect, rayleighCoeffs } from './directTimeHistory'
-
-// ── the hysteretic material ─────────────────────────────────────────────
-describe('hysteresis — bilinear kinematic hardening', () => {
-  const epp: BilinearParams = { k0: 100, Fy: 10 }          // u_y = 0.1
-  const hard: BilinearParams = { k0: 100, Fy: 10, b: 0.05 }
-
-  it('is linear below yield and caps at Fy (elastic-perfectly-plastic)', () => {
-    expect(bilinearProbe(0.05, newBilinearState(), epp).f).toBeCloseTo(5, 12)
-    expect(bilinearProbe(0.10, newBilinearState(), epp).f).toBeCloseTo(10, 12)   // exactly at yield
-    expect(bilinearProbe(0.50, newBilinearState(), epp).f).toBeCloseTo(10, 12)   // plateau
-    expect(bilinearProbe(0.50, newBilinearState(), epp).yielding).toBe(true)
-  })
-
-  it('hardens on the post-yield branch at b·k₀', () => {
-    const f1 = bilinearProbe(0.2, newBilinearState(), hard).f
-    const f2 = bilinearProbe(0.3, newBilinearState(), hard).f
-    expect(bilinearProbe(0.1, newBilinearState(), hard).f).toBeCloseTo(10, 12)   // still Fy at u_y
-    expect((f2 - f1) / 0.1).toBeCloseTo(0.05 * 100, 10)                          // slope = b·k₀
-  })
-
-  it('unloads elastically at k₀ after yielding (the thing pushover cannot do)', () => {
-    // push to u = 0.3 (plastic), then unload to 0.25
-    const { f } = bilinearPath([0.3, 0.25], epp)
-    expect(f[0]).toBeCloseTo(10, 12)
-    expect(f[1]).toBeCloseTo(10 - 100 * 0.05, 10)     // k₀ unloading ⇒ 5
-  })
-
-  it('yields in the reverse direction after a full reversal', () => {
-    const { f } = bilinearPath([0.3, -0.3], epp)
-    expect(f[0]).toBeCloseTo(10, 12)
-    expect(f[1]).toBeCloseTo(-10, 12)
-  })
-
-  it('dissipates the closed-form loop energy 4·Fy·(A − u_y) per steady-state cycle', () => {
-    const A = 0.4
-    const seg = (pts: number[], from: number, to: number) => {
-      for (let i = 1; i <= 200; i++) pts.push(from + ((to - from) * i) / 200)
-    }
-    // virgin loading 0→A alone dissipates only Fy·(A−u_y); the closed form is the
-    // STEADY-STATE loop, so difference out that first half-excursion.
-    const first: number[] = []; seg(first, 0, A)
-    const plusCycle = [...first]; seg(plusCycle, A, -A); seg(plusCycle, -A, A)
-
-    const e1 = bilinearPath(first, epp).state.dissipated
-    const e2 = bilinearPath(plusCycle, epp).state.dissipated
-    expect(e1).toBeCloseTo(10 * (A - 0.1), 6)                     // = 3, the virgin leg
-    expect(e2 - e1).toBeCloseTo(bilinearCycleEnergy(A, epp), 6)   // = 12, the loop
-    expect(bilinearCycleEnergy(A, epp)).toBeCloseTo(4 * 10 * (0.4 - 0.1), 12)
-  })
-
-  it('dissipates nothing while the response stays elastic', () => {
-    const { state } = bilinearPath([0.05, -0.05, 0.05, 0], epp)
-    expect(state.dissipated).toBe(0)
-    expect(state.cumPlastic).toBe(0)
-  })
-
-  it('an infinite Fy is a plain linear spring', () => {
-    const lin: BilinearParams = { k0: 100, Fy: Infinity }
-    expect(bilinearProbe(5, newBilinearState(), lin).f).toBeCloseTo(500, 12)
-    expect(bilinearProbe(5, newBilinearState(), lin).yielding).toBe(false)
-    expect(bilinearCommit(5, 0, newBilinearState(), lin).state.dissipated).toBe(0)
-  })
-})
 
 // ── assembly ────────────────────────────────────────────────────────────
 describe('nonlinearTimeHistory — K₀ assembly', () => {

--- a/webapp/src/engine/nonlinearTimeHistory.ts
+++ b/webapp/src/engine/nonlinearTimeHistory.ts
@@ -140,7 +140,7 @@ export function nonlinearTimeHistory(inp: NonlinearTHInput): NonlinearTHResult |
   })
 
   let states: BilinearState[] = inp.springs.map(() => newBilinearState())
-  let u = new Array(n).fill(0), v = new Array(n).fill(0)
+  const u = new Array(n).fill(0), v = new Array(n).fill(0)
   let uPrev = new Array(n).fill(0)
 
   /** Internal force vector and tangent at a trial u, given the committed states. */

--- a/webapp/src/pages/SlopeStability.tsx
+++ b/webapp/src/pages/SlopeStability.tsx
@@ -41,7 +41,8 @@ function groundOf(H: number, betaDeg: number, crestW: number, toeW: number): Pt[
 function SlopeSvg({ ground, res, water }: { ground: Pt[]; res: CircleResult | null; water?: Pt[] }) {
   const W = 640, Hpx = 320, pad = 30
   const xs = ground.map((p) => p.x), ys = ground.map((p) => p.y)
-  let minX = Math.min(...xs), maxX = Math.max(...xs), minY = Math.min(...ys), maxY = Math.max(...ys)
+  const minX = Math.min(...xs), maxX = Math.max(...xs)
+  let minY = Math.min(...ys), maxY = Math.max(...ys)
   if (res) { minY = Math.min(minY, res.circle.yc - res.circle.R); maxY = Math.max(maxY, res.circle.yc) }
   const sx = (W - 2 * pad) / Math.max(1e-6, maxX - minX)
   const sy = (Hpx - 2 * pad) / Math.max(1e-6, maxY - minY)
@@ -50,7 +51,8 @@ function SlopeSvg({ ground, res, water }: { ground: Pt[]; res: CircleResult | nu
   const Y = (y: number) => Hpx - pad - (y - minY) * s
 
   const groundPath = ground.map((p, i) => `${i ? 'L' : 'M'}${X(p.x).toFixed(1)},${Y(p.y).toFixed(1)}`).join(' ')
-  let arcPath = '', slicePts: string[] = [], massPath = '', center = null as null | { cx: number; cy: number }
+  const slicePts: string[] = []
+  let arcPath = '', massPath = '', center = null as null | { cx: number; cy: number }
   if (res) {
     const sl = res.slices, { xc, yc, R } = res.circle
     const yArc = (x: number) => yc - Math.sqrt(Math.max(0, R * R - (x - xc) ** 2))


### PR DESCRIPTION
## Audit scope
A full pass over the engine calculations and tests. Most of it needed no action — reported below for the record — plus three real gaps, **all of them mine from this session**.

## Clean, no action needed
- **1533 tests passing**, `npx tsc -b` clean, `npm run build` clean.
- **33 validation benchmarks**: all finite, **none above 1% deviation**, and the worst case (`direct-th-decay`) consumes only **4% of its tolerance budget** — most sit at machine precision (1e-16). No benchmark is passing marginally.
- **No skipped / `.only` / `.todo` tests** anywhere in the suite.
- **No `any`** in engine code (the single grep hit is a comment).
- **L3 statics self-checks present** — reaction equilibrium, closed-form cantilever `δ = PL³/3EI`, fixed-end moments — in `frame3d`, `frame2d`, `modelBridge`, `truss`, `beamAnalysis`.

## Three gaps fixed

**1. `hysteresis.ts` had no matching test file.** 5 exported functions, with its cases living inside `nonlinearTimeHistory.test.ts` — breaking the repo rule that every engine module carries its own `*.test.ts`. Split into `hysteresis.test.ts` (assertions unchanged). The only modules now lacking a test file are type-only (`model`, `schedule/model`, `progress`) or Worker/pool infrastructure that can't be unit-tested (`framePool`, `frameWorker`, `solverWorker`).

**2. Five lint errors I introduced** — `prefer-const` on `u`/`v` in `nonlinearTimeHistory` (mutated in place, never reassigned) and on `minX`/`maxX`/`slicePts` in `SlopeStability.tsx`. Repo lint **44 → 39 errors**; the remainder is pre-existing debt the CI workflow already documents as non-blocking.

**3. `axialOnly` had no equilibrium check** — the single most important invariant of an active-set solve is that *dropping a member must not leave unbalanced force*. I'd verified it ad hoc while auditing; it's now permanent:
- `ΣR = ΣF` to **1e-9** in both load directions and at two magnitudes, with an assertion that a member really did deactivate;
- a **linearity guard** — within one unchanged active set the response must scale exactly (120/50), proving the iteration injects no spurious state between solves.

**Suite 1533 → 1535.**

## Not fixed (pre-existing, flagged not bundled)
39 remaining lint errors across `truss.ts`, `pileCap.ts`, `qty.tsx`, `ModelSpace.tsx`, `TorsionDesign.tsx` and others — untouched by this session and already known to CI. Cleaning them is its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_