### PR TITLE
Clear the eslint backlog and make lint gate CI

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -36,12 +36,10 @@ jobs:
         run: npm ci
       - name: Typecheck
         run: npx tsc -b
-      # Non-blocking for now: main has 28 pre-existing eslint errors (react-hooks
-      # render-safety in ModelSpace/Diagram/useCalcResult + assorted no-useless-*).
-      # Remove continue-on-error once they're fixed so lint gates like the rest.
+      # Gating. `npm run lint` runs with --max-warnings 0, so warnings fail too —
+      # main is clean and the point of the gate is to keep it that way.
       - name: Lint
         run: npm run lint
-        continue-on-error: true
       - name: Test
         run: npm test
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -566,9 +566,10 @@ backlog — and this fix round. Remaining work lives in #325's unticked boxes.
   the next N-vs-kN slip fails loud.
 
 **Process / UI:**
-- **#320 — real CI gate**: `tsc -b` + lint (non-blocking: 28 pre-existing
-  eslint errors) + `npm test` gate the Pages deploy; optimizer-test timeout
-  headroom; Roadmap truth-up.
+- **#320 — real CI gate**: `tsc -b` + lint + `npm test` gate the Pages deploy;
+  optimizer-test timeout headroom; Roadmap truth-up. (Lint ran with
+  `continue-on-error` until #445 cleared the backlog — it now blocks, with
+  `--max-warnings 0`.)
 - **#331 — discoverability**: searchable “All tools” grid on Home; Structural
   dropdown sub-grouped into 6 disciplines (two-column panel); ARIA menu
   semantics.
@@ -584,7 +585,7 @@ _Tests after #334: **1028 passing**; `tsc -b` clean._
 _Remaining roadmap: Pressure Grouting (empirical — skipped by design); Phase 4
 items are owner-driven (marketing/monetisation). Prioritised follow-ups: the
 unticked boxes in **issue #325** (page-shell unification, mobile tables, FEM
-run feedback, eslint zero-out, bundle splitting, ModelSpace split,
+run feedback, ~~eslint zero-out~~ (done, #445), bundle splitting, ModelSpace split,
 ValidationMap transcription, project save/load…). The xlsx vuln + optimizer-test
 timeout from that list are now resolved — see the PRs #362–#371 section below._
 

--- a/webapp/eslint.config.js
+++ b/webapp/eslint.config.js
@@ -18,5 +18,12 @@ export default defineConfig([
     languageOptions: {
       globals: globals.browser,
     },
+    rules: {
+      // `_`-prefixed names are the conventional "deliberately discarded" marker
+      // — most often the omitted key of an object rest-destructure.
+      '@typescript-eslint/no-unused-vars': ['error', {
+        varsIgnorePattern: '^_', argsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_',
+      }],
+    },
   },
 ])

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings 0",
     "preview": "vite preview",
     "test": "vitest run"
   },

--- a/webapp/src/components/AppShell.tsx
+++ b/webapp/src/components/AppShell.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useState, type ReactNode } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { SIDEBAR_GROUPS, ALL_TOOLS } from '../lib/tools'
-import { CommandPalette, usePaletteHotkey } from './CommandPalette'
+import { CommandPalette } from './CommandPalette'
+import { usePaletteHotkey } from '../lib/usePaletteHotkey'
 
 // Workbench shell (docs/design/uiux-2026-07): persistent ink-navy sidebar with
 // the grouped tool catalog + ⌘K search, and a slim breadcrumb header. Wraps
@@ -101,7 +102,7 @@ export function AppShell({ children }: { children: ReactNode }) {
         </header>
         {children}
       </div>
-      <CommandPalette open={palette} onClose={() => setPalette(false)} />
+      {palette && <CommandPalette onClose={() => setPalette(false)} />}
     </div>
   )
 }

--- a/webapp/src/components/CommandPalette.tsx
+++ b/webapp/src/components/CommandPalette.tsx
@@ -5,10 +5,19 @@ import { ALL_TOOLS } from '../lib/tools'
 // ⌘K command palette — fuzzy tool finder over the registry. Opened by the
 // sidebar / home search boxes or Ctrl/⌘+K anywhere; arrow keys + Enter
 // navigate, Escape closes. Pure UI on top of lib/tools.
-export function CommandPalette({ open, onClose }: { open: boolean; onClose: () => void }) {
+//
+// Mount it CONDITIONALLY (`{open && <CommandPalette … />}`) rather than passing
+// an `open` prop: a fresh mount gives fresh query/selection state, so the reset
+// does not need an effect that sets state on every open.
+export function CommandPalette({ onClose }: { onClose: () => void }) {
   const nav = useNavigate()
   const [q, setQ] = useState('')
   const [sel, setSel] = useState(0)
+  // Selection resets when the query changes. Adjusting state during render (the
+  // pattern React documents for derived state) rather than in an effect avoids
+  // rendering one frame with a stale, possibly out-of-range index.
+  const [prevQ, setPrevQ] = useState(q)
+  if (q !== prevQ) { setPrevQ(q); setSel(0) }
   const inputRef = useRef<HTMLInputElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
 
@@ -19,13 +28,10 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
       `${t.name} ${t.sub} ${t.groupLabel}`.toLowerCase().includes(needle))
   }, [q])
 
