### PR TITLE
Restructure plans: Guest ≈ Free, and add a Max tier

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1127,23 +1127,56 @@ account.
 NOTHING is gated. A missing env var must not brick the app behind a form that
 cannot work. Verified in a browser — `/model` stays reachable unconfigured.
 
-**Plans shipped in #463.** `lib/plans.ts` is pure and tested: three tiers
-(guest / free / pro), FEATURE-based entitlements rather than route-based, model
-size ceilings, and `upgradeMessage` which names the plan that actually unlocks
-a thing instead of a generic "upgrade to continue". Tests assert the properties
-people assume but that silently break: the tiers are strictly CUMULATIVE, limits
-never tighten as price rises, the top plan holds every feature that exists, and
-an unknown plan id falls back to the LEAST privileged tier.
+**Plans shipped in #463, restructured to four tiers in #464.** `lib/plans.ts` is
+pure and tested, with FEATURE-based entitlements rather than route-based:
+
+| | Guest | Free ($0) | Pro ($19) | Max ($49) |
+|---|---|---|---|---|
+| Calculators | 5 runs each | unlimited | unlimited | unlimited |
+| Saved projects | — | 3 | unlimited | unlimited |
+| Model Space | — | — | ≤ 400 members | unlimited |
+| Design pipeline, optimiser, reports, estimating | — | — | ✓ | ✓ |
+| Nonlinear analysis, scheduling | — | — | — | ✓ |
+
+The shape is deliberate: **Guest and Free are the same product**, differing only
+in that Free has an account behind it (no trial counter, a few saved projects).
+Nobody should have to pay to finish a beam check. The paid tiers carry the
+project-scale tools.
+
+Tests assert the properties people assume but that silently break: the tiers are
+strictly CUMULATIVE, limits never tighten as price rises, the top plan holds
+every feature that exists, an unknown plan id falls back to the LEAST privileged
+tier, and `upgradeMessage` names **Max** — not Pro — for the features only Max
+has.
 
 A plan is read from Supabase user metadata and can never be granted by the
 browser — otherwise the paywall would be a suggestion. Until a checkout webhook
-exists, every account is `free`.
+exists, every account is `free`. To grant yourself a paid tier for testing, set
+`{"plan": "pro"}` (or `"max"`) on your user in the Supabase dashboard under
+Authentication → Users → User Metadata.
 
 **Payments are still not done, and should not be faked.** `CHECKOUT_ENABLED` is
 a named constant pinned to false by a test, so flipping it on without adding a
 server to verify the webhook makes the suite object. The pricing page lists Pro
-so its contents are visible and says plainly that it is not open for sign-up;
-no card details are collected anywhere in the app.
+and Max so their contents are visible and says plainly that they are not open
+for sign-up; no card details are collected anywhere in the app.
+
+**KNOWN GAP — the tiers are catalogued but NOT ENFORCED.** `planAllows`,
+`withinModelLimit` and `withinProjectLimit` have no call sites outside the
+pricing badge, so a signed-in Free account can still open `/model`, run the
+optimiser and export a report. Routes are gated on the *session* (`RequireAuth`
++ `trialQuota`); nothing yet gates on the *plan*. The wiring was drafted against
+the single choke point that all heavy work funnels through — `useSolver.run(kind,
+…)` in `lib/useSolver.ts`, whose `kind` maps 1:1 onto a feature — plus the
+`Optimize design` and `Export PDF report` buttons in `pages/ModelSpace.tsx`.
+Worth pairing with a guard test that reads `SolverRequest['kind']` from
+`engine/solverWorker.ts` and fails when a new solver kind is unclassified, since
+an unmapped kind would default to allowed.
+
+Note also that whatever ships must say plainly what it is: **every calculation
+in this app runs in the browser**, so a client-side gate is a product boundary,
+not a security one — the same caveat `trialQuota` already carries. Real
+enforcement would mean moving the solver behind an authenticated API.
 
 **Not verifiable here:** a real sign-in round trip, since this environment has
 no Supabase project. Everything up to the network call is tested; the call

