### PR TITLE
Real PDF reports on six more calculator pages

### DIFF
--- a/webapp/src/components/ReportControls.tsx
+++ b/webapp/src/components/ReportControls.tsx
@@ -1,10 +1,29 @@
 import { useState, type JSX } from 'react'
+import type { CalcPdfInput } from '../lib/calcPdf'
+import { ExportPdfButton } from './ExportPdfButton'
+
+/**
+ * A page's report payload, minus the parts this component already owns.
+ *
+ * `docTitle` comes from `title`, `badges` from `badges`, and `lh` from the
+ * letterhead fields rendered below — so a page supplies only what is genuinely
+ * its own: the verdict, the numbers and the input echo.
+ */
+export type CalcReportData = Omit<CalcPdfInput, 'docTitle' | 'badges' | 'lh' | 'drawing'>
 
 export interface ReportControlsProps {
   /** Report heading, also used as the print/PDF document title. */
   title: string
   /** Code badges shown on the printed letterhead (e.g. ['ACI 318-14']). */
   badges?: string[]
+  /**
+   * Structured results. When present the page exports a real PDF calc sheet —
+   * the same one Model Space produces, via the shared `pdfKit`.
+   *
+   * Optional because the pages are being converted in batches: one without it
+   * still falls back to the browser print path rather than losing its export.
+   */
+  report?: CalcReportData
 }
 
 /**
@@ -15,7 +34,7 @@ export interface ReportControlsProps {
  * grid — ahead of the page's themed content. Pages with structured results
  * use the full PrintReport instead (components/calc.tsx).
  */
-export function ReportControls({ title, badges = ['NSCP 2015', 'ACI 318-14'] }: ReportControlsProps): JSX.Element {
+export function ReportControls({ title, badges = ['NSCP 2015', 'ACI 318-14'], report }: ReportControlsProps): JSX.Element {
   const [project, setProject] = useState('')
   const [sheet, setSheet] = useState('')
   const [preparedBy, setPreparedBy] = useState('')
@@ -53,10 +72,16 @@ export function ReportControls({ title, badges = ['NSCP 2015', 'ACI 318-14'] }: 
           {field('Project / job', project, setProject, 'Lot 12 Residence')}
           {field('Sheet', sheet, setSheet, 'S-01 · Rev A', true)}
           {field('Prepared by', preparedBy, setPreparedBy, 'Engineer, CE')}
-          <button type="button" onClick={print}
-            className="ml-auto inline-flex items-center gap-2 rounded-md bg-[#0f4c92] px-4 py-2 text-sm font-semibold text-white hover:bg-[#0d3f78]">
-            ⎙ Export report
-          </button>
+          {report ? (
+            <ExportPdfButton {...report} docTitle={title} badges={badges}
+              lh={{ project, sheet, preparedBy }}
+              className="ml-auto inline-flex items-center gap-2 rounded-md bg-[#0f4c92] px-4 py-2 text-sm font-semibold text-white hover:bg-[#0d3f78] disabled:opacity-50" />
+          ) : (
+            <button type="button" onClick={print}
+              className="ml-auto inline-flex items-center gap-2 rounded-md bg-[#0f4c92] px-4 py-2 text-sm font-semibold text-white hover:bg-[#0d3f78]">
+              ⎙ Export report
+            </button>
+          )}
         </div>
       </div>
 

--- a/webapp/src/pages/DevLength.tsx
+++ b/webapp/src/pages/DevLength.tsx
@@ -54,6 +54,34 @@ export default function DevLength() {
     })
   }, [f])
 
