### PR TITLE
Link the favicon that already ships

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Civil Engineering</title>
   </head>
   <body>


### PR DESCRIPTION
One line in `webapp/index.html`.

`webapp/public/favicon.svg` has always been built into `dist`, but `index.html` never referenced it. With no icon link the browser falls back to requesting `/favicon.ico`, which doesn't exist — so **every page load logged a 404 and an unhandled `TypeError: Failed to fetch`**.

## Verified in a real browser, before and after

- **Before:** both errors on every load. I'd already confirmed these weren't introduced by recent work by building and running `main` the same way while checking #454.
- **After:** `favicon.svg` returns **200** and the console reports `errors: none` — both the 404 and the unhandled rejection are gone.

`npm test` 1751 passing · `npx tsc -b` · `npm run build` clean.

## A correction

When I flagged this in earlier PRs I said `/vite.svg` shipped unreferenced. That was wrong — there is no `vite.svg`. It returned 200 only because `vite preview` serves the SPA fallback for unknown paths, so my probe was reading `index.html`. The unreferenced asset was `favicon.svg` all along; the fix is the same, but the reasoning I gave for it wasn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_