### PR TITLE
Worked solutions for the seven geotechnical calculators

### DIFF
--- a/webapp/src/lib/geotechSolutions.ts
+++ b/webapp/src/lib/geotechSolutions.ts
@@ -1,0 +1,249 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Worked solutions for the ground-anchorage calculators — soil nail,
+// micropile, rock anchor and shotcrete facing.
+//
+// These read differently from the reinforced-concrete sheets, and deliberately
+// so. An RC check ends in "provide this much steel"; a ground-anchorage check
+// ends in "the capacity is X, the demand is Y, the margin is X/Y". So each
+// sheet derives the capacity in each failure mode, states which one governs,
+// and compares the resulting factor of safety against the required one.
+//
+// Utilisation is reported as FS_required / FS_achieved so it reads ≤ 1 on a
+// pass, matching every structural check in the app — see the note in each
+// page's report payload.
+// ─────────────────────────────────────────────────────────────────────────
+import type { SoilNailResult } from '../engine/soilNail'
+import type { MicropileResult } from '../engine/micropile'
+import type { RockAnchorResult } from '../engine/rockAnchor'
+import type { FacingResult } from '../engine/shotcreteFacing'
+import { type SolutionStep, type SolutionLine, sn0, sn1, sn2, sn3, sn4 } from './solution'
+
+const txt = (text: string): SolutionLine => ({ text })
+const eq = (tex: string): SolutionLine => ({ tex })
+const fsOrDash = (v: number) => (Number.isFinite(v) ? sn2(v) : '\\infty')
+
+// ── Soil nail ─────────────────────────────────────────────────────────────
+export interface SoilNailSolutionInput {
+  z: number; Sh: number; Sv: number
+  gamma: number; phiDeg: number; surcharge?: number
+  barDia: number; fy: number
+  drillDia: number; bondLength: number; qu: number
+  FSpullout?: number; FStensile?: number
+}
+
+export function buildSoilNailSolution(i: SoilNailSolutionInput, r: SoilNailResult): SolutionStep[] {
+  const FSp = i.FSpullout ?? 2.0, FSt = i.FStensile ?? 1.8
+  const q = i.surcharge ?? 0
+  const sigma = i.gamma * i.z + q
+  const Ab = (Math.PI / 4) * i.barDia ** 2
+  const bondArea = Math.PI * i.drillDia * i.bondLength
+
+  return [
+    {
+      title: 'Earth pressure at the nail',
+      clause: 'FHWA GEC-7 · Rankine active state',
+      lines: [
+        txt('The wall is assumed to yield enough to mobilise the active state, so Rankine’s coefficient applies. The vertical stress at the nail depth includes any surcharge carried at the surface.'),
+        eq(String.raw`K_a = \tan^2\!\left(45^\circ - \tfrac{\phi}{2}\right) = \tan^2\!\left(45^\circ - \tfrac{${sn1(i.phiDeg)}^\circ}{2}\right) = ${sn3(r.Ka)}`),
+        eq(String.raw`\sigma_v = \gamma z + q = ${sn1(i.gamma)}(${sn2(i.z)}) + ${sn1(q)} = ${sn2(sigma)}\ \text{kPa}`),
+      ],
+    },
+    {
+      title: 'Nail force demand',
+      clause: 'FHWA GEC-7 — tributary area',
+      lines: [
+        txt('Each nail carries the active thrust over its tributary panel — one horizontal spacing by one vertical spacing. This is the demand every capacity below is compared against.'),
+        eq(String.raw`T_{max} = K_a\,\sigma_v\,S_h S_v = ${sn3(r.Ka)}(${sn2(sigma)})(${sn2(i.Sh)})(${sn2(i.Sv)}) = \mathbf{${sn2(r.Tmax)}}\ \text{kN}`),
+      ],
+    },
+    {
+      title: 'Bar tensile capacity',
+      clause: 'FHWA GEC-7 — FS 1.8 on yield',
+      pass: r.tensileOK,
+      lines: [
+        txt('The nail bar yielding is one of the two failure modes. Capacity is the bar area times its yield strength, and the required margin is applied to the ultimate rather than to a reduced design value.'),
+        eq(String.raw`A_b = \tfrac{\pi}{4}d_b^2 = \tfrac{\pi}{4}(${sn0(i.barDia)})^2 = ${sn1(Ab)}\ \text{mm}^2`),
+        eq(String.raw`T_n = A_b f_y = ${sn1(Ab)} \times ${sn0(i.fy)} / 10^3 = ${sn2(r.Tn)}\ \text{kN},\qquad T_{all} = \frac{T_n}{${sn1(FSt)}} = ${sn2(r.Tall)}\ \text{kN}`),
+        eq(String.raw`FS_{tensile} = \frac{T_n}{T_{max}} = \frac{${sn2(r.Tn)}}{${sn2(r.Tmax)}} = ${fsOrDash(r.fsTensile)} \;${r.tensileOK ? '\\ge' : '<'}\; ${sn1(FSt)} \Rightarrow \textbf{${r.tensileOK ? 'OK' : 'FAILS'}}`),
+      ],
+    },
+    {
+      title: 'Grout-to-ground pullout capacity',
+      clause: 'FHWA GEC-7 — FS 2.0 on bond',
+      pass: r.pulloutOK,
+      lines: [
+        txt('The second failure mode: the grout column pulling out of the ground. Capacity is the bond stress acting over the cylindrical surface of the drilled length behind the failure surface — so only the bond length beyond the active wedge counts.'),
+        eq(String.raw`A_{bond} = \pi\,D_{DH}\,L_b = \pi(${sn3(i.drillDia)})(${sn2(i.bondLength)}) = ${sn3(bondArea)}\ \text{m}^2`),
+        eq(String.raw`Q_{ult} = q_u\,\pi D_{DH} L_b = ${sn1(i.qu)} \times ${sn3(bondArea)} = ${sn2(r.Qult)}\ \text{kN},\qquad Q_{all} = \frac{Q_{ult}}{${sn1(FSp)}} = ${sn2(r.Qall)}\ \text{kN}`),
+        eq(String.raw`FS_{pullout} = \frac{Q_{ult}}{T_{max}} = \frac{${sn2(r.Qult)}}{${sn2(r.Tmax)}} = ${fsOrDash(r.fsPullout)} \;${r.pulloutOK ? '\\ge' : '<'}\; ${sn1(FSp)} \Rightarrow \textbf{${r.pulloutOK ? 'OK' : 'FAILS'}}`),
+        eq(String.raw`L_{b,req} = \frac{FS \cdot T_{max}}{q_u \pi D_{DH}} = ${sn2(r.bondLengthReq)}\ \text{m}`),
+      ],
+      note: r.bondLengthReq > i.bondLength
+        ? `Bond length provided (${sn2(i.bondLength)} m) is less than required — lengthen the nail.`
+        : undefined,
+    },
+  ]
+}
+
+// ── Micropile ─────────────────────────────────────────────────────────────
+export interface MicropileSolutionInput {
+  mode: 'compression' | 'tension'
+  barDia: number; fyBar: number; groutDia: number; fcGrout: number
+  casing: boolean; casingOD: number; casingID: number; fyCasing: number
+  bondDia: number; bondLength: number; alphaBond: number; FS?: number; P: number
+}
+
+export function buildMicropileSolution(i: MicropileSolutionInput, r: MicropileResult): SolutionStep[] {
+  const FS = i.FS ?? 2.0
+  const bondArea = Math.PI * i.bondDia * i.bondLength
+  const a = r.areas as unknown as Record<string, number>
+
+  return [
+    {
+      title: 'Cross-section areas',
+      clause: 'FHWA-NHI-05-039 §5',
+      lines: [
+        txt(`A micropile carries load through a steel bar, the grout annulus, and — where fitted — a permanent casing. In ${i.mode} the contributions differ: grout is counted in compression but not in tension, where the steel alone carries the load.`),
+        eq(String.raw`\text{bar } \varnothing${sn0(i.barDia)}:\ A_{bar} = \tfrac{\pi}{4}(${sn0(i.barDia)})^2 = ${sn1((Math.PI / 4) * i.barDia ** 2)}\ \text{mm}^2`),
+        eq(String.raw`\text{grout } \varnothing${sn0(i.groutDia)}:\ A_{grout} = ${sn0(a.grout ?? 0)}\ \text{mm}^2${i.casing ? String.raw`,\quad \text{casing } ${sn0(i.casingOD)}/${sn0(i.casingID)}:\ A_{casing} = ${sn0(a.casing ?? 0)}\ \text{mm}^2` : ''}`),
+      ],
+    },
+    {
+      title: 'Structural capacity',
+      clause: 'FHWA-NHI-05-039 §5.5',
+      lines: [
+        txt(i.mode === 'compression'
+          ? 'In compression the allowable load combines the grout at 0.4f′c with the steel at 0.47fy — the low factors are what keeps a micropile serviceable rather than merely un-failed.'
+          : 'In tension the grout is assumed cracked and contributes nothing; the steel alone carries the load at 0.55fy.'),
+        eq(String.raw`P_{c,allow} = ${sn2(r.structural)}\ \text{kN}\quad(\text{${i.mode}})`),
+      ],
+    },
+    {
+      title: 'Grout-to-ground bond capacity',
+      clause: 'FHWA-NHI-05-039 §5.6',
+      lines: [
+        txt('Bond capacity is the grout-to-ground strength over the cylindrical bond surface. αbond comes from the ground type and the drilling method, and is the single most uncertain number in a micropile design — which is why the safety factor sits on it.'),
+        eq(String.raw`A_{bond} = \pi D_b L_b = \pi(${sn3(i.bondDia)})(${sn2(i.bondLength)}) = ${sn3(bondArea)}\ \text{m}^2`),
+        eq(String.raw`Q_{ult} = \alpha_{bond}\,\pi D_b L_b = ${sn1(i.alphaBond)} \times ${sn3(bondArea)} = ${sn2(r.Qult)}\ \text{kN}`),
+        eq(String.raw`Q_{allow} = \frac{Q_{ult}}{${sn1(FS)}} = ${sn2(r.Qbond)}\ \text{kN}`),
+      ],
+    },
+    {
+      title: 'Governing capacity and margin',
+      clause: 'FHWA-NHI-05-039 §5',
+      pass: r.ok,
+      lines: [
+        txt('The lower of the two governs. If bond governs, a longer bond zone helps; if structural governs, a longer pile does nothing and the section must change.'),
+        eq(String.raw`P_{allow} = \min(P_{c,allow},\ Q_{allow}) = \min(${sn2(r.structural)},\ ${sn2(r.Qbond)}) = \mathbf{${sn2(r.allowable)}}\ \text{kN}\quad(\text{${r.governs} governs})`),
+        eq(String.raw`FS = \frac{P_{allow}}{P} = \frac{${sn2(r.allowable)}}{${sn2(i.P)}} = ${fsOrDash(r.fs)} \;${r.ok ? '\\ge' : '<'}\; 1.0 \Rightarrow \textbf{${r.ok ? 'OK' : 'FAILS'}}`),
+        eq(String.raw`L_{b,req} = ${sn2(r.bondLengthReq)}\ \text{m}\quad(\text{provided } ${sn2(i.bondLength)}\ \text{m})`),
+      ],
+      note: r.governs === 'bond'
+        ? 'Bond governs — extending the bond zone raises capacity.'
+        : 'Structural capacity governs — a longer pile will not help; increase the bar or add casing.',
+    },
+  ]
+}
+
+// ── Rock anchor ───────────────────────────────────────────────────────────
+export interface RockAnchorSolutionInput {
+  fpu: number; Aps: number
+  holeDia: number; bondLength: number; tauUlt: number; FS?: number; T: number
+}
+
+export function buildRockAnchorSolution(i: RockAnchorSolutionInput, r: RockAnchorResult): SolutionStep[] {
+  const FS = i.FS ?? 2.0
+  const bondArea = Math.PI * i.holeDia * i.bondLength
+
+  return [
+    {
+      title: 'Tendon capacity',
+      clause: 'PTI DC35.1 §6',
+      pass: r.tendonOK,
+      lines: [
+        txt('GUTS is the guaranteed ultimate tensile strength of the strand or bar. A permanent anchor is designed at 60% of it, which leaves room for the proof load without yielding the tendon.'),
+        eq(String.raw`GUTS = f_{pu} A_{ps} = ${sn0(i.fpu)} \times ${sn0(i.Aps)} / 10^3 = ${sn2(r.GUTS)}\ \text{kN}`),
+        eq(String.raw`T_d = 0.60\,GUTS = ${sn2(r.Td)}\ \text{kN} \;${r.tendonOK ? '\\ge' : '<'}\; T = ${sn2(i.T)}\ \text{kN}`),
+      ],
+    },
+    {
+      title: 'Ground bond capacity',
+      clause: 'PTI DC35.1 §6.4',
+      pass: r.bondOK,
+      lines: [
+        txt('The grout-to-rock bond over the cylindrical bond length. τult depends on rock type and roughness and is normally confirmed by a sacrificial test anchor before production work.'),
+        eq(String.raw`A_{bond} = \pi D_h L_b = \pi(${sn3(i.holeDia)})(${sn2(i.bondLength)}) = ${sn3(bondArea)}\ \text{m}^2`),
+        eq(String.raw`Q_{ult} = \tau_{ult}\,\pi D_h L_b = ${sn1(i.tauUlt)} \times ${sn3(bondArea)} = ${sn2(r.Qult)}\ \text{kN}`),
+        eq(String.raw`Q_{all} = \frac{Q_{ult}}{${sn1(FS)}} = ${sn2(r.Qall)}\ \text{kN} \;${r.bondOK ? '\\ge' : '<'}\; T = ${sn2(i.T)}\ \text{kN}`),
+        eq(String.raw`L_{b,req} = ${sn2(r.bondLengthReq)}\ \text{m}\quad(\text{provided } ${sn2(i.bondLength)}\ \text{m})`),
+      ],
+    },
+    {
+      title: 'Governing capacity and test load',
+      clause: 'PTI DC35.1 §8 (testing)',
+      pass: r.ok,
+      lines: [
+        txt('The lower of tendon and bond governs. Every production anchor is proof-loaded to the lesser of 1.33× the design load and 80% of GUTS — enough to demonstrate the bond, not enough to damage the tendon.'),
+        eq(String.raw`T_{allow} = \min(T_d,\ Q_{all}) = \min(${sn2(r.Td)},\ ${sn2(r.Qall)}) = \mathbf{${sn2(r.allowable)}}\ \text{kN}\quad(\text{${r.governs} governs})`),
+        eq(String.raw`FS = \frac{T_{allow}}{T} = \frac{${sn2(r.allowable)}}{${sn2(i.T)}} = ${fsOrDash(r.fs)} \;${r.ok ? '\\ge' : '<'}\; 1.0`),
+        eq(String.raw`T_{test} = \min(1.33T,\ 0.80\,GUTS) = \min(${sn2(1.33 * i.T)},\ ${sn2(0.8 * r.GUTS)}) = \mathbf{${sn2(r.testLoad)}}\ \text{kN}`),
+      ],
+    },
+  ]
+}
+
+// ── Shotcrete facing ──────────────────────────────────────────────────────
+export interface FacingSolutionInput {
+  SH: number; SV: number; hc: number; cover: number
+  AsVert: number; AsHoriz: number; fc: number; fy: number
+  bearingPlate: number; CF?: number; nailHeadForce: number
+}
+
+export function buildFacingSolution(i: FacingSolutionInput, r: FacingResult): SolutionStep[] {
+  const CF = i.CF ?? 2.0
+  return [
+    {
+      title: 'Facing section',
+      clause: 'FHWA GEC-7 §6',
+      lines: [
+        txt('The facing spans between nail heads in both directions, so it is checked as a two-way panel. Effective depth is taken to the single reinforcement layer at mid-thickness of a thin facing.'),
+        eq(String.raw`h_c = ${sn0(i.hc)}\ \text{mm},\quad cover = ${sn0(i.cover)}\ \text{mm} \Rightarrow d = ${sn1(r.d)}\ \text{mm}`),
+        eq(String.raw`S_H \times S_V = ${sn2(i.SH)} \times ${sn2(i.SV)}\ \text{m},\qquad CF = ${sn2(CF)}`),
+      ],
+    },
+    {
+      title: 'Flexural strength of the panel',
+      clause: 'FHWA GEC-7 §6.4',
+      lines: [
+        txt('Nominal moment per metre in each direction, converted to a nail-head force by the yield-line factor CF. The weaker direction governs — a panel reinforced generously one way and sparsely the other is only as strong as the sparse way.'),
+        eq(String.raw`m_{vert} = ${sn2(r.mVert)}\ \text{kN·m/m},\qquad m_{horiz} = ${sn2(r.mHoriz)}\ \text{kN·m/m}`),
+        eq(String.raw`R_{FF,vert} = ${sn2(r.RffVert)}\ \text{kN},\qquad R_{FF,horiz} = ${sn2(r.RffHoriz)}\ \text{kN}`),
+        eq(String.raw`R_{FF} = \min(R_{FF,vert},\ R_{FF,horiz}) = ${sn2(r.Rff)}\ \text{kN}`),
+      ],
+    },
+    {
+      title: 'Punching strength at the nail head',
+      clause: 'FHWA GEC-7 §6.5',
+      lines: [
+        txt('The second failure mode: the nail head punching a cone through the facing. It depends on the bearing-plate size and the facing thickness, not on the reinforcement — so more steel does not fix a punching failure.'),
+        eq(String.raw`R_{FP} = ${sn2(r.Rfp)}\ \text{kN}\quad(\text{bearing plate } ${sn2(i.bearingPlate)}\ \text{m},\ h_c = ${sn0(i.hc)}\ \text{mm})`),
+      ],
+    },
+    {
+      title: 'Governing strength and margin',
+      clause: 'FHWA GEC-7 §6',
+      pass: r.ok,
+      lines: [
+        txt('The lower of flexure and punching governs the facing.'),
+        eq(String.raw`R_F = \min(R_{FF},\ R_{FP}) = \min(${sn2(r.Rff)},\ ${sn2(r.Rfp)}) = \mathbf{${sn2(r.strength)}}\ \text{kN}\quad(\text{${r.governs} governs})`),
+        eq(String.raw`FS = \frac{R_F}{T_{head}} = \frac{${sn2(r.strength)}}{${sn2(i.nailHeadForce)}} = ${fsOrDash(r.fs)} \;${r.ok ? '\\ge' : '<'}\; 1.0 \Rightarrow \textbf{${r.ok ? 'OK' : 'FAILS'}}`),
+      ],
+      note: r.governs === 'punching'
+        ? 'Punching governs — a larger bearing plate or a thicker facing helps; more reinforcement does not.'
+        : 'Flexure governs — additional reinforcement in the weaker direction raises capacity.',
+    },
+  ]
+}
+
+/** Shared re-export so pages can import one symbol set. */
+export { sn0, sn1, sn2, sn3, sn4 }

