### PR TITLE
Settlement page — /settlement

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1041,3 +1041,36 @@ pre-existing.
   intensities, because Newmark adds a0·M to the tangent diagonal and
   regularises it. It shares `assembleFrame` but keeps its own Newton loop, and
   it was deliberately left unchanged.
+
+## Backlog closeout (PRs #457–#459, July 2026)
+
+- **#457 — T-section gross & cracked properties** for the §424.2 deflection
+  check, removing the conservatism #446 recorded as follow-up. The true T sits
+  BETWEEN the two rectangles people substitute for it: web-only 0.61·Ig (what
+  #446 used) and full-depth-at-bf 2.0·Ig (what #446 rejected). Hogging is
+  handled separately — the flange is then in tension and cracked, so a T-beam
+  over a support is a rectangular beam — and Mcr's yt now follows the governing
+  moment's sign. Threaded through `pipeline` from the same effective flange the
+  design already computes.
+
+- **#458 — `engine/settlement.ts`** (P4 #12, first half): Boussinesq stress
+  distribution, elastic and Schmertmann immediate settlement, Terzaghi 1-D
+  consolidation with the recompression / virgin / crossing branches, and U ↔ Tv.
+  `validation.ts`: `consolidation-nc`, `consolidation-tv90`.
+
+- **#459 — the `/settlement` page**, following the #430/#431 engine-then-page
+  split. Editable layer table, Boussinesq-vs-2:1 stress profile, per-layer
+  branch and contribution. Documented in the `/docs` catalogue in the same PR.
+
+**Two judgement calls worth remembering from #458.** The Tv expressions are the
+published closed-form FITS to Terzaghi's series, not the series: 0.1963 vs the
+tabulated 0.197 at U = 50%, and a 1.3% step between branches at U = 60%. My
+first docstring claimed they "meet by construction" — false, now stated and
+tested. And the Boussinesq table value is published to four decimals, so it
+cannot meet `validation.ts`'s 0.01% gate; that comparison stays in the unit test
+at the precision the reference carries rather than the gate being loosened.
+
+**Remaining from P4 #12:** laterally loaded piles (Broms / p-y). Nothing else on
+the recorded backlog is open except the `,\ ` LaTeX thin-space question in
+`beamSolution`/`columnSolution`, which changes rendered output and needs the
+user's call.

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -30,6 +30,7 @@ import StairDesign from './pages/StairDesign'
 import WoodSlab from './pages/WoodSlab'
 import Micropile from './pages/Micropile'
 import SlopeStability from './pages/SlopeStability'
+import Settlement from './pages/Settlement'
 import RockAnchor from './pages/RockAnchor'
 import SeismicWizard from './pages/SeismicWizard'
 import WaterTank from './pages/WaterTank'
@@ -97,6 +98,7 @@ export default function App() {
         <Route path="/wood-slab" element={<WoodSlab />} />
         <Route path="/micropile" element={<Micropile />} />
         <Route path="/slope" element={<SlopeStability />} />
+        <Route path="/settlement" element={<Settlement />} />
         <Route path="/rock-anchor" element={<RockAnchor />} />
         <Route path="/seismic-wizard" element={<SeismicWizard />} />
         <Route path="/water-tank" element={<WaterTank />} />

--- a/webapp/src/lib/docsContentAnalysis.ts
+++ b/webapp/src/lib/docsContentAnalysis.ts
@@ -195,6 +195,76 @@ export const ANALYSIS_TOOLS: DocTool[] = [
     ],
   },
   {
+    id: 'settlement',
+    name: 'Settlement',
+    route: '/settlement',
+    group: 'Foundations & geotechnical',
+    summary: 'How far a footing will settle and how long it will take — immediate plus primary consolidation on a layered profile.',
+    basis: 'Boussinesq stress distribution; Terzaghi one-dimensional consolidation; Schmertmann strain influence.',
+    sections: [
+      {
+        id: 'settle-footing',
+        title: 'Footing & groundwater',
+        body: 'Bearing capacity asks whether the soil will fail; this asks how far it will move. On compressible '
+          + 'ground the settlement check usually governs, and it is the one a client notices.',
+        controls: [
+          { kind: 'field', name: 'Bearing pressure q', unit: 'kPa', what: 'Net pressure applied at the founding level. Everything below scales with it, and it is the Δp Schmertmann uses.' },
+          { kind: 'field', name: 'Width B / Length L', unit: 'm', what: 'Plan dimensions. They set how deep the stress bulb reaches — a wide footing stresses soil far below a narrow one at the same pressure, which is why a raft can settle more than a pad carrying the same load.' },
+          { kind: 'field', name: 'Founding depth Df', unit: 'm', what: 'Depth of the base below ground. Soil above it is excluded from the consolidation sum, and it sets the overburden relief in Schmertmann\u2019s C₁.' },
+          { kind: 'field', name: 'Water table', unit: 'm', what: 'Depth to groundwater. Below it the saturated unit weight applies and pore pressure is subtracted, so the effective stress driving consolidation falls.' },
+          { kind: 'field', name: 'Soil modulus Es', unit: 'kPa', what: 'Deformation modulus for the immediate settlement — used by both the elastic formula and the Schmertmann sublayers.' },
+          { kind: 'field', name: 'Poisson ν', what: 'Poisson\u2019s ratio in the elastic settlement, through the (1−ν²) term.' },
+          { kind: 'field', name: 'Time horizon', unit: 'yr', what: 'When to report the degree of consolidation, and the elapsed time in Schmertmann\u2019s creep factor C₂.' },
+        ],
+      },
+      {
+        id: 'settle-profile',
+        title: 'Soil profile',
+        body: 'One row per layer, top down. Every field is editable in place.',
+        controls: [
+          { kind: 'field', name: 'H', unit: 'm', what: 'Layer thickness. Also sets the drainage path — half the thickness when both faces drain.' },
+          { kind: 'field', name: 'γ / γsat', unit: 'kN/m³', what: 'Bulk unit weight above the water table and saturated below it; together they build the effective overburden.' },
+          { kind: 'field', name: 'e₀', what: 'Initial void ratio. Leave at zero for a layer that does not consolidate — it is then carried for overburden only.' },
+          { kind: 'field', name: 'Cc', what: 'Virgin compression index. Zero means the layer contributes no consolidation settlement. Cr defaults to Cc/6 unless set explicitly.' },
+          { kind: 'field', name: 'σ′p', unit: 'kPa', what: 'Preconsolidation pressure. Zero means normally consolidated. This is the single most consequential input: charging an overconsolidated crust virgin compression it will never see overestimates its settlement several-fold.' },
+          { kind: 'field', name: 'cv', unit: 'm²/yr', what: 'Coefficient of consolidation — sets how fast, not how much. Without it the time answers read "cv not given" rather than guessing.' },
+        ],
+      },
+      {
+        id: 'settle-stress',
+        title: 'Stress increase below the footing',
+        controls: [
+          { kind: 'output', name: 'Boussinesq curve', what: 'Δσ against depth at the footing centre, where stress and settlement peak. This is what the consolidation sum actually integrates.' },
+          { kind: 'output', name: '2:1 spread curve', what: 'The hand-check rule, shown for comparison only. It is the average over the spread area rather than the centre peak, so it plots below the Boussinesq curve and the two converge with depth.' },
+        ],
+      },
+      {
+        id: 'settle-results',
+        title: 'Settlement results',
+        controls: [
+          { kind: 'output', name: 'Immediate — elastic', unit: 'mm', what: 'Se = q·B·(1−ν²)·If/Es, the quick closed-form estimate.' },
+          { kind: 'output', name: 'Immediate — Schmertmann', unit: 'mm', what: 'Strain-influence method, the one to prefer on sands: it places the peak strain below the footing (about B/2 for a square) rather than at the surface, and reports the C₁ depth-relief and C₂ creep factors it used.' },
+          { kind: 'output', name: 'Primary consolidation', unit: 'mm', what: 'Terzaghi settlement summed over the layers, each sliced twenty ways so the stress increase is integrated rather than sampled at mid-height.' },
+          { kind: 'output', name: 'Total', unit: 'mm', what: 'Elastic plus consolidation, flagged against the 25 mm figure usually taken as the limit for an isolated footing.' },
+          { kind: 'output', name: 'Degree of consolidation', unit: '%', what: 'How much of the primary settlement has occurred by the time horizon, governed by the layer contributing the most settlement.' },
+          { kind: 'output', name: 'Time to 90% consolidation', unit: 'yr', what: 'From t = Tv·H_dr²/cv. Single-face drainage takes four times as long as double, since the path doubles and time goes as its square.' },
+        ],
+      },
+      {
+        id: 'settle-layers',
+        title: 'Consolidation by layer',
+        controls: [
+          { kind: 'output', name: 'σ′₀ / Δσ / σ′p', unit: 'kPa', what: 'Effective overburden, stress increase and preconsolidation pressure at the layer mid-height — the three numbers that decide which branch applies.' },
+          { kind: 'output', name: 'Branch', what: 'Which part of the e–log σ′ curve was used: recompression while the final stress stays below σ′p, virgin once past it, both when the increment crosses σ′p, or none for a layer with no compressibility data.' },
+          { kind: 'output', name: 'Sc', unit: 'mm', what: 'That layer\u2019s contribution, so the governing layer is visible rather than buried in a total.' },
+        ],
+        notes: [
+          'The time factors are the standard closed-form fits to Terzaghi\u2019s Fourier series, accurate to about 1% — not the series itself. The two branches differ by 1.3% where they meet at 60% consolidation.',
+        ],
+      },
+    ],
+  },
+  {
     id: 'slope-stability',
     name: 'Slope Stability',
     route: '/slope',

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -43,6 +43,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/rock-anchor',      name: 'Rock Anchor',      sub: 'PTI · tendon · bond',      group: 'Geotechnical' },
       { to: '/shotcrete-facing', name: 'Shotcrete Facing', sub: 'FHWA · flexure · punching', group: 'Geotechnical' },
       { to: '/slope',            name: 'Slope Stability',  sub: 'Slices · Bishop/Fellenius/Janbu', group: 'Geotechnical' },
+      { to: '/settlement',       name: 'Settlement',       sub: 'Boussinesq · Terzaghi · Schmertmann', group: 'Geotechnical' },
       { to: '/seismic-wizard',   name: 'Seismic Wizard',   sub: 'NSCP 208 Ca/Cv/I/R',       group: 'Seismic & Loads' },
       { to: '/load-combinations', name: 'Load Combinations', sub: 'NSCP 2015 §203.3 LRFD',  group: 'Seismic & Loads' },
       { to: '/wood-slab',        name: 'Wood Slab',        sub: 'Deck-on-joist · NDS §3 / NSCP §6', group: 'Timber' },

--- a/webapp/src/pages/Settlement.tsx
+++ b/webapp/src/pages/Settlement.tsx
@@ -1,0 +1,249 @@
+import { useMemo, useState } from 'react'
+import { ReportControls } from '../components/ReportControls'
+import {
+  consolidationSettlement, elasticSettlement, schmertmannSettlement,
+  effectiveStress, stressUnderRect, stress2to1,
+  timeToConsolidation, consolidationAfter, drainagePath,
+  type SoilLayer,
+} from '../engine/settlement'
+
+function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
+const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
+const f1 = (n: number) => (Number.isFinite(n) ? n.toFixed(1) : '—')
+const f0 = (n: number) => (Number.isFinite(n) ? Math.round(n).toString() : '—')
+
+function Field({ label, value, onChange, unit, step = 'any' }: {
+  label: string; value: number; onChange: (v: number) => void; unit?: string; step?: string
+}) {
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="mb-1 font-medium text-slate-600">{label}{unit ? ` (${unit})` : ''}</span>
+      <input type="number" step={step} value={value} onChange={(e) => onChange(num(e.target.value))}
+        className="rounded-md border border-slate-300 px-2.5 py-1.5" />
+    </label>
+  )
+}
+
+function Out({ label, value, ok, sub }: { label: string; value: string; ok?: boolean; sub?: string }) {
+  return (
+    <div className="flex items-baseline justify-between border-t border-slate-100 py-1 text-sm">
+      <span className="text-slate-500">{label}{sub && <span className="ml-1 text-[11px] text-slate-400">{sub}</span>}</span>
+      <span className={`font-mono font-medium ${ok === undefined ? 'text-slate-800' : ok ? 'text-emerald-600' : 'text-red-600'}`}>{value}</span>
+    </div>
+  )
+}
+
+/** Stress-bulb profile: Δσ against depth, Boussinesq vs the 2:1 hand rule. */
+function StressProfile({ q, B, L, Df, zMax }: { q: number; B: number; L: number; Df: number; zMax: number }) {
+  const W = 460, H = 260, padL = 46, padR = 90, padT = 12, padB = 34
+  const n = 60
+  const pts = Array.from({ length: n + 1 }, (_, k) => {
+    const z = (zMax * k) / n
+    return { z, b: stressUnderRect(q, B, L, z), t: stress2to1(q, B, L, z) }
+  })
+  const sMax = Math.max(q, 1e-9)
+  const X = (s: number) => padL + ((W - padL - padR) * s) / sMax
+  const Y = (z: number) => padT + ((H - padT - padB) * z) / Math.max(zMax, 1e-9)
+  const path = (key: 'b' | 't') =>
+    pts.map((p, i) => `${i ? 'L' : 'M'}${X(p[key]).toFixed(1)},${Y(p.z).toFixed(1)}`).join(' ')
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="w-full rounded-lg border border-slate-200 bg-white" style={{ maxHeight: 280 }}>
+      <line x1={padL} y1={padT} x2={padL} y2={H - padB} stroke="#475569" strokeWidth={1.2} />
+      <line x1={padL} y1={padT} x2={W - padR} y2={padT} stroke="#475569" strokeWidth={1.2} />
+      {[0, 0.5, 1].map((f) => (
+        <g key={f}>
+          <text x={X(sMax * f)} y={padT - 3} fontSize={9} fill="#64748b" textAnchor="middle">{f0(sMax * f)}</text>
+          <line x1={X(sMax * f)} y1={padT} x2={X(sMax * f)} y2={H - padB} stroke="#e2e8f0" strokeWidth={0.7} />
+        </g>
+      ))}
+      {[0, 0.5, 1].map((f) => (
+        <text key={`z${f}`} x={padL - 5} y={Y(zMax * f) + 3} fontSize={9} fill="#64748b" textAnchor="end">{f1(zMax * f)}</text>
+      ))}
+      {Df > 0 && Df < zMax && (
+        <g>
+          <line x1={padL} y1={Y(Df)} x2={W - padR} y2={Y(Df)} stroke="#f59e0b" strokeWidth={1} strokeDasharray="4 3" />
+          <text x={W - padR + 4} y={Y(Df) + 3} fontSize={8.5} fill="#b45309">founding level</text>
+        </g>
+      )}
+      <path d={path('t')} fill="none" stroke="#94a3b8" strokeWidth={1.6} strokeDasharray="5 3" />
+      <path d={path('b')} fill="none" stroke="#0056b3" strokeWidth={2} />
+      <g fontSize={9}>
+        <rect x={W - padR + 4} y={padT + 10} width={10} height={2.5} fill="#0056b3" />
+        <text x={W - padR + 18} y={padT + 15} fill="#334155">Boussinesq</text>
+        <rect x={W - padR + 4} y={padT + 26} width={10} height={2.5} fill="#94a3b8" />
+        <text x={W - padR + 18} y={padT + 31} fill="#334155">2:1 spread</text>
+      </g>
+      <text x={(padL + W - padR) / 2} y={H - 6} fontSize={9.5} fill="#334155" textAnchor="middle" fontWeight={700}>
+        Δσ (kPa)
+      </text>
+      <text x={11} y={H / 2} fontSize={9.5} fill="#334155" textAnchor="middle" fontWeight={700}
+        transform={`rotate(-90 11 ${H / 2})`}>depth below base (m)</text>
+    </svg>
+  )
+}
+
+const LAYER_DEFAULTS: SoilLayer[] = [
+  { name: 'Sand fill', H: 3, gamma: 18, gammaSat: 20 },
+  { name: 'Soft clay', H: 6, gamma: 17, gammaSat: 18, e0: 1.1, Cc: 0.35, cv: 1.5, sigmaP: 90 },
+  { name: 'Stiff clay', H: 5, gamma: 19, gammaSat: 20, e0: 0.7, Cc: 0.18, cv: 4, sigmaP: 300 },
+]
+
+export default function Settlement() {
+  const [q, setQ] = useState(120)
+  const [B, setB] = useState(2.5)
+  const [L, setL] = useState(3.5)
+  const [Df, setDf] = useState(1.5)
+  const [wt, setWt] = useState(3)
+  const [Es, setEs] = useState(25000)
+  const [nu, setNu] = useState(0.3)
+  const [years, setYears] = useState(10)
+  const [layers, setLayers] = useState<SoilLayer[]>(LAYER_DEFAULTS)
+
+  const setLayer = (i: number, patch: Partial<SoilLayer>) =>
+    setLayers((ls) => ls.map((l, k) => (k === i ? { ...l, ...patch } : l)))
+
+  const cons = useMemo(
+    () => consolidationSettlement({ layers, q, B, L, Df, waterTable: wt, slices: 20 }),
+    [layers, q, B, L, Df, wt],
+  )
+  const elastic = useMemo(() => elasticSettlement({ q, B, L, Es, nu }), [q, B, L, Es, nu])
+  const schmert = useMemo(() => schmertmannSettlement({
+    dp: q, B, L, sigma0: effectiveStress(layers, Df, wt), gamma: layers[0]?.gamma ?? 18,
+    layers: Array.from({ length: 40 }, () => ({ H: 0.2, Es })), years,
+  }), [q, B, L, Df, wt, layers, Es, years])
+
+  const totalDepth = layers.reduce((a, l) => a + l.H, 0)
+  const total = elastic + cons.total
+  // the layer that dominates primary consolidation drives the time estimate
+  const govLayer = cons.layers.reduce(
+    (best, l, i) => (l.settlement > (cons.layers[best]?.settlement ?? -1) ? i : best), 0)
+  const govSoil = layers[govLayer]
+  const t90 = govSoil ? timeToConsolidation(govSoil, 0.9) : Infinity
+  const Uat = govSoil ? consolidationAfter(govSoil, years) : 0
+
+  return (
+    <main className="mx-auto max-w-3xl px-5 py-10">
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
+      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Foundation settlement</h1>
+      <ReportControls title="Settlement Report" badges={['Boussinesq', 'Terzaghi', 'Schmertmann']} />
+      <p className="mt-2 text-sm text-slate-600">
+        Immediate (elastic and Schmertmann) plus primary consolidation settlement of a rectangular footing on a
+        layered profile. Stress increase by Boussinesq; consolidation layer by layer with the overconsolidated
+        branch handled separately, so a stiff crust is not charged virgin compression it will never see.
+      </p>
+
+      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Footing &amp; groundwater</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Field label="Bearing pressure q" unit="kPa" value={q} onChange={setQ} />
+          <Field label="Width B" unit="m" value={B} onChange={setB} step="0.1" />
+          <Field label="Length L" unit="m" value={L} onChange={setL} step="0.1" />
+          <Field label="Founding depth Df" unit="m" value={Df} onChange={setDf} step="0.1" />
+          <Field label="Water table" unit="m" value={wt} onChange={setWt} step="0.5" />
+          <Field label="Soil modulus Es" unit="kPa" value={Es} onChange={setEs} step="1000" />
+          <Field label="Poisson ν" value={nu} onChange={setNu} step="0.05" />
+          <Field label="Time horizon" unit="yr" value={years} onChange={setYears} step="1" />
+        </div>
+      </section>
+
+      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Soil profile</h2>
+        <div className="overflow-x-auto">
+          <table className="w-full text-right text-[12px]">
+            <thead className="text-slate-500">
+              <tr className="border-b border-slate-200">
+                <th className="py-1 pr-2 text-left">Layer</th>
+                <th className="py-1 pr-2">H (m)</th><th className="py-1 pr-2">γ</th><th className="py-1 pr-2">γsat</th>
+                <th className="py-1 pr-2">e₀</th><th className="py-1 pr-2">Cc</th>
+                <th className="py-1 pr-2">σ′p (kPa)</th><th className="py-1 pr-2">cv (m²/yr)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {layers.map((l, i) => (
+                <tr key={i} className="border-b border-slate-100">
+                  <td className="py-1 pr-2 text-left text-slate-700">{l.name ?? `Layer ${i + 1}`}</td>
+                  {([
+                    ['H', l.H], ['gamma', l.gamma], ['gammaSat', l.gammaSat ?? l.gamma],
+                    ['e0', l.e0 ?? 0], ['Cc', l.Cc ?? 0], ['sigmaP', l.sigmaP ?? 0], ['cv', l.cv ?? 0],
+                  ] as const).map(([key, v]) => (
+                    <td key={key} className="py-0.5 pr-2">
+                      <input type="number" step="any" value={v}
+                        onChange={(e) => setLayer(i, { [key]: num(e.target.value) } as Partial<SoilLayer>)}
+                        className="w-16 rounded border border-slate-200 px-1 py-0.5 text-right font-mono" />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p className="mt-2 text-[11px] text-slate-500">
+          Leave e₀ or Cc at zero for a layer that does not consolidate (granular fill, rock) — it is then carried
+          for overburden only. σ′p at zero means normally consolidated. Cr defaults to Cc/6 unless you set it.
+        </p>
+      </section>
+
+      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Stress increase below the footing</h2>
+        <StressProfile q={q} B={B} L={L} Df={Df} zMax={Math.max(totalDepth, 2 * B)} />
+        <p className="mt-2 text-[11px] text-slate-500">
+          Boussinesq at the footing CENTRE, where the stress and therefore the settlement peak. The 2:1 rule is the
+          average over the spread area, so it sits below the centre value and the two converge with depth.
+        </p>
+      </section>
+
+      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-2 text-[1.05rem] font-bold text-[#0056b3]">Settlement</h2>
+        <Out label="Immediate — elastic" value={`${f1(elastic)} mm`} sub="q·B·(1−ν²)·If/Es" />
+        <Out label="Immediate — Schmertmann" value={`${f1(schmert.settlement)} mm`}
+          sub={`C₁ ${f2(schmert.C1)} · C₂ ${f2(schmert.C2)} · Izp ${f2(schmert.Izp)}`} />
+        <Out label="Primary consolidation" value={`${f1(cons.total)} mm`} sub={`${layers.length} layers`} />
+        <Out label="Total (elastic + consolidation)" value={`${f1(total)} mm`}
+          ok={total <= 25} sub="25 mm is the usual limit for an isolated footing" />
+        <Out label={`Degree of consolidation at ${f0(years)} yr`} value={`${f0(Uat * 100)} %`}
+          sub={govSoil ? `governed by ${govSoil.name ?? 'the thickest contributor'}` : undefined} />
+        <Out label="Time to 90% consolidation"
+          value={Number.isFinite(t90) ? `${f1(t90)} yr` : 'cv not given'}
+          sub={govSoil ? `drainage path ${f2(drainagePath(govSoil))} m` : undefined} />
+      </section>
+
+      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-2 text-[1.05rem] font-bold text-[#0056b3]">Consolidation by layer</h2>
+        <div className="overflow-x-auto">
+          <table className="w-full text-right text-[12px]">
+            <thead className="text-slate-500">
+              <tr className="border-b border-slate-200">
+                <th className="py-1 pr-3 text-left">Layer</th><th className="py-1 pr-3">z mid (m)</th>
+                <th className="py-1 pr-3">σ′₀ (kPa)</th><th className="py-1 pr-3">Δσ (kPa)</th>
+                <th className="py-1 pr-3">σ′p (kPa)</th><th className="py-1 pr-3 text-left">Branch</th>
+                <th className="py-1 pr-3">Sc (mm)</th>
+              </tr>
+            </thead>
+            <tbody className="font-mono">
+              {cons.layers.map((l) => (
+                <tr key={l.name} className="border-b border-slate-100">
+                  <td className="py-0.5 pr-3 text-left">{l.name}</td>
+                  <td className="py-0.5 pr-3">{f2(l.zMid)}</td>
+                  <td className="py-0.5 pr-3">{f1(l.sigma0)}</td>
+                  <td className="py-0.5 pr-3">{f1(l.dSigma)}</td>
+                  <td className="py-0.5 pr-3">{f1(l.sigmaP)}</td>
+                  <td className={`py-0.5 pr-3 text-left ${l.branch === 'none' ? 'text-slate-400' : 'text-slate-600'}`}>
+                    {l.branch}
+                  </td>
+                  <td className="py-0.5 pr-3 font-semibold">{f1(l.settlement)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p className="mt-2 text-[10px] text-slate-500">
+          Sc = Cc·H/(1+e₀)·log₁₀(σ′f/σ′₀) on the virgin branch, Cr in place of Cc while σ′f stays below σ′p, and
+          both terms when the increment crosses σ′p. Each layer is sliced 20 ways so Δσ is integrated rather than
+          sampled at mid-height. Time factors are the standard closed-form fits to Terzaghi&rsquo;s series, good to
+          about 1% — not the series itself.
+        </p>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
The page for the engine in [#458](https://github.com/BitLess246/civilEngineering/pull/458), following the same engine-then-page split the slope-stability work used ([#430](https://github.com/BitLess246/civilEngineering/pull/430)/[#431](https://github.com/BitLess246/civilEngineering/pull/431)).

## What's on it

- **Editable layer table** — thickness, bulk and saturated unit weights, e₀, Cc, σ′p, cv, edited in place.
- **Stress profile** plotting Boussinesq against the 2:1 hand rule, so the difference between a *centre peak* and a *spread average* is visible rather than asserted in a comment.
- **Headline settlements** — elastic, Schmertmann (with the C₁, C₂ and Izp it used), primary consolidation, total against the 25 mm figure, degree of consolidation at the time horizon and time to 90%.
- **Per-layer breakdown** showing **which branch** of the e–log σ′ curve each layer used and what it contributed. Burying that in a total is exactly how an overconsolidated crust gets charged virgin compression without anyone noticing.

Registered in the tool list and documented in the `/docs` catalogue **in the same PR** — the docs guard only catches a missing *route*, not a missing *control*, so the catalogue has to be updated deliberately or #450's claim quietly goes stale.

## Verified in the browser, not asserted

Default profile (2.5 × 3.5 m footing at 1.5 m, 120 kPa, soft clay over stiff clay):

| | |
|---|---|
| Immediate — elastic | 13.1 mm |
| Immediate — Schmertmann | 10.6 mm (C₁ 0.89, C₂ 1.40, Izp 0.65) |
| Primary consolidation | 78.7 mm |
| Time to 90% | 5.1 yr, drainage path 3.00 m |

Two things make those numbers trustworthy rather than merely present:

- **The time checks by hand:** Tv(0.9) = 0.848 × (3 m)² / (1.5 m²/yr) = 5.09 yr.
- **The two immediate methods agree to ~25%** — they share no code path, so landing on the same order is a real cross-check on both.

Inputs recompute live; the per-layer table correctly shows `recompression` for the σ′p = 90 kPa clay and `none` for the granular fill. No console errors — the favicon fix from [#455](https://github.com/BitLess246/civilEngineering/pull/455) means the console is genuinely clean now, so an error appearing here would mean something.

`npm test` 1794 passing · `npx tsc -b` · `npm run lint` · `npm run build` all clean, each on its own exit code.

## Remaining

Laterally loaded piles (Broms / p-y) closes out P4 #12, and is the last open item on the recorded backlog apart from the LaTeX thin-space question that needs your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_