### PR TITLE
Price in pesos, monthly and annual

### DIFF
--- a/docs/Billing.md
+++ b/docs/Billing.md
@@ -105,6 +105,46 @@ know who paid unless checkout carries the Supabase user id:
 
 Without it the event is rejected with `no-user` and nothing is granted.
 
+## PayMongo subscriptions — enable this first
+
+Recurring billing is **not on by default**. Email `support@paymongo.com` and ask
+them to activate **Subscriptions and Card Vaulting**. Nothing below can be done
+until they confirm, so send it early.
+
+Once enabled:
+
+1. **Create four billing plans via the API** — one per tier per period:
+
+   | Plan | Interval | Amount |
+   |---|---|---|
+   | Pro monthly | month | `139900` |
+   | Pro annual | year | `1509900` |
+   | Max monthly | month | `299900` |
+   | Max annual | year | `3239900` |
+
+   **PayMongo amounts are in centavos**, so ₱1,399 is `139900`. A factor-of-100
+   error here is the classic payments bug, and it is wrong in both directions.
+
+2. **Map all four returned ids** into the webhook's price map — an annual Pro
+   subscriber must resolve to `pro` exactly as a monthly one does:
+
+   ```
+   BILLING_PRICE_MAP='plan_pro_mo=pro,plan_pro_yr=pro,plan_max_mo=max,plan_max_yr=max'
+   ```
+
+   Many ids mapping to one tier is expected and already supported.
+
+3. **Attach `metadata.user_id`** to the subscription at checkout — see step 4
+   above; without it the webhook rejects with `no-user`.
+
+### Card vaulting, and GCash
+
+Card subscriptions need the card tokenised/vaulted at first checkout, which is
+part of what support enables. **GCash recurring is a separate arrangement** —
+it does not come automatically with subscriptions. Ask about it in the same
+email: GCash is likely the dominant payment method for Philippine engineers, and
+a subscription that only works on cards will convert poorly here.
+
 ## Still to do
 
 **Checkout itself is not wired up.** `CHECKOUT_ENABLED` in `webapp/src/lib/plans.ts`
@@ -127,14 +167,16 @@ expects. It fails closed, so a wrong guess denies a paying customer — visible
 and fixable — rather than granting a free one. The Paddle and Stripe shapes are
 the standard documented ones but deserve the same one-event check.
 
-**Recurring billing on PayMongo.** Confirm subscriptions are available on your
-account before committing to a monthly plan. If only one-off payments are
-available, monthly billing needs a different design (scheduled charges against a
-saved payment method), which is materially more work than this.
+**Amounts in centavos.** Every PayMongo amount is an integer number of
+centavos. Create the plans as `139900`, never `1399`.
 
-**Currency.** PayMongo settles in PHP; `/pricing` currently shows USD. Pick one
-and make the pricing page and the provider agree — a customer seeing $19 and
-being charged ₱1,100 is a support ticket at best.
+**Currency is settled.** `/pricing` is priced in pesos and matches what PayMongo
+will charge: ₱1,399 / ₱2,999 monthly, ₱15,099 / ₱32,399 annually. A test pins
+each annual price to within a tenth of a percentage point of the advertised 10%
+discount, so the page and the billing plans cannot drift apart unnoticed.
 
-**Business registration.** PayMongo onboards registered Philippine businesses.
-Worth confirming eligibility before building the rest of the flow.
+**E-wallet KYC.** GCash, Maya and GrabPay each need PayMongo's
+business-information form completed — trade name, TIN, and a sworn declaration
+before the first payout, or withholding tax is applied. QRPh needs none of that
+and is already active; QR Ph is the BSP national standard, which GCash and Maya
+can both scan, so payments can be taken while wallet approval is pending.

--- a/docs/PricingStrategy.md
+++ b/docs/PricingStrategy.md
@@ -1,5 +1,26 @@
 # Pricing Strategy
 