+  // Development length has no pass/fail — it produces required lengths rather
+  // than checking a demand — so the report carries no checks and the verdict
+  // line states the governing tension length instead.
+  const report = r ? {
+    docCode: 'S-DL',
+    ok: true,
+    governing: `ld = ${f0(r.ld)} mm tension · ldc = ${f0(r.ldc)} mm compression`,
+    stats: [
+      { label: 'ld (tension)', value: f0(r.ld), unit: 'mm' },
+      { label: 'Class B splice', value: f0(r.ls_B), unit: 'mm' },
+      { label: 'ldc (compression)', value: f0(r.ldc), unit: 'mm' },
+    ],
+    data: [
+      ['Bar ⌀ db', `${f.db} mm`],
+      ["Concrete f'c", `${f.fc} MPa`],
+      ['Steel fy', `${f.fy} MPa`],
+      ['Casting position ψt', `${r.psi_t.toFixed(2)}${f.topBar ? ' (top bar)' : ''}`],
+      ['Epoxy ψe', `${r.psi_e.toFixed(2)} (${f.epoxy})`],
+      ['Bar size ψs', r.psi_s.toFixed(2)],
+      ['ψt·ψe (capped 1.7)', r.psi_te.toFixed(2)],
+      ['λ (lightweight)', f.lambda],
+      ['Confinement (cb+Ktr)/db', r.confine.toFixed(2)],
+      ['ld before 300 mm floor', `${f0(r.ld_raw)} mm`],
+      ['Class A splice', `${f0(r.ls_A)} mm`],
+      ['Compression splice', `${f0(r.lsc)} mm`],
+    ] as [string, string][],
+  } : undefined
+
   return (
     <div className="mx-auto max-w-[1500px] p-6">
       <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
@@ -64,7 +92,7 @@ export default function DevLength() {
         ACI 318-14 §25.4 development + §25.5 splices. SI units (mm, MPa).
         Tension §25.4.2.3 · Compression §25.4.9.2 · Splices §25.5.2/5.
       </p>
-      <ReportControls title="Development & Splice Lengths" />
+      <ReportControls title="Development & Splice Lengths" badges={['ACI 318-14 §25.4', 'NSCP 2015']} report={report} />
 
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
         {/* ── INPUTS ── */}

--- a/webapp/src/pages/PunchingShear.tsx
+++ b/webapp/src/pages/PunchingShear.tsx
@@ -57,6 +57,30 @@ export default function PunchingShear() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fKey, allFinite, d])
 
