### PR TITLE
Billing webhook — the server half of checkout, with PayMongo

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1155,11 +1155,37 @@ exists, every account is `free`. To grant yourself a paid tier for testing, set
 `{"plan": "pro"}` (or `"max"`) on your user in the Supabase dashboard under
 Authentication → Users → User Metadata.
 
-**Payments are still not done, and should not be faked.** `CHECKOUT_ENABLED` is
-a named constant pinned to false by a test, so flipping it on without adding a
-server to verify the webhook makes the suite object. The pricing page lists Pro
-and Max so their contents are visible and says plainly that they are not open
-for sign-up; no card details are collected anywhere in the app.
+**Billing webhook shipped in #467 — the server half of checkout.**
+`supabase/functions/billing-webhook/` (Deno) verifies the provider's HMAC, maps
+the event to a plan and writes `user_metadata.plan` with the service-role key.
+Idempotent: the applied event id is stored beside the plan, so provider retries
+are no-ops. Pure logic in `supabase/functions/_shared/` is covered by the app's
+vitest suite (48 tests) — vite.config's `test.include` was extended to reach it,
+so the money path is not the one untested corner.
+
+Three providers verified: **Paddle**, **Stripe** and **PayMongo** (chosen for
+this audience — Philippine engineers, so GCash/Maya matter). Constant-time
+digest comparison, ±300 s replay window checked both directions, missing secret
+rejects. PayMongo's `te=`/`li=` split is resolved by explicit mode, because
+accepting either would let a widely-shared test secret approve a live payment.
+
+Two invariants pinned by tests: an unrecognised price NEVER resolves to a plan,
+and anything not-active resolves DOWN to free. Everything fails CLOSED — the
+opposite of `authClient`/`usePlan`, deliberately.
+
+Full setup steps and the pre-launch checklist are in `docs/Billing.md`.
+
+**Checkout itself is still not wired, and payments are still not faked.**
+`CHECKOUT_ENABLED` remains pinned false by a test. What is missing is a
+`billing-checkout` function creating a session with `metadata.user_id` attached
+(PayMongo has no static link that carries per-user metadata), the pricing-page
+buttons, and a `/billing/success` page. The pricing page still says plainly that
+paid plans are not open; no card details are collected anywhere in the app.
+
+**Unverified, flagged rather than assumed:** PayMongo's event field paths were
+written from the documented envelope, not a captured event — send one test event
+through before launch. Also confirm PayMongo subscriptions are available on the
+account, and settle the PHP-vs-USD mismatch between the provider and `/pricing`.
 
 **Enforcement shipped in #466.** `lib/featureGate.ts` maps every gated thing
 onto the feature it needs, in one pure tested place:

--- a/docs/Billing.md
+++ b/docs/Billing.md
@@ -1,0 +1,140 @@
+# Billing — how a payment becomes a plan
+
+## Why any of this needs a server
+
+A plan is read from Supabase `user_metadata.plan`, and the feature gate trusts
+that field. So the only question that matters is **who is allowed to write it**.
+
+It cannot be the browser. A "user upgraded" request sent from a page can be
+forged by the person sending it — they control the code. It has to be the
+payment provider telling us, over a channel we can prove came from them. That
+proof is an HMAC computed with a secret only the provider and our server share,
+which is why the secret cannot live in a `VITE_*` variable, and why there is a
+Supabase Edge Function.
+
+```
+  browser                provider                 Edge Function            Supabase
+  ───────                ────────                 ─────────────            ────────
+  "Buy Pro"  ─────────▶  hosted checkout
+                         (customer pays)
+                              │
+                              └── POST webhook ──▶ verify HMAC
+                                  + signature       parse event
+                                                    map price → plan
+                                                    write metadata ──────▶ plan: "pro"
+                                                                              │
+  gate reads user.plan ◀──────────────────────────────────────── session ─────┘
+```
+
+## What is built (this phase)
+
+`supabase/functions/billing-webhook/` — verifies the signature, maps the event
+to a plan, writes it with the service-role key. Idempotent: the applied event id
+is stored next to the plan, so a provider retry is a no-op.
+
+`supabase/functions/_shared/` — the pure logic, covered by the app's vitest
+suite (48 tests):
+
+- `signature.ts` — HMAC-SHA256 verification for **Paddle**, **Stripe** and
+  **PayMongo**. Constant-time digest comparison, a ±300 s replay window checked
+  in both directions, and rejection on a missing secret.
+- `events.ts` — provider event → `set-plan` / `ignore` / `reject`.
+
+### Two rules the tests pin
+
+**An unrecognised price never resolves to a plan.** A typo in `BILLING_PRICE_MAP`
+makes the webhook reject loudly rather than silently granting a tier nobody paid
+for.
+
+**Anything that is not an active paid state resolves down to `free`.** The
+dangerous direction is leaving a paid tier standing after the money stopped.
+`past_due` is deliberately treated as active — the provider is still retrying
+the card, and cutting someone off mid-retry loses a customer who meant to pay.
+
+Everything here **fails closed**, the opposite of `authClient`/`usePlan`, which
+fail open so an unconfigured fork stays usable. The asymmetry is deliberate: the
+cost of being wrong is "nobody can use the app" in one case and "anyone can
+grant themselves a paid plan" in the other.
+
+## Setup
+
+### 1. Deploy the function
+
+```bash
+supabase functions deploy billing-webhook --no-verify-jwt
+```
+
+`--no-verify-jwt` is required: the caller is the payment provider, not a
+signed-in user. The signature check is what authenticates it instead.
+
+### 2. Set the secrets
+
+```bash
+supabase secrets set \
+  BILLING_PROVIDER=paymongo \
+  BILLING_WEBHOOK_SECRET=whsk_... \
+  BILLING_MODE=test \
+  BILLING_PRICE_MAP='plan_pro_id=pro,plan_max_id=max'
+```
+
+`SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are injected by the platform —
+do not set them by hand, and never put the service-role key in the web app.
+
+| Secret | Notes |
+|---|---|
+| `BILLING_PROVIDER` | `paddle`, `stripe` or `paymongo` |
+| `BILLING_WEBHOOK_SECRET` | the endpoint's signing secret |
+| `BILLING_MODE` | `test` or `live`. **PayMongo only** — it sends both a test (`te=`) and a live (`li=`) digest, and this picks which is authoritative. Accepting either would let a test-mode secret approve a live payment. |
+| `BILLING_PRICE_MAP` | `priceId=plan` pairs. Get the ids from the provider dashboard. |
+
+### 3. Point the provider at it
+
+Webhook URL: `https://<project-ref>.supabase.co/functions/v1/billing-webhook`
+
+Subscribe to subscription lifecycle events (created / updated / cancelled) and,
+for PayMongo, `payment.paid` and `payment.failed`.
+
+### 4. Attach the user id at checkout
+
+**This is the step that everything else depends on.** The webhook has no way to
+know who paid unless checkout carries the Supabase user id:
+
+- **Paddle** — `customData: { user_id: <id> }`
+- **Stripe** — `client_reference_id`, or subscription `metadata.user_id`
+- **PayMongo** — `metadata: { user_id: <id> }` on the checkout session
+
+Without it the event is rejected with `no-user` and nothing is granted.
+
+## Still to do
+
+**Checkout itself is not wired up.** `CHECKOUT_ENABLED` in `webapp/src/lib/plans.ts`
+is still pinned `false` by a test, and the pricing page still says paid plans are
+not open. This phase built the half that receives and verifies payment; the half
+that *starts* one is next, and needs:
+
+- a `billing-checkout` Edge Function that creates a session with
+  `metadata.user_id` attached (PayMongo has no static link that can carry
+  per-user metadata, so this cannot be a plain URL in an env var)
+- checkout buttons on `/pricing` and a `/billing/success` return page
+- `CHECKOUT_ENABLED` derived from configuration rather than hard-coded
+
+### Confirm before going live
+
+**PayMongo field paths are unverified.** `fromPaymongo` was written from the
+documented envelope shape, not from a captured event. Send one test event
+through and confirm `metadata.user_id` and the price identifier arrive where it
+expects. It fails closed, so a wrong guess denies a paying customer — visible
+and fixable — rather than granting a free one. The Paddle and Stripe shapes are
+the standard documented ones but deserve the same one-event check.
+
+**Recurring billing on PayMongo.** Confirm subscriptions are available on your
+account before committing to a monthly plan. If only one-off payments are
+available, monthly billing needs a different design (scheduled charges against a
+saved payment method), which is materially more work than this.
+
+**Currency.** PayMongo settles in PHP; `/pricing` currently shows USD. Pick one
+and make the pricing page and the provider agree — a customer seeing $19 and
+being charged ₱1,100 is a support ticket at best.
+
+**Business registration.** PayMongo onboards registered Philippine businesses.
+Worth confirming eligibility before building the rest of the flow.