--- a/webapp/src/lib/docsContentShell.ts
+++ b/webapp/src/lib/docsContentShell.ts
@@ -132,10 +132,13 @@ export const SHELL_TOOLS: DocTool[] = [
       {
         id: 'acct-why',
         title: 'What an account changes',
-        body: 'The single-purpose calculators are free to try without one — five runs of each. The heavy, stateful '
-          + 'features (3D Model Space, the frame and truss workbenches, the estimating and scheduling modules, the '
-          + 'seismic wizard) need an account. Documentation and the validation page are always open to everyone.',
+        body: 'The single-purpose calculators are free to try without one — five runs of each — and an account '
+          + 'removes that counter and lets you save projects. It does not unlock a different set of calculators. '
+          + 'The heavy, stateful features (3D Model Space, the frame and truss workbenches, the estimating and '
+          + 'scheduling modules, the seismic wizard) need an account AND a paid plan. Documentation and the '
+          + 'validation page are always open to everyone.',
         notes: [
+          'Routes are gated on the session today; the per-plan feature checks are catalogued in lib/plans.ts but are not yet wired into those pages, so a signed-in free account can still reach the project-scale tools. That gap is tracked in HANDOFF.md.',
           'The guest run counter is stored in your browser, so clearing site data resets it. It exists to prompt sign-up on tools that are deliberately free to try — it is not a security boundary, and the features that require an account are gated on the session itself.',
           'If the deployment has no Supabase keys configured, sign-in is unavailable and NOTHING is gated — the app stays fully usable rather than locking behind a form that cannot work.',
         ],
@@ -178,26 +181,30 @@ export const SHELL_TOOLS: DocTool[] = [
     name: 'Pricing — plans and what each unlocks',
     route: '/pricing',
     group: 'Getting around',
-    summary: 'The three tiers, what each includes, and why paid plans are not open for sign-up yet.',
+    summary: 'The four tiers, what each includes, and why paid plans are not open for sign-up yet.',
     sections: [
       {
         id: 'pricing-tiers',
         title: 'The tiers',
-        body: 'Cumulative: a dearer plan never takes anything away, which is asserted by a test rather than left '
-          + 'to care when a feature is added.',
+        body: 'Guest and Free are the same product \u2014 every single-purpose calculator \u2014 and differ only in that '
+          + 'Free has an account behind it. Nobody should have to pay to finish a beam check. The paid tiers carry '
+          + 'the project-scale tools. Cumulative: a dearer plan never takes anything away, which is asserted by a '
+          + 'test rather than left to care when a feature is added.',
         controls: [
           { kind: 'output', name: 'Guest', what: 'No account. Five runs of each single-purpose calculator, plus unlimited access to the documentation and validation pages.' },
-          { kind: 'output', name: 'Free', what: 'An account, no payment. Removes the trial limits entirely and opens the 3D Model Space and the design pipeline, up to 50 members per model, with saved projects.' },
-          { kind: 'output', name: 'Pro', what: 'Unlimited model size, plus the section optimiser, nonlinear analysis, report export, estimating and construction scheduling.' },
+          { kind: 'output', name: 'Free', what: 'The same calculators with no trial counter, and up to three saved projects. No payment, no model space.' },
+          { kind: 'output', name: 'Pro', what: 'The 3D Model Space up to 400 members and everything built on it \u2014 design pipeline, section optimiser, estimating and take-off, structure reports \u2014 with unlimited saved projects.' },
+          { kind: 'output', name: 'Max', what: 'Everything in Pro with no model-size limit, plus the nonlinear and dynamic solvers (pushover, biaxial pushover, time history) and construction scheduling.' },
         ],
       },
       {
         id: 'pricing-checkout',
-        title: 'Why Pro cannot be bought yet',
+        title: 'Why the paid tiers cannot be bought yet',
         body: 'Taking card payments safely needs a server to verify the payment provider\u2019s webhook. A browser '
           + 'cannot do that, because anything checked in the browser can be forged by the person paying. Rather '
-          + 'than show a button that looks like it charges a card and does not, Pro is listed so its contents are '
-          + 'visible and marked as not open for sign-up. No card details are collected anywhere in this app.',
+          + 'than show a button that looks like it charges a card and does not, Pro and Max are listed so their '
+          + 'contents are visible and marked as not open for sign-up. No card details are collected anywhere in '
+          + 'this app.',
         notes: [
           'A plan is read from the account\u2019s server-side metadata and can never be granted by the browser — otherwise the paywall would be a suggestion. An unrecognised plan value falls back to the least-privileged tier.',
         ],

--- a/webapp/src/lib/plans.test.ts
+++ b/webapp/src/lib/plans.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
-  PLANS, planOf, planAllows, withinModelLimit, lowestPlanWith,
+  PLANS, planOf, planAllows, withinModelLimit, withinProjectLimit, lowestPlanWith,
   upgradeMessage, featureLabel, CHECKOUT_ENABLED,
   type Feature,
 } from './plans'
@@ -33,7 +33,20 @@ describe('plan catalogue', () => {
     for (let k = 1; k < PLANS.length; k++) {
       expect(rank(PLANS[k].maxMembers)).toBeGreaterThanOrEqual(rank(PLANS[k - 1].maxMembers))
       expect(rank(PLANS[k].calculatorRuns)).toBeGreaterThanOrEqual(rank(PLANS[k - 1].calculatorRuns))
+      expect(rank(PLANS[k].maxProjects)).toBeGreaterThanOrEqual(rank(PLANS[k - 1].maxProjects))
     }
+  })
+
+  it('gives guest and free the same feature set — an account is the only difference', () => {
+    // The deliberate shape of the ladder: signing up must not be what unlocks
+    // a calculator, only what removes the trial counter and allows saving.
+    const guest = PLANS.find((p) => p.id === 'guest')!
+    const free = PLANS.find((p) => p.id === 'free')!
+    expect(free.features.filter((f) => f !== 'saved-projects')).toEqual([...guest.features])
+    expect(guest.calculatorRuns).toBe(5)
+    expect(free.calculatorRuns).toBeNull()
+    expect(guest.maxProjects).toBe(0)
+    expect(free.maxProjects).toBeGreaterThan(0)
   })
 
   it('the top plan includes every feature that exists', () => {
@@ -68,16 +81,25 @@ describe('planAllows', () => {
     for (const f of ALL) expect(planAllows('guest', f), f).toBe(false)
   })
 
-  it('gives free the model space but not the paid extras', () => {
-    expect(planAllows('free', 'model-space')).toBe(true)
-    expect(planAllows('free', 'design-pipeline')).toBe(true)
+  it('gives free saved projects and nothing else — the calculators need no feature', () => {
+    expect(planAllows('free', 'saved-projects')).toBe(true)
+    expect(planAllows('free', 'model-space')).toBe(false)
+    expect(planAllows('free', 'design-pipeline')).toBe(false)
     expect(planAllows('free', 'optimizer')).toBe(false)
-    expect(planAllows('free', 'reports')).toBe(false)
-    expect(planAllows('free', 'nonlinear')).toBe(false)
   })
 
-  it('gives pro everything', () => {
-    for (const f of ALL) expect(planAllows('pro', f), f).toBe(true)
+  it('gives pro the model space and what is built on it, but not the heavy solvers', () => {
+    expect(planAllows('pro', 'model-space')).toBe(true)
+    expect(planAllows('pro', 'design-pipeline')).toBe(true)
+    expect(planAllows('pro', 'optimizer')).toBe(true)
+    expect(planAllows('pro', 'reports')).toBe(true)
+    expect(planAllows('pro', 'estimating')).toBe(true)
+    expect(planAllows('pro', 'nonlinear')).toBe(false)
+    expect(planAllows('pro', 'scheduling')).toBe(false)
+  })
+
+  it('gives max everything', () => {
+    for (const f of ALL) expect(planAllows('max', f), f).toBe(true)
   })
 
   it('accepts a plan object as well as an id', () => {
@@ -86,40 +108,62 @@ describe('planAllows', () => {
 })
 
 describe('withinModelLimit', () => {
-  it('blocks a guest from any model at all', () => {
-    expect(withinModelLimit('guest', 1)).toBe(false)
-    expect(withinModelLimit('guest', 0)).toBe(true)
+  it('blocks guest and free from any model at all — the model space is paid', () => {
+    for (const id of ['guest', 'free'] as const) {
+      expect(withinModelLimit(id, 1), id).toBe(false)
+      expect(withinModelLimit(id, 0), id).toBe(true)
+    }
   })
 
-  it('enforces the free ceiling exactly at the boundary', () => {
-    expect(withinModelLimit('free', 50)).toBe(true)
-    expect(withinModelLimit('free', 51)).toBe(false)
+  it('enforces the pro ceiling exactly at the boundary', () => {
+    expect(withinModelLimit('pro', 400)).toBe(true)
+    expect(withinModelLimit('pro', 401)).toBe(false)
   })
 
-  it('never limits pro', () => {
-    expect(withinModelLimit('pro', 1_000_000)).toBe(true)
+  it('never limits max', () => {
+    expect(withinModelLimit('max', 1_000_000)).toBe(true)
+  })
+})
+
+describe('withinProjectLimit', () => {
+  it('lets a guest save nothing', () => {
+    expect(withinProjectLimit('guest', 0)).toBe(false)
+  })
+
+  it('stops free at its allowance — the check is "may I save one MORE"', () => {
+    // Off-by-one bait: holding 2 of 3 may save; holding 3 of 3 may not.
+    expect(withinProjectLimit('free', 2)).toBe(true)
+    expect(withinProjectLimit('free', 3)).toBe(false)
+  })
+
+  it('never limits the paid tiers', () => {
+    expect(withinProjectLimit('pro', 10_000)).toBe(true)
+    expect(withinProjectLimit('max', 10_000)).toBe(true)
   })
 })
 
 describe('lowestPlanWith', () => {
   it('names the cheapest plan that includes a feature', () => {
-    expect(lowestPlanWith('model-space')?.id).toBe('free')
-    expect(lowestPlanWith('design-pipeline')?.id).toBe('free')
+    expect(lowestPlanWith('saved-projects')?.id).toBe('free')
+    expect(lowestPlanWith('model-space')?.id).toBe('pro')
+    expect(lowestPlanWith('design-pipeline')?.id).toBe('pro')
     expect(lowestPlanWith('optimizer')?.id).toBe('pro')
-    expect(lowestPlanWith('reports')?.id).toBe('pro')
+    expect(lowestPlanWith('nonlinear')?.id).toBe('max')
+    expect(lowestPlanWith('scheduling')?.id).toBe('max')
   })
 })
 
 describe('upgradeMessage', () => {
   it('says nothing when the feature is already available', () => {
     expect(upgradeMessage('pro', 'optimizer')).toBeNull()
-    expect(upgradeMessage('free', 'model-space')).toBeNull()
+    expect(upgradeMessage('free', 'saved-projects')).toBeNull()
+    expect(upgradeMessage('max', 'nonlinear')).toBeNull()
   })
 
   it('tells a guest to create a FREE account when free is enough', () => {
-    const m = upgradeMessage('guest', 'model-space')!
+    const m = upgradeMessage('guest', 'saved-projects')!
     expect(m).toMatch(/free account/i)
-    expect(m).toContain(featureLabel('model-space'))
+    expect(m).toContain(featureLabel('saved-projects'))
   })
 
   it('names the plan that actually unlocks it, not a generic upgrade', () => {
@@ -127,6 +171,16 @@ describe('upgradeMessage', () => {
     expect(m).toContain('Pro')
     expect(m).toContain(featureLabel('optimizer'))
     expect(m).not.toMatch(/upgrade to continue/i)
+  })
+
+  it('points at Max, not Pro, for the features only Max has', () => {
+    // The failure this catches: adding a top tier but leaving the message
+    // pointing at the tier that no longer unlocks the thing.
+    for (const f of ['nonlinear', 'scheduling'] as const) {
+      const m = upgradeMessage('pro', f)!
+      expect(m, f).toContain('Max')
+      expect(m, f).not.toContain('Pro plan')
+    }
   })
 
   it('has a label for every feature — no raw identifiers reach a user', () => {

--- a/webapp/src/lib/plans.ts
+++ b/webapp/src/lib/plans.ts
@@ -17,7 +17,7 @@
 // The pricing page says so plainly rather than showing a button that pretends.
 // ─────────────────────────────────────────────────────────────────────────
 
-export type PlanId = 'guest' | 'free' | 'pro'
+export type PlanId = 'guest' | 'free' | 'pro' | 'max'
 
 export type Feature =
   /** The 3D model space at all. */
@@ -48,6 +48,8 @@ export interface Plan {
   maxMembers: number | null
   /** Runs per calculator; null = unlimited. */
   calculatorRuns: number | null
+  /** Saved projects the account may keep; 0 = cannot save, null = no limit. */
+  maxProjects: number | null
   /** Shown as bullet points on the pricing page. */
   highlights: readonly string[]
 }
@@ -58,15 +60,27 @@ const ALL_FEATURES: readonly Feature[] = [
   'estimating', 'scheduling', 'nonlinear', 'saved-projects',
 ]
 
+/**
+ * The tiers, cheapest first.
+ *
+ * The shape of the ladder: Guest and Free are deliberately the SAME product —
+ * the single-purpose calculators — and differ only in that Free has an account
+ * behind it, which removes the trial counter and lets a few projects be saved.
+ * Nobody should have to pay to finish a beam check. The paid tiers are where
+ * the project-scale tools live: Pro carries the 3D Model Space and everything
+ * built on it, and Max adds the analyses that are heaviest to run and rarest to
+ * need — nonlinear/dynamic solves and construction scheduling.
+ */
 export const PLANS: readonly Plan[] = [
   {
     id: 'guest',
     name: 'Guest',
     price: null,
-    tagline: 'Try the calculators without an account.',
+    tagline: 'Try every calculator without an account.',
     features: [],
     maxMembers: 0,
     calculatorRuns: 5,
+    maxProjects: 0,
     highlights: [
       '5 runs of each single-purpose calculator',
       'Full documentation and validation pages',
@@ -77,31 +91,50 @@ export const PLANS: readonly Plan[] = [
     id: 'free',
     name: 'Free',
     price: 0,
-    tagline: 'Everything a student or a single check needs.',
-    features: ['model-space', 'design-pipeline', 'saved-projects'],
-    maxMembers: 50,
+    tagline: 'The same calculators, without the trial counter.',
+    features: ['saved-projects'],
+    maxMembers: 0,
     calculatorRuns: null,
+    maxProjects: 3,
     highlights: [
       'Unlimited use of every calculator',
-      '3D Model Space, up to 50 members',
-      'Full design pipeline on those models',
-      'Save projects to your account',
+      'Save up to 3 projects to your account',
+      'Worked solutions and PDF calc sheets on every page',
+      'Full documentation and validation pages',
     ],
   },
   {
     id: 'pro',
     name: 'Pro',
     price: 19,
-    tagline: 'For production work on real buildings.',
+    tagline: 'The 3D Model Space and the tools built on it.',
+    features: ['model-space', 'design-pipeline', 'optimizer', 'reports', 'estimating', 'saved-projects'],
+    maxMembers: 400,
+    calculatorRuns: null,
+    maxProjects: null,
+    highlights: [
+      '3D Model Space, up to 400 members',
+      'Full design pipeline — slabs, beams, columns, footings',
+      'Section optimiser',
+      'Estimating and take-off',
+      'Structure reports and PDF drawings',
+      'Unlimited saved projects',
+    ],
+  },
+  {
+    id: 'max',
+    name: 'Max',
+    price: 49,
+    tagline: 'Everything, including the nonlinear and dynamic solvers.',
     features: ALL_FEATURES,
     maxMembers: null,
     calculatorRuns: null,
+    maxProjects: null,
     highlights: [
-      'Unlimited model size',
-      'Section optimiser',
-      'Nonlinear analysis — pushover, time history, buckling',
-      'Printable and PDF reports',
-      'Estimating, take-off and construction scheduling',
+      'Everything in Pro, with no model-size limit',
+      'Nonlinear analysis — pushover, biaxial pushover, time history',
+      'Construction scheduling and the critical path',
+      'Priority on new engines as they ship',
     ],
   },
 ]
@@ -124,6 +157,16 @@ export function withinModelLimit(plan: PlanId | Plan, members: number): boolean 
   const p = typeof plan === 'string' ? planOf(plan) : plan
   if (p.maxMembers === null) return true
   return members <= p.maxMembers
+}
+
+/**
+ * Whether an account holding `projects` saved projects may save another.
+ * `maxProjects: 0` (guest) cannot save at all; `null` means no limit.
+ */
+export function withinProjectLimit(plan: PlanId | Plan, projects: number): boolean {
+  const p = typeof plan === 'string' ? planOf(plan) : plan
+  if (p.maxProjects === null) return true
+  return projects < p.maxProjects
 }
 
 /** The cheapest plan that includes a feature, or null if none does. */

--- a/webapp/src/pages/Pricing.tsx
+++ b/webapp/src/pages/Pricing.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '../lib/auth/authContext'
 import { planOf } from '../lib/plans'
 
 function PlanCard({ plan, current }: { plan: Plan; current: boolean }) {
-  const featured = plan.id === 'free'
+  const featured = plan.id === 'pro'
   return (
     <div className={`flex flex-col rounded-xl border bg-white p-5 shadow-sm ${
       featured ? 'border-[#0056b3] ring-1 ring-[#0056b3]/20' : 'border-slate-200'}`}>
@@ -60,29 +60,30 @@ export default function Pricing() {
       <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Plans</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Pricing</h1>
       <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
-        Every calculator is free to try without an account. A free account removes the trial limits and opens the
-        3D Model Space; Pro adds the optimiser, nonlinear analysis, reports, estimating and scheduling.
+        Every calculator is free, with or without an account — a free account only removes the trial counter and
+        lets you save work. The paid tiers are for project-scale tools: Pro opens the 3D Model Space and everything
+        built on it, and Max adds the nonlinear and dynamic solvers plus construction scheduling.
       </p>
 
       {!CHECKOUT_ENABLED && (
         <div className="mt-5 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-[13px] leading-6 text-amber-900">
           <strong>Paid plans are not open for sign-up yet.</strong> Taking card payments safely needs a server to
           verify the payment provider&rsquo;s webhook — a browser cannot do that, because anything checked in the
-          browser can be forged by the person paying. Until that exists, Pro is listed so you can see what it
-          covers, and no card details are collected anywhere in this app. The free tier is fully available.
+          browser can be forged by the person paying. Until that exists, Pro and Max are listed so you can see what
+          they cover, and no card details are collected anywhere in this app. Guest and Free are fully available.
         </div>
       )}
 
-      <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {PLANS.map((p) => <PlanCard key={p.id} plan={p} current={p.id === current.id} />)}
       </div>
 
       <h2 className="mt-10 text-[1.05rem] font-bold text-[#0056b3]">What counts as a &ldquo;calculator&rdquo;</h2>
       <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
         The single-purpose pages — beam, column, footing, retaining wall, settlement, lateral pile, connections,
-        slope stability and the rest. Each gives one answer from one set of inputs. The 3D Model Space, the frame
-        and truss workbenches, estimating and scheduling are project-scale tools that hold state across a whole
-        building, and those need an account.
+        slope stability and the rest. Each gives one answer from one set of inputs, and every one of them stays
+        free. The 3D Model Space, the frame and truss workbenches, estimating and scheduling are project-scale
+        tools that hold state across a whole building, and those are what the paid tiers are for.
       </p>
       <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-600">
         Documentation and the{' '}


### PR DESCRIPTION
Reshapes the tier ladder as requested: Guest and Free become the same product,
and a **Max** tier joins Pro at the top.

## The shape

Signing up is no longer what unlocks a calculator. Guest and Free carry the
**same feature set**; the only differences are ones an account can actually
justify — no trial counter, and a few saved projects. Nobody should have to pay,
or even register, to finish a beam check.

| | Guest | Free ($0) | Pro ($19) | Max ($49) |
|---|---|---|---|---|
| Single-purpose calculators | 5 runs each | unlimited | unlimited | unlimited |
| Saved projects | — | 3 | unlimited | unlimited |
| 3D Model Space | — | — | ≤ 400 members | unlimited |
| Design pipeline · optimiser · reports · estimating | — | — | ✓ | ✓ |
| Nonlinear analysis · construction scheduling | — | — | — | ✓ |

Pro vs Max splits on **cost to run** rather than arbitrary feature-withholding:
Max holds the solvers that are heaviest to execute and rarest to need — pushover,
biaxial pushover, time history — plus scheduling.

## New: `maxProjects` and `withinProjectLimit`

Its test pins the off-by-one this kind of check invites. The question is "may I
save one *more*", so holding 2 of 3 passes and holding 3 of 3 does not.

## Two new invariant tests

Beyond the existing cumulative / monotonic-limits / least-privileged-fallback set:

- **Guest and Free differ only by `saved-projects`** — so a future edit cannot
  quietly make signing up the thing that unlocks a tool. That is the property
  this whole change is about, so it is asserted rather than trusted.
- **`upgradeMessage` names Max, not Pro, for the features only Max has** — the
  exact failure mode of adding a top tier and leaving the copy pointing at the
  old one.

## Also updated

`Pricing.tsx` goes to four cards (Pro featured), and both the `/pricing` docs
catalogue entry and the accounts page are rewritten — both described the old
three-tier split and would otherwise have been wrong the moment this merged.

## Verification

`npx tsc -b` = 0 · `npm run lint` = 0 · `npm test` **1884 passing** ·
`npm run build` = 0.

Browser-checked on `/pricing` (headless Chromium, full render): all four cards
present with their prices and highlights, Free no longer advertises the model
space, the "not open for sign-up" notice names Pro **and** Max, the "Your plan"
badge shows on Guest, **0 payment inputs**, no console errors.

## Honest gap, now written down

These tiers are **catalogued but not enforced anywhere.** `planAllows`,
`withinModelLimit` and `withinProjectLimit` have no call sites outside the
pricing badge, so a signed-in Free account can still open `/model`, run the
optimiser and export a report. Routes are gated on the *session*; nothing is
gated on the *plan*.

`HANDOFF.md` now records this in the same section, along with the intended wiring
point — `useSolver.run(kind, …)` is the single choke point every heavy job passes
through, and its `kind` maps 1:1 onto a feature — and the note that whatever
ships must say plainly what it is: every calculation runs in the browser, so a
client-side gate is a product boundary, not a security one.

## Layer

Not an engine layer — `src/lib/` policy plus one page and the docs catalogue. No
calculation touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_