--- a/webapp/src/lib/lateralPileSolution.ts
+++ b/webapp/src/lib/lateralPileSolution.ts
@@ -1,0 +1,132 @@
+// Worked solution for a laterally loaded pile — Broms ultimate capacity plus a
+// p–y beam-on-nonlinear-springs analysis. Mirrors engine/lateralPile.ts.
+//
+// The sheet answers two different questions and keeps them apart, because
+// conflating them is the classic error here:
+//
+//  • BROMS gives the ULTIMATE lateral load. It is a strength check, and the
+//    governing capacity is the LOWER of the short-pile (soil crushes) and
+//    long-pile (a plastic hinge forms) mechanisms. Which one wins is what makes
+//    a pile "short" or "long" — that is a verdict about the pile's stiffness
+//    relative to the soil, not a statement about its length in metres.
+//
+//  • p–y gives the SERVICEABILITY answer — how far the head moves and where the
+//    maximum moment sits. Broms cannot give either, and a pile that satisfies
+//    Broms comfortably can still be unserviceable on deflection.
+import type { BromsResult, PyResult, PileHead } from '../engine/lateralPile'
+import { type SolutionStep, type SolutionLine, sn0, sn1, sn2, sn3 } from './solution'
+
+const txt = (text: string): SolutionLine => ({ text })
+const eq = (tex: string): SolutionLine => ({ tex })
+
+export interface LateralPileSolutionInput {
+  soilKind: 'clay' | 'sand'
+  L: number; D: number; EI: number; My: number
+  H: number; e: number; head: PileHead
+  cu: number; e50: number
+  phiDeg: number; k: number; gamma: number
+  /** Head-deflection yardstick the p–y result is judged against, mm. */
+  yLimit?: number
+}
+
+export function buildLateralPileSolution(
+  i: LateralPileSolutionInput, broms: BromsResult, py: PyResult,
+): SolutionStep[] {
+  const yLimit = i.yLimit ?? 25
+  const clay = i.soilKind === 'clay'
+  const util = broms.Hu > 0 ? i.H / broms.Hu : Infinity
+  const capOK = util <= 1
+  const defOK = py.yHead <= yLimit
+  const Kp = Math.tan(((45 + i.phiDeg / 2) * Math.PI) / 180) ** 2
+  const eEff = i.head === 'free' ? i.e : 0
+
+  const steps: SolutionStep[] = [
+    {
+      title: 'Pile, load and soil',
+      clause: 'Broms (1964) · API RP 2A-WSD §6.8',
+      lines: [
+        txt(`The pile is loaded laterally at ${i.e > 0 ? 'an eccentricity above ground' : 'ground level'} with a ${i.head} head. Head fixity matters more than almost any other input: restraining the head against rotation roughly doubles the ultimate capacity and cuts the deflection several-fold, but it moves the maximum moment to the head, where the cap connection has to carry it.`),
+        eq(String.raw`L = ${sn2(i.L)}\ \text{m},\qquad D = ${sn2(i.D)}\ \text{m},\qquad EI = ${sn0(i.EI)}\ \text{kN·m}^2,\qquad M_y = ${sn1(i.My)}\ \text{kN·m}`),
+        eq(String.raw`H = ${sn1(i.H)}\ \text{kN},\qquad e = ${sn2(i.e)}\ \text{m},\qquad \text{head: ${i.head}}`),
+        clay
+          ? eq(String.raw`\text{cohesive: } c_u = ${sn1(i.cu)}\ \text{kPa},\qquad \varepsilon_{50} = ${sn3(i.e50)},\qquad \gamma' = ${sn1(i.gamma)}\ \text{kN/m}^3`)
+          : eq(String.raw`\text{cohesionless: } \phi = ${sn1(i.phiDeg)}^\circ,\qquad k = ${sn0(i.k)}\ \text{kN/m}^3,\qquad \gamma' = ${sn1(i.gamma)}\ \text{kN/m}^3`),
+      ],
+    },
+    clay
+      ? {
+        title: 'Soil resistance profile — cohesive',
+        clause: 'Broms (1964a) — cohesive soils',
+        lines: [
+          txt('Broms takes the ultimate soil resistance in clay as 9·cu·d, constant with depth, and neglects it over the top 1.5 diameters where the ground heaves and gaps open behind the pile. That truncated top is why a short pile in clay is less efficient than the full length suggests.'),
+          eq(String.raw`q_u = 9\,c_u\,d = 9(${sn1(i.cu)})(${sn2(i.D)}) = ${sn1(9 * i.cu * i.D)}\ \text{kN/m}`),
+          eq(String.raw`\text{ignored depth } a = 1.5d = ${sn2(1.5 * i.D)}\ \text{m}`),
+        ],
+      }
+      : {
+        title: 'Soil resistance profile — cohesionless',
+        clause: 'Broms (1964b) — cohesionless soils',
+        lines: [
+          txt('In sand the resistance grows linearly with depth as 3·Kp·γ′·z·d — three times the Rankine passive pressure, Broms\u2019 allowance for the three-dimensional wedge that forms in front of a pile rather than a wall.'),
+          eq(String.raw`K_p = \tan^2\!\left(45^\circ + \tfrac{\phi}{2}\right) = \tan^2\!\left(45^\circ + \tfrac{${sn1(i.phiDeg)}^\circ}{2}\right) = ${sn3(Kp)}`),
+          eq(String.raw`p_u(z) = 3K_p\,\gamma'\,z\,d = 3(${sn3(Kp)})(${sn1(i.gamma)})(z)(${sn2(i.D)})\ \text{kN/m}`),
+        ],
+      },
+    {
+      title: 'Short-pile mechanism — soil governs',
+      clause: 'Broms (1964) — rigid rotation',
+      lines: [
+        txt('A stiff pile in weak soil rotates as a rigid body and fails when the soil ahead of it is fully mobilised. The pile itself never yields, so its section strength is irrelevant to this mechanism — only the soil and the embedded length matter.'),
+        clay
+          ? eq(String.raw`H_{u,short} = ${sn1(broms.shortPile)}\ \text{kN}\quad\text{(moment equilibrium about the ${i.head === 'fixed' ? 'toe, pure translation' : 'point of rotation'})}`)
+          : eq(String.raw`H_{u,short} = ${i.head === 'fixed' ? String.raw`1.5K_p\gamma' dL^2` : String.raw`\frac{0.5K_p\gamma' dL^3}{e + L}`} = ${sn1(broms.shortPile)}\ \text{kN}`),
+      ],
+    },
+    {
+      title: 'Long-pile mechanism — a hinge forms',
+      clause: 'Broms (1964) — plastic hinge',
+      lines: [
+        txt(`A flexible pile in strong soil does not rotate bodily; the moment builds until the section yields and a plastic hinge forms at the depth where the shear passes through zero. Here the section strength My governs and extra length buys nothing.${i.head === 'fixed' ? ' A fixed head needs two hinges — one at the head, one in the ground — hence the factor of 2 on My.' : ''}`),
+        eq(String.raw`\text{hinge at } z = ${sn2(broms.zMax)}\ \text{m below ground},\qquad M_{max} = ${sn1(broms.Mmax)}\ \text{kN·m}`),
+        eq(String.raw`H_{u,long} = ${Number.isFinite(broms.longPile) ? `${sn1(broms.longPile)}\\ \\text{kN}` : '\\infty'}\quad\text{from } M(H) = ${i.head === 'fixed' ? '2' : '1'}\,M_y = ${sn1((i.head === 'fixed' ? 2 : 1) * i.My)}\ \text{kN·m}`),
+      ],
+    },
+    {
+      title: 'Governing capacity',
+      clause: 'Broms (1964) — lower-bound mechanism',
+      pass: capOK,
+      lines: [
+        txt(`The pile fails by whichever mechanism needs the smaller load, so the capacity is the lower of the two. This one is a ${broms.mode.toUpperCase()} pile: ${broms.mode === 'short' ? 'the soil yields before the section does, so strengthening the section will not help — lengthen it or improve the ground.' : 'the section yields before the soil does, so lengthening the pile will not help — a stronger section will.'}`),
+        eq(String.raw`H_u = \min(${sn1(broms.shortPile)},\ ${Number.isFinite(broms.longPile) ? sn1(broms.longPile) : '\\infty'}) = \mathbf{${sn1(broms.Hu)}}\ \text{kN}\quad(\text{${broms.mode} pile})`),
+        eq(String.raw`\frac{H}{H_u} = \frac{${sn1(i.H)}}{${sn1(broms.Hu)}} = ${sn3(util)} \;${capOK ? '\\le' : '>'}\; 1 \Rightarrow \textbf{${capOK ? 'OK' : 'OVERLOADED'}}`),
+      ],
+      note: 'Broms is an ULTIMATE capacity with no factor of safety built in. Apply the project global factor (commonly 2–3 on the ultimate lateral load) or check against factored actions.',
+    },
+    {
+      title: 'p–y analysis — deflection and moment',
+      clause: `${clay ? 'Matlock (1970) soft clay' : 'API RP 2A-WSD §6.8 sand'} p–y curves`,
+      pass: defOK,
+      lines: [
+        txt('The pile is now modelled as a beam on nonlinear soil springs and solved by Newton iteration. This is the serviceability answer: Broms says what fails it, p–y says how far it moves and where the design moment actually sits, which is rarely at the ground surface.'),
+        eq(String.raw`EI\frac{d^4y}{dz^4} + p(y,z) = 0,\qquad \text{${sn0(py.stations.length)} stations over } ${sn2(i.L)}\ \text{m},\qquad e_{eff} = ${sn2(eEff)}\ \text{m}`),
+        eq(String.raw`y_{head} = \mathbf{${sn2(py.yHead)}}\ \text{mm},\qquad M_{max} = \mathbf{${sn1(py.Mmax)}}\ \text{kN·m at } z = ${sn2(py.zMmax)}\ \text{m}`),
+        eq(String.raw`${sn2(py.yHead)} \;${defOK ? '\\le' : '>'}\; ${sn0(yLimit)}\ \text{mm} \Rightarrow \textbf{${defOK ? 'OK' : 'EXCEEDS THE DEFLECTION YARDSTICK'}}`),
+        eq(String.raw`\text{Newton: } ${py.converged ? 'converged' : '\\textbf{DID NOT CONVERGE}'}\ \text{in } ${sn0(py.iterations)}\ \text{iterations, residual } ${py.residual.toExponential(1)}`),
+      ],
+      note: py.converged
+        ? `${yLimit} mm is a common serviceability yardstick, not a code limit — the tolerable head movement is a project decision set by what the pile supports.`
+        : 'The p–y solve did not converge: the deflection and moment above are the last iterate, not a solution. Reduce the load or refine the discretisation before using them.',
+    },
+    {
+      title: 'Section moment demand',
+      clause: 'Broms (1964) vs p–y — moment comparison',
+      lines: [
+        txt('The two methods give moments for different load levels — Broms at the ultimate load Hu, p–y at the applied load H — so they are not interchangeable. Design the section for the p–y moment at the factored load, and check that it still exceeds My only where a hinge is intended.'),
+        eq(String.raw`M_{max}^{p-y}(H = ${sn1(i.H)}\ \text{kN}) = ${sn1(py.Mmax)}\ \text{kN·m}\quad\text{vs}\quad M_y = ${sn1(i.My)}\ \text{kN·m}`),
+        eq(String.raw`\frac{M_{max}}{M_y} = ${i.My > 0 ? sn3(py.Mmax / i.My) : '\\infty'}\quad${i.My > 0 && py.Mmax > i.My ? String.raw`\Rightarrow \text{the section has already yielded at the service load}` : String.raw`\Rightarrow \text{elastic at this load}`}`),
+      ],
+    },
+  ]
+
+  return steps
+}

