### PR TITLE
Subscription plans, entitlements and a pricing page

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1127,10 +1127,23 @@ account.
 NOTHING is gated. A missing env var must not brick the app behind a form that
 cannot work. Verified in a browser — `/model` stays reachable unconfigured.
 
-**Not done, and needing a decision:** subscriptions. Plans and a pricing page
-are straightforward; taking card payments is not, because a static SPA cannot
-verify a webhook. That needs a server (Supabase Edge Functions would do) and is
-its own piece of work.
+**Plans shipped in #463.** `lib/plans.ts` is pure and tested: three tiers
+(guest / free / pro), FEATURE-based entitlements rather than route-based, model
+size ceilings, and `upgradeMessage` which names the plan that actually unlocks
+a thing instead of a generic "upgrade to continue". Tests assert the properties
+people assume but that silently break: the tiers are strictly CUMULATIVE, limits
+never tighten as price rises, the top plan holds every feature that exists, and
+an unknown plan id falls back to the LEAST privileged tier.
+
+A plan is read from Supabase user metadata and can never be granted by the
+browser — otherwise the paywall would be a suggestion. Until a checkout webhook
+exists, every account is `free`.
+
+**Payments are still not done, and should not be faked.** `CHECKOUT_ENABLED` is
+a named constant pinned to false by a test, so flipping it on without adding a
+server to verify the webhook makes the suite object. The pricing page lists Pro
+so its contents are visible and says plainly that it is not open for sign-up;
+no card details are collected anywhere in the app.
 
 **Not verifiable here:** a real sign-in round trip, since this environment has
 no Supabase project. Everything up to the network call is tested; the call

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -31,6 +31,7 @@ import Micropile from './pages/Micropile'
 import SlopeStability from './pages/SlopeStability'
 import Settlement from './pages/Settlement'
 import LateralPile from './pages/LateralPile'
+import Pricing from './pages/Pricing'
 import SignIn from './pages/auth/SignIn'
 import SignUp from './pages/auth/SignUp'
 import ForgotPassword from './pages/auth/ForgotPassword'
@@ -105,6 +106,7 @@ export default function App() {
         <Route path="/slope" element={<SlopeStability />} />
         <Route path="/settlement" element={<Settlement />} />
         <Route path="/lateral-pile" element={<LateralPile />} />
+        <Route path="/pricing" element={<Pricing />} />
         <Route path="/signin" element={<SignIn />} />
         <Route path="/signup" element={<SignUp />} />
         <Route path="/forgot-password" element={<ForgotPassword />} />

--- a/webapp/src/lib/auth/authClient.ts
+++ b/webapp/src/lib/auth/authClient.ts
@@ -27,6 +27,15 @@ export interface AuthUser {
   name: string | null
   /** True once the address has been confirmed. */
   emailVerified: boolean
+  /**
+   * Subscription plan id from user metadata.
+   *
+   * Read-only here, and null until something sets it. Nothing in the browser
+   * may grant itself a plan — that has to come from the server side (a
+   * checkout webhook, or an admin setting it by hand), or the paywall would be
+   * a suggestion. `planOf` maps an unknown value to the least-privileged plan.
+   */
+  plan: string | null
 }
 
 export type AuthErrorKind =
@@ -111,7 +120,8 @@ const toUser = (s: Session | null): AuthUser | null => {
   if (!u) return null
   const meta = (u.user_metadata ?? {}) as Record<string, unknown>
   const name = typeof meta.name === 'string' ? meta.name : null
-  return { id: u.id, email: u.email ?? null, name, emailVerified: !!u.email_confirmed_at }
+  const plan = typeof meta.plan === 'string' ? meta.plan : null
+  return { id: u.id, email: u.email ?? null, name, emailVerified: !!u.email_confirmed_at, plan }
 }
 
 export async function signIn(email: string, password: string): Promise<AuthResult<AuthUser | null>> {

--- a/webapp/src/lib/docsContentShell.ts
+++ b/webapp/src/lib/docsContentShell.ts
@@ -173,4 +173,35 @@ export const SHELL_TOOLS: DocTool[] = [
       },
     ],
   },
