### PR TITLE
Model Space: surface the member-end plastic hinge engines in the Nonlinear tab

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -757,9 +757,16 @@ _Analysis completeness (P3):_
   collapse load flat at Mp/L over a 6× drift range where load control instead
   runs the displacement to >10 m, and traces a monotonically descending branch
   when the hinge softens (b < 0) — which load control structurally cannot do.
+  **UI** (#443): the Model Space **Nonlinear** tab has a *Plasticity model*
+  selector — "Member-end plastic hinges" (default) or "Shear building (storey
+  springs)". The hinge path reports the equivalent-frame period and condensation
+  summary, hinges yielded / total, peak base shear vs the elastic demand, peak
+  roof drift, dissipated energy, Newton convergence, and a table of yielded
+  hinges ordered by plastic rotation. When nothing yields it says so explicitly
+  rather than showing a blank panel — an elastic outcome is a result.
   **Still open**: 3D/biaxial hinges; true arc-length (Riks) control for
-  snap-BACK, where even displacement control at a single DOF fails; and a UI
-  surface for the hinge engines.
+  snap-BACK, where even displacement control at a single DOF fails; and the
+  `axialMode` UI + per-combo active-set routing.
 - **Load combinations with nonlinear members (DECIDED)**: tension/compression-only
   members break superposition, and the owner's decision is **per-combo active
   set** — solve every NSCP combo independently with its own active-set iteration

--- a/webapp/src/engine/solverWorker.ts
+++ b/webapp/src/engine/solverWorker.ts
@@ -13,6 +13,7 @@ import { modalAnalysis } from './modal'
 import { runPushoverModel, type PushoverModelOpts } from './pushoverModel'
 import { runTimeHistoryModel, makeGroundMotion, type TimeHistoryModelOpts, type GroundMotionSpec } from './timeHistoryModel'
 import { runNonlinearModel, type NonlinearModelOpts } from './nonlinearModel'
+import { runNonlinearFrameModel } from './nonlinearFrameModel'
 import { driftCheck } from './seismic'
 import { assessIrregularities } from './irregularity'
 import { designStructureAsync, optimizeStructureAsync, selectBarDiameters, type SoilOptions, type FootingPlan, type AnalyzeOptions } from './pipeline'
@@ -26,7 +27,12 @@ export type SolverRequest =
   | { id: number; kind: 'modal'; model: StructuralModel; nModes: number }
   | { id: number; kind: 'pushover'; model: StructuralModel; opts: PushoverModelOpts }
   | { id: number; kind: 'timeHistory'; model: StructuralModel; opts: TimeHistoryModelOpts }
-  | { id: number; kind: 'nonlinearTH'; model: StructuralModel; spec: GroundMotionSpec; opts: NonlinearModelOpts }
+  | {
+      id: number; kind: 'nonlinearTH'; model: StructuralModel; spec: GroundMotionSpec
+      opts: NonlinearModelOpts
+      /** 'shear' = storey-spring reduction; 'hinges' = distributed member-end hinges. */
+      hingeModel?: 'shear' | 'hinges'
+    }
 
 const ctx = self as unknown as Worker
 