--- a/supabase/functions/_shared/events.test.ts
+++ b/supabase/functions/_shared/events.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest'
+import { parsePriceMap, isActiveStatus, fromPaddle, fromStripe, fromPaymongo, parseEvent } from './events'
+
+const PRICES = { pri_pro: 'pro', pri_max: 'max' } as const
+const P = { ...PRICES } as Record<string, 'pro' | 'max' | 'free'>
+
+describe('parsePriceMap', () => {
+  it('parses the env form', () => {
+    expect(parsePriceMap('pri_a=pro,pri_b=max')).toEqual({ pri_a: 'pro', pri_b: 'max' })
+  })
+
+  it('tolerates whitespace and empty input', () => {
+    expect(parsePriceMap(' pri_a = pro , pri_b = max ')).toEqual({ pri_a: 'pro', pri_b: 'max' })
+    expect(parsePriceMap(undefined)).toEqual({})
+    expect(parsePriceMap('')).toEqual({})
+  })
+
+  it('DROPS entries naming a plan that does not exist', () => {
+    // A typo like 'professional' must not become a tier. Dropping it means the
+    // price later fails to map and the webhook rejects loudly, instead of
+    // minting a user with a nonsense plan the gate would resolve to guest.
+    expect(parsePriceMap('pri_a=professional,pri_b=max')).toEqual({ pri_b: 'max' })
+    expect(parsePriceMap('pri_a=admin')).toEqual({})
+    expect(parsePriceMap('pri_a=guest')).toEqual({})
+  })
+
+  it('ignores malformed pairs', () => {
+    expect(parsePriceMap('nonsense,=pro,pri_a=')).toEqual({})
+  })
+})
+
+describe('isActiveStatus', () => {
+  it('counts past_due as active — the card is still being retried', () => {
+    expect(isActiveStatus('past_due')).toBe(true)
+    expect(isActiveStatus('active')).toBe(true)
+    expect(isActiveStatus('trialing')).toBe(true)
+  })
+
+  it('counts everything else as not paying', () => {
+    for (const s of ['canceled', 'cancelled', 'unpaid', 'paused', 'incomplete', '', 'ACTIVE']) {
+      expect(isActiveStatus(s), s).toBe(false)
+    }
+  })
+})
+
+describe('fromPaddle', () => {
+  const evt = (over: Record<string, unknown> = {}) => ({
+    event_id: 'evt_01', event_type: 'subscription.activated',
+    data: {
+      status: 'active',
+      custom_data: { user_id: 'user-1' },
+      items: [{ price: { id: 'pri_pro' } }],
+      ...over,
+    },
+  })
+
+  it('maps an active subscription to its plan', () => {
+    expect(fromPaddle(evt(), P)).toEqual({ kind: 'set-plan', userId: 'user-1', plan: 'pro', eventId: 'evt_01' })
+  })
+
+  it('downgrades to free on any non-active status', () => {
+    for (const status of ['canceled', 'paused', 'unpaid']) {
+      expect(fromPaddle(evt({ status }), P), status)
+        .toEqual({ kind: 'set-plan', userId: 'user-1', plan: 'free', eventId: 'evt_01' })
+    }
+  })
+
+  it('REJECTS an unknown price instead of guessing a tier', () => {
+    const r = fromPaddle(evt({ items: [{ price: { id: 'pri_typo' } }] }), P)
+    expect(r).toEqual({ kind: 'reject', why: 'unknown-price', detail: 'pri_typo' })
+  })
+
+  it('rejects an event with no user to attribute it to', () => {
+    expect(fromPaddle(evt({ custom_data: null }), P).kind).toBe('reject')
+  })
+
+  it('rejects an event with no id, since idempotency depends on it', () => {
+    expect(fromPaddle({ ...evt(), event_id: undefined }, P)).toEqual({ kind: 'reject', why: 'no-event-id' })
+  })
+
+  it('ignores event types it does not act on', () => {
+    const r = fromPaddle({ ...evt(), event_type: 'customer.updated' }, P)
+    expect(r.kind).toBe('ignore')
+  })
+
+  it('does not throw on junk', () => {
+    for (const junk of [null, undefined, 42, 'x', {}, { data: null }]) {
+      expect(() => fromPaddle(junk, P)).not.toThrow()
+      expect(fromPaddle(junk, P).kind).toBe('reject')
+    }
+  })
+})
+
+describe('fromStripe', () => {
+  const evt = (over: Record<string, unknown> = {}) => ({
+    id: 'evt_stripe_1', type: 'customer.subscription.updated',
+    data: { object: {
+      status: 'active', metadata: { user_id: 'user-9' },
+      items: { data: [{ price: { id: 'pri_max' } }] }, ...over,
+    } },
+  })
+
+  it('maps an active subscription to its plan', () => {
+    expect(fromStripe(evt(), P))
+      .toEqual({ kind: 'set-plan', userId: 'user-9', plan: 'max', eventId: 'evt_stripe_1' })
+  })
+
+  it('falls back to client_reference_id when metadata is absent', () => {
+    const r = fromStripe(evt({ metadata: null, client_reference_id: 'user-ref' }), P)
+    expect(r).toMatchObject({ kind: 'set-plan', userId: 'user-ref' })
+  })
+
+  it('downgrades on cancellation and rejects an unknown price', () => {
+    expect(fromStripe(evt({ status: 'canceled' }), P)).toMatchObject({ kind: 'set-plan', plan: 'free' })
+    expect(fromStripe(evt({ items: { data: [{ price: { id: 'nope' } }] } }), P))
+      .toMatchObject({ kind: 'reject', why: 'unknown-price' })
+  })
+
+  it('does not throw on junk', () => {
+    for (const junk of [null, {}, { data: {} }]) expect(fromStripe(junk, P).kind).toBe('reject')
+  })
+})
+
+describe('fromPaymongo', () => {
+  const evt = (attrs: Record<string, unknown> = {}, type = 'subscription.updated') => ({
+    data: { id: 'evt_pm_1', type: 'event', attributes: { type, data: { id: 'sub_1', attributes: {
+      status: 'active', metadata: { user_id: 'user-ph' }, plan_id: 'pri_pro', ...attrs,
+    } } } },
+  })
+
+  it('maps an active subscription to its plan', () => {
+    expect(fromPaymongo(evt(), P))
+      .toEqual({ kind: 'set-plan', userId: 'user-ph', plan: 'pro', eventId: 'evt_pm_1' })
+  })
+
+  it('reads a line item when there is no plan_id', () => {
+    const r = fromPaymongo(evt({ plan_id: undefined, line_items: [{ id: 'pri_max' }] }, 'payment.paid'), P)
+    expect(r).toMatchObject({ kind: 'set-plan', plan: 'max' })
+  })
+
+  it('downgrades on a failed payment', () => {
+    expect(fromPaymongo(evt({}, 'payment.failed'), P)).toMatchObject({ kind: 'set-plan', plan: 'free' })
+  })
+
+  it('downgrades on an inactive subscription', () => {
+    expect(fromPaymongo(evt({ status: 'cancelled' }), P)).toMatchObject({ kind: 'set-plan', plan: 'free' })
+  })
+
+  it('REJECTS an unknown price rather than granting anything', () => {
+    expect(fromPaymongo(evt({ plan_id: 'pri_unknown' }), P)).toMatchObject({ kind: 'reject', why: 'unknown-price' })
+  })
+
+  it('rejects when the shape is not what we expect, rather than guessing', () => {
+    // The field paths here are unconfirmed against a real PayMongo event, so
+    // the behaviour on a surprise shape is the property that matters: it must
+    // deny, which is visible and fixable, not grant.
+    for (const junk of [null, {}, { data: {} }, { data: { id: 'e', attributes: {} } }]) {
+      const r = fromPaymongo(junk, P)
+      expect(['reject', 'ignore'], JSON.stringify(junk)).toContain(r.kind)
+      expect(r.kind).not.toBe('set-plan')
+    }
+  })
+})
+
+describe('parseEvent dispatch', () => {
+  it('never returns set-plan for an empty event, on any provider', () => {
+    for (const p of ['paddle', 'stripe', 'paymongo'] as const) {
+      expect(parseEvent(p, {}, P).kind, p).not.toBe('set-plan')
+    }
+  })
+
+  it('never grants a plan when the price map is empty', () => {
+    // The misconfiguration case: secrets set, PRICE_MAP forgotten. Every
+    // provider must refuse rather than fall back to a tier.
+    const active = [
+      ['paddle', { event_id: 'e', event_type: 'subscription.activated', data: { status: 'active', custom_data: { user_id: 'u' }, items: [{ price: { id: 'x' } }] } }],
+      ['stripe', { id: 'e', type: 'customer.subscription.updated', data: { object: { status: 'active', metadata: { user_id: 'u' }, items: { data: [{ price: { id: 'x' } }] } } } }],
+      ['paymongo', { data: { id: 'e', attributes: { type: 'subscription.updated', data: { attributes: { status: 'active', metadata: { user_id: 'u' }, plan_id: 'x' } } } } }],
+    ] as const
+    for (const [prov, e] of active) {
+      expect(parseEvent(prov, e, {}), prov).toMatchObject({ kind: 'reject', why: 'unknown-price' })
+    }
+  })
+})