+  const report = r ? {
+    docCode: 'S-PS',
+    ok: r.ok,
+    governing: `Vu/φVc = ${r.ratio.toFixed(2)} · b₀ = ${f0(r.b0)} mm · αs = ${r.alphaS}`,
+    stats: [
+      { label: 'φVc', value: f1(r.phiVc), unit: 'kN' },
+      { label: 'Critical perimeter b₀', value: f0(r.b0), unit: 'mm' },
+      { label: 'Effective depth d', value: f1(d), unit: 'mm' },
+    ],
+    checks: [{ name: 'Punching shear Vu/φVc', ratio: r.ratio, ok: r.ok }],
+    data: [
+      ['Column c₁ × c₂', `${f.c1} × ${f.c2} mm`],
+      ['Slab thickness h', `${f.h} mm`],
+      ['Clear cover', `${f.cover} mm`],
+      ['Bar ⌀', `${f.barDia} mm`],
+      ["Concrete f'c", `${f.fc} MPa`],
+      ['λ (lightweight)', f.lambda],
+      ['Factored shear Vu', `${f1(f.Vu)} kN`],
+      ['Column position', f.position],
+      ['βc (aspect)', r.betac.toFixed(2)],
+      ['Vc governing', `${f1(r.Vc)} kN (min of ${f1(r.Vc1)} / ${f1(r.Vc2)} / ${f1(r.Vc3)})`],
+    ] as [string, string][],
+  } : undefined
+
   return (
     <div className="mx-auto max-w-[1500px] p-6">
       <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
@@ -67,7 +91,7 @@ export default function PunchingShear() {
         Two-way slab–column punching shear — ACI 318-14 §22.6.
         Critical perimeter at d/2 from column face. φ = 0.75.
       </p>
-      <ReportControls title="Punching Shear" />
+      <ReportControls title="Punching Shear" badges={['ACI 318-14 §22.6', 'NSCP 2015']} report={report} />
 
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
         {/* ── INPUTS ── */}

--- a/webapp/src/pages/SlabDesign.tsx
+++ b/webapp/src/pages/SlabDesign.tsx
@@ -103,6 +103,43 @@ export default function SlabDesign() {
 
   const defl = r?.deflection
 
+  const report = r ? {
+    docCode: 'S-SL',
+    ok: r.applicable && (!defl || (defl.liveOK && defl.totalOK)),
+    governing: r.applicable
+      ? `Two-way DDM · h = ${r.h} mm · wu = ${f1(r.wu)} kPa`
+      : 'DDM not fully applicable — see notes',
+    stats: [
+      { label: 'Adopted thickness h', value: String(r.h), unit: 'mm' },
+      { label: 'Factored load wu', value: f1(r.wu), unit: 'kPa' },
+      { label: 'Panel ratio ly/lx', value: f2(r.ratio) },
+    ],
+    checks: [
+      // Thickness and deflection are the two the slab can actually fail on;
+      // the strip moments are satisfied by design, not checked against a demand.
+      { name: 'Minimum thickness h/hmin', ratio: r.h > 0 ? r.hmin / r.h : 0, ok: r.h >= r.hmin },
+      ...(defl ? [
+        { name: 'Immediate live deflection (L/360)', ratio: defl.immLive / defl.limitLive, ok: defl.liveOK },
+        { name: 'Total long-term deflection (L/240)', ratio: defl.total / defl.limitTotal, ok: defl.totalOK },
+      ] : []),
+    ],
+    data: [
+      ['Spans lx × ly', `${f2(f.lx)} × ${f2(f.ly)} m`],
+      ['Column width', `${f.colWidth} mm`],
+      ['Dead load D', `${f1(f.D)} kPa`],
+      ['Live load L', `${f1(f.L)} kPa`],
+      ["Concrete f'c", `${f.fc} MPa`],
+      ['Steel fy', `${f.fy} MPa`],
+      ['Cover / bar ⌀', `${f.cover} / ${f.barDia} mm`],
+      ['Minimum thickness', `${Math.round(r.hmin)} mm`],
+      ['Panel action', r.twoWay ? 'two-way' : 'one-way'],
+      ['Exterior x / y', `${f.extX} / ${f.extY}`],
+      ['Beams on edges', f.withBeams],
+      ['Mo (x / y)', `${f1(r.x.Mo)} / ${f1(r.y.Mo)} kN·m`],
+      ...(r.notes.length ? [['DDM notes', r.notes.join(' · ')] as [string, string]] : []),
+    ] as [string, string][],
+  } : undefined
+
   return (
     <div className="mx-auto max-w-[1500px] p-6">
       <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
@@ -112,7 +149,7 @@ export default function SlabDesign() {
         column-strip / middle-strip flexure; temp/shrinkage minimum; §408.7.2.2 spacing; mid-panel deflection by
         crossing-strip method (Branson I_e).
       </p>
-      <ReportControls title="Two-Way Slab Design Report" />
+      <ReportControls title="Two-Way Slab (DDM)" badges={['ACI 318-14 §8.10', 'NSCP 2015 §408.10']} report={report} />
 
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
         {/* ── INPUTS ── */}

--- a/webapp/src/pages/StairDesign.tsx
+++ b/webapp/src/pages/StairDesign.tsx
@@ -42,11 +42,40 @@ export default function StairDesign() {
 
   const r = designStair({ span, t, R, G, fc, fy, barDia, cover, finishes, live, support })
 
+  const report = {
+    docCode: 'S-ST',
+    ok: r.ok,
+    governing: `Mu = ${f2(r.Mu)} kN·m/m · waist ${t} mm at ${f2(r.geom.thetaDeg)}°`,
+    stats: [
+      { label: 'Main steel', value: `⌀${barDia} @${f0(r.mainSpacing)}`, unit: 'mm' },
+      { label: 'Distribution', value: `⌀${barDia} @${f0(r.distSpacing)}`, unit: 'mm' },
+      { label: 'Effective depth d', value: f0(r.d), unit: 'mm' },
+    ],
+    checks: [
+      { name: 'Waist thickness t/tmin', ratio: t > 0 ? r.tMin / t : 0, ok: r.tMinOK },
+    ],
+    data: [
+      ['Span', `${f2(span)} m`],
+      ['Waist thickness t', `${t} mm`],
+      ['Riser / going', `${R} / ${G} mm`],
+      ['Inclination θ', `${f2(r.geom.thetaDeg)}°`],
+      ["Concrete f'c", `${fc} MPa`],
+      ['Steel fy', `${fy} MPa`],
+      ['Cover / bar ⌀', `${cover} / ${barDia} mm`],
+      ['Finishes', `${f2(finishes)} kPa`],
+      ['Live load', `${f2(live)} kPa`],
+      ['Support', support],
+      ['Design moment Mu', `${f2(r.Mu)} kN·m/m`],
+      ['As main / distribution', `${f0(r.AsMain)} / ${f0(r.AsDist)} mm²/m`],
+      ['Minimum waist tmin', `${f0(r.tMin)} mm`],
+    ] as [string, string][],
+  }
+
   return (
     <main className="mx-auto max-w-3xl px-5 py-10">
       <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Structural</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">RC stair flight — waist slab</h1>
-      <ReportControls title="Stair Design Report" badges={['NSCP 2015', 'ACI 318-14']} />
+      <ReportControls title="Stair Design" badges={['NSCP 2015', 'ACI 318-14']} report={report} />
       <p className="mt-2 text-sm text-slate-600">
         One-way waist-slab stair to NSCP 2015 / ACI 318-14. Self-weight of the inclined waist plus
         triangular treads, finishes, and the NSCP 205 stair live load (4.8 kPa), designed per metre width.

--- a/webapp/src/pages/TorsionDesign.tsx
+++ b/webapp/src/pages/TorsionDesign.tsx
@@ -36,6 +36,42 @@ export default function TorsionDesign() {
     [fKey, allFinite],
   )
 
+  const report = r ? {
+    docCode: 'S-TO',
+    ok: r.interactionOK,
+    governing: r.torsionNeeded
+      ? `Section interaction ${(r.lhs / r.rhs).toFixed(2)} · torsion required (Tu ≥ Tu,th)`
+      : `Torsion negligible — Tu < Tu,th = ${f1(r.Tu_th)} kN·m`,
+    stats: [
+      { label: 'Stirrups (Av+2At)/s', value: f3(r.AvPlus2At), unit: 'mm²/mm' },
+      { label: 'Spacing adopted', value: f1(r.sAdopt), unit: 'mm' },
+      { label: 'Long. steel Al', value: f1(r.Al_design), unit: 'mm²' },
+    ],
+    checks: [
+      // §22.7.7.1 is a stress-interaction limit, so the "ratio" is lhs/rhs.
+      { name: 'Section interaction √[(Vu/bwd)²+(Tuph/1.7Aoh²)²] ≤ φ(Vc/bwd+⅔√f′c)',
+        ratio: r.rhs > 0 ? r.lhs / r.rhs : 0, ok: r.interactionOK },
+    ],
+    data: [
+      ['Section b × h', `${f.b} × ${f.h} mm`],
+      ['Clear cover', `${f.cover} mm`],
+      ['Stirrup ⌀ / bar ⌀', `${f.stirrupDia} / ${f.barDia} mm`],
+      ["Concrete f'c", `${f.fc} MPa`],
+      ['Steel fy / fyt', `${f.fy} / ${f.fyt} MPa`],
+      ['Torsion Tu', `${f1(f.Tu)} kN·m`],
+      ['Shear Vu', `${f1(f.Vu)} kN`],
+      ['Stirrup legs', String(f.legs)],
+      ['Effective depth d', `${f1(r.d)} mm`],
+      ['Acp / pcp', `${f1(r.Acp)} mm² / ${f1(r.pcp)} mm`],
+      ['Aoh / ph', `${f1(r.Aoh)} mm² / ${f1(r.ph)} mm`],
+      ['Ao = 0.85·Aoh', `${f1(r.Ao)} mm²`],
+      ['Threshold Tu,th', `${f1(r.Tu_th)} kN·m`],
+      ['Cracking torsion Tcr', `${f1(r.Tcr)} kN·m`],
+      ['φVc', `${f1(r.phiVc)} kN`],
+      ['Max spacing', `${f1(r.sMax)} mm`],
+    ] as [string, string][],
+  } : undefined
+
   return (
     <div className="mx-auto max-w-[1500px] p-6">
       <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
@@ -45,7 +81,7 @@ export default function TorsionDesign() {
       <p className="no-print mt-1 text-slate-600">
         Rectangular RC section — ACI 318-14 §22.7 combined shear + torsion. SI units (mm, kN, MPa).
       </p>
-      <ReportControls title="Torsion Design" />
+      <ReportControls title="Torsion Design" badges={['ACI 318-14 §22.7', 'NSCP 2015']} report={report} />
 
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
         {/* ── INPUTS ── */}

--- a/webapp/src/pages/WaterTank.tsx
+++ b/webapp/src/pages/WaterTank.tsx
@@ -40,11 +40,42 @@ export default function WaterTank() {
 
   const r = designCircularTank({ H, D, t, freeboard, fc, sigmaSt, sigmaCt, cover, barDia })
 
+  const report = {
+    docCode: 'S-WT',
+    ok: r.thicknessOK && r.freeboardOK,
+    governing: `Hoop tension T = ${f2(r.T)} kN/m at base · concrete tensile stress ${f2(r.fct)} MPa`,
+    stats: [
+      { label: 'Hoop steel', value: `⌀${barDia} @${f0(r.hoopSpacing)}`, unit: 'mm' },
+      { label: 'Vertical steel', value: `⌀${barDia} @${f0(r.vertSpacing)}`, unit: 'mm' },
+      { label: 'Hoop tension T', value: f2(r.T), unit: 'kN/m' },
+    ],
+    checks: [
+      // Serviceability governs a liquid-retaining wall: the wall is sized so
+      // uncracked concrete carries the ring tension, not so steel yields late.
+      { name: 'Concrete tensile stress fct/σct', ratio: sigmaCt > 0 ? r.fct / sigmaCt : 0, ok: r.thicknessOK },
+    ],
+    data: [
+      ['Water depth H', `${f2(H)} m`],
+      ['Internal diameter D', `${f2(D)} m`],
+      ['Wall thickness t', `${t} mm`],
+      ['Freeboard', `${f2(freeboard)} m${r.freeboardOK ? '' : ' — below recommended'}`],
+      ["Concrete f'c", `${fc} MPa`],
+      ['Permissible steel stress σst', `${sigmaSt} MPa`],
+      ['Permissible concrete tension σct', `${sigmaCt} MPa`],
+      ['Cover / bar ⌀', `${cover} / ${barDia} mm`],
+      ['Effective depth d', `${f0(r.d)} mm`],
+      ['Base moment M', `${f2(r.M)} kN·m/m`],
+      ['Hoop As', `${f0(r.hoopAs)} mm²/m`],
+      ['Vertical As', `${f0(r.vertAs)} mm²/m`],
+      ['Concrete tensile stress fct', `${f2(r.fct)} MPa`],
+    ] as [string, string][],
+  }
+
   return (
     <main className="mx-auto max-w-3xl px-5 py-10">
       <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Structural</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Circular RC water tank — wall</h1>
-      <ReportControls title="Water Tank Design Report" badges={['IS 3370', 'ACI 350']} />
+      <ReportControls title="Circular Water Tank" badges={['IS 3370', 'ACI 350']} report={report} />
       <p className="mt-2 text-sm text-slate-600">
         Permissible-stress (working-stress) wall design for a circular liquid-retaining tank, following the
         crack-control philosophy of IS 3370 / ACI 350. Hoop (ring) tension governs the horizontal steel;


### PR DESCRIPTION
Continues the report work from #465. That PR converted the 8 pages using
`PrintReport`; this one starts on the 25 using `ReportControls`, which still
handed the job to the browser's print dialogue.

## The enabling change

`ReportControls` now takes an optional structured report and, when given one,
produces the same PDF calc sheet as Model Space via the shared `pdfKit`.

**Optional on purpose.** These pages convert in batches, and one without a
payload keeps its old print path rather than losing its export halfway through
the migration.

A page supplies only what is genuinely its own — the verdict, the numbers, the
input echo. `docTitle`, `badges` and the letterhead come from props and state
`ReportControls` already owns, so there's nothing to keep in sync.

## Converted in this batch

| Route | Sheet | Checks reported |
|---|---|---|
| `/slab-design` | Two-Way Slab (DDM) | thickness + both deflection limits |
| `/punching-shear` | Punching Shear | Vu/φVc, with b₀, αs and all three Vc terms |
| `/torsion` | Torsion Design | §22.7.7.1 interaction as lhs/rhs |
| `/dev-length` | Development & Splice | **none** — see below |
| `/stair` | Stair Design | waist t/tmin |
| `/water-tank` | Circular Water Tank | concrete tensile stress fct/σct |

**Where a page has no pass/fail, it says so rather than inventing a ratio.**
Development Length is the clear case: it produces *required lengths*, it doesn't
check a demand against a capacity. Its verdict line states `ld` and `ldc`
instead, and it reports no checks — a fabricated ratio there would have been a
number with no meaning.

For the water tank the reported check is the **concrete tensile stress**, not a
steel utilisation: serviceability is what actually governs a liquid-retaining
wall, since it's sized so uncracked concrete carries the ring tension.

## Verified in a browser

All six download a valid `%PDF` with a sensible filename, no console errors, and
the old print button is gone from each.

```
/slab-design     two-way-slab-ddm              91 kB
/punching-shear  punching-shear                85 kB
/torsion         torsion-design                89 kB
/dev-length      development-splice-lengths    83 kB
/stair           stair-design                  86 kB
/water-tank      circular-water-tank           87 kB
```

The torsion sheet was **rendered and read**, not just counted: Acp 240000 mm²
for a 400×600 section, pcp 2000 mm, Ao = 0.85·Aoh = 132994 mm². The numbers on
the page are the engine's, correctly placed.

## Verification

`npx tsc -b` = 0 · `npm run lint` = 0 · `npm test` **1975 passing** ·
`npm run build` = 0.

## Remaining

19 pages still on browser print — beam/frame/truss analysis, the steel and
connection pages, the geotechnical set, seismic wizard, plumbing, load path,
load combinations, wood slab. Next batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_