### PR TITLE
Enforce the plan tiers

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1161,22 +1161,42 @@ server to verify the webhook makes the suite object. The pricing page lists Pro
 and Max so their contents are visible and says plainly that they are not open
 for sign-up; no card details are collected anywhere in the app.
 
-**KNOWN GAP — the tiers are catalogued but NOT ENFORCED.** `planAllows`,
-`withinModelLimit` and `withinProjectLimit` have no call sites outside the
-pricing badge, so a signed-in Free account can still open `/model`, run the
-optimiser and export a report. Routes are gated on the *session* (`RequireAuth`
-+ `trialQuota`); nothing yet gates on the *plan*. The wiring was drafted against
-the single choke point that all heavy work funnels through — `useSolver.run(kind,
-…)` in `lib/useSolver.ts`, whose `kind` maps 1:1 onto a feature — plus the
-`Optimize design` and `Export PDF report` buttons in `pages/ModelSpace.tsx`.
-Worth pairing with a guard test that reads `SolverRequest['kind']` from
-`engine/solverWorker.ts` and fails when a new solver kind is unclassified, since
-an unmapped kind would default to allowed.
+**Enforcement shipped in #466.** `lib/featureGate.ts` maps every gated thing
+onto the feature it needs, in one pure tested place:
 
-Note also that whatever ships must say plainly what it is: **every calculation
-in this app runs in the browser**, so a client-side gate is a product boundary,
-not a security one — the same caveat `trialQuota` already carries. Real
-enforcement would mean moving the solver behind an authenticated API.
+- `SOLVER_FEATURE` — each `SolverRequest['kind']` → its feature. A guard test
+  parses `engine/solverWorker.ts` and fails if a kind is unclassified OR stale,
+  because an unmapped kind reads as `undefined` and would run on any plan. The
+  guard was checked by deleting a mapping and confirming it fails.
+- `ROUTE_FEATURE` — each gated route prefix → its feature, key-set-equal to
+  `trialQuota.GATED_PREFIXES` by test, so "must I sign in?" and "is it on my
+  plan?" cannot drift. Matching is on a segment boundary: `/modelling-guide` is
+  not swallowed by `/model`.
+- `gateSolve` reports the FEATURE before the size when both would block —
+  "your model is too big" is misleading when paying for size alone would not
+  help.
+
+Wiring: `RequireAuth` renders `UpgradeGate` (a page naming the plan) instead of
+redirecting; `ModelSpace` wraps `useSolver.run` so the check happens once at the
+choke point, with the nonlinear/optimiser buttons disabled and an inline notice.
+
+**Both backstops earned their place.** `exportPdf` has TWO buttons reaching it
+(workspace header and results bar) and the header one was missed on the first
+pass — found by dumping every button in the browser, not by reading the file.
+
+**Fail-open when auth is unconfigured**, matching `RequireAuth`: `usePlan`
+returns the top plan so a fork, CI or preview build stays fully usable rather
+than becoming a demo of a paywall nobody can pass. Verified in a browser.
+
+**Nobody can buy a plan yet**, so in practice every account is `free` and sees
+only the calculators. Grant yourself a tier for testing in the Supabase
+dashboard: Authentication → Users → your user → User Metadata → `{"plan":"pro"}`
+or `"max"`.
+
+**This is a product boundary, not a security one.** Every calculation runs in
+the browser; anyone with devtools can flip the plan object. Real enforcement
+means moving the solver behind an authenticated API. The header of
+`featureGate.ts` says so, so nobody later reads these checks as protection.
 
 **Not verifiable here:** a real sign-in round trip, since this environment has
 no Supabase project. Everything up to the network call is tested; the call

--- a/webapp/src/components/RequireAuth.tsx
+++ b/webapp/src/components/RequireAuth.tsx
@@ -1,7 +1,11 @@
 import { Navigate, useLocation } from 'react-router-dom'
 import type { ReactNode } from 'react'
 import { useAuth } from '../lib/auth/authContext'
+import { usePlan } from '../lib/auth/usePlan'
 import { canRun } from '../lib/trialQuota'