+> **This document is the original plan, and the shipped prices no longer match
+> it.** What is actually implemented, in `webapp/src/lib/plans.ts`:
+>
+> | Shipped tier | Monthly | Annual | Notes |
+> |---|---|---|---|
+> | Guest | — | — | 5 runs of each calculator, no account |
+> | Free | ₱0 | ₱0 | same calculators, 3 saved projects |
+> | Pro | ₱1,399 | ₱15,099 | 3D Model Space ≤400 members, pipeline, optimiser, estimating, reports |
+> | Max | ₱2,999 | ₱32,399 | + nonlinear/dynamic solvers, scheduling, no size limit |
+>
+> Three differences worth a decision rather than a drift:
+>
+> - **Professional was ₱499; Pro ships at ₱1,399.** Roughly 3× the planned
+>   price. Deliberate or not, it is the number on the page.
+> - **Enterprise was ₱2,999 for team accounts and shared projects.** Max ships
+>   at the same price but sells *nonlinear analysis*, not teams. Team accounts
+>   and shared projects do not exist yet, so if Enterprise is still wanted it is
+>   a fifth tier, not a rename of Max.
+> - **Educational licences are not implemented.** No free-for-universities path
+>   exists in the plan model.
+
 ---
 
 # Free Tier

--- a/webapp/src/lib/docsContentShell.ts
+++ b/webapp/src/lib/docsContentShell.ts
@@ -194,7 +194,7 @@ export const SHELL_TOOLS: DocTool[] = [
           { kind: 'output', name: 'Guest', what: 'No account. Five runs of each single-purpose calculator, plus unlimited access to the documentation and validation pages.' },
           { kind: 'output', name: 'Free', what: 'The same calculators with no trial counter, and up to three saved projects. No payment, no model space.' },
           { kind: 'output', name: 'Pro', what: 'The 3D Model Space up to 400 members and everything built on it \u2014 design pipeline, section optimiser, estimating and take-off, structure reports \u2014 with unlimited saved projects.' },
-          { kind: 'output', name: 'Max', what: 'Everything in Pro with no model-size limit, plus the nonlinear and dynamic solvers (pushover, biaxial pushover, time history) and construction scheduling.' },
+          { kind: 'output', name: 'Max', what: '\u20b12,999/month or \u20b132,399/year. Everything in Pro with no model-size limit, plus the nonlinear and dynamic solvers (pushover, biaxial pushover, time history) and construction scheduling.' },
         ],
       },
       {

--- a/webapp/src/lib/plans.test.ts
+++ b/webapp/src/lib/plans.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest'
 import {
   PLANS, planOf, planAllows, withinModelLimit, withinProjectLimit, lowestPlanWith,
   upgradeMessage, featureLabel, CHECKOUT_ENABLED,
+  priceFor, monthlyEquivalent, annualSaving, annualDiscountOf, formatPeso,
+  ANNUAL_DISCOUNT, CURRENCY,
   type Feature,
 } from './plans'
 
@@ -14,7 +16,7 @@ describe('plan catalogue', () => {
   it('is ordered cheapest first and has no duplicate ids', () => {
     const ids = PLANS.map((p) => p.id)
     expect(new Set(ids).size).toBe(ids.length)
-    const prices = PLANS.map((p) => p.price ?? 0)
+    const prices = PLANS.map((p) => p.priceMonthly ?? 0)
     for (let k = 1; k < prices.length; k++) expect(prices[k]).toBeGreaterThanOrEqual(prices[k - 1])
   })
 
@@ -199,5 +201,90 @@ describe('checkout', () => {
     // Asserted rather than assumed: if someone flips this on without adding a
     // server to verify the webhook, this test is the thing that objects.
     expect(CHECKOUT_ENABLED).toBe(false)
+  })
+})
+
+
+describe('pricing', () => {
+  const paid = PLANS.filter((p) => p.priceMonthly)
+
+  it('prices everything in pesos, because that is what PayMongo settles in', () => {
+    expect(CURRENCY).toBe('PHP')
+    expect(formatPeso(1399)).toBe('₱1,399')
+    expect(formatPeso(15099)).toBe('₱15,099')
+    expect(formatPeso(0)).toBe('₱0')
+  })
+
+  it('rounds rather than printing centavos', () => {
+    expect(formatPeso(1258.25)).toBe('₱1,258')
+    expect(formatPeso(2699.92)).toBe('₱2,700')
+  })
+
+  it('gives every paid plan BOTH a monthly and an annual price', () => {
+    expect(paid.length).toBeGreaterThan(0)
+    for (const p of paid) {
+      expect(p.priceMonthly, p.id).toBeGreaterThan(0)
+      expect(p.priceAnnual, p.id).toBeGreaterThan(0)
+    }
+  })
+
+  it('honours the advertised annual discount, within the rounding band', () => {
+    // The number a customer is charged is stored, not computed, so this is what
+    // stops a tidied-up figure drifting away from the "10% off" printed beside
+    // it. The prices are deliberately rounded to a 99 ending, which cannot land
+    // on exactly 10%: Pro is 10.06% off and Max 9.97%. A tenth of a PERCENTAGE
+    // POINT is the band that rounding needs and that a real mistake — a digit
+    // dropped, a discount applied twice — would blow straight through.
+    const BAND = 0.001
+    for (const p of paid) {
+      const off = annualDiscountOf(p)
+      expect(Math.abs(off - ANNUAL_DISCOUNT), `${p.id} is ${(off * 100).toFixed(2)}% off`)
+        .toBeLessThan(BAND)
+    }
+  })
+
+  it('states the actual discount each plan achieves', () => {
+    // Written down rather than left implicit, so the marketing claim and the
+    // arithmetic are visibly the same thing.
+    expect(annualDiscountOf('pro') * 100).toBeCloseTo(10.06, 1)
+    expect(annualDiscountOf('max') * 100).toBeCloseTo(9.97, 1)
+  })
+
+  it('always makes annual cheaper per month than monthly', () => {
+    // The property the whole annual option rests on. If a rounding edit ever
+    // inverted it, the page would be advertising a saving that costs more.
+    for (const p of paid) {
+      expect(monthlyEquivalent(p, 'annual')!, p.id).toBeLessThan(monthlyEquivalent(p, 'monthly')!)
+      expect(p.priceAnnual!, p.id).toBeLessThan(p.priceMonthly! * 12)
+    }
+  })
+
+  it('reports a real peso saving for paying yearly', () => {
+    for (const p of paid) {
+      expect(annualSaving(p), p.id).toBe(p.priceMonthly! * 12 - p.priceAnnual!)
+      expect(annualSaving(p), p.id).toBeGreaterThan(0)
+    }
+  })
+
+  it('quotes the agreed headline figures', () => {
+    expect(priceFor('pro', 'monthly')).toBe(1399)
+    expect(priceFor('max', 'monthly')).toBe(2999)
+    expect(priceFor('pro', 'annual')).toBe(15099)
+    expect(priceFor('max', 'annual')).toBe(32399)
+  })
+
+  it('charges nothing for free and nothing at all for guest', () => {
+    expect(priceFor('free', 'monthly')).toBe(0)
+    expect(priceFor('free', 'annual')).toBe(0)
+    expect(priceFor('guest', 'monthly')).toBeNull()
+    expect(priceFor('guest', 'annual')).toBeNull()
+    expect(annualSaving('free')).toBe(0)
+    expect(annualSaving('guest')).toBe(0)
+    expect(annualDiscountOf('guest')).toBe(0)
+  })
+
+  it('keeps monthly prices ordered by tier', () => {
+    expect(priceFor('pro', 'monthly')!).toBeLessThan(priceFor('max', 'monthly')!)
+    expect(priceFor('pro', 'annual')!).toBeLessThan(priceFor('max', 'annual')!)
   })
 })

--- a/webapp/src/lib/plans.ts
+++ b/webapp/src/lib/plans.ts
@@ -11,9 +11,13 @@
 // questions and conflating them is how a paywall ends up inconsistent, with a
 // page reachable but its main button dead for no stated reason.
 //
-// NO PAYMENTS ARE TAKEN. Nothing here charges anyone or claims to. A plan is
-// read from the user's Supabase metadata, so it can be set by hand today and by
-// a checkout webhook later; until that webhook exists every account is `free`.
+// PRICED IN PESOS, because PayMongo settles in pesos. Showing a dollar figure
+// while charging a peso one is how a customer ends up disputing a card charge
+// they did not recognise.
+//
+// NO PAYMENTS ARE TAKEN YET. The billing webhook exists (supabase/functions/
+// billing-webhook) and verifies real provider signatures, but nothing starts a
+// payment, so `CHECKOUT_ENABLED` is still false and every account is `free`.
 // The pricing page says so plainly rather than showing a button that pretends.
 // ─────────────────────────────────────────────────────────────────────────
 
@@ -37,11 +41,36 @@ export type Feature =
   /** Save projects to the account. */
   | 'saved-projects'
 
+/** How often a paid plan is billed. */
+export type BillingPeriod = 'monthly' | 'annual'
+
+/**
+ * Everything is priced in Philippine pesos.
+ *
+ * Not a cosmetic choice: PayMongo settles in PHP, and a page quoting dollars
+ * while the card statement reads pesos is a support ticket at best and a
+ * chargeback at worst. The currency the customer is shown must be the currency
+ * they are charged.
+ */
+export const CURRENCY = 'PHP'
+
+/** Headline discount for paying yearly. */
+export const ANNUAL_DISCOUNT = 0.10
+
 export interface Plan {
   id: PlanId
   name: string
-  /** Monthly price in USD. 0 = free; null = not purchasable (guest). */
-  price: number | null
+  /** Price per month when billed monthly, in PHP. 0 = free; null = guest. */
+  priceMonthly: number | null
+  /**
+   * Total charged once per year, in PHP — already discounted, not a rate.
+   *
+   * Stored rather than computed from `priceMonthly · 12 · 0.9` so the number a
+   * customer is charged is the number written here, and rounding to a tidy
+   * figure cannot drift from what the page displays. A test pins each one to
+   * within a tenth of a percent of the headline discount.
+   */
+  priceAnnual: number | null
   tagline: string
   features: readonly Feature[]
   /** Hard ceiling on model size, or null for no limit. */
@@ -75,7 +104,8 @@ export const PLANS: readonly Plan[] = [
   {
     id: 'guest',
     name: 'Guest',
-    price: null,
+    priceMonthly: null,
+    priceAnnual: null,
     tagline: 'Try every calculator without an account.',
     features: [],
     maxMembers: 0,
@@ -90,7 +120,8 @@ export const PLANS: readonly Plan[] = [
   {
     id: 'free',
     name: 'Free',
-    price: 0,
+    priceMonthly: 0,
+    priceAnnual: 0,
     tagline: 'The same calculators, without the trial counter.',
     features: ['saved-projects'],
     maxMembers: 0,
@@ -106,7 +137,8 @@ export const PLANS: readonly Plan[] = [
   {
     id: 'pro',
     name: 'Pro',
-    price: 19,
+    priceMonthly: 1_399,
+    priceAnnual: 15_099,
     tagline: 'The 3D Model Space and the tools built on it.',
     features: ['model-space', 'design-pipeline', 'optimizer', 'reports', 'estimating', 'saved-projects'],
     maxMembers: 400,
@@ -124,7 +156,8 @@ export const PLANS: readonly Plan[] = [
   {
     id: 'max',
     name: 'Max',
-    price: 49,
+    priceMonthly: 2_999,
+    priceAnnual: 32_399,
     tagline: 'Everything, including the nonlinear and dynamic solvers.',
     features: ALL_FEATURES,
     maxMembers: null,
@@ -169,9 +202,52 @@ export function withinProjectLimit(plan: PlanId | Plan, projects: number): boole
   return projects < p.maxProjects
 }
 
+/** Price for a plan on a given billing period, in PHP. */
+export function priceFor(plan: PlanId | Plan, period: BillingPeriod): number | null {
+  const p = typeof plan === 'string' ? planOf(plan) : plan
+  return period === 'annual' ? p.priceAnnual : p.priceMonthly
+}
+
+/**
+ * What a plan works out to per month on a given period.
+ *
+ * The number to put next to an annual price: "₱1,258/month, billed annually" is
+ * the comparison a customer is actually making, and making them divide by
+ * twelve is how a good deal goes unnoticed.
+ */
+export function monthlyEquivalent(plan: PlanId | Plan, period: BillingPeriod): number | null {
+  const price = priceFor(plan, period)
+  if (price === null) return null
+  return period === 'annual' ? price / 12 : price
+}
+
+/** Pesos saved over a year by paying annually. 0 when there is nothing to save. */
+export function annualSaving(plan: PlanId | Plan): number {
+  const p = typeof plan === 'string' ? planOf(plan) : plan
+  if (!p.priceMonthly || !p.priceAnnual) return 0
+  return Math.max(0, p.priceMonthly * 12 - p.priceAnnual)
+}
+
+/** The actual discount achieved by a plan's annual price, as a fraction. */
+export function annualDiscountOf(plan: PlanId | Plan): number {
+  const p = typeof plan === 'string' ? planOf(plan) : plan
+  if (!p.priceMonthly || !p.priceAnnual) return 0
+  return 1 - p.priceAnnual / (p.priceMonthly * 12)
+}
+
+/**
+ * Peso amount for display — `₱1,399`, no decimals.
+ *
+ * Fixed to en-PH rather than the visitor's locale so the grouping matches the
+ * amount the payment page will show; a price that reads differently in two
+ * places invites a double-take at exactly the wrong moment.
+ */
+export const formatPeso = (amount: number): string =>
+  `₱${Math.round(amount).toLocaleString('en-PH')}`
+
 /** The cheapest plan that includes a feature, or null if none does. */
 export function lowestPlanWith(feature: Feature): Plan | null {
-  const ranked = [...PLANS].sort((a, b) => (a.price ?? Infinity) - (b.price ?? Infinity))
+  const ranked = [...PLANS].sort((a, b) => (a.priceMonthly ?? Infinity) - (b.priceMonthly ?? Infinity))
   return ranked.find((p) => p.features.includes(feature)) ?? null
 }
 
@@ -187,7 +263,7 @@ export function upgradeMessage(current: PlanId, feature: Feature): string | null
   const target = lowestPlanWith(feature)
   if (!target) return 'That feature is not available on any plan yet.'
   if (current === 'guest') {
-    return target.price === 0
+    return target.priceMonthly === 0
       ? `Create a free account to use ${featureLabel(feature)}.`
       : `${featureLabel(feature)} needs the ${target.name} plan — create an account to get started.`
   }

--- a/webapp/src/pages/Pricing.tsx
+++ b/webapp/src/pages/Pricing.tsx
@@ -1,9 +1,35 @@
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
-import { PLANS, CHECKOUT_ENABLED, type Plan } from '../lib/plans'
+import {
+  PLANS, CHECKOUT_ENABLED, planOf, priceFor, monthlyEquivalent, annualSaving,
+  annualDiscountOf, formatPeso, ANNUAL_DISCOUNT, type Plan, type BillingPeriod,
+} from '../lib/plans'
 import { useAuth } from '../lib/auth/authContext'
-import { planOf } from '../lib/plans'
 
-function PlanCard({ plan, current }: { plan: Plan; current: boolean }) {
+function PriceLine({ plan, period }: { plan: Plan; period: BillingPeriod }) {
+  const price = priceFor(plan, period)
+  if (price === null) return <p className="mt-3 text-2xl font-bold text-slate-800">—</p>
+  if (price === 0) return <p className="mt-3 text-2xl font-bold text-slate-800">Free</p>
+
+  const perMonth = monthlyEquivalent(plan, period)!
+  return (
+    <div className="mt-3">
+      <p className="text-2xl font-bold text-slate-800">
+        {formatPeso(perMonth)}
+        <span className="text-sm font-medium text-slate-500"> /month</span>
+      </p>
+      {period === 'annual' ? (
+        <p className="mt-0.5 text-[12px] leading-5 text-slate-500">
+          {formatPeso(price)} billed yearly · save {formatPeso(annualSaving(plan))}
+        </p>
+      ) : (
+        <p className="mt-0.5 text-[12px] leading-5 text-slate-500">billed monthly</p>
+      )}
+    </div>
+  )
+}
+
+function PlanCard({ plan, current, period }: { plan: Plan; current: boolean; period: BillingPeriod }) {
   const featured = plan.id === 'pro'
   return (
     <div className={`flex flex-col rounded-xl border bg-white p-5 shadow-sm ${
@@ -17,10 +43,7 @@ function PlanCard({ plan, current }: { plan: Plan; current: boolean }) {
         )}
       </div>
       <p className="mt-1 text-[13px] leading-5 text-slate-600">{plan.tagline}</p>
-      <p className="mt-3 text-2xl font-bold text-slate-800">
-        {plan.price === null ? '—' : plan.price === 0 ? 'Free' : `$${plan.price}`}
-        {plan.price ? <span className="text-sm font-medium text-slate-500"> /month</span> : null}
-      </p>
+      <PriceLine plan={plan} period={period} />
       <ul className="mt-4 flex-1 space-y-1.5">
         {plan.highlights.map((h) => (
           <li key={h} className="flex gap-2 text-[13px] leading-5 text-slate-700">
@@ -31,7 +54,7 @@ function PlanCard({ plan, current }: { plan: Plan; current: boolean }) {
       <div className="mt-5">
         {plan.id === 'guest' ? (
           <p className="text-center text-[12px] text-slate-500">No sign-up needed</p>
-        ) : plan.price === 0 ? (
+        ) : plan.priceMonthly === 0 ? (
           <Link to="/signup"
             className="block rounded-md bg-[#0056b3] px-4 py-2 text-center text-sm font-semibold text-white hover:bg-[#0f4c92]">
             Create a free account
@@ -51,9 +74,33 @@ function PlanCard({ plan, current }: { plan: Plan; current: boolean }) {
   )
 }
 
+/** Monthly / annual switch. Annual is preselected — it is the better deal. */
+function PeriodToggle({ period, onChange }: { period: BillingPeriod; onChange: (p: BillingPeriod) => void }) {
+  const btn = (p: BillingPeriod, label: string) => (
+    <button key={p} type="button" onClick={() => onChange(p)}
+      aria-pressed={period === p}
+      className={`rounded-md px-4 py-1.5 text-[13px] font-semibold transition ${
+        period === p ? 'bg-white text-[#0056b3] shadow-sm' : 'text-slate-600 hover:text-[#0056b3]'}`}>
+      {label}
+    </button>
+  )
+  return (
+    <div className="mt-5 flex flex-wrap items-center gap-3">
+      <div className="inline-flex rounded-lg bg-slate-100 p-1">
+        {btn('monthly', 'Monthly')}
+        {btn('annual', 'Annual')}
+      </div>
+      <span className="rounded-full bg-emerald-50 px-2.5 py-1 text-[11.5px] font-semibold text-emerald-700">
+        Save {Math.round(ANNUAL_DISCOUNT * 100)}% paying yearly
+      </span>
+    </div>
+  )
+}
+
 export default function Pricing() {
   const { user } = useAuth()
   const current = planOf(user ? (user.plan ?? 'free') : 'guest')
+  const [period, setPeriod] = useState<BillingPeriod>('annual')
 
   return (
     <main className="mx-auto max-w-5xl px-5 py-10">
@@ -65,18 +112,26 @@ export default function Pricing() {
         built on it, and Max adds the nonlinear and dynamic solvers plus construction scheduling.
       </p>
 
+      <PeriodToggle period={period} onChange={setPeriod} />
+
       {!CHECKOUT_ENABLED && (
         <div className="mt-5 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-[13px] leading-6 text-amber-900">
-          <strong>Paid plans are not open for sign-up yet.</strong> Taking card payments safely needs a server to
-          verify the payment provider&rsquo;s webhook — a browser cannot do that, because anything checked in the
-          browser can be forged by the person paying. Until that exists, Pro and Max are listed so you can see what
-          they cover, and no card details are collected anywhere in this app. Guest and Free are fully available.
+          <strong>Paid plans are not open for sign-up yet.</strong> Payments are handled by PayMongo, and the
+          server that verifies a payment is in place — but nothing yet starts one, so no card details are collected
+          anywhere in this app. Pro and Max are listed so you can see what they cover. Guest and Free are fully
+          available.
         </div>
       )}
 
       <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        {PLANS.map((p) => <PlanCard key={p.id} plan={p} current={p.id === current.id} />)}
+        {PLANS.map((p) => <PlanCard key={p.id} plan={p} current={p.id === current.id} period={period} />)}
       </div>
+
+      <p className="mt-4 text-[12px] leading-6 text-slate-500">
+        Prices are in Philippine pesos and include no hidden fees. Annual billing saves{' '}
+        {formatPeso(annualSaving('pro'))} on Pro ({(annualDiscountOf('pro') * 100).toFixed(1)}%) and{' '}
+        {formatPeso(annualSaving('max'))} on Max ({(annualDiscountOf('max') * 100).toFixed(1)}%) over a year.
+      </p>
 
       <h2 className="mt-10 text-[1.05rem] font-bold text-[#0056b3]">What counts as a &ldquo;calculator&rdquo;</h2>
       <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">


### PR DESCRIPTION
PayMongo settles in PHP, so the page now quotes PHP. Showing a dollar figure
while the card statement reads pesos is how a customer disputes a charge they
didn't recognise — the currency shown is now the currency charged.

| | Monthly | Annual | Actual discount |
|---|---|---|---|
| **Pro** | ₱1,399 | ₱15,099 | 10.06% |
| **Max** | ₱2,999 | ₱32,399 | 9.97% |

## Annual prices are stored, not computed

The number a customer is charged should be the number written down. Both annual
figures are rounded to a `99` ending, which can't land on exactly 10% — so a
test pins each to within a tenth of a **percentage point** of the headline
discount: wide enough for that rounding, far too tight for a dropped digit or a
discount applied twice. A second test states the achieved 10.06% / 9.97%
outright, so the marketing claim and the arithmetic are visibly the same thing.

Worth noting how that band was arrived at: my first attempt used
`toBeCloseTo(0.1, 3)`, which allows ±0.05pp and failed. The docstring had
*already* said "a tenth of a percent" before the test was written, so making the
bound explicit says what was actually meant — rather than loosening a check to
fit a result.

Two more properties asserted, because a rounding edit could invert them
silently: **annual is always cheaper per month than monthly**, and the annual
saving is always positive.

## Pricing page

A Monthly/Annual toggle defaulting to **Annual** — the better deal — showing the
per-month equivalent with the yearly total and pesos saved underneath. Making
someone divide by twelve is how a good offer goes unread.

Browser-verified: Annual shows ₱1,258 and ₱2,700 per month with ₱15,099/₱32,399
billed yearly and ₱1,689/₱3,589 saved; Monthly shows ₱1,399 and ₱2,999 with no
yearly line; no dollar figure anywhere; still **zero payment inputs**, no console
errors.

## PayMongo subscription setup documented

`docs/Billing.md` now records what you found: **Subscriptions and Card Vaulting
must be enabled by emailing `support@paymongo.com`** before anything else works.
Plus the four billing plans to create, with amounts **in centavos** — `139900`,
not `1399`; the factor-of-100 error is the classic payments bug — and the price
map carrying all four ids, since annual Pro must resolve to `pro` exactly as
monthly does (many-to-one is already supported).

Also recorded: **GCash recurring is a separate arrangement** from card
subscriptions. That matters when GCash is likely to be the dominant method for
this audience — a subscription that only works on cards will convert poorly here.

## Flagged, not silently overwritten

`docs/PricingStrategy.md` **disagrees with these prices**, and I've left your
strategy thinking intact with a note at the top rather than editing it to match:

- **Professional was planned at ₱499.** Pro ships at ₱1,399 — roughly 3×.
- **Enterprise was ₱2,999 for team accounts and shared projects.** Max ships at
  that price selling *nonlinear analysis* instead. Teams and shared projects
  don't exist, so if Enterprise is still wanted it's a fifth tier, not a rename.
- **Educational licences** (free for universities) aren't implemented at all.

Three decisions to make, rather than a stale doc quietly contradicting the
running product.

## Note

`CHECKOUT_ENABLED` is still `false` — nothing here starts a payment.

Also: this branch was rebased onto `8521c9e` mid-work. The local clone had gone
stale and was missing the billing-webhook merge, so the first commit would have
been based a commit behind.

## Verification

`npx tsc -b` = 0 · `npm run lint` = 0 · `npm test` **1975 passing** ·
`npm run build` = 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_