### PR TITLE
Public site requirements — policies, contact, footer, Plans in the nav

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -14,6 +14,10 @@ import FrameAnalysis from './pages/FrameAnalysis'
 import LoadPath from './pages/LoadPath'
 import Documentation from './pages/Documentation'
 import Validation from './pages/Validation'
+import Terms from './pages/legal/Terms'
+import Privacy from './pages/legal/Privacy'
+import Refunds from './pages/legal/Refunds'
+import Contact from './pages/legal/Contact'
 // three.js is heavy — the 3D pages load in their own lazy chunks.
 const ModelSpace = lazy(() => import('./pages/ModelSpace'))
 const TrussSpace = lazy(() => import('./pages/TrussSpace'))
@@ -71,6 +75,10 @@ export default function App() {
           <AppShell>
             <Routes>
         <Route path="/docs" element={<Documentation />} />
+        <Route path="/terms" element={<Terms />} />
+        <Route path="/privacy" element={<Privacy />} />
+        <Route path="/refunds" element={<Refunds />} />
+        <Route path="/contact" element={<Contact />} />
         <Route path="/validation" element={<Validation />} />
         <Route path="/foundation" element={<FoundationDesign />} />
         <Route path="/pile-cap" element={<PileCapDesign />} />

--- a/webapp/src/components/AppShell.tsx
+++ b/webapp/src/components/AppShell.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from 'react-router-dom'
 import { SIDEBAR_GROUPS, ALL_TOOLS } from '../lib/tools'
 import { CommandPalette } from './CommandPalette'
 import { usePaletteHotkey } from '../lib/usePaletteHotkey'
+import { SiteFooter } from './SiteFooter'
 
 // Workbench shell (docs/design/uiux-2026-07): persistent ink-navy sidebar with
 // the grouped tool catalog + ⌘K search, and a slim breadcrumb header. Wraps
@@ -101,6 +102,7 @@ export function AppShell({ children }: { children: ReactNode }) {
           </div>
         </header>
         {children}
+        <SiteFooter />
       </div>
       {palette && <CommandPalette onClose={() => setPalette(false)} />}
     </div>

--- a/webapp/src/components/SiteFooter.tsx
+++ b/webapp/src/components/SiteFooter.tsx
@@ -1,0 +1,79 @@
+import { Link } from 'react-router-dom'
+import { SITE, businessName, addressLines, missingSiteFields } from '../lib/siteConfig'
+
+/**
+ * Public footer.
+ *
+ * Carries the business identity and the policy links on every page, which is
+ * both what a customer expects to find and what a payment provider looks for
+ * when reviewing a merchant site. Hidden in print — a calc sheet does not need
+ * a refund policy on it.
+ */
+export function SiteFooter() {
+  const addr = addressLines()
+  const incomplete = missingSiteFields().length > 0
+  return (
+    <footer className="no-print mt-12 border-t border-[#e3e1da] bg-white">
+      <div className="mx-auto grid max-w-[1200px] gap-6 px-6 py-8 sm:grid-cols-2 lg:grid-cols-4">
+        <div>
+          <div className="flex items-baseline gap-2">
+            <span className="text-[13px] font-extrabold tracking-[.14em] text-[#0f1b2a]">CIVENG</span>
+            <span className="text-[8.5px] font-semibold uppercase tracking-[.22em] text-[#7a7568]">Toolkit</span>
+          </div>
+          <p className="mt-2 text-[12px] leading-5 text-slate-500">
+            Structural and geotechnical calculation software to NSCP 2015, ACI 318-14 and AISC 360-16.
+          </p>
+        </div>
+
+        <div>
+          <p className="text-[11px] font-bold uppercase tracking-wide text-slate-500">Product</p>
+          <ul className="mt-2 space-y-1 text-[12.5px]">
+            <li><Link to="/pricing" className="text-slate-600 hover:text-[#0056b3]">Plans and pricing</Link></li>
+            <li><Link to="/docs" className="text-slate-600 hover:text-[#0056b3]">Documentation</Link></li>
+            <li><Link to="/validation" className="text-slate-600 hover:text-[#0056b3]">Validation</Link></li>
+          </ul>
+        </div>
+
+        <div>
+          <p className="text-[11px] font-bold uppercase tracking-wide text-slate-500">Legal</p>
+          <ul className="mt-2 space-y-1 text-[12.5px]">
+            <li><Link to="/terms" className="text-slate-600 hover:text-[#0056b3]">Terms and Conditions</Link></li>
+            <li><Link to="/privacy" className="text-slate-600 hover:text-[#0056b3]">Privacy Policy</Link></li>
+            <li><Link to="/refunds" className="text-slate-600 hover:text-[#0056b3]">Refund Policy</Link></li>
+            <li><Link to="/contact" className="text-slate-600 hover:text-[#0056b3]">Contact</Link></li>
+          </ul>
+        </div>
+
+        <div>
+          <p className="text-[11px] font-bold uppercase tracking-wide text-slate-500">Contact</p>
+          <address className="mt-2 space-y-0.5 text-[12.5px] not-italic leading-5 text-slate-600">
+            {SITE.legalName.trim() && <div className="font-semibold text-slate-700">{SITE.legalName}</div>}
+            {addr.map((l) => <div key={l}>{l}</div>)}
+            <div>
+              <a href={`mailto:${SITE.supportEmail}`} className="hover:text-[#0056b3]">{SITE.supportEmail}</a>
+            </div>
+            {SITE.supportPhone.trim() && <div>{SITE.supportPhone}</div>}
+          </address>
+        </div>
+      </div>
+
+      <div className="border-t border-[#eeece5]">
+        <div className="mx-auto flex max-w-[1200px] flex-wrap items-center gap-x-4 gap-y-1 px-6 py-3 text-[11.5px] text-slate-500">
+          <span>© {new Date().getFullYear()} {businessName()}. All rights reserved.</span>
+          <span className="hidden sm:inline">·</span>
+          <span>Prices in Philippine pesos.</span>
+          <span className="hidden sm:inline">·</span>
+          <span>
+            Results are computed from your inputs and must be checked by a licensed engineer before
+            construction use.
+          </span>
+          {incomplete && (
+            <span className="rounded bg-red-50 px-1.5 py-0.5 font-mono text-[10.5px] font-semibold text-red-700">
+              business details incomplete — see /contact
+            </span>
+          )}
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/webapp/src/lib/docsContent.ts
+++ b/webapp/src/lib/docsContent.ts
@@ -23,6 +23,8 @@ export const DOC_TOOLS: DocTool[] = [
  */
 export const DOC_ROUTE_ALIASES: Record<string, string> = {
   '/signup': 'account', '/forgot-password': 'account', '/reset-password': 'account',
+  // the four public policy pages share one docs entry
+  '/privacy': 'legal', '/refunds': 'legal', '/contact': 'legal',
   // the five estimators share one page in the docs
   '/estimate/beam': 'estimates',
   '/estimate/column': 'estimates',

--- a/webapp/src/lib/docsContentShell.ts
+++ b/webapp/src/lib/docsContentShell.ts
@@ -211,4 +211,29 @@ export const SHELL_TOOLS: DocTool[] = [
       },
     ],
   },
+  {
+    id: 'legal',
+    name: 'Terms, Privacy, Refunds and Contact',
+    route: '/terms',
+    group: 'Getting around',
+    summary: 'The public policy pages: what the service is, how your data is handled, when a payment is refunded, and how to reach a person.',
+    sections: [
+      {
+        id: 'legal-pages',
+        title: 'The four pages',
+        body: 'Open to everyone, always \u2014 a customer must be able to read the terms and find a way to '
+          + 'complain without an account, and a payment provider reviewing the site will not have one either.',
+        controls: [
+          { kind: 'output', name: 'Terms and Conditions', what: 'What the service is, what an account gets you, how subscriptions renew, and the professional-responsibility clause: the software computes, it does not practise engineering, and every result must be checked before construction use.' },
+          { kind: 'output', name: 'Privacy Policy', what: 'What is collected and why, under the Data Privacy Act of 2012 (RA 10173), including your rights as a data subject and how to exercise them. Calculations run in your browser; card details never reach us.' },
+          { kind: 'output', name: 'Refund Policy', what: '14 days on a first subscription payment, no reason needed; a surprise renewal refunded if unused; refunds regardless of age when a defect stops you using what you paid for.' },
+          { kind: 'output', name: 'Contact', what: 'Business name, registered address, email, phone and support hours, plus what to include in a bug report or a billing question.' },
+        ],
+        notes: [
+          'Every business detail on these pages comes from one file, `lib/siteConfig.ts`. Anything still blank is rendered as a visible red marker and listed in a banner at the top of the page \u2014 an unfinished policy says it is unfinished rather than reading as confident and wrong.',
+          'The policies are drafts written for a Philippine software business. They are not legal advice and have not been reviewed by a lawyer.',
+        ],
+      },
+    ],
+  },
 ]

--- a/webapp/src/lib/siteConfig.test.ts
+++ b/webapp/src/lib/siteConfig.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import {
+  SITE, missingSiteFields, isSiteConfigured, addressLines, addressOneLine, businessName,
+  type SiteConfig,
+} from './siteConfig'
+
+const complete: SiteConfig = {
+  ...SITE,
+  legalName: 'Example Engineering Services',
+  address: { line1: '12 Rizal Street', city: 'Cebu City', province: 'Cebu', postalCode: '6000', country: 'Philippines' },
+  supportEmail: 'support@example.ph',
+  supportPhone: '+63 32 000 0000',
+  siteUrl: 'https://example.ph',
+}
+
+describe('missingSiteFields', () => {
+  it('names every blank required detail on the shipped config', () => {
+    // Not asserting a fixed count — the point is that the app KNOWS what is
+    // missing and can say so, rather than rendering a policy with holes in it.
+    const missing = missingSiteFields()
+    for (const m of missing) expect(m.length).toBeGreaterThan(3)
+    expect(isSiteConfigured()).toBe(missing.length === 0)
+  })
+
+  it('reports nothing once every detail is supplied', () => {
+    expect(missingSiteFields(complete)).toEqual([])
+    expect(isSiteConfigured(complete)).toBe(true)
+  })
+
+  it('treats whitespace as blank', () => {
+    // '   ' in a config file looks filled in a diff and is not.
+    expect(missingSiteFields({ ...complete, legalName: '   ' })).toContain('Registered business name')
+    expect(missingSiteFields({ ...complete, supportPhone: '\t' })).toContain('Customer service number')
+  })
+
+  it('requires a whole address, not just a street', () => {
+    for (const part of ['line1', 'city', 'province', 'postalCode'] as const) {
+      const partial = { ...complete, address: { ...complete.address, [part]: '' } }
+      expect(missingSiteFields(partial), part).toContain('Registered business address')
+    }
+  })
+
+  it('does NOT demand a TIN — publishing it is a deliberate choice', () => {
+    expect(missingSiteFields({ ...complete, tin: '' })).toEqual([])
+  })
+})
+
+describe('address formatting', () => {
+  it('renders the lines a reader expects', () => {
+    expect(addressLines(complete.address)).toEqual([
+      '12 Rizal Street', 'Cebu City, Cebu 6000', 'Philippines',
+    ])
+  })
+
+  it('includes line 2 when present', () => {
+    const a = { ...complete.address, line2: 'Unit 4B' }
+    expect(addressLines(a)).toContain('Unit 4B')
+  })
+
+  it('never emits an empty or comma-only line from a blank address', () => {
+    // The failure this prevents: a footer showing ", " above "Philippines".
+    const lines = addressLines(SITE.address)
+    for (const l of lines) {
+      expect(l.trim().length).toBeGreaterThan(0)
+      expect(l).not.toMatch(/^[,\s]+$/)
+    }
+    expect(addressOneLine(complete.address)).toBe('12 Rizal Street, Cebu City, Cebu 6000, Philippines')
+  })
+})
+
+describe('businessName', () => {
+  it('prefers the registered name once there is one', () => {
+    expect(businessName(complete)).toBe('Example Engineering Services')
+  })
+
+  it('falls back to the trade name rather than rendering nothing', () => {
+    expect(businessName({ ...complete, legalName: '' })).toBe(complete.tradeName)
+    expect(businessName().length).toBeGreaterThan(0)
+  })
+})

--- a/webapp/src/lib/siteConfig.ts
+++ b/webapp/src/lib/siteConfig.ts
@@ -1,0 +1,125 @@
+// ─────────────────────────────────────────────────────────────────────────
+// BUSINESS IDENTITY — every legal/contact fact the public pages state.
+//
+// One file, because these details appear in the Terms, the Privacy Policy, the
+// Refund Policy, the Contact page and the footer, and a business address that
+// is right in four places and stale in the fifth is worse than one that is
+// obviously missing everywhere.
+//
+// NOTHING HERE IS INVENTED. The blank fields are blank because they are facts
+// only the business owner knows — a registered name, a TIN, a real street
+// address. They appear in documents a customer and a payment provider will
+// rely on, so a plausible-looking placeholder would be a lie printed under a
+// heading that says "Terms and Conditions". `missingSiteFields()` lists what is
+// still unset, and the legal pages show that list rather than pretending.
+//
+// Fill these in before taking a single payment.
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface PostalAddress {
+  line1: string
+  line2?: string
+  city: string
+  province: string
+  postalCode: string
+  country: string
+}
+
+export interface SiteConfig {
+  /** Trading name shown throughout the app. */
+  tradeName: string
+  /** Registered business name — DTI/SEC. Blank until registered. */
+  legalName: string
+  /** Registered business address. Must match the PayMongo application. */
+  address: PostalAddress
+  /** Where customers reach a human. */
+  supportEmail: string
+  /** Customer-service number given to PayMongo; shown to payers. */
+  supportPhone: string
+  /** BIR Tax Identification Number. */
+  tin: string
+  /** Public site origin, used for canonical links. */
+  siteUrl: string
+  /** Working hours line for the contact page. */
+  supportHours: string
+  /** Date the policies were last substantively revised. */
+  policiesUpdated: string
+}
+
+export const SITE: SiteConfig = {
+  tradeName: 'CivEng Toolkit',
+
+  // ── FILL THESE IN ────────────────────────────────────────────────────
+  legalName: '',
+  address: {
+    line1: '',
+    city: '',
+    province: '',
+    postalCode: '',
+    country: 'Philippines',
+  },
+  supportPhone: '',
+  tin: '',
+  siteUrl: '',
+  // ─────────────────────────────────────────────────────────────────────
+
+  // Already known: this is the support address given on the PayMongo
+  // application. A domain address reads better to customers, but this is real
+  // and reachable, which matters more than it looks.
+  supportEmail: 'raymval246@gmail.com',
+
+  supportHours: 'Monday to Friday, 9:00–18:00 (PST, UTC+8)',
+  policiesUpdated: '30 July 2026',
+}
+
+/** Human labels for the fields a customer-facing document needs. */
+const REQUIRED: [keyof SiteConfig | 'address', string][] = [
+  ['legalName', 'Registered business name'],
+  ['address', 'Registered business address'],
+  ['supportEmail', 'Support email'],
+  ['supportPhone', 'Customer service number'],
+  ['siteUrl', 'Public site URL'],
+]
+
+/**
+ * Which required details are still blank.
+ *
+ * Empty array means the public pages are complete. Anything else is rendered on
+ * the page itself — the point is that an unfinished policy is visibly
+ * unfinished rather than quietly wrong. TIN is deliberately NOT in this list:
+ * it is needed for PayMongo onboarding and the BIR, not for a customer-facing
+ * policy, and printing it publicly is a choice the owner should make
+ * deliberately rather than by default.
+ */
+export function missingSiteFields(site: SiteConfig = SITE): string[] {
+  const out: string[] = []
+  for (const [key, label] of REQUIRED) {
+    if (key === 'address') {
+      const a = site.address
+      if (!a.line1.trim() || !a.city.trim() || !a.province.trim() || !a.postalCode.trim()) out.push(label)
+      continue
+    }
+    const v = site[key as keyof SiteConfig]
+    if (typeof v === 'string' && !v.trim()) out.push(label)
+  }
+  return out
+}
+
+/** True when every customer-facing detail is filled in. */
+export const isSiteConfigured = (site: SiteConfig = SITE): boolean =>
+  missingSiteFields(site).length === 0
+
+/** Address as display lines, skipping blanks. */
+export function addressLines(a: PostalAddress = SITE.address): string[] {
+  const cityLine = [a.city, a.province].filter((s) => s.trim()).join(', ')
+  const postLine = [cityLine, a.postalCode].filter((s) => s.trim()).join(' ')
+  return [a.line1, a.line2 ?? '', postLine, a.country].map((s) => s.trim()).filter(Boolean)
+}
+
+/** One-line address, for a footer or a meta tag. */
+export const addressOneLine = (a: PostalAddress = SITE.address): string =>
+  addressLines(a).join(', ')
+
+/** The name to use in prose — registered name if known, else the trade name. */
+export const businessName = (site: SiteConfig = SITE): string =>
+  site.legalName.trim() || site.tradeName

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -10,6 +10,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
     tools: [
       { to: '/docs', name: 'Documentation', sub: 'Toolkit guide' },
       { to: '/validation', name: 'Validation', sub: 'Engine vs hand calc' },
+      { to: '/pricing', name: 'Plans', sub: 'Pricing · PHP' },
     ],
   },
   {

--- a/webapp/src/lib/trialQuota.ts
+++ b/webapp/src/lib/trialQuota.ts
@@ -56,6 +56,10 @@ export const GATED_PREFIXES: readonly string[] = [
 export const PUBLIC_ROUTES: readonly string[] = [
   '/', '/docs', '/validation', '/about', '/pricing',
   '/signin', '/signup', '/forgot-password', '/reset-password',
+  // Policy and contact pages. A customer must be able to read the terms and
+  // find a way to complain WITHOUT an account — and a payment provider
+  // reviewing the site will not have one either.
+  '/terms', '/privacy', '/refunds', '/contact',
 ]
 
 export type AccessVerdict =

--- a/webapp/src/pages/Home.tsx
+++ b/webapp/src/pages/Home.tsx
@@ -58,6 +58,7 @@ export default function Home({ onAuth }: { onAuth: (mode: 'login' | 'signup') =>
             <a href="#tools" className="rounded-md px-2.5 py-1.5 text-[12.5px] font-semibold text-[#b6c2d0] hover:bg-white/5 hover:text-white">Tools</a>
             <Link to="/docs" className="rounded-md px-2.5 py-1.5 text-[12.5px] font-semibold text-[#b6c2d0] hover:bg-white/5 hover:text-white">Docs</Link>
             <Link to="/validation" className="rounded-md px-2.5 py-1.5 text-[12.5px] font-semibold text-[#b6c2d0] hover:bg-white/5 hover:text-white">Validation</Link>
+            <Link to="/pricing" className="rounded-md px-2.5 py-1.5 text-[12.5px] font-semibold text-[#b6c2d0] hover:bg-white/5 hover:text-white">Plans</Link>
           </div>
           <div className="ml-auto flex items-center gap-2.5">
             <div className="hidden sm:block">{searchBox(false)}</div>

--- a/webapp/src/pages/legal/Contact.tsx
+++ b/webapp/src/pages/legal/Contact.tsx
@@ -1,0 +1,99 @@
+import { Link } from 'react-router-dom'
+import { SITE, businessName, addressLines, missingSiteFields } from '../../lib/siteConfig'
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="border-t border-slate-100 py-3 sm:grid sm:grid-cols-[160px_1fr] sm:gap-4">
+      <dt className="text-[12px] font-semibold uppercase tracking-wide text-slate-500">{label}</dt>
+      <dd className="mt-1 text-[14px] leading-6 text-slate-800 sm:mt-0">{children}</dd>
+    </div>
+  )
+}
+
+const Unset = ({ what }: { what: string }) => (
+  <span className="rounded bg-red-50 px-1 font-mono text-[12px] font-semibold text-red-700">
+    [{what} not set]
+  </span>
+)
+
+export default function Contact() {
+  const missing = missingSiteFields()
+  const addr = addressLines()
+  return (
+    <main className="mx-auto max-w-3xl px-5 py-10">
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Support</p>
+      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Contact us</h1>
+      <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+        A real person reads these. If something is wrong with a calculation, tell us what you entered
+        and what you expected — that is usually enough to reproduce it.
+      </p>
+
+      {missing.length > 0 && (
+        <div className="mt-5 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-[13px] leading-6 text-red-900">
+          <strong>Contact details incomplete.</strong> Missing: {missing.join(', ')}. Set them in{' '}
+          <code className="rounded bg-white/70 px-1">webapp/src/lib/siteConfig.ts</code>.
+        </div>
+      )}
+
+      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <dl>
+          <Row label="Business name">
+            {SITE.legalName.trim()
+              ? <><strong>{SITE.legalName}</strong>{' '}<span className="text-slate-500">trading as {SITE.tradeName}</span></>
+              : <Unset what="registered business name" />}
+          </Row>
+          <Row label="Address">
+            {addr.length > 1
+              ? <address className="not-italic">{addr.map((l) => <div key={l}>{l}</div>)}</address>
+              : <Unset what="registered business address" />}
+          </Row>
+          <Row label="Email">
+            <a href={`mailto:${SITE.supportEmail}`} className="text-[#0056b3] underline">{SITE.supportEmail}</a>
+          </Row>
+          <Row label="Phone">
+            {SITE.supportPhone.trim()
+              ? <a href={`tel:${SITE.supportPhone.replace(/\s+/g, '')}`} className="text-[#0056b3] underline">{SITE.supportPhone}</a>
+              : <Unset what="customer service number" />}
+          </Row>
+          <Row label="Support hours">{SITE.supportHours}</Row>
+        </dl>
+      </section>
+
+      <h2 className="mt-8 text-[1.05rem] font-bold text-[#0056b3]">What to include</h2>
+      <div className="mt-2 space-y-3 text-sm leading-6 text-slate-700">
+        <p>
+          <strong>A wrong or surprising result:</strong> the tool name, the inputs you used, and the
+          number you expected. If you have a hand calculation, send it — that is the fastest possible
+          bug report, and it is how several engine corrections have started.
+        </p>
+        <p>
+          <strong>Billing:</strong> write from the address on the account and give the date and
+          amount. See the <Link to="/refunds" className="text-[#0056b3] underline">Refund
+          Policy</Link> for what we can do and how long it takes.
+        </p>
+        <p>
+          <strong>Privacy requests</strong> — a copy of your data, a correction, or deletion — go to
+          the same address. Your rights are set out in the{' '}
+          <Link to="/privacy" className="text-[#0056b3] underline">Privacy Policy</Link>.
+        </p>
+      </div>
+
+      <h2 className="mt-8 text-[1.05rem] font-bold text-[#0056b3]">Before you write</h2>
+      <p className="mt-2 text-sm leading-6 text-slate-700">
+        The <Link to="/docs" className="text-[#0056b3] underline">documentation</Link> explains every
+        control on every page, and the{' '}
+        <Link to="/validation" className="text-[#0056b3] underline">validation page</Link> shows the
+        engine checked against closed-form results. If you are asking &ldquo;is this number
+        right?&rdquo;, that page may answer it faster than we can.
+      </p>
+
+      <p className="mt-8 border-t border-slate-200 pt-4 text-[13px] text-slate-500">
+        {businessName()} is a Philippine business. Our{' '}
+        <Link to="/terms" className="text-[#0056b3] underline">Terms</Link>,{' '}
+        <Link to="/privacy" className="text-[#0056b3] underline">Privacy Policy</Link> and{' '}
+        <Link to="/refunds" className="text-[#0056b3] underline">Refund Policy</Link> apply to all
+        use of the service.
+      </p>
+    </main>
+  )
+}

--- a/webapp/src/pages/legal/LegalLayout.tsx
+++ b/webapp/src/pages/legal/LegalLayout.tsx
@@ -1,0 +1,78 @@
+import type { ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { SITE, missingSiteFields } from '../../lib/siteConfig'
+
+/**
+ * Shared chrome for the public policy pages.
+ *
+ * The incomplete-config banner is the important part. These documents are
+ * relied on by customers and reviewed by the payment provider, so a policy with
+ * blank business details must SAY it is incomplete rather than render a
+ * confident-looking page with holes in it.
+ */
+export function LegalLayout({ title, subtitle, children }: {
+  title: string; subtitle?: string; children: ReactNode
+}) {
+  const missing = missingSiteFields()
+  return (
+    <main className="mx-auto max-w-3xl px-5 py-10">
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Legal</p>
+      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">{title}</h1>
+      {subtitle && <p className="mt-2 text-sm leading-6 text-slate-600">{subtitle}</p>}
+      <p className="mt-1 text-[12px] text-slate-500">Last updated {SITE.policiesUpdated}</p>
+
+      {missing.length > 0 && (
+        <div className="mt-5 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-[13px] leading-6 text-red-900">
+          <strong>This document is incomplete.</strong> The following business details have not been
+          filled in yet, so the statements below that rely on them are unfinished:
+          <ul className="mt-1.5 list-inside list-disc">
+            {missing.map((m) => <li key={m}>{m}</li>)}
+          </ul>
+          <p className="mt-1.5">
+            Set them in <code className="rounded bg-white/70 px-1">webapp/src/lib/siteConfig.ts</code> and
+            redeploy. This notice disappears on its own once they are all present.
+          </p>
+        </div>
+      )}
+
+      <div className="prose-sm mt-6 space-y-5 text-[14px] leading-7 text-slate-700">{children}</div>
+
+      <div className="mt-10 border-t border-slate-200 pt-5 text-[13px] text-slate-500">
+        <p>
+          These policies are drafts written for a Philippine software business. They are not legal
+          advice and have not been reviewed by a lawyer. Have them checked before relying on them
+          commercially — particularly the data-protection sections, which carry statutory duties
+          under the Data Privacy Act.
+        </p>
+        <p className="mt-2 flex flex-wrap gap-x-4 gap-y-1">
+          <Link to="/terms" className="text-[#0056b3] underline">Terms</Link>
+          <Link to="/privacy" className="text-[#0056b3] underline">Privacy</Link>
+          <Link to="/refunds" className="text-[#0056b3] underline">Refunds</Link>
+          <Link to="/contact" className="text-[#0056b3] underline">Contact</Link>
+          <Link to="/pricing" className="text-[#0056b3] underline">Plans</Link>
+        </p>
+      </div>
+    </main>
+  )
+}
+
+/** Numbered section heading, so clauses can be cited in an email. */
+export function Clause({ n, title, children }: { n: string; title: string; children: ReactNode }) {
+  return (
+    <section id={`s${n}`}>
+      <h2 className="mt-6 text-[15px] font-bold text-[#0f1b2a]">{n}. {title}</h2>
+      <div className="mt-1.5 space-y-2">{children}</div>
+    </section>
+  )
+}
+
+/** A business detail that may not be filled in yet — never silently blank. */
+export function Detail({ value, what }: { value: string; what: string }) {
+  const v = value.trim()
+  if (v) return <>{v}</>
+  return (
+    <span className="rounded bg-red-50 px-1 font-mono text-[12px] font-semibold text-red-700">
+      [{what} not set]
+    </span>
+  )
+}

--- a/webapp/src/pages/legal/Privacy.tsx
+++ b/webapp/src/pages/legal/Privacy.tsx
@@ -1,0 +1,135 @@
+import { Link } from 'react-router-dom'
+import { LegalLayout, Clause, Detail } from './LegalLayout'
+import { SITE, businessName, addressOneLine } from '../../lib/siteConfig'
+
+export default function Privacy() {
+  const name = businessName()
+  return (
+    <LegalLayout
+      title="Privacy Policy"
+      subtitle={`How ${name} handles your personal information, under the Data Privacy Act of 2012 (RA 10173).`}
+    >
+      <Clause n="1" title="Who controls your data">
+        <p>
+          The personal information controller is{' '}
+          <strong><Detail value={SITE.legalName} what="registered business name" /></strong>, of{' '}
+          <Detail value={addressOneLine()} what="registered business address" />.
+        </p>
+        <p>
+          For any privacy question or request, write to{' '}
+          <a href={`mailto:${SITE.supportEmail}`} className="text-[#0056b3] underline">{SITE.supportEmail}</a>.
+        </p>
+      </Clause>
+
+      <Clause n="2" title="What we collect">
+        <p><strong>If you use the calculators without an account:</strong> nothing that identifies you.
+          The calculations run in your browser. A counter of how many times you have used each free
+          tool is kept in your own browser&rsquo;s storage and is never sent to us — clearing your
+          site data resets it.</p>
+        <p><strong>If you create an account:</strong> your email address, your password (stored only
+          as a cryptographic hash, never in readable form), a display name if you give one, and your
+          subscription plan.</p>
+        <p><strong>If you save a project:</strong> the model and inputs you chose to save.</p>
+        <p><strong>If you pay:</strong> our payment provider processes your card or e-wallet details.
+          <strong> We never see or store your card number.</strong> We receive only confirmation that
+          a payment succeeded and which plan it was for.</p>
+        <p><strong>Automatically:</strong> standard server logs from our hosting provider — IP
+          address, browser type, pages requested — kept for security and troubleshooting.</p>
+      </Clause>
+
+      <Clause n="3" title="Why we use it, and on what basis">
+        <ul className="list-inside list-disc space-y-1">
+          <li><strong>To provide the service</strong> — authenticate you, apply your plan, store your
+            projects. Basis: performance of our contract with you.</li>
+          <li><strong>To take payment</strong> — process subscriptions and issue receipts.
+            Basis: contract, and our legal obligation to keep accounting records.</li>
+          <li><strong>To keep the service secure</strong> — detect abuse and investigate faults.
+            Basis: our legitimate interest in a working, un-abused service.</li>
+          <li><strong>To contact you about the service</strong> — billing notices, security notices,
+            material changes to these policies. Basis: contract.</li>
+        </ul>
+        <p>
+          We do not sell your personal information, and we do not use your project data to train
+          anything or to advertise to you.
+        </p>
+      </Clause>
+
+      <Clause n="4" title="Who else processes it">
+        <p>We use a small number of providers, each only for the purpose named:</p>
+        <ul className="list-inside list-disc space-y-1">
+          <li><strong>Supabase</strong> — accounts, authentication and saved projects.</li>
+          <li><strong>Vercel</strong> — hosting and delivery of the website.</li>
+          <li><strong>PayMongo</strong> — payment processing. They are a separate controller of the
+            payment details you give them; see their own privacy policy.</li>
+        </ul>
+        <p>
+          Some of these store data on servers outside the Philippines. Where that happens, the
+          transfer is covered by the provider&rsquo;s contractual data-protection commitments, as
+          required by the Data Privacy Act.
+        </p>
+      </Clause>
+
+      <Clause n="5" title="How long we keep it">
+        <ul className="list-inside list-disc space-y-1">
+          <li><strong>Account and project data</strong> — while your account is open, and for 30 days
+            after you close it, so an accidental deletion can be undone.</li>
+          <li><strong>Payment and billing records</strong> — for the period Philippine tax law
+            requires records to be retained.</li>
+          <li><strong>Server logs</strong> — a short rolling window, then discarded.</li>
+        </ul>
+      </Clause>
+
+      <Clause n="6" title="Your rights under RA 10173">
+        <p>As a data subject you have the right to:</p>
+        <ul className="list-inside list-disc space-y-1">
+          <li>be <strong>informed</strong> about how your data is processed;</li>
+          <li><strong>access</strong> a copy of the personal data we hold about you;</li>
+          <li>have inaccurate data <strong>corrected</strong>;</li>
+          <li><strong>object</strong> to processing, or withdraw consent where consent is the basis;</li>
+          <li>have your data <strong>erased or blocked</strong> in the circumstances the Act provides;</li>
+          <li><strong>data portability</strong> — receive your data in a usable electronic format;</li>
+          <li><strong>damages</strong> for a violation of your rights; and</li>
+          <li>lodge a complaint with the <strong>National Privacy Commission</strong>.</li>
+        </ul>
+        <p>
+          Write to <a href={`mailto:${SITE.supportEmail}`} className="text-[#0056b3] underline">{SITE.supportEmail}</a>{' '}
+          to exercise any of these. We will respond within the period the Act allows.
+        </p>
+      </Clause>
+
+      <Clause n="7" title="Security">
+        <p>
+          Passwords are hashed by our authentication provider and are never visible to us or stored
+          in readable form. Traffic to the site is encrypted in transit. Access to production data is
+          limited to what is needed to operate the service.
+        </p>
+        <p>
+          No system is perfectly secure. If a breach occurs that is likely to put your rights at
+          risk, we will notify you and the National Privacy Commission as the Act requires.
+        </p>
+      </Clause>
+
+      <Clause n="8" title="Cookies and local storage">
+        <p>
+          We use browser storage for two things: keeping you signed in, and remembering your free-tool
+          usage count. We do not use advertising or third-party tracking cookies.
+        </p>
+      </Clause>
+
+      <Clause n="9" title="Children">
+        <p>
+          The service is intended for engineering professionals and students and is not directed at
+          children under 13. We do not knowingly collect their personal information.
+        </p>
+      </Clause>
+
+      <Clause n="10" title="Changes">
+        <p>
+          We will post any update here and change the date at the top. Material changes will also be
+          sent by email. See also our{' '}
+          <Link to="/terms" className="text-[#0056b3] underline">Terms</Link>.
+        </p>
+      </Clause>
+    </LegalLayout>
+  )
+}

--- a/webapp/src/pages/legal/Refunds.tsx
+++ b/webapp/src/pages/legal/Refunds.tsx
@@ -1,0 +1,120 @@
+import { Link } from 'react-router-dom'
+import { LegalLayout, Clause, Detail } from './LegalLayout'
+import { SITE, businessName } from '../../lib/siteConfig'
+
+export default function Refunds() {
+  const name = businessName()
+  return (
+    <LegalLayout
+      title="Refund and Cancellation Policy"
+      subtitle={`When ${name} refunds a subscription payment, and how to ask.`}
+    >
+      <Clause n="1" title="Try it before you pay">
+        <p>
+          Every single-purpose calculator is free to use — permanently, with an account, and for a
+          number of trial runs without one. The{' '}
+          <Link to="/validation" className="text-[#0056b3] underline">validation page</Link> shows our
+          engine checked against hand calculations, and the{' '}
+          <Link to="/docs" className="text-[#0056b3] underline">documentation</Link> covers every
+          control.
+        </p>
+        <p>
+          We would much rather you satisfied yourself that the software is right for you before
+          paying than ask for your money back afterwards.
+        </p>
+      </Clause>
+
+      <Clause n="2" title="14-day refund on a first subscription">
+        <p>
+          If you are unhappy with a paid plan, tell us within <strong>14 days</strong> of your first
+          payment and we will refund it in full. You do not need to give a reason.
+        </p>
+        <p>
+          This applies to your first payment on an account. Renewals are covered by clause 3.
+        </p>
+      </Clause>
+
+      <Clause n="3" title="Renewals">
+        <p>
+          Subscriptions renew automatically. You can cancel at any time, and cancelling stops the
+          next renewal while leaving you access for the period you have already paid for.
+        </p>
+        <p>
+          <strong>If a renewal catches you by surprise</strong> — you meant to cancel and forgot, and
+          you have not used the service since it renewed — write to us within 14 days of the charge
+          and we will refund it. We would rather return the money than keep a payment somebody did
+          not intend to make.
+        </p>
+        <p>
+          Beyond that, renewal payments are not refundable for periods already used, since a
+          subscription is access rather than goods.
+        </p>
+      </Clause>
+
+      <Clause n="4" title="Annual plans">
+        <p>
+          Annual plans are covered by the same 14-day first-payment refund. After 14 days, if you
+          cancel part-way through a year we do not refund the remainder as a matter of course — but
+          if your circumstances have changed materially, ask. We will look at it.
+        </p>
+      </Clause>
+
+      <Clause n="5" title="If something is broken">
+        <p>
+          The 14-day window does not limit your rights when the service does not do what we said it
+          does. If a defect prevents you from using a feature you paid for and we cannot fix it in
+          reasonable time, you are entitled to a refund for the affected period regardless of how
+          long you have been a customer.
+        </p>
+        <p>
+          Nothing in this policy limits your rights under the Consumer Act of the Philippines
+          (RA 7394) or any other law.
+        </p>
+      </Clause>
+
+      <Clause n="6" title="What is not refunded">
+        <ul className="list-inside list-disc space-y-1">
+          <li>Periods you have already used, outside the cases above.</li>
+          <li>Accounts closed for a breach of the{' '}
+            <Link to="/terms" className="text-[#0056b3] underline">Terms</Link>.</li>
+          <li>Disappointment with a calculation result that the software produced correctly from the
+            inputs given. Checking the inputs and the result is the engineer&rsquo;s responsibility —
+            see clause 3 of the Terms.</li>
+        </ul>
+      </Clause>
+
+      <Clause n="7" title="How to request a refund">
+        <p>
+          Email <a href={`mailto:${SITE.supportEmail}`} className="text-[#0056b3] underline">{SITE.supportEmail}</a>{' '}
+          from the address on the account, saying which payment you mean. You do not need a form or a
+          reference number — the date and amount is enough.
+        </p>
+        <p>
+          You can also call <Detail value={SITE.supportPhone} what="customer service number" /> during{' '}
+          {SITE.supportHours}.
+        </p>
+      </Clause>
+
+      <Clause n="8" title="How long it takes">
+        <p>
+          We acknowledge refund requests within <strong>2 business days</strong> and approve or
+          explain within <strong>7 business days</strong>.
+        </p>
+        <p>
+          Approved refunds go back to the original payment method. How quickly the money appears is
+          up to your bank or e-wallet provider — usually a few business days for e-wallets and up to
+          one billing cycle for cards. We cannot speed that part up, but we can tell you the date we
+          released it.
+        </p>
+      </Clause>
+
+      <Clause n="9" title="Cancelling without a refund">
+        <p>
+          To simply stop future billing, cancel from your account or write to us. Cancellation is
+          effective immediately for future renewals; you keep access until the end of the period you
+          have paid for.
+        </p>
+      </Clause>
+    </LegalLayout>
+  )
+}

--- a/webapp/src/pages/legal/Terms.tsx
+++ b/webapp/src/pages/legal/Terms.tsx
@@ -1,0 +1,153 @@
+import { Link } from 'react-router-dom'
+import { LegalLayout, Clause, Detail } from './LegalLayout'
+import { SITE, businessName, addressOneLine } from '../../lib/siteConfig'
+
+export default function Terms() {
+  const name = businessName()
+  return (
+    <LegalLayout
+      title="Terms and Conditions"
+      subtitle={`The agreement between you and ${name} for use of the ${SITE.tradeName}.`}
+    >
+      <Clause n="1" title="Who you are contracting with">
+        <p>
+          The {SITE.tradeName} is operated by <strong><Detail value={SITE.legalName} what="registered business name" /></strong>,
+          a business registered in the Philippines, with its registered address at{' '}
+          <Detail value={addressOneLine()} what="registered business address" />.
+        </p>
+        <p>
+          Contact: <a href={`mailto:${SITE.supportEmail}`} className="text-[#0056b3] underline">{SITE.supportEmail}</a>
+          {' · '}<Detail value={SITE.supportPhone} what="customer service number" />
+        </p>
+      </Clause>
+
+      <Clause n="2" title="What this service is">
+        <p>
+          The {SITE.tradeName} is engineering calculation software. It performs structural and
+          geotechnical calculations to Philippine and international design codes — NSCP 2015,
+          ACI 318-14, AISC 360-16 and others named on each page — and produces calculation sheets
+          from the inputs you supply.
+        </p>
+        <p>
+          Most calculations run entirely in your own browser. Nothing you type into a calculator is
+          sent to us unless you save a project to your account.
+        </p>
+      </Clause>
+
+      <Clause n="3" title="Professional responsibility — read this one">
+        <p>
+          <strong>This software does not practise engineering, and it does not replace an engineer.</strong>{' '}
+          Every result it produces is a computation from the inputs you gave it. It cannot know
+          whether those inputs describe your structure, whether the code clause it applied is the
+          right one for your situation, or whether the result is buildable.
+        </p>
+        <p>
+          You are responsible for checking every result before it is used for construction. Under
+          Philippine law, structural design must be prepared and sealed by a licensed Civil
+          Engineer, and nothing produced here is sealed or certified. Where a calculation sheet
+          carries your name, it carries it because you typed it in — not because we verified
+          anything.
+        </p>
+        <p>
+          We publish our engine benchmarks against hand calculations on the{' '}
+          <Link to="/validation" className="text-[#0056b3] underline">validation page</Link> so you can
+          judge the software for yourself. That page is open to everyone, and always will be.
+        </p>
+      </Clause>
+
+      <Clause n="4" title="Accounts">
+        <p>
+          You may use the single-purpose calculators without an account, subject to a trial limit.
+          An account removes that limit and allows saved projects. You are responsible for keeping
+          your password secure and for activity under your account.
+        </p>
+        <p>
+          You must give an email address you control. You may close your account at any time by
+          writing to us; see the <Link to="/privacy" className="text-[#0056b3] underline">Privacy
+          Policy</Link> for what happens to your data.
+        </p>
+      </Clause>
+
+      <Clause n="5" title="Paid plans">
+        <p>
+          Paid plans are described on the <Link to="/pricing" className="text-[#0056b3] underline">Plans
+          page</Link>, in Philippine pesos. Prices shown include any applicable taxes unless stated
+          otherwise on that page.
+        </p>
+        <p>
+          Subscriptions renew automatically at the end of each billing period until cancelled. You
+          may cancel at any time; cancellation stops the next renewal and does not shorten the
+          period you have already paid for. Refunds are governed by our{' '}
+          <Link to="/refunds" className="text-[#0056b3] underline">Refund Policy</Link>.
+        </p>
+        <p>
+          We may change prices. If we do, the new price applies from your next renewal, and we will
+          tell you by email before it takes effect.
+        </p>
+      </Clause>
+
+      <Clause n="6" title="Acceptable use">
+        <p>You agree not to:</p>
+        <ul className="list-inside list-disc space-y-1">
+          <li>resell, sublicense or redistribute access to the service;</li>
+          <li>attempt to circumvent plan limits, or share one account across a team;</li>
+          <li>copy or extract the calculation engine for use outside this service;</li>
+          <li>interfere with the service or attempt to gain access to other users&rsquo; data.</li>
+        </ul>
+      </Clause>
+
+      <Clause n="7" title="Your content">
+        <p>
+          Models, projects and inputs you create remain yours. You grant us only the permission
+          needed to store and display them back to you. We do not use your project data to promote
+          the service or share it with third parties, except as described in the Privacy Policy.
+        </p>
+      </Clause>
+
+      <Clause n="8" title="Availability">
+        <p>
+          We aim to keep the service available but do not guarantee uninterrupted access. We may
+          suspend it for maintenance or for reasons outside our control. Because the calculators run
+          in your browser, most of them keep working during a server outage.
+        </p>
+      </Clause>
+
+      <Clause n="9" title="Limitation of liability">
+        <p>
+          To the extent permitted by Philippine law, our total liability arising from your use of the
+          service is limited to the amount you paid us in the twelve months before the claim.
+        </p>
+        <p>
+          We are not liable for construction cost, delay, rework, or loss arising from a design
+          decision. That follows from clause 3: the engineering judgement is yours, and the
+          responsibility that goes with it cannot be transferred to a calculator. Nothing here
+          excludes liability that cannot be excluded by law, including for fraud.
+        </p>
+      </Clause>
+
+      <Clause n="10" title="Ending the agreement">
+        <p>
+          You may stop using the service at any time. We may suspend or close an account that
+          breaches these terms, and will explain why. If we close your account other than for a
+          breach, we will refund the unused part of a prepaid period.
+        </p>
+      </Clause>
+
+      <Clause n="11" title="Governing law">
+        <p>
+          These terms are governed by the laws of the Republic of the Philippines. Disputes are
+          subject to the exclusive jurisdiction of the courts of{' '}
+          <Detail value={SITE.address.city} what="business city" />, Philippines.
+        </p>
+      </Clause>
+
+      <Clause n="12" title="Changes to these terms">
+        <p>
+          We may update these terms. Material changes will be announced by email or in the app at
+          least 14 days before they take effect. Continuing to use the service after that means you
+          accept the revised terms.
+        </p>
+      </Clause>
+    </LegalLayout>
+  )
+}


### PR DESCRIPTION
What a payment provider looks for when reviewing a merchant site, and what a
customer is entitled to find without an account.

| Route | Page |
|---|---|
| `/terms` | Terms and Conditions |
| `/privacy` | Privacy Policy — written against the Data Privacy Act (RA 10173) |
| `/refunds` | Refund and Cancellation Policy |
| `/contact` | Business identity, address, email, phone, support hours |

All four are in `PUBLIC_ROUTES`. Someone must be able to read the terms and find
a way to complain **without signing up** — and a reviewer at PayMongo won't have
an account either.

## Nothing about the business is invented

`lib/siteConfig.ts` holds every legal and contact fact in one place, and the
**registered name, address, phone, TIN and site URL are deliberately blank**.

Those are facts only you know, and they appear in documents a customer and a
payment provider rely on. A plausible-looking placeholder would be a lie printed
under a heading that says "Terms and Conditions".

So the app states what it doesn't know:

- `missingSiteFields()` lists the unset details
- each policy page shows that list in a red banner at the top
- each unset value renders inline as `[registered business address not set]`
- the footer carries a "business details incomplete" chip

All of it disappears on its own once you fill in the file.

**TIN is deliberately not required** — it's needed for PayMongo onboarding and the
BIR, not for a customer-facing policy, and publishing it should be your
deliberate choice rather than a default. A test pins that.

## 👉 What you need to fill in

One file, `webapp/src/lib/siteConfig.ts`:

```ts
legalName: '',                    // as on your DTI/SEC certificate
address: { line1: '', city: '', province: '', postalCode: '', country: 'Philippines' },
supportPhone: '',                 // the number you gave PayMongo
tin: '',                          // optional on the public site
siteUrl: '',                      // e.g. https://civil-engineering-zeta.vercel.app
```

`supportEmail` is already set to `raymval246@gmail.com` — the support address
from your PayMongo application. A domain address reads better to customers, but
this one is real and reachable, which matters more.

## The policies are substantive, not boilerplate

Three that matter:

- **Terms clause 3** says plainly that the software does not practise
  engineering, that results must be checked before construction use, and that a
  sheet carries your name because you typed it in — not because anything was
  verified. That clause is what lets clause 9 limit liability *honestly*.
- **Privacy** states that calculations run in the browser and card numbers never
  reach us, names the three processors (Supabase, Vercel, PayMongo), and lists
  the RA 10173 data-subject rights with how to exercise them.
- **Refunds** gives 14 days on a first payment with no reason needed, **and**
  refunds a surprise renewal that went unused — that money was never meant to be
  paid. It also states that a defect entitles a refund *regardless of age*, so
  the 14-day window can't be read as a cap on that.

Every page carries a note that these are drafts, not legal advice, and have not
been reviewed by a lawyer. **Please have them checked** — the data-protection
sections carry statutory duties.

## Also

`SiteFooter` on every workbench page (hidden in print), **Plans** in the Home nav
and the sidebar Reference group, and a docs entry — which the docs guard demanded
before it would let the routes exist.

## Verified in a browser

All four render, **none redirects to `/signin`**, the footer carries the policy
links everywhere, the incomplete banner shows exactly the five unset fields, no
console errors.

`npx tsc -b` = 0 · `npm run lint` = 0 · `npm test` **1985 passing** (10 new) ·
`npm run build` = 0.

## Next

The rest of your request — signed-in state in the header, and a Profile tab
wired to the report letterhead — is the following PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_