--- a/webapp/src/lib/settlementSolution.ts
+++ b/webapp/src/lib/settlementSolution.ts
@@ -1,0 +1,128 @@
+// Worked solution for foundation settlement — Boussinesq stress increase,
+// Terzaghi one-dimensional consolidation, Schmertmann strain influence.
+// Mirrors engine/settlement.ts.
+//
+// This sheet has NO pass/fail, and that is deliberate. Settlement is a
+// PREDICTION, not a code check: there is no capacity to divide by. A 25 mm
+// limit is common but it is a project decision, and asserting one on the
+// engineer's behalf would be putting words in their mouth. The sheet gives the
+// numbers and the assumptions behind them, and leaves the judgement where it
+// belongs.
+import type { SoilLayer, ConsolidationResult, SchmertmannResult } from '../engine/settlement'
+import { type SolutionStep, type SolutionLine, sn0, sn1, sn2, sn3 } from './solution'
+
+const txt = (text: string): SolutionLine => ({ text })
+const eq = (tex: string): SolutionLine => ({ tex })
+
+/** Readable names for the e–log σ′ branch the engine picked per layer. */
+const BRANCH: Record<string, string> = {
+  'normally-consolidated': 'virgin, NC',
+  recompression: 'recompression only',
+  'recompression+virgin': 'recompression then virgin',
+  none: 'non-compressible',
+}
+
+export interface SettlementSolutionInput {
+  q: number; B: number; L: number; Df: number; waterTable: number
+  Es: number; nu: number; years: number
+  layers: SoilLayer[]
+}
+
+export interface SettlementSolutionResult {
+  cons: ConsolidationResult
+  elastic: number
+  schmert: SchmertmannResult
+  total: number
+  govLayer: number
+  t90: number
+  Uat: number
+  sigma0: number
+}
+
+export function buildSettlementSolution(
+  i: SettlementSolutionInput, r: SettlementSolutionResult,
+): SolutionStep[] {
+  const totalDepth = i.layers.reduce((a, l) => a + l.H, 0)
+  const gov = r.cons.layers[r.govLayer]
+  const govSoil = i.layers[r.govLayer]
+
+  const steps: SolutionStep[] = [
+    {
+      title: 'Foundation and profile',
+      clause: 'Terzaghi / Boussinesq — elastic half-space',
+      lines: [
+        txt('Settlement has two parts that occur on different timescales: an immediate elastic distortion as the load is applied, and a slow consolidation as pore water drains from the clay. They are computed separately and added.'),
+        eq(String.raw`q = ${sn1(i.q)}\ \text{kPa},\qquad B \times L = ${sn2(i.B)} \times ${sn2(i.L)}\ \text{m},\qquad D_f = ${sn2(i.Df)}\ \text{m}`),
+        eq(String.raw`\text{water table } ${Number.isFinite(i.waterTable) ? `\\text{at } ${sn2(i.waterTable)}\\ \\text{m}` : '\\text{not encountered (dry profile)}'},\qquad \text{profile } ${sn2(totalDepth)}\ \text{m in } ${i.layers.length}\ \text{layers}`),
+        eq(String.raw`\sigma'_0 \text{ at founding level} = ${sn2(r.sigma0)}\ \text{kPa}`),
+      ],
+    },
+    {
+      title: 'Immediate (elastic) settlement',
+      clause: 'Elastic half-space — Steinbrenner influence',
+      lines: [
+        txt('The immediate component treats the soil as an elastic half-space. It occurs essentially as the load is applied, so it is usually taken up during construction and rarely damages finishes.'),
+        eq(String.raw`E_s = ${sn0(i.Es)}\ \text{kPa},\qquad \nu = ${sn2(i.nu)}`),
+        eq(String.raw`S_e = \frac{qB(1-\nu^2)}{E_s}I_s = \mathbf{${sn2(r.elastic)}}\ \text{mm}`),
+      ],
+    },
+    {
+      title: 'Stress increase with depth',
+      clause: 'Boussinesq — rectangular loaded area',
+      lines: [
+        txt('The stress from the footing spreads and decays with depth. Each clay layer is sliced and the Boussinesq increase evaluated at the mid-height of every slice, which matters because Δσ falls off sharply and a single mid-layer value over-predicts a thick stratum.'),
+        eq(String.raw`\Delta\sigma_z = q\,I_\sigma\!\left(\tfrac{B}{2z},\ \tfrac{L}{2z}\right)\quad\text{(four-corner superposition beneath the footing centre)}`),
+        ...r.cons.layers.map((L, k) => eq(
+          String.raw`\text{layer ${k + 1} @ } z_{mid} = ${sn2(L.zMid)}\ \text{m}: \Delta\sigma = ${sn2(L.dSigma)}\ \text{kPa},\ \sigma'_0 = ${sn2(L.sigma0)}\ \text{kPa},\ \sigma'_p = ${sn2(L.sigmaP)}\ \text{kPa}`,
+        )),
+      ],
+    },
+    {
+      title: 'Primary consolidation',
+      clause: 'Terzaghi 1-D consolidation',
+      lines: [
+        txt('Each layer compresses on the recompression line up to its preconsolidation pressure and on the virgin line beyond it — a layer whose final stress crosses σ′p uses both branches, which is why an overconsolidated crust is not charged virgin compression it will never see.'),
+        ...r.cons.layers.map((L, k) => eq(
+          String.raw`\text{layer ${k + 1} (${BRANCH[L.branch]}): } S_c = ${sn2(L.settlement)}\ \text{mm}`,
+        )),
+        ...(govSoil ? [eq(
+          String.raw`\text{governs — layer ${r.govLayer + 1}: } C_c = ${sn3(govSoil.Cc ?? 0)},\ C_r = ${sn3(govSoil.Cr ?? (govSoil.Cc ?? 0) / 6)},\ e_0 = ${sn3(govSoil.e0 ?? 0)},\ H = ${sn2(govSoil.H)}\ \text{m}`,
+        )] : []),
+        eq(String.raw`S_c = \sum \frac{H}{1+e_0}\left[C_r\log\frac{\sigma'_p}{\sigma'_0} + C_c\log\frac{\sigma'_0+\Delta\sigma}{\sigma'_p}\right] = \mathbf{${sn2(r.cons.total)}}\ \text{mm}`),
+        eq(String.raw`S_{total} = S_e + S_c = ${sn2(r.elastic)} + ${sn2(r.cons.total)} = \mathbf{${sn2(r.total)}}\ \text{mm}`),
+      ],
+    },
+    {
+      title: 'Rate of consolidation',
+      clause: 'Terzaghi — time factor Tv',
+      lines: [
+        txt('How long the consolidation takes depends on the square of the drainage path, so a layer draining both faces consolidates four times faster than the same layer draining one. This is why the governing layer for magnitude is not always the one that governs the programme.'),
+        ...(gov && Number.isFinite(r.t90) ? [eq(
+          String.raw`t_{90} \text{ (layer ${r.govLayer + 1})} = \frac{T_{90} H_{dr}^2}{c_v} = ${sn2(r.t90)}\ \text{years}`,
+        )] : [txt('The governing layer has no finite t₉₀ with the given cv.')]),
+        eq(String.raw`U(t = ${sn0(i.years)}\ \text{y}) = ${sn1(r.Uat * 100)}\%\quad\Rightarrow\quad S(t) \approx ${sn2(r.Uat * r.cons.total)}\ \text{mm of the primary settlement}`),
+      ],
+    },
+    {
+      title: 'Schmertmann check',
+      clause: 'Schmertmann strain-influence method',
+      lines: [
+        txt('An independent estimate for granular soils, using the strain-influence diagram rather than consolidation theory. C₁ corrects for embedment depth and C₂ for creep — the two together are why a Schmertmann figure grows with time even in sand.'),
+        eq(String.raw`C_1 = 1 - 0.5\frac{\sigma'_0}{\Delta p} = ${sn3(r.schmert.C1)},\qquad C_2 = 1 + 0.2\log_{10}\frac{t}{0.1} = ${sn3(r.schmert.C2)}`),
+        eq(String.raw`I_{zp} = ${sn3(r.schmert.Izp)},\qquad z_{influence} = ${sn2(r.schmert.zInfluence)}\ \text{m}`),
+        eq(String.raw`S = C_1 C_2 \Delta p \sum\frac{I_z}{E_s}\Delta z = \mathbf{${sn2(r.schmert.settlement)}}\ \text{mm at } ${sn0(i.years)}\ \text{years}`),
+      ],
+      note: 'An independent method on different assumptions — compare it with the consolidation figure rather than adding the two.',
+    },
+    {
+      title: 'What this does and does not tell you',
+      clause: 'Skempton & MacDonald (1956) — tolerable settlement',
+      lines: [
+        txt('This sheet PREDICTS a movement; it does not check one. There is no capacity to divide by and therefore no pass or fail. Whether the predicted settlement is acceptable depends on the structure, its finishes, its services and — usually more critically than the total — the DIFFERENTIAL settlement between footings, which a single-footing calculation cannot give you.'),
+        txt('Common serviceability yardsticks are 25 mm total and an angular distortion of 1/500 for framed buildings, but those are project decisions, not code limits, and they are the engineer’s to set.'),
+      ],
+    },
+  ]
+
+  return steps
+}