--- a/supabase/functions/_shared/events.ts
+++ b/supabase/functions/_shared/events.ts
@@ -1,0 +1,194 @@
+// ─────────────────────────────────────────────────────────────────────────
+// WEBHOOK EVENT → PLAN CHANGE.
+//
+// Turns a verified provider event into "set user X to plan Y", or into an
+// explicit refusal. Pure and provider-shaped-input only, so every branch is
+// testable without a network or a Supabase project.
+//
+// TWO RULES THAT ARE NOT NEGOTIABLE:
+//
+//   1. An unrecognised price/product NEVER resolves to a plan. Defaulting to
+//      anything means a misconfigured price id silently grants a tier nobody
+//      paid for. It returns `unknown-price` and the caller rejects loudly.
+//
+//   2. A cancellation, refund or failed payment resolves DOWNWARD, to 'free'.
+//      The dangerous direction is leaving a paid tier in place after the money
+//      stopped, so anything that is not an active paid state is treated as
+//      not-paid rather than ignored.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Plan ids, mirrored from webapp/src/lib/plans.ts. */
+export type PlanId = 'guest' | 'free' | 'pro' | 'max'
+
+export type EventOutcome =
+  | { kind: 'set-plan'; userId: string; plan: PlanId; eventId: string }
+  /** Understood, but nothing to do (e.g. an event type we do not act on). */
+  | { kind: 'ignore'; eventId: string; why: string }
+  /** Malformed or unmappable — the caller must NOT treat this as success. */
+  | { kind: 'reject'; why: 'no-user' | 'unknown-price' | 'unparseable' | 'no-event-id'; detail?: string }
+
+/** price/product id → plan. Supplied from env so ids are not baked into code. */
+export type PriceMap = Record<string, PlanId>
+
+/**
+ * Parse `PRICE_MAP` env: `pri_abc=pro,pri_def=max`.
+ *
+ * Entries naming an unknown plan are dropped rather than trusted, so a typo
+ * like `pri_abc=professional` fails closed at the mapping step instead of
+ * producing a user with a nonsense tier.
+ */
+export function parsePriceMap(raw: string | undefined): PriceMap {
+  const out: PriceMap = {}
+  if (!raw) return out
+  for (const pair of raw.split(',')) {
+    const i = pair.indexOf('=')
+    if (i <= 0) continue
+    const id = pair.slice(0, i).trim()
+    const plan = pair.slice(i + 1).trim()
+    if (id && (plan === 'pro' || plan === 'max' || plan === 'free')) out[id] = plan
+  }
+  return out
+}
+
+/** Subscription states that mean "currently paying". */
+const ACTIVE = new Set(['active', 'trialing', 'past_due'])
+
+/**
+ * `past_due` counts as active on purpose: the provider is still retrying the
+ * card, and cutting someone off during a retry window over an expired card is
+ * how you lose a customer who fully intended to pay. The provider will send a
+ * cancellation if the retries run out, and that downgrades.
+ */
+export const isActiveStatus = (s: string): boolean => ACTIVE.has(s)
+
+// ── Paddle ────────────────────────────────────────────────────────────────
+interface PaddleEvent {
+  event_id?: string
+  event_type?: string
+  data?: {
+    status?: string
+    custom_data?: { user_id?: string } | null
+    items?: { price?: { id?: string } | null }[] | null
+  }
+}
+
+export function fromPaddle(evt: unknown, prices: PriceMap): EventOutcome {
+  const e = evt as PaddleEvent
+  const eventId = e?.event_id
+  if (!eventId) return { kind: 'reject', why: 'no-event-id' }
+  const type = e.event_type ?? ''
+  if (!type.startsWith('subscription.') && !type.startsWith('transaction.completed')) {
+    return { kind: 'ignore', eventId, why: `unhandled type ${type}` }
+  }
+  const userId = e.data?.custom_data?.user_id
+  if (!userId) return { kind: 'reject', why: 'no-user', detail: type }
+
+  const status = e.data?.status ?? ''
+  if (!isActiveStatus(status)) return { kind: 'set-plan', userId, plan: 'free', eventId }
+
+  const priceId = e.data?.items?.[0]?.price?.id
+  const plan = priceId ? prices[priceId] : undefined
+  if (!plan) return { kind: 'reject', why: 'unknown-price', detail: priceId ?? '(none)' }
+  return { kind: 'set-plan', userId, plan, eventId }
+}
+
+// ── Stripe ────────────────────────────────────────────────────────────────
+interface StripeEvent {
+  id?: string
+  type?: string
+  data?: {
+    object?: {
+      status?: string
+      client_reference_id?: string | null
+      metadata?: { user_id?: string } | null
+      items?: { data?: { price?: { id?: string } | null }[] } | null
+    }
+  }
+}
+
+export function fromStripe(evt: unknown, prices: PriceMap): EventOutcome {
+  const e = evt as StripeEvent
+  const eventId = e?.id
+  if (!eventId) return { kind: 'reject', why: 'no-event-id' }
+  const type = e.type ?? ''
+  if (!type.startsWith('customer.subscription.')) {
+    return { kind: 'ignore', eventId, why: `unhandled type ${type}` }
+  }
+  const obj = e.data?.object
+  // checkout sets client_reference_id; subscription objects carry metadata
+  const userId = obj?.metadata?.user_id || obj?.client_reference_id || undefined
+  if (!userId) return { kind: 'reject', why: 'no-user', detail: type }
+
+  const status = obj?.status ?? ''
+  if (!isActiveStatus(status)) return { kind: 'set-plan', userId, plan: 'free', eventId }
+
+  const priceId = obj?.items?.data?.[0]?.price?.id
+  const plan = priceId ? prices[priceId] : undefined
+  if (!plan) return { kind: 'reject', why: 'unknown-price', detail: priceId ?? '(none)' }
+  return { kind: 'set-plan', userId, plan, eventId }
+}
+
+// ── PayMongo ──────────────────────────────────────────────────────────────
+//
+// Envelope: { data: { id, type: 'event', attributes: { type, data: {…} } } }
+// where the INNER `attributes.type` is the event name ('payment.paid',
+// 'subscription.updated', …) and `attributes.data` is the resource.
+//
+// ⚠ THE FIELD PATHS BELOW ARE WRITTEN FROM THE DOCUMENTED ENVELOPE AND HAVE NOT
+// BEEN CHECKED AGAINST A REAL PAYMONGO EVENT. Send one test event through
+// before going live and confirm `metadata.user_id` and the price identifier
+// arrive where this expects them. Everything here fails CLOSED — an
+// unrecognised shape returns `reject`, never a plan — so a wrong guess denies a
+// paid customer (visible, fixable) rather than granting a free one (silent).
+interface PaymongoEvent {
+  data?: {
+    id?: string
+    attributes?: {
+      type?: string
+      data?: {
+        id?: string
+        attributes?: {
+          status?: string
+          metadata?: { user_id?: string } | null
+          /** Set on subscription resources; absent on one-off payments. */
+          plan_id?: string
+          /** Line items on a checkout session / payment. */
+          line_items?: { id?: string }[] | null
+        }
+      }
+    }
+  }
+}
+
+export function fromPaymongo(evt: unknown, prices: PriceMap): EventOutcome {
+  const e = evt as PaymongoEvent
+  const eventId = e?.data?.id
+  if (!eventId) return { kind: 'reject', why: 'no-event-id' }
+  const type = e.data?.attributes?.type ?? ''
+  const acted = type.startsWith('subscription.') || type === 'payment.paid' || type === 'payment.failed'
+  if (!acted) return { kind: 'ignore', eventId, why: `unhandled type ${type}` }
+
+  const res = e.data?.attributes?.data?.attributes
+  const userId = res?.metadata?.user_id
+  if (!userId) return { kind: 'reject', why: 'no-user', detail: type }
+
+  // A failed payment or an inactive subscription drops to free, same as the
+  // other providers — the risky direction is leaving a paid tier standing.
+  const status = res?.status ?? ''
+  if (type === 'payment.failed' || (type.startsWith('subscription.') && !isActiveStatus(status))) {
+    return { kind: 'set-plan', userId, plan: 'free', eventId }
+  }
+
+  const priceId = res?.plan_id ?? res?.line_items?.[0]?.id
+  const plan = priceId ? prices[priceId] : undefined
+  if (!plan) return { kind: 'reject', why: 'unknown-price', detail: priceId ?? '(none)' }
+  return { kind: 'set-plan', userId, plan, eventId }
+}
+
+export const parseEvent = (
+  provider: 'paddle' | 'stripe' | 'paymongo', evt: unknown, prices: PriceMap,
+): EventOutcome => (
+  provider === 'paddle' ? fromPaddle(evt, prices)
+    : provider === 'stripe' ? fromStripe(evt, prices)
+      : fromPaymongo(evt, prices)
+)

