### PR TITLE
Soil investigation Phase 0 — model, provenance, registry, store

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1227,3 +1227,93 @@ means moving the solver behind an authenticated API. The header of
 **Not verifiable here:** a real sign-in round trip, since this environment has
 no Supabase project. Everything up to the network call is tested; the call
 itself needs your keys.
+---
+
+# Soil Investigation module — Phase 0 shipped
+
+A geotechnical investigation-management module: enter a site investigation once
+(boreholes, layers, samples, field and laboratory tests), interpret design
+parameters from it, and feed those into the analysis engines that already exist
+rather than retyping soil properties on every calculator page.
+
+## The architectural decision, and its cost
+
+The module was specified against a ~30-table Postgres schema. **This repo has no
+database.** `supabase/` contains only the billing webhook function — no
+`migrations/`, no tables; Supabase is used for auth only, and every project in
+the app (schedules, models) persists to localStorage.
+
+So Phase 0 builds the model on `engine/soils/store.ts`, a versioned key-value
+store over a swappable `StorageBackend` — the same arrangement the scheduling
+module has been running on. Designing thirty tables plus RLS policies against a
+schema that will still move as the laboratory engines land means writing
+migrations for guesses.
+
+**The cost is real:** until the backend swap lands (Phase 8), an investigation
+lives in one browser on one machine, and laboratory data is expensive to
+re-enter. `exportJSON` is the backup mechanism, not a convenience, and the UI
+must treat it that way.
+
+## What Phase 0 contains (no UI)
+
+| Module | Role |
+|---|---|
+| `soils/model.ts` | Investigation → Borehole → Layer → Sample → LabTest, plus SPT. JSON-serialisable throughout. |
+| `soils/provenance.ts` | `measured` / `derived` / `correlated` / `assumed` as a discriminated union on every parameter value. |
+| `soils/registry.ts` | 21 calculations declared with equation, units, symbols, assumptions, limitations and source — *before* they are implemented. |
+| `soils/standards.ts` | 25 ASTM/AASHTO designations as a typed const. |
+| `soils/store.ts` | Versioned persistence + JSON import/export. |
+| `soils/validate.ts` | Integrity rules that report and never repair. |
+| `soils/sample.ts` | A valid two-borehole Baguio City fixture. |
+
+## Three decisions worth not re-litigating
+
+**Provenance is on the value, not in a parallel result type.** `φ = 32°` from a
+triaxial, from an SPT correlation, and from Friday-afternoon judgement carry
+different confidence and different liability, and once all three render as "32°"
+the difference is gone — including from the engineer defending the report two
+years later. Retrofitting this across thirty engines later would not happen, so
+it is in from day one. The proposed `CalculationResult<T>` was dropped: the
+existing `SolutionStep[]` convention already carries method, clause, substituted
+inputs and pass/fail, and renders to both screen and PDF.
+
+**`engineering_standards` is a const, not a table.** The goal behind it — one
+place to change a designation, no string literals in forty modules — is right; a
+table is the wrong mechanism client-side. `StandardId` derives from the object,
+so a mistyped citation fails to compile.
+
+**Validation reports, never repairs.** A gap between 4.20 m and 4.50 m is either
+a logging error or an unrecovered run, and only whoever was on the rig knows
+which. Errors are the impossible (PL > LL, overlapping layers, groundwater below
+the hole); warnings are the merely unusual (N = 2, 33% recovery, a gap) —
+because flagging the unusual as an error trains people to ignore errors.
+
+## Guards that will bite on later phases
+
+- Every correlation must state a reference AND at least one limitation. A
+  correlation without a stated range of validity reads exactly like a
+  measurement — the most dangerous thing this module could ship.
+- Every symbol in a registry equation must appear in its symbol table.
+- Every registry equation must survive `texToPlain` with no stray commands.
+- The clean fixture must validate with zero errors *and* zero warnings.
+- Route-carrying phases also hit `docsContent.test.ts` (every route needs a docs
+  entry) and `featureGate.ts` (`ROUTE_FEATURE` key-set equality).
+
+## Remaining phases
+
+1. **Classification** — Atterberg, sieve (D10/D30/D60, Cu, Cc), USCS D2487,
+   AASHTO, plasticity chart, grain-size curve.
+2. **SPT** — N60 corrections, (N₁)₆₀, correlation library (every entry tagged
+   `correlated` with its source).
+3. **Investigation UI** — borehole page, graphical log column, profile editor.
+4. **Laboratory suite** — moisture, Gs, compaction, direct shear, UCS, triaxial,
+   consolidation, permeability, CBR.
+5. **Parameter engine + wiring** — one parameter table per layer feeding the
+   existing bearing/settlement/slope/earth-pressure/pile pages. *The payoff
+   phase; everything before it is data entry.*
+6. **Engine gaps** — liquefaction (NCEER, can consume PGA from `nscpSeismic`),
+   bearing depth/inclination factors and method selection, Coulomb.
+7. **Report** — the 22-section document builder on `pdfKit` chrome.
+8. **Postgres, CPT, 3D subsurface.**
+
+**Open for the user:** which plan tier gates this (suggest `pro`+).

--- a/webapp/src/engine/soils/model.ts
+++ b/webapp/src/engine/soils/model.ts
@@ -1,0 +1,344 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Soil-investigation data model. Layer 1 (schema) for the geotechnical
+// investigation module.
+//
+// Pure, JSON-serialisable types shared by the classification, field-test,
+// laboratory and parameter engines and by the UI. The whole investigation
+// round-trips through `JSON.stringify` unchanged, which is what lets `store.ts`
+// keep it in localStorage today and in Postgres later without the model moving.
+//
+// HIERARCHY
+//
+//     Investigation
+//       └── Borehole            (or trial pit / CPT sounding)
+//             ├── SoilLayer     (stratigraphy — what the ground IS)
+//             ├── Sample        (what was taken out of it)
+//             │     └── LabTest (what was measured on the sample)
+//             └── SptTest       (measured in the hole, not on a sample)
+//
+// Samples hang off the BOREHOLE and reference a layer, rather than hanging off
+// the layer. A sample recovered across a stratigraphic boundary belongs to the
+// hole at a depth, not to one layer, and forcing it under a layer would make
+// the boundary un-editable afterwards — re-picking a contact would orphan
+// laboratory data that is far more expensive than the interpretation.
+//
+// MEASUREMENTS ARE STORED, RESULTS ARE COMPUTED. Every test keeps the numbers
+// that were read off the apparatus. Water content is not stored; the container,
+// wet and dry masses are, and w is computed from them. This costs a little
+// space and buys the ability to re-derive everything when a correction
+// methodology changes — the same reason `spt.blows` keeps all three increments
+// instead of only N₆₀.
+//
+// UNITS (stated once, at the module boundary, per CLAUDE.md):
+//   depth, elevation, length  m
+//   masses                    g
+//   unit weight               kN/m³
+//   stress, strength, modulus kPa
+//   permeability              m/s
+//   angles                    degrees
+//   percentages               0–100 (not 0–1)
+//   dates                     ISO 'YYYY-MM-DD'
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { SourcedValue } from './provenance'
+import type { StandardId } from './standards'
+
+// ── Investigation ─────────────────────────────────────────────────────────
+
+export type InvestigationStatus =
+  | 'draft'
+  | 'fieldwork'
+  | 'laboratory'
+  | 'analysis'
+  | 'review'
+  | 'completed'
+
+export interface SiteInfo {
+  projectName: string
+  client?: string
+  location?: string
+  /** Decimal degrees, WGS-84. */
+  latitude?: number
+  longitude?: number
+  /** Site datum elevation, m. */
+  elevation?: number
+  description?: string
+  /** Free-text notes on topography, access, existing structures. */
+  existingConditions?: string
+}
+
+export interface InvestigationMeta {
+  /** Investigation reference, e.g. 'SI-2026-014'. */
+  investigationNo: string
+  title: string
+  site: SiteInfo
+  consultant?: string
+  engineer?: string
+  organisation?: string
+  /** ISO dates. */
+  investigationDate?: string
+  reportDate?: string
+  status: InvestigationStatus
+}
+
+export interface Investigation {
+  meta: InvestigationMeta
+  boreholes: Borehole[]
+  /** Interpreted design parameters per layer (Phase 5 fills these). */
+  parameters: LayerParameters[]
+  /** Free-text observations that belong to the investigation, not one hole. */
+  fieldObservations?: string
+}
+
+// ── Borehole ──────────────────────────────────────────────────────────────
+
+export type ExplorationKind = 'borehole' | 'trial-pit' | 'cpt' | 'cptu' | 'hand-auger'
+
+export type DrillingMethod =
+  | 'rotary-wash' | 'hollow-stem-auger' | 'solid-flight-auger'
+  | 'percussion' | 'hand-auger' | 'excavated'
+
+export interface Borehole {
+  id: string
+  /** Hole designation as it appears on the log, e.g. 'BH-01'. */
+  name: string
+  kind: ExplorationKind
+  latitude?: number
+  longitude?: number
+  /** Ground surface elevation at the hole, m. */
+  groundElevation?: number
+  plannedDepth?: number
+  /** Depth actually reached, m. */
+  actualDepth: number
+  /** Hole diameter, mm — feeds the SPT borehole-diameter correction C_B. */
+  diameter?: number
+  method?: DrillingMethod
+  startDate?: string
+  completionDate?: string
+  /** Depth to groundwater, m below ground. Absent ⇒ not encountered. */
+  groundwaterDepth?: number
+  /** Depth after the hole stabilised, when a second reading was taken. */
+  groundwaterDepthStabilised?: number
+  terminationReason?: string
+  remarks?: string
+
+  layers: SoilLayer[]
+  samples: Sample[]
+  spt: SptTest[]
+}
+
+// ── Stratigraphy ──────────────────────────────────────────────────────────
+
+export type Consistency =
+  | 'very-soft' | 'soft' | 'firm' | 'stiff' | 'very-stiff' | 'hard'
+
+export type Density =
+  | 'very-loose' | 'loose' | 'medium-dense' | 'dense' | 'very-dense'
+
+export type MoistureCondition = 'dry' | 'moist' | 'wet' | 'saturated'
+
+export interface SoilLayer {
+  id: string
+  /** Depth below ground to the top and base of the layer, m. */
+  depthTop: number
+  depthBottom: number
+  /**
+   * USCS group symbol once classified, e.g. 'SC'. Left blank until Phase 1
+   * classifies it — an unclassified layer is an honest state, and a guessed
+   * symbol is not.
+   */
+  symbol?: string
+  /** Descriptive name, e.g. 'Clayey Sand'. */
+  name: string
+  /** Full log description as it prints on the borehole log. */
+  description?: string
+  colour?: string
+  consistency?: Consistency
+  density?: Density
+  moisture?: MoistureCondition
+  remarks?: string
+}
+
+// ── Samples ───────────────────────────────────────────────────────────────
+
+export type SampleType =
+  | 'disturbed' | 'undisturbed' | 'split-spoon' | 'shelby-tube' | 'bulk' | 'core'
+
+export interface Sample {
+  id: string
+  /** Sample designation on the log, e.g. 'S-03'. */
+  name: string
+  /** Layer this sample is attributed to, when it sits within one. */
+  layerId?: string
+  type: SampleType
+  depthTop: number
+  depthBottom: number
+  standard?: StandardId
+  /** Length of sample recovered and length of the drive, m — recovery ratio. */
+  recoveryLength?: number
+  driveLength?: number
+  sampleDate?: string
+  remarks?: string
+  tests: LabTest[]
+}
+
+/** Recovery ratio as a percentage, or undefined when either length is absent. */
+export function recoveryRatio(s: Sample): number | undefined {
+  if (s.recoveryLength == null || !s.driveLength) return undefined
+  return (s.recoveryLength / s.driveLength) * 100
+}
+
+// ── Field tests: SPT ──────────────────────────────────────────────────────
+
+export type HammerType = 'donut' | 'safety' | 'automatic'
+export type SamplerType = 'standard' | 'liner-absent'
+
+/**
+ * One SPT at one depth. The three 150 mm increments are kept separately: N is
+ * the sum of the SECOND and THIRD, the first being the seating drive. Storing
+ * only N would make that convention un-auditable.
+ */
+export interface SptTest {
+  id: string
+  /** Depth to the top of the drive, m. */
+  depth: number
+  /** Blows for each 150 mm increment. Index 0 is the seating drive. */
+  blows: [number, number, number]
+  /**
+   * Penetration achieved in each increment, mm. Normally [150, 150, 150];
+   * a short increment means refusal, which the N-value must not hide.
+   */
+  penetration?: [number, number, number]
+  hammer?: HammerType
+  /** Measured hammer energy ratio, %. Overrides the type default when given. */
+  energyRatio?: number
+  /** Rod length below the hammer, m — feeds C_R. */
+  rodLength?: number
+  sampler?: SamplerType
+  /** Sample recovered from this drive, when one was kept. */
+  sampleId?: string
+  remarks?: string
+}
+
+/** Field N: the sum of the second and third increments (ASTM D1586). */
+export const fieldN = (t: SptTest): number => t.blows[1] + t.blows[2]
+
+/** True when any increment failed to reach 150 mm — refusal, N is a lower bound. */
+export const isRefusal = (t: SptTest): boolean =>
+  t.penetration != null && t.penetration.some((p) => p < 150)
+
+// ── Laboratory tests ──────────────────────────────────────────────────────
+
+export type LabTestType =
+  | 'moisture' | 'specific-gravity' | 'sieve' | 'hydrometer' | 'atterberg'
+  | 'compaction' | 'direct-shear' | 'triaxial' | 'ucs' | 'consolidation'
+  | 'permeability' | 'cbr' | 'swell'
+
+export type LabTestStatus = 'planned' | 'in-progress' | 'complete' | 'void'
+
+/**
+ * A laboratory test. `data` holds the raw measurements in a shape specific to
+ * the test type — the individual test engines (Phase 4) own those shapes and
+ * declare them; this layer only guarantees the envelope.
+ *
+ * A void test is kept rather than deleted. A specimen that failed on a seating
+ * error is part of the record, and silently removing it makes the sample look
+ * like it was tested once and passed.
+ */
+export interface LabTest {
+  id: string
+  type: LabTestType
+  standard: StandardId
+  status: LabTestStatus
+  testDate?: string
+  laboratory?: string
+  operator?: string
+  remarks?: string
+  /** Raw measurements, keyed by the owning test engine. */
+  data?: Record<string, unknown>
+}
+
+// ── Interpreted parameters ────────────────────────────────────────────────
+
+/**
+ * The design parameters for one layer — the single place downstream analysis
+ * reads from, so a value is entered or interpreted once rather than retyped
+ * into the bearing, settlement and slope pages separately.
+ *
+ * Every field is a `SourcedValue`, so the parameter table can show what each
+ * number rests on. That is the whole point of the module: not to produce
+ * parameters, but to produce parameters you can account for.
+ */
+export interface LayerParameters {
+  /** The layer these describe. Layers in different holes are correlated by the
+   *  engineer, so this points at ONE layer and the report says which hole. */
+  layerId: string
+  boreholeId: string
+
+  unitWeight?: SourcedValue
+  dryUnitWeight?: SourcedValue
+  saturatedUnitWeight?: SourcedValue
+
+  /** Total-stress parameters. */
+  cohesion?: SourcedValue
+  frictionAngle?: SourcedValue
+  /** Effective-stress parameters (c′, φ′). */
+  effectiveCohesion?: SourcedValue
+  effectiveFrictionAngle?: SourcedValue
+  undrainedShearStrength?: SourcedValue
+
+  youngsModulus?: SourcedValue
+  poissonRatio?: SourcedValue
+
+  compressionIndex?: SourcedValue
+  recompressionIndex?: SourcedValue
+  preconsolidationPressure?: SourcedValue
+  coefficientOfConsolidation?: SourcedValue
+
+  permeability?: SourcedValue
+  relativeDensity?: SourcedValue
+  voidRatio?: SourcedValue
+  specificGravity?: SourcedValue
+}
+
+/** Every populated parameter on a layer, for provenance summaries. */
+export function parameterValues(p: LayerParameters): SourcedValue[] {
+  const { layerId: _l, boreholeId: _b, ...rest } = p
+  return Object.values(rest).filter((v): v is SourcedValue => v != null)
+}
+
+// ── Derived views ─────────────────────────────────────────────────────────
+
+/** Layer thickness, m. */
+export const layerThickness = (l: SoilLayer): number => l.depthBottom - l.depthTop
+
+/** Elevation of a depth in a hole, or undefined when the collar is unsurveyed. */
+export function elevationAt(bh: Borehole, depth: number): number | undefined {
+  return bh.groundElevation == null ? undefined : bh.groundElevation - depth
+}
+
+/** The layer containing a depth, or undefined above/below the logged profile.
+ *  A depth on a contact belongs to the LOWER layer, matching how a log reads. */
+export function layerAtDepth(bh: Borehole, depth: number): SoilLayer | undefined {
+  return bh.layers.find((l) => depth >= l.depthTop && depth < l.depthBottom)
+    ?? bh.layers.find((l) => depth === l.depthBottom && l === bh.layers[bh.layers.length - 1])
+}
+
+/** Every laboratory test in a hole, flattened with its sample. */
+export function boreholeTests(bh: Borehole): { sample: Sample; test: LabTest }[] {
+  return bh.samples.flatMap((sample) => sample.tests.map((test) => ({ sample, test })))
+}
+
+/** An empty investigation with sensible metadata. */
+export function emptyInvestigation(title = 'Untitled Investigation'): Investigation {
+  return {
+    meta: {
+      investigationNo: '',
+      title,
+      site: { projectName: '' },
+      status: 'draft',
+    },
+    boreholes: [],
+    parameters: [],
+  }
+}