--- a/webapp/src/lib/slopeSolution.ts
+++ b/webapp/src/lib/slopeSolution.ts
@@ -1,0 +1,126 @@
+// Worked solution for circular slope stability by the method of slices —
+// Fellenius/OMS, Bishop's simplified and Janbu's simplified. Mirrors
+// engine/slopeStability.ts.
+//
+// Two things this sheet has to say that a bare FS number cannot:
+//
+//  • WHICH CIRCLE. The reported FS belongs to one particular slip surface out
+//    of a grid of thousands. A factor of safety with no circle attached is not
+//    a result, so the search extent and the winning centre/radius are printed.
+//
+//  • WHY THE METHODS DIFFER. Fellenius ignores interslice forces and is
+//    therefore conservative — typically 5–15% below Bishop, more with high
+//    pore pressure. That spread is not an error in either method; it is the
+//    price of the assumption, and an engineer reading three numbers deserves
+//    to be told which one to believe (Bishop, for a circular surface).
+import type { CircleResult, SearchResult, SlopeSoil } from '../engine/slopeStability'
+import { type SolutionStep, type SolutionLine, sn0, sn1, sn2, sn3 } from './solution'
+
+const txt = (text: string): SolutionLine => ({ text })
+const eq = (tex: string): SolutionLine => ({ tex })
+
+export type SlopeMethod = 'bishop' | 'fellenius' | 'janbu'
+
+export interface SlopeSolutionInput {
+  H: number; beta: number; crestW: number; toeW: number
+  soil: SlopeSoil
+  ru: number
+  method: SlopeMethod
+  /** Required factor of safety the result is judged against. */
+  FSreq?: number
+}
+
+const METHOD_LABEL: Record<SlopeMethod, string> = {
+  bishop: "Bishop's simplified", fellenius: 'Fellenius / OMS', janbu: "Janbu's simplified",
+}
+
+export function buildSlopeSolution(
+  i: SlopeSolutionInput, r: SearchResult, crit: CircleResult,
+): SolutionStep[] {
+  const FSreq = i.FSreq ?? 1.5
+  const FS = { bishop: crit.bishop.FS, fellenius: crit.fellenius.FS, janbu: crit.janbu.FS }[i.method]
+  const ok = FS >= FSreq
+  const n = crit.slices.length
+  const tanphi = Math.tan((i.soil.phiDeg * Math.PI) / 180)
+  // A handful of representative slices — printing thirty rows would bury the
+  // method under its own arithmetic.
+  const sample = [0, Math.floor(n / 3), Math.floor((2 * n) / 3), n - 1]
+    .filter((k, idx, a) => k >= 0 && k < n && a.indexOf(k) === idx)
+
+  return [
+    {
+      title: 'Slope geometry and soil',
+      clause: 'Terzaghi — limit equilibrium',
+      lines: [
+        txt('The slope is idealised as a plane face between a level crest and a level toe, and failure is assumed to occur on a circular arc through the mass. Only one soil is modelled, so a layered profile has to be run with weighted-average parameters or by a layered method.'),
+        eq(String.raw`H = ${sn2(i.H)}\ \text{m},\qquad \beta = ${sn1(i.beta)}^\circ,\qquad \text{crest } ${sn2(i.crestW)}\ \text{m},\ \text{toe } ${sn2(i.toeW)}\ \text{m}`),
+        eq(String.raw`c' = ${sn1(i.soil.c)}\ \text{kPa},\qquad \phi' = ${sn1(i.soil.phiDeg)}^\circ,\qquad \gamma = ${sn1(i.soil.gamma)}\ \text{kN/m}^3`),
+        eq(String.raw`r_u = \frac{u}{\gamma h} = ${sn2(i.ru)}\quad${i.ru > 0 ? String.raw`\Rightarrow \text{pore pressure reduces every effective normal force}` : String.raw`\Rightarrow u = 0\ \text{(drained, no pore pressure)}`}`),
+      ],
+    },
+    {
+      title: 'Critical circle search',
+      clause: 'Terzaghi — limit equilibrium (grid search)',
+      lines: [
+        txt('The factor of safety belongs to a slip surface, not to a slope, so the governing circle has to be found rather than assumed. A grid of trial centres and radii is swept and the circle with the lowest Bishop FS is reported — the mass most likely to move.'),
+        eq(String.raw`${sn0(r.evaluated)}\ \text{valid circles evaluated} \Rightarrow \text{critical circle: } x_c = ${sn2(crit.circle.xc)}\ \text{m},\ y_c = ${sn2(crit.circle.yc)}\ \text{m},\ R = ${sn2(crit.circle.R)}\ \text{m}`),
+        eq(String.raw`\text{sliced into } ${sn0(n)}\ \text{vertical slices}`),
+      ],
+      note: 'The minimum found is a grid minimum. Refine the grid if the winning circle sits on its edge.',
+    },
+    {
+      title: 'Slice forces',
+      clause: 'Terzaghi — method of slices',
+      lines: [
+        txt('Each slice contributes its weight W = γ·b·h. The component along the base W·sinα drives the slide; the component normal to it, less the pore water force, mobilises friction. α is negative near the toe where the arc turns up, and those slices resist rather than drive.'),
+        eq(String.raw`W = \gamma\,b\,h = ${sn1(i.soil.gamma)}\,b\,h,\qquad u = r_u\,\gamma\,h = ${sn2(i.ru)}(${sn1(i.soil.gamma)})h,\qquad \ell = \frac{b}{\cos\alpha}`),
+        ...sample.map((k) => {
+          const s = crit.slices[k]
+          return eq(String.raw`\text{slice ${k + 1}: } b = ${sn2(s.b)},\ h = ${sn2(s.h)}\ \text{m},\ \alpha = ${sn1((s.alpha * 180) / Math.PI)}^\circ,\ W = ${sn1(s.W)}\ \text{kN/m},\ u = ${sn1(s.u)}\ \text{kPa}`)
+        }),
+        eq(String.raw`\sum W\sin\alpha = ${sn1(crit.bishop.driving)}\ \text{kN/m}\quad(\text{driving})`),
+      ],
+    },
+    {
+      title: 'Fellenius / Ordinary Method of Slices',
+      clause: 'Fellenius (1936) — Terzaghi limit equilibrium',
+      lines: [
+        txt('The simplest method: interslice forces are ignored entirely, so the normal force on each base is just W·cosα. That assumption violates equilibrium of the slice and always errs on the safe side, which is why Fellenius is used as a lower bound and as the starting guess for the iterative methods below.'),
+        eq(String.raw`FS = \frac{\sum\left[c'\ell + (W\cos\alpha - u\ell)\tan\phi'\right]}{\sum W\sin\alpha} = \frac{${sn1(crit.fellenius.resisting)}}{${sn1(crit.fellenius.driving)}} = \mathbf{${sn3(crit.fellenius.FS)}}`),
+      ],
+    },
+    {
+      title: "Bishop's simplified",
+      clause: 'Bishop (1955) — Terzaghi limit equilibrium',
+      lines: [
+        txt('Bishop keeps the interslice normal forces and assumes only that the interslice shear vanishes. FS then appears on both sides through mα, so the equation is iterated to convergence. For a circular surface this is the method to report — it satisfies moment equilibrium and sits within about 1% of rigorous methods.'),
+        eq(String.raw`m_\alpha = \cos\alpha + \frac{\sin\alpha\,\tan\phi'}{FS},\qquad \tan\phi' = ${sn3(tanphi)}`),
+        eq(String.raw`FS = \frac{1}{\sum W\sin\alpha}\sum\frac{c'b + (W - ub)\tan\phi'}{m_\alpha} = \frac{${sn1(crit.bishop.resisting)}}{${sn1(crit.bishop.driving)}} = \mathbf{${sn3(crit.bishop.FS)}}`),
+        eq(String.raw`\text{converged in } ${sn0(crit.bishop.iterations)}\ \text{iterations} \Rightarrow \textbf{${crit.bishop.converged ? 'converged' : 'DID NOT CONVERGE'}}`),
+      ],
+      note: crit.bishop.converged ? undefined : 'Bishop did not converge on this circle — treat the value as unreliable and check the geometry and pore pressure.',
+    },
+    {
+      title: "Janbu's simplified",
+      clause: 'Janbu (1973) — Terzaghi limit equilibrium',
+      lines: [
+        txt('Janbu satisfies force equilibrium instead of moment equilibrium, which makes it the method for non-circular surfaces. Force equilibrium alone under-predicts, so an empirical correction f₀ — a function of how deep the slip mass is relative to its length — is applied.'),
+        eq(String.raw`f_0 = 1 + b_1\left[\tfrac{d}{L} - 1.4\left(\tfrac{d}{L}\right)^2\right] = ${sn3(crit.f0)}`),
+        eq(String.raw`FS = f_0\,\frac{\sum\dfrac{c'b + (W - ub)\tan\phi'}{n_\alpha}}{\sum W\tan\alpha} = \mathbf{${sn3(crit.janbu.FS)}}`),
+      ],
+    },
+    {
+      title: 'Factor of safety',
+      clause: 'Terzaghi limit equilibrium — FS acceptance',
+      pass: ok,
+      lines: [
+        txt(`Three methods on the same circle. Fellenius is the conservative bound, Bishop the one to design to for a circular surface, Janbu the force-equilibrium comparison. A spread between them is expected — it measures the interslice assumption, not an error.`),
+        eq(String.raw`FS_{Fellenius} = ${sn3(crit.fellenius.FS)},\qquad FS_{Bishop} = ${sn3(crit.bishop.FS)},\qquad FS_{Janbu} = ${sn3(crit.janbu.FS)}`),
+        eq(String.raw`\text{reported (${METHOD_LABEL[i.method]}): } FS = ${sn3(FS)} \;${ok ? '\\ge' : '<'}\; FS_{req} = ${sn2(FSreq)} \Rightarrow \textbf{${ok ? 'STABLE' : 'UNSTABLE — flatten, drain or reinforce'}}`),
+      ],
+      note: ok
+        ? 'FS ≥ 1.5 is the usual long-term requirement for a permanent slope; 1.3 is commonly accepted for temporary works and 1.1–1.2 under seismic pseudo-static loading.'
+        : 'Options in rough order of cost: flatten the face, lower ru by drainage, bench the slope, or reinforce with soil nails or anchors.',
+    },
+  ]
+}

