### PR TITLE
Real PDF reports on the geotechnical pages

### DIFF
--- a/webapp/src/pages/LateralPile.tsx
+++ b/webapp/src/pages/LateralPile.tsx
@@ -117,11 +117,49 @@ export default function LateralPile() {
   const util = broms.Hu > 0 ? H / broms.Hu : Infinity
   const headOK = py.yHead <= 25    // 25 mm is the usual serviceability yardstick
 
+  const report = {
+    docCode: 'G-LP',
+    ok: util <= 1 && headOK && py.converged,
+    governing: `Broms ${broms.mode}-pile Hu = ${f1(broms.Hu)} kN · head deflection ${f1(py.yHead)} mm`,
+    stats: [
+      { label: 'Ultimate capacity Hu', value: f1(broms.Hu), unit: 'kN' },
+      { label: 'Head deflection', value: f1(py.yHead), unit: 'mm' },
+      { label: 'Max moment (p–y)', value: f1(py.Mmax), unit: 'kN·m' },
+    ],
+    checks: [
+      { name: `Lateral capacity H/Hu (Broms, ${broms.mode} pile)`, ratio: util, ok: util <= 1 },
+      // 25 mm is the usual serviceability yardstick, not a code limit — stated
+      // in the check name so it reads as the convention it is.
+      { name: 'Head deflection vs 25 mm', ratio: py.yHead / 25, ok: headOK },
+    ],
+    data: [
+      ['Soil model', soilKind],
+      ['Pile length L', `${f2(L)} m`],
+      ['Diameter D', `${f2(D)} m`],
+      ['Flexural stiffness EI', `${f0(EI)} kN·m²`],
+      ['Yield moment My', `${f1(My)} kN·m`],
+      ['Lateral load H', `${f1(H)} kN`],
+      ['Load eccentricity e', `${f2(e)} m`],
+      ['Head fixity', head],
+      ...(soilKind === 'clay'
+        ? [['Undrained strength cu', `${f1(cu)} kPa`] as [string, string],
+           ['Strain ε₅₀', f2(e50)] as [string, string]]
+        : [['Friction angle φ', `${f1(phi)}°`] as [string, string],
+           ['Subgrade modulus k', `${f0(k)} kN/m³`] as [string, string]]),
+      ['Effective unit weight γ′', `${f1(gamma)} kN/m³`],
+      ['Broms short-pile capacity', `${f1(broms.shortPile)} kN`],
+      ['Broms long-pile capacity', `${f1(broms.longPile)} kN`],
+      ['Broms Mmax at Hu', `${f1(broms.Mmax)} kN·m`],
+      ['p–y max moment depth', `${f2(py.zMmax)} m`],
+      ['p–y convergence', `${py.converged ? 'converged' : 'DID NOT CONVERGE'} in ${py.iterations} iterations (residual ${py.residual.toExponential(1)})`],
+    ] as [string, string][],
+  }
+
   return (
     <main className="mx-auto max-w-3xl px-5 py-10">
       <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Laterally loaded pile</h1>
-      <ReportControls title="Lateral Pile Report" badges={['Broms', 'Matlock', 'API RP 2A']} />
+      <ReportControls title="Laterally Loaded Pile" badges={['Broms', 'Matlock', 'API RP 2A']} report={report} />
       <p className="mt-2 text-sm text-slate-600">
         Two questions, two methods. <strong>Broms</strong> gives the ultimate lateral capacity in closed form and
         says whether the soil or the pile section fails first. <strong>p-y</strong> solves the pile as a beam on

--- a/webapp/src/pages/Micropile.tsx
+++ b/webapp/src/pages/Micropile.tsx
@@ -47,11 +47,39 @@ export default function Micropile() {
     mode, bondDia, bondLength, alphaBond, FS: 2, P,
   })
 
+  const report = {
+    docCode: 'G-MP',
+    ok: r.ok,
+    governing: `${r.governs === 'bond' ? 'Grout-to-ground bond' : 'Structural capacity'} governs · FS ${f2(r.fs)}`,
+    stats: [
+      { label: 'Allowable capacity', value: f2(r.allowable), unit: 'kN' },
+      { label: 'Applied load P', value: f2(P), unit: 'kN' },
+      { label: 'Bond length required', value: f2(r.bondLengthReq), unit: 'm' },
+    ],
+    checks: [
+      { name: `Governing capacity (${r.governs})`, ratio: r.allowable > 0 ? P / r.allowable : 0, ok: r.ok },
+    ],
+    data: [
+      ['Load case', mode],
+      ['Applied load P', `${f2(P)} kN`],
+      ['Bar ⌀ / fy', `${barDia} mm / ${fyBar} MPa`],
+      ['Grout ⌀ / f′c', `${groutDia} mm / ${fcGrout} MPa`],
+      ['Permanent casing', casing ? `yes — OD ${casingOD} / ID ${casingID} mm, fy ${fyCasing} MPa` : 'no'],
+      ['Bond ⌀', `${f2(bondDia)} m`],
+      ['Bond length provided', `${f2(bondLength)} m`],
+      ['Grout-to-ground bond αbond', `${f2(alphaBond)} kPa`],
+      ['Allowable structural', `${f2(r.structural)} kN`],
+      ['Ultimate bond Qult', `${f2(r.Qult)} kN`],
+      ['Allowable bond Qbond', `${f2(r.Qbond)} kN`],
+      ['Governing mode', r.governs],
+    ] as [string, string][],
+  }
+
   return (
     <main className="mx-auto max-w-3xl px-5 py-10">
       <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Micropile — axial capacity</h1>
-      <ReportControls title="Micropile Design Report" badges={['FHWA-NHI-05-039']} />
+      <ReportControls title="Micropile" badges={['FHWA-NHI-05-039']} report={report} />
       <p className="mt-2 text-sm text-slate-600">
         FHWA-NHI-05-039 allowable-stress check: structural capacity of the bar/casing/grout vs the
         grout-ground bond capacity of the bonded zone. Governing allowable = the smaller of the two.

--- a/webapp/src/pages/RockAnchor.tsx
+++ b/webapp/src/pages/RockAnchor.tsx
@@ -37,11 +37,41 @@ export default function RockAnchor() {
 
   const r = designRockAnchor({ fpu, Aps, holeDia, bondLength, tauUlt, FS: 2, T })
 
+  // Utilisation from the factor of safety, as in the other geotechnical pages.
+  const report = {
+    docCode: 'G-RA',
+    ok: r.ok,
+    governing: `${r.governs === 'tendon' ? 'Tendon' : 'Ground bond'} governs · FS ${f2(r.fs)}`,
+    stats: [
+      { label: 'Allowable load', value: f2(r.allowable), unit: 'kN' },
+      { label: 'Design load Td', value: f2(r.Td), unit: 'kN' },
+      { label: 'Bond length required', value: f2(r.bondLengthReq), unit: 'm' },
+    ],
+    checks: [
+      { name: 'Tendon capacity', ratio: r.Td > 0 ? T / r.Td : 0, ok: r.tendonOK },
+      { name: 'Ground bond (FS 2.0)', ratio: r.Qall > 0 ? T / r.Qall : 0, ok: r.bondOK },
+    ],
+    data: [
+      ['Tendon fpu', `${f2(fpu)} MPa`],
+      ['Tendon area Aps', `${f2(Aps)} mm²`],
+      ['Hole ⌀', `${f2(holeDia)} m`],
+      ['Bond length provided', `${f2(bondLength)} m`],
+      ['Ultimate bond τ', `${f2(tauUlt)} kPa`],
+      ['Service load T', `${f2(T)} kN`],
+      ['GUTS', `${f2(r.GUTS)} kN`],
+      ['Design load Td', `${f2(r.Td)} kN`],
+      ['Proof / acceptance test load', `${f2(r.testLoad)} kN`],
+      ['Ultimate ground bond Qult', `${f2(r.Qult)} kN`],
+      ['Allowable ground bond Qall', `${f2(r.Qall)} kN`],
+      ['Governing mode', r.governs],
+    ] as [string, string][],
+  }
+
   return (
     <main className="mx-auto max-w-3xl px-5 py-10">
       <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Rock / ground anchor</h1>
-      <ReportControls title="Rock Anchor Report" badges={['PTI DC35.1']} />
+      <ReportControls title="Rock Anchor" badges={['PTI DC35.1']} report={report} />
       <p className="mt-2 text-sm text-slate-600">
         PTI DC35.1 / FHWA-IF-99-015 check: prestressing-tendon design load (0.60·GUTS) and grout-ground
         (rock socket) bond capacity vs the applied anchor tension. Governing allowable = the smaller.

--- a/webapp/src/pages/Settlement.tsx
+++ b/webapp/src/pages/Settlement.tsx
@@ -122,11 +122,41 @@ export default function Settlement() {
   const t90 = govSoil ? timeToConsolidation(govSoil, 0.9) : Infinity
   const Uat = govSoil ? consolidationAfter(govSoil, years) : 0
 
+  // Settlement is a PREDICTION, not a code check — there is no capacity to
+  // divide by — so this report carries no pass/fail. The verdict line states
+  // the total instead. A 25 mm serviceability limit is common but is a project
+  // decision, not something to assert on the engineer's behalf.
+  const report = {
+    docCode: 'G-ST',
+    ok: true,
+    governing: `Total ${f1(total)} mm — ${f1(elastic)} immediate + ${f1(cons.total)} consolidation`,
+    stats: [
+      { label: 'Total settlement', value: f1(total), unit: 'mm' },
+      { label: 'Immediate (elastic)', value: f1(elastic), unit: 'mm' },
+      { label: 'Primary consolidation', value: f1(cons.total), unit: 'mm' },
+    ],
+    data: [
+      ['Applied pressure q', `${f1(q)} kPa`],
+      ['Footing B × L', `${f2(B)} × ${f2(L)} m`],
+      ['Founding depth Df', `${f2(Df)} m`],
+      ['Water table', `${f2(wt)} m`],
+      ['Elastic modulus Es', `${f0(Es)} kPa`],
+      ["Poisson's ratio ν", f2(nu)],
+      ['Profile depth', `${f2(totalDepth)} m in ${layers.length} layers`],
+      ['Elastic settlement', `${f1(elastic)} mm`],
+      ['Consolidation settlement', `${f1(cons.total)} mm`],
+      [`Schmertmann at ${years} y`, `${f1(schmert.settlement)} mm (C₁ ${f2(schmert.C1)}, C₂ ${f2(schmert.C2)})`],
+      ['Governing layer', `#${govLayer + 1} — ${f1(cons.layers[govLayer]?.settlement ?? 0)} mm`],
+      ['t₉₀ (governing layer)', Number.isFinite(t90) ? `${f2(t90)} years` : '—'],
+      ['U at ' + years + ' years', `${f0(Uat * 100)} %`],
+    ] as [string, string][],
+  }
+
   return (
     <main className="mx-auto max-w-3xl px-5 py-10">
       <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Foundation settlement</h1>
-      <ReportControls title="Settlement Report" badges={['Boussinesq', 'Terzaghi', 'Schmertmann']} />
+      <ReportControls title="Foundation Settlement" badges={['Boussinesq', 'Terzaghi', 'Schmertmann']} report={report} />
       <p className="mt-2 text-sm text-slate-600">
         Immediate (elastic and Schmertmann) plus primary consolidation settlement of a rectangular footing on a
         layered profile. Stress increase by Boussinesq; consolidation layer by layer with the overconsolidated

--- a/webapp/src/pages/ShotcreteFacing.tsx
+++ b/webapp/src/pages/ShotcreteFacing.tsx
@@ -42,11 +42,43 @@ export default function ShotcreteFacing() {
 
   const r = designFacing({ SH, SV, hc, cover, AsVert, AsHoriz, fc, fy, bearingPlate, CF, nailHeadForce })
 
+  const report = {
+    docCode: 'G-SF',
+    ok: r.ok,
+    governing: `${r.governs === 'flexure' ? 'Flexure' : 'Punching'} governs · facing strength ${f2(r.strength)} kN vs nail head ${f2(nailHeadForce)} kN`,
+    stats: [
+      { label: 'Facing strength', value: f2(r.strength), unit: 'kN' },
+      { label: 'Nail-head force', value: f2(nailHeadForce), unit: 'kN' },
+      { label: 'Effective depth d', value: f2(r.d), unit: 'mm' },
+    ],
+    checks: [
+      { name: `Facing capacity (${r.governs}, CF ${f2(CF)})`,
+        ratio: r.strength > 0 ? (nailHeadForce * CF) / r.strength : 0, ok: r.ok },
+    ],
+    data: [
+      ['Nail spacing SH × SV', `${f2(SH)} × ${f2(SV)} m`],
+      ['Facing thickness hc', `${hc} mm`],
+      ['Cover', `${cover} mm`],
+      ['Vertical steel AsVert', `${f2(AsVert)} mm²/m`],
+      ['Horizontal steel AsHoriz', `${f2(AsHoriz)} mm²/m`],
+      ["Shotcrete f'c", `${fc} MPa`],
+      ['Steel fy', `${fy} MPa`],
+      ['Bearing plate', `${f2(bearingPlate)} m`],
+      ['Critical factor CF', f2(CF)],
+      ['Nail-head force', `${f2(nailHeadForce)} kN`],
+      ['Panel moment vertical', `${f2(r.mVert)} kN·m/m`],
+      ['Panel moment horizontal', `${f2(r.mHoriz)} kN·m/m`],
+      ['Flexural strength Rff', `${f2(r.Rff)} kN`],
+      ['Punching strength Rfp', `${f2(r.Rfp)} kN`],
+      ['Governing mode', r.governs],
+    ] as [string, string][],
+  }
+
   return (
     <main className="mx-auto max-w-3xl px-5 py-10">
       <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Soil-nail shotcrete facing</h1>
-      <ReportControls title="Shotcrete Facing Report" badges={['FHWA GEC-7']} />
+      <ReportControls title="Shotcrete Facing" badges={['FHWA GEC-7']} report={report} />
       <p className="mt-2 text-sm text-slate-600">
         FHWA GEC-7 facing check. The thin shotcrete panel spans <b>between</b> the nail heads, so earth
         pressure bends it like a two-way slab on point supports — hogging over each nail, sagging at

--- a/webapp/src/pages/SlopeStability.tsx
+++ b/webapp/src/pages/SlopeStability.tsx
@@ -112,11 +112,44 @@ export default function SlopeStability() {
   const FS = crit ? { bishop: crit.bishop.FS, fellenius: crit.fellenius.FS, janbu: crit.janbu.FS }[method] : NaN
   const govOK = FS >= 1.5
 
+  // Utilisation from the factor of safety: 1.5 is the conventional long-term
+  // requirement for a permanent slope, so FS_required / FS_achieved is ≤ 1
+  // exactly when it passes.
+  const report = crit ? {
+    docCode: 'G-SS',
+    ok: govOK,
+    governing: `${method} FS = ${f2(FS)} on the critical circle (target 1.5)`,
+    stats: [
+      { label: `FS (${method})`, value: f2(FS) },
+      { label: 'Circle radius R', value: f2(crit.circle.R), unit: 'm' },
+      { label: 'Centre (x, y)', value: `${f2(crit.circle.xc)}, ${f2(crit.circle.yc)}` },
+    ],
+    checks: [
+      { name: 'Factor of safety vs 1.5', ratio: FS > 0 ? 1.5 / FS : 0, ok: govOK },
+    ],
+    data: [
+      ['Slope height H', `${f2(H)} m`],
+      ['Face angle β', `${f2(beta)}°`],
+      ['Crest / toe width', `${f2(crestW)} / ${f2(toeW)} m`],
+      ['Cohesion c', `${f2(c)} kPa`],
+      ['Friction angle φ', `${f2(phi)}°`],
+      ['Unit weight γ', `${f2(gamma)} kN/m³`],
+      ['Pore pressure ru', f2(ru)],
+      ['Reported method', method],
+      ['FS Bishop', f2(crit.bishop.FS)],
+      ['FS Fellenius', f2(crit.fellenius.FS)],
+      ['FS Janbu', f2(crit.janbu.FS)],
+      ['Driving ΣW·sinα', `${f2(crit.bishop.driving)} kN`],
+      ['Resisting Σ', `${f2(crit.bishop.resisting)} kN`],
+      ['Bishop converged', `${crit.bishop.converged ? 'yes' : 'NO'} (${crit.bishop.iterations} iterations)`],
+    ] as [string, string][],
+  } : undefined
+
   return (
     <main className="mx-auto max-w-3xl px-5 py-10">
       <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Slope stability — method of slices</h1>
-      <ReportControls title="Slope Stability Report" badges={['Bishop', 'Fellenius', 'Janbu']} />
+      <ReportControls title="Slope Stability" badges={['Bishop', 'Fellenius', 'Janbu']} report={report} />
       <p className="mt-2 text-sm text-slate-600">
         Circular-failure factor of safety by the method of slices — Fellenius/OMS, Bishop&rsquo;s simplified and
         Janbu&rsquo;s simplified — with a grid search for the critical (minimum-FS) circle. Pore pressure via ru.

--- a/webapp/src/pages/SoilNail.tsx
+++ b/webapp/src/pages/SoilNail.tsx
@@ -44,11 +44,44 @@ export default function SoilNail() {
     drillDia, bondLength, qu, FSpullout: 2.0, FStensile: 1.8,
   })
 
+  // A geotechnical check states a FACTOR OF SAFETY, not a demand/capacity
+  // ratio, so the report's utilisation is FS_required / FS_achieved — which is
+  // ≤ 1 exactly when the design passes, matching every other check in the app.
+  const report = {
+    docCode: 'G-SN',
+    ok: r.tensileOK && r.pulloutOK,
+    governing: `Tmax = ${f2(r.Tmax)} kN · FS pullout ${f2(r.fsPullout)} · FS tensile ${f2(r.fsTensile)}`,
+    stats: [
+      { label: 'Nail force Tmax', value: f2(r.Tmax), unit: 'kN' },
+      { label: 'Allowable bond Qall', value: f2(r.Qall), unit: 'kN' },
+      { label: 'Bond length required', value: f2(r.bondLengthReq), unit: 'm' },
+    ],
+    checks: [
+      { name: 'Bar tensile (FS 1.8)', ratio: r.fsTensile > 0 ? 1.8 / r.fsTensile : 0, ok: r.tensileOK },
+      { name: 'Grout pullout (FS 2.0)', ratio: r.fsPullout > 0 ? 2.0 / r.fsPullout : 0, ok: r.pulloutOK },
+    ],
+    data: [
+      ['Depth z', `${f2(z)} m`],
+      ['Spacing Sh × Sv', `${f2(Sh)} × ${f2(Sv)} m`],
+      ['Unit weight γ', `${f2(gamma)} kN/m³`],
+      ['Friction angle φ', `${f2(phi)}°`],
+      ['Surcharge q', `${f2(q)} kPa`],
+      ['Bar ⌀ / fy', `${barDia} mm / ${fy} MPa`],
+      ['Drill ⌀', `${f2(drillDia)} m`],
+      ['Bond length provided', `${f2(bondLength)} m`],
+      ['Bond strength qu', `${f2(qu)} kPa`],
+      ['Active coefficient Ka', f2(r.Ka)],
+      ['Nominal bar strength Tn', `${f2(r.Tn)} kN`],
+      ['Allowable bar strength Tall', `${f2(r.Tall)} kN`],
+      ['Ultimate pullout Qult', `${f2(r.Qult)} kN`],
+    ] as [string, string][],
+  }
+
   return (
     <main className="mx-auto max-w-3xl px-5 py-10">
       <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
       <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Soil-nail wall — per-nail check</h1>
-      <ReportControls title="Soil-Nail Wall Report" badges={['FHWA GEC-7']} />
+      <ReportControls title="Soil-Nail Wall" badges={['FHWA GEC-7']} report={report} />
       <p className="mt-2 text-sm text-slate-600">
         Preliminary FHWA GEC-7 checks for a single nail: tributary active demand vs bar-tensile and
         grout-ground pullout capacities. Global (slip-surface) stability is separate — use the{' '}


### PR DESCRIPTION
Second batch of the report conversion (after #465, #469). Seven geotechnical
pages move from browser print to the shared calc sheet.

| Route | Sheet | Basis |
|---|---|---|
| `/settlement` | Foundation Settlement | Boussinesq · Terzaghi · Schmertmann |
| `/lateral-pile` | Laterally Loaded Pile | Broms + p–y |
| `/slope` | Slope Stability | Bishop · Fellenius · Janbu |
| `/soil-nail` | Soil-Nail Wall | FHWA GEC-7 |
| `/micropile` | Micropile | FHWA-NHI-05-039 |
| `/rock-anchor` | Rock Anchor | PTI DC35.1 |
| `/shotcrete-facing` | Shotcrete Facing | FHWA GEC-7 |

## Factor of safety → utilisation

A geotechnical check states a **factor of safety**, not a demand/capacity ratio.
So the reported utilisation is `FS_required / FS_achieved`, which is ≤ 1 exactly
when the design passes — reading the same way as every structural check in the
app.

Doing it the other way round would have printed **4.79 next to a green PASS** and
**0.5 next to a red FAIL**, which is precisely backwards.

Where the target FS is a convention rather than a code limit, the check name says
so — "Factor of safety vs 1.5" on the slope, "Head deflection vs 25 mm" on the
lateral pile — so nobody reads a house rule as a clause.

## Settlement reports no pass/fail

It *predicts a movement*; there's no capacity to divide by. The verdict line
states the total instead. A 25 mm serviceability limit is common, but it's a
project decision, and asserting it on the engineer's behalf would be putting
words in their mouth.

## Convergence is on the sheet

The lateral pile report records whether the p–y solve converged, with iteration
count and final residual. A non-converged nonlinear solve that reports a tidy
deflection is the dangerous kind of wrong, so it belongs on the printed sheet and
not only on screen.

## Not converted: `/geotech`

It's a **toolkit page** — four independent sub-calculators (Rankine, bearing
capacity, infinite slope), each holding its own state inside a child component —
so the page root has no results to report. Converting it means lifting state out
of those cards, which is a refactor rather than a report change. Inventing a
report with no data would be worse, so it's left as it is and noted.

## Verified in a browser

All seven download a valid `%PDF` with a sensible filename, no console errors,
old print button gone from each (85–92 kB).

The soil-nail sheet was **rendered and read**: Ka 0.33 = tan²(45−φ/2) for φ=30°;
FS tensile 203.71/88.50 = 2.30 with utilisation 1.8/2.30 = 0.78; Qall = 424.12/2
= 212.06 kN. The arithmetic on the page is the engine's.

## Verification

`npx tsc -b` = 0 · `npm run lint` = 0 · `npm test` **1975 passing** ·
`npm run build` = 0.

## Remaining

12 pages — steel and connections, beam/frame/truss analysis, seismic wizard,
plumbing, load path, load combinations, wood slab, plus the `/geotech` toolkit
above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_