--- a/webapp/src/engine/soils/provenance.test.ts
+++ b/webapp/src/engine/soils/provenance.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import {
+  measured, derived, correlated, assumed,
+  describeProvenance, isEvidenceBased, provenanceMix, standardsUsed,
+  type SourcedValue,
+} from './provenance'
+import { isCalcId } from './registry'
+import { isStandardId } from './standards'
+
+const phiMeasured = measured(31, '°', { testId: 't1', standard: 'd3080', sampleId: 'S-02' })
+const phiCorrelated = correlated(34, '°', {
+  basis: 'corrected SPT (N₁)₆₀ = 18',
+  source: 'Hatanaka & Uchida (1996)',
+  scatter: '±3°',
+})
+const piDerived = derived(23, '%', { calculation: 'atterberg.plasticity-index', from: ['LL', 'PL'] })
+const nuAssumed = assumed(0.3, '—', { rationale: 'Typical for a medium dense sand; no test available.' })
+
+describe('provenance describes where a value came from', () => {
+  it('names the standard for a measured value', () => {
+    expect(describeProvenance(phiMeasured.provenance))
+      .toBe('Measured — ASTM D3080 on sample S-02')
+  })
+
+  it('names the correlation AND its scatter', () => {
+    // A correlation quoted without its scatter reads far more precise than it
+    // is — which is exactly the misreading this module exists to prevent.
+    const text = describeProvenance(phiCorrelated.provenance)
+    expect(text).toContain('Hatanaka & Uchida (1996)')
+    expect(text).toContain('±3°')
+    expect(text.startsWith('Correlated')).toBe(true)
+  })
+
+  it('names the calculation for a derived value', () => {
+    expect(describeProvenance(piDerived.provenance))
+      .toBe('Derived — atterberg.plasticity-index from LL, PL')
+  })
+
+  it('requires a rationale for an assumption and prints it', () => {
+    expect(describeProvenance(nuAssumed.provenance)).toContain('no test available')
+  })
+
+  it('never returns an empty description for any kind', () => {
+    // A value whose provenance cannot be described is a bug; a blank would hide it.
+    const all = [phiMeasured, phiCorrelated, piDerived, nuAssumed]
+    for (const v of all) expect(describeProvenance(v.provenance).length).toBeGreaterThan(10)
+  })
+})
+
+describe('evidence', () => {
+  it('counts measured and derived as evidence-based, correlated and assumed as not', () => {
+    expect(isEvidenceBased(phiMeasured.provenance)).toBe(true)
+    expect(isEvidenceBased(piDerived.provenance)).toBe(true)
+    expect(isEvidenceBased(phiCorrelated.provenance)).toBe(false)
+    expect(isEvidenceBased(nuAssumed.provenance)).toBe(false)
+  })
+
+  it('summarises the mix across a parameter set', () => {
+    const mix = provenanceMix([phiMeasured, phiCorrelated, piDerived, nuAssumed, phiCorrelated])
+    expect(mix).toEqual({ measured: 1, derived: 1, correlated: 2, assumed: 1 })
+  })
+
+  it('lists the standards a set of values was measured to, without duplicates', () => {
+    const values: SourcedValue[] = [
+      phiMeasured,
+      measured(2.67, '—', { testId: 't2', standard: 'd854' }),
+      measured(29, '°', { testId: 't3', standard: 'd3080' }),
+      phiCorrelated,
+    ]
+    expect(standardsUsed(values)).toEqual(['d3080', 'd854'])
+  })
+})
+
+describe('provenance ids point at things that exist', () => {
+  it('a derived value names a real registry calculation', () => {
+    // Catches a typo'd calculation id, which would otherwise surface as a blank
+    // equation in a printed calculation sheet.
+    expect(isCalcId(piDerived.provenance.kind === 'derived' && piDerived.provenance.calculation)).toBe(true)
+  })
+
+  it('a measured value names a real standard', () => {
+    expect(isStandardId(phiMeasured.provenance.kind === 'measured' && phiMeasured.provenance.standard)).toBe(true)
+  })
+})
+
+describe('SourcedValue carries its own unit', () => {
+  it('so a parameter table can render without a lookup', () => {
+    expect(phiMeasured.unit).toBe('°')
+    expect(piDerived.unit).toBe('%')
+  })
+
+  it('round-trips through JSON — the model has to be storable', () => {
+    const back = JSON.parse(JSON.stringify(phiCorrelated)) as SourcedValue
+    expect(back).toEqual(phiCorrelated)
+    expect(describeProvenance(back.provenance)).toBe(describeProvenance(phiCorrelated.provenance))
+  })
+})

--- a/webapp/src/engine/soils/provenance.ts
+++ b/webapp/src/engine/soils/provenance.ts
@@ -1,0 +1,166 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Where a geotechnical parameter CAME FROM. Layer 8.
+//
+// This is the single most important type in the soil-investigation module, and
+// the reason is professional rather than technical.
+//
+// A report that prints
+//
+//     φ = 32°
+//
+// tells the reader nothing about whether that came out of a triaxial cell, out
+// of a correlation with SPT blow counts, or out of the engineer's judgement on
+// a Friday afternoon. Those three numbers carry wildly different confidence and
+// wildly different liability, and once they are all rendered as "32°" the
+// difference is gone forever — including from the engineer who has to defend
+// the report two years later.
+//
+// So every parameter that reaches an analysis carries its provenance, and the
+// report prints it. A CORRELATED value is not a defect; presenting one as if it
+// were MEASURED is.
+//
+// The four kinds are deliberately not ranked into a single "quality" number.
+// A well-run correlation on twenty SPT points can be worth more than one
+// unconsolidated-undrained triaxial on a disturbed sample, and collapsing that
+// into a score would hide exactly the judgement the reader needs to make.
+// ─────────────────────────────────────────────────────────────────────────
+
+import { type StandardId, cite } from './standards'
+
+export type ProvenanceKind = 'measured' | 'derived' | 'correlated' | 'assumed'
+
+/** Read directly off a field or laboratory test run to a standard. */
+export interface MeasuredProvenance {
+  kind: 'measured'
+  /** Id of the `LabTest` / field test the value was read from. */
+  testId: string
+  standard: StandardId
+  /** Sample the test was run on, when the value is sample-specific. */
+  sampleId?: string
+}
+
+/** Computed from other values by an exact relation — no empiricism involved. */
+export interface DerivedProvenance {
+  kind: 'derived'
+  /** Registry id of the calculation that produced it (see registry.ts). */
+  calculation: string
+  /** Ids or names of the inputs it was computed from. */
+  from: string[]
+}
+
+/**
+ * Estimated from an empirical correlation. `basis` says what it was correlated
+ * FROM (e.g. 'corrected SPT (N₁)₆₀ = 18'), `source` cites whose correlation.
+ * `scatter` records the spread the published correlation carries, because a
+ * correlation quoted without its scatter reads far more precise than it is.
+ */
+export interface CorrelatedProvenance {
+  kind: 'correlated'
+  basis: string
+  source: string
+  scatter?: string
+}
+
+/** Chosen by the engineer. Requires a rationale — no silent defaults. */
+export interface AssumedProvenance {
+  kind: 'assumed'
+  /** Who made the call (falls back to the report's preparer when blank). */
+  by?: string
+  rationale: string
+}
+
+export type Provenance =
+  | MeasuredProvenance
+  | DerivedProvenance
+  | CorrelatedProvenance
+  | AssumedProvenance
+
+/**
+ * A number that knows where it came from. `unit` is carried on the value rather
+ * than implied by the field name so a parameter table can render itself without
+ * a lookup, and so a unit change is a data change rather than a code change.
+ */
+export interface SourcedValue {
+  value: number
+  unit: string
+  provenance: Provenance
+  /** Free-text qualifier shown next to the value, e.g. 'mean of 3 tests'. */
+  note?: string
+}
+
+// ── Constructors ──────────────────────────────────────────────────────────
+// Named so a call site reads as a sentence: measured(32, '°', {...}).
+
+export const measured = (
+  value: number, unit: string, p: Omit<MeasuredProvenance, 'kind'>, note?: string,
+): SourcedValue => ({ value, unit, provenance: { kind: 'measured', ...p }, note })
+
+export const derived = (
+  value: number, unit: string, p: Omit<DerivedProvenance, 'kind'>, note?: string,
+): SourcedValue => ({ value, unit, provenance: { kind: 'derived', ...p }, note })
+
+export const correlated = (
+  value: number, unit: string, p: Omit<CorrelatedProvenance, 'kind'>, note?: string,
+): SourcedValue => ({ value, unit, provenance: { kind: 'correlated', ...p }, note })
+
+export const assumed = (
+  value: number, unit: string, p: Omit<AssumedProvenance, 'kind'>, note?: string,
+): SourcedValue => ({ value, unit, provenance: { kind: 'assumed', ...p }, note })
+
+// ── Presentation ──────────────────────────────────────────────────────────
+
+/** Short label for a table column. */
+export const PROVENANCE_LABEL: Record<ProvenanceKind, string> = {
+  measured: 'Measured',
+  derived: 'Derived',
+  correlated: 'Correlated',
+  assumed: 'Assumed',
+}
+
+/**
+ * One-line explanation of where a value came from, for the parameter table and
+ * the PDF footnote. Never returns an empty string — a value whose provenance
+ * cannot be described is a bug, and printing a blank would hide it.
+ */
+export function describeProvenance(p: Provenance): string {
+  switch (p.kind) {
+    case 'measured':
+      return `Measured — ${cite(p.standard)}${p.sampleId ? ` on sample ${p.sampleId}` : ''}`
+    case 'derived':
+      return `Derived — ${p.calculation}${p.from.length ? ` from ${p.from.join(', ')}` : ''}`
+    case 'correlated':
+      return `Correlated — from ${p.basis} (${p.source})${p.scatter ? `; scatter ${p.scatter}` : ''}`
+    case 'assumed':
+      return `Assumed${p.by ? ` by ${p.by}` : ''} — ${p.rationale}`
+  }
+}
+
+/**
+ * Whether a value rests on a physical measurement of THIS soil, directly or
+ * through an exact derivation. Correlations and assumptions do not, however
+ * reasonable they are.
+ *
+ * Used to warn when an analysis is running entirely on estimated parameters —
+ * a legitimate thing to do at feasibility stage, and a legitimate thing to be
+ * told about before the foundation is poured.
+ */
+export const isEvidenceBased = (p: Provenance): boolean =>
+  p.kind === 'measured' || p.kind === 'derived'
+
+/** Count each kind across a set of values, for a report summary. */
+export function provenanceMix(values: SourcedValue[]): Record<ProvenanceKind, number> {
+  const mix: Record<ProvenanceKind, number> = { measured: 0, derived: 0, correlated: 0, assumed: 0 }
+  for (const v of values) mix[v.provenance.kind] += 1
+  return mix
+}
+
+/**
+ * Every distinct standard a set of values was measured to — the input to a
+ * report's "tests performed" list, in catalogue order rather than insertion
+ * order so two runs of the same investigation list them identically.
+ */
+export function standardsUsed(values: SourcedValue[]): StandardId[] {
+  const ids = new Set<StandardId>()
+  for (const v of values) if (v.provenance.kind === 'measured') ids.add(v.provenance.standard)
+  return [...ids].sort()
+}