--- a/supabase/functions/_shared/signature.test.ts
+++ b/supabase/functions/_shared/signature.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest'
+import {
+  timingSafeEqual, hmacSha256Hex, verifyPaddle, verifyStripe, verifyPaymongo,
+  verifySignature, SIGNATURE_HEADER, DEFAULT_TOLERANCE_S,
+} from './signature'
+
+const SECRET = 'whsec_test_2f8a9c1e4b6d'
+const BODY = '{"event_id":"evt_1","data":{"status":"active"}}'
+const NOW = 1_800_000_000
+
+describe('timingSafeEqual', () => {
+  it('matches identical strings and rejects any difference', () => {
+    expect(timingSafeEqual('abc', 'abc')).toBe(true)
+    expect(timingSafeEqual('abc', 'abd')).toBe(false)
+    expect(timingSafeEqual('abc', 'ab')).toBe(false)
+    expect(timingSafeEqual('', '')).toBe(true)
+    expect(timingSafeEqual('a', '')).toBe(false)
+  })
+
+  it('does not short-circuit on the first differing character', () => {
+    // Both comparisons must do the same work. This cannot assert wall-clock
+    // timing reliably in CI, so it asserts the observable proxy: a mismatch in
+    // position 0 and one in the last position both simply return false, with
+    // no length- or prefix-dependent early exit visible in behaviour.
+    const a = 'f'.repeat(64)
+    expect(timingSafeEqual(a, 'e' + a.slice(1))).toBe(false)
+    expect(timingSafeEqual(a, a.slice(0, 63) + 'e')).toBe(false)
+  })
+})
+
+describe('hmacSha256Hex', () => {
+  it('matches a known RFC-style vector', async () => {
+    // HMAC-SHA256(key='key', msg='The quick brown fox jumps over the lazy dog')
+    expect(await hmacSha256Hex('key', 'The quick brown fox jumps over the lazy dog'))
+      .toBe('f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8')
+  })
+
+  it('is lowercase hex of full digest length', async () => {
+    const h = await hmacSha256Hex(SECRET, BODY)
+    expect(h).toMatch(/^[0-9a-f]{64}$/)
+  })
+})
+
+describe('verifyPaddle', () => {
+  const sign = async (body = BODY, ts = NOW, secret = SECRET) =>
+    `ts=${ts};h1=${await hmacSha256Hex(secret, `${ts}:${body}`)}`
+
+  it('accepts a correctly signed body', async () => {
+    const r = await verifyPaddle({ rawBody: BODY, header: await sign(), secret: SECRET, nowS: NOW })
+    expect(r.ok).toBe(true)
+  })
+
+  it('rejects a body altered after signing', async () => {
+    const header = await sign()
+    const r = await verifyPaddle({ rawBody: BODY.replace('active', 'canceled'), header, secret: SECRET, nowS: NOW })
+    expect(r).toEqual({ ok: false, reason: 'mismatch' })
+  })
+
+  it('rejects a signature made with a different secret', async () => {
+    const header = await sign(BODY, NOW, 'whsec_attacker')
+    expect(await verifyPaddle({ rawBody: BODY, header, secret: SECRET, nowS: NOW }))
+      .toEqual({ ok: false, reason: 'mismatch' })
+  })
+
+  it('rejects a replay outside the tolerance window, in BOTH directions', async () => {
+    const old = await sign(BODY, NOW - DEFAULT_TOLERANCE_S - 1)
+    expect(await verifyPaddle({ rawBody: BODY, header: old, secret: SECRET, nowS: NOW }))
+      .toEqual({ ok: false, reason: 'stale' })
+    const future = await sign(BODY, NOW + DEFAULT_TOLERANCE_S + 1)
+    expect(await verifyPaddle({ rawBody: BODY, header: future, secret: SECRET, nowS: NOW }))
+      .toEqual({ ok: false, reason: 'stale' })
+  })
+
+  it('accepts right at the tolerance boundary', async () => {
+    const edge = await sign(BODY, NOW - DEFAULT_TOLERANCE_S)
+    expect((await verifyPaddle({ rawBody: BODY, header: edge, secret: SECRET, nowS: NOW })).ok).toBe(true)
+  })
+
+  it('FAILS CLOSED with no secret configured', async () => {
+    expect(await verifyPaddle({ rawBody: BODY, header: await sign(), secret: undefined, nowS: NOW }))
+      .toEqual({ ok: false, reason: 'no-secret' })
+    expect(await verifyPaddle({ rawBody: BODY, header: await sign(), secret: '', nowS: NOW }))
+      .toEqual({ ok: false, reason: 'no-secret' })
+  })
+
+  it('rejects malformed or missing headers rather than throwing', async () => {
+    for (const header of [null, '', 'garbage', 'ts=abc;h1=deadbeef', 'ts=123', 'h1=deadbeef', 'ts=123;h1=zzz']) {
+      const r = await verifyPaddle({ rawBody: BODY, header, secret: SECRET, nowS: NOW })
+      expect(r.ok, String(header)).toBe(false)
+      if (!r.ok) expect(['malformed-header', 'stale']).toContain(r.reason)
+    }
+  })
+})
+
+describe('verifyStripe', () => {
+  const sign = async (body = BODY, t = NOW, secret = SECRET) =>
+    `t=${t},v1=${await hmacSha256Hex(secret, `${t}.${body}`)}`
+
+  it('accepts a correctly signed body', async () => {
+    expect((await verifyStripe({ rawBody: BODY, header: await sign(), secret: SECRET, nowS: NOW })).ok).toBe(true)
+  })
+
+  it('accepts when ANY v1 matches, as during secret rotation', async () => {
+    const good = await hmacSha256Hex(SECRET, `${NOW}.${BODY}`)
+    const header = `t=${NOW},v1=${'0'.repeat(64)},v1=${good}`
+    expect((await verifyStripe({ rawBody: BODY, header, secret: SECRET, nowS: NOW })).ok).toBe(true)
+  })
+
+  it('rejects when no v1 matches', async () => {
+    const header = `t=${NOW},v1=${'0'.repeat(64)},v1=${'1'.repeat(64)}`
+    expect(await verifyStripe({ rawBody: BODY, header, secret: SECRET, nowS: NOW }))
+      .toEqual({ ok: false, reason: 'mismatch' })
+  })
+
+  it('rejects a tampered body and a stale timestamp', async () => {
+    expect(await verifyStripe({ rawBody: BODY + ' ', header: await sign(), secret: SECRET, nowS: NOW }))
+      .toEqual({ ok: false, reason: 'mismatch' })
+    expect(await verifyStripe({ rawBody: BODY, header: await sign(BODY, NOW - 999), secret: SECRET, nowS: NOW }))
+      .toEqual({ ok: false, reason: 'stale' })
+  })
+
+  it('fails closed with no secret and on malformed headers', async () => {
+    expect((await verifyStripe({ rawBody: BODY, header: await sign(), secret: undefined, nowS: NOW })).ok).toBe(false)
+    for (const header of [null, 'v1=abc', `t=${NOW}`, 't=x,v1=abc']) {
+      expect((await verifyStripe({ rawBody: BODY, header, secret: SECRET, nowS: NOW })).ok, String(header)).toBe(false)
+    }
+  })
+})
+
+describe('verifyPaymongo', () => {
+  const sign = async (opts: { body?: string; t?: number; secret?: string; te?: string; li?: string } = {}) => {
+    const { body = BODY, t = NOW, secret = SECRET } = opts
+    const d = await hmacSha256Hex(secret, `${t}.${body}`)
+    return `t=${t},te=${opts.te ?? d},li=${opts.li ?? d}`
+  }
+
+  it('accepts a correctly signed live event', async () => {
+    expect((await verifyPaymongo({ rawBody: BODY, header: await sign(), secret: SECRET, nowS: NOW, mode: 'live' })).ok)
+      .toBe(true)
+  })
+
+  it('accepts a correctly signed test event in test mode', async () => {
+    expect((await verifyPaymongo({ rawBody: BODY, header: await sign(), secret: SECRET, nowS: NOW, mode: 'test' })).ok)
+      .toBe(true)
+  })
+
+  it('does NOT let a valid test signature approve a live event', async () => {
+    // The whole reason mode is explicit: test keys circulate far more freely,
+    // and accepting whichever digest happens to match would make one enough.
+    const good = await hmacSha256Hex(SECRET, `${NOW}.${BODY}`)
+    const header = `t=${NOW},te=${good},li=${'0'.repeat(64)}`
+    expect(await verifyPaymongo({ rawBody: BODY, header, secret: SECRET, nowS: NOW, mode: 'live' }))
+      .toEqual({ ok: false, reason: 'mismatch' })
+    // …and the same header is fine when the endpoint IS in test mode
+    expect((await verifyPaymongo({ rawBody: BODY, header, secret: SECRET, nowS: NOW, mode: 'test' })).ok).toBe(true)
+  })
+
+  it('rejects tampering, staleness, a missing secret and junk headers', async () => {
+    expect((await verifyPaymongo({ rawBody: '{}', header: await sign(), secret: SECRET, nowS: NOW, mode: 'live' })).ok).toBe(false)
+    expect(await verifyPaymongo({ rawBody: BODY, header: await sign({ t: NOW - 9999 }), secret: SECRET, nowS: NOW, mode: 'live' }))
+      .toEqual({ ok: false, reason: 'stale' })
+    expect(await verifyPaymongo({ rawBody: BODY, header: await sign(), secret: undefined, nowS: NOW, mode: 'live' }))
+      .toEqual({ ok: false, reason: 'no-secret' })
+    for (const header of [null, 'nonsense', `t=${NOW}`, `t=x,li=abc`]) {
+      expect((await verifyPaymongo({ rawBody: BODY, header, secret: SECRET, nowS: NOW, mode: 'live' })).ok, String(header)).toBe(false)
+    }
+  })
+})
+
+describe('verifySignature dispatch', () => {
+  it('routes to the right verifier for each provider', async () => {
+    const paddle = `ts=${NOW};h1=${await hmacSha256Hex(SECRET, `${NOW}:${BODY}`)}`
+    const dotted = await hmacSha256Hex(SECRET, `${NOW}.${BODY}`)
+    expect((await verifySignature('paddle', { rawBody: BODY, header: paddle, secret: SECRET, nowS: NOW })).ok).toBe(true)
+    expect((await verifySignature('stripe', { rawBody: BODY, header: `t=${NOW},v1=${dotted}`, secret: SECRET, nowS: NOW })).ok).toBe(true)
+    expect((await verifySignature('paymongo', { rawBody: BODY, header: `t=${NOW},li=${dotted}`, secret: SECRET, nowS: NOW })).ok).toBe(true)
+  })
+
+  it('does not accept one provider’s header format under another', async () => {
+    const paddle = `ts=${NOW};h1=${await hmacSha256Hex(SECRET, `${NOW}:${BODY}`)}`
+    expect((await verifySignature('stripe', { rawBody: BODY, header: paddle, secret: SECRET, nowS: NOW })).ok).toBe(false)
+    expect((await verifySignature('paymongo', { rawBody: BODY, header: paddle, secret: SECRET, nowS: NOW })).ok).toBe(false)
+  })
+
+  it('names a header for every provider it can dispatch to', () => {
+    for (const p of ['paddle', 'stripe', 'paymongo'] as const) {
+      expect(SIGNATURE_HEADER[p], p).toBeTruthy()
+      expect(SIGNATURE_HEADER[p], p).toBe(SIGNATURE_HEADER[p].toLowerCase())
+    }
+  })
+})