+import { gateRoute, featureForRoute } from '../lib/featureGate'
+import { featureLabel } from '../lib/plans'
+import { UpgradeGate } from './UpgradeNotice'
 
 /**
  * Route gate. Sends a visitor to sign-in when the route needs an account.
@@ -16,6 +20,7 @@ import { canRun } from '../lib/trialQuota'
  */
 export function RequireAuth({ children }: { children: ReactNode }) {
   const { loading, configured, access } = useAuth()
+  const plan = usePlan()
   const loc = useLocation()
   if (!configured) return <>{children}</>
   if (loading) {
@@ -28,5 +33,21 @@ export function RequireAuth({ children }: { children: ReactNode }) {
     return <Navigate to="/signin" replace state={{ from: loc.pathname + loc.search }} />
   }
   if (!canRun(verdict)) return <Navigate to="/signin" replace state={{ from: loc.pathname }} />
+
+  // Signed in, but is it on the plan? Shown as a page rather than a redirect:
+  // bouncing someone away from a link they followed, with no explanation, is
+  // the worst version of a paywall. They came here on purpose — say what this
+  // page does and what would open it.
+  const planVerdict = gateRoute(loc.pathname, plan)
+  if (!planVerdict.allowed) {
+    const feature = featureForRoute(loc.pathname)
+    return (
+      <UpgradeGate
+        title={feature ? `${featureLabel(feature)[0].toUpperCase()}${featureLabel(feature).slice(1)}` : 'Not on your plan'}
+        message={planVerdict.message}
+        blurb={`You are on the ${plan.name} plan. Every single-purpose calculator stays available on it.`}
+      />
+    )
+  }
   return <>{children}</>
 }

--- a/webapp/src/components/UpgradeNotice.tsx
+++ b/webapp/src/components/UpgradeNotice.tsx
@@ -1,0 +1,56 @@
+import { Link } from 'react-router-dom'
+
+/**
+ * Explains why something is unavailable and what would unlock it.
+ *
+ * Always states the plan by name — the message comes from `upgradeMessage`,
+ * which never says "upgrade to continue". A paywall that does not say what it
+ * wants is just a broken button.
+ */
+export function UpgradeNotice({ message, compact }: { message: string; compact?: boolean }) {
+  if (compact) {
+    return (
+      <p className="mt-1 text-[11.5px] leading-5 text-amber-800">
+        🔒 {message}{' '}
+        <Link to="/pricing" className="font-semibold underline">See plans</Link>
+      </p>
+    )
+  }
+  return (
+    <div className="col-span-full rounded-lg border border-amber-200 bg-amber-50 px-4 py-3">
+      <p className="text-[13px] font-semibold text-amber-900">🔒 Not on your plan</p>
+      <p className="mt-1 text-[12.5px] leading-6 text-amber-900">{message}</p>
+      <Link to="/pricing"
+        className="mt-2 inline-block rounded-md bg-amber-600 px-3 py-1.5 text-[12px] font-semibold text-white hover:bg-amber-700">
+        Compare plans
+      </Link>
+    </div>
+  )
+}
+
+/**
+ * Full-page version, for a route the plan cannot open at all.
+ *
+ * Shows what the page WOULD do rather than bouncing the visitor somewhere else:
+ * being redirected away with no explanation is the worst version of a paywall.
+ */
+export function UpgradeGate({ title, message, blurb }: { title: string; message: string; blurb?: string }) {
+  return (
+    <main className="mx-auto max-w-2xl px-5 py-16 text-center">
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Plan required</p>
+      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">{title}</h1>
+      <p className="mx-auto mt-3 max-w-lg text-sm leading-6 text-slate-600">{message}</p>
+      {blurb && <p className="mx-auto mt-2 max-w-lg text-[13px] leading-6 text-slate-500">{blurb}</p>}
+      <div className="mt-6 flex flex-wrap justify-center gap-3">
+        <Link to="/pricing"
+          className="rounded-md bg-[#0056b3] px-5 py-2 text-sm font-semibold text-white hover:bg-[#0f4c92]">
+          Compare plans
+        </Link>
+        <Link to="/docs"
+          className="rounded-md border border-slate-300 px-5 py-2 text-sm font-semibold text-slate-700 hover:border-[#0056b3] hover:text-[#0056b3]">
+          Browse the calculators
+        </Link>
+      </div>
+    </main>
+  )
+}

--- a/webapp/src/lib/auth/usePlan.ts
+++ b/webapp/src/lib/auth/usePlan.ts
@@ -1,0 +1,44 @@
+import { useCallback, useMemo } from 'react'
+import { useAuth } from './authContext'
+import { isAuthConfigured } from './authClient'
+import { planOf, type Feature, type Plan } from '../plans'
+import { gateAction, gateSolve, type GateVerdict, type SolverKind } from '../featureGate'
+
+/**
+ * The signed-in account's plan.
+ *
+ * WHEN AUTH IS NOT CONFIGURED, EVERYTHING IS UNLOCKED. That is deliberate and
+ * matches `RequireAuth`: a deployment with no Supabase keys (a fork, CI, a
+ * preview build) must stay fully usable rather than becoming a demo of a
+ * paywall nobody can get past. The failure direction is "open", because the
+ * alternative is a brick.
+ *
+ * Otherwise the plan comes from server-side user metadata via `AuthUser.plan`,
+ * and an unrecognised value falls back to `guest` — the least privileged.
+ */
+export function usePlan(): Plan {
+  const { user } = useAuth()
+  return useMemo(() => {
+    if (!isAuthConfigured()) return planOf('max')
+    return planOf(user ? (user.plan ?? 'free') : 'guest')
+  }, [user])
+}
+
+export interface PlanGate {
+  plan: Plan
+  /** May this feature be used at all? */
+  allows: (f: Feature) => boolean
+  /** Verdict for a non-solver action, with a message when refused. */
+  action: (f: Feature) => GateVerdict
+  /** Verdict for a solver job on a model of `members` members. */
+  solve: (kind: SolverKind, members: number) => GateVerdict
+}
+
+/** The plan plus the three questions pages actually ask of it. */
+export function usePlanGate(): PlanGate {
+  const plan = usePlan()
+  const allows = useCallback((f: Feature) => plan.features.includes(f), [plan])
+  const action = useCallback((f: Feature) => gateAction(f, plan), [plan])
+  const solve = useCallback((kind: SolverKind, members: number) => gateSolve(kind, plan, members), [plan])
+  return useMemo(() => ({ plan, allows, action, solve }), [plan, allows, action, solve])
+}

--- a/webapp/src/lib/featureGate.test.ts
+++ b/webapp/src/lib/featureGate.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest'
+import {
+  SOLVER_FEATURE, ROUTE_FEATURE, gateSolve, gateAction, gateRoute, featureForRoute,
+  modelLimitMessage, type SolverKind,
+} from './featureGate'
+import { GATED_PREFIXES, PUBLIC_ROUTES } from './trialQuota'
+import { PLANS, planOf, type Feature } from './plans'
+
+// The worker's own source, so the guard below compares against what actually
+// ships rather than against a copy of it.
+const workerSrc = Object.values(
+  import.meta.glob('../engine/solverWorker.ts', { query: '?raw', import: 'default', eager: true }),
+)[0] as string
+
+describe('solver kind coverage', () => {
+  /** Every `kind: 'x'` in the SolverRequest union. */
+  const declared = (): string[] => {
+    const union = workerSrc.slice(
+      workerSrc.indexOf('export type SolverRequest'),
+      workerSrc.indexOf('const ctx = self'),
+    )
+    return [...new Set([...union.matchAll(/kind:\s*'([A-Za-z]+)'/g)].map((m) => m[1]))]
+  }
+
+  it('finds the union in the worker source at all', () => {
+    // If this fails the parse has drifted and the guard below is vacuous —
+    // which would be worse than a plain mismatch, because it would pass.
+    expect(declared().length).toBeGreaterThan(4)
+    expect(declared()).toContain('analyze')
+  })
+
+  it('classifies EVERY solver kind the worker accepts', () => {
+    // An unmapped kind reads as `undefined` from the table, which `gateSolve`
+    // treats as "no feature required" — i.e. it would run on any plan. This is
+    // the test that stops a new solver shipping through the paywall unnoticed.
+    for (const k of declared()) {
+      expect(Object.keys(SOLVER_FEATURE), `unclassified solver kind: ${k}`).toContain(k)
+    }
+  })
+
+  it('has no entry for a kind the worker no longer accepts', () => {
+    const d = declared()
+    for (const k of Object.keys(SOLVER_FEATURE)) {
+      expect(d, `stale solver kind in SOLVER_FEATURE: ${k}`).toContain(k)
+    }
+  })
+})
+
+describe('gateSolve', () => {
+  const BIG = 10_000
+
+  it('lets Max run everything', () => {
+    for (const k of Object.keys(SOLVER_FEATURE) as SolverKind[]) {
+      expect(gateSolve(k, 'max', BIG).allowed, k).toBe(true)
+    }
+  })
+
+  it('refuses guests and free accounts every solver job', () => {
+    for (const plan of ['guest', 'free'] as const) {
+      for (const k of Object.keys(SOLVER_FEATURE) as SolverKind[]) {
+        expect(gateSolve(k, plan, 10).allowed, `${plan}/${k}`).toBe(false)
+      }
+    }
+  })
+
+  it('lets Pro analyse and design but not run the nonlinear solvers', () => {
+    for (const k of ['analyze', 'modal', 'design', 'optimize'] as SolverKind[]) {
+      expect(gateSolve(k, 'pro', 100).allowed, k).toBe(true)
+    }
+    for (const k of ['pushover', 'biaxialPushover', 'timeHistory', 'nonlinearTH'] as SolverKind[]) {
+      const v = gateSolve(k, 'pro', 100)
+      expect(v.allowed, k).toBe(false)
+      if (!v.allowed) expect(v.message, k).toContain('Max')
+    }
+  })
+
+  it('enforces the Pro member ceiling at the boundary', () => {
+    const limit = planOf('pro').maxMembers!
+    expect(gateSolve('analyze', 'pro', limit).allowed).toBe(true)
+    const over = gateSolve('analyze', 'pro', limit + 1)
+    expect(over.allowed).toBe(false)
+    if (!over.allowed) {
+      expect(over.reason).toBe('model-limit')
+      if (over.reason === 'model-limit') {
+        expect(over.limit).toBe(limit)
+        expect(over.members).toBe(limit + 1)
+      }
+    }
+  })
+
+  it('reports the FEATURE, not the size, when both would block', () => {
+    // A free account with a 5000-member model is over every limit, but being
+    // told "your model is too big" would be misleading — the size is not what
+    // stands in the way, and would not be after paying for the size alone.
+    const v = gateSolve('analyze', 'free', 5000)
+    expect(v.allowed).toBe(false)
+    if (!v.allowed) expect(v.reason).toBe('feature')
+  })
+
+  it('treats an unknown plan id as the least privileged', () => {
+    for (const bad of ['', 'PRO', 'admin', 'enterprise']) {
+      expect(gateSolve('analyze', bad as never, 1).allowed, bad).toBe(false)
+    }
+  })
+
+  it('always carries a message a user could act on', () => {
+    for (const plan of PLANS) {
+      for (const k of Object.keys(SOLVER_FEATURE) as SolverKind[]) {
+        const v = gateSolve(k, plan.id, 5000)
+        if (!v.allowed) {
+          expect(v.message.length, `${plan.id}/${k}`).toBeGreaterThan(10)
+          expect(v.message, `${plan.id}/${k}`).not.toContain('undefined')
+        }
+      }
+    }
+  })
+})
+
+describe('gateAction', () => {
+  it('gates report export on the plan, with no size condition', () => {
+    expect(gateAction('reports', 'pro').allowed).toBe(true)
+    expect(gateAction('reports', 'free').allowed).toBe(false)
+    expect(gateAction('scheduling', 'pro').allowed).toBe(false)
+    expect(gateAction('scheduling', 'max').allowed).toBe(true)
+  })
+
+  it('names the unlocking plan in the refusal', () => {
+    const v = gateAction('estimating', 'free')
+    expect(v.allowed).toBe(false)
+    if (!v.allowed) expect(v.message).toContain('Pro')
+  })
+})
+
+describe('modelLimitMessage', () => {
+  it('is empty for an unlimited plan — there is nothing to say', () => {
+    expect(modelLimitMessage('max', 99_999)).toBe('')
+  })
+
+  it('quotes the real ceiling and the real count', () => {
+    const m = modelLimitMessage('pro', 512)
+    expect(m).toContain('400')
+    expect(m).toContain('512')
+    expect(m).toContain('Max')
+  })
+
+  it('never renders an undefined for any plan', () => {
+    for (const p of PLANS) {
+      expect(modelLimitMessage(p.id, 10), p.id).not.toContain('undefined')
+    }
+  })
+})
+
+describe('route gating', () => {
+  it('covers exactly the prefixes that require a session — no more, no less', () => {
+    // A gated prefix with no feature would be reachable by any signed-in
+    // account; a feature on an ungated prefix would be unreachable copy.
+    expect([...Object.keys(ROUTE_FEATURE)].sort()).toEqual([...GATED_PREFIXES].sort())
+  })
+
+  it('leaves public and trial routes alone', () => {
+    for (const r of [...PUBLIC_ROUTES, '/beam-design', '/settlement', '/lateral-pile']) {
+      expect(featureForRoute(r), r).toBeNull()
+      expect(gateRoute(r, 'guest').allowed, r).toBe(true)
+    }
+  })
+
+  it('gates the project-scale routes by tier', () => {
+    expect(gateRoute('/model', 'free').allowed).toBe(false)
+    expect(gateRoute('/model', 'pro').allowed).toBe(true)
+    expect(gateRoute('/estimate/slab', 'pro').allowed).toBe(true)
+    expect(gateRoute('/schedule', 'pro').allowed).toBe(false)
+    expect(gateRoute('/schedule', 'max').allowed).toBe(true)
+  })
+
+  it('matches on a segment boundary, not a bare string prefix', () => {
+    // '/modelling-guide' must not be swallowed by the '/model' entry.
+    expect(featureForRoute('/modelling-guide')).toBeNull()
+    expect(featureForRoute('/model')).toBe('model-space')
+    expect(featureForRoute('/model/anything')).toBe('model-space')
+  })
+
+  it('ignores a query string when matching', () => {
+    expect(featureForRoute('/schedule?view=gantt')).toBe('scheduling')
+  })
+})
+
+describe('feature coverage', () => {
+  it('every feature a solver needs is one some plan actually sells', () => {
+    const sold = new Set<Feature>(PLANS.flatMap((p) => [...p.features]))
+    for (const f of Object.values(SOLVER_FEATURE)) {
+      if (f) expect(sold, `no plan includes ${f}`).toContain(f)
+    }
+  })
+})

--- a/webapp/src/lib/featureGate.ts
+++ b/webapp/src/lib/featureGate.ts
@@ -1,0 +1,169 @@
+// ─────────────────────────────────────────────────────────────────────────
+// FEATURE GATE — which plan may run which piece of heavy work.
+//
+// `plans.ts` says what a tier INCLUDES. This says where those entitlements bite:
+// it maps every solver job and every gated action onto the feature it needs, so
+// the decision is made once, in a pure function, rather than as scattered
+// `plan === 'pro'` checks inside a 5,000-line page.
+//
+// WHAT THIS IS NOT: a security boundary — the same warning `trialQuota` carries,
+// and here it matters more. Every calculation in this app runs IN THE BROWSER,
+// in a Web Worker on the user's own machine. There is no server to ask. Anyone
+// with devtools can flip a plan object and run the optimiser, and no amount of
+// client-side code can prevent that. This gate exists to present a coherent
+// product — to tell an honest user what their plan includes and what it does
+// not — NOT to protect compute. Protecting compute would mean moving the solver
+// behind an authenticated API, which is a different project.
+//
+// Saying so plainly here is the point: the risk is that someone later reads
+// these checks as enforcement and stops there.
+// ─────────────────────────────────────────────────────────────────────────
+import { PLANS, planOf, planAllows, upgradeMessage, withinModelLimit, type Feature, type Plan, type PlanId } from './plans'
+
+/**
+ * Every job kind `useSolver` can dispatch.
+ *
+ * Mirrors `SolverRequest['kind']` in `engine/solverWorker.ts`. It is duplicated
+ * rather than imported so this module stays free of the worker's type graph —
+ * and a guard test reads the worker source and fails if the two ever diverge,
+ * because a new solver kind silently defaulting to "allowed" is exactly the
+ * failure this table exists to prevent.
+ */
+export type SolverKind =
+  | 'analyze' | 'design' | 'optimize' | 'modal'
+  | 'pushover' | 'biaxialPushover' | 'timeHistory' | 'nonlinearTH'
+
+/**
+ * The feature each solver job needs.
+ *
+ * `null` would mean "no feature required"; nothing maps to it today, and the
+ * type keeps the option explicit rather than letting an unmapped kind fall
+ * through as allowed.
+ */
+export const SOLVER_FEATURE: Record<SolverKind, Feature | null> = {
+  // Linear analysis and modal extraction are the Model Space itself — Pro.
+  analyze: 'model-space',
+  modal: 'model-space',
+  // The automated design pass over the whole structure — Pro.
+  design: 'design-pipeline',
+  // Section optimisation runs the pipeline repeatedly — Pro.
+  optimize: 'optimizer',
+  // Every nonlinear/dynamic solve — pushover, biaxial pushover, and both
+  // time-history paths (modal superposition and direct integration) — Max.
+  // These are the longest-running jobs in the app, which is why they sit at
+  // the top tier rather than being withheld arbitrarily.
+  pushover: 'nonlinear',
+  biaxialPushover: 'nonlinear',
+  timeHistory: 'nonlinear',
+  nonlinearTH: 'nonlinear',
+}
+
+/** Why a job was refused, or that it may proceed. */
+export type GateVerdict =
+  | { allowed: true }
+  /** The plan does not include the feature at all. */
+  | { allowed: false; reason: 'feature'; feature: Feature; message: string }
+  /** The plan includes it, but the model is over the tier's size ceiling. */
+  | { allowed: false; reason: 'model-limit'; limit: number; members: number; message: string }
+
+/**
+ * Whether `plan` may run a solver job on a model of `members` members.
+ *
+ * Feature first, then size: being told "the optimiser is a Pro feature" is more
+ * useful than "your model is too big" when both are true, because the size
+ * limit would not be the thing standing in the way once the feature is bought.
+ */
+export function gateSolve(kind: SolverKind, plan: PlanId | Plan, members: number): GateVerdict {
+  const p = typeof plan === 'string' ? planOf(plan) : plan
+  const feature = SOLVER_FEATURE[kind]
+  if (feature && !planAllows(p, feature)) {
+    return {
+      allowed: false, reason: 'feature', feature,
+      message: upgradeMessage(p.id, feature) ?? 'That feature is not on your plan.',
+    }
+  }
+  if (!withinModelLimit(p, members)) {
+    // maxMembers is non-null here: withinModelLimit only returns false when it is
+    const limit = p.maxMembers ?? 0
+    return {
+      allowed: false, reason: 'model-limit', limit, members,
+      message: modelLimitMessage(p, members),
+    }
+  }
+  return { allowed: true }
+}
+
+/**
+ * The sentence shown when a model outgrows its tier.
+ *
+ * The zero-limit case never actually surfaces: a plan with `maxMembers: 0` also
+ * lacks `model-space`, so `gateSolve` refuses on the feature first and returns
+ * the upgrade message instead. It is written anyway so the function is total
+ * rather than relying on that ordering holding forever.
+ */
+export function modelLimitMessage(plan: PlanId | Plan, members: number): string {
+  const p = typeof plan === 'string' ? planOf(plan) : plan
+  const limit = p.maxMembers
+  if (limit === null) return ''
+  if (limit === 0) return `The ${p.name} plan does not include the 3D Model Space.`
+  const next = PLANS.find((q) => (q.maxMembers ?? Infinity) > limit)
+  return `The ${p.name} plan analyses models up to ${limit} members; this one has ${members}.`
+    + (next ? ` ${next.name} removes the limit.` : '')
+}
+
+/**
+ * The feature each gated route prefix needs.
+ *
+ * Keyed by the SAME prefixes `trialQuota.GATED_PREFIXES` uses to require a
+ * session, because the two answer different halves of one question — "must I
+ * sign in?" and "is it on my plan?" — and a prefix that has one but not the
+ * other is a page that either lets the wrong people in or turns away the right
+ * ones. A test asserts the key sets match exactly.
+ */
+export const ROUTE_FEATURE: Record<string, Feature> = {
+  '/model': 'model-space',
+  '/frame': 'model-space',
+  '/truss': 'model-space',
+  '/seismic-wizard': 'model-space',
+  '/estimate': 'estimating',
+  '/schedule': 'scheduling',
+}
+
+/**
+ * The feature a route needs, or null when it needs none.
+ *
+ * Longest prefix wins, so a future '/model-lite' cannot be captured by
+ * '/model'. Matching is on a path SEGMENT boundary for the same reason.
+ */
+export function featureForRoute(route: string): Feature | null {
+  const path = route.split('?')[0]
+  let best: { len: number; feature: Feature } | null = null
+  for (const [prefix, feature] of Object.entries(ROUTE_FEATURE)) {
+    if (path === prefix || path.startsWith(prefix + '/')) {
+      if (!best || prefix.length > best.len) best = { len: prefix.length, feature }
+    }
+  }
+  return best?.feature ?? null
+}
+
+/** Verdict for opening a route under a plan. */
+export function gateRoute(route: string, plan: PlanId | Plan): GateVerdict {
+  const feature = featureForRoute(route)
+  if (!feature) return { allowed: true }
+  return gateAction(feature, plan)
+}
+
+/**
+ * Whether a non-solver action is on the plan — PDF export, saving a project.
+ *
+ * Split from `gateSolve` because these carry no model-size condition: exporting
+ * a report you were allowed to produce should not fail on member count.
+ */
+export function gateAction(feature: Feature, plan: PlanId | Plan): GateVerdict {
+  const p = typeof plan === 'string' ? planOf(plan) : plan
+  if (planAllows(p, feature)) return { allowed: true }
+  return {
+    allowed: false, reason: 'feature', feature,
+    message: upgradeMessage(p.id, feature) ?? 'That feature is not on your plan.',
+  }
+}

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -1,4 +1,5 @@
 import { Suspense, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { Link } from 'react-router-dom'
 import { Canvas, useFrame } from '@react-three/fiber'
 import { OrbitControls, Text } from '@react-three/drei'
 import * as THREE from 'three'
@@ -74,6 +75,9 @@ import { loadCustomMaterials, saveCustomMaterials, type CustomMaterial } from '.
 import { buildSectionShapes } from '../lib/sectionShapes3d'
 import { SectionShape } from '../components/SectionShape'
 import { f0, f1, f2 } from '../lib/format'
+import { usePlanGate } from '../lib/auth/usePlan'
+import { UpgradeNotice } from '../components/UpgradeNotice'
+import type { SolverKind } from '../lib/featureGate'
 
 /** A sensible default timber deck (DFL No.2 joists 50×200 @ 400, 25 mm plank). */
 const DEFAULT_DECK: WoodDeck = {
@@ -1132,7 +1136,40 @@ export default function ModelSpace() {
   const [wallT, setWallT] = useState(150); const [wallShear, setWallShear] = useState(false)
   const fileRef = useRef<HTMLInputElement>(null)
   const controlsRef = useRef<React.ComponentRef<typeof OrbitControls>>(null)
-  const { busy, run, progress } = useSolver()   // off-thread FEM/design/optimise
+  const { busy, run: runSolver, progress } = useSolver()   // off-thread FEM/design/optimise
+  const gate = usePlanGate()
+  const [planBlock, setPlanBlock] = useState<string | null>(null)
+
+  /**
+   * Every heavy job goes through here, so the plan check happens ONCE at the
+   * single choke point instead of at each of the dozen call sites. The buttons
+   * below are also disabled when a feature is off-plan, so this should never be
+   * the thing a user hits — it is the backstop that makes a missed button the
+   * cheap kind of mistake.
+   *
+   * Not a security boundary: this runs in the browser, like every calculation
+   * in this app. See the header of lib/featureGate.ts.
+   */
+  const run = ((kind, payload) => {
+    const v = gate.solve(kind as SolverKind, model?.members.length ?? 0)
+    if (!v.allowed) {
+      setPlanBlock(v.message)
+      return Promise.reject(new Error(v.message))
+    }
+    setPlanBlock(null)
+    return runSolver(kind, payload)
+    // Cast to the solver's own signature: the wrapper is transparent, and
+    // re-deriving the per-kind payload mapping here would duplicate useSolver's
+    // types for no gain.
+  }) as typeof runSolver
+
+  // Verdicts for the sections a Pro account can see but not necessarily use.
+  // Computed once here rather than at each button so the wording stays
+  // identical wherever the same feature is refused.
+  const nMembers = model?.members.length ?? 0
+  const nonlinearGate = gate.solve('pushover', nMembers)
+  const optimizeGate = gate.solve('optimize', nMembers)
+  const reportsGate = gate.action('reports')
 
   // Hold Shift to PAN with a left-drag (otherwise left-drag orbits); right-drag
   // pans too. Toggles the OrbitControls left-button mode on Shift down/up.
@@ -1577,6 +1614,12 @@ export default function ModelSpace() {
    *  bundle). Replaces the old print-the-page path. */
   const exportPdf = async () => {
     if (!model || !design || exporting) return
+    // Backstop, for the same reason `run` has one: there are TWO buttons that
+    // reach this (the workspace header and the results bar), and a check that
+    // lives only on the buttons is one refactor away from being bypassed. The
+    // second one was in fact missed on the first pass here.
+    const v = gate.action('reports')
+    if (!v.allowed) { setPlanBlock(v.message); return }
     setExporting(true)
     try {
       let img = modelImg
@@ -1919,6 +1962,20 @@ export default function ModelSpace() {
 
   return (
     <div className="mx-auto max-w-[1700px] p-4">
+      {/* Backstop message from the gated `run`. The buttons for off-plan
+          features are already disabled, so reaching this means a path was
+          missed — it is shown rather than swallowed so that shows up. */}
+      {planBlock && (
+        <div className="no-print mb-3 flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3">
+          <span aria-hidden>🔒</span>
+          <div className="min-w-0 flex-1">
+            <p className="text-[12.5px] leading-6 text-amber-900">{planBlock}</p>
+            <Link to="/pricing" className="text-[12px] font-semibold text-amber-900 underline">Compare plans</Link>
+          </div>
+          <button type="button" onClick={() => setPlanBlock(null)}
+            className="text-[11px] font-semibold text-amber-900/70 hover:text-amber-900" aria-label="Dismiss">✕</button>
+        </div>
+      )}
       {/* ── Workspace header (docs/design/uiux-2026-07) ── */}
       <div className="flex flex-wrap items-center gap-3">
         <div className="flex min-w-0 flex-wrap items-center gap-2.5">
@@ -1955,8 +2012,9 @@ export default function ModelSpace() {
             className="rounded-md bg-[#0f4c92] px-4 py-2 text-[12.5px] font-bold text-white hover:bg-[#0d3f78] disabled:opacity-40">
             Design all
           </button>
-          <button type="button" onClick={() => void exportPdf()} disabled={!design || exporting}
-            title={design ? 'Download the calculation report as a PDF' : 'Run “Design all” first'}
+          <button type="button" onClick={() => void exportPdf()} disabled={!design || exporting || !reportsGate.allowed}
+            title={!reportsGate.allowed ? reportsGate.message
+              : design ? 'Download the calculation report as a PDF' : 'Run “Design all” first'}
             className="rounded-md border border-[#0f4c92] bg-white px-3.5 py-2 text-[12.5px] font-bold text-[#0f4c92] hover:bg-[#eaf1f9] disabled:opacity-40">
             {exporting ? '⏳ Building PDF…' : '⎙ Export PDF'}
           </button>
@@ -3836,9 +3894,10 @@ export default function ModelSpace() {
                   record (two-column t/ag, one-column with Δt, or PEER AT2) or use the built-in synthetic motion.
                 </p>
                 <div className="col-span-full flex flex-wrap gap-2">
-                  <button type="button" onClick={runTimeHistory} disabled={!model || !!busy || meshErrors} className={btn}>
+                  <button type="button" onClick={runTimeHistory} disabled={!model || !!busy || meshErrors || !nonlinearGate.allowed} className={btn}>
                     {busy === 'timeHistory' ? '⏳ Integrating…' : '∿ Run time-history'}
                   </button>
+                  {!nonlinearGate.allowed && <UpgradeNotice compact message={nonlinearGate.message} />}
                   {thCsv && (
                     <button type="button" onClick={runResponseSpectrum} className={btn}>
                       ⌁ Response spectrum
@@ -3924,9 +3983,10 @@ export default function ModelSpace() {
                   lateral tangent — drift is amplified, hinges form earlier, and the collapse base shear drops.
                 </p>
                 <div className="col-span-full">
-                  <button type="button" onClick={runPushover} disabled={!model || !!busy || meshErrors} className={btn}>
+                  <button type="button" onClick={runPushover} disabled={!model || !!busy || meshErrors || !nonlinearGate.allowed} className={btn}>
                     {busy === 'pushover' ? '⏳ Pushing…' : '⤧ Run pushover'}
                   </button>
+                  {!nonlinearGate.allowed && <UpgradeNotice compact message={nonlinearGate.message} />}
                   {meshErrors && <p className="mt-1 text-[11px] font-medium text-red-600">Resolve the mesh errors in the Analysis tab to enable pushover.</p>}
                 </div>
                 {busy === 'pushover' && <SolverProgress p={progress} />}
@@ -3972,9 +4032,10 @@ export default function ModelSpace() {
                   offsets cannot be represented by the hinge element; if the model uses them, the result panel says so.
                 </p>
                 <div className="col-span-full">
-                  <button type="button" onClick={runBiaxialPushover} disabled={!model || !!busy || meshErrors} className={btn}>
+                  <button type="button" onClick={runBiaxialPushover} disabled={!model || !!busy || meshErrors || !nonlinearGate.allowed} className={btn}>
                     {busy === 'biaxialPushover' ? '⏳ Pushing…' : '◈ Run biaxial pushover'}
                   </button>
+                  {!nonlinearGate.allowed && <UpgradeNotice compact message={nonlinearGate.message} />}
                 </div>
                 {busy === 'biaxialPushover' && <SolverProgress p={progress} />}
               </Sec>
@@ -4207,10 +4268,11 @@ export default function ModelSpace() {
                   <button type="button" onClick={runPipeline} disabled={!model || !!busy || meshErrors} className={btn}>
                     {busy === 'design' ? '⏳ Designing…' : '🏗 Design structure'}
                   </button>
-                  <button type="button" onClick={optimize} disabled={!model || !!busy || meshErrors} className={btn}
+                  <button type="button" onClick={optimize} disabled={!model || !!busy || meshErrors || !optimizeGate.allowed} className={btn}
                     title="Grow each failing member's own section until nothing fails, then trim back">
                     {busy === 'optimize' ? '⏳ Optimizing…' : '🏁 Optimize design'}
                   </button>
+                  {!optimizeGate.allowed && <UpgradeNotice compact message={optimizeGate.message} />}
                 </div>
                 {meshErrors && (
                   <p className="col-span-full text-[11px] font-medium text-red-600">
@@ -4347,7 +4409,8 @@ export default function ModelSpace() {
                 {label}
               </button>
             ))}
-            <button type="button" onClick={() => void exportPdf()} disabled={exporting}
+            <button type="button" onClick={() => void exportPdf()} disabled={exporting || !reportsGate.allowed}
+              title={reportsGate.allowed ? 'Download the calculation report as a PDF' : reportsGate.message}
               className="mb-1 ml-auto rounded-md bg-[#0f4c92] px-4 py-2 text-[12.5px] font-bold text-white hover:bg-[#0d3f78] disabled:opacity-40">
               {exporting ? '⏳ Building PDF…' : '⎙ Export PDF report'}
             </button>


### PR DESCRIPTION
The tiers were catalogued but nothing consulted them — a signed-in Free account
could open `/model`, run the optimiser and export a report. `lib/featureGate.ts`
now maps every gated thing onto the feature it needs, in one pure tested place,
and the app asks it.

## Two tables, each with a guard test

The failure mode here is *silence*, so both tables are checked against the code
they mirror rather than against a copy of it.

**`SOLVER_FEATURE`** — every `SolverRequest['kind']` → its feature. An unmapped
kind reads as `undefined`, which `gateSolve` treats as "no feature required" —
i.e. **a new solver would ship straight through the paywall**. The guard parses
`engine/solverWorker.ts` and fails on an unclassified *or* a stale kind. I
verified it bites by deleting a mapping and watching it go red, rather than
trusting a test that has never failed.

**`ROUTE_FEATURE`** — every gated route prefix → its feature, asserted
key-set-equal to `trialQuota.GATED_PREFIXES`, so *"must I sign in?"* and *"is it
on my plan?"* cannot drift apart. Matching is on a path **segment** boundary, so
a future `/modelling-guide` is not swallowed by `/model`.

## Feature before size

`gateSolve` reports the feature when both would block. Telling a Free account
with a 5,000-member model that it's *too big* would be misleading — the size is
not what stands in the way, and paying for size alone wouldn't fix it.

## Wiring

- `RequireAuth` renders an **`UpgradeGate` page naming the plan** instead of
  redirecting. Bouncing someone off a link they followed, with no explanation,
  is the worst version of a paywall.
- `ModelSpace` wraps `useSolver.run`, so the check happens once at the choke
  point every heavy job passes through, with the nonlinear and optimiser buttons
  disabled and an inline notice underneath.

## Both backstops earned their place

`exportPdf` has **two** buttons reaching it — the workspace header and the
results bar — and **the header one was missed on the first pass.** It turned up
by dumping every button in the browser, not by reading the file. That is exactly
why the handler now checks as well as the buttons.

## Fail-open when auth is unconfigured

`usePlan` returns the top plan when there are no Supabase keys, matching
`RequireAuth`'s existing behaviour: a fork, CI, or a preview build stays fully
usable instead of becoming a demo of a paywall nobody can get past.

## Verified in a browser, with sessions injected at each tier

| Plan | `/model` | `/estimate` | `/schedule` | `/beam-design` |
|---|---|---|---|---|
| free | blocked | blocked | blocked | open |
| pro | open | open | **blocked** | open |
| max | open | open | open | open |

And inside Model Space **with a model generated**, so that a disabled button
means the gate rather than "no model yet":

- `pro` — *Run pushover* disabled, notice reads "🔒 nonlinear analysis is part of
  the Max plan"
- `max` — *Run pushover* **enabled**, no notice

Unconfigured build re-checked: every route renders, zero console errors.

*(A detection note: my first pass reported the routes as unblocked. The page was
in fact blocked — the "Plan required" label renders uppercase via CSS and my
check was case-sensitive. The code was right; the probe was wrong.)*

## This is a product boundary, not a security one

Every calculation in this app runs in the browser. Anyone with devtools can flip
the plan object, and no client-side code can prevent that. Real enforcement means
moving the solver behind an authenticated API. The module header says so plainly
so nobody later reads these checks as protection.

## Note on rollout

Checkout isn't live, so **every account is `free`** and will see only the
calculators. Grant yourself a tier for testing in the Supabase dashboard:
Authentication → Users → your user → User Metadata → `{"plan": "pro"}` or
`"max"`.

## Verification

`npx tsc -b` = 0 · `npm run lint` = 0 · `npm test` **1917 passing** (21 new) ·
`npm run build` = 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_