+  {
+    id: 'pricing',
+    name: 'Pricing — plans and what each unlocks',
+    route: '/pricing',
+    group: 'Getting around',
+    summary: 'The three tiers, what each includes, and why paid plans are not open for sign-up yet.',
+    sections: [
+      {
+        id: 'pricing-tiers',
+        title: 'The tiers',
+        body: 'Cumulative: a dearer plan never takes anything away, which is asserted by a test rather than left '
+          + 'to care when a feature is added.',
+        controls: [
+          { kind: 'output', name: 'Guest', what: 'No account. Five runs of each single-purpose calculator, plus unlimited access to the documentation and validation pages.' },
+          { kind: 'output', name: 'Free', what: 'An account, no payment. Removes the trial limits entirely and opens the 3D Model Space and the design pipeline, up to 50 members per model, with saved projects.' },
+          { kind: 'output', name: 'Pro', what: 'Unlimited model size, plus the section optimiser, nonlinear analysis, report export, estimating and construction scheduling.' },
+        ],
+      },
+      {
+        id: 'pricing-checkout',
+        title: 'Why Pro cannot be bought yet',
+        body: 'Taking card payments safely needs a server to verify the payment provider\u2019s webhook. A browser '
+          + 'cannot do that, because anything checked in the browser can be forged by the person paying. Rather '
+          + 'than show a button that looks like it charges a card and does not, Pro is listed so its contents are '
+          + 'visible and marked as not open for sign-up. No card details are collected anywhere in this app.',
+        notes: [
+          'A plan is read from the account\u2019s server-side metadata and can never be granted by the browser — otherwise the paywall would be a suggestion. An unrecognised plan value falls back to the least-privileged tier.',
+        ],
+      },
+    ],
+  },
 ]