--- a/supabase/functions/_shared/signature.ts
+++ b/supabase/functions/_shared/signature.ts
@@ -1,0 +1,198 @@
+// ─────────────────────────────────────────────────────────────────────────
+// WEBHOOK SIGNATURE VERIFICATION — the whole reason a server exists here.
+//
+// A payment webhook is an unauthenticated POST from the open internet that says
+// "this person paid you". Anyone can send that request. The ONLY thing
+// separating a real payment from a forged one is an HMAC computed with a secret
+// that only the provider and this function know. Get this wrong and the paywall
+// is decorative — which is exactly the reason none of it could live in the
+// browser, where the secret would be public.
+//
+// FAILS CLOSED, DELIBERATELY. `lib/auth/authClient` and `usePlan` fail OPEN when
+// unconfigured, so a fork of this repo stays usable. This module does the
+// opposite: a missing secret, an unparseable header, a stale timestamp or a
+// mismatched digest all REJECT. The asymmetry is the point — the cost of being
+// wrong is "nobody can use the app" in one case and "anyone can grant themselves
+// a paid plan" in the other.
+//
+// Runs on Web Crypto only (`crypto.subtle`, `TextEncoder`), so the same source
+// executes under Deno in the Edge Function and under Node in the test suite.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** How far a webhook's own timestamp may be from ours before it is a replay. */
+export const DEFAULT_TOLERANCE_S = 300
+
+export type VerifyResult =
+  | { ok: true }
+  | { ok: false; reason: 'no-secret' | 'malformed-header' | 'stale' | 'mismatch' }
+
+const enc = new TextEncoder()
+
+/**
+ * Constant-time string comparison.
+ *
+ * `a === b` on a digest leaks, through how long it takes to fail, how many
+ * leading characters an attacker guessed right — which turns forging a
+ * signature into a few thousand requests instead of brute force. Comparing
+ * every character regardless, and OR-ing the differences, removes that signal.
+ * Length is folded in the same way rather than short-circuiting on it.
+ */
+export function timingSafeEqual(a: string, b: string): boolean {
+  let diff = a.length ^ b.length
+  const n = Math.max(a.length, b.length)
+  for (let i = 0; i < n; i++) {
+    diff |= (a.charCodeAt(i) || 0) ^ (b.charCodeAt(i) || 0)
+  }
+  return diff === 0
+}
+
+/** Lowercase hex HMAC-SHA256 of `payload` under `secret`. */
+export async function hmacSha256Hex(secret: string, payload: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw', enc.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'],
+  )
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(payload))
+  return [...new Uint8Array(sig)].map((b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+export interface VerifyInput {
+  /**
+   * The EXACT bytes the provider signed, as received.
+   *
+   * Never `JSON.stringify(await req.json())` — re-serialising changes key order,
+   * whitespace and number formatting, so the digest will not match and, worse,
+   * might match for a body that differs from what was signed.
+   */
+  rawBody: string
+  /** The provider's signature header, verbatim. */
+  header: string | null
+  /** The endpoint's signing secret. */
+  secret: string | undefined
+  /** Seconds since epoch; injectable so tolerance can be tested. */
+  nowS?: number
+  toleranceS?: number
+}
+
+/**
+ * Paddle (Billing v2): `Paddle-Signature: ts=1700000000;h1=<hex>`
+ * signed over `${ts}:${rawBody}`.
+ */
+export async function verifyPaddle(input: VerifyInput): Promise<VerifyResult> {
+  const { rawBody, header, secret } = input
+  if (!secret) return { ok: false, reason: 'no-secret' }
+  if (!header) return { ok: false, reason: 'malformed-header' }
+
+  const parts = new Map<string, string>()
+  for (const seg of header.split(';')) {
+    const i = seg.indexOf('=')
+    if (i > 0) parts.set(seg.slice(0, i).trim(), seg.slice(i + 1).trim())
+  }
+  const ts = parts.get('ts')
+  const h1 = parts.get('h1')
+  if (!ts || !h1 || !/^\d+$/.test(ts) || !/^[0-9a-f]+$/i.test(h1)) {
+    return { ok: false, reason: 'malformed-header' }
+  }
+  if (isStale(Number(ts), input)) return { ok: false, reason: 'stale' }
+
+  const expected = await hmacSha256Hex(secret, `${ts}:${rawBody}`)
+  return timingSafeEqual(expected, h1.toLowerCase()) ? { ok: true } : { ok: false, reason: 'mismatch' }
+}
+
+/**
+ * Stripe: `Stripe-Signature: t=1700000000,v1=<hex>[,v1=<hex>…]`
+ * signed over `${t}.${rawBody}`.
+ *
+ * Multiple `v1` values appear while a secret is being rotated; ANY match is
+ * valid, and each is compared in constant time rather than bailing on the first.
+ */
+export async function verifyStripe(input: VerifyInput): Promise<VerifyResult> {
+  const { rawBody, header, secret } = input
+  if (!secret) return { ok: false, reason: 'no-secret' }
+  if (!header) return { ok: false, reason: 'malformed-header' }
+
+  let t: string | undefined
+  const v1: string[] = []
+  for (const seg of header.split(',')) {
+    const i = seg.indexOf('=')
+    if (i <= 0) continue
+    const k = seg.slice(0, i).trim(), v = seg.slice(i + 1).trim()
+    if (k === 't') t = v
+    else if (k === 'v1') v1.push(v)
+  }
+  if (!t || !/^\d+$/.test(t) || v1.length === 0 || !v1.every((s) => /^[0-9a-f]+$/i.test(s))) {
+    return { ok: false, reason: 'malformed-header' }
+  }
+  if (isStale(Number(t), input)) return { ok: false, reason: 'stale' }
+
+  const expected = await hmacSha256Hex(secret, `${t}.${rawBody}`)
+  let matched = false
+  for (const candidate of v1) {
+    // no early exit: every candidate is compared so the work is uniform
+    if (timingSafeEqual(expected, candidate.toLowerCase())) matched = true
+  }
+  return matched ? { ok: true } : { ok: false, reason: 'mismatch' }
+}
+
+/**
+ * A signature is only good for a window around its own timestamp.
+ *
+ * Without this, a signature captured once stays valid forever, and anyone who
+ * ever saw a legitimate webhook body could replay it. Future timestamps are
+ * rejected on the same window so a forged clock cannot buy an indefinite one.
+ */
+function isStale(tsS: number, { nowS, toleranceS = DEFAULT_TOLERANCE_S }: VerifyInput): boolean {
+  const now = nowS ?? Math.floor(Date.now() / 1000)
+  return Math.abs(now - tsS) > toleranceS
+}
+
+/**
+ * PayMongo: `Paymongo-Signature: t=1700000000,te=<hex>,li=<hex>`
+ * signed over `${t}.${rawBody}` — the same construction as Stripe, with the
+ * digest split by mode instead of by key version.
+ *
+ * `te` is the TEST-mode signature and `li` the LIVE one. Which of the two is
+ * authoritative depends on the key the endpoint was configured with, so it is
+ * passed in explicitly rather than accepting whichever happens to match:
+ * accepting either would let a test-mode secret — far more widely shared, and
+ * often pasted into chats and issues — approve a live payment.
+ */
+export async function verifyPaymongo(
+  input: VerifyInput & { mode: 'test' | 'live' },
+): Promise<VerifyResult> {
+  const { rawBody, header, secret, mode } = input
+  if (!secret) return { ok: false, reason: 'no-secret' }
+  if (!header) return { ok: false, reason: 'malformed-header' }
+
+  const parts = new Map<string, string>()
+  for (const seg of header.split(',')) {
+    const i = seg.indexOf('=')
+    if (i > 0) parts.set(seg.slice(0, i).trim(), seg.slice(i + 1).trim())
+  }
+  const t = parts.get('t')
+  const digest = parts.get(mode === 'live' ? 'li' : 'te')
+  if (!t || !digest || !/^\d+$/.test(t) || !/^[0-9a-f]+$/i.test(digest)) {
+    return { ok: false, reason: 'malformed-header' }
+  }
+  if (isStale(Number(t), input)) return { ok: false, reason: 'stale' }
+
+  const expected = await hmacSha256Hex(secret, `${t}.${rawBody}`)
+  return timingSafeEqual(expected, digest.toLowerCase()) ? { ok: true } : { ok: false, reason: 'mismatch' }
+}
+
+export type Provider = 'paddle' | 'stripe' | 'paymongo'
+
+/** Signature header name each provider sends. */
+export const SIGNATURE_HEADER: Record<Provider, string> = {
+  paddle: 'paddle-signature',
+  stripe: 'stripe-signature',
+  paymongo: 'paymongo-signature',
+}
+
+/** Verify under whichever provider is configured. */
+export function verifySignature(
+  provider: Provider, input: VerifyInput & { mode?: 'test' | 'live' },
+): Promise<VerifyResult> {
+  if (provider === 'paddle') return verifyPaddle(input)
+  if (provider === 'stripe') return verifyStripe(input)
+  return verifyPaymongo({ ...input, mode: input.mode ?? 'live' })
+}

--- a/supabase/functions/billing-webhook/index.ts
+++ b/supabase/functions/billing-webhook/index.ts
@@ -1,0 +1,107 @@
+// ─────────────────────────────────────────────────────────────────────────
+// BILLING WEBHOOK — the server half of checkout, and the only place a plan is
+// ever granted.
+//
+// Runs on Supabase Edge Functions (Deno). It lives here rather than in the SPA
+// because it needs two things the browser must never hold: the webhook signing
+// secret (without which any POST could claim a payment) and the service_role
+// key (which can write another user's metadata).
+//
+// DEPLOY WITHOUT JWT VERIFICATION — the provider is not a signed-in user:
+//     supabase functions deploy billing-webhook --no-verify-jwt
+// The signature check below is what authenticates the caller instead.
+//
+// Secrets (supabase secrets set …):
+//   BILLING_PROVIDER      paddle | stripe | paymongo
+//   BILLING_WEBHOOK_SECRET  the endpoint's signing secret
+//   BILLING_MODE          test | live      (PayMongo only; picks te= vs li=)
+//   BILLING_PRICE_MAP     pri_abc=pro,pri_def=max
+//   SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY  (injected by the platform)
+//
+// The pure logic is in ../_shared and is covered by the app's vitest suite;
+// this file is the I/O shell around it, kept deliberately thin.
+// ─────────────────────────────────────────────────────────────────────────
+import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { SIGNATURE_HEADER, verifySignature, type Provider } from '../_shared/signature.ts'
+import { parseEvent, parsePriceMap } from '../_shared/events.ts'
+
+const env = (k: string) => Deno.env.get(k)
+
+/** Never echo the reason for a rejection — it tells a prober what to fix. */
+const deny = (status = 400) => new Response('rejected', { status })
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method !== 'POST') return new Response('method not allowed', { status: 405 })
+
+  const provider = env('BILLING_PROVIDER') as Provider | undefined
+  if (provider !== 'paddle' && provider !== 'stripe' && provider !== 'paymongo') {
+    console.error('BILLING_PROVIDER is not set to a known provider')
+    return deny(500)
+  }
+
+  // Read the body ONCE, as text. Verification must run over the exact bytes the
+  // provider signed — re-serialising parsed JSON changes key order and spacing
+  // and the digest will not match.
+  const rawBody = await req.text()
+  const header = req.headers.get(SIGNATURE_HEADER[provider])
+
+  const sig = await verifySignature(provider, {
+    rawBody,
+    header,
+    secret: env('BILLING_WEBHOOK_SECRET'),
+    mode: env('BILLING_MODE') === 'test' ? 'test' : 'live',
+  })
+  if (!sig.ok) {
+    console.warn('signature rejected:', sig.reason)
+    return deny(sig.reason === 'no-secret' ? 500 : 401)
+  }
+
+  let payload: unknown
+  try { payload = JSON.parse(rawBody) } catch { return deny() }
+
+  const outcome = parseEvent(provider, payload, parsePriceMap(env('BILLING_PRICE_MAP')))
+  if (outcome.kind === 'reject') {
+    // Loud, because every one of these is a misconfiguration on our side — a
+    // price id missing from BILLING_PRICE_MAP, or a checkout that forgot to
+    // attach the user id. Silence here means paying customers not getting what
+    // they bought.
+    console.error('unusable event:', outcome.why, outcome.detail ?? '')
+    return deny(422)
+  }
+  if (outcome.kind === 'ignore') return new Response('ignored', { status: 200 })
+
+  const url = env('SUPABASE_URL'), key = env('SUPABASE_SERVICE_ROLE_KEY')
+  if (!url || !key) { console.error('service role credentials missing'); return deny(500) }
+  const admin = createClient(url, key, { auth: { persistSession: false } })
+
+  // Idempotency: providers retry until they get a 2xx, and a retry must not
+  // re-apply a change that has since been superseded by a later event. The
+  // last applied event id is kept alongside the plan, and a repeat is a no-op.
+  const { data: existing, error: readErr } = await admin.auth.admin.getUserById(outcome.userId)
+  if (readErr || !existing?.user) {
+    console.error('no such user:', outcome.userId, readErr?.message ?? '')
+    return deny(404)
+  }
+  const meta = (existing.user.user_metadata ?? {}) as Record<string, unknown>
+  if (meta.billing_event_id === outcome.eventId) {
+    return new Response('already applied', { status: 200 })
+  }
+
+  const { error } = await admin.auth.admin.updateUserById(outcome.userId, {
+    user_metadata: {
+      ...meta,
+      plan: outcome.plan,
+      billing_event_id: outcome.eventId,
+      billing_updated_at: new Date().toISOString(),
+    },
+  })
+  if (error) {
+    // 5xx so the provider retries — a dropped write here is a customer who paid
+    // and did not get their plan.
+    console.error('failed to write plan:', error.message)
+    return new Response('retry', { status: 500 })
+  }
+
+  console.log(`plan=${outcome.plan} user=${outcome.userId} event=${outcome.eventId}`)
+  return new Response('ok', { status: 200 })
+})

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -21,6 +21,9 @@ export default defineConfig(({ command }) => ({
   },
   test: {
     environment: 'node',
-    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    // The Supabase Edge Function's pure logic (webhook signature verification
+    // and event parsing) lives outside src/ but is plain Web-Crypto TypeScript,
+    // so the one suite covers it rather than leaving the money path untested.
+    include: ['src/**/*.{test,spec}.{ts,tsx}', '../supabase/functions/**/*.test.ts'],
   },
 }))