--- a/webapp/src/lib/texText.test.ts
+++ b/webapp/src/lib/texText.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { texToPlain } from './texText'
+import { MONO } from './pdfFonts'
 
 // Real formula shapes from the lib/*Solution builders (the strings the PDF
 // report converts), checked against hand-written plain-text equivalents.
@@ -53,4 +54,76 @@ describe('texToPlain', () => {
     ]
     for (const s of samples) expect(texToPlain(s)).not.toMatch(/\\[a-zA-Z]/)
   })
+
+  // ── Regressions found by reading an exported PDF, not by reading the code ──
+  it('does not stall on a superscript it cannot convert', () => {
+    // `^\circ` renders back to something starting with the same character the
+    // scanner is looking for. Restarting the scan at index 0 made the loop
+    // find it forever, so every LATER superscript in the same equation was
+    // dropped: "γ = 18.0 kN/m³" printed as "γ = 18.0 kN/m^3".
+    expect(texToPlain(String.raw`\phi = 25.0^\circ,\ \gamma = 18.0\ \text{kN/m}^3`))
+      .toBe('φ = 25.0°, γ = 18.0 kN/m³')
+    expect(texToPlain(String.raw`a^\circ b^2 c^3 d^{10}`)).toBe('a° b² c³ d¹⁰')
+  })
+
+  it('renders a degree symbol without a stray caret', () => {
+    expect(texToPlain(String.raw`\beta = 30.0^\circ`)).toBe('β = 30.0°')
+    expect(texToPlain(String.raw`45^\circ + \tfrac{\phi}{2}`)).toBe('45° + φ/2')
+  })
+
+  it('uses only glyphs the embedded PDF fonts can actually draw', () => {
+    // jsPDF draws a glyph the embedded subset lacks as NOTHING — no tofu, no
+    // warning, just a gap. "c'ℓ + N tanφ'" was printing as "c' + N tanφ'" and
+    // "ℓe/d" as "e/d", because DejaVu Sans MONO (which sets the equations) has
+    // no U+2113 and the combining macron U+0304 is outside the subset.
+    // This walks the whole conversion vocabulary so the next addition that
+    // reaches for an exotic glyph fails here instead of in a printed sheet.
+    const vocabulary = [
+      String.raw`\checkmark \Rightarrow \rightarrow \leftarrow \to \varepsilon \varnothing`,
+      String.raw`\lambda \alpha \beta \gamma \delta \Delta \epsilon \theta \kappa \sigma \Sigma \omega \Omega`,
+      String.raw`\phi \Phi \psi \rho \tau \mu \nu \eta \pi \chi \zeta`,
+      String.raw`\approx \infty \propto \lceil x \rceil \lfloor y \rfloor`,
+      String.raw`\cdot \times \div \pm \leq \geq \le \ge \neq \ne \sum`,
+      String.raw`\circ \degree \prime \ell \min \max \tan \cos \sin \ln \log`,
+      String.raw`\sqrt{x} \frac{a}{b} \bar{y} \overline{y} \bar{q}`,
+      String.raw`x^0 x^1 x^2 x^3 x^4 x^5 x^6 x^7 x^8 x^9 x^{-1} x^{+1} x^\circ`,
+    ].map(texToPlain).join('')
+
+    const missing = [...new Set(vocabulary)]
+      .filter((ch) => ch !== ' ')
+      .filter((ch) => !MONO_GLYPHS.has(ch.codePointAt(0)!))
+    expect(missing.map((c) => `${c} U+${c.codePointAt(0)!.toString(16)}`)).toEqual([])
+  })
 })
