### PR TITLE
Lateral pile page — /lateral-pile

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1090,5 +1090,8 @@ at the precision the reference carries rather than the gate being loosened.
 
 **The recorded backlog is now clear** apart from the `,\ ` LaTeX thin-space
 question in `beamSolution`/`columnSolution`, which changes rendered output and
-needs the user's call. A `/lateral-pile` page would be the natural follow-up if
-the engine should be reachable from the UI.
+needs the user's call. - **#461 — the `/lateral-pile` page.** Broms capacity card (both mechanisms,
+  with the governing one named) beside a p-y working-load panel showing
+  deflection / moment / reaction profiles, head deflection against the 25 mm
+  yardstick, and the solver's iteration count and residual. Documented in the
+  `/docs` catalogue in the same PR.

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -31,6 +31,7 @@ import WoodSlab from './pages/WoodSlab'
 import Micropile from './pages/Micropile'
 import SlopeStability from './pages/SlopeStability'
 import Settlement from './pages/Settlement'
+import LateralPile from './pages/LateralPile'
 import RockAnchor from './pages/RockAnchor'
 import SeismicWizard from './pages/SeismicWizard'
 import WaterTank from './pages/WaterTank'
@@ -99,6 +100,7 @@ export default function App() {
         <Route path="/micropile" element={<Micropile />} />
         <Route path="/slope" element={<SlopeStability />} />
         <Route path="/settlement" element={<Settlement />} />
+        <Route path="/lateral-pile" element={<LateralPile />} />
         <Route path="/rock-anchor" element={<RockAnchor />} />
         <Route path="/seismic-wizard" element={<SeismicWizard />} />
         <Route path="/water-tank" element={<WaterTank />} />

--- a/webapp/src/lib/docsContentAnalysis.ts
+++ b/webapp/src/lib/docsContentAnalysis.ts
@@ -195,6 +195,66 @@ export const ANALYSIS_TOOLS: DocTool[] = [
     ],
   },
   {
+    id: 'lateral-pile',
+    name: 'Lateral Pile',
+    route: '/lateral-pile',
+    group: 'Foundations & geotechnical',
+    summary: 'Ultimate lateral capacity and working-load response of a single pile, by Broms and by p-y analysis.',
+    basis: 'Broms (1964) limit equilibrium; Matlock soft-clay and API RP 2A sand p-y curves.',
+    sections: [
+      {
+        id: 'lp-pile',
+        title: 'Pile & loading',
+        body: 'Two methods answer two different questions and are both shown. Broms gives the ultimate load and '
+          + 'which mechanism fails first; p-y gives deflection and the moment diagram at a working load, which is '
+          + 'what a serviceability check needs and Broms cannot provide.',
+        controls: [
+          { kind: 'field', name: 'Embedded length L', unit: 'm', what: 'Length below ground. Beyond the pile\u2019s active length extra depth stops changing the head response — that is the signature of a "long" pile.' },
+          { kind: 'field', name: 'Diameter D', unit: 'm', what: 'Pile diameter or width. Scales the soil resistance directly, and sets the reference deflection y50 in the clay curve.' },
+          { kind: 'field', name: 'Rigidity EI', unit: 'kN·m²', what: 'Flexural rigidity of the pile section. A stiffer pile deflects less and carries more moment over a shorter depth.' },
+          { kind: 'field', name: 'Yield moment My', unit: 'kN·m', what: 'Plastic moment of the section. Broms compares it against the soil mechanism to decide which one governs, so a low My turns a short pile into a hinge failure.' },
+          { kind: 'field', name: 'Lateral load H', unit: 'kN', what: 'Working lateral load for the p-y analysis. Broms is independent of it — the ratio H/Hu is reported separately.' },
+          { kind: 'field', name: 'Load height e', unit: 'm', what: 'Height of the load above ground. It adds an overturning moment at the head, which reduces capacity and increases deflection. Ignored for a fixed head, which cannot rotate.' },
+          { kind: 'choice', name: 'Head condition', what: 'Free lets the head rotate; fixed represents a pile capped into a rigid cap. A fixed head is stronger and deflects less, and in Broms it allows a second plastic hinge at the head.' },
+          { kind: 'choice', name: 'Soil type', what: 'Clay uses the 9·cu·d Broms resistance with Matlock\u2019s p-y curve; sand uses 3·Kp·γ·z·d with the API RP 2A curve. The choice switches both methods together.' },
+        ],
+      },
+      {
+        id: 'lp-soil',
+        title: 'Soil',
+        controls: [
+          { kind: 'field', name: "Unit weight γ′", unit: 'kN/m³', what: 'Effective unit weight, which builds the confining stress down the pile.' },
+          { kind: 'field', name: 'Undrained cu', unit: 'kPa', what: 'Clay only. Sets both the Broms 9·cu·d resistance and the Matlock ultimate reaction.' },
+          { kind: 'field', name: 'Strain ε₅₀', what: 'Clay only. Strain at half the failure stress, which fixes y50 = 2.5·ε₅₀·D — the deflection at which half the ultimate reaction is mobilised. Larger values mean a softer, more ductile response.' },
+          { kind: 'field', name: "Friction φ′", unit: '°', what: 'Sand only. Drives Kp in Broms and the API wedge coefficients in the p-y curve.' },
+          { kind: 'field', name: 'Subgrade k', unit: 'kN/m³', what: 'Sand only. Initial modulus of subgrade reaction, giving the p-y curve its slope k·z at the origin.' },
+        ],
+      },
+      {
+        id: 'lp-broms',
+        title: 'Ultimate capacity — Broms',
+        controls: [
+          { kind: 'output', name: 'Ultimate lateral load Hu', unit: 'kN', what: 'The governing capacity — always the lower of the two mechanisms below. An ultimate value: apply your own factor of safety, typically 2 to 3 for a working load.' },
+          { kind: 'output', name: 'Short-pile (soil) capacity', unit: 'kN', what: 'Load at which the soil fails and the pile rotates as a rigid body.' },
+          { kind: 'output', name: 'Long-pile (hinge) capacity', unit: 'kN', what: 'Load at which a plastic hinge forms in the pile section (two hinges when the head is fixed).' },
+          { kind: 'output', name: 'Governing mechanism', what: 'Which of the two came out lower. This is what makes a pile "short" or "long" — it is a verdict about the pile and soil together, not a length.' },
+          { kind: 'output', name: 'Applied H / Hu', what: 'Utilisation against the ultimate capacity, flagged when it exceeds 1.' },
+        ],
+      },
+      {
+        id: 'lp-py',
+        title: 'Response at working load — p-y',
+        controls: [
+          { kind: 'output', name: 'Deflection / moment / reaction profiles', what: 'Three panels down the pile: y in mm, bending moment, and mobilised soil reaction. The peak of each is printed beneath it.' },
+          { kind: 'output', name: 'Head deflection', unit: 'mm', what: 'Deflection at ground level, checked against the 25 mm figure commonly taken as the serviceability limit.' },
+          { kind: 'output', name: 'Maximum moment', unit: 'kN·m', what: 'Peak bending moment and the depth it occurs at — usually a few diameters down, not at the head, which is what sizes the reinforcement.' },
+          { kind: 'output', name: 'Moment utilisation M/My', what: 'Peak moment against the section\u2019s yield moment.' },
+          { kind: 'output', name: 'Solution', what: 'Iterations and the final residual. Reported rather than hidden, so a solve that fell short of tolerance is visible instead of being presented as an answer.' },
+        ],
+      },
+    ],
+  },
+  {
     id: 'settlement',
     name: 'Settlement',
     route: '/settlement',

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -44,6 +44,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/shotcrete-facing', name: 'Shotcrete Facing', sub: 'FHWA · flexure · punching', group: 'Geotechnical' },
       { to: '/slope',            name: 'Slope Stability',  sub: 'Slices · Bishop/Fellenius/Janbu', group: 'Geotechnical' },
       { to: '/settlement',       name: 'Settlement',       sub: 'Boussinesq · Terzaghi · Schmertmann', group: 'Geotechnical' },
+      { to: '/lateral-pile',     name: 'Lateral Pile',     sub: 'Broms · p-y (Matlock/API)', group: 'Geotechnical' },
       { to: '/seismic-wizard',   name: 'Seismic Wizard',   sub: 'NSCP 208 Ca/Cv/I/R',       group: 'Seismic & Loads' },
       { to: '/load-combinations', name: 'Load Combinations', sub: 'NSCP 2015 §203.3 LRFD',  group: 'Seismic & Loads' },
       { to: '/wood-slab',        name: 'Wood Slab',        sub: 'Deck-on-joist · NDS §3 / NSCP §6', group: 'Timber' },

--- a/webapp/src/pages/LateralPile.tsx
+++ b/webapp/src/pages/LateralPile.tsx
@@ -1,0 +1,214 @@
+import { useMemo, useState } from 'react'
+import { ReportControls } from '../components/ReportControls'
+import {
+  bromsClay, bromsSand, pyAnalysis,
+  type PileHead, type SoilModel, type PyResult, type BromsResult,
+} from '../engine/lateralPile'
+
+function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
+const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
+const f1 = (n: number) => (Number.isFinite(n) ? n.toFixed(1) : '—')
+const f0 = (n: number) => (Number.isFinite(n) ? Math.round(n).toString() : '—')
+
+function Field({ label, value, onChange, unit, step = 'any' }: {
+  label: string; value: number; onChange: (v: number) => void; unit?: string; step?: string
+}) {
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="mb-1 font-medium text-slate-600">{label}{unit ? ` (${unit})` : ''}</span>
+      <input type="number" step={step} value={value} onChange={(e) => onChange(num(e.target.value))}
+        className="rounded-md border border-slate-300 px-2.5 py-1.5" />
+    </label>
+  )
+}
+
+function Out({ label, value, ok, sub }: { label: string; value: string; ok?: boolean; sub?: string }) {
+  return (
+    <div className="flex items-baseline justify-between border-t border-slate-100 py-1 text-sm">
+      <span className="text-slate-500">{label}{sub && <span className="ml-1 text-[11px] text-slate-400">{sub}</span>}</span>
+      <span className={`font-mono font-medium ${ok === undefined ? 'text-slate-800' : ok ? 'text-emerald-600' : 'text-red-600'}`}>{value}</span>
+    </div>
+  )
+}
+
+/** Deflection, moment and soil-reaction profiles down the pile. */
+function PyProfiles({ res, L }: { res: PyResult; L: number }) {
+  const W = 470, H = 300, padT = 18, padB = 30
+  const panelW = (W - 30) / 3
+  const series = [
+    { key: 'y' as const, title: 'y (mm)', color: '#0056b3' },
+    { key: 'moment' as const, title: 'M (kN·m)', color: '#b45309' },
+    { key: 'p' as const, title: 'p (kN/m)', color: '#0f766e' },
+  ]
+  const Y = (z: number) => padT + ((H - padT - padB) * z) / Math.max(L, 1e-9)
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="w-full rounded-lg border border-slate-200 bg-white" style={{ maxHeight: 320 }}>
+      {series.map((s, si) => {
+        const vals = res.stations.map((st) => st[s.key])
+        const m = Math.max(...vals.map(Math.abs), 1e-9)
+        const x0 = 12 + si * (panelW + 6)
+        const cx = x0 + panelW / 2
+        const X = (v: number) => cx + ((panelW / 2 - 6) * v) / m
+        const d = res.stations
+          .map((st, i) => `${i ? 'L' : 'M'}${X(st[s.key]).toFixed(1)},${Y(st.z).toFixed(1)}`).join(' ')
+        return (
+          <g key={s.key}>
+            <line x1={cx} y1={padT} x2={cx} y2={H - padB} stroke="#e2e8f0" strokeWidth={0.9} />
+            <line x1={x0} y1={padT} x2={x0 + panelW} y2={padT} stroke="#475569" strokeWidth={1} />
+            <path d={d} fill="none" stroke={s.color} strokeWidth={1.8} />
+            <text x={cx} y={11} fontSize={9} fill="#334155" textAnchor="middle" fontWeight={700}>{s.title}</text>
+            <text x={cx} y={H - 18} fontSize={8} fill="#94a3b8" textAnchor="middle">±{f1(m)}</text>
+          </g>
+        )
+      })}
+      <text x={12} y={H - 4} fontSize={8.5} fill="#64748b">z = 0</text>
+      <text x={W - 40} y={H - 4} fontSize={8.5} fill="#64748b">z = {f1(L)} m</text>
+    </svg>
+  )
+}
+
+function BromsCard({ r, title }: { r: BromsResult; title: string }) {
+  return (
+    <div className="rounded-lg border border-slate-200 p-3">
+      <p className="mb-1 text-[12px] font-bold text-slate-700">{title}</p>
+      <Out label="Ultimate lateral load Hu" value={`${f1(r.Hu)} kN`} />
+      <Out label="Short-pile (soil) capacity" value={`${f1(r.shortPile)} kN`}
+        ok={r.mode === 'short' ? false : undefined} />
+      <Out label="Long-pile (hinge) capacity" value={`${f1(r.longPile)} kN`}
+        ok={r.mode === 'long' ? false : undefined} />
+      <Out label="Governing mechanism" value={r.mode === 'short' ? 'soil failure' : 'pile hinge'} />
+      <Out label="Mmax at Hu" value={`${f1(r.Mmax)} kN·m`} sub={`at z = ${f2(r.zMax)} m`} />
+    </div>
+  )
+}
+
+export default function LateralPile() {
+  const [soilKind, setSoilKind] = useState<'clay' | 'sand'>('clay')
+  const [L, setL] = useState(12)
+  const [D, setD] = useState(0.6)
+  const [EI, setEI] = useState(180000)
+  const [My, setMy] = useState(900)
+  const [H, setH] = useState(150)
+  const [e, setE] = useState(0.5)
+  const [head, setHead] = useState<PileHead>('free')
+  // clay
+  const [cu, setCu] = useState(40)
+  const [e50, setE50] = useState(0.01)
+  // sand
+  const [phi, setPhi] = useState(33)
+  const [k, setK] = useState(25000)
+  const [gamma, setGamma] = useState(9)
+
+  const soil: SoilModel = soilKind === 'clay'
+    ? { kind: 'clay', cu, gamma, e50 }
+    : { kind: 'sand', gamma, phiDeg: phi, k }
+
+  const broms = useMemo(() => (soilKind === 'clay'
+    ? bromsClay({ L, d: D, cu, My, e, head })
+    : bromsSand({ L, d: D, gamma, phiDeg: phi, My, e, head })),
+  [soilKind, L, D, cu, My, e, head, gamma, phi])
+
+  const py = useMemo(
+    () => pyAnalysis({ L, D, EI, H, e: head === 'free' ? e : 0, head, soil, elements: 60 }),
+    [L, D, EI, H, e, head, soilKind, cu, e50, gamma, phi, k], // eslint-disable-line react-hooks/exhaustive-deps
+  )
+
+  const util = broms.Hu > 0 ? H / broms.Hu : Infinity
+  const headOK = py.yHead <= 25    // 25 mm is the usual serviceability yardstick
+
+  return (
+    <main className="mx-auto max-w-3xl px-5 py-10">
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
+      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Laterally loaded pile</h1>
+      <ReportControls title="Lateral Pile Report" badges={['Broms', 'Matlock', 'API RP 2A']} />
+      <p className="mt-2 text-sm text-slate-600">
+        Two questions, two methods. <strong>Broms</strong> gives the ultimate lateral capacity in closed form and
+        says whether the soil or the pile section fails first. <strong>p-y</strong> solves the pile as a beam on
+        nonlinear soil springs and gives what Broms cannot — head deflection, and where the maximum moment sits.
+      </p>
+
+      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Pile &amp; loading</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Field label="Embedded length L" unit="m" value={L} onChange={setL} step="0.5" />
+          <Field label="Diameter D" unit="m" value={D} onChange={setD} step="0.05" />
+          <Field label="Rigidity EI" unit="kN·m²" value={EI} onChange={setEI} step="10000" />
+          <Field label="Yield moment My" unit="kN·m" value={My} onChange={setMy} step="50" />
+          <Field label="Lateral load H" unit="kN" value={H} onChange={setH} step="10" />
+          <Field label="Load height e" unit="m" value={e} onChange={setE} step="0.25" />
+          <label className="flex flex-col text-sm">
+            <span className="mb-1 font-medium text-slate-600">Head condition</span>
+            <select value={head} onChange={(ev) => setHead(ev.target.value as PileHead)}
+              className="rounded-md border border-slate-300 px-2.5 py-1.5">
+              <option value="free">Free (rotates)</option>
+              <option value="fixed">Fixed (capped)</option>
+            </select>
+          </label>
+          <label className="flex flex-col text-sm">
+            <span className="mb-1 font-medium text-slate-600">Soil type</span>
+            <select value={soilKind} onChange={(ev) => setSoilKind(ev.target.value as 'clay' | 'sand')}
+              className="rounded-md border border-slate-300 px-2.5 py-1.5">
+              <option value="clay">Clay (Matlock)</option>
+              <option value="sand">Sand (API)</option>
+            </select>
+          </label>
+        </div>
+
+        <h2 className="mb-3 mt-5 text-[1.05rem] font-bold text-[#0056b3]">Soil</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Field label="Unit weight γ′" unit="kN/m³" value={gamma} onChange={setGamma} step="0.5" />
+          {soilKind === 'clay' ? (
+            <>
+              <Field label="Undrained cu" unit="kPa" value={cu} onChange={setCu} step="5" />
+              <Field label="Strain ε₅₀" value={e50} onChange={setE50} step="0.005" />
+            </>
+          ) : (
+            <>
+              <Field label="Friction φ′" unit="°" value={phi} onChange={setPhi} step="1" />
+              <Field label="Subgrade k" unit="kN/m³" value={k} onChange={setK} step="5000" />
+            </>
+          )}
+        </div>
+        {head === 'fixed' && (
+          <p className="mt-2 text-[11px] text-amber-700">
+            A fixed head has no free rotation, so the load height e is not used by either method.
+          </p>
+        )}
+      </section>
+
+      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Ultimate capacity — Broms</h2>
+        <BromsCard r={broms} title={soilKind === 'clay' ? 'Cohesive (9·cu·d below 1.5d)' : 'Cohesionless (3·Kp·γ·z·d)'} />
+        <div className="mt-3">
+          <Out label="Applied H / Hu" value={f2(util)} ok={util <= 1}
+            sub={util <= 1 ? 'within ultimate capacity' : 'exceeds ultimate capacity'} />
+        </div>
+        <p className="mt-2 text-[11px] text-slate-500">
+          The governing capacity is the LOWER of the two mechanisms, which is also what tells you which kind of pile
+          this is — &ldquo;short&rdquo; is a verdict, not a length. Broms is an ultimate check: apply your own factor
+          of safety, typically 2 to 3 on Hu for a working load.
+        </p>
+      </section>
+
+      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Response at working load — p-y</h2>
+        <PyProfiles res={py} L={L} />
+        <div className="mt-3">
+          <Out label="Head deflection" value={`${f2(py.yHead)} mm`} ok={headOK}
+            sub="25 mm is the usual serviceability yardstick" />
+          <Out label="Maximum moment" value={`${f1(py.Mmax)} kN·m`} sub={`at z = ${f2(py.zMmax)} m`} />
+          <Out label="Moment utilisation M/My" value={f2(My > 0 ? py.Mmax / My : Infinity)}
+            ok={My > 0 && py.Mmax <= My} />
+          <Out label="Solution" value={py.converged ? `converged in ${f0(py.iterations)} iterations` : 'did not converge'}
+            ok={py.converged} sub={`residual ${py.residual.toExponential(1)}`} />
+        </div>
+        <p className="mt-2 text-[11px] text-slate-500">
+          Clay uses Matlock&rsquo;s soft-clay curve, sand the API RP 2A sand curve. The pile is modelled as beam
+          elements on nonlinear springs and solved by Newton; the residual is reported so a solve that fell short is
+          visible rather than silently presented as an answer. Deflections are relative to the undeflected pile axis.
+        </p>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
The page for the engine in [#460](https://github.com/BitLess246/civilEngineering/pull/460), making both methods reachable from the UI.

## Why both methods are on one page

They answer different questions, and showing only one would hide that:

- **Broms** gives the ultimate load and **names which mechanism fails first** — soil or pile hinge. That verdict is the useful output, because "short pile" is a statement about the pile *and* soil together, not a length.
- **p-y** gives the working-load deflection and **where the maximum moment actually sits** — usually a few diameters down, not at the head. That's what sizes the reinforcement, and Broms cannot provide it.

The p-y panel reports its **iteration count and residual** rather than hiding them, so a solve that fell short of tolerance is visible instead of being quietly presented as an answer.

## Verified in the browser

Default clay case:

| | |
|---|---|
| Broms Hu | 390.6 kN, governed by **pile hinge** |
| Broms Mmax at Hu | 900.0 kN·m = My **exactly** |
| p-y head deflection | 24.34 mm (against the 25 mm yardstick) |
| p-y maximum moment | 302.9 kN·m at z = 3.00 m |
| Solver | converged, 9 iterations, residual 1.1e-10 |

That second row is the internal consistency check: when the hinge branch governs, the moment at Hu must equal My exactly, and it does. Switching to sand recomputes and swaps in the φ′ and k inputs. No console errors.

Registered in the tool list and documented in the `/docs` catalogue in the same PR — the docs guard only catches a missing *route*, not a missing *control*.

`npm test` 1819 passing · `npx tsc -b` · `npm run lint` · `npm run build` all clean, each on its own exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_