### PR DESCRIPTION
A plan is read from `user_metadata.plan` and the gate trusts that field, so the
only question that matters is **who may write it**.

Not the browser. A "user upgraded" request sent from a page can be forged by the
person sending it — they control the code. It has to be the provider telling us
over a channel we can prove came from them, and that proof is an HMAC with a
secret the browser must never hold. That is the entire reason this is a Supabase
Edge Function and not a `fetch` call.

## PayMongo, as asked

Added alongside Paddle and Stripe, and it's arguably the right default here: the
audience is Philippine engineers (the whole app is NSCP-based), and PayMongo
gives them **GCash, Maya and GrabPay** — which card-only foreign processors
don't. Provider is a single env var; the other two work identically.

## The security properties are tested, not asserted (48 tests)

- **Constant-time digest comparison.** `a === b` on an HMAC leaks, through how
  long it takes to fail, how many leading characters an attacker guessed right.
- **±300 s replay window, checked in both directions**, so a forged *future*
  timestamp can't buy an indefinitely valid signature.
- **Missing secret rejects.** The module fails **closed** — deliberately the
  opposite of `authClient`/`usePlan`, which fail open so an unconfigured fork
  stays usable. Being wrong costs "nobody can use the app" one way and "anyone
  can grant themselves a paid plan" the other.
