### PR TITLE
Signed-in state in the header, and a profile wired to the letterhead

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -18,6 +18,7 @@ import Terms from './pages/legal/Terms'
 import Privacy from './pages/legal/Privacy'
 import Refunds from './pages/legal/Refunds'
 import Contact from './pages/legal/Contact'
+import Profile from './pages/auth/Profile'
 // three.js is heavy — the 3D pages load in their own lazy chunks.
 const ModelSpace = lazy(() => import('./pages/ModelSpace'))
 const TrussSpace = lazy(() => import('./pages/TrussSpace'))
@@ -119,6 +120,7 @@ export default function App() {
         <Route path="/signup" element={<SignUp />} />
         <Route path="/forgot-password" element={<ForgotPassword />} />
         <Route path="/reset-password" element={<ResetPassword />} />
+        <Route path="/profile" element={<Profile />} />
         <Route path="/rock-anchor" element={<RockAnchor />} />
         <Route path="/seismic-wizard" element={<RequireAuth><SeismicWizard /></RequireAuth>} />
         <Route path="/water-tank" element={<WaterTank />} />

--- a/webapp/src/components/AccountMenu.tsx
+++ b/webapp/src/components/AccountMenu.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { useAuth } from '../lib/auth/authContext'
+import { usePlan } from '../lib/auth/usePlan'
+import { CHECKOUT_ENABLED } from '../lib/plans'
+
+/**
+ * Who am I, and how do I get out.
+ *
+ * The app previously showed "Log in / Sign up" whether or not you were signed
+ * in, so there was no way to tell — and no way to sign out. This is the fix.
+ *
+ * `dark` renders it for the ink-navy home nav; the default suits the light
+ * workbench header.
+ */
+export function AccountMenu({ dark }: { dark?: boolean }) {
+  const { user, loading, configured, signOut } = useAuth()
+  const plan = usePlan()
+  const nav = useNavigate()
+  const [open, setOpen] = useState(false)
+  const box = useRef<HTMLDivElement>(null)
+
+  // Close on an outside click or Escape. Without this the panel stays open
+  // behind whatever you clicked next, which reads as a stuck menu.
+  useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent) => {
+      if (box.current && !box.current.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false) }
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  const linkCls = dark
+    ? 'px-2 py-1.5 text-[12.5px] font-semibold text-[#b6c2d0] hover:text-white'
+    : 'px-2 py-1 text-[12px] font-semibold text-[#5c6675] hover:text-[#0f4c92]'
+  const cta = dark
+    ? 'rounded-md bg-[#0f4c92] px-3.5 py-2 text-[12.5px] font-semibold text-white hover:bg-[#135caf]'
+    : 'rounded-md bg-[#0f4c92] px-3 py-1.5 text-[12px] font-semibold text-white hover:bg-[#0d3f78]'
+
+  // Nothing to offer when the deployment has no auth configured — showing a
+  // sign-in button that cannot work is worse than showing none.
+  if (!configured) return null
+
+  // Hold the space during the session lookup rather than flashing "Log in" at
+  // someone who IS signed in.
+  if (loading) {
+    return <span className={dark ? 'px-2 text-[12.5px] text-[#7d8ea3]' : 'px-2 text-[12px] text-[#a39d8d]'}>…</span>
+  }
+
+  if (!user) {
+    return (
+      <div className="flex items-center gap-2">
+        <Link to="/signin" className={linkCls}>Log in</Link>
+        <Link to="/signup" className={cta}>Sign up</Link>
+      </div>
+    )
+  }
+
+  const label = user.name?.trim() || user.email || 'Account'
+  const initial = label.charAt(0).toUpperCase()
+
+  return (
+    <div className="relative" ref={box}>
+      <button type="button" onClick={() => setOpen((v) => !v)}
+        aria-expanded={open} aria-haspopup="menu"
+        className={`flex items-center gap-2 rounded-md px-1.5 py-1 ${
+          dark ? 'hover:bg-white/10' : 'hover:bg-[#f4f3ef]'}`}>
+        <span className="flex h-6 w-6 flex-none items-center justify-center rounded-full bg-[#0f4c92] text-[11px] font-bold text-white">
+          {initial}
+        </span>
+        <span className={`hidden max-w-[140px] truncate text-[12px] font-semibold sm:inline ${
+          dark ? 'text-white' : 'text-[#0f1b2a]'}`}>{label}</span>
+        <span className={`hidden rounded px-1.5 py-px font-mono text-[9.5px] font-semibold uppercase sm:inline ${
+          dark ? 'bg-white/15 text-white' : 'bg-[#eaf1f9] text-[#0f4c92]'}`}>{plan.name}</span>
+        <svg viewBox="0 0 24 24" width="11" height="11" fill="none" stroke="currentColor" strokeWidth="3"
+          className={dark ? 'text-[#b6c2d0]' : 'text-[#8b8574]'}><polyline points="6 9 12 15 18 9" /></svg>
+      </button>
+
+      {open && (
+        <div role="menu"
+          className="absolute right-0 z-50 mt-1.5 w-60 overflow-hidden rounded-lg border border-slate-200 bg-white shadow-lg">
+          <div className="border-b border-slate-100 px-3.5 py-2.5">
+            <p className="truncate text-[12.5px] font-semibold text-[#0f1b2a]">{label}</p>
+            {user.email && user.email !== label && (
+              <p className="truncate text-[11px] text-slate-500">{user.email}</p>
+            )}
+            <p className="mt-1 text-[11px] text-slate-500">
+              On the <strong className="text-[#0f4c92]">{plan.name}</strong> plan
+              {!user.emailVerified && <span className="text-amber-700"> · email not verified</span>}
+            </p>
+          </div>
+          <nav className="py-1 text-[12.5px]">
+            <Link to="/profile" onClick={() => setOpen(false)}
+              className="block px-3.5 py-1.5 text-slate-700 hover:bg-[#f4f3ef] hover:text-[#0f4c92]">
+              Profile and letterhead
+            </Link>
+            <Link to="/pricing" onClick={() => setOpen(false)}
+              className="block px-3.5 py-1.5 text-slate-700 hover:bg-[#f4f3ef] hover:text-[#0f4c92]">
+              {CHECKOUT_ENABLED && plan.id !== 'max' ? 'Upgrade plan' : 'Plans and pricing'}
+            </Link>
+            <Link to="/contact" onClick={() => setOpen(false)}
+              className="block px-3.5 py-1.5 text-slate-700 hover:bg-[#f4f3ef] hover:text-[#0f4c92]">
+              Contact support
+            </Link>
+          </nav>
+          <div className="border-t border-slate-100 py-1">
+            <button type="button"
+              onClick={async () => { setOpen(false); await signOut(); nav('/') }}
+              className="block w-full px-3.5 py-1.5 text-left text-[12.5px] font-semibold text-red-700 hover:bg-red-50">
+              Sign out
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/webapp/src/components/AppShell.tsx
+++ b/webapp/src/components/AppShell.tsx
@@ -4,6 +4,7 @@ import { SIDEBAR_GROUPS, ALL_TOOLS } from '../lib/tools'
 import { CommandPalette } from './CommandPalette'
 import { usePaletteHotkey } from '../lib/usePaletteHotkey'
 import { SiteFooter } from './SiteFooter'
+import { AccountMenu } from './AccountMenu'
 
 // Workbench shell (docs/design/uiux-2026-07): persistent ink-navy sidebar with
 // the grouped tool catalog + ⌘K search, and a slim breadcrumb header. Wraps
@@ -93,12 +94,15 @@ export function AppShell({ children }: { children: ReactNode }) {
                 <span className="ml-1 hidden rounded border border-[#cddcf0] bg-[#eaf1f9] px-1.5 py-px font-mono text-[9.5px] font-medium text-[#0f4c92] sm:inline">{tool.sub}</span>
               </>)}
             </div>
+            <div className="ml-auto flex items-center gap-2.5">
             <button type="button" onClick={() => setPalette(true)}
-              className="ml-auto flex items-center gap-2 rounded-md border border-[#d6d3c9] bg-[#fcfbf8] px-2.5 py-1 text-xs text-[#8b8574] hover:border-[#0f4c92] hover:text-[#0f4c92]">
+              className="flex items-center gap-2 rounded-md border border-[#d6d3c9] bg-[#fcfbf8] px-2.5 py-1 text-xs text-[#8b8574] hover:border-[#0f4c92] hover:text-[#0f4c92]">
               <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round"><circle cx="11" cy="11" r="7" /><line x1="21" y1="21" x2="16.5" y2="16.5" /></svg>
               <span className="hidden sm:inline">Find a tool</span>
               <span className="rounded border border-[#d6d3c9] px-1 py-px font-mono text-[9.5px]">⌘K</span>
             </button>
+            <AccountMenu />
+            </div>
           </div>
         </header>
         {children}

--- a/webapp/src/components/ReportControls.tsx
+++ b/webapp/src/components/ReportControls.tsx
@@ -1,6 +1,7 @@
 import { useState, type JSX } from 'react'
 import type { CalcPdfInput } from '../lib/calcPdf'
 import { ExportPdfButton } from './ExportPdfButton'
+import { loadProfile, letterheadDefaults } from '../lib/auth/profile'
 
 /**
  * A page's report payload, minus the parts this component already owns.
@@ -35,9 +36,13 @@ export interface ReportControlsProps {
  * use the full PrintReport instead (components/calc.tsx).
  */
 export function ReportControls({ title, badges = ['NSCP 2015', 'ACI 318-14'], report }: ReportControlsProps): JSX.Element {
-  const [project, setProject] = useState('')
+  // Seeded from the saved profile, as INITIAL state rather than an effect —
+  // an effect would overwrite whatever the user had already typed on a
+  // re-render, and this is a starting value, not a binding.
+  const [defaults] = useState(() => letterheadDefaults(loadProfile()))
+  const [project, setProject] = useState(defaults.project)
   const [sheet, setSheet] = useState('')
-  const [preparedBy, setPreparedBy] = useState('')
+  const [preparedBy, setPreparedBy] = useState(defaults.preparedBy)
   const today = new Date().toISOString().slice(0, 10)
 
   const print = () => {

--- a/webapp/src/components/calc.tsx
+++ b/webapp/src/components/calc.tsx
@@ -120,6 +120,7 @@ export function DrawingCard({ title, meta, children, pdfDrawing }: {
 
 // ── Report letterhead (screen card) ─────────────────────────────────────────
 export interface LetterheadState { project: string; sheet: string; preparedBy: string }
+
 export function LetterheadCard({ lh, onChange }: { lh: LetterheadState; onChange: (p: Partial<LetterheadState>) => void }) {
   const today = new Date().toISOString().slice(0, 10)
   const cell = (label: string, value: string, key: keyof LetterheadState, ph: string, mono = false) => (

--- a/webapp/src/lib/auth/profile.test.ts
+++ b/webapp/src/lib/auth/profile.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import {
+  loadProfile, saveProfile, preparedByLine, letterheadDefaults, hasProfile,
+  EMPTY_PROFILE, type Profile,
+} from './profile'
+
+const store = () => {
+  const m = new Map<string, string>()
+  return {
+    getItem: (k: string) => m.get(k) ?? null,
+    setItem: (k: string, v: string) => { m.set(k, v) },
+    raw: m,
+  }
+}
+
+const full: Profile = {
+  preparedBy: 'R. Valdepeñas', licenseNo: '0123456',
+  organisation: 'Example Design Office', defaultProject: 'Lot 12 Residence',
+}
+
+describe('load / save', () => {
+  it('round-trips a profile', () => {
+    const s = store()
+    saveProfile(full, s)
+    expect(loadProfile(s)).toEqual(full)
+  })
+
+  it('reads empty when nothing is stored', () => {
+    expect(loadProfile(store())).toEqual(EMPTY_PROFILE)
+  })
+
+  it('survives corrupt storage instead of throwing', () => {
+    // A half-written value or another app's key on the same origin must not
+    // take down every page that reads the letterhead.
+    const s = store()
+    s.setItem('civeng-profile', '{not json')
+    expect(loadProfile(s)).toEqual(EMPTY_PROFILE)
+  })
+
+  it('ignores fields of the wrong type rather than putting them on a sheet', () => {
+    const s = store()
+    s.setItem('civeng-profile', JSON.stringify({ preparedBy: { evil: true }, licenseNo: 42 }))
+    const p = loadProfile(s)
+    expect(p.preparedBy).toBe('')
+    expect(p.licenseNo).toBe('')
+  })
+
+  it('trims and caps length, so a pasted essay cannot break the letterhead', () => {
+    const s = store()
+    s.setItem('civeng-profile', JSON.stringify({ preparedBy: `  ${'x'.repeat(500)}  ` }))
+    expect(loadProfile(s).preparedBy.length).toBe(120)
+  })
+
+  it('does not throw when storage is unavailable', () => {
+    // Private browsing: localStorage exists but setItem throws on write.
+    const hostile = {
+      getItem: () => { throw new Error('denied') },
+      setItem: () => { throw new Error('denied') },
+    }
+    expect(() => saveProfile(full, hostile)).not.toThrow()
+    expect(loadProfile(hostile)).toEqual(EMPTY_PROFILE)
+  })
+})
+
+describe('preparedByLine', () => {
+  it('appends the PRC number when there is one', () => {
+    expect(preparedByLine(full)).toBe('R. Valdepeñas · PRC 0123456')
+  })
+
+  it('gives just the name when there is no licence', () => {
+    expect(preparedByLine({ ...full, licenseNo: '' })).toBe('R. Valdepeñas')
+  })
+
+  it('is empty without a name, rather than printing a stray licence number', () => {
+    // "· PRC 0123456" alone on a sheet would look like a rendering fault.
+    expect(preparedByLine({ ...full, preparedBy: '' })).toBe('')
+    expect(preparedByLine(EMPTY_PROFILE)).toBe('')
+  })
+})
+
+describe('letterheadDefaults', () => {
+  it('supplies the project and prepared-by lines', () => {
+    expect(letterheadDefaults(full)).toEqual({
+      project: 'Lot 12 Residence', preparedBy: 'R. Valdepeñas · PRC 0123456',
+    })
+  })
+
+  it('leaves blanks blank instead of inventing a placeholder', () => {
+    expect(letterheadDefaults(EMPTY_PROFILE)).toEqual({ project: '', preparedBy: '' })
+  })
+})
+
+describe('hasProfile', () => {
+  it('is false for empty and whitespace-only', () => {
+    expect(hasProfile(EMPTY_PROFILE)).toBe(false)
+    expect(hasProfile({ ...EMPTY_PROFILE, preparedBy: '   ' })).toBe(false)
+  })
+
+  it('is true once any field is set', () => {
+    expect(hasProfile({ ...EMPTY_PROFILE, organisation: 'X' })).toBe(true)
+  })
+})

--- a/webapp/src/lib/auth/profile.ts
+++ b/webapp/src/lib/auth/profile.ts
@@ -1,0 +1,88 @@
+// ─────────────────────────────────────────────────────────────────────────
+// USER PROFILE — the details that go on a calculation sheet.
+//
+// An engineer types the same three things into the report letterhead on every
+// page: their name, their licence number, their firm. This holds them once so
+// the letterhead can start filled in.
+//
+// STORED LOCALLY, NOT IN THE ACCOUNT — deliberately. Writing to Supabase
+// `user_metadata` from the browser is possible, but that is the SAME field the
+// billing webhook writes `plan` into, and a client that can PATCH its own
+// metadata is a client that can try to set `plan: 'max'`. Row-level security
+// would be the answer, and until that exists these preferences are worth far
+// less than the risk of opening that door. They are cosmetic — a name printed
+// on a sheet — so localStorage is the honest place for them.
+//
+// The consequence is stated in the UI: these follow the browser, not the login.
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface Profile {
+  /** Printed as "Prepared by" on every calculation sheet. */
+  preparedBy: string
+  /** PRC licence number, appended to the name when present. */
+  licenseNo: string
+  /** Firm or organisation, printed as the default project owner. */
+  organisation: string
+  /** Default project name for new sheets. */
+  defaultProject: string
+}
+
+export const EMPTY_PROFILE: Profile = {
+  preparedBy: '', licenseNo: '', organisation: '', defaultProject: '',
+}
+
+const KEY = 'civeng-profile'
+
+type Store = Pick<Storage, 'getItem' | 'setItem'>
+
+const defaultStore = (): Store | null => {
+  try { return window.localStorage } catch { return null }
+}
+
+/** Read the saved profile. Never throws — a corrupt value reads as empty. */
+export function loadProfile(store: Store | null = defaultStore()): Profile {
+  try {
+    const raw = store?.getItem(KEY)
+    if (!raw) return { ...EMPTY_PROFILE }
+    const parsed = JSON.parse(raw) as Partial<Profile>
+    // field-by-field so an unexpected shape cannot inject junk into the sheet
+    return {
+      preparedBy: str(parsed.preparedBy),
+      licenseNo: str(parsed.licenseNo),
+      organisation: str(parsed.organisation),
+      defaultProject: str(parsed.defaultProject),
+    }
+  } catch {
+    return { ...EMPTY_PROFILE }
+  }
+}
+
+const str = (v: unknown): string => (typeof v === 'string' ? v.trim().slice(0, 120) : '')
+
+/** Persist the profile. Silent on failure — private mode should not break a page. */
+export function saveProfile(p: Profile, store: Store | null = defaultStore()): void {
+  try { store?.setItem(KEY, JSON.stringify(p)) } catch { /* storage unavailable */ }
+}
+
+/**
+ * The "Prepared by" line for a calculation sheet.
+ *
+ * Appends the licence number when there is one, because a sealed sheet names
+ * both — and an engineer who filled the field in should not have to retype it
+ * into the name every time.
+ */
+export function preparedByLine(p: Profile): string {
+  const name = p.preparedBy.trim()
+  const lic = p.licenseNo.trim()
+  if (!name) return ''
+  return lic ? `${name} · PRC ${lic}` : name
+}
+
+/** Letterhead defaults from the profile. Blank fields stay blank. */
+export function letterheadDefaults(p: Profile): { project: string; preparedBy: string } {
+  return { project: p.defaultProject.trim(), preparedBy: preparedByLine(p) }
+}
+
+/** Whether anything has been filled in — drives the "set up your profile" hint. */
+export const hasProfile = (p: Profile): boolean =>
+  Object.values(p).some((v) => v.trim().length > 0)

--- a/webapp/src/lib/docsContent.ts
+++ b/webapp/src/lib/docsContent.ts
@@ -23,6 +23,7 @@ export const DOC_TOOLS: DocTool[] = [
  */
 export const DOC_ROUTE_ALIASES: Record<string, string> = {
   '/signup': 'account', '/forgot-password': 'account', '/reset-password': 'account',
+  '/profile': 'account',
   // the four public policy pages share one docs entry
   '/privacy': 'legal', '/refunds': 'legal', '/contact': 'legal',
   // the five estimators share one page in the docs

--- a/webapp/src/lib/letterhead.ts
+++ b/webapp/src/lib/letterhead.ts
@@ -1,0 +1,17 @@
+import type { LetterheadState } from '../components/calc'
+import { loadProfile, letterheadDefaults } from './auth/profile'
+
+/**
+ * Starting letterhead for a page, pre-filled from the saved profile.
+ *
+ * Pages call this as `useState(() => initialLetterhead('S-01 · Rev A'))` so the
+ * engineer's name and project arrive already typed. The sheet number stays
+ * per-page: it identifies the drawing, not the person.
+ *
+ * Lives here rather than in `components/calc` because that file may only export
+ * components — the repo's fast-refresh rule, and a reasonable boundary anyway.
+ */
+export const initialLetterhead = (sheet = ''): LetterheadState => {
+  const d = letterheadDefaults(loadProfile())
+  return { project: d.project, sheet, preparedBy: d.preparedBy }
+}

--- a/webapp/src/lib/trialQuota.ts
+++ b/webapp/src/lib/trialQuota.ts
@@ -60,6 +60,8 @@ export const PUBLIC_ROUTES: readonly string[] = [
   // find a way to complain WITHOUT an account — and a payment provider
   // reviewing the site will not have one either.
   '/terms', '/privacy', '/refunds', '/contact',
+  // Profile: the letterhead settings are browser-local and work signed out.
+  '/profile',
 ]
 
 export type AccessVerdict =

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { PageHeader, VerdictPanel, DrawingCard, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
+import { initialLetterhead } from '../lib/letterhead'
 import { designBeam, beamServiceDeflection, type BeamDesignInput, type BeamDesignResult } from '../engine/beamDesign'
 import type { BeamSupport } from '../engine/beamDeflection'
 import type { CriticalSection } from '../engine/beamSections'
@@ -67,7 +68,7 @@ export default function BeamDesign() {
   }, [params])
 
   const [f, setF] = useState<FormState>({ ...DEFAULTS, ...(handoff.multi ? {} : handoff.single) })
-  const [lh, setLh] = useState<LetterheadState>({ project: '', sheet: 'S-01 · Rev A', preparedBy: '' })
+  const [lh, setLh] = useState<LetterheadState>(() => initialLetterhead('S-01 · Rev A'))
   const [span, setSpan] = useState<number>(NaN)
   const [support, setSupport] = useState<BeamSupport>('simple')
   const [svcWD, setSvcWD] = useState<number>(NaN)

--- a/webapp/src/pages/ColumnDesign.tsx
+++ b/webapp/src/pages/ColumnDesign.tsx
@@ -6,6 +6,7 @@ import {
 import { factoredLoad } from '../engine/loads'
 import { ColumnSchematic } from '../components/ColumnSchematic'
 import { PageHeader, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
+import { initialLetterhead } from '../lib/letterhead'
 import { InteractionDiagram } from '../components/InteractionDiagram'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { axialColumnSolution, eccentricColumnSolution, slendernessSolution } from '../lib/columnSolution'
@@ -21,7 +22,7 @@ type BarMode = 'design' | 'analyze'
 
 export default function ColumnDesign() {
   const [mode, setMode] = useState<Mode>('axial')
-  const [lh, setLh] = useState<LetterheadState>({ project: '', sheet: 'C-01 · Rev A', preparedBy: '' })
+  const [lh, setLh] = useState<LetterheadState>(() => initialLetterhead('C-01 · Rev A'))
   const [shape, setShape] = useState<ColumnShape>('tied')
   const [b, setB] = useState(400); const [h, setH] = useState(400); const [D, setD] = useState(400)
   const [cover, setCover] = useState(40)

--- a/webapp/src/pages/CombinedFootingDesign.tsx
+++ b/webapp/src/pages/CombinedFootingDesign.tsx
@@ -3,6 +3,7 @@ import { designCombinedFooting, type CombinedFootingInput } from '../engine/comb
 import { designFlexibleCombinedFooting } from '../engine/flexibleCombinedFooting'
 import { CombinedFootingSchematic } from '../components/CombinedFootingSchematic'
 import { PageHeader, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
+import { initialLetterhead } from '../lib/letterhead'
 import { Diagram } from '../components/Diagram'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { buildCombinedFootingSolution } from '../lib/combinedFootingSolution'
@@ -120,7 +121,7 @@ function Row({ label, value, check }: { label: ReactNode; value: ReactNode; chec
 
 export default function CombinedFootingDesign() {
   const [form, setForm] = useState<FormState>(DEFAULTS)
-  const [lh, setLh] = useState<LetterheadState>({ project: '', sheet: 'F-02 · Rev A', preparedBy: '' })
+  const [lh, setLh] = useState<LetterheadState>(() => initialLetterhead('F-02 · Rev A'))
   const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) => setForm((s) => ({ ...s, [k]: v }))
 
   const valid = useMemo(() => {

--- a/webapp/src/pages/FoundationDesign.tsx
+++ b/webapp/src/pages/FoundationDesign.tsx
@@ -12,6 +12,7 @@ import { WorkedSolution } from '../components/WorkedSolution'
 import { buildFoundationSolution, type SolutionCtx } from '../lib/foundationSolution'
 import { Math } from '../lib/math'
 import { PageHeader, CalcSection, VerdictPanel, DrawingCard, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
+import { initialLetterhead } from '../lib/letterhead'
 import { f0, f2, f3 } from '../lib/format'
 import 'katex/dist/katex.min.css'
 
@@ -164,7 +165,7 @@ function steelRow(label: ReactNode, s: DirSteel, db: number) {
 
 export default function FoundationDesign() {
   const [form, setForm] = useState<FormState>(DEFAULTS)
-  const [lh, setLh] = useState<LetterheadState>({ project: '', sheet: 'F-01 · Rev A', preparedBy: '' })
+  const [lh, setLh] = useState<LetterheadState>(() => initialLetterhead('F-01 · Rev A'))
   const [batch, setBatch] = useState<BatchResult | null>(null)
   const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) => setForm((s) => ({ ...s, [k]: v }))
   const ecc = form.loadingType === 'eccentric'

--- a/webapp/src/pages/Home.tsx
+++ b/webapp/src/pages/Home.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react'
+import { AccountMenu } from '../components/AccountMenu'
 import { Link } from 'react-router-dom'
 import { SIDEBAR_GROUPS, ALL_TOOLS } from '../lib/tools'
 import { CommandPalette } from '../components/CommandPalette'
@@ -62,8 +63,7 @@ export default function Home({ onAuth }: { onAuth: (mode: 'login' | 'signup') =>
           </div>
           <div className="ml-auto flex items-center gap-2.5">
             <div className="hidden sm:block">{searchBox(false)}</div>
-            <button onClick={() => onAuth('login')} className="px-2 py-1.5 text-[12.5px] font-semibold text-[#b6c2d0] hover:text-white">Log in</button>
-            <button onClick={() => onAuth('signup')} className="rounded-md bg-[#0f4c92] px-3.5 py-2 text-[12.5px] font-semibold text-white hover:bg-[#135caf]">Sign up</button>
+            <AccountMenu dark />
           </div>
         </div>
       </nav>

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -33,6 +33,7 @@ import { buildSeismicMass, GRAVITY } from '../engine/modal'
 import { autoRigidOffsets } from '../engine/rigidEndZones'
 import { computeWind, computeCladding, type WindResult, type WindEnclosure, type CladdingResult } from '../engine/wind'
 import { LetterheadCard, type LetterheadState } from '../components/calc'
+import { initialLetterhead } from '../lib/letterhead'
 import { JointConnections3D } from '../components/JointConnections3D'
 import { ConnectionDetail2D } from '../components/ConnectionDetail2D'
 import { connectionRowSolution } from '../lib/connectionSolution'
@@ -1113,7 +1114,7 @@ export default function ModelSpace() {
   const [report] = useState<'' | 'schedules' | 'drawings' | 'solutions' | 'full' | 'sol-only' | 'draw-only'>('')  // consolidated report template (interactive on screen; PDF carries everything)
   const [resultsTab, setResultsTab] = useState<'schedules' | 'boq' | 'schedule'>('schedules')  // results section tab
   const [modelImg, setModelImg] = useState<string | null>(null)   // 3D snapshot for the PDF report
-  const [lh, setLh] = useState<LetterheadState>({ project: '', sheet: '', preparedBy: '' })
+  const [lh, setLh] = useState<LetterheadState>(() => initialLetterhead(''))
   const [exporting, setExporting] = useState(false)               // PDF build in flight
   const [ioMenu, setIoMenu] = useState(false)                     // Import/Export dropdown
   const [concreteClass, setConcreteClass] = useState<ConcreteClass>((si.concreteClass as ConcreteClass) ?? 'A')   // mix class for the take-off

--- a/webapp/src/pages/PileCapDesign.tsx
+++ b/webapp/src/pages/PileCapDesign.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, type ReactNode } from 'react'
 import { designPileCap, type PileArrangement } from '../engine/pileCap'
 import { PileCapSchematic } from '../components/PileCapSchematic'
 import { PageHeader, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
+import { initialLetterhead } from '../lib/letterhead'
 import { Math as KTex } from '../lib/math'
 import { f0, f2, f3 } from '../lib/format'
 import 'katex/dist/katex.min.css'
@@ -124,7 +125,7 @@ function steelRow(label: ReactNode, s: { bars: number; spacing: number; As: numb
 
 export default function PileCapDesign() {
   const [form, setForm] = useState<FormState>(DEFAULTS)
-  const [lh, setLh] = useState<LetterheadState>({ project: '', sheet: 'PC-01 · Rev A', preparedBy: '' })
+  const [lh, setLh] = useState<LetterheadState>(() => initialLetterhead('PC-01 · Rev A'))
   const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) => setForm(s => ({ ...s, [k]: v }))
 
   const valid = Object.values(form).every(v => typeof v === 'string' || Number.isFinite(v as number))

--- a/webapp/src/pages/PrestressedBeam.tsx
+++ b/webapp/src/pages/PrestressedBeam.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { designPrestressed } from '../engine/prestressedBeam'
 import { buildPrestressedSolution } from '../lib/prestressedSolution'
 import { PageHeader, VerdictPanel, DrawingCard, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
+import { initialLetterhead } from '../lib/letterhead'
 import { Num, Pick, Card } from '../components/qty'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { DimBelow, DimSide } from '../components/dims'
@@ -59,7 +60,7 @@ export default function PrestressedBeam() {
   const [wSDL, setWSDL] = useState(6); const [wLL, setWLL] = useState(12)
   const [RH, setRH] = useState(75)
   const [klass, setKlass] = useState<'U' | 'T'>('U')
-  const [lh, setLh] = useState<LetterheadState>({ project: '', sheet: '', preparedBy: '' })
+  const [lh, setLh] = useState<LetterheadState>(() => initialLetterhead(''))
 
   const inp = useMemo(() => ({
     b, h, span, fc, fci, Aps, fpu, e, fpj: (fpjPct / 100) * fpu, wSDL, wLL, RH, klass,

--- a/webapp/src/pages/RetainingWall.tsx
+++ b/webapp/src/pages/RetainingWall.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import { designRetainingWall, type RetainingWallInput } from '../engine/retainingWall'
 import { Num, Card, ResultCard, Row } from '../components/qty'
 import { PageHeader, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
+import { initialLetterhead } from '../lib/letterhead'
 import { f1, f2, f3 } from '../lib/format'
 
 type FormState = RetainingWallInput & { gamma_c: number }
@@ -28,7 +29,7 @@ function Status({ ok, label }: { ok: boolean; label: string }) {
 
 export default function RetainingWall() {
   const [f, setF] = useState<FormState>(DEFAULTS)
-  const [lh, setLh] = useState<LetterheadState>({ project: '', sheet: 'RW-01 · Rev A', preparedBy: '' })
+  const [lh, setLh] = useState<LetterheadState>(() => initialLetterhead('RW-01 · Rev A'))
   const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) =>
     setF((s) => ({ ...s, [k]: v }))
 

--- a/webapp/src/pages/TBeamDesign.tsx
+++ b/webapp/src/pages/TBeamDesign.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { designTBeam, type TBeamKind } from '../engine/tbeam'
 import { buildTBeamSolution } from '../lib/tbeamSolution'
 import { PageHeader, VerdictPanel, DrawingCard, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
+import { initialLetterhead } from '../lib/letterhead'
 import { Num, Pick, Card } from '../components/qty'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { TSection } from '../components/TSection'
@@ -19,7 +20,7 @@ export default function TBeamDesign() {
   const [cover, setCover] = useState(40); const [stirrupDia, setStirrupDia] = useState(10); const [barDia, setBarDia] = useState(25)
   const [fc, setFc] = useState(21); const [fy, setFy] = useState(415)
   const [Mu, setMu] = useState(400)
-  const [lh, setLh] = useState<LetterheadState>({ project: '', sheet: '', preparedBy: '' })
+  const [lh, setLh] = useState<LetterheadState>(() => initialLetterhead(''))
 
   const inp = useMemo(() => ({
     kind, bw, h, hf, bfGiven: bfGiven > 0 ? bfGiven : undefined, ln, sw,

--- a/webapp/src/pages/auth/Profile.tsx
+++ b/webapp/src/pages/auth/Profile.tsx
@@ -1,0 +1,137 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useAuth } from '../../lib/auth/authContext'
+import { usePlan } from '../../lib/auth/usePlan'
+import { loadProfile, saveProfile, preparedByLine, type Profile as ProfileData } from '../../lib/auth/profile'
+import { CHECKOUT_ENABLED, formatPeso, priceFor } from '../../lib/plans'
+
+function Field({ label, value, onChange, placeholder, hint }: {
+  label: string; value: string; onChange: (v: string) => void; placeholder?: string; hint?: string
+}) {
+  const id = `p-${label.toLowerCase().replace(/\W+/g, '-')}`
+  return (
+    <label htmlFor={id} className="flex flex-col text-sm">
+      <span className="mb-1 font-medium text-slate-700">{label}</span>
+      <input id={id} value={value} placeholder={placeholder} maxLength={120}
+        onChange={(e) => onChange(e.target.value)}
+        className="rounded-md border border-slate-300 px-3 py-2 outline-none focus:border-[#0f4c92]" />
+      {hint && <span className="mt-1 text-[11.5px] text-slate-500">{hint}</span>}
+    </label>
+  )
+}
+
+export default function Profile() {
+  const { user, configured } = useAuth()
+  const plan = usePlan()
+  const [form, setForm] = useState<ProfileData>(() => loadProfile())
+  const [saved, setSaved] = useState(false)
+
+  const set = <K extends keyof ProfileData>(k: K) => (v: ProfileData[K]) => {
+    setForm((s) => ({ ...s, [k]: v }))
+    setSaved(false)
+  }
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault()
+    saveProfile(form)
+    setSaved(true)
+  }
+
+  const preview = preparedByLine(form)
+
+  return (
+    <main className="mx-auto max-w-3xl px-5 py-10">
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Account</p>
+      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Profile</h1>
+
+      {/* ── Account ── */}
+      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-[1.02rem] font-bold text-[#0056b3]">Account</h2>
+        {!configured ? (
+          <p className="mt-2 text-[13px] leading-6 text-slate-600">
+            Sign-in is not set up on this deployment, so there is no account to show. The letterhead
+            settings below still work — they are stored in this browser.
+          </p>
+        ) : user ? (
+          <dl className="mt-3 space-y-2 text-[13px]">
+            <div className="flex justify-between gap-4 border-b border-slate-100 pb-2">
+              <dt className="text-slate-500">Email</dt>
+              <dd className="font-medium text-slate-800">{user.email ?? '—'}</dd>
+            </div>
+            <div className="flex justify-between gap-4 border-b border-slate-100 pb-2">
+              <dt className="text-slate-500">Email verified</dt>
+              <dd className={user.emailVerified ? 'font-medium text-emerald-700' : 'font-medium text-amber-700'}>
+                {user.emailVerified ? 'Yes' : 'Not yet — check your inbox'}
+              </dd>
+            </div>
+            <div className="flex justify-between gap-4">
+              <dt className="text-slate-500">Plan</dt>
+              <dd className="font-medium text-slate-800">
+                {plan.name}
+                {plan.priceMonthly ? (
+                  <span className="text-slate-500"> · {formatPeso(priceFor(plan, 'monthly')!)}/month</span>
+                ) : null}
+              </dd>
+            </div>
+          </dl>
+        ) : (
+          <p className="mt-2 text-[13px] leading-6 text-slate-600">
+            You are not signed in. <Link to="/signin" className="text-[#0056b3] underline">Sign in</Link>{' '}
+            or <Link to="/signup" className="text-[#0056b3] underline">create an account</Link> to save
+            projects. The letterhead settings below work either way.
+          </p>
+        )}
+        <p className="mt-3 text-[12px] leading-5 text-slate-500">
+          {CHECKOUT_ENABLED
+            ? <>Manage your subscription on the <Link to="/pricing" className="text-[#0056b3] underline">Plans page</Link>.</>
+            : <>Paid plans are not open for sign-up yet — see <Link to="/pricing" className="text-[#0056b3] underline">Plans</Link> for what they include.</>}
+        </p>
+      </section>
+
+      {/* ── Letterhead ── */}
+      <form onSubmit={submit} className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-[1.02rem] font-bold text-[#0056b3]">Calculation sheet letterhead</h2>
+        <p className="mt-1 text-[13px] leading-6 text-slate-600">
+          These fill in the report letterhead on every calculator, so you stop retyping them on each
+          sheet. You can still change them per sheet before exporting.
+        </p>
+
+        <div className="mt-4 grid gap-4 sm:grid-cols-2">
+          <Field label="Prepared by" value={form.preparedBy} onChange={set('preparedBy')}
+            placeholder="Engineer name" hint="Printed on every calculation sheet." />
+          <Field label="PRC licence no." value={form.licenseNo} onChange={set('licenseNo')}
+            placeholder="0123456" hint="Appended after your name when set." />
+          <Field label="Organisation" value={form.organisation} onChange={set('organisation')}
+            placeholder="Firm or office" />
+          <Field label="Default project" value={form.defaultProject} onChange={set('defaultProject')}
+            placeholder="Lot 12 Residence" hint="Starting value for the Project field." />
+        </div>
+
+        <div className="mt-4 rounded-lg border border-slate-200 bg-[#f9f8f4] px-3.5 py-2.5">
+          <p className="text-[10.5px] font-semibold uppercase tracking-widest text-slate-500">Sheet preview</p>
+          <p className="mt-1 font-mono text-[13px] text-slate-800">
+            Prepared by: {preview || <span className="text-slate-400">(not set)</span>}
+          </p>
+          <p className="font-mono text-[13px] text-slate-800">
+            Project: {form.defaultProject.trim() || <span className="text-slate-400">(not set)</span>}
+          </p>
+        </div>
+
+        <div className="mt-4 flex items-center gap-3">
+          <button type="submit"
+            className="rounded-md bg-[#0056b3] px-4 py-2 text-sm font-semibold text-white hover:bg-[#0f4c92]">
+            Save
+          </button>
+          {saved && <span role="status" className="text-[13px] font-medium text-emerald-700">Saved</span>}
+        </div>
+
+        <p className="mt-4 border-t border-slate-100 pt-3 text-[12px] leading-5 text-slate-500">
+          <strong>These are stored in this browser, not in your account.</strong> They follow the
+          device rather than the login, so a different computer starts blank and clearing site data
+          clears them. That is deliberate: the same account field carries your subscription plan, and
+          a page that could write to it is a page that could try to grant itself one.
+        </p>
+      </form>
+    </main>
+  )
+}


### PR DESCRIPTION
Three things you couldn't do before: **tell whether you were signed in**, **sign
out**, and **stop retyping your name on every calculation sheet**.

## The bug you spotted

Home rendered "Log in / Sign up" unconditionally — it never consulted the
session — and the workbench header had no account UI at all, so there was no way
to sign out short of clearing site data.

`AccountMenu` replaces both. Signed out: Log in / Sign up. Signed in: avatar,
your name, your plan badge, and a menu with Profile, Plans, Contact and **Sign
out**.

It also:
- **holds its space during the initial session lookup** rather than flashing
  "Log in" at someone who is already signed in;
- **renders nothing when auth is unconfigured** — a sign-in button that cannot
  work is worse than no button;
- closes on outside-click and Escape, so it doesn't sit stuck behind whatever
  you clicked next.

## Profile → letterhead

`/profile` holds Prepared by, PRC licence number, organisation and default
project, with a live preview of the sheet line. `initialLetterhead()` seeds the
report letterhead on all nine pages that carry one, so **"R. Valdepeñas · PRC
0123456" is already typed** when a page opens.

Per-sheet edits still work — this is a starting value, not a binding, which is
why it's initial state and not an effect that would overwrite what you'd just
typed.

## Stored in the browser, not the account — and the page says so

Writing these to Supabase `user_metadata` from the client is possible, but that's
the **same field the billing webhook writes `plan` into**. A client that can
PATCH its own metadata is a client that can try to set `plan: 'max'`. Row-level
security is the real answer; until it exists, a name printed on a sheet isn't
worth opening that door.

The trade-off — settings follow the device, not the login — is stated on the page
rather than left to be discovered.

`loadProfile` is defensive because it feeds a document: corrupt JSON reads empty,
wrong-typed fields are dropped rather than rendered, values are trimmed and
capped at 120 chars, and a hostile localStorage (private browsing) throws
nothing. **13 tests**, including that a licence number never prints without a
name — "· PRC 0123456" alone on a sheet reads as a rendering fault.

## Verified in a browser with an injected session

| | Log in / Sign up | Account chip | Letterhead |
|---|---|---|---|
| signed out, home | shown | — | — |
| signed in, home | **gone** | shown | — |
| signed in, workbench + profile | **gone** | shown | **pre-filled** |
| signed out, no profile | shown | — | blank |

Menu opens with the plan line and Sign out. No page errors.

*One correction to my own check, not the code: the plan badge renders as "PRO" —
uppercased by CSS — so my case-sensitive assertion for "Pro" reported it missing
when it was rendering fine.*

## Note

`/profile` is public. The letterhead half works signed out, and gating it would
make the settings vanish exactly when someone is trying to set them up.

`initialLetterhead` lives in `lib/letterhead.ts` rather than `components/calc`,
which may only export components — the lint rule caught that.

## Verification

`npx tsc -b` = 0 · `npm run lint` = 0 · `npm test` **1998 passing** (13 new) ·
`npm run build` = 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_