+
+/**
+ * Character codes the embedded mono subset can draw, read from the TTF's own
+ * cmap. Reading the font is the point: a hand-maintained allow-list would drift
+ * from the bytes that actually ship.
+ */
+const MONO_GLYPHS: Set<number> = (() => {
+  const bin = atob(MONO)
+  const b = new DataView(Uint8Array.from(bin, (c) => c.charCodeAt(0)).buffer)
+  const tag = (o: number) => String.fromCharCode(...[0, 1, 2, 3].map((k) => b.getUint8(o + k)))
+
+  let cmap = 0
+  for (let i = 0; i < b.getUint16(4); i++) {
+    const o = 12 + i * 16
+    if (tag(o) === 'cmap') cmap = b.getUint32(o + 8)
+  }
+  let sub = 0
+  for (let i = 0; i < b.getUint16(cmap + 2); i++) {
+    const o = cmap + 4 + i * 8
+    const pid = b.getUint16(o), eid = b.getUint16(o + 2)
+    if (pid === 3 && (eid === 1 || eid === 10)) sub = cmap + b.getUint32(o + 4)
+  }
+  // format 4: parallel endCode / startCode arrays, 0xffff-terminated
+  const segX2 = b.getUint16(sub + 6)
+  const endO = sub + 14, startO = endO + segX2 + 2
+  const set = new Set<number>()
+  for (let i = 0; i < segX2 / 2; i++) {
+    const end = b.getUint16(endO + i * 2), start = b.getUint16(startO + i * 2)
+    for (let c = start; c <= end && c !== 0xffff; c++) set.add(c)
+  }
+  return set
+})()