- Verification runs over the **raw body**, never re-serialised JSON.
- Stripe accepts any of several `v1` digests during secret rotation, comparing
  all of them with no early exit.
- **PayMongo sends both a test (`te=`) and a live (`li=`) digest**, and the mode
  is explicit — accepting whichever happens to match would let a test-mode
  secret, far more widely shared, approve a live payment. A test pins that.
- Known-vector check on the HMAC itself, so a broken implementation can't pass
  by agreeing with itself.

## Two mapping invariants, also pinned

**An unrecognised price never resolves to a plan.** A typo in `BILLING_PRICE_MAP`
rejects loudly instead of silently granting a tier nobody paid for — and
`parsePriceMap` *drops* entries naming a non-existent plan, so `pri_x=professional`
fails at configuration rather than becoming a nonsense tier.

**Anything not in an active paid state resolves down to `free`.** `past_due`
counts as active on purpose: the card is still being retried, and cutting someone
off mid-retry loses a customer who meant to pay.

## Idempotency

Providers retry until they get a 2xx, so the applied event id is stored beside
the plan and a repeat is a no-op. A failed write returns 5xx **so the provider
retries** — a dropped write is a customer who paid and didn't get their plan.

The pure logic lives in `supabase/functions/_shared/` and `vite.config`'s
`test.include` was extended to reach it, so the money path isn't the one untested
corner of the repo.