@@ -73,13 +79,22 @@ ctx.onmessage = async (e: MessageEvent<SolverRequest>) => {
       const timeHistory = runTimeHistoryModel(msg.model, msg.opts)
       ctx.postMessage({ id: msg.id, ok: true, result: { timeHistory } })
     } else if (msg.kind === 'nonlinearTH') {
-      onProgress({ phase: 'Nonlinear time-history (Newmark + Newton-Raphson)' })
       const gm = makeGroundMotion(msg.spec)
-      // never ship the full displacement field back across the worker boundary
-      const inelastic = runNonlinearModel(msg.model, gm, { ...msg.opts, collect: false })
-      onProgress({ phase: 'Elastic reference run' })
-      const elastic = runNonlinearModel(msg.model, gm, { ...msg.opts, elastic: true, collect: false })
-      ctx.postMessage({ id: msg.id, ok: true, result: { nonlinear: { inelastic, elastic } } })
+      if (msg.hingeModel === 'hinges') {
+        // distributed member-end plastic hinges on the equivalent plane frame
+        onProgress({ phase: 'Nonlinear TH — member-end hinges' })
+        const inelastic = runNonlinearFrameModel(msg.model, gm, { dir: msg.opts.dir, zeta: msg.opts.zeta, b: msg.opts.b, rho: msg.opts.rho })
+        onProgress({ phase: 'Elastic reference run' })
+        const elastic = runNonlinearFrameModel(msg.model, gm, { dir: msg.opts.dir, zeta: msg.opts.zeta, elastic: true })
+        ctx.postMessage({ id: msg.id, ok: true, result: { hinge: { inelastic, elastic } } })
+      } else {
+        onProgress({ phase: 'Nonlinear time-history (Newmark + Newton-Raphson)' })
+        // never ship the full displacement field back across the worker boundary
+        const inelastic = runNonlinearModel(msg.model, gm, { ...msg.opts, collect: false })
+        onProgress({ phase: 'Elastic reference run' })
+        const elastic = runNonlinearModel(msg.model, gm, { ...msg.opts, elastic: true, collect: false })
+        ctx.postMessage({ id: msg.id, ok: true, result: { nonlinear: { inelastic, elastic } } })
+      }
     } else if (msg.kind === 'design') {
       let m = msg.model
       if (msg.tryBars) {

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -53,6 +53,7 @@ import { elasticResponseSpectrum, nscp208DesignCurve, type AccelSpectrum, type D
 import { parseAccelerogram } from '../engine/accelerogram'
 import type { TimeHistoryModelResult, GroundMotionKind, CsvAccelerogramOpts } from '../engine/timeHistoryModel'
 import type { NonlinearModelResult } from '../engine/nonlinearModel'
+import type { NonlinearFrameModelResult } from '../engine/nonlinearFrameModel'
 import { BeamSchematic } from '../components/BeamSchematic'
 import { TSection } from '../components/TSection'
 import { ColumnSchematic } from '../components/ColumnSchematic'
@@ -1004,6 +1005,8 @@ export default function ModelSpace() {
   const [nlB, setNlB] = useState(3)              // post-yield stiffness ratio, %
   const [nlRho, setNlRho] = useState(1.5)        // assumed tension steel ratio, %
   const [nl, setNl] = useState<{ inelastic: NonlinearModelResult | null; elastic: NonlinearModelResult | null } | null>(null)
+  const [nlKindModel, setNlKindModel] = useState<'shear' | 'hinges'>('hinges')
+  const [nlHinge, setNlHinge] = useState<{ inelastic: NonlinearFrameModelResult | null; elastic: NonlinearFrameModelResult | null } | null>(null)
   const [shellStress, setShellStress] = useState<{ nodes: ShellNode[]; elems: ShellElem[]; stresses: ElementStress[] } | null>(null)
   const [slabFE, setSlabFE] = useState<SlabFEScheduleRow[] | null>(null)
   const [recSpec, setRecSpec] = useState<{ spec: AccelSpectrum; design: DesignSpectrumPoint[]; name: string } | null>(null)
@@ -1164,12 +1167,19 @@ export default function ModelSpace() {
 
   const runNonlinear = () => {
     if (!model || busy || meshErrors) return
+    setNl(null); setNlHinge(null)
     run('nonlinearTH', {
-      model,
+      model, hingeModel: nlKindModel,
       spec: { kind: nlKind, dt: 0.01, duration: nlDur, pga: nlPga * GRAVITY, freq: nlFreq, dir: nlDir === 'x' ? 0 : 2 },
       opts: { dir: nlDir, zeta: nlZeta / 100, b: nlB / 100, rho: nlRho / 100 },
-    }).then((r) => setNl((r as { nonlinear: { inelastic: NonlinearModelResult | null; elastic: NonlinearModelResult | null } }).nonlinear))
-      .catch((e) => console.error('nonlinear time-history failed', e))
+    }).then((r) => {
+      const res = r as {
+        nonlinear?: { inelastic: NonlinearModelResult | null; elastic: NonlinearModelResult | null }
+        hinge?: { inelastic: NonlinearFrameModelResult | null; elastic: NonlinearFrameModelResult | null }
+      }
+      setNl(res.nonlinear ?? null)
+      setNlHinge(res.hinge ?? null)
+    }).catch((e) => console.error('nonlinear time-history failed', e))
   }
 
   const runTimeHistory = () => {
@@ -3751,6 +3761,8 @@ export default function ModelSpace() {
           {tab === 'nonlinear' && (
             <div className="divide-y divide-[#eeece5] px-4 py-1">
               <Sec title="Nonlinear time-history (hysteretic, Newmark + Newton-Raphson)">
+                <Pick label="Plasticity model" value={nlKindModel} onChange={setNlKindModel}
+                  options={[['hinges', 'Member-end plastic hinges'], ['shear', 'Shear building (storey springs)']]} />
                 <Pick label="Direction" value={nlDir} onChange={setNlDir} options={[['x', '+X'], ['z', '+Z']]} />
                 <Pick label="Ground motion" value={nlKind} onChange={setNlKind}
                   options={[['rampedSine', 'Ramped sine'], ['harmonic', 'Harmonic'], ['pulse', 'Pulse']]} />
@@ -3762,18 +3774,37 @@ export default function ModelSpace() {
                   hint="storey spring hardening (0 = elastic-perfectly-plastic)" />
                 <Num label="Concrete ρ (tension)" unit="%" value={nlRho} onChange={setNlRho} step="0.1"
                   hint="assumed steel ratio for Mp (concrete only)" />
-                <p className="col-span-full text-[11px] text-slate-500">
-                  The frame is reduced to an equivalent nonlinear <strong>shear building</strong>: one bilinear
-                  hysteretic spring per storey — mass from the seismic mass, stiffness k₀ = V/Δ from a static
-                  lateral probe, capacity Fy = Σ2·Mp/h. Newmark-β with Newton-Raphson iteration each step;
-                  Rayleigh damping on the initial stiffness. An elastic reference run is solved alongside so the
-                  inelastic force reduction is visible.
-                </p>
-                <p className="col-span-full rounded-md bg-amber-50 px-2 py-1.5 text-[11px] text-amber-800">
-                  <strong>Assumes a shear-type (strong-beam / weak-column) mechanism.</strong> A frame that hinges
-                  in its beams has a lower real capacity than Σ2·Mp/h, so Fy would be unconservative — confirm the
-                  governing mechanism with the Pushover tab first. One direction at a time; torsion ignored.
-                </p>
+                {nlKindModel === 'hinges' ? (
+                  <>
+                    <p className="col-span-full text-[11px] text-slate-500">
+                      The 3D model is condensed to an <strong>equivalent plane frame</strong> (all frame lines
+                      parallel to the loading direction are combined), then integrated with a bilinear hysteretic
+                      plastic hinge at <strong>every member end</strong> — Newmark-β with Newton-Raphson each step.
+                      Hinge capacity is reduced by <strong>P–M interaction</strong>, so axial load lowers Mp.
+                      An elastic reference run is solved alongside.
+                    </p>
+                    <p className="col-span-full rounded-md bg-slate-50 px-2 py-1.5 text-[11px] text-slate-600">
+                      No shear-type assumption — a beam-hinging frame hinges in its beams, because every member end
+                      carries its own hinge. Plane-frame idealization: exact when the parallel frames are identical
+                      and deform together; one direction at a time, torsion ignored.
+                    </p>
+                  </>
+                ) : (
+                  <>
+                    <p className="col-span-full text-[11px] text-slate-500">
+                      The frame is reduced to an equivalent nonlinear <strong>shear building</strong>: one bilinear
+                      hysteretic spring per storey — mass from the seismic mass, stiffness k₀ = V/Δ from a static
+                      lateral probe, capacity Fy = Σ2·Mp/h. Newmark-β with Newton-Raphson iteration each step;
+                      Rayleigh damping on the initial stiffness. An elastic reference run is solved alongside so the
+                      inelastic force reduction is visible.
+                    </p>
+                    <p className="col-span-full rounded-md bg-amber-50 px-2 py-1.5 text-[11px] text-amber-800">
+                      <strong>Assumes a shear-type (strong-beam / weak-column) mechanism.</strong> A frame that hinges
+                      in its beams has a lower real capacity than Σ2·Mp/h, so Fy would be unconservative — confirm the
+                      governing mechanism with the Pushover tab first. One direction at a time; torsion ignored.
+                    </p>
+                  </>
+                )}
                 <div className="col-span-full">
                   <button type="button" onClick={runNonlinear} disabled={!model || !!busy || meshErrors} className={btn}>
                     {busy === 'nonlinearTH' ? '⏳ Integrating…' : '⚡ Run nonlinear time-history'}
@@ -3784,6 +3815,84 @@ export default function ModelSpace() {
               </Sec>
 
               {model && <ValidationPanel issues={meshIssues} />}
+
+              {nlHinge?.inelastic && (() => {
+                const ie = nlHinge.inelastic!, el = nlHinge.elastic
+                const R = el && ie.response.peakBaseShear > 0
+                  ? el.response.peakBaseShear / ie.response.peakBaseShear : null
+                const yielded = ie.response.hinges.filter((h) => h.yielded)
+                  .sort((a, b) => Math.abs(b.plastic) - Math.abs(a.plastic))
+                return (
+                  <>
+                    <Sec grid={false} title="Response summary — member-end hinges">
+                      <Row label="Equivalent frame period T₁" value={`${f2(ie.period)} s`}
+                        sub={`${ie.frame.nodes.length} nodes · ${ie.frame.members.length} members · ${ie.frame.framesCombined} parallel frame lines combined`} />
+                      <Row label="Hinges yielded" value={`${ie.response.yieldedHinges} of ${ie.response.hinges.length}`}
+                        alert={!ie.response.converged} />
+                      <Row label="Peak base shear" value={`${f1(ie.response.peakBaseShear)} kN`}
+                        sub={el ? `elastic demand ${f1(el.response.peakBaseShear)} kN` : undefined} />
+                      {R != null && R > 1.01 && (
+                        <Row label="Force reduction (elastic / inelastic)" value={`${f2(R)}×`}
+                          sub="ductility-derived demand reduction, not a code R factor" />
+                      )}
+                      <Row label="Peak roof displacement" value={`${f1(ie.response.peakDisp * 1000)} mm`} />
+                      <Row label="Hysteretic energy dissipated" value={`${f1(ie.response.totalDissipated)} kN·m`} />
+                      <Row label="Newton convergence" value={ie.response.converged ? `✓ ≤ ${ie.response.maxIterations} iterations` : '✗ did not converge'}
+                        alert={!ie.response.converged} />
+                    </Sec>
+
+                    {yielded.length === 0 && (
+                      <Sec grid={false} title="Hinge state">
+                        <p className="text-sm text-slate-600">
+                          No hinge yielded — the frame stayed <strong>elastic</strong> under this record. That is a
+                          result, not a failure: raise the PGA, lower the frequency toward the {f2(ie.period)} s
+                          period, or use lighter sections to drive it inelastic.
+                        </p>
+                      </Sec>
+                    )}
+                    {yielded.length > 0 && (
+                      <Sec grid={false} title="Yielded hinges (largest plastic rotation first)">
+                        <div className="overflow-x-auto">
+                          <table className="w-full text-right text-[12px]">
+                            <thead className="text-slate-500">
+                              <tr className="border-b border-slate-200">
+                                <th className="py-1 pr-2 text-left">Member</th><th className="py-1 pr-2 text-left">End</th>
+                                <th className="py-1 pr-2">M (kN·m)</th><th className="py-1 pr-2">θ (mrad)</th>
+                                <th className="py-1 pr-2">θp (mrad)</th><th className="py-1 pr-2">E (kN·m)</th>
+                              </tr>
+                            </thead>
+                            <tbody className="font-mono">
+                              {yielded.slice(0, 20).map((h) => (
+                                <tr key={`${h.member}-${h.end}`} className="border-b border-slate-100 bg-amber-50">
+                                  <td className="py-0.5 pr-2 text-left">{h.member}</td>
+                                  <td className="py-0.5 pr-2 text-left">{h.end}</td>
+                                  <td className="py-0.5 pr-2">{f1(h.moment)}</td>
+                                  <td className="py-0.5 pr-2">{f1(h.rotation * 1000)}</td>
+                                  <td className="py-0.5 pr-2">{f1(h.plastic * 1000)}</td>
+                                  <td className="py-0.5 pr-2">{f1(h.dissipated)}</td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </div>
+                        <p className="mt-2 text-[10px] text-slate-500">
+                          θp is the permanent (plastic) rotation left in the hinge. Member ids are the condensed
+                          frame&rsquo;s — each combines the parallel 3D members at that grid position.
+                          {yielded.length > 20 && ` Showing the 20 worst of ${yielded.length}.`}
+                        </p>
+                      </Sec>
+                    )}
+                  </>
+                )
+              })()}
+              {nlHinge && !nlHinge.inelastic && (
+                <Sec grid={false} title="Nonlinear time-history — member-end hinges">
+                  <p className="text-sm text-slate-600">
+                    The model could not be condensed to a plane frame in this direction — it needs members lying
+                    in the loading plane, at least one support, and a positive seismic mass.
+                  </p>
+                </Sec>
+              )}
 
               {nl?.inelastic && (() => {
                 const ie = nl.inelastic!, el = nl.elastic


### PR DESCRIPTION
## Summary
The hinge engines (#438–#442) had **no UI** — five PRs of capability unreachable from the app. The Nonlinear tab already carried the ground-motion inputs and worker plumbing, so the hinge model slots in **beside** the shear-building reduction rather than needing a tab of its own.

- **`solverWorker`** — `nonlinearTH` takes `hingeModel: 'shear' | 'hinges'` and dispatches to `runNonlinearModel` or `runNonlinearFrameModel`, running the elastic reference alongside in both cases.
- **`ModelSpace`** — a **Plasticity model** selector (member-end hinges by default), with the explanatory note switching to match. The hinge path explicitly states it carries **no shear-type assumption**, since every member end has its own hinge — precisely the limitation the storey-spring reduction had to warn about.

Results show the equivalent-frame period and condensation summary (nodes / members / parallel frame lines combined), hinges yielded of total, peak base shear against the elastic demand, peak roof drift, dissipated energy, Newton convergence, and a table of yielded hinges ordered by plastic rotation (worst 20, with the total stated).

## Two deliberate choices
1. **The PGA default stays at a physically sensible 0.4 g** (NSCP Zone 4). The generated demo frame is strong enough to stay elastic there — 0 of 20 hinges — and I did **not** inflate the default to make the feature look busy. Instead the elastic outcome is reported explicitly: *"the frame stayed elastic under this record; that is a result, not a failure"*, with concrete guidance (raise PGA, tune frequency toward T₁, lighter sections).
2. **Non-convergence is surfaced as an alert.** It's reachable — at ~2.4 g on the demo frame Newton stops converging within 30 iterations — and the UI says so rather than presenting the numbers as sound.

## Verification
Exercised the full **worker → UI data path with the tab's own defaults**: both runs return, the condensation reports **9 nodes / 10 members / 2 combined frame lines at T₁ = 0.269 s**, and the payload JSON-serialises across the worker boundary at ~101 KB. Yield sweep for the panel states: 0.4 g → 0/20, 0.8 g → 3/20, 1.2 g → 7/20, 1.6 g → 12/20, 2.4 g → 18/20 but non-converged.

**Suite 1581** unchanged (presentation over already-tested engines), `npx tsc -b` clean, `npm run build` succeeds.

⚠️ **Not browser-verified** — this session has no preview tooling. The panel reuses the established `Sec`/`Row`/`Pick` primitives and the same worker round-trip as the existing Nonlinear/Pushover paths.

## Next
`axialMode` UI + the per-combo active-set routing you specified — the remaining engine-only capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_