--- a/webapp/src/lib/texText.ts
+++ b/webapp/src/lib/texText.ts
@@ -26,7 +26,12 @@ const SYMBOLS: [string, string][] = [
   ['\\cdot', '·'], ['\\times', '×'], ['\\div', '÷'], ['\\pm', '±'],
   ['\\leq', '≤'], ['\\geq', '≥'], ['\\le', '≤'], ['\\ge', '≥'],
   ['\\neq', '≠'], ['\\ne', '≠'], ['\\sum', 'Σ'], ['\\to', '→'],
-  ['\\circ', '°'], ['\\degree', '°'], ['\\prime', '′'], ['\\ell', 'ℓ'],
+  ['\\circ', '°'], ['\\degree', '°'], ['\\prime', '′'],
+  // ℓ (U+2113) deliberately becomes a plain l: equations are set in DejaVu Sans
+  // MONO, which has no U+2113 at all — the character is not in the upstream
+  // font, so no subset can add it — and jsPDF draws a missing glyph as nothing.
+  // "c'ℓ" was silently printing as "c'". A plain l is legible; a blank is not.
+  ['\\ell', 'l'],
   ['\\min', 'min'], ['\\max', 'max'], ['\\tan', 'tan'], ['\\cos', 'cos'],
   ['\\sin', 'sin'], ['\\ln', 'ln'], ['\\log', 'log'],
   ['\\qquad', '    '], ['\\quad', '  '],
@@ -59,6 +64,18 @@ function grabArg(s: string, at: number): [string, number] {
   return [s[at] ?? '', at + 1]
 }
 
+/**
+ * Precomposed macron letters. The combining macron U+0304 is NOT in the
+ * embedded subsets, so `x` + U+0304 drew as a bare `x` — the bar vanished and
+ * a mean silently read as an instantaneous value. Anything without a
+ * precomposed form falls back to the explicit `_bar` shorthand instead.
+ */
+const MACRON: Record<string, string> = {
+  a: 'ā', e: 'ē', i: 'ī', o: 'ō', u: 'ū', y: 'ȳ',
+  A: 'Ā', E: 'Ē', I: 'Ī', O: 'Ō', U: 'Ū', Y: 'Ȳ',
+}
+const overbar = (a: string) => MACRON[a.trim()] ?? `${a.trim()}_bar`
+
 /** Does a fraction/sqrt operand need parentheses in linear form? */
 const needsParens = (s: string) => /[+\-−·×/ ]/.test(s.trim())
 const wrap = (s: string) => (needsParens(s) ? `(${s.trim()})` : s.trim())
@@ -66,8 +83,15 @@ const wrap = (s: string) => (needsParens(s) ? `(${s.trim()})` : s.trim())
 /** Replace every \cmd{a}(…{b}) via a handler, innermost-safe (single pass per
  *  occurrence, called until the command disappears). */
 function replaceCommand(s: string, cmd: string, nArgs: number, render: (args: string[]) => string): string {
-  for (let guard = 0; guard < 200; guard++) {
-    const at = s.indexOf(cmd)
+  // The cursor must advance PAST what was just emitted. Restarting the scan at
+  // index 0 deadlocks whenever a handler re-emits its own command — `^\circ`
+  // renders back to `^°`, so the loop found the same caret 200 times and every
+  // LATER superscript in the same equation was silently dropped ("kN/m³" came
+  // out as "kN/m^3"). Args are converted recursively, so nothing before the
+  // cursor still needs processing.
+  let from = 0
+  for (let guard = 0; guard < 500; guard++) {
+    const at = s.indexOf(cmd, from)
     if (at < 0) return s
     let i = at + cmd.length
     const args: string[] = []
@@ -77,7 +101,9 @@ function replaceCommand(s: string, cmd: string, nArgs: number, render: (args: st
       args.push(content)
       i = next
     }
-    s = s.slice(0, at) + render(args.map((a) => texToPlain(a))) + s.slice(i)
+    const out = render(args.map((a) => texToPlain(a)))
+    s = s.slice(0, at) + out + s.slice(i)
+    from = at + out.length
   }
   return s
 }
@@ -91,8 +117,7 @@ export function texToPlain(tex: string): string {
   s = replaceCommand(s, '\\sqrt', 1, ([a]) => `√${needsParens(a) ? `(${a.trim()})` : a.trim()}`)
   for (const t of ['\\textbf', '\\text', '\\mathbf', '\\mathrm', '\\operatorname'])
     s = replaceCommand(s, t, 1, ([a]) => a)
-  s = replaceCommand(s, '\\overline', 1, ([a]) => (a === 'y' ? 'ȳ' : a === 'x' ? 'x̄' : `${a}̄`))
-  s = replaceCommand(s, '\\bar', 1, ([a]) => (a === 'y' ? 'ȳ' : a === 'x' ? 'x̄' : `${a}̄`))
+  for (const c of ['\\overline', '\\bar']) s = replaceCommand(s, c, 1, ([a]) => overbar(a))
   // delimiter sizing → keep the delimiter
   s = s.replace(/\\left\s*/g, '').replace(/\\right\s*/g, '').replace(/\\[bB]igg?[lr]?\s*/g, '')
   // symbols (order matters: longest names first in the table)
@@ -100,7 +125,10 @@ export function texToPlain(tex: string): string {
   // superscripts: ^{…} then ^c — digits/sign to unicode, else caret notation
   s = replaceCommand(s, '^', 1, ([a]) => {
     const t = a.trim()
-    if ([...t].every((ch) => SUP[ch] !== undefined)) return [...t].map((ch) => SUP[ch]).join('')
+    // ° and ′ are already superscript-height glyphs — `30^\circ` reads as 30°,
+    // never as 30^°.
+    if (t === '°' || t === '′' || t === '″') return t
+    if (t.length > 0 && [...t].every((ch) => SUP[ch] !== undefined)) return [...t].map((ch) => SUP[ch]).join('')
     return `^${needsParens(t) ? `(${t})` : t}`
   })
   // subscripts flatten: M_u → Mu, A_{s,max} → As,max

--- a/webapp/src/lib/workedSolutions.test.ts
+++ b/webapp/src/lib/workedSolutions.test.ts
@@ -12,6 +12,22 @@ import { designCircularTank } from '../engine/waterTank'
 import { buildSlabSolution } from './slabSolution'
 import { buildStairSolution } from './stairSolution'
 import { buildWaterTankSolution } from './waterTankSolution'
+import { designSoilNail } from '../engine/soilNail'
+import { designMicropile } from '../engine/micropile'
+import { designRockAnchor } from '../engine/rockAnchor'
+import { designFacing } from '../engine/shotcreteFacing'
+import {
+  buildSoilNailSolution, buildMicropileSolution, buildRockAnchorSolution, buildFacingSolution,
+} from './geotechSolutions'
+import {
+  consolidationSettlement, elasticSettlement, schmertmannSettlement, effectiveStress,
+  timeToConsolidation, consolidationAfter, type SoilLayer,
+} from '../engine/settlement'
+import { buildSettlementSolution } from './settlementSolution'
+import { searchCriticalCircle, type Pt, type SlopeSoil } from '../engine/slopeStability'
+import { buildSlopeSolution } from './slopeSolution'
+import { bromsClay, pyAnalysis } from '../engine/lateralPile'
+import { buildLateralPileSolution } from './lateralPileSolution'
 
 // ─────────────────────────────────────────────────────────────────────────
 // What a worked solution has to be, applied to every builder at once.
@@ -44,6 +60,67 @@ const tankIn = {
   sigmaSt: 130, sigmaCt: 1.3, cover: 40, barDia: 16,
 }
 
+// ── Geotechnical ─────────────────────────────────────────────────────────
+const nailIn = {
+  z: 5, Sh: 1.5, Sv: 1.5, gamma: 18, phiDeg: 30, surcharge: 10,
+  barDia: 25, fy: 415, drillDia: 150, bondLength: 8, qu: 100,
+}
+const mpSection = { barDia: 32, fyBar: 517, groutDia: 200, fcGrout: 28 }
+const mpIn = {
+  mode: 'compression' as const, ...mpSection,
+  casing: false, casingOD: 0, casingID: 0, fyCasing: 248,
+  bondDia: 200, bondLength: 10, alphaBond: 200, P: 600,
+}
+const anchorIn = {
+  fpu: 1860, Aps: 1400, holeDia: 150, bondLength: 6, tauUlt: 700, T: 800,
+}
+const facingIn = {
+  SH: 1.5, SV: 1.5, hc: 150, cover: 40, AsVert: 335, AsHoriz: 335,
+  fc: 21, fy: 415, bearingPlate: 0.225, nailHeadForce: 60,
+}
+
+const setLayers: SoilLayer[] = [
+  { name: 'Sand fill', H: 3, gamma: 18, gammaSat: 20 },
+  { name: 'Soft clay', H: 6, gamma: 17, gammaSat: 18, e0: 1.1, Cc: 0.35, cv: 1.5, sigmaP: 90 },
+  { name: 'Stiff clay', H: 5, gamma: 19, gammaSat: 20, e0: 0.7, Cc: 0.18, cv: 4, sigmaP: 300 },
+]
+const setIn = { q: 120, B: 2.5, L: 3.5, Df: 1.5, waterTable: 3, Es: 25000, nu: 0.3, years: 10, layers: setLayers }
+
+function settlementCase() {
+  const cons = consolidationSettlement({
+    layers: setLayers, q: setIn.q, B: setIn.B, L: setIn.L, Df: setIn.Df,
+    waterTable: setIn.waterTable, slices: 20,
+  })
+  const elastic = elasticSettlement({ q: setIn.q, B: setIn.B, L: setIn.L, Es: setIn.Es, nu: setIn.nu })
+  const schmert = schmertmannSettlement({
+    dp: setIn.q, B: setIn.B, L: setIn.L,
+    sigma0: effectiveStress(setLayers, setIn.Df, setIn.waterTable), gamma: setLayers[0].gamma,
+    layers: Array.from({ length: 40 }, () => ({ H: 0.2, Es: setIn.Es })), years: setIn.years,
+  })
+  const govLayer = cons.layers.reduce(
+    (best, l, k) => (l.settlement > (cons.layers[best]?.settlement ?? -1) ? k : best), 0)
+  const govSoil = setLayers[govLayer]
+  return {
+    cons, elastic, schmert, total: elastic + cons.total, govLayer,
+    t90: timeToConsolidation(govSoil, 0.9), Uat: consolidationAfter(govSoil, setIn.years),
+    sigma0: effectiveStress(setLayers, setIn.Df, setIn.waterTable),
+  }
+}
+
+// 10 m slope at 30°, c-φ soil — the same default the page ships with.
+const slopeGround: Pt[] = [
+  { x: 0, y: 10 }, { x: 8, y: 10 },
+  { x: 8 + 10 / Math.tan((30 * Math.PI) / 180), y: 0 },
+  { x: 8 + 10 / Math.tan((30 * Math.PI) / 180) + 12, y: 0 },
+]
+const slopeSoil: SlopeSoil = { c: 20, phiDeg: 25, gamma: 18 }
+
+const pileIn = {
+  soilKind: 'clay' as const, L: 12, D: 0.6, EI: 180000, My: 900,
+  H: 150, e: 0.5, head: 'free' as const,
+  cu: 40, e50: 0.01, phiDeg: 33, k: 25000, gamma: 9,
+}
+
 const BUILDERS: [string, () => SolutionStep[]][] = [
   ['punching shear', () => buildPunchingSolution(punchIn, designPunchingShear(punchIn))],
   ['torsion', () => buildTorsionSolution(torsIn, designTorsion(torsIn))],
@@ -51,6 +128,26 @@ const BUILDERS: [string, () => SolutionStep[]][] = [
   ['two-way slab', () => buildSlabSolution(slabIn, designSlabDDM(slabIn))],
   ['stair', () => buildStairSolution(stairIn, designStair(stairIn))],
   ['water tank', () => buildWaterTankSolution(tankIn, designCircularTank(tankIn))],
+  ['soil nail', () => buildSoilNailSolution(nailIn, designSoilNail(nailIn))],
+  ['micropile', () => buildMicropileSolution(mpIn, designMicropile({ section: mpSection, ...mpIn }))],
+  ['rock anchor', () => buildRockAnchorSolution(anchorIn, designRockAnchor(anchorIn))],
+  ['shotcrete facing', () => buildFacingSolution(facingIn, designFacing(facingIn))],
+  ['settlement', () => buildSettlementSolution(setIn, settlementCase())],
+  ['slope stability', () => {
+    const res = searchCriticalCircle(slopeGround, slopeSoil, { n: 30 })!
+    return buildSlopeSolution(
+      { H: 10, beta: 30, crestW: 8, toeW: 12, soil: slopeSoil, ru: 0, method: 'bishop' },
+      res, res.critical,
+    )
+  }],
+  ['lateral pile', () => {
+    const broms = bromsClay({ L: pileIn.L, d: pileIn.D, cu: pileIn.cu, My: pileIn.My, e: pileIn.e, head: pileIn.head })
+    const py = pyAnalysis({
+      L: pileIn.L, D: pileIn.D, EI: pileIn.EI, H: pileIn.H, e: pileIn.e, head: pileIn.head,
+      soil: { kind: 'clay', cu: pileIn.cu, gamma: pileIn.gamma, e50: pileIn.e50 }, elements: 60,
+    })
+    return buildLateralPileSolution(pileIn, broms, py)
+  }],
 ]
 
 const eqs = (steps: SolutionStep[]) =>
@@ -72,7 +169,14 @@ describe.each(BUILDERS)('%s worked solution', (_name, build) => {
     // that the citation contains a § character. (My first version demanded §
     // and failed on "ACI 318-14 Table 9.3.1.1" and "IS 3370 / ACI 350", both
     // of which are perfectly good references.)
-    const STANDARD = /ACI|NSCP|AISC|IS \d|PTI|FHWA|Broms|Terzaghi|Boussinesq|working stress|thin-cylinder|Good practice/i
+    const STANDARD = new RegExp([
+      'ACI', 'NSCP', 'AISC', String.raw`IS \d`, 'PTI', 'FHWA', 'API RP',
+      // Named methods are citations too — each is a published paper an
+      // engineer can pull, which is exactly what this test is protecting.
+      'Broms', 'Terzaghi', 'Boussinesq', 'Bishop', 'Fellenius', 'Janbu',
+      'Schmertmann', 'Steinbrenner', 'Matlock', 'Skempton',
+      'working stress', 'thin-cylinder', 'Good practice',
+    ].join('|'), 'i')
     for (const s of steps) {
       expect(s.clause, s.title).toBeTruthy()
       expect(s.clause!, s.title).toMatch(STANDARD)
@@ -139,5 +243,46 @@ describe('degenerate inputs do not produce a broken sheet', () => {
     const ldStep = steps.find((s) => s.title.includes('tension'))!
     if (r.ld_raw < 300) expect(ldStep.note).toMatch(/300 mm floor/)
     expect(eqs(steps).join(' ')).toContain(r.ld.toFixed(0))
+  })
+
+  it('states a dry settlement profile in words instead of printing Infinity', () => {
+    // waterTable: Infinity is the engine's "no water table" sentinel, and
+    // sn2(Infinity) would print the word Infinity into the sheet.
+    const dry = { ...setIn, waterTable: Infinity }
+    const steps = buildSettlementSolution(dry, settlementCase())
+    expect(eqs(steps).join(' ')).toContain('not encountered')
+    for (const t of eqs(steps)) expect(t).not.toMatch(/NaN|undefined|Infinity/)
+  })
+
+  it('calls an unstable slope unstable', () => {
+    // Steep and weak: the critical circle should fall well short of FS 1.5.
+    const weak: SlopeSoil = { c: 5, phiDeg: 18, gamma: 19 }
+    const res = searchCriticalCircle(slopeGround, weak, { n: 30 })!
+    const steps = buildSlopeSolution(
+      { H: 10, beta: 30, crestW: 8, toeW: 12, soil: weak, ru: 0.3, method: 'bishop' }, res, res.critical)
+    const verdict = steps.find((s) => s.pass !== undefined)!
+    expect(verdict.pass).toBe(res.critical.bishop.FS >= 1.5)
+    expect(verdict.pass).toBe(false)
+    expect(eqs(steps).join(' ')).toContain('UNSTABLE')
+    // Fellenius ignores interslice forces, so it must not exceed Bishop.
+    expect(res.critical.fellenius.FS).toBeLessThanOrEqual(res.critical.bishop.FS + 1e-9)
+  })
+
+  it('names the Broms mechanism that actually governs', () => {
+    // A weak section yields before the soil does ⇒ long pile; a very strong
+    // one cannot, so the soil governs ⇒ short pile. The sheet has to say which.
+    const py = pyAnalysis({
+      L: 12, D: 0.6, EI: 180000, H: 150, e: 0.5, head: 'free',
+      soil: { kind: 'clay', cu: 40, gamma: 9, e50: 0.01 }, elements: 60,
+    })
+    for (const My of [50, 1e7]) {
+      const broms = bromsClay({ L: 12, d: 0.6, cu: 40, My, e: 0.5, head: 'free' })
+      const steps = buildLateralPileSolution({ ...pileIn, My }, broms, py)
+      const gov = steps.find((s) => s.title.includes('Governing'))!
+      expect(eqs([gov]).join(' ')).toContain(`\\text{${broms.mode} pile}`)
+      for (const t of eqs(steps)) expect(t).not.toMatch(/NaN|undefined|Infinity/)
+    }
+    expect(bromsClay({ L: 12, d: 0.6, cu: 40, My: 50, e: 0.5, head: 'free' }).mode).toBe('long')
+    expect(bromsClay({ L: 12, d: 0.6, cu: 40, My: 1e7, e: 0.5, head: 'free' }).mode).toBe('short')
   })
 })

--- a/webapp/src/pages/LateralPile.tsx
+++ b/webapp/src/pages/LateralPile.tsx
@@ -4,6 +4,7 @@ import {
   bromsClay, bromsSand, pyAnalysis,
   type PileHead, type SoilModel, type PyResult, type BromsResult,
 } from '../engine/lateralPile'
+import { buildLateralPileSolution } from '../lib/lateralPileSolution'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -117,6 +118,10 @@ export default function LateralPile() {
   const util = broms.Hu > 0 ? H / broms.Hu : Infinity
   const headOK = py.yHead <= 25    // 25 mm is the usual serviceability yardstick
 
+  const solution = buildLateralPileSolution(
+    { soilKind, L, D, EI, My, H, e, head, cu, e50, phiDeg: phi, k, gamma }, broms, py,
+  )
+
   const report = {
     docCode: 'G-LP',
     ok: util <= 1 && headOK && py.converged,
@@ -153,6 +158,7 @@ export default function LateralPile() {
       ['p–y max moment depth', `${f2(py.zMmax)} m`],
       ['p–y convergence', `${py.converged ? 'converged' : 'DID NOT CONVERGE'} in ${py.iterations} iterations (residual ${py.residual.toExponential(1)})`],
     ] as [string, string][],
+    steps: solution,
   }
 
   return (

--- a/webapp/src/pages/Micropile.tsx
+++ b/webapp/src/pages/Micropile.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { designMicropile } from '../engine/micropile'
 import { ReportControls } from '../components/ReportControls'
+import { buildMicropileSolution } from '../lib/geotechSolutions'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -47,6 +48,8 @@ export default function Micropile() {
     mode, bondDia, bondLength, alphaBond, FS: 2, P,
   })
 
+  const solution = buildMicropileSolution({ mode, barDia, fyBar, groutDia, fcGrout, casing, casingOD, casingID, fyCasing, bondDia, bondLength, alphaBond, P }, r)
+
   const report = {
     docCode: 'G-MP',
     ok: r.ok,
@@ -73,6 +76,7 @@ export default function Micropile() {
       ['Allowable bond Qbond', `${f2(r.Qbond)} kN`],
       ['Governing mode', r.governs],
     ] as [string, string][],
+    steps: solution,
   }
 
   return (

--- a/webapp/src/pages/RockAnchor.tsx
+++ b/webapp/src/pages/RockAnchor.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { designRockAnchor } from '../engine/rockAnchor'
 import { ReportControls } from '../components/ReportControls'
+import { buildRockAnchorSolution } from '../lib/geotechSolutions'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -38,6 +39,8 @@ export default function RockAnchor() {
   const r = designRockAnchor({ fpu, Aps, holeDia, bondLength, tauUlt, FS: 2, T })
 
   // Utilisation from the factor of safety, as in the other geotechnical pages.
+  const solution = buildRockAnchorSolution({ fpu, Aps, holeDia, bondLength, tauUlt, FS: 2, T }, r)
+
   const report = {
     docCode: 'G-RA',
     ok: r.ok,
@@ -65,6 +68,7 @@ export default function RockAnchor() {
       ['Allowable ground bond Qall', `${f2(r.Qall)} kN`],
       ['Governing mode', r.governs],
     ] as [string, string][],
+    steps: solution,
   }
 
   return (

--- a/webapp/src/pages/Settlement.tsx
+++ b/webapp/src/pages/Settlement.tsx
@@ -6,6 +6,7 @@ import {
   timeToConsolidation, consolidationAfter, drainagePath,
   type SoilLayer,
 } from '../engine/settlement'
+import { buildSettlementSolution } from '../lib/settlementSolution'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -126,6 +127,11 @@ export default function Settlement() {
   // divide by — so this report carries no pass/fail. The verdict line states
   // the total instead. A 25 mm serviceability limit is common but is a project
   // decision, not something to assert on the engineer's behalf.
+  const solution = buildSettlementSolution(
+    { q, B, L, Df, waterTable: wt, Es, nu, years, layers },
+    { cons, elastic, schmert, total, govLayer, t90, Uat, sigma0: effectiveStress(layers, Df, wt) },
+  )
+
   const report = {
     docCode: 'G-ST',
     ok: true,
@@ -150,6 +156,7 @@ export default function Settlement() {
       ['t₉₀ (governing layer)', Number.isFinite(t90) ? `${f2(t90)} years` : '—'],
       ['U at ' + years + ' years', `${f0(Uat * 100)} %`],
     ] as [string, string][],
+    steps: solution,
   }
 
   return (

--- a/webapp/src/pages/ShotcreteFacing.tsx
+++ b/webapp/src/pages/ShotcreteFacing.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { designFacing } from '../engine/shotcreteFacing'
 import { ReportControls } from '../components/ReportControls'
+import { buildFacingSolution } from '../lib/geotechSolutions'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -42,6 +43,8 @@ export default function ShotcreteFacing() {
 
   const r = designFacing({ SH, SV, hc, cover, AsVert, AsHoriz, fc, fy, bearingPlate, CF, nailHeadForce })
 
+  const solution = buildFacingSolution({ SH, SV, hc, cover, AsVert, AsHoriz, fc, fy, bearingPlate, CF, nailHeadForce }, r)
+
   const report = {
     docCode: 'G-SF',
     ok: r.ok,
@@ -72,6 +75,7 @@ export default function ShotcreteFacing() {
       ['Punching strength Rfp', `${f2(r.Rfp)} kN`],
       ['Governing mode', r.governs],
     ] as [string, string][],
+    steps: solution,
   }
 
   return (

--- a/webapp/src/pages/SlopeStability.tsx
+++ b/webapp/src/pages/SlopeStability.tsx
@@ -4,6 +4,7 @@ import {
   searchCriticalCircle, surfaceY,
   type Pt, type SlopeSoil, type WaterModel, type CircleResult,
 } from '../engine/slopeStability'
+import { buildSlopeSolution } from '../lib/slopeSolution'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -143,6 +144,9 @@ export default function SlopeStability() {
       ['Resisting Σ', `${f2(crit.bishop.resisting)} kN`],
       ['Bishop converged', `${crit.bishop.converged ? 'yes' : 'NO'} (${crit.bishop.iterations} iterations)`],
     ] as [string, string][],
+    steps: buildSlopeSolution(
+      { H, beta, crestW, toeW, soil, ru, method }, res!, crit,
+    ),
   } : undefined
 
   return (

--- a/webapp/src/pages/SoilNail.tsx
+++ b/webapp/src/pages/SoilNail.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { designSoilNail } from '../engine/soilNail'
 import { ReportControls } from '../components/ReportControls'
+import { buildSoilNailSolution } from '../lib/geotechSolutions'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -47,6 +48,8 @@ export default function SoilNail() {
   // A geotechnical check states a FACTOR OF SAFETY, not a demand/capacity
   // ratio, so the report's utilisation is FS_required / FS_achieved — which is
   // ≤ 1 exactly when the design passes, matching every other check in the app.
+  const solution = buildSoilNailSolution({ z, Sh, Sv, gamma, phiDeg: phi, surcharge: q, barDia, fy, drillDia, bondLength, qu, FSpullout: 2.0, FStensile: 1.8 }, r)
+
   const report = {
     docCode: 'G-SN',
     ok: r.tensileOK && r.pulloutOK,
@@ -75,6 +78,7 @@ export default function SoilNail() {
       ['Allowable bar strength Tall', `${f2(r.Tall)} kN`],
       ['Ultimate pullout Qult', `${f2(r.Qult)} kN`],
     ] as [string, string][],
+    steps: solution,
   }
 
   return (


### PR DESCRIPTION
**Layer 8 (geotech) + the shared report renderer.** Completes the worked-solution pass over the calculator reports. Every geotech sheet now carries the formula, the substituted values with units, and the reasoning — instead of a results table.

## New solution builders

| Module | Pages | What the sheet derives |
|---|---|---|
| `geotechSolutions.ts` | soil nail, micropile, rock anchor, shotcrete facing | capacity in each failure mode, which one governs, FS vs FS required |
| `settlementSolution.ts` | settlement | Boussinesq Δσ per layer, Terzaghi consolidation naming the e–log σ′ branch each layer used, rate of consolidation, Schmertmann cross-check |
| `slopeSolution.ts` | slope stability | critical-circle search (extent, winning centre/radius, slice count), representative slice forces, then Fellenius / Bishop / Janbu on that one circle |
| `lateralPileSolution.ts` | lateral pile | Broms short- and long-pile mechanisms with the governing one named, then the p–y serviceability answer and its convergence report |

Three deliberate departures from the RC sheets, each stated in the module header:

- **Ground anchorage reads differently.** An RC check ends in "provide this much steel"; an anchorage check ends in "capacity X, demand Y, margin X/Y". Each builder derives capacity per failure mode rather than sizing reinforcement.
- **Settlement has no pass/fail.** It is a prediction, not a code check — there is no capacity to divide by. The closing step says so explicitly, including that differential settlement usually governs over total, and that 25 mm / 1:500 are project decisions rather than code limits.
- **"Short pile" is a verdict, not a length.** Which Broms mechanism governs is what makes a pile short or long, and the sheet says which and what that implies (strengthen the section vs lengthen it / improve the ground).

## Tests

`workedSolutions.test.ts` now runs the shared property suite over **all thirteen builders**: ≥3 titled steps, a standard cited on every step, prose over 30 characters, digits in every equation, a `symbol = substitution = result` chain in the majority, units on results, never NaN/undefined/Infinity. Plus targeted cases for a dry settlement profile, an unstable slope (with `FS_Fellenius ≤ FS_Bishop` pinned), and both Broms mechanisms.

The clause regex was widened to accept named methods (Bishop, Fellenius, Janbu, Schmertmann, Steinbrenner, Matlock, Skempton, API RP) — each is a published paper a reader can pull, which is exactly what the test protects.

## Three rendering defects, found by reading an exported PDF

These affected the **existing** sheets too, including Model Space:

1. **`texToPlain`'s command scanner restarted at index 0.** `^\circ` renders back to a string starting with `^`, so the loop found the same caret 200 times and every *later* superscript in the same equation was silently dropped — `kN/m³` printed as `kN/m^3`. The cursor now advances past the emitted output.
2. **`^\circ` printed a stray caret** (`30.0^°`). `°` and `′` are already superscript-height glyphs.
3. **Missing glyphs drew as nothing.** jsPDF renders a glyph absent from the embedded subset as a blank — no tofu, no warning. `c'ℓ` was printing as `c'`, and Model Space's `ℓe/d` as `e/d`. DejaVu Sans **Mono** (which sets the equations) has no U+2113 at all, so no subset can add it; `\ell` now maps to a plain `l`. The combining macron U+0304 was outside the subset, so `\bar` now uses precomposed macron letters.

A new test walks the whole conversion vocabulary against the shipped font's own `cmap`, so the next addition that reaches for an exotic glyph fails in CI instead of in a printed sheet. I confirmed all three new guards *bite* by reverting each fix and watching the test fail.

## Verification

- `npm test` — 2106 passed / 153 files · `npx tsc -b` · `npm run lint` · `npm run build` all green.
- All seven pages exported in headless Chromium; the PDFs were read back with pdfjs — worked solution present on every one, 2 pages each, no NaN/undefined/raw LaTeX, no console errors.
- The slope sheet was checked against **rendered pixels** before and after the `texToPlain` fixes, since the text layer alone would not have shown the blank glyphs.

## Honest limits

- Only the equations are checked for substitution; prose accuracy is reviewed by eye, not by test.
- The slope sheet prints four representative slices out of thirty — the full table would bury the method in its own arithmetic.
- The critical circle is a *grid* minimum; the sheet notes to refine the grid if the winner sits on its edge.
- `\ell → l` is a legibility trade, not a typographic win. `l` is distinguishable from `1` in DejaVu Sans Mono, and a visible `l` beats an invisible `ℓ`.

## Remaining on the reports backlog

Still on browser print: steel/connections, beam/frame/truss analysis, seismic wizard, plumbing, load path, load combinations, wood slab, and the `/geotech` toolkit (which needs a state-lifting refactor first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_