## What is NOT done

**Checkout itself.** `CHECKOUT_ENABLED` is still pinned `false` by a test and
`/pricing` still says paid plans aren't open. This phase built the half that
*receives* payment, not the half that starts one. That needs a `billing-checkout`
function attaching `metadata.user_id` — PayMongo has no static link that can
carry per-user metadata, so it can't be a URL in an env var.

## Three things to confirm before going live

1. **PayMongo field paths are unverified.** `fromPaymongo` was written from the
   documented envelope, not a captured event. Send one test event through and
   check `metadata.user_id` and the price id land where it expects. It fails
   closed, so a wrong guess denies a paying customer — visible and fixable —
   rather than granting a free one.
2. **Recurring billing.** Confirm PayMongo subscriptions are available on your
   account. If only one-off payments are, monthly billing needs a different
   design (scheduled charges against a saved method) — materially more work.
3. **Currency.** PayMongo settles in PHP; `/pricing` shows USD. A customer seeing
   $19 and being charged ₱1,100 is a support ticket at best.

Also worth checking early: PayMongo onboards registered Philippine businesses.

All of this is in [`docs/Billing.md`](https://github.com/BitLess246/civilEngineering/blob/feature/billing-webhook/docs/Billing.md)
with the full setup steps.

## Verification

`npx tsc -b` = 0 · `npm run lint` = 0 · `npm test` **1965 passing** (48 new) ·
`npm run build` = 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_