--- a/webapp/src/engine/soils/registry.test.ts
+++ b/webapp/src/engine/soils/registry.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CALCULATIONS, type CalcId, calc, isCalcId,
+  calculationsIn, limitationsOf, assumptionsOf,
+} from './registry'
+import { STANDARDS, type StandardId, cite, citeFull, isStandardId, standardsByCategory } from './standards'
+import { texToPlain } from '../../lib/texText'
+
+const IDS = Object.keys(CALCULATIONS) as CalcId[]
+const STANDARD_IDS = Object.keys(STANDARDS) as StandardId[]
+
+// ─────────────────────────────────────────────────────────────────────────
+// The registry is a promise: every calculation this module performs is
+// declared with its equation, units, assumptions and source BEFORE it is
+// implemented. These tests are what keep that promise honest as entries are
+// added — an entry that skips its reference or its symbol table fails here
+// rather than surfacing as a blank line in a printed calculation sheet.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('every registry entry is fully described', () => {
+  it('has entries to check', () => {
+    expect(IDS.length).toBeGreaterThan(15)
+  })
+
+  it.each(IDS)('%s — title, equation, unit and symbols', (id) => {
+    const e = calc(id)
+    expect(e.title.length, 'title').toBeGreaterThan(3)
+    expect(e.equation.length, 'equation').toBeGreaterThan(5)
+    expect(e.unit.length, 'unit').toBeGreaterThan(0)
+    expect(Object.keys(e.symbols).length, 'symbols').toBeGreaterThan(0)
+  })
+
+  it.each(IDS)('%s — cites a standard or a published reference', (id) => {
+    // A formula with no source is exactly the "opaque collection of formulas"
+    // this registry exists to prevent.
+    const e = calc(id)
+    expect(e.standard ?? e.reference, `${id} has neither a standard nor a reference`).toBeTruthy()
+    if (e.standard) expect(isStandardId(e.standard)).toBe(true)
+  })
+
+  it.each(IDS)('%s — every symbol description states its units', (id) => {
+    // "mass of water" is not enough; "mass of water, g" is. A genuinely
+    // dimensionless quantity says so by being a coefficient/index/ratio.
+    const HAS_UNIT = /,\s*[^,]*(%|\bg\b|\bmm\b|\bm\b|mm²|m²|m³|m\/s|kPa|MPa|kN\/m³|\bN\b|degrees|blows|°C)\s*$/i
+    const DIMENSIONLESS = /\b(coefficient|index|ratio|factor|correction|specific gravity|group symbol|strain)\b/i
+    for (const [sym, desc] of Object.entries(calc(id).symbols)) {
+      expect(desc.length, `${id}/${sym}`).toBeGreaterThan(5)
+      expect(
+        HAS_UNIT.test(desc) || DIMENSIONLESS.test(desc),
+        `${id}/${sym}: "${desc}" states neither a unit nor that it is dimensionless`,
+      ).toBe(true)
+    }
+  })
+
+  it.each(IDS)('%s — the equation converts cleanly for the PDF', (id) => {
+    // Registry equations are printed in calculation sheets through texToPlain.
+    // A stray command would print as a gap, so it is caught here.
+    const plain = texToPlain(calc(id).equation)
+    expect(plain, id).not.toMatch(/\\[a-zA-Z]/)
+    expect(plain.length, id).toBeGreaterThan(3)
+  })
+
+  it('every symbol used in an equation appears in the symbol table', () => {
+    // Guards the common drift: an equation gains a term and the nomenclature
+    // block silently stops explaining it.
+    const missing: string[] = []
+    for (const id of IDS) {
+      const e = calc(id)
+      // Parentheses too, so '(N_1)_{60}' reduces to the root N.
+      const declared = Object.keys(e.symbols).map((s) => s.replace(/[\\{}()]/g, ''))
+      // Root symbols only — a subscripted variant is covered by its root.
+      const roots = new Set(declared.map((d) => d.split('_')[0]).filter(Boolean))
+      const used = [...e.equation.matchAll(/(?<![\\a-zA-Z])([A-Za-z]{1,3})_\{?/g)].map((m) => m[1])
+      for (const u of used) {
+        if (!roots.has(u) && !['log', 'tan', 'sin', 'cos', 'text', 'frac', 'sum', 'le'].includes(u)) {
+          missing.push(`${id}: ${u}`)
+        }
+      }
+    }
+    expect(missing).toEqual([])
+  })
+})
+
+describe('correlations carry their caveats', () => {
+  const correlations = calculationsIn('correlation')
+
+  it('there are correlations registered', () => {
+    expect(correlations.length).toBeGreaterThanOrEqual(4)
+  })
+
+  it.each(correlations)('%s — states a reference and at least one limitation', (id) => {
+    // A correlation without a stated range of validity is the single most
+    // dangerous thing this module could ship: it reads exactly like a
+    // measurement. Every one must say where it stops holding.
+    const e = calc(id)
+    expect(e.reference, `${id} must name whose correlation it is`).toBeTruthy()
+    expect(e.limitations?.length ?? 0, `${id} must state its limitations`).toBeGreaterThan(0)
+  })
+
+  it('names the scatter or applicability, not just the formula', () => {
+    const text = correlations.flatMap((id) => calc(id).limitations ?? []).join(' ')
+    expect(text).toMatch(/scatter|±|ranges|not applicable|outside the data|read high/i)
+  })
+})
+
+describe('limitation and assumption aggregation', () => {
+  it('de-duplicates across calculations', () => {
+    const ids: CalcId[] = ['correlation.phi-from-n60', 'correlation.phi-from-n60', 'ucs.undrained-strength']
+    const lims = limitationsOf(ids)
+    expect(new Set(lims).size).toBe(lims.length)
+    expect(lims.length).toBeGreaterThan(2)
+  })
+
+  it('returns an empty list for entries that declare none', () => {
+    expect(limitationsOf(['uscs.a-line'])).toEqual([])
+    expect(assumptionsOf(['uscs.a-line'])).toEqual([])
+  })
+
+  it('collects the assumption behind cu = qu/2, which is the one that bites', () => {
+    const a = assumptionsOf(['ucs.undrained-strength']).join(' ')
+    expect(a).toMatch(/saturated cohesive/i)
+    expect(limitationsOf(['ucs.undrained-strength']).join(' ')).toMatch(/granular|fissured/i)
+  })
+})
+
+describe('id guards', () => {
+  it('recognises real ids and rejects invented ones', () => {
+    expect(isCalcId('spt.n60')).toBe(true)
+    expect(isCalcId('spt.n61')).toBe(false)
+    expect(isCalcId(42)).toBe(false)
+  })
+
+  it('categories partition the registry', () => {
+    const cats = ['index', 'classification', 'field', 'strength', 'consolidation', 'correlation', 'analysis'] as const
+    const total = cats.reduce((n, c) => n + calculationsIn(c).length, 0)
+    expect(total).toBe(IDS.length)
+  })
+})
+
+describe('standards catalogue', () => {
+  it.each(STANDARD_IDS)('%s — designation, title and body', (id) => {
+    const s = STANDARDS[id]
+    expect(s.designation).toMatch(/^(ASTM|AASHTO|BS|ISO|NSCP|PNS)\s/)
+    expect(s.title.length).toBeGreaterThan(15)
+  })
+
+  it('renders a short citation and a full one', () => {
+    expect(cite('d4318')).toBe('ASTM D4318')
+    expect(citeFull('d4318')).toContain('Liquid Limit')
+  })
+
+  it('has no duplicate designations', () => {
+    const designations = STANDARD_IDS.map((id) => STANDARDS[id].designation)
+    expect(new Set(designations).size).toBe(designations.length)
+  })
+
+  it('groups by category', () => {
+    expect(standardsByCategory('classification').map((s) => s.designation)).toContain('ASTM D2487')
+    expect(standardsByCategory('field').map((s) => s.designation)).toContain('ASTM D1586')
+  })
+
+  it('rejects an id that is not in the catalogue', () => {
+    expect(isStandardId('d9999')).toBe(false)
+    expect(isStandardId(undefined)).toBe(false)
+  })
+})