--- a/webapp/src/lib/plans.test.ts
+++ b/webapp/src/lib/plans.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest'
+import {
+  PLANS, planOf, planAllows, withinModelLimit, lowestPlanWith,
+  upgradeMessage, featureLabel, CHECKOUT_ENABLED,
+  type Feature,
+} from './plans'
+
+const ALL: Feature[] = [
+  'model-space', 'design-pipeline', 'optimizer', 'reports',
+  'estimating', 'scheduling', 'nonlinear', 'saved-projects',
+]
+
+describe('plan catalogue', () => {
+  it('is ordered cheapest first and has no duplicate ids', () => {
+    const ids = PLANS.map((p) => p.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    const prices = PLANS.map((p) => p.price ?? 0)
+    for (let k = 1; k < prices.length; k++) expect(prices[k]).toBeGreaterThanOrEqual(prices[k - 1])
+  })
+
+  it('is strictly cumulative — a dearer plan never loses a feature', () => {
+    // The property people assume about tiers, and the one that silently breaks
+    // when a feature is added to the middle tier and forgotten at the top.
+    for (let k = 1; k < PLANS.length; k++) {
+      for (const f of PLANS[k - 1].features) {
+        expect(PLANS[k].features, `${PLANS[k].id} lost ${f} from ${PLANS[k - 1].id}`).toContain(f)
+      }
+    }
+  })
+
+  it('limits never tighten as the price rises', () => {
+    const rank = (v: number | null) => (v === null ? Infinity : v)
+    for (let k = 1; k < PLANS.length; k++) {
+      expect(rank(PLANS[k].maxMembers)).toBeGreaterThanOrEqual(rank(PLANS[k - 1].maxMembers))
+      expect(rank(PLANS[k].calculatorRuns)).toBeGreaterThanOrEqual(rank(PLANS[k - 1].calculatorRuns))
+    }
+  })
+
+  it('the top plan includes every feature that exists', () => {
+    const top = PLANS[PLANS.length - 1]
+    for (const f of ALL) expect(top.features, `top plan missing ${f}`).toContain(f)
+  })
+
+  it('gives every plan a name, tagline and highlights', () => {
+    for (const p of PLANS) {
+      expect(p.name.length).toBeGreaterThan(0)
+      expect(p.tagline.length).toBeGreaterThan(10)
+      expect(p.highlights.length).toBeGreaterThan(1)
+    }
+  })
+})
+
+describe('planOf', () => {
+  it('resolves known ids', () => {
+    for (const p of PLANS) expect(planOf(p.id).id).toBe(p.id)
+  })
+
+  it('falls back to the LEAST privileged plan for anything unknown', () => {
+    // The safe direction: a corrupt or absent plan claim must not grant access.
+    for (const bad of [null, undefined, '', 'enterprise', 'PRO', 'admin']) {
+      expect(planOf(bad).id, String(bad)).toBe('guest')
+    }
+  })
+})
+
+describe('planAllows', () => {
+  it('gives a guest nothing', () => {
+    for (const f of ALL) expect(planAllows('guest', f), f).toBe(false)
+  })
+
+  it('gives free the model space but not the paid extras', () => {
+    expect(planAllows('free', 'model-space')).toBe(true)
+    expect(planAllows('free', 'design-pipeline')).toBe(true)
+    expect(planAllows('free', 'optimizer')).toBe(false)
+    expect(planAllows('free', 'reports')).toBe(false)
+    expect(planAllows('free', 'nonlinear')).toBe(false)
+  })
+
+  it('gives pro everything', () => {
+    for (const f of ALL) expect(planAllows('pro', f), f).toBe(true)
+  })
+
+  it('accepts a plan object as well as an id', () => {
+    expect(planAllows(planOf('pro'), 'optimizer')).toBe(true)
+  })
+})
+
+describe('withinModelLimit', () => {
+  it('blocks a guest from any model at all', () => {
+    expect(withinModelLimit('guest', 1)).toBe(false)
+    expect(withinModelLimit('guest', 0)).toBe(true)
+  })
+
+  it('enforces the free ceiling exactly at the boundary', () => {
+    expect(withinModelLimit('free', 50)).toBe(true)
+    expect(withinModelLimit('free', 51)).toBe(false)
+  })
+
+  it('never limits pro', () => {
+    expect(withinModelLimit('pro', 1_000_000)).toBe(true)
+  })
+})
+
+describe('lowestPlanWith', () => {
+  it('names the cheapest plan that includes a feature', () => {
+    expect(lowestPlanWith('model-space')?.id).toBe('free')
+    expect(lowestPlanWith('design-pipeline')?.id).toBe('free')
+    expect(lowestPlanWith('optimizer')?.id).toBe('pro')
+    expect(lowestPlanWith('reports')?.id).toBe('pro')
+  })
+})
+
+describe('upgradeMessage', () => {
+  it('says nothing when the feature is already available', () => {
+    expect(upgradeMessage('pro', 'optimizer')).toBeNull()
+    expect(upgradeMessage('free', 'model-space')).toBeNull()
+  })
+
+  it('tells a guest to create a FREE account when free is enough', () => {
+    const m = upgradeMessage('guest', 'model-space')!
+    expect(m).toMatch(/free account/i)
+    expect(m).toContain(featureLabel('model-space'))
+  })
+
+  it('names the plan that actually unlocks it, not a generic upgrade', () => {
+    const m = upgradeMessage('free', 'optimizer')!
+    expect(m).toContain('Pro')
+    expect(m).toContain(featureLabel('optimizer'))
+    expect(m).not.toMatch(/upgrade to continue/i)
+  })
+
+  it('has a label for every feature — no raw identifiers reach a user', () => {
+    for (const f of ALL) {
+      const label = featureLabel(f)
+      expect(label.length, f).toBeGreaterThan(3)
+      // the point is that the raw identifier never reaches a user — not that
+      // the prose avoids hyphens, which "take-off" legitimately needs
+      expect(label, f).not.toBe(f)
+    }
+  })
+})
+
+describe('checkout', () => {
+  it('is off, because a static SPA cannot verify a payment webhook', () => {
+    // Asserted rather than assumed: if someone flips this on without adding a
+    // server to verify the webhook, this test is the thing that objects.
+    expect(CHECKOUT_ENABLED).toBe(false)
+  })
+})

--- a/webapp/src/lib/plans.ts
+++ b/webapp/src/lib/plans.ts
@@ -1,0 +1,177 @@
+// ─────────────────────────────────────────────────────────────────────────
+// SUBSCRIPTION PLANS AND ENTITLEMENTS — what each tier may do.
+//
+// Pure and tested, for the same reason `trialQuota` is: these rules decide what
+// a paying customer gets, so they belong in one inspectable place rather than
+// scattered as `plan === 'pro'` checks across pages.
+//
+// The model is FEATURE-based, not route-based. Routes answer "may I open this
+// page?" (`trialQuota`); features answer "may I do this thing?" — export a PDF,
+// run the optimiser, build a model past N members. Those are different
+// questions and conflating them is how a paywall ends up inconsistent, with a
+// page reachable but its main button dead for no stated reason.
+//
+// NO PAYMENTS ARE TAKEN. Nothing here charges anyone or claims to. A plan is
+// read from the user's Supabase metadata, so it can be set by hand today and by
+// a checkout webhook later; until that webhook exists every account is `free`.
+// The pricing page says so plainly rather than showing a button that pretends.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type PlanId = 'guest' | 'free' | 'pro'
+
+export type Feature =
+  /** The 3D model space at all. */
+  | 'model-space'
+  /** Run the full design pipeline (slabs → beams → columns → footings). */
+  | 'design-pipeline'
+  /** Section optimisation. */
+  | 'optimizer'
+  /** Generate a printable/PDF report. */
+  | 'reports'
+  /** Estimating and take-off. */
+  | 'estimating'
+  /** Construction scheduling. */
+  | 'scheduling'
+  /** Nonlinear analysis — pushover, time history, buckling. */
+  | 'nonlinear'
+  /** Save projects to the account. */
+  | 'saved-projects'
+
+export interface Plan {
+  id: PlanId
+  name: string
+  /** Monthly price in USD. 0 = free; null = not purchasable (guest). */
+  price: number | null
+  tagline: string
+  features: readonly Feature[]
+  /** Hard ceiling on model size, or null for no limit. */
+  maxMembers: number | null
+  /** Runs per calculator; null = unlimited. */
+  calculatorRuns: number | null
+  /** Shown as bullet points on the pricing page. */
+  highlights: readonly string[]
+}
+
+/** Everything a paid tier unlocks — listed once so the tiers cannot drift. */
+const ALL_FEATURES: readonly Feature[] = [
+  'model-space', 'design-pipeline', 'optimizer', 'reports',
+  'estimating', 'scheduling', 'nonlinear', 'saved-projects',
+]
+
+export const PLANS: readonly Plan[] = [
+  {
+    id: 'guest',
+    name: 'Guest',
+    price: null,
+    tagline: 'Try the calculators without an account.',
+    features: [],
+    maxMembers: 0,
+    calculatorRuns: 5,
+    highlights: [
+      '5 runs of each single-purpose calculator',
+      'Full documentation and validation pages',
+      'No account, no email required',
+    ],
+  },
+  {
+    id: 'free',
+    name: 'Free',
+    price: 0,
+    tagline: 'Everything a student or a single check needs.',
+    features: ['model-space', 'design-pipeline', 'saved-projects'],
+    maxMembers: 50,
+    calculatorRuns: null,
+    highlights: [
+      'Unlimited use of every calculator',
+      '3D Model Space, up to 50 members',
+      'Full design pipeline on those models',
+      'Save projects to your account',
+    ],
+  },
+  {
+    id: 'pro',
+    name: 'Pro',
+    price: 19,
+    tagline: 'For production work on real buildings.',
+    features: ALL_FEATURES,
+    maxMembers: null,
+    calculatorRuns: null,
+    highlights: [
+      'Unlimited model size',
+      'Section optimiser',
+      'Nonlinear analysis — pushover, time history, buckling',
+      'Printable and PDF reports',
+      'Estimating, take-off and construction scheduling',
+    ],
+  },
+]
+
+const byId = new Map(PLANS.map((p) => [p.id, p]))
+
+/** Look up a plan; unknown ids fall back to `guest`, the least-privileged. */
+export const planOf = (id: string | null | undefined): Plan =>
+  byId.get((id ?? '') as PlanId) ?? byId.get('guest')!
+
+/** Whether a plan includes a feature. */
+export const planAllows = (plan: PlanId | Plan, feature: Feature): boolean =>
+  (typeof plan === 'string' ? planOf(plan) : plan).features.includes(feature)
+
+/**
+ * Whether a model of `members` members is within the plan's ceiling.
+ * `maxMembers: 0` (guest) blocks any model at all; `null` means no limit.
+ */
+export function withinModelLimit(plan: PlanId | Plan, members: number): boolean {
+  const p = typeof plan === 'string' ? planOf(plan) : plan
+  if (p.maxMembers === null) return true
+  return members <= p.maxMembers
+}
+
+/** The cheapest plan that includes a feature, or null if none does. */
+export function lowestPlanWith(feature: Feature): Plan | null {
+  const ranked = [...PLANS].sort((a, b) => (a.price ?? Infinity) - (b.price ?? Infinity))
+  return ranked.find((p) => p.features.includes(feature)) ?? null
+}
+
+/**
+ * A sentence explaining what to do about a blocked feature.
+ *
+ * Returned from here rather than written at each call site so the wording stays
+ * consistent, and so it always names the plan that actually unlocks the thing
+ * instead of a generic "upgrade to continue".
+ */
+export function upgradeMessage(current: PlanId, feature: Feature): string | null {
+  if (planAllows(current, feature)) return null
+  const target = lowestPlanWith(feature)
+  if (!target) return 'That feature is not available on any plan yet.'
+  if (current === 'guest') {
+    return target.price === 0
+      ? `Create a free account to use ${featureLabel(feature)}.`
+      : `${featureLabel(feature)} needs the ${target.name} plan — create an account to get started.`
+  }
+  return `${featureLabel(feature)} is part of the ${target.name} plan.`
+}
+
+/** Human name for a feature, used in the messages above. */
+export function featureLabel(f: Feature): string {
+  switch (f) {
+    case 'model-space': return 'the 3D Model Space'
+    case 'design-pipeline': return 'the design pipeline'
+    case 'optimizer': return 'the section optimiser'
+    case 'reports': return 'report export'
+    case 'estimating': return 'estimating and take-off'
+    case 'scheduling': return 'construction scheduling'
+    case 'nonlinear': return 'nonlinear analysis'
+    case 'saved-projects': return 'saved projects'
+  }
+}
+
+/**
+ * Whether checkout is live.
+ *
+ * Hard-coded false, and deliberately a named constant rather than a comment: a
+ * static SPA cannot verify a payment webhook, so a paid plan cannot be sold
+ * from the browser alone. Until a server exists to do that, the pricing page
+ * shows what a plan WOULD include and says checkout is not open, instead of a
+ * button that looks like it charges a card and does not.
+ */
+export const CHECKOUT_ENABLED = false

--- a/webapp/src/pages/Pricing.tsx
+++ b/webapp/src/pages/Pricing.tsx
@@ -1,0 +1,95 @@
+import { Link } from 'react-router-dom'
+import { PLANS, CHECKOUT_ENABLED, type Plan } from '../lib/plans'
+import { useAuth } from '../lib/auth/authContext'
+import { planOf } from '../lib/plans'
+
+function PlanCard({ plan, current }: { plan: Plan; current: boolean }) {
+  const featured = plan.id === 'free'
+  return (
+    <div className={`flex flex-col rounded-xl border bg-white p-5 shadow-sm ${
+      featured ? 'border-[#0056b3] ring-1 ring-[#0056b3]/20' : 'border-slate-200'}`}>
+      <div className="flex items-baseline justify-between">
+        <h2 className="text-[1.05rem] font-bold text-[#0056b3]">{plan.name}</h2>
+        {current && (
+          <span className="rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-700">
+            Your plan
+          </span>
+        )}
+      </div>
+      <p className="mt-1 text-[13px] leading-5 text-slate-600">{plan.tagline}</p>
+      <p className="mt-3 text-2xl font-bold text-slate-800">
+        {plan.price === null ? '—' : plan.price === 0 ? 'Free' : `$${plan.price}`}
+        {plan.price ? <span className="text-sm font-medium text-slate-500"> /month</span> : null}
+      </p>
+      <ul className="mt-4 flex-1 space-y-1.5">
+        {plan.highlights.map((h) => (
+          <li key={h} className="flex gap-2 text-[13px] leading-5 text-slate-700">
+            <span className="text-emerald-600">✓</span><span>{h}</span>
+          </li>
+        ))}
+      </ul>
+      <div className="mt-5">
+        {plan.id === 'guest' ? (
+          <p className="text-center text-[12px] text-slate-500">No sign-up needed</p>
+        ) : plan.price === 0 ? (
+          <Link to="/signup"
+            className="block rounded-md bg-[#0056b3] px-4 py-2 text-center text-sm font-semibold text-white hover:bg-[#0f4c92]">
+            Create a free account
+          </Link>
+        ) : CHECKOUT_ENABLED ? (
+          <Link to="/signup"
+            className="block rounded-md bg-[#0056b3] px-4 py-2 text-center text-sm font-semibold text-white hover:bg-[#0f4c92]">
+            Choose {plan.name}
+          </Link>
+        ) : (
+          <div className="rounded-md border border-dashed border-slate-300 px-3 py-2 text-center text-[12px] text-slate-500">
+            Not open for sign-up yet
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default function Pricing() {
+  const { user } = useAuth()
+  const current = planOf(user ? (user.plan ?? 'free') : 'guest')
+
+  return (
+    <main className="mx-auto max-w-5xl px-5 py-10">
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Plans</p>
+      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Pricing</h1>
+      <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+        Every calculator is free to try without an account. A free account removes the trial limits and opens the
+        3D Model Space; Pro adds the optimiser, nonlinear analysis, reports, estimating and scheduling.
+      </p>
+
+      {!CHECKOUT_ENABLED && (
+        <div className="mt-5 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-[13px] leading-6 text-amber-900">
+          <strong>Paid plans are not open for sign-up yet.</strong> Taking card payments safely needs a server to
+          verify the payment provider&rsquo;s webhook — a browser cannot do that, because anything checked in the
+          browser can be forged by the person paying. Until that exists, Pro is listed so you can see what it
+          covers, and no card details are collected anywhere in this app. The free tier is fully available.
+        </div>
+      )}
+
+      <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {PLANS.map((p) => <PlanCard key={p.id} plan={p} current={p.id === current.id} />)}
+      </div>
+
+      <h2 className="mt-10 text-[1.05rem] font-bold text-[#0056b3]">What counts as a &ldquo;calculator&rdquo;</h2>
+      <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+        The single-purpose pages — beam, column, footing, retaining wall, settlement, lateral pile, connections,
+        slope stability and the rest. Each gives one answer from one set of inputs. The 3D Model Space, the frame
+        and truss workbenches, estimating and scheduling are project-scale tools that hold state across a whole
+        building, and those need an account.
+      </p>
+      <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-600">
+        Documentation and the{' '}
+        <Link to="/validation" className="text-[#0056b3] underline">validation page</Link>{' '}
+        are open to everyone, always. Being able to check the engine against hand calculations should never be
+        behind a paywall.
+      </p>
+    </main>
+  )
+}

--- a/webapp/src/pages/auth/SignUp.tsx
+++ b/webapp/src/pages/auth/SignUp.tsx
@@ -48,8 +48,8 @@ export default function SignUp() {
   return (
     <AuthCard
       title="Create an account"
-      subtitle="Free. Unlocks the 3D model space, the design pipeline, reports and saved projects."
-      footer={<>Already registered? <Link to="/signin" className="font-medium text-[#0056b3] underline">Sign in</Link></>}
+      subtitle="Free. Removes the trial limits and opens the 3D Model Space, the design pipeline and saved projects."
+      footer={<>Already registered? <Link to="/signin" className="font-medium text-[#0056b3] underline">Sign in</Link>{' · '}<Link to="/pricing" className="font-medium text-[#0056b3] underline">Compare plans</Link></>}
     >
       {!configured ? <NotConfigured /> : (
         <form onSubmit={submit} noValidate>


### PR DESCRIPTION
Adds the plan catalogue, the entitlement rules that go with it, and a `/pricing`
page. This is the first half of subscriptions — **the half that does not take
money.**

## PAYMENTS ARE NOT INCLUDED, AND ARE NOT FAKED

A static SPA cannot verify a payment provider's webhook, because anything
checked in the browser can be forged by the person paying. So there is no
checkout button, no card field, and no "subscribe" flow that pretends. Instead
`CHECKOUT_ENABLED` is a named constant pinned to **false by a test** — if someone
flips it on without adding a server to verify the webhook, that test is the thing
that objects. The pricing page states plainly, in an amber notice, why paid
plans are not open for sign-up yet.

Verified in the browser: **0 payment inputs on `/pricing`.**

## Feature-based entitlements, not route-based

Routes answer "may I open this page?" — that is `trialQuota`, shipped in #462.
Features answer "may I *do* this thing?" — export a PDF, run the optimiser,
build past N members. Conflating the two is how a paywall ends up inconsistent:
a page reachable but its main button dead for no stated reason. `plans.ts` keeps
them separate.

`webapp/src/lib/plans.ts`:
- `PLANS` — Guest / Free / Pro, ordered cheapest first
- `planOf(id)` — unknown, corrupt or absent id falls back to **guest**, the
  least-privileged plan. The safe direction.
- `planAllows`, `withinModelLimit`, `lowestPlanWith`
- `upgradeMessage(current, feature)` — names the plan that actually unlocks the
  thing ("the section optimiser is part of the Pro plan"), never a generic
  "upgrade to continue"
- `featureLabel` — so no raw identifier like `design-pipeline` reaches a user

## The three tiers

Picked rather than asking a third time, from the answers already given
("single-purpose tools free, heavy tools gated"):

| | Guest | Free ($0) | Pro ($19/mo) |
|---|---|---|---|
| Calculators | 5 runs each | unlimited | unlimited |
| Model Space | — | ≤ 50 members | unlimited |
| Design pipeline | — | ✓ | ✓ |
| Optimiser, reports, nonlinear, estimating, scheduling | — | — | ✓ |

## Tests (20, all passing)

They assert the properties people *assume* about tiers and that break silently:

- **strictly cumulative** — a dearer plan never loses a feature the cheaper one
  had (breaks when a feature is added to the middle tier and forgotten at the top)
- **limits never tighten as price rises**
- **the top plan holds every feature that exists**
- **unknown plan id ⇒ least-privileged**, checked for `null`, `''`, `'PRO'`,
  `'admin'`
- `CHECKOUT_ENABLED === false`

## Also

- `AuthUser.plan` read from Supabase `user_metadata`. Read-only, and documented
  as such: nothing in the browser may grant itself a plan, or the paywall would
  be a suggestion.
- `/pricing` route, docs-catalogue entry (the docs guard test caught its
  absence), "Compare plans" link in the sign-up footer.

## Layer

Not an engine layer — `src/lib/` policy plus one page. No calculation touched.

## Verification

`npx tsc -b` = 0 · `npm run lint` = 0 · `npm test` **1878 passing** ·
`npm run build` = 0. Browser-checked on `/pricing`: all three cards render with
their prices, the "Your plan" badge shows on the current tier, the amber notice
is present, no console errors.

## Remaining

Checkout itself needs a server to verify the webhook — Supabase Edge Functions
is the natural place. That is the second half, not started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_