-  useEffect(() => { if (open) { setQ(''); setSel(0); setTimeout(() => inputRef.current?.focus(), 0) } }, [open])
-  useEffect(() => { setSel(0) }, [q])
+  useEffect(() => { inputRef.current?.focus() }, [])
   useEffect(() => {
     listRef.current?.querySelector('[data-selected="true"]')?.scrollIntoView({ block: 'nearest' })
   }, [sel])
-
-  if (!open) return null
 
   const go = (to: string) => { onClose(); nav(to) }
   const onKey = (e: React.KeyboardEvent) => {
@@ -60,15 +66,4 @@ export function CommandPalette({ open, onClose }: { open: boolean; onClose: () =
       </div>
     </div>
   )
-}
-
-/** Global Ctrl/⌘+K listener for the mounting shell. */
-export function usePaletteHotkey(setOpen: (v: boolean | ((o: boolean) => boolean)) => void) {
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') { e.preventDefault(); setOpen((o) => !o) }
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [setOpen])
 }

--- a/webapp/src/components/ConstructionSchedule.tsx
+++ b/webapp/src/components/ConstructionSchedule.tsx
@@ -29,6 +29,15 @@ export function ConstructionSchedule({ model, design }: { model: StructuralModel
   const [durOverride, setDurOverride] = useState<Record<string, number>>({})
   const [depOverride, setDepOverride] = useState<Record<string, ActivityLink[]>>({})
   const [depErr, setDepErr] = useState<string | null>(null)
+  /** Push the (edited) network into the /schedule module. Re-opening UPDATES the
+   *  same linked project — refreshing structure while keeping the scheduler-side
+   *  calendar, resources, baselines and per-activity actuals — instead of making
+   *  a new copy each time. Declared with the other hooks, ABOVE the early
+   *  return below, so the hook order can never depend on the model. */
+  const [linked, setLinked] = useState<boolean>(() => {
+    const id = defaultBackend().getItem(SCHEDULE_LINK_KEY)
+    return !!(id && createStore(defaultBackend()).exists(id))
+  })
 
   const activities = useMemo(() =>
     (base?.activities ?? []).map((a) => {
@@ -48,14 +57,6 @@ export function ConstructionSchedule({ model, design }: { model: StructuralModel
   const setDuration = (id: string, d: number) => setDurOverride((o) => ({ ...o, [id]: d }))
   const resetAll = () => { setDurOverride({}); setDepOverride({}); setDepErr(null) }
 
-  /** Push the (edited) network into the /schedule module. Re-opening UPDATES the
-   *  same linked project — refreshing structure while keeping the scheduler-side
-   *  calendar, resources, baselines and per-activity actuals — instead of making
-   *  a new copy each time. */
-  const [linked, setLinked] = useState<boolean>(() => {
-    const id = defaultBackend().getItem(SCHEDULE_LINK_KEY)
-    return !!(id && createStore(defaultBackend()).exists(id))
-  })
   const openInScheduler = () => {
     const backend = defaultBackend()
     const store = createStore(backend)

--- a/webapp/src/components/Diagram.tsx
+++ b/webapp/src/components/Diagram.tsx
@@ -57,7 +57,10 @@ export function Diagram({
 
   const fmt = (v: number) => v.toFixed(decimals)
 
-  function Marker({ i, place }: { i: number; place: 'above' | 'below' }) {
+  // A plain render helper, not a nested component: declaring a component inside
+  // another component's body gives it a new identity every render (remounting
+  // its subtree). Called as `marker(i, place)`, it is just more JSX inline.
+  const marker = (i: number, place: 'above' | 'below') => {
     const x = sx(xs[i]), y = sy(ys[i])
     const ly = place === 'above' ? y - 9 : y + 15
     return (
@@ -106,8 +109,8 @@ export function Diagram({
       <polygon points={fillPts} fill={color} opacity={0.12} />
       <polyline points={linePts} fill="none" stroke={color} strokeWidth={1.8} />
 
-      {markExtrema && Math.abs(ys[iMax]) > 1e-6 && <Marker i={iMax} place="above" />}
-      {markExtrema && Math.abs(ys[iMin]) > 1e-6 && <Marker i={iMin} place="below" />}
+      {markExtrema && Math.abs(ys[iMax]) > 1e-6 && marker(iMax, 'above')}
+      {markExtrema && Math.abs(ys[iMin]) > 1e-6 && marker(iMin, 'below')}
     </svg>
   )
 }

--- a/webapp/src/components/FitView.tsx
+++ b/webapp/src/components/FitView.tsx
@@ -28,6 +28,10 @@ export function FitView({ box, dir = [1, 0.8, 1], margin = 1.3 }: {
     const dist = (radius / Math.sin(fov / 2)) * margin
     const d = new THREE.Vector3(...dir).normalize()
     persp.position.copy(center.clone().add(d.multiplyScalar(dist)))
+    // The three.js camera is an external mutable object owned by the r3f
+    // renderer, not React state — repositioning it imperatively is the whole
+    // point of this component, and there is no declarative equivalent.
+    // eslint-disable-next-line react-hooks/immutability
     persp.near = Math.max(dist / 100, 0.01)
     persp.far = dist * 10
     persp.updateProjectionMatrix()

--- a/webapp/src/components/qty.tsx
+++ b/webapp/src/components/qty.tsx
@@ -92,6 +92,3 @@ export function QtyPage({ title, reportTitle, intro, children }: {
   )
 }
 
-export const kg = (v: number) => (Number.isFinite(v) ? `${v.toFixed(1)} kg` : '—')
-export const m3 = (v: number) => (Number.isFinite(v) ? `${v.toFixed(2)} m³` : '—')
-export const m = (v: number) => (Number.isFinite(v) ? `${v.toFixed(2)} m` : '—')

--- a/webapp/src/engine/accelerogram.ts
+++ b/webapp/src/engine/accelerogram.ts
@@ -46,7 +46,7 @@ export function parseAccelerogram(
   let dtHint: number | undefined = opts?.dt
   if (dtHint == null) {
     for (const line of csv.split('\n')) {
-      const m = line.match(/DT\s*=\s*([\d.eE+\-]+)\s*SEC/i)
+      const m = line.match(/DT\s*=\s*([\d.eE+-]+)\s*SEC/i)
       if (m) {
         const v = parseFloat(m[1])
         if (v > 0) { dtHint = v; break }

--- a/webapp/src/engine/nonlinearFrame.ts
+++ b/webapp/src/engine/nonlinearFrame.ts
@@ -375,7 +375,7 @@ export function nonlinearFrame(inp: NLFrameInput): NLFrameResult | null {
     : (inp.schedule
       ?? Array.from({ length: nSteps }, (_, i) => ((i + 1) * (inp.lambdaMax ?? 3)) / nSteps))
 
-  let d = new Array(nf).fill(0)
+  const d = new Array(nf).fill(0)
   let dPrev = new Array(nf).fill(0)
   const steps: NLFrameStep[] = []
   let mechanism = false, allConverged = true

--- a/webapp/src/engine/pileCap.ts
+++ b/webapp/src/engine/pileCap.ts
@@ -229,11 +229,13 @@ export function designPileCap(inp: PileCapInput): PileCapResult {
   for (let i = 0; i < N; i++) {
     const armX = Math.abs(coords[i].x) - inp.colX / 2;
     if (armX > 0) {
-      (coords[i].x > 0 ? (MuXpos += factReactions[i] * armX) : (MuXneg += factReactions[i] * armX));
+      if (coords[i].x > 0) MuXpos += factReactions[i] * armX;
+      else MuXneg += factReactions[i] * armX;
     }
     const armY = Math.abs(coords[i].y) - inp.colY / 2;
     if (armY > 0) {
-      (coords[i].y > 0 ? (MuYpos += factReactions[i] * armY) : (MuYneg += factReactions[i] * armY));
+      if (coords[i].y > 0) MuYpos += factReactions[i] * armY;
+      else MuYneg += factReactions[i] * armY;
     }
   }
   const MuX = Math.max(MuXpos, MuXneg) / 1e3; // kN·mm → kN·m

--- a/webapp/src/engine/slopeStability.ts
+++ b/webapp/src/engine/slopeStability.ts
@@ -84,7 +84,10 @@ export function sliceCircle(ground: Pt[], circle: SlipCircle, n: number, water?:
     else if (gp * gc < 0) {
       // bisection
       let a = xp, bb = x
-      for (let k = 0; k < 40; k++) { const mid = (a + bb) / 2; (g(a) * g(mid) <= 0 ? (bb = mid) : (a = mid)) }
+      for (let k = 0; k < 40; k++) {
+        const mid = (a + bb) / 2
+        if (g(a) * g(mid) <= 0) bb = mid; else a = mid
+      }
       roots.push((a + bb) / 2)
     }
     xp = x; gp = gc

--- a/webapp/src/engine/truss.ts
+++ b/webapp/src/engine/truss.ts
@@ -70,11 +70,12 @@ export function generateTruss(spec: TrussSpec): TrussModel {
   // triangle b–b–t), keeping every generated truss statically determinate.
   for (let i = 0; i < n; i++) {
     if (gable && (i === 0 || i === n - 1)) continue
-    let a: string, b: string
-    if (spec.type === 'warren') { (i % 2 === 0) ? (a = `b${i}`, b = top(i + 1)) : (a = top(i), b = `b${i + 1}`) }
-    else if (spec.type === 'fink') { (i % 2 === 0) ? (a = `b${i}`, b = top(i + 1)) : (a = top(i), b = `b${i + 1}`) }  // W-pattern web
-    else if (spec.type === 'howe') { (i < mid) ? (a = top(i), b = `b${i + 1}`) : (a = `b${i}`, b = top(i + 1)) }
-    else { (i < mid) ? (a = `b${i}`, b = top(i + 1)) : (a = top(i), b = `b${i + 1}`) }   // pratt + roof + scissor
+    // warren & fink alternate the diagonal each panel (fink = W-pattern web);
+    // howe and pratt/roof/scissor mirror about mid-span, in opposite senses.
+    const alt = spec.type === 'warren' || spec.type === 'fink'
+      ? i % 2 === 0
+      : spec.type === 'howe' ? i >= mid : i < mid
+    const [a, b] = alt ? [`b${i}`, top(i + 1)] : [top(i), `b${i + 1}`]
     add(a, b, 'diagonal')
   }
 

--- a/webapp/src/lib/beamSolution.ts
+++ b/webapp/src/lib/beamSolution.ts
@@ -95,7 +95,7 @@ export function buildBeamSolution(i: BeamDesignInput, r: BeamDesignResult): Solu
     title: 'Bar layout — spacing check & layers (§407.7)',
     lines: [
       txt(`Minimum clear spacing between parallel bars in a layer is max(d_b, 25 mm) = ${sn0(r.sMinClear)} mm (§407.7.1). The clear web width is b − 2(cover + dₛ) = ${sn0(bw)} mm, so at most ${r.maxPerLayer} bars fit per layer.`),
-      eq(String.raw`n = \lceil A_s / A_b \rceil = \lceil ${sn0(r.As)} / ${sn0(Ab)} \rceil = ${r.bars}\ \text{bars} \Rightarrow \text{layers: } [${r.layers.join(',\ ')}]`),
+      eq(String.raw`n = \lceil A_s / A_b \rceil = \lceil ${sn0(r.As)} / ${sn0(Ab)} \rceil = ${r.bars}\ \text{bars} \Rightarrow \text{layers: } [${r.layers.join(', ')}]`),
       eq(String.raw`s_{clear} = \dfrac{${sn0(bw)} - ${r.layers[0]}(${sn0(i.barDia)})}{${Math.max(1, r.layers[0] - 1)}} = ${sn0(r.sClear)}\ \text{mm} \;\ge\; ${sn0(r.sMinClear)}\ \text{mm}\ \checkmark`),
       ...(multiLayer ? [
         txt('With more than one layer (25 mm clear between layers, §407.7.2) the bar-group centroid rises above the extreme layer — Varignon: ȳ = Σnᵢyᵢ/Σnᵢ — which reduces d, so the design re-runs at the new d until the layer arrangement stops changing.'),
@@ -105,7 +105,7 @@ export function buildBeamSolution(i: BeamDesignInput, r: BeamDesignResult): Solu
       ]),
       ...(r.comprLayers.length > 0 ? [
         txt(`Compression side — same rule: s_min = max(d_b′, 25) = ${sn0(r.comprSMinClear)} mm, so at most ${r.comprMaxPerLayer} compression bars fit per layer.`),
-        eq(String.raw`n' = ${r.comprBars}\ \text{bars} \Rightarrow \text{layers: } [${r.comprLayers.join(',\ ')}],\quad s_{clear}' = ${sn0(r.comprSClear)}\ \text{mm} \ge ${sn0(r.comprSMinClear)}\ \checkmark`),
+        eq(String.raw`n' = ${r.comprBars}\ \text{bars} \Rightarrow \text{layers: } [${r.comprLayers.join(', ')}],\quad s_{clear}' = ${sn0(r.comprSClear)}\ \text{mm} \ge ${sn0(r.comprSMinClear)}\ \checkmark`),
         ...(r.comprLayers.length > 1 ? [
           txt('Stacking compression layers drops the compression-steel centroid (Varignon), DEEPENING d′ — which reduces the (d − d′) lever arm and feeds back into As2 and A′s.'),
           eq(String.raw`\bar{y}' = ${sn1(r.comprYBar)}\ \text{mm} \Rightarrow d' = ${sn1(r.dPrime - r.comprYBar)} + ${sn1(r.comprYBar)} = \mathbf{${sn1(r.dPrime)}}\ \text{mm}`),

--- a/webapp/src/lib/columnSolution.ts
+++ b/webapp/src/lib/columnSolution.ts
@@ -115,7 +115,7 @@ export function eccentricColumnSolution(
     clause: 'strain compatibility',
     lines: [
       txt(`${i.numBars} bars are detailed around the cage: ${r.nx} per ${i.b}-mm face and ${r.ny} per ${i.h}-mm face (corners shared). Each row enters the P–M sum as its own layer — side bars near the neutral axis contribute little moment, so this layout gives a lower Mb than the two-face idealisation.`),
-      eq(String.raw`\text{layers } d_i = [${r.layers.map((L) => sn1(L.d)).join(',\ ')}]\ \text{mm},\quad n_i = [${r.layers.map((L) => L.n).join(',\ ')}]`),
+      eq(String.raw`\text{layers } d_i = [${r.layers.map((L) => sn1(L.d)).join(', ')}]\ \text{mm},\quad n_i = [${r.layers.map((L) => L.n).join(', ')}]`),
     ],
   }] : []
 

--- a/webapp/src/lib/format.ts
+++ b/webapp/src/lib/format.ts
@@ -2,3 +2,10 @@ export const f0 = (v: number) => (Number.isFinite(v) ? Math.round(v).toString() 
 export const f1 = (v: number) => (Number.isFinite(v) ? v.toFixed(1) : '—')
 export const f2 = (v: number) => (Number.isFinite(v) ? v.toFixed(2) : '—')
 export const f3 = (v: number) => (Number.isFinite(v) ? v.toFixed(3) : '—')
+
+// Unit-suffixed quantity formatters (take-off pages). Kept here rather than in
+// `components/qty.tsx` so that module exports components only — a file mixing
+// components with plain values breaks React Fast Refresh.
+export const kg = (v: number) => (Number.isFinite(v) ? `${v.toFixed(1)} kg` : '—')
+export const m3 = (v: number) => (Number.isFinite(v) ? `${v.toFixed(2)} m³` : '—')
+export const m = (v: number) => (Number.isFinite(v) ? `${v.toFixed(2)} m` : '—')

--- a/webapp/src/lib/math.tsx
+++ b/webapp/src/lib/math.tsx
@@ -1,14 +1,5 @@
 import katex from 'katex'
-
-// '⌀' and '§' have no KaTeX glyph metrics — every render logs
-// "LaTeX-incompatible input" / "No character metrics" warnings and falls back
-// to a wrong-font glyph. Swap them for the proper commands before compiling
-// (\varnothing renders ∅; \S renders §). The \text{⌀} form must be lifted out
-// of text mode first or \varnothing would throw there; \S is valid in both.
-export const sanitizeTex = (tex: string) =>
-  tex.replaceAll('\\text{⌀}', '\\varnothing ')
-    .replaceAll('⌀', '\\varnothing ')
-    .replaceAll('§', '\\S ')
+import { sanitizeTex } from './tex'
 
 // Tiny KaTeX wrapper — renders to an HTML string and injects it. Avoids the
 // react-katex peer-dependency friction with React 19 and keeps full control.

--- a/webapp/src/lib/tex.test.ts
+++ b/webapp/src/lib/tex.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { sanitizeTex } from './math'
+import { sanitizeTex } from './tex'
 
 describe('sanitizeTex — KaTeX-incompatible glyph replacement', () => {
   it('bare ⌀ (math mode) becomes \\varnothing', () => {

--- a/webapp/src/lib/tex.ts
+++ b/webapp/src/lib/tex.ts
@@ -1,0 +1,13 @@
+// '⌀' and '§' have no KaTeX glyph metrics — every render logs
+// "LaTeX-incompatible input" / "No character metrics" warnings and falls back
+// to a wrong-font glyph. Swap them for the proper commands before compiling
+// (\varnothing renders ∅; \S renders §). The \text{⌀} form must be lifted out
+// of text mode first or \varnothing would throw there; \S is valid in both.
+//
+// Lives beside `math.tsx` rather than inside it so that module exports only the
+// <Math> component — a file mixing components with plain values breaks React
+// Fast Refresh.
+export const sanitizeTex = (tex: string) =>
+  tex.replaceAll('\\text{⌀}', '\\varnothing ')
+    .replaceAll('⌀', '\\varnothing ')
+    .replaceAll('§', '\\S ')

--- a/webapp/src/lib/useCalcResult.ts
+++ b/webapp/src/lib/useCalcResult.ts
@@ -15,11 +15,15 @@ export function useCalcResult<T>(
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   // Use a ref so the effect always calls the latest closure without re-running.
+  // Written after commit — assigning during render would make the render impure.
   const latestFn = useRef(fetchFn)
-  latestFn.current = fetchFn
+  useEffect(() => { latestFn.current = fetchFn })
 
   useEffect(() => {
     let cancelled = false
+    // Entering the debounce IS the loading state; there is nothing to derive it
+    // from, because the trigger is a deps change rather than a value.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoading(true)
     const t = setTimeout(() => {
       latestFn.current()

--- a/webapp/src/lib/usePaletteHotkey.ts
+++ b/webapp/src/lib/usePaletteHotkey.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react'
+
+/**
+ * Global Ctrl/⌘+K listener for the shell that mounts the command palette.
+ *
+ * Lives here rather than in `CommandPalette.tsx` so that module exports only
+ * the component — a file mixing components with other exports breaks React
+ * Fast Refresh.
+ */
+export function usePaletteHotkey(setOpen: (v: boolean | ((o: boolean) => boolean)) => void) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') { e.preventDefault(); setOpen((o) => !o) }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [setOpen])
+}

--- a/webapp/src/lib/useSolver.ts
+++ b/webapp/src/lib/useSolver.ts
@@ -20,6 +20,9 @@ export function useSolver() {
   const [progress, setProgress] = useState<SolveProgress | null>(null)
 
   useEffect(() => {
+    // capture the map for the cleanup closure — `pending.current` could point
+    // at a different object by the time the effect tears down
+    const inflight = pending.current
     const w = new Worker(new URL('../engine/solverWorker.ts', import.meta.url), { type: 'module' })
     w.onmessage = (e: MessageEvent<WorkerMsg>) => {
       const { id, ok, result, error, progress: prog } = e.data
@@ -31,7 +34,7 @@ export function useSolver() {
     }
     w.onerror = (e) => { for (const p of pending.current.values()) p.reject(new Error(e.message)); pending.current.clear(); setBusy(''); setProgress(null) }
     worker.current = w
-    return () => { w.terminate(); pending.current.clear() }
+    return () => { w.terminate(); inflight.clear() }
   }, [])
 
   const run = useCallback(<K extends Kind>(kind: K, payload: PayloadByKind[K]): Promise<unknown> => {

--- a/webapp/src/pages/BeamEstimate.tsx
+++ b/webapp/src/pages/BeamEstimate.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { estimateBeam, type BeamInput, type BeamBarGroup, type ConcreteClass } from '../engine/quantities'
-import { Num, ClassPick, Card, ResultCard, Row, QtyPage, kg, m3, m } from '../components/qty'
+import { Num, ClassPick, Card, ResultCard, Row, QtyPage } from '../components/qty'
+import { kg, m3, m } from '../lib/format'
 
 const g = (lengthPerPiece: number, numPieces: number, diaMm: number): BeamBarGroup => ({ lengthPerPiece, numPieces, diaMm })
 

--- a/webapp/src/pages/BoxCulvertEstimate.tsx
+++ b/webapp/src/pages/BoxCulvertEstimate.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { estimateBoxCulvert, type BoxCulvertInput, type ConcreteClass } from '../engine/quantities'
-import { Num, ClassPick, Card, ResultCard, Row, QtyPage, kg, m3, m } from '../components/qty'
+import { Num, ClassPick, Card, ResultCard, Row, QtyPage } from '../components/qty'
+import { kg, m3, m } from '../lib/format'
 
 const DEFAULTS: BoxCulvertInput = {
   grossArea: 6, holeArea: 2, length: 5, concreteClass: 'A', customFactor: 9, spliceLength: 0.3,

--- a/webapp/src/pages/ChbEstimate.tsx
+++ b/webapp/src/pages/ChbEstimate.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { estimateChb, type ChbInput, type ChbSize } from '../engine/quantities'
-import { Num, Pick, Card, ResultCard, Row, QtyPage, m3 } from '../components/qty'
+import { Num, Pick, Card, ResultCard, Row, QtyPage } from '../components/qty'
+import { m3 } from '../lib/format'
 
 const DEFAULTS: ChbInput = { wallArea: 30, holeArea: 4, size: '6' }
 

--- a/webapp/src/pages/ColumnEstimate.tsx
+++ b/webapp/src/pages/ColumnEstimate.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { estimateColumn, type ColumnInput, type ConcreteClass } from '../engine/quantities'
-import { Num, ClassPick, Card, ResultCard, Row, QtyPage, kg, m3, m } from '../components/qty'
+import { Num, ClassPick, Card, ResultCard, Row, QtyPage } from '../components/qty'
+import { kg, m3, m } from '../lib/format'
 
 const DEFAULTS: ColumnInput = {
   length: 0.4, width: 0.4, height: 3, numStructures: 4, concreteClass: 'A', customFactor: 9, spliceLength: 0.3,

--- a/webapp/src/pages/FoundationDesign.tsx
+++ b/webapp/src/pages/FoundationDesign.tsx
@@ -259,7 +259,7 @@ export default function FoundationDesign() {
       long: view.long, short: view.short, ecc: view.ecc,
     }
     return buildFoundationSolution(ctx)
-  }, [view, form, serviceLoad, ultimateLoad, individual])
+  }, [view, form, serviceLoad, ultimateLoad, individual, circular, colWidth, colWidthY])
 
   // Verdict data — presentation of engine outputs only: utilization is the
   // required-over-provided effective depth per shear mode (capacity grows with

--- a/webapp/src/pages/Home.tsx
+++ b/webapp/src/pages/Home.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { SIDEBAR_GROUPS, ALL_TOOLS } from '../lib/tools'
-import { CommandPalette, usePaletteHotkey } from '../components/CommandPalette'
+import { CommandPalette } from '../components/CommandPalette'
+import { usePaletteHotkey } from '../lib/usePaletteHotkey'
 
 // Home — search-first tool directory on the drawing-sheet workbench theme
 // (docs/design/uiux-2026-07/Redesign - Home): dark hero with drafting grid,
@@ -154,7 +155,7 @@ export default function Home({ onAuth }: { onAuth: (mode: 'login' | 'signup') =>
         </div>
       </section>
 
-      <CommandPalette open={palette} onClose={() => setPalette(false)} />
+      {palette && <CommandPalette onClose={() => setPalette(false)} />}
     </div>
   )
 }

--- a/webapp/src/pages/LoadCombinations.tsx
+++ b/webapp/src/pages/LoadCombinations.tsx
@@ -13,10 +13,12 @@ export default function LoadCombinations() {
     setD(s => ({ ...s, [k]: v }))
 
   const allFinite = Object.values(d).every(Number.isFinite)
+  // `d` is a fresh object every render, so memoize on its VALUE identity
+  const dKey = JSON.stringify(d)
   const r = useMemo(
     () => (allFinite ? calcLoadCombinations(d) : null),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [JSON.stringify(d), allFinite],
+    [dKey, allFinite],
   )
 
   return (

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -512,10 +512,12 @@ function ModeShapePlayer({ shape, nodePos, members, amp }: {
   members: { id: string; i: string; j: string }[]
   amp: number
 }) {
+  // Latest-value refs so `useFrame` reads the current amp/shape without the
+  // animation restarting on every prop change. Written after commit — assigning
+  // during render would make the render impure.
   const ampRef = useRef(amp)
-  ampRef.current = amp
   const shapeRef = useRef(shape)
-  shapeRef.current = shape
+  useEffect(() => { ampRef.current = amp; shapeRef.current = shape }, [amp, shape])
 
   const { group, lineGeos } = useMemo(() => {
     const g = new THREE.Group()
@@ -532,6 +534,10 @@ function ModeShapePlayer({ shape, nodePos, members, amp }: {
     return { group: g, lineGeos: geos }
   }, [members, nodePos])
 
+  // Writes straight into the GPU buffers each frame. The geometries are
+  // three.js objects owned by the renderer, not React state — re-rendering 60×
+  // a second to animate a mode shape is exactly what this avoids.
+  // eslint-disable-next-line react-hooks/immutability
   useFrame(({ clock }) => {
     const scale = ampRef.current * Math.sin(clock.elapsedTime * Math.PI * 1.2)
     const sh = shapeRef.current
@@ -542,6 +548,7 @@ function ModeShapePlayer({ shape, nodePos, members, amp }: {
       const pos = geo.attributes.position as THREE.BufferAttribute
       pos.setXYZ(0, aO.x + (da?.[0] ?? 0) * scale, aO.y + (da?.[1] ?? 0) * scale, aO.z + (da?.[2] ?? 0) * scale)
       pos.setXYZ(1, bO.x + (db?.[0] ?? 0) * scale, bO.y + (db?.[1] ?? 0) * scale, bO.z + (db?.[2] ?? 0) * scale)
+      // eslint-disable-next-line react-hooks/immutability
       pos.needsUpdate = true
     }
   })
@@ -1923,7 +1930,7 @@ export default function ModelSpace() {
                   // framing beam. Intermediate columns keep meeting at the node,
                   // so the storey above fills the joint block.
                   const fo = faceOff?.get(m.id)
-                  let aV = a, bV = bb
+                  let aV: THREE.Vector3, bV: THREE.Vector3
                   if (m.role === 'column') {
                     const contAt = (nid: string) => model.members.some((o) => o.id !== m.id && o.role === 'column' && (o.i === nid || o.j === nid))
                     aV = manI ? a.clone().add(v3(manI)) : (fo?.offI && !contAt(m.i) ? a.clone().sub(v3(fo.offI)) : a)
@@ -3728,7 +3735,7 @@ export default function ModelSpace() {
                             // Quick sample count (non-comment, non-empty lines with at least one number)
                             const npts = text.split('\n').filter((l) => {
                               const t = l.trim()
-                              return t && !/^[#%!]/.test(t) && /[\d.\-]/.test(t) && !isNaN(parseFloat(t.split(/[\s,;]+/)[0]))
+                              return t && !/^[#%!]/.test(t) && /[\d.-]/.test(t) && !isNaN(parseFloat(t.split(/[\s,;]+/)[0]))
                             }).length
                             setThCsv({ text, name: f.name, npts })
                           })

--- a/webapp/src/pages/PlumbingDesign.tsx
+++ b/webapp/src/pages/PlumbingDesign.tsx
@@ -61,10 +61,11 @@ export default function PlumbingDesign() {
   const [flowOverride, setFlowOverride] = useState(0)   // L/s; 0 ⇒ use Hunter's curve
   const [material, setMaterial] = useState<keyof typeof HAZEN_C>('copper')
 
-  const supplyInput: WaterSupplyInput = {
+  // memoized so the two solves below don't re-run on every unrelated render
+  const supplyInput: WaterSupplyInput = useMemo(() => ({
     items, occupancy: occ, hunterSystem, designFlowLps: flowOverride > 0 ? flowOverride : undefined,
     Lpipe, fittingLength, riseZ, pMainKPa: pMain, pMeterKPa: pMeter, pFixtureKPa: pFixture, material,
-  }
+  }), [items, occ, hunterSystem, flowOverride, Lpipe, fittingLength, riseZ, pMain, pMeter, pFixture, material])
   const supply = useMemo(() => designWaterSupply(supplyInput), [supplyInput])
   const supplySteps = useMemo(() => waterSupplySolution(supplyInput, supply), [supplyInput, supply])
 

--- a/webapp/src/pages/PunchingShear.tsx
+++ b/webapp/src/pages/PunchingShear.tsx
@@ -41,6 +41,8 @@ export default function PunchingShear() {
 
   const d = f.h - f.cover - f.barDia / 2     // effective depth
 
+  // `f` is a fresh object every render, so memoize on its VALUE identity
+  const fKey = JSON.stringify(f)
   const r = useMemo((): ReturnType<typeof designPunchingShear> | null => {
     if (!allFinite || d <= 0) return null
     const inp: PunchingInput = {
@@ -53,7 +55,7 @@ export default function PunchingShear() {
     }
     return designPunchingShear(inp)
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(f), allFinite, d])
+  }, [fKey, allFinite, d])
 
   return (
     <div className="mx-auto max-w-[1500px] p-6">

--- a/webapp/src/pages/RetainingWall.tsx
+++ b/webapp/src/pages/RetainingWall.tsx
@@ -35,10 +35,12 @@ export default function RetainingWall() {
   const allFinite = REQUIRED.every((k) => Number.isFinite(f[k] as number))
     && Number.isFinite(f.q_sur)
 
+  // `f` is a fresh object every render, so memoize on its VALUE identity
+  const fKey = JSON.stringify(f)
   const r = useMemo(
     () => (allFinite ? designRetainingWall(f) : null),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [JSON.stringify(f), allFinite],
+    [fKey, allFinite],
   )
 
   return (

--- a/webapp/src/pages/ScheduleDashboard.tsx
+++ b/webapp/src/pages/ScheduleDashboard.tsx
@@ -96,7 +96,7 @@ function Dashboard({ project, solve }: { project: ScheduleProject; solve: Schedu
 
   const [dataDate, setDataDate] = useState(defaultData)
   const [acInput, setAcInput] = useState(0)
-  const dataOffset = dataDateOffset(cal, start, dataDate)
+  const dataOffset = useMemo(() => dataDateOffset(cal, start, dataDate), [cal, start, dataDate])
 
   const nameOf = useMemo(() => new Map(project.activities.map((a) => [a.id, a.name])), [project])
   const prog = useMemo(() => projectProgress(project.activities, solve.cpm!, dataOffset), [project, solve.cpm, dataOffset])

--- a/webapp/src/pages/SlabEstimate.tsx
+++ b/webapp/src/pages/SlabEstimate.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { estimateSlab, type SlabInput, type ConcreteClass } from '../engine/quantities'
-import { Num, ClassPick, Card, ResultCard, Row, QtyPage, kg, m3, m } from '../components/qty'
+import { Num, ClassPick, Card, ResultCard, Row, QtyPage } from '../components/qty'
+import { kg, m3, m } from '../lib/format'
 
 const DEFAULTS: SlabInput = {
   slabArea: 20, thickness: 0.125, numStructures: 1, concreteClass: 'A', customFactor: 9, spliceLength: 0.3,

--- a/webapp/src/pages/SteelDesign.tsx
+++ b/webapp/src/pages/SteelDesign.tsx
@@ -438,7 +438,7 @@ function ConnectionTab() {
         ]),
       },
     ]
-  }, [res, boltGrade, db, nRows, nCols, sy, ex_edge, tPlate, FuPlate, FyPlate, threads, Vu, Hu, ex_load, ey_load, e_out, b_gage])
+  }, [res, boltGrade, db, nRows, nCols, sy, ex_edge, tPlate, FuPlate, threads, Vu, Hu, ex_load, ey_load, e_out, b_gage])
 
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.2fr_0.9fr_1fr]">

--- a/webapp/src/pages/TorsionDesign.tsx
+++ b/webapp/src/pages/TorsionDesign.tsx
@@ -28,10 +28,12 @@ export default function TorsionDesign() {
 
   const allFinite = REQUIRED.every((k) => Number.isFinite(f[k] as number))
 
+  // `f` is a fresh object every render, so memoize on its VALUE identity
+  const fKey = JSON.stringify(f)
   const r = useMemo(
     () => (allFinite ? designTorsion(f) : null),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [JSON.stringify(f), allFinite],
+    [fKey, allFinite],
   )
 
   return (


### PR DESCRIPTION
**40 errors + 5 warnings → 0 / 0.** `continue-on-error` comes off the CI lint step, and `npm run lint` now runs with `--max-warnings 0` so warnings can't accumulate again either.

## Real fixes, not suppressions

| Rule | What was actually wrong |
|---|---|
| `rules-of-hooks` | `ConstructionSchedule` called `useState` **after** an early return — hook order depended on whether the model had members. **This was a live bug**, not a style complaint. Moved up with the other hooks. |
| `static-components` | `Diagram`'s `Marker` was a component declared inside another component's body: new identity every render, remounting its subtree. Now a plain `marker(i, place)` render helper. |
| `refs` (×3) | `ModeShapePlayer` and `useCalcResult` wrote `ref.current` during render. Both moved into effects — the latest-ref pattern, written after commit. |
| `set-state-in-effect` (×2) | `CommandPalette` reset its state in an effect keyed on `open`. Now mounted conditionally (`{open && <CommandPalette …/>}`), so a fresh mount gives fresh state; the query→selection reset uses React's documented adjust-during-render pattern. |
| `use-memo` (×4) | Four pages depended on an inline `JSON.stringify(f)`. The key is hoisted to a named `fKey`/`dKey`. |
| `only-export-components` (×5) | Split non-component exports out of files that also export components (Fast Refresh): `sanitizeTex` → `lib/tex.ts`, `usePaletteHotkey` → `lib/usePaletteHotkey.ts`, `kg`/`m3`/`m` → `lib/format.ts`. |
| `no-unused-expressions` (×7) | Ternaries used as statements in `truss`, `pileCap`, `slopeStability` rewritten as if/else. |
| `preserve-manual-memoization` (×2) | `dataOffset` memoized so the compiler can prove it stable. |
| the rest | `no-useless-escape`, `prefer-const`, `no-useless-assignment`, and all five `exhaustive-deps` warnings (ref captured for cleanup in `useSolver`, missing deps in `FoundationDesign`, `supplyInput` memoized in `PlumbingDesign`, unused dep dropped in `SteelDesign`). |

## The three suppressions I did keep

Each carries its reason inline:

- `FitView` — the three.js camera is an external mutable object owned by the r3f renderer, not React state. Repositioning it imperatively is the entire purpose of the component.
- `ModeShapePlayer` — per-frame `BufferAttribute` writes. Re-rendering 60× a second to animate a mode shape is exactly what this avoids.
- `useCalcResult` — `setLoading(true)` **is** the debounce entry; the trigger is a deps change, so there is no value to derive it from.

`@typescript-eslint/no-unused-vars` is also configured to ignore `_`-prefixed names — the conventional "deliberately discarded" marker, most often the omitted key of an object rest-destructure.

## Verification

`npm test` **1594 passing**, `npx tsc -b` clean, `npm run build` clean, `npm run lint` clean at `--max-warnings 0`.

Because several of these changed component structure rather than just text, I drove the affected UI headlessly:

- **Command palette** — opens on ⌘K, filters (18 rows for "beam"), arrow keys move the selection, Enter navigates, and the query is empty on re-open (the mount-reset behaviour that replaced the effect).
- **Diagram markers** — 12 extrema labels render across the member force diagrams.
- **Mode-shape player** — modal analysis runs, selecting a mode animates it, no errors.
- **Construction schedule** — renders after Design all: 30.8 d expected duration, 16 activities / 14 critical, editable critical-path diagram, correct un-linked button label.
- **Moved formatters** — all five estimate pages still show their kg/m³ units.
- **Plumbing / foundation / steel / schedule** pages render with no console or page errors.

## One thing I did NOT change

`beamSolution.ts` / `columnSolution.ts` joined bar layers with `',\ '`. In a plain string literal that is simply `', '` — the LaTeX thin space was never reaching KaTeX, despite the surrounding `String.raw` template. I kept the rendering byte-identical rather than silently changing output in a lint PR. If the thin space was intended, that's a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_