--- a/webapp/src/engine/soils/registry.ts
+++ b/webapp/src/engine/soils/registry.ts
@@ -1,0 +1,422 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Calculation registry for the soil-investigation module. Layer 8.
+//
+// One declared entry per calculation the module performs: the equation, its
+// units, what it assumes, where it stops being valid, and what it is taken
+// from. Registered BEFORE the calculation is implemented, so the reference is
+// something the code was written against rather than something reconstructed
+// afterwards.
+//
+// Three jobs:
+//
+//  1. `DerivedProvenance.calculation` points at a registry id, so a derived
+//     parameter can print the equation that made it without the report layer
+//     knowing anything about geotechnics.
+//  2. `limitations` are the conditions the formula stops holding under. These
+//     become runtime warnings, which is the difference between a tool that
+//     computes q_u/2 and one that says "c_u ≈ q_u/2 assumes a saturated
+//     cohesive soil; this layer classifies as SM".
+//  3. Every entry needs a matching `docs/ValidationMap.md` row before its
+//     engine ships (CLAUDE.md L9), and the test in this module's suite pins
+//     that the ids stay unique and fully described.
+//
+// The registry is data, not behaviour. It deliberately does NOT hold the
+// implementing function: a formula string that has drifted from the code is
+// worse than no formula string, so the two are kept apart and each engine's
+// own test is what ties its output to the reference.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { StandardId } from './standards'
+
+export type CalcCategory =
+  | 'index' | 'classification' | 'field' | 'strength'
+  | 'consolidation' | 'correlation' | 'analysis'
+
+export interface CalcEntry {
+  /** Human title as it appears in a calculation sheet heading. */
+  title: string
+  category: CalcCategory
+  /**
+   * The equation in KaTeX, symbols only — the substituted form is built by the
+   * worked-solution builder at run time from real values.
+   */
+  equation: string
+  /** Result units, in the module convention (see model.ts). */
+  unit: string
+  /** What each symbol means, so a sheet can print a nomenclature block. */
+  symbols: Record<string, string>
+  /** Standard the procedure comes from, when it is a standardised test. */
+  standard?: StandardId
+  /** Textbook or paper the relation is taken from, when it is not a standard. */
+  reference?: string
+  /** Conditions taken as true without checking. */
+  assumptions?: string[]
+  /** Conditions the relation stops holding under — these become warnings. */
+  limitations?: string[]
+}
+
+/**
+ * Keys are stable ids stored inside investigation JSON as
+ * `DerivedProvenance.calculation`. Renaming one is a breaking change.
+ */
+export const CALCULATIONS = {
+  // ── Index properties ──
+  'moisture.water-content': {
+    title: 'Water content',
+    category: 'index',
+    equation: String.raw`w = \frac{M_w}{M_s} \times 100 = \frac{M_{wet} - M_{dry}}{M_{dry} - M_{can}} \times 100`,
+    unit: '%',
+    symbols: {
+      w: 'water content, %',
+      M_w: 'mass of water, g',
+      M_s: 'mass of dry solids, g',
+      'M_{wet}': 'mass of can + wet soil, g',
+      'M_{dry}': 'mass of can + dry soil, g',
+      'M_{can}': 'mass of the empty can, g',
+    },
+    standard: 'd2216',
+    assumptions: ['Oven-drying at 110 ± 5 °C removes free water only.'],
+    limitations: [
+      'Organic soils and soils with gypsum lose structural water at 110 °C — dry at 60 °C and say so.',
+    ],
+  },
+
+  'gs.specific-gravity': {
+    title: 'Specific gravity of solids',
+    category: 'index',
+    equation: String.raw`G_s = \frac{M_s}{M_s + (M_{pw} - M_{pws})} \cdot K`,
+    unit: '—',
+    symbols: {
+      G_s: 'specific gravity of solids at 20 °C',
+      M_s: 'mass of dry solids, g',
+      'M_{pw}': 'mass of pycnometer + water, g',
+      'M_{pws}': 'mass of pycnometer + water + solids, g',
+      K: 'temperature correction to 20 °C',
+    },
+    standard: 'd854',
+    limitations: ['De-airing is the dominant error source; an under-de-aired run reads low.'],
+  },
+
+  'sieve.percent-passing': {
+    title: 'Percent passing',
+    category: 'index',
+    equation: String.raw`P_i = 100 - \frac{\sum_{k \le i} M_k}{M_{total}} \times 100`,
+    unit: '%',
+    symbols: {
+      P_i: 'percent passing sieve i, %',
+      M_k: 'mass retained on sieve k, g',
+      'M_{total}': 'total dry mass of the specimen, g',
+    },
+    standard: 'd6913',
+    limitations: [
+      'Masses must close on the total within 1%; a larger loss invalidates the grading.',
+    ],
+  },
+
+  'sieve.uniformity': {
+    title: 'Coefficient of uniformity',
+    category: 'index',
+    equation: String.raw`C_u = \frac{D_{60}}{D_{10}}`,
+    unit: '—',
+    symbols: {
+      C_u: 'coefficient of uniformity',
+      'D_{60}': 'grain size at 60% passing, mm',
+      'D_{10}': 'grain size at 10% passing, mm',
+    },
+    standard: 'd2487',
+    limitations: [
+      'Undefined when the curve does not reach 10% passing — a soil with more than 10% fines has no D₁₀ from sieving alone.',
+    ],
+  },
+
+  'sieve.curvature': {
+    title: 'Coefficient of curvature',
+    category: 'index',
+    equation: String.raw`C_c = \frac{D_{30}^2}{D_{10} \cdot D_{60}}`,
+    unit: '—',
+    symbols: {
+      C_c: 'coefficient of curvature',
+      'D_{30}': 'grain size at 30% passing, mm',
+      'D_{10}': 'grain size at 10% passing, mm',
+      'D_{60}': 'grain size at 60% passing, mm',
+    },
+    standard: 'd2487',
+  },
+
+  'atterberg.plasticity-index': {
+    title: 'Plasticity index',
+    category: 'index',
+    equation: String.raw`PI = LL - PL`,
+    unit: '%',
+    symbols: {
+      PI: 'plasticity index, %',
+      LL: 'liquid limit, %',
+      PL: 'plastic limit, %',
+    },
+    standard: 'd4318',
+    limitations: [
+      'A soil whose PL cannot be obtained is reported non-plastic (NP), not PI = 0.',
+    ],
+  },
+
+  'atterberg.liquidity-index': {
+    title: 'Liquidity index',
+    category: 'index',
+    equation: String.raw`LI = \frac{w - PL}{PI}`,
+    unit: '—',
+    symbols: {
+      LI: 'liquidity index',
+      w: 'natural water content, %',
+      PL: 'plastic limit, %',
+      PI: 'plasticity index, %',
+    },
+    reference: 'Terzaghi, Peck & Mesri, Soil Mechanics in Engineering Practice',
+    limitations: ['Meaningless for a non-plastic soil (PI = 0 divides by zero).'],
+  },
+
+  // ── Classification ──
+  'uscs.classify': {
+    title: 'USCS group symbol',
+    category: 'classification',
+    equation: String.raw`\text{fines, gradation } (C_u, C_c) \text{ and plasticity } (LL, PI) \Rightarrow \text{group symbol}`,
+    unit: '—',
+    symbols: {
+      'fines': 'percent passing the 0.075 mm (No. 200) sieve, %',
+      C_u: 'coefficient of uniformity',
+      C_c: 'coefficient of curvature',
+      LL: 'liquid limit, %',
+      PI: 'plasticity index, %',
+    },
+    standard: 'd2487',
+    assumptions: ['Gradation and plasticity are from the same specimen.'],
+    limitations: [
+      'D2487 classifies from laboratory data; a field description without tests is D2488 and carries a different confidence.',
+      'Borderline soils take a dual symbol — the classifier must not pick one silently.',
+    ],
+  },
+
+  'uscs.a-line': {
+    title: 'Casagrande A-line',
+    category: 'classification',
+    equation: String.raw`PI_{A} = 0.73\,(LL - 20)`,
+    unit: '%',
+    symbols: { PI_A: 'plasticity index on the A-line, %', LL: 'liquid limit, %' },
+    standard: 'd2487',
+  },
+
+  'uscs.u-line': {
+    title: 'Casagrande U-line (upper bound)',
+    category: 'classification',
+    equation: String.raw`PI_{U} = 0.9\,(LL - 8)`,
+    unit: '%',
+    symbols: { PI_U: 'plasticity index on the U-line, %', LL: 'liquid limit, %' },
+    standard: 'd2487',
+    limitations: [
+      'A point plotting above the U-line is not a soil type — it is a testing error, and should be re-run rather than classified.',
+    ],
+  },
+
+  // ── Field: SPT ──
+  'spt.n60': {
+    title: 'Energy-corrected SPT blow count',
+    category: 'field',
+    equation: String.raw`N_{60} = N \cdot \frac{E_R}{60} \cdot C_B \cdot C_S \cdot C_R`,
+    unit: 'blows/300 mm',
+    symbols: {
+      'N_{60}': 'blow count at 60% energy ratio, blows/300 mm',
+      N: 'field blow count (2nd + 3rd increments), blows/300 mm',
+      E_R: 'hammer energy ratio, %',
+      C_B: 'borehole-diameter correction',
+      C_S: 'sampler correction',
+      C_R: 'rod-length correction',
+    },
+    standard: 'd1586',
+    reference: 'Skempton (1986); Youd et al. (2001) NCEER',
+    assumptions: ['Energy ratio is the measured value when given, otherwise a hammer-type default.'],
+    limitations: [
+      'Hammer-type defaults span a wide range in practice — a measured E_R is worth far more than the correction it replaces.',
+      'Refusal blow counts are a lower bound; correcting one does not make it a measurement.',
+    ],
+  },
+
+  'spt.n1-60': {
+    title: 'Overburden-corrected SPT blow count',
+    category: 'field',
+    equation: String.raw`(N_1)_{60} = C_N \cdot N_{60}, \qquad C_N = \sqrt{\frac{P_a}{\sigma'_{v0}}} \le 1.7`,
+    unit: 'blows/300 mm',
+    symbols: {
+      '(N_1)_{60}': 'blow count corrected to 100 kPa effective overburden, blows/300 mm',
+      C_N: 'overburden correction factor',
+      P_a: 'atmospheric pressure, 100 kPa',
+      "\\sigma'_{v0}": 'effective vertical stress at the test depth, kPa',
+    },
+    reference: 'Liao & Whitman (1986); capped per Youd et al. (2001)',
+    limitations: [
+      'Applies to granular soils. Correcting a clay N-value for overburden is not meaningful.',
+      'C_N is capped at 1.7 — shallow tests would otherwise be inflated without limit.',
+    ],
+  },
+
+  // ── Strength ──
+  'ucs.qu': {
+    title: 'Unconfined compressive strength',
+    category: 'strength',
+    equation: String.raw`q_u = \frac{P}{A_c}, \qquad A_c = \frac{A_0}{1 - \varepsilon}`,
+    unit: 'kPa',
+    symbols: {
+      q_u: 'unconfined compressive strength, kPa',
+      P: 'axial load at failure, N',
+      A_c: 'corrected cross-sectional area, mm²',
+      A_0: 'initial area, mm²',
+      '\\varepsilon': 'axial strain at failure',
+    },
+    standard: 'd2166',
+    assumptions: ['The specimen deforms as a right cylinder (area correction).'],
+  },
+
+  'ucs.undrained-strength': {
+    title: 'Undrained shear strength from UCS',
+    category: 'strength',
+    equation: String.raw`c_u = \frac{q_u}{2}`,
+    unit: 'kPa',
+    symbols: { c_u: 'undrained shear strength, kPa', q_u: 'unconfined compressive strength, kPa' },
+    standard: 'd2166',
+    assumptions: ['Saturated cohesive soil under φ = 0 conditions (total-stress Mohr circle through the origin).'],
+    limitations: [
+      'Not valid for fissured, partly saturated or granular soils — the assumption φ = 0 fails and c_u comes out unconservative.',
+      'A UCS on a disturbed specimen underestimates in-situ strength; sample quality governs.',
+    ],
+  },
+
+  'directshear.envelope': {
+    title: 'Mohr–Coulomb failure envelope',
+    category: 'strength',
+    equation: String.raw`\tau_f = c' + \sigma'_n \tan\phi'`,
+    unit: 'kPa',
+    symbols: {
+      '\\tau_f': 'shear stress at failure, kPa',
+      "c'": 'effective cohesion intercept, kPa',
+      "\\sigma'_n": 'effective normal stress, kPa',
+      "\\phi'": 'effective friction angle, degrees',
+    },
+    standard: 'd3080',
+    assumptions: ['Failure envelope is linear over the tested stress range.'],
+    limitations: [
+      'c′ and φ′ are only valid over the normal stresses tested — extrapolating to a much higher footing stress overestimates strength.',
+      'A negative fitted cohesion is a fitting artefact, not a soil property; report c′ = 0.',
+    ],
+  },
+
+  // ── Consolidation ──
+  'consolidation.void-ratio': {
+    title: 'Void ratio from height change',
+    category: 'consolidation',
+    equation: String.raw`e = e_0 - \frac{\Delta H}{H_s}, \qquad H_s = \frac{M_s}{G_s \rho_w A}`,
+    unit: '—',
+    symbols: {
+      e: 'void ratio at the load step',
+      e_0: 'initial void ratio',
+      '\\Delta H': 'cumulative compression, mm',
+      H_s: 'equivalent height of solids, mm',
+      M_s: 'dry mass of the specimen, g',
+      G_s: 'specific gravity of solids',
+      A: 'specimen area, mm²',
+    },
+    standard: 'd2435',
+  },
+
+  'consolidation.cc': {
+    title: 'Compression index',
+    category: 'consolidation',
+    equation: String.raw`C_c = \frac{e_1 - e_2}{\log_{10}(\sigma'_2 / \sigma'_1)}`,
+    unit: '—',
+    symbols: {
+      C_c: 'compression index (virgin branch)',
+      e_1: 'void ratio at σ′₁',
+      e_2: 'void ratio at σ′₂',
+      "\\sigma'": 'effective vertical stress, kPa',
+    },
+    standard: 'd2435',
+    limitations: ['Taken on the straight virgin portion only — points below σ′_p give C_r, not C_c.'],
+  },
+
+  // ── Correlations (never presented as measurements) ──
+  'correlation.phi-from-n60': {
+    title: 'Friction angle from corrected SPT',
+    category: 'correlation',
+    equation: String.raw`\phi' = \sqrt{20\,(N_1)_{60}} + 20`,
+    unit: 'degrees',
+    symbols: { "\\phi'": 'effective friction angle, degrees', '(N_1)_{60}': 'corrected blow count, blows/300 mm' },
+    reference: 'Hatanaka & Uchida (1996)',
+    limitations: [
+      'Clean sands only. Applying it to silty or clayey soil is outside the data it was fitted to.',
+      'Scatter of roughly ±3° — a correlated φ′ should never be quoted to a decimal place.',
+    ],
+  },
+
+  'correlation.dr-from-n60': {
+    title: 'Relative density from corrected SPT',
+    category: 'correlation',
+    equation: String.raw`D_r = \sqrt{\frac{(N_1)_{60}}{60}} \times 100`,
+    unit: '%',
+    symbols: { D_r: 'relative density, %', '(N_1)_{60}': 'corrected blow count, blows/300 mm' },
+    reference: 'Skempton (1986), normally consolidated clean sand',
+    limitations: [
+      'Fitted to normally consolidated clean sand; overconsolidated or aged deposits read high.',
+    ],
+  },
+
+  'correlation.cu-from-n60': {
+    title: 'Undrained shear strength from SPT',
+    category: 'correlation',
+    equation: String.raw`c_u \approx 6\,N_{60}`,
+    unit: 'kPa',
+    symbols: { c_u: 'undrained shear strength, kPa', 'N_{60}': 'energy-corrected blow count, blows/300 mm' },
+    reference: 'Stroud (1974), for plasticity index around 20–30%',
+    limitations: [
+      'The coefficient ranges from about 4 to 6 with plasticity — this is an order-of-magnitude estimate.',
+      'SPT in soft clay is a poor test outright; prefer a vane, a UCS or a triaxial where one exists.',
+    ],
+  },
+
+  'correlation.cc-from-ll': {
+    title: 'Compression index from liquid limit',
+    category: 'correlation',
+    equation: String.raw`C_c = 0.009\,(LL - 10)`,
+    unit: '—',
+    symbols: { C_c: 'compression index', LL: 'liquid limit, %' },
+    reference: 'Terzaghi & Peck (1967), normally consolidated clays of moderate sensitivity',
+    limitations: [
+      'Terzaghi & Peck quote roughly ±30% — settlement from a correlated C_c carries that error straight through.',
+      'Not applicable to organic, sensitive or overconsolidated clays.',
+    ],
+  },
+} as const satisfies Record<string, CalcEntry>
+
+export type CalcId = keyof typeof CALCULATIONS
+
+export const calc = (id: CalcId): CalcEntry => CALCULATIONS[id]
+
+export const isCalcId = (v: unknown): v is CalcId =>
+  typeof v === 'string' && v in CALCULATIONS
+
+export const calculationsIn = (category: CalcCategory): CalcId[] =>
+  (Object.keys(CALCULATIONS) as CalcId[]).filter((id) => calc(id).category === category)
+
+/**
+ * Every limitation carried by a set of calculations, de-duplicated. A report
+ * that used three correlations should print all three sets of caveats, once
+ * each, rather than burying them in the modules that applied them.
+ */
+export function limitationsOf(ids: CalcId[]): string[] {
+  const out = new Set<string>()
+  for (const id of ids) for (const l of calc(id).limitations ?? []) out.add(l)
+  return [...out]
+}
+
+/** Every assumption carried by a set of calculations, de-duplicated. */
+export function assumptionsOf(ids: CalcId[]): string[] {
+  const out = new Set<string>()
+  for (const id of ids) for (const a of calc(id).assumptions ?? []) out.add(a)
+  return [...out]
+}

--- a/webapp/src/engine/soils/sample.ts
+++ b/webapp/src/engine/soils/sample.ts
@@ -1,0 +1,163 @@
+// A realistic, VALID sample investigation — two boreholes on a Baguio City
+// site with a fill crust over soft clay over dense sand.
+//
+// Used as the seed for "load an example" in the UI and as the fixture the
+// validation tests measure against: the suite asserts this passes clean, then
+// breaks one field at a time. A fixture that already carries warnings would
+// make those tests unable to tell a new warning from an old one.
+
+import type { Investigation } from './model'
+
+export function sampleInvestigation(): Investigation {
+  return {
+    meta: {
+      investigationNo: 'SI-2026-014',
+      title: 'Geotechnical Investigation — 6-Storey Commercial Building',
+      site: {
+        projectName: 'ABC Commercial Building',
+        client: 'ABC Development Corp.',
+        location: 'Session Road, Baguio City',
+        latitude: 16.4108,
+        longitude: 120.5960,
+        elevation: 1_450,
+        description: 'Gently sloping corner lot, previously occupied by a two-storey structure since demolished.',
+        existingConditions: 'Slab-on-grade of the former structure remains over the northern half of the lot.',
+      },
+      consultant: '',
+      engineer: '',
+      investigationDate: '2026-06-15',
+      status: 'laboratory',
+    },
+    fieldObservations: 'Seepage observed at the base of the cut along the eastern boundary during fieldwork.',
+    boreholes: [
+      {
+        id: 'bh1',
+        name: 'BH-01',
+        kind: 'borehole',
+        latitude: 16.41082,
+        longitude: 120.59605,
+        groundElevation: 1_450.35,
+        plannedDepth: 20,
+        actualDepth: 20,
+        diameter: 100,
+        method: 'rotary-wash',
+        startDate: '2026-06-15',
+        completionDate: '2026-06-17',
+        groundwaterDepth: 7.8,
+        terminationReason: 'Planned depth reached in dense sand.',
+        layers: [
+          {
+            id: 'bh1-l1', depthTop: 0, depthBottom: 1.5, name: 'Fill',
+            description: 'Loose silty sand fill with brick and concrete fragments.',
+            colour: 'brown', density: 'loose', moisture: 'moist',
+          },
+          {
+            id: 'bh1-l2', depthTop: 1.5, depthBottom: 4.2, name: 'Silty Sand',
+            description: 'Medium dense silty fine to medium SAND, trace gravel.',
+            colour: 'light brown', density: 'medium-dense', moisture: 'moist',
+          },
+          {
+            id: 'bh1-l3', depthTop: 4.2, depthBottom: 8.5, name: 'Lean Clay',
+            description: 'Soft to firm lean CLAY with sand, occasional organic partings.',
+            colour: 'grey', consistency: 'soft', moisture: 'wet',
+          },
+          {
+            id: 'bh1-l4', depthTop: 8.5, depthBottom: 20, name: 'Poorly Graded Sand',
+            description: 'Dense to very dense poorly graded SAND, trace fines.',
+            colour: 'grey-brown', density: 'dense', moisture: 'saturated',
+          },
+        ],
+        samples: [
+          {
+            id: 'bh1-s1', name: 'S-01', layerId: 'bh1-l2', type: 'split-spoon',
+            depthTop: 1.5, depthBottom: 1.95, standard: 'd1586',
+            recoveryLength: 0.38, driveLength: 0.45, sampleDate: '2026-06-15',
+            tests: [
+              { id: 'bh1-s1-t1', type: 'moisture', standard: 'd2216', status: 'complete', testDate: '2026-06-18' },
+              { id: 'bh1-s1-t2', type: 'sieve', standard: 'd6913', status: 'complete', testDate: '2026-06-19' },
+            ],
+          },
+          {
+            id: 'bh1-s2', name: 'S-02', layerId: 'bh1-l3', type: 'shelby-tube',
+            depthTop: 5, depthBottom: 5.75, standard: 'd1587',
+            recoveryLength: 0.71, driveLength: 0.75, sampleDate: '2026-06-16',
+            tests: [
+              { id: 'bh1-s2-t1', type: 'moisture', standard: 'd2216', status: 'complete', testDate: '2026-06-18' },
+              { id: 'bh1-s2-t2', type: 'atterberg', standard: 'd4318', status: 'complete', testDate: '2026-06-19' },
+              { id: 'bh1-s2-t3', type: 'ucs', standard: 'd2166', status: 'complete', testDate: '2026-06-22' },
+              { id: 'bh1-s2-t4', type: 'consolidation', standard: 'd2435', status: 'in-progress' },
+            ],
+          },
+          {
+            id: 'bh1-s3', name: 'S-03', layerId: 'bh1-l4', type: 'split-spoon',
+            depthTop: 9, depthBottom: 9.45, standard: 'd1586',
+            recoveryLength: 0.3, driveLength: 0.45, sampleDate: '2026-06-16',
+            tests: [
+              { id: 'bh1-s3-t1', type: 'sieve', standard: 'd6913', status: 'complete', testDate: '2026-06-19' },
+            ],
+          },
+        ],
+        spt: [
+          { id: 'bh1-n1', depth: 1.5, blows: [3, 4, 4], penetration: [150, 150, 150], hammer: 'safety', rodLength: 3, sampleId: 'bh1-s1' },
+          { id: 'bh1-n2', depth: 3, blows: [5, 7, 7], penetration: [150, 150, 150], hammer: 'safety', rodLength: 4.5 },
+          { id: 'bh1-n3', depth: 4.5, blows: [1, 2, 2], penetration: [150, 150, 150], hammer: 'safety', rodLength: 6 },
+          { id: 'bh1-n4', depth: 6, blows: [1, 2, 3], penetration: [150, 150, 150], hammer: 'safety', rodLength: 7.5 },
+          { id: 'bh1-n5', depth: 9, blows: [12, 16, 19], penetration: [150, 150, 150], hammer: 'safety', rodLength: 10.5, sampleId: 'bh1-s3' },
+          { id: 'bh1-n6', depth: 12, blows: [15, 21, 24], penetration: [150, 150, 150], hammer: 'safety', rodLength: 13.5 },
+          { id: 'bh1-n7', depth: 15, blows: [18, 25, 28], penetration: [150, 150, 150], hammer: 'safety', rodLength: 16.5 },
+          { id: 'bh1-n8', depth: 18, blows: [22, 29, 33], penetration: [150, 150, 150], hammer: 'safety', rodLength: 19.5 },
+        ],
+      },
+      {
+        id: 'bh2',
+        name: 'BH-02',
+        kind: 'borehole',
+        latitude: 16.41075,
+        longitude: 120.59618,
+        groundElevation: 1_449.10,
+        plannedDepth: 20,
+        actualDepth: 20,
+        diameter: 100,
+        method: 'rotary-wash',
+        startDate: '2026-06-18',
+        completionDate: '2026-06-20',
+        groundwaterDepth: 7.2,
+        terminationReason: 'Planned depth reached in dense sand.',
+        layers: [
+          {
+            id: 'bh2-l1', depthTop: 0, depthBottom: 2.1, name: 'Fill',
+            description: 'Loose silty sand fill.', colour: 'brown', density: 'loose', moisture: 'moist',
+          },
+          {
+            id: 'bh2-l2', depthTop: 2.1, depthBottom: 9.4, name: 'Lean Clay',
+            description: 'Soft lean CLAY with sand.', colour: 'grey', consistency: 'soft', moisture: 'wet',
+          },
+          {
+            id: 'bh2-l3', depthTop: 9.4, depthBottom: 20, name: 'Poorly Graded Sand',
+            description: 'Dense poorly graded SAND.', colour: 'grey-brown', density: 'dense', moisture: 'saturated',
+          },
+        ],
+        samples: [
+          {
+            id: 'bh2-s1', name: 'S-01', layerId: 'bh2-l2', type: 'shelby-tube',
+            depthTop: 4, depthBottom: 4.75, standard: 'd1587',
+            recoveryLength: 0.68, driveLength: 0.75, sampleDate: '2026-06-18',
+            tests: [
+              { id: 'bh2-s1-t1', type: 'moisture', standard: 'd2216', status: 'complete', testDate: '2026-06-21' },
+              { id: 'bh2-s1-t2', type: 'atterberg', standard: 'd4318', status: 'complete', testDate: '2026-06-22' },
+              { id: 'bh2-s1-t3', type: 'triaxial', standard: 'd4767', status: 'planned' },
+            ],
+          },
+        ],
+        spt: [
+          { id: 'bh2-n1', depth: 1.5, blows: [2, 3, 4], penetration: [150, 150, 150], hammer: 'safety', rodLength: 3 },
+          { id: 'bh2-n2', depth: 4.5, blows: [1, 2, 2], penetration: [150, 150, 150], hammer: 'safety', rodLength: 6, sampleId: 'bh2-s1' },
+          { id: 'bh2-n3', depth: 7.5, blows: [2, 2, 3], penetration: [150, 150, 150], hammer: 'safety', rodLength: 9 },
+          { id: 'bh2-n4', depth: 10.5, blows: [14, 18, 21], penetration: [150, 150, 150], hammer: 'safety', rodLength: 12 },
+          { id: 'bh2-n5', depth: 15, blows: [19, 26, 30], penetration: [150, 150, 150], hammer: 'safety', rodLength: 16.5 },
+        ],
+      },
+    ],
+    parameters: [],
+  }
+}

--- a/webapp/src/engine/soils/standards.ts
+++ b/webapp/src/engine/soils/standards.ts
@@ -1,0 +1,181 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Test-standard catalogue for the soil-investigation module. Layer 8.
+//
+// Every field and laboratory test cites the standard it was run to, and a
+// report that says "Moisture Content 18.4%" without saying "to ASTM D2216" is
+// not a laboratory result — it is a number. So the standard is part of the
+// data model, not decoration.
+//
+// This is a typed constant rather than a database table on purpose. The
+// original design called for an `engineering_standards` table; the goal behind
+// that (one place to change a designation, no string literals scattered through
+// forty modules) is right, but a table is the wrong mechanism for a
+// client-side app: a const gives the same single source of truth PLUS
+// compile-time typo checking, tree-shaking, and no round-trip. `StandardId` is
+// derived from the object, so a mistyped citation fails to compile.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type StandardBody = 'ASTM' | 'AASHTO' | 'BS' | 'ISO' | 'NSCP' | 'PNS'
+
+export type StandardCategory =
+  | 'index'          // moisture, specific gravity, gradation, plasticity
+  | 'classification'
+  | 'compaction'
+  | 'strength'
+  | 'consolidation'
+  | 'permeability'
+  | 'field'
+  | 'pavement'
+
+export interface Standard {
+  /** Designation as it must appear in a report, e.g. 'ASTM D2216'. */
+  designation: string
+  body: StandardBody
+  title: string
+  category: StandardCategory
+  /**
+   * Year of the edition this module was written against, when it matters.
+   * Absent means the module does not depend on edition-specific content.
+   */
+  edition?: string
+}
+
+/**
+ * The catalogue. Keys are stable machine ids — they appear in stored
+ * investigation JSON, so RENAMING A KEY IS A BREAKING CHANGE that needs a
+ * store migration. Designations may be edited freely; keys may not.
+ */
+export const STANDARDS = {
+  // ── Index properties ──
+  d2216: {
+    designation: 'ASTM D2216', body: 'ASTM', category: 'index',
+    title: 'Laboratory Determination of Water (Moisture) Content of Soil and Rock by Mass',
+  },
+  d854: {
+    designation: 'ASTM D854', body: 'ASTM', category: 'index',
+    title: 'Specific Gravity of Soil Solids by Water Pycnometer',
+  },
+  d6913: {
+    designation: 'ASTM D6913', body: 'ASTM', category: 'index',
+    title: 'Particle-Size Distribution (Gradation) of Soils Using Sieve Analysis',
+  },
+  d7928: {
+    designation: 'ASTM D7928', body: 'ASTM', category: 'index',
+    title: 'Particle-Size Distribution of Fine-Grained Soils Using the Sedimentation (Hydrometer) Analysis',
+  },
+  d4318: {
+    designation: 'ASTM D4318', body: 'ASTM', category: 'index',
+    title: 'Liquid Limit, Plastic Limit, and Plasticity Index of Soils',
+  },
+
+  // ── Classification ──
+  d2487: {
+    designation: 'ASTM D2487', body: 'ASTM', category: 'classification',
+    title: 'Classification of Soils for Engineering Purposes (Unified Soil Classification System)',
+  },
+  d2488: {
+    designation: 'ASTM D2488', body: 'ASTM', category: 'classification',
+    title: 'Description and Identification of Soils (Visual-Manual Procedures)',
+  },
+  m145: {
+    designation: 'AASHTO M 145', body: 'AASHTO', category: 'classification',
+    title: 'Classification of Soils and Soil-Aggregate Mixtures for Highway Construction Purposes',
+  },
+
+  // ── Compaction ──
+  d698: {
+    designation: 'ASTM D698', body: 'ASTM', category: 'compaction',
+    title: 'Laboratory Compaction Characteristics of Soil Using Standard Effort (600 kN·m/m³)',
+  },
+  d1557: {
+    designation: 'ASTM D1557', body: 'ASTM', category: 'compaction',
+    title: 'Laboratory Compaction Characteristics of Soil Using Modified Effort (2,700 kN·m/m³)',
+  },
+
+  // ── Strength ──
+  d3080: {
+    designation: 'ASTM D3080', body: 'ASTM', category: 'strength',
+    title: 'Direct Shear Test of Soils Under Consolidated Drained Conditions',
+  },
+  d2166: {
+    designation: 'ASTM D2166', body: 'ASTM', category: 'strength',
+    title: 'Unconfined Compressive Strength of Cohesive Soil',
+  },
+  d2850: {
+    designation: 'ASTM D2850', body: 'ASTM', category: 'strength',
+    title: 'Unconsolidated-Undrained Triaxial Compression Test on Cohesive Soils',
+  },
+  d4767: {
+    designation: 'ASTM D4767', body: 'ASTM', category: 'strength',
+    title: 'Consolidated Undrained Triaxial Compression Test for Cohesive Soils',
+  },
+  d7181: {
+    designation: 'ASTM D7181', body: 'ASTM', category: 'strength',
+    title: 'Consolidated Drained Triaxial Compression Test for Soils',
+  },
+
+  // ── Consolidation & permeability ──
+  d2435: {
+    designation: 'ASTM D2435', body: 'ASTM', category: 'consolidation',
+    title: 'One-Dimensional Consolidation Properties of Soils Using Incremental Loading',
+  },
+  d5084: {
+    designation: 'ASTM D5084', body: 'ASTM', category: 'permeability',
+    title: 'Measurement of Hydraulic Conductivity of Saturated Porous Materials Using a Flexible Wall Permeameter',
+  },
+  d2434: {
+    designation: 'ASTM D2434', body: 'ASTM', category: 'permeability',
+    title: 'Permeability of Granular Soils (Constant Head)',
+  },
+
+  // ── Field ──
+  d1586: {
+    designation: 'ASTM D1586', body: 'ASTM', category: 'field',
+    title: 'Standard Penetration Test (SPT) and Split-Barrel Sampling of Soils',
+  },
+  d1587: {
+    designation: 'ASTM D1587', body: 'ASTM', category: 'field',
+    title: 'Thin-Walled Tube Sampling of Fine-Grained Soils for Geotechnical Purposes',
+  },
+  d2573: {
+    designation: 'ASTM D2573', body: 'ASTM', category: 'field',
+    title: 'Field Vane Shear Test in Saturated Fine-Grained Soils',
+  },
+  d5778: {
+    designation: 'ASTM D5778', body: 'ASTM', category: 'field',
+    title: 'Electronic Friction Cone and Piezocone Penetration Testing of Soils',
+  },
+  d1556: {
+    designation: 'ASTM D1556', body: 'ASTM', category: 'field',
+    title: 'Density and Unit Weight of Soil in Place by Sand-Cone Method',
+  },
+
+  // ── Pavement ──
+  d1883: {
+    designation: 'ASTM D1883', body: 'ASTM', category: 'pavement',
+    title: 'California Bearing Ratio (CBR) of Laboratory-Compacted Soils',
+  },
+  d4546: {
+    designation: 'ASTM D4546', body: 'ASTM', category: 'pavement',
+    title: 'One-Dimensional Swell or Collapse of Soils',
+  },
+} as const satisfies Record<string, Standard>
+
+export type StandardId = keyof typeof STANDARDS
+
+export const standard = (id: StandardId): Standard => STANDARDS[id]
+
+/** Report-ready citation, e.g. 'ASTM D4318'. */
+export const cite = (id: StandardId): string => STANDARDS[id].designation
+
+/** Citation with title, for an appendix or a methodology section. */
+export const citeFull = (id: StandardId): string =>
+  `${STANDARDS[id].designation} — ${STANDARDS[id].title}`
+
+export const standardsByCategory = (category: StandardCategory): Standard[] =>
+  (Object.keys(STANDARDS) as StandardId[])
+    .map((id) => STANDARDS[id])
+    .filter((s) => s.category === category)
+
+export const isStandardId = (v: unknown): v is StandardId =>
+  typeof v === 'string' && v in STANDARDS

--- a/webapp/src/engine/soils/store.test.ts
+++ b/webapp/src/engine/soils/store.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createStore, memoryBackend, exportJSON, importJSON, SOILS_SCHEMA_VERSION,
+} from './store'
+import { sampleInvestigation } from './sample'
+import { emptyInvestigation } from './model'
+
+describe('soils store', () => {
+  it('round-trips an investigation unchanged', () => {
+    const store = createStore(memoryBackend())
+    const inv = sampleInvestigation()
+    store.save('a', inv)
+    expect(store.load('a')).toEqual(inv)
+  })
+
+  it('lists investigations newest first, with counts', () => {
+    const store = createStore(memoryBackend())
+    store.save('a', sampleInvestigation(), '2026-01-01T00:00:00Z')
+    store.save('b', emptyInvestigation('Later'), '2026-06-01T00:00:00Z')
+
+    const list = store.list()
+    expect(list.map((s) => s.id)).toEqual(['b', 'a'])
+
+    const a = list.find((s) => s.id === 'a')!
+    expect(a.boreholeCount).toBe(2)
+    expect(a.sampleCount).toBe(4)
+    expect(a.investigationNo).toBe('SI-2026-014')
+    expect(a.status).toBe('laboratory')
+  })
+
+  it('reports a missing investigation as null rather than throwing', () => {
+    const store = createStore(memoryBackend())
+    expect(store.load('nope')).toBeNull()
+    expect(store.exists('nope')).toBe(false)
+  })
+
+  it('removes an investigation', () => {
+    const store = createStore(memoryBackend())
+    store.save('a', sampleInvestigation())
+    store.remove('a')
+    expect(store.load('a')).toBeNull()
+    expect(store.list()).toEqual([])
+  })
+
+  it('survives a corrupt entry instead of taking the whole listing down', () => {
+    // One bad key must not make every other investigation unreachable.
+    const backend = memoryBackend({
+      'soils:investigation:bad': '{ not json',
+      'soils:investigation:half': '{"version":1,"savedAt":"x","investigation":{"meta":{}}}',
+    })
+    const store = createStore(backend)
+    store.save('good', sampleInvestigation())
+
+    expect(store.list().map((s) => s.id)).toEqual(['good'])
+    expect(store.load('bad')).toBeNull()
+    expect(store.load('half')).toBeNull()
+  })
+
+  it('ignores keys that belong to other modules', () => {
+    const backend = memoryBackend({ 'schedule:project:x': '{}', 'unrelated': 'y' })
+    const store = createStore(backend)
+    store.save('a', sampleInvestigation())
+    expect(store.list()).toHaveLength(1)
+  })
+})
+
+describe('import / export', () => {
+  it('exports a versioned wrapper that imports back identically', () => {
+    const inv = sampleInvestigation()
+    const json = exportJSON(inv)
+    expect(JSON.parse(json).version).toBe(SOILS_SCHEMA_VERSION)
+    expect(importJSON(json)).toEqual(inv)
+  })
+
+  it('accepts a bare investigation as well as the wrapper', () => {
+    const inv = sampleInvestigation()
+    expect(importJSON(JSON.stringify(inv))).toEqual(inv)
+  })
+
+  it('refuses malformed JSON and unrecognised shapes', () => {
+    expect(() => importJSON('{ not json')).toThrow(/not valid JSON/)
+    expect(() => importJSON('{"hello":1}')).toThrow(/unrecognised/)
+    expect(() => importJSON('null')).toThrow(/unrecognised/)
+  })
+
+  it('refuses an import carrying an integrity ERROR', () => {
+    // A half-successful import is worse than one that refused: the user would
+    // not know which parts of their data survived.
+    const inv = sampleInvestigation()
+    inv.boreholes[0].layers[1].depthBottom = 5.0   // overlaps the layer below
+    expect(() => importJSON(exportJSON(inv))).toThrow(/integrity error/)
+  })
+
+  it('allows an import that only carries WARNINGS', () => {
+    const inv = sampleInvestigation()
+    inv.boreholes[0].layers[1].depthBottom = 4.0   // a gap — advisory only
+    expect(() => importJSON(exportJSON(inv))).not.toThrow()
+  })
+})

--- a/webapp/src/engine/soils/store.ts
+++ b/webapp/src/engine/soils/store.ts
@@ -1,0 +1,201 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Soil-investigation persistence. Layer 1.
+//
+// A key-value store over a swappable `StorageBackend`: browser localStorage in
+// the app, an in-memory backend in tests. Investigations are stored one key
+// each under `soils:investigation:<id>`, wrapped with a schema version so a
+// future format change migrates on read instead of corrupting old saves.
+//
+// WHY LOCALSTORAGE AND NOT POSTGRES, for now. The module's shape is going to
+// move as the laboratory engines land, and designing thirty tables plus
+// row-level-security policies against a schema that is still moving means
+// writing migrations for guesses. The `StorageBackend` seam is the whole point:
+// when the shape settles, a Supabase-backed backend drops in behind this same
+// interface and nothing above it changes. The scheduling module has been
+// running on exactly this arrangement.
+//
+// The cost of that choice is real and worth stating: laboratory data is
+// expensive to re-enter, and until the backend swap lands an investigation
+// lives in one browser on one machine. `exportJSON` is therefore not a
+// convenience — it is the backup mechanism, and the UI should treat it that way.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { Investigation } from './model'
+import { validateInvestigation } from './validate'
+
+/** Current on-disk schema version. Bump + add a migration when the shape changes. */
+export const SOILS_SCHEMA_VERSION = 1
+
+const KEY_PREFIX = 'soils:investigation:'
+
+/** Minimal storage contract (a subset of the Web Storage API). */
+export interface StorageBackend {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+  keys(): string[]
+}
+
+/** In-memory backend for tests / non-browser environments. */
+export function memoryBackend(seed?: Record<string, string>): StorageBackend {
+  const map = new Map<string, string>(seed ? Object.entries(seed) : [])
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k)! : null),
+    setItem: (k, v) => void map.set(k, v),
+    removeItem: (k) => void map.delete(k),
+    keys: () => [...map.keys()],
+  }
+}
+
+/** Browser localStorage backend, or an in-memory fallback when unavailable. */
+export function defaultBackend(): StorageBackend {
+  const ls = typeof globalThis !== 'undefined' ? (globalThis as { localStorage?: Storage }).localStorage : undefined
+  if (!ls) return memoryBackend()
+  return {
+    getItem: (k) => ls.getItem(k),
+    setItem: (k, v) => ls.setItem(k, v),
+    removeItem: (k) => ls.removeItem(k),
+    keys: () => Array.from({ length: ls.length }, (_, i) => ls.key(i)).filter((k): k is string => k !== null),
+  }
+}
+
+export interface StoredInvestigation {
+  version: number
+  savedAt: string
+  investigation: Investigation
+}
+
+/** Listing entry — enough for a picker without parsing every full record. */
+export interface InvestigationSummary {
+  id: string
+  investigationNo: string
+  title: string
+  projectName: string
+  status: Investigation['meta']['status']
+  savedAt: string
+  boreholeCount: number
+  sampleCount: number
+}
+
+export interface SoilsStore {
+  list(): InvestigationSummary[]
+  load(id: string): Investigation | null
+  save(id: string, investigation: Investigation, savedAt?: string): StoredInvestigation
+  remove(id: string): void
+  exists(id: string): boolean
+}
+
+export function createStore(backend: StorageBackend = defaultBackend()): SoilsStore {
+  const keyOf = (id: string) => KEY_PREFIX + id
+  const idOf = (key: string) => key.slice(KEY_PREFIX.length)
+
+  const readStored = (key: string): StoredInvestigation | null => {
+    const raw = backend.getItem(key)
+    if (raw == null) return null
+    try {
+      const parsed = JSON.parse(raw) as StoredInvestigation
+      // A corrupt entry must not take the listing down with it, so the shape is
+      // checked here rather than trusted from the key prefix alone.
+      if (!parsed || typeof parsed !== 'object' || !isInvestigation(parsed.investigation)) return null
+      return migrate(parsed)
+    } catch {
+      return null
+    }
+  }
+
+  return {
+    list() {
+      const out: InvestigationSummary[] = []
+      for (const key of backend.keys()) {
+        if (!key.startsWith(KEY_PREFIX)) continue
+        const stored = readStored(key)
+        if (!stored) continue
+        const inv = stored.investigation
+        out.push({
+          id: idOf(key),
+          investigationNo: inv.meta.investigationNo,
+          title: inv.meta.title,
+          projectName: inv.meta.site.projectName,
+          status: inv.meta.status,
+          savedAt: stored.savedAt,
+          boreholeCount: inv.boreholes.length,
+          sampleCount: inv.boreholes.reduce((n, b) => n + b.samples.length, 0),
+        })
+      }
+      return out.sort((a, b) => b.savedAt.localeCompare(a.savedAt))
+    },
+    load(id) {
+      return readStored(keyOf(id))?.investigation ?? null
+    },
+    save(id, investigation, savedAt = new Date().toISOString()) {
+      const stored: StoredInvestigation = { version: SOILS_SCHEMA_VERSION, savedAt, investigation }
+      backend.setItem(keyOf(id), JSON.stringify(stored))
+      return stored
+    },
+    remove(id) {
+      backend.removeItem(keyOf(id))
+    },
+    exists(id) {
+      return backend.getItem(keyOf(id)) != null
+    },
+  }
+}
+
+/** Migrate a stored wrapper to the current schema version (no-op at v1). */
+function migrate(stored: StoredInvestigation): StoredInvestigation {
+  // Future: while (stored.version < SOILS_SCHEMA_VERSION) { …; stored.version++ }
+  return stored
+}
+
+// ── JSON import / export ─────────────────────────────────────────────────
+
+/** Serialise an investigation to a versioned JSON string for download. */
+export function exportJSON(investigation: Investigation, savedAt = new Date().toISOString()): string {
+  const stored: StoredInvestigation = { version: SOILS_SCHEMA_VERSION, savedAt, investigation }
+  return JSON.stringify(stored, null, 2)
+}
+
+/**
+ * Parse an investigation from an exported JSON string. Accepts either the
+ * versioned wrapper or a bare `Investigation`. Throws on malformed JSON, an
+ * unrecognised shape, or any error-level integrity failure — an import that
+ * half-succeeded would be worse than one that refused.
+ */
+export function importJSON(json: string): Investigation {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(json)
+  } catch {
+    throw new Error('Import failed: not valid JSON.')
+  }
+
+  const investigation = extract(parsed)
+  if (!investigation) throw new Error('Import failed: unrecognised soil-investigation format.')
+
+  const errors = validateInvestigation(investigation).filter((i) => i.severity === 'error')
+  if (errors.length) {
+    throw new Error(
+      `Import failed: ${errors.length} integrity error(s): ${errors.map((e) => e.message).join(' ')}`,
+    )
+  }
+  return investigation
+}
+
+function isInvestigation(v: unknown): v is Investigation {
+  if (typeof v !== 'object' || v === null) return false
+  const p = v as Partial<Investigation>
+  return (
+    p.meta != null && typeof p.meta === 'object' &&
+    typeof (p.meta as Investigation['meta']).title === 'string' &&
+    Array.isArray(p.boreholes) &&
+    Array.isArray(p.parameters)
+  )
+}
+
+/** Pull an `Investigation` out of either a wrapper or a bare object. */
+function extract(parsed: unknown): Investigation | null {
+  if (typeof parsed !== 'object' || parsed === null) return null
+  const obj = parsed as Record<string, unknown>
+  const candidate = 'investigation' in obj ? obj.investigation : obj
+  return isInvestigation(candidate) ? candidate : null
+}

--- a/webapp/src/engine/soils/validate.test.ts
+++ b/webapp/src/engine/soils/validate.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest'
+import { validateInvestigation, validateAtterberg, hasErrors } from './validate'
+import { sampleInvestigation } from './sample'
+import type { Investigation } from './model'
+
+/** Deep-clone the fixture so each case can corrupt one field in isolation. */
+const fixture = (): Investigation => structuredClone(sampleInvestigation())
+const codes = (inv: Investigation) => validateInvestigation(inv).map((i) => i.code)
+
+describe('validateInvestigation — the clean fixture', () => {
+  it('passes with no errors AND no warnings', () => {
+    // A fixture that already carried warnings would make every test below
+    // unable to distinguish a new warning from an existing one.
+    expect(validateInvestigation(sampleInvestigation())).toEqual([])
+  })
+})
+
+describe('stratigraphy', () => {
+  it('flags an overlap as an ERROR — two soils cannot occupy the same ground', () => {
+    const inv = fixture()
+    inv.boreholes[0].layers[1].depthBottom = 5.0   // now overlaps the clay at 4.2
+    const issues = validateInvestigation(inv)
+    const overlap = issues.find((i) => i.code === 'layer-overlap')!
+    expect(overlap.severity).toBe('error')
+    expect(overlap.message).toContain('4.20')
+  })
+
+  it('flags a gap as a WARNING — an unrecovered run is a real thing to log', () => {
+    const inv = fixture()
+    inv.boreholes[0].layers[1].depthBottom = 4.0   // 0.2 m unlogged before the clay
+    const gap = validateInvestigation(inv).find((i) => i.code === 'layer-gap')!
+    expect(gap.severity).toBe('warning')
+    expect(hasErrors(validateInvestigation(inv))).toBe(false)
+  })
+
+  it('never repairs the data it complains about', () => {
+    // The whole point of the module: report, never mutate. Only the person who
+    // was on the rig knows whether a gap is an error or an unrecovered run.
+    const inv = fixture()
+    inv.boreholes[0].layers[1].depthBottom = 4.0
+    const before = structuredClone(inv)
+    validateInvestigation(inv)
+    expect(inv).toEqual(before)
+  })
+
+  it('rejects a zero-thickness layer and a profile deeper than the hole', () => {
+    const inv = fixture()
+    inv.boreholes[0].layers[0].depthBottom = 0
+    expect(codes(inv)).toContain('layer-zero-thickness')
+
+    const inv2 = fixture()
+    inv2.boreholes[0].layers[3].depthBottom = 25   // hole terminated at 20
+    const issue = validateInvestigation(inv2).find((i) => i.code === 'profile-below-termination')!
+    expect(issue.severity).toBe('error')
+  })
+
+  it('warns when the profile stops short of the termination depth', () => {
+    const inv = fixture()
+    inv.boreholes[0].layers[3].depthBottom = 18
+    const issue = validateInvestigation(inv).find((i) => i.code === 'profile-short-of-termination')!
+    expect(issue.severity).toBe('warning')
+  })
+})
+
+describe('boreholes', () => {
+  it('rejects two holes sharing a name — logs would be ambiguous', () => {
+    const inv = fixture()
+    inv.boreholes[1].name = 'BH-01'
+    const issue = validateInvestigation(inv).find((i) => i.code === 'duplicate-borehole-name')!
+    expect(issue.severity).toBe('error')
+  })
+
+  it('rejects groundwater logged below the bottom of the hole', () => {
+    const inv = fixture()
+    inv.boreholes[0].groundwaterDepth = 25
+    expect(codes(inv)).toContain('groundwater-below-hole')
+  })
+
+  it('rejects a completion date before the start date', () => {
+    const inv = fixture()
+    inv.boreholes[0].completionDate = '2026-06-14'
+    expect(codes(inv)).toContain('borehole-dates')
+  })
+})
+
+describe('samples', () => {
+  it('rejects recovery longer than the drive', () => {
+    const inv = fixture()
+    inv.boreholes[0].samples[0].recoveryLength = 0.60   // drive is 0.45
+    const issue = validateInvestigation(inv).find((i) => i.code === 'recovery-over-100')!
+    expect(issue.severity).toBe('error')
+  })
+
+  it('warns on poor recovery rather than blocking it', () => {
+    const inv = fixture()
+    inv.boreholes[0].samples[0].recoveryLength = 0.15   // 33%
+    const issue = validateInvestigation(inv).find((i) => i.code === 'low-recovery')!
+    expect(issue.severity).toBe('warning')
+  })
+
+  it('warns when a strength test is run on a disturbed sample', () => {
+    // S-01 is a split-spoon sample: fine for classification, not for a triaxial.
+    const inv = fixture()
+    inv.boreholes[0].samples[0].tests.push({
+      id: 'bad', type: 'triaxial', standard: 'd4767', status: 'planned',
+    })
+    const issue = validateInvestigation(inv).find((i) => i.code === 'strength-test-on-disturbed')!
+    expect(issue.severity).toBe('warning')
+    expect(issue.message).toContain('undisturbed')
+  })
+
+  it('does not warn about a VOID strength test on a disturbed sample', () => {
+    const inv = fixture()
+    inv.boreholes[0].samples[0].tests.push({
+      id: 'bad', type: 'triaxial', standard: 'd4767', status: 'void',
+    })
+    expect(codes(inv)).not.toContain('strength-test-on-disturbed')
+  })
+
+  it('rejects a sample attributed to a layer in another hole', () => {
+    const inv = fixture()
+    inv.boreholes[0].samples[0].layerId = 'bh2-l1'
+    expect(codes(inv)).toContain('sample-unknown-layer')
+  })
+})
+
+describe('SPT', () => {
+  it('treats an unusually high N as a WARNING, not an error', () => {
+    // Flagging the merely unusual as an error trains the user to ignore errors.
+    const inv = fixture()
+    inv.boreholes[0].spt[7].blows = [40, 60, 65]
+    const issues = validateInvestigation(inv)
+    expect(issues.find((i) => i.code === 'spt-very-high')!.severity).toBe('warning')
+    expect(hasErrors(issues)).toBe(false)
+  })
+
+  it('rejects a negative blow count and an out-of-hole depth', () => {
+    const inv = fixture()
+    inv.boreholes[0].spt[0].blows = [3, -1, 4]
+    expect(codes(inv)).toContain('spt-negative-blows')
+
+    const inv2 = fixture()
+    inv2.boreholes[0].spt[0].depth = 30
+    expect(codes(inv2)).toContain('spt-outside-hole')
+  })
+
+  it('warns that a refusal N is a lower bound, not a measurement', () => {
+    const inv = fixture()
+    inv.boreholes[0].spt[7].penetration = [150, 150, 75]
+    const issue = validateInvestigation(inv).find((i) => i.code === 'spt-refusal')!
+    expect(issue.severity).toBe('warning')
+    expect(issue.message).toMatch(/lower bound/)
+  })
+
+  it('rejects an energy ratio outside 0–100%', () => {
+    const inv = fixture()
+    inv.boreholes[0].spt[0].energyRatio = 160
+    expect(codes(inv)).toContain('spt-energy-ratio')
+  })
+
+  it('rejects an SPT pointing at a sample from another hole', () => {
+    const inv = fixture()
+    inv.boreholes[0].spt[0].sampleId = 'bh2-s1'
+    expect(codes(inv)).toContain('spt-unknown-sample')
+  })
+})
+
+describe('design parameters', () => {
+  it('rejects parameters pointing at a layer that is not in the stated hole', () => {
+    const inv = fixture()
+    inv.parameters.push({ boreholeId: 'bh1', layerId: 'bh2-l2' })
+    expect(codes(inv)).toContain('parameters-unknown-layer')
+  })
+
+  it('rejects parameters pointing at a hole that does not exist', () => {
+    const inv = fixture()
+    inv.parameters.push({ boreholeId: 'bh9', layerId: 'x' })
+    expect(codes(inv)).toContain('parameters-unknown-borehole')
+  })
+})
+
+describe('validateAtterberg', () => {
+  it('rejects PL above LL — one of the two tests is wrong', () => {
+    const issues = validateAtterberg({ liquidLimit: 35, plasticLimit: 40 })
+    const e = issues.find((i) => i.code === 'pl-above-ll')!
+    expect(e.severity).toBe('error')
+    expect(e.message).toMatch(/negative plasticity index/)
+  })
+
+  it('accepts a normal clay', () => {
+    expect(validateAtterberg({ liquidLimit: 48, plasticLimit: 25, naturalMoisture: 30 })).toEqual([])
+  })
+
+  it('warns when the natural moisture exceeds the liquid limit', () => {
+    const issues = validateAtterberg({ liquidLimit: 42, plasticLimit: 23, naturalMoisture: 55 })
+    const w = issues.find((i) => i.code === 'moisture-above-ll')!
+    expect(w.severity).toBe('warning')
+    expect(w.message).toMatch(/sensitive|quick/)
+  })
+
+  it('rejects a negative limit and a shrinkage limit above the plastic limit', () => {
+    expect(validateAtterberg({ liquidLimit: -5 }).map((i) => i.code)).toContain('limit-negative')
+    expect(validateAtterberg({ plasticLimit: 20, shrinkageLimit: 25 }).map((i) => i.code)).toContain('sl-above-pl')
+  })
+
+  it('handles a partially entered form without inventing failures', () => {
+    // The form validates as the user types; a half-filled form is not an error.
+    expect(validateAtterberg({})).toEqual([])
+    expect(validateAtterberg({ liquidLimit: 48 })).toEqual([])
+  })
+})

--- a/webapp/src/engine/soils/validate.ts
+++ b/webapp/src/engine/soils/validate.ts
@@ -1,0 +1,313 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Soil-investigation integrity validation. Layer 1.
+//
+// Returns a flat list of issues so the UI can surface every problem at once
+// rather than throwing on the first. Errors block save/import; warnings are
+// advisory and must not.
+//
+// THE RULE THIS MODULE EXISTS TO ENFORCE: never silently repair engineering
+// data. If a log has a gap between 4.20 m and 4.50 m, that gap is either a
+// logging error or an unrecovered interval, and only the person who was on the
+// rig knows which. Closing it automatically would destroy the evidence that
+// something needs checking, and would do it invisibly. So every rule here
+// REPORTS and none of them mutate.
+//
+// The second rule: distinguish "impossible" from "unusual". A plastic limit
+// above the liquid limit is impossible — that is an error. An SPT N of 2 is
+// unusual, and perfectly real in soft clay — that is a warning. Flagging the
+// second as an error would train the user to ignore the first.
+// ─────────────────────────────────────────────────────────────────────────
+
+import {
+  type Investigation, type Borehole,
+  fieldN, layerThickness, recoveryRatio,
+} from './model'
+
+export type IssueSeverity = 'error' | 'warning'
+
+export interface ValidationIssue {
+  severity: IssueSeverity
+  /** Stable machine code, e.g. 'layer-gap'. */
+  code: string
+  message: string
+  boreholeId?: string
+  layerId?: string
+  sampleId?: string
+  testId?: string
+}
+
+/** Depths within this tolerance are treated as coincident (mm, expressed in m). */
+const DEPTH_TOL = 1e-6
+
+export function validateInvestigation(inv: Investigation): ValidationIssue[] {
+  const issues: ValidationIssue[] = []
+  const err = (code: string, message: string, ref: Partial<ValidationIssue> = {}) =>
+    issues.push({ severity: 'error', code, message, ...ref })
+  const warn = (code: string, message: string, ref: Partial<ValidationIssue> = {}) =>
+    issues.push({ severity: 'warning', code, message, ...ref })
+
+  if (!inv.meta.title.trim()) warn('no-title', 'The investigation has no title.')
+  if (!inv.meta.investigationNo.trim()) {
+    warn('no-investigation-no', 'No investigation number — the report cover will be incomplete.')
+  }
+  if (!inv.boreholes.length) warn('no-boreholes', 'No boreholes have been logged yet.')
+
+  const boreholeIds = new Set<string>()
+  const boreholeNames = new Set<string>()
+  const layerIds = new Set<string>()
+
+  for (const bh of inv.boreholes) {
+    if (boreholeIds.has(bh.id)) err('duplicate-borehole-id', `Duplicate borehole id "${bh.id}".`, { boreholeId: bh.id })
+    boreholeIds.add(bh.id)
+
+    if (boreholeNames.has(bh.name)) {
+      err('duplicate-borehole-name',
+        `Two boreholes are both called "${bh.name}" — logs and the location plan would be ambiguous.`,
+        { boreholeId: bh.id })
+    }
+    boreholeNames.add(bh.name)
+
+    validateBorehole(bh, err, warn, layerIds)
+  }
+
+  // Parameters must point at layers that exist, in the hole they claim.
+  const layersByBorehole = new Map(inv.boreholes.map((b) => [b.id, new Set(b.layers.map((l) => l.id))]))
+  for (const p of inv.parameters) {
+    const holeLayers = layersByBorehole.get(p.boreholeId)
+    if (!holeLayers) {
+      err('parameters-unknown-borehole',
+        `Design parameters reference borehole "${p.boreholeId}", which does not exist.`,
+        { boreholeId: p.boreholeId, layerId: p.layerId })
+    } else if (!holeLayers.has(p.layerId)) {
+      err('parameters-unknown-layer',
+        `Design parameters reference layer "${p.layerId}", which is not in borehole "${p.boreholeId}".`,
+        { boreholeId: p.boreholeId, layerId: p.layerId })
+    }
+  }
+
+  return issues
+}
+
+type Report = (code: string, message: string, ref?: Partial<ValidationIssue>) => void
+
+function validateBorehole(bh: Borehole, err: Report, warn: Report, seenLayerIds: Set<string>): void {
+  const ref = { boreholeId: bh.id }
+
+  if (!(bh.actualDepth > 0)) {
+    err('borehole-no-depth', `${bh.name}: termination depth must be greater than zero.`, ref)
+  }
+  if (bh.plannedDepth != null && bh.actualDepth < bh.plannedDepth - DEPTH_TOL) {
+    warn('borehole-short',
+      `${bh.name}: terminated at ${bh.actualDepth.toFixed(2)} m, short of the planned ${bh.plannedDepth.toFixed(2)} m.` +
+      (bh.terminationReason ? '' : ' No termination reason recorded.'), ref)
+  }
+  if (bh.groundwaterDepth != null && bh.groundwaterDepth > bh.actualDepth + DEPTH_TOL) {
+    err('groundwater-below-hole',
+      `${bh.name}: groundwater logged at ${bh.groundwaterDepth.toFixed(2)} m, below the ${bh.actualDepth.toFixed(2)} m termination depth.`,
+      ref)
+  }
+  if (bh.startDate && bh.completionDate && bh.completionDate < bh.startDate) {
+    err('borehole-dates', `${bh.name}: completion date is before the start date.`, ref)
+  }
+
+  validateStratigraphy(bh, err, warn, seenLayerIds)
+
+  // ── Samples ──
+  const sampleIds = new Set<string>()
+  const layerIdSet = new Set(bh.layers.map((l) => l.id))
+  for (const s of bh.samples) {
+    const sref = { ...ref, sampleId: s.id }
+    if (sampleIds.has(s.id)) err('duplicate-sample-id', `Duplicate sample id "${s.id}".`, sref)
+    sampleIds.add(s.id)
+
+    if (s.depthBottom < s.depthTop - DEPTH_TOL) {
+      err('sample-inverted', `${bh.name}/${s.name}: sample base is above its top.`, sref)
+    }
+    if (s.depthBottom > bh.actualDepth + DEPTH_TOL) {
+      err('sample-below-hole',
+        `${bh.name}/${s.name}: sample extends to ${s.depthBottom.toFixed(2)} m, below the termination depth.`, sref)
+    }
+    if (s.layerId && !layerIdSet.has(s.layerId)) {
+      err('sample-unknown-layer', `${bh.name}/${s.name}: attributed to layer "${s.layerId}", which is not in this hole.`, sref)
+    }
+
+    const rec = recoveryRatio(s)
+    if (rec != null) {
+      if (rec > 100 + 1e-9) {
+        err('recovery-over-100',
+          `${bh.name}/${s.name}: recovery of ${rec.toFixed(0)}% exceeds the drive length.`, sref)
+      } else if (rec < 50) {
+        warn('low-recovery',
+          `${bh.name}/${s.name}: recovery ${rec.toFixed(0)}% — laboratory results on this sample carry reduced confidence.`, sref)
+      }
+    }
+
+    // Undisturbed testing on a disturbed sample is a category error worth naming.
+    const STRENGTH_TESTS = new Set(['triaxial', 'ucs', 'consolidation', 'direct-shear', 'permeability'])
+    if (s.type === 'disturbed' || s.type === 'bulk' || s.type === 'split-spoon') {
+      for (const t of s.tests) {
+        if (STRENGTH_TESTS.has(t.type) && t.status !== 'void') {
+          warn('strength-test-on-disturbed',
+            `${bh.name}/${s.name}: a ${t.type} test on a ${s.type} sample — strength and compressibility need an undisturbed specimen.`,
+            { ...sref, testId: t.id })
+        }
+      }
+    }
+
+    const testIds = new Set<string>()
+    for (const t of s.tests) {
+      if (testIds.has(t.id)) err('duplicate-test-id', `Duplicate test id "${t.id}".`, { ...sref, testId: t.id })
+      testIds.add(t.id)
+    }
+  }
+
+  validateSpt(bh, err, warn, sampleIds)
+}
+
+/**
+ * Stratigraphy must be ordered, contiguous and non-overlapping. Overlaps are
+ * errors (two soils cannot occupy the same ground); gaps are warnings, because
+ * an unrecovered interval is a real thing a log can honestly record.
+ */
+function validateStratigraphy(bh: Borehole, err: Report, warn: Report, seenLayerIds: Set<string>): void {
+  const ref = { boreholeId: bh.id }
+  if (!bh.layers.length) {
+    warn('no-layers', `${bh.name}: no soil layers logged.`, ref)
+    return
+  }
+
+  for (const l of bh.layers) {
+    const lref = { ...ref, layerId: l.id }
+    if (seenLayerIds.has(l.id)) err('duplicate-layer-id', `Duplicate layer id "${l.id}".`, lref)
+    seenLayerIds.add(l.id)
+
+    if (layerThickness(l) <= DEPTH_TOL) {
+      err('layer-zero-thickness',
+        `${bh.name}: layer "${l.name}" has zero or negative thickness (${l.depthTop} – ${l.depthBottom} m).`, lref)
+    }
+    if (l.depthTop < -DEPTH_TOL) {
+      err('layer-negative-depth', `${bh.name}: layer "${l.name}" starts above ground level.`, lref)
+    }
+  }
+
+  const sorted = [...bh.layers].sort((a, b) => a.depthTop - b.depthTop)
+  if (sorted.some((l, i) => l !== bh.layers[i])) {
+    warn('layers-unordered', `${bh.name}: layers are not stored in depth order.`, ref)
+  }
+
+  if (sorted[0].depthTop > DEPTH_TOL) {
+    warn('profile-starts-below-ground',
+      `${bh.name}: the logged profile starts at ${sorted[0].depthTop.toFixed(2)} m, not at ground level.`, ref)
+  }
+
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = sorted[i - 1], cur = sorted[i]
+    const gap = cur.depthTop - prev.depthBottom
+    if (gap < -DEPTH_TOL) {
+      err('layer-overlap',
+        `${bh.name}: "${prev.name}" and "${cur.name}" overlap between ${cur.depthTop.toFixed(2)} m and ${prev.depthBottom.toFixed(2)} m.`,
+        { ...ref, layerId: cur.id })
+    } else if (gap > DEPTH_TOL) {
+      warn('layer-gap',
+        `${bh.name}: unlogged interval between ${prev.depthBottom.toFixed(2)} m and ${cur.depthTop.toFixed(2)} m — record it as an unrecovered run or close the contact.`,
+        { ...ref, layerId: cur.id })
+    }
+  }
+
+  const base = sorted[sorted.length - 1].depthBottom
+  if (base < bh.actualDepth - DEPTH_TOL) {
+    warn('profile-short-of-termination',
+      `${bh.name}: the logged profile ends at ${base.toFixed(2)} m but the hole reached ${bh.actualDepth.toFixed(2)} m.`, ref)
+  }
+  if (base > bh.actualDepth + DEPTH_TOL) {
+    err('profile-below-termination',
+      `${bh.name}: the logged profile reaches ${base.toFixed(2)} m, deeper than the ${bh.actualDepth.toFixed(2)} m termination depth.`, ref)
+  }
+}
+
+function validateSpt(bh: Borehole, err: Report, warn: Report, sampleIds: Set<string>): void {
+  const ref = { boreholeId: bh.id }
+  const seen = new Set<string>()
+
+  for (const t of bh.spt) {
+    const tref = { ...ref, testId: t.id }
+    if (seen.has(t.id)) err('duplicate-spt-id', `Duplicate SPT id "${t.id}".`, tref)
+    seen.add(t.id)
+
+    if (t.depth < -DEPTH_TOL || t.depth > bh.actualDepth + DEPTH_TOL) {
+      err('spt-outside-hole',
+        `${bh.name}: SPT at ${t.depth.toFixed(2)} m is outside the 0 – ${bh.actualDepth.toFixed(2)} m hole.`, tref)
+    }
+    if (t.blows.some((b) => b < 0 || !Number.isFinite(b))) {
+      err('spt-negative-blows', `${bh.name}: SPT at ${t.depth.toFixed(2)} m has a negative or non-finite blow count.`, tref)
+    }
+    if (t.sampleId && !sampleIds.has(t.sampleId)) {
+      err('spt-unknown-sample',
+        `${bh.name}: SPT at ${t.depth.toFixed(2)} m references sample "${t.sampleId}", which is not in this hole.`, tref)
+    }
+    if (t.energyRatio != null && (t.energyRatio <= 0 || t.energyRatio > 100)) {
+      err('spt-energy-ratio', `${bh.name}: hammer energy ratio must be between 0 and 100%.`, tref)
+    }
+    if (t.penetration && t.penetration.some((p) => p < 0 || p > 150 + DEPTH_TOL)) {
+      err('spt-penetration', `${bh.name}: SPT increment penetration must be between 0 and 150 mm.`, tref)
+    }
+
+    // Unusual, not impossible — a warning, so the errors above stay meaningful.
+    const N = fieldN(t)
+    if (N === 0) {
+      warn('spt-zero',
+        `${bh.name}: SPT at ${t.depth.toFixed(2)} m gives N = 0 — weight-of-rods penetration, which should be logged as such rather than as a blow count.`,
+        tref)
+    } else if (N > 100) {
+      warn('spt-very-high',
+        `${bh.name}: SPT at ${t.depth.toFixed(2)} m gives N = ${N}. Above 50 the test is refusal; verify the field record.`, tref)
+    }
+    if (t.penetration && t.penetration.some((p) => p < 150 - DEPTH_TOL)) {
+      warn('spt-refusal',
+        `${bh.name}: SPT at ${t.depth.toFixed(2)} m did not achieve full penetration — N is a lower bound and correlations should not be applied to it.`,
+        tref)
+    }
+  }
+}
+
+// ── Atterberg consistency ────────────────────────────────────────────────
+// Kept here rather than in the (future) Atterberg engine so the rule is
+// available to a form as the numbers are typed, before any test object exists.
+
+export interface AtterbergCheck {
+  liquidLimit?: number
+  plasticLimit?: number
+  shrinkageLimit?: number
+  naturalMoisture?: number
+}
+
+/** Physical consistency of the Atterberg limits. Empty ⇒ nothing wrong. */
+export function validateAtterberg(a: AtterbergCheck): ValidationIssue[] {
+  const issues: ValidationIssue[] = []
+  const err = (code: string, message: string) => issues.push({ severity: 'error', code, message })
+  const warn = (code: string, message: string) => issues.push({ severity: 'warning', code, message })
+  const { liquidLimit: LL, plasticLimit: PL, shrinkageLimit: SL, naturalMoisture: w } = a
+
+  for (const [name, v] of [['Liquid limit', LL], ['Plastic limit', PL], ['Shrinkage limit', SL]] as const) {
+    if (v != null && v < 0) err('limit-negative', `${name} cannot be negative.`)
+  }
+  if (LL != null && PL != null && PL > LL) {
+    err('pl-above-ll',
+      `Plastic limit (${PL}%) exceeds the liquid limit (${LL}%) — the soil would have a negative plasticity index. One of the two tests is wrong.`)
+  }
+  if (PL != null && SL != null && SL > PL) {
+    err('sl-above-pl', `Shrinkage limit (${SL}%) exceeds the plastic limit (${PL}%).`)
+  }
+  if (LL != null && LL > 200) {
+    warn('ll-very-high', `Liquid limit of ${LL}% is extreme — verify the test; only highly organic soils reach this.`)
+  }
+  if (LL != null && w != null && w > LL) {
+    warn('moisture-above-ll',
+      `Natural moisture (${w}%) exceeds the liquid limit — the soil is at a liquidity index above 1 and may be sensitive or quick.`)
+  }
+  return issues
+}
+
+/** Convenience: does this issue list block a save? */
+export const hasErrors = (issues: ValidationIssue[]): boolean =>
+  issues.some((i) => i.severity === 'error')


### PR DESCRIPTION
**Layer 1 (schema) for a new geotechnical investigation-management module.** Phase 0 of 8. No UI — this is the set of decisions every later phase inherits, with the tests that hold them.

The goal for the module overall: enter a site investigation **once** (boreholes, layers, samples, field and lab tests), interpret design parameters from it, and feed those into the bearing / settlement / slope / earth-pressure / pile engines that already exist — instead of retyping γ, c and φ on every calculator page.

## The architectural call, and what it costs

The module was specified against a ~30-table Postgres schema. **This repo has no database.** `supabase/` contains only the billing webhook — no `migrations/`, no tables; Supabase is auth-only, and every project in the app persists to localStorage.

So the model goes on `store.ts`, a versioned key-value store over a swappable `StorageBackend` — the same arrangement `engine/schedule` has been running on. Designing thirty tables plus RLS policies against a schema that will still move as the laboratory engines land means writing migrations for guesses.

**The cost is real and is stated in the module header, not buried:** until the backend swap (Phase 8), an investigation lives in one browser on one machine, and lab data is expensive to re-enter. `exportJSON` is the backup mechanism, not a convenience, and the UI must treat it that way.

## What's in it

| Module | Role |
|---|---|
| `model.ts` | Investigation → Borehole → Layer → Sample → LabTest, plus SPT |
| `provenance.ts` | `measured` / `derived` / `correlated` / `assumed` on every parameter value |
| `registry.ts` | 21 calculations declared with equation, units, symbols, assumptions, limitations, source |
| `standards.ts` | 25 ASTM/AASHTO designations as a typed const |
| `store.ts` | Versioned persistence + JSON import/export |
| `validate.ts` | Integrity rules that report and never repair |
| `sample.ts` | A valid two-borehole fixture |

## Three decisions worth not re-litigating later

**Provenance lives on the value, not in a parallel result type.** `φ = 32°` from a triaxial cell, from an SPT correlation, and from engineering judgement carry different confidence and different liability — and once all three render as "32°", that difference is gone for good, including from the engineer defending the report two years later. Retrofitting this across thirty engines would never actually happen, so it's in from day one.

The proposed `CalculationResult<T>` was **dropped**: `SolutionStep[]` already carries method, clause citation, substituted inputs, intermediate values and pass/fail, and renders to both screen and PDF. The spec's "[View Calculation]" feature is the Worked Solution section shipped in #473–#475.

**`engineering_standards` is a const, not a table.** The goal behind it — one place to change a designation, no string literals across forty modules — is right; a table is the wrong mechanism client-side. `StandardId` derives from the object, so a mistyped citation fails to compile rather than printing a blank.

**Validation reports and never repairs.** A gap between 4.20 m and 4.50 m is either a logging error or an unrecovered run, and only whoever was on the rig knows which — closing it automatically would destroy the evidence *and* do it invisibly. Errors are the impossible (PL > LL, overlapping layers, groundwater below the hole); warnings are the merely unusual (N = 2, 33% recovery, an unlogged interval). Flagging the unusual as an error trains people to ignore errors. A test asserts the validator does not mutate its input.

Two smaller ones: **samples hang off the borehole** and reference a layer, so re-picking a contact can't orphan expensive lab data. **Measurements are stored, results are computed** — SPT keeps all three increments rather than N₆₀, so a change in correction methodology can be re-derived instead of lost.

## Guards that will bite on later phases

- Every **correlation** must state a reference **and** at least one limitation. A correlation with no stated range of validity reads exactly like a measurement — the most dangerous thing this module could ship.
- Every symbol in a registry equation must appear in its symbol table.
- Every registry equation must survive `texToPlain` with no stray commands (they get printed in calc sheets).
- Every symbol description must state its unit or say it's dimensionless.
- The clean fixture must validate with **zero errors and zero warnings**, so a later test can't confuse a new warning with an existing one.

I verified the correlation guard and the symbol-table guard bite by breaking each and watching them fail.

## Honest notes

- Two of my own test regexes were wrong on the first pass: the unit check used `\b` after `%`, which can never match at end-of-string and so rejected `'water content, %'`; the symbol-root extraction didn't handle `(N_1)_{60}`. Both were test bugs. The same run did catch a **real** data gap — two SPT symbol descriptions genuinely had no units — which is what the check was for.
- The registry's 21 entries are *declarations*, not implementations. Each one's engine still needs its own test against a published example, plus a `docs/ValidationMap.md` row, before it ships (CLAUDE.md L9).
- No routes, so the docs and feature-gate guards don't apply yet. They will from Phase 3.

## Verification

`npm test` — **2281 passed / 157 files** (175 new) · `npx tsc -b` · `npm run lint` · `npm run build` all green.

## Next

Phase 1 — classification: Atterberg, sieve (D10/D30/D60, Cu, Cc), USCS D2487, AASHTO, plus the plasticity chart and grain-size curve as SVG. `HANDOFF.md` carries all eight phases.

**Open question for you:** which plan tier gates this module. I'd suggest `pro`+, since it produces a deliverable report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_