### PR TITLE
Soil investigation Phase 1 — classification engines (Atterberg, sieve, USCS, AASHTO)

### DIFF
--- a/webapp/src/engine/soils/aashto.test.ts
+++ b/webapp/src/engine/soils/aashto.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest'
+import { classifyAASHTO, groupIndex, partialGroupIndex } from './aashto'
+import { classifyUSCS } from './uscs'
+
+describe('group index (AASHTO M 145 Eq. 1)', () => {
+  it('is zero for a clean granular soil', () => {
+    expect(groupIndex(10, 20, 3)).toBe(0)
+    expect(groupIndex(35, 40, 10)).toBe(0)
+  })
+
+  it('matches a hand calculation', () => {
+    // F = 60, LL = 45, PI = 20:
+    //   (60−35)[0.2 + 0.005(45−40)] + 0.01(60−15)(20−10)
+    // = 25(0.225) + 0.01(45)(10) = 5.625 + 4.5 = 10.125 → 10
+    expect(groupIndex(60, 45, 20)).toBe(10)
+  })
+
+  it('never returns a negative index', () => {
+    // M 145: "when the calculated group index is negative, the group index
+    // shall be reported as zero". The raw value here is −1.5.
+    //   (40−35)[0.2 + 0.005(20−40)] + 0.01(40−15)(2−10)
+    // = 5(0.1) + 0.01(25)(−8) = 0.5 − 2.0 = −1.5
+    expect(groupIndex(40, 20, 2)).toBe(0)
+    expect(groupIndex(45, 25, 5)).toBe(0)
+  })
+
+  it('is only meaningful inside the domain M 145 applies it to', () => {
+    // F = LL = PI = 0 is not a soil, and the expression returns 2 there. The
+    // classifier never calls it outside the silt-clay groups and A-2-6/7, and
+    // the docstring says so — better than bending the formula to flatter a
+    // degenerate input.
+    expect(groupIndex(0, 0, 0)).toBe(2)
+    const granular = classifyAASHTO({ passing10: 45, passing40: 25, passing200: 10, liquidLimit: 20, plasticityIndex: 3 })
+    expect(granular.groupIndex).toBe(0)
+  })
+
+  it('evaluates the equation signed rather than clamping each term first', () => {
+    // Clamping (LL−40) and (PI−10) at zero before summing is a DIFFERENT
+    // equation: it would drop the −2.0 above and report 1 instead of 0.
+    const signed = (40 - 35) * (0.2 + 0.005 * (20 - 40)) + 0.01 * (40 - 15) * (2 - 10)
+    expect(signed).toBeCloseTo(-1.5, 10)
+    expect(groupIndex(40, 20, 2)).toBe(0)
+  })
+
+  it('rises with fines and with plasticity', () => {
+    expect(groupIndex(70, 45, 20)).toBeGreaterThan(groupIndex(50, 45, 20))
+    expect(groupIndex(60, 45, 30)).toBeGreaterThan(groupIndex(60, 45, 15))
+  })
+
+  it('partial index uses only the plasticity term, for A-2-6 and A-2-7', () => {
+    expect(partialGroupIndex(30, 20)).toBe(Math.round(0.01 * 15 * 10))
+    expect(partialGroupIndex(30, 5)).toBe(0)
+  })
+})
+
+describe('granular soils (≤ 35% passing No. 200)', () => {
+  it('classifies well-graded gravel as A-1-a', () => {
+    const r = classifyAASHTO({ passing10: 45, passing40: 25, passing200: 10, liquidLimit: 20, plasticityIndex: 3 })
+    expect(r.group).toBe('A-1-a')
+    expect(r.groupIndex).toBe(0)
+    expect(r.rating).toBe('excellent to good')
+  })
+
+  it('classifies coarse sand as A-1-b', () => {
+    const r = classifyAASHTO({ passing10: 80, passing40: 45, passing200: 20, liquidLimit: 20, plasticityIndex: 4 })
+    expect(r.group).toBe('A-1-b')
+  })
+
+  it('classifies non-plastic fine sand as A-3', () => {
+    const r = classifyAASHTO({ passing10: 95, passing40: 80, passing200: 8, liquidLimit: 0, plasticityIndex: 0 })
+    expect(r.group).toBe('A-3')
+  })
+
+  it('does not call a plastic fine sand A-3', () => {
+    // A-3 requires non-plastic; with PI 5 the soil drops to the A-2 family.
+    const r = classifyAASHTO({ passing10: 95, passing40: 80, passing200: 8, liquidLimit: 25, plasticityIndex: 5 })
+    expect(r.group).toBe('A-2-4')
+  })
+
+  it('splits the A-2 family on LL 41 and PI 11', () => {
+    const base = { passing10: 90, passing40: 70, passing200: 30 }
+    expect(classifyAASHTO({ ...base, liquidLimit: 35, plasticityIndex: 8 }).group).toBe('A-2-4')
+    expect(classifyAASHTO({ ...base, liquidLimit: 45, plasticityIndex: 8 }).group).toBe('A-2-5')
+    expect(classifyAASHTO({ ...base, liquidLimit: 35, plasticityIndex: 15 }).group).toBe('A-2-6')
+    expect(classifyAASHTO({ ...base, liquidLimit: 45, plasticityIndex: 15 }).group).toBe('A-2-7')
+  })
+
+  it('gives a group index only to A-2-6 and A-2-7', () => {
+    const base = { passing10: 90, passing40: 70, passing200: 30 }
+    expect(classifyAASHTO({ ...base, liquidLimit: 35, plasticityIndex: 8 }).groupIndex).toBe(0)
+    expect(classifyAASHTO({ ...base, liquidLimit: 35, plasticityIndex: 20 }).groupIndex)
+      .toBe(partialGroupIndex(30, 20))
+  })
+
+  it('reads the table in order — the first satisfied group wins', () => {
+    // This soil satisfies A-1-b's criteria and would also satisfy A-2-4 if the
+    // groups were tested independently. M 145 is an elimination procedure, so
+    // A-1-b is the answer.
+    const r = classifyAASHTO({ passing10: 60, passing40: 40, passing200: 20, liquidLimit: 25, plasticityIndex: 5 })
+    expect(r.group).toBe('A-1-b')
+  })
+})
+
+describe('silt-clay soils (> 35% passing No. 200)', () => {
+  const base = { passing10: 100, passing40: 95 }
+
+  it('classifies A-4 through A-6', () => {
+    expect(classifyAASHTO({ ...base, passing200: 60, liquidLimit: 30, plasticityIndex: 8 }).group).toBe('A-4')
+    expect(classifyAASHTO({ ...base, passing200: 60, liquidLimit: 45, plasticityIndex: 8 }).group).toBe('A-5')
+    expect(classifyAASHTO({ ...base, passing200: 60, liquidLimit: 35, plasticityIndex: 20 }).group).toBe('A-6')
+  })
+
+  it('splits A-7-5 and A-7-6 on PI vs LL − 30', () => {
+    // LL 60: A-7-5 while PI ≤ 30, A-7-6 above it.
+    expect(classifyAASHTO({ ...base, passing200: 70, liquidLimit: 60, plasticityIndex: 28 }).group).toBe('A-7-5')
+    expect(classifyAASHTO({ ...base, passing200: 70, liquidLimit: 60, plasticityIndex: 35 }).group).toBe('A-7-6')
+    expect(classifyAASHTO({ ...base, passing200: 70, liquidLimit: 60, plasticityIndex: 30 }).group).toBe('A-7-5')
+  })
+
+  it('labels the group with its index', () => {
+    // LL 45, PI 20: PI > LL − 30 = 15, so this is A-7-6, not A-7-5.
+    const r = classifyAASHTO({ ...base, passing200: 60, liquidLimit: 45, plasticityIndex: 20 })
+    expect(r.label).toBe(`A-7-6 (${r.groupIndex})`)
+    expect(r.groupIndex).toBe(groupIndex(60, 45, 20))
+    expect(r.groupIndex).toBe(10)
+  })
+
+  it('rates silt-clay as fair to poor subgrade', () => {
+    expect(classifyAASHTO({ ...base, passing200: 60, liquidLimit: 30, plasticityIndex: 8 }).rating).toBe('fair to poor')
+  })
+})
+
+describe('boundaries and missing data', () => {
+  it('puts the granular / silt-clay split at 35%', () => {
+    const base = { passing10: 100, passing40: 90, liquidLimit: 30, plasticityIndex: 8 }
+    expect(classifyAASHTO({ ...base, passing200: 35 }).granular).toBe(true)
+    expect(classifyAASHTO({ ...base, passing200: 35.1 }).granular).toBe(false)
+  })
+
+  it('refuses to classify without Atterberg limits when they matter', () => {
+    const r = classifyAASHTO({ passing10: 100, passing40: 95, passing200: 60 })
+    expect(r.group).toBeUndefined()
+    expect(r.rating).toBe('unknown')
+    expect(r.reason).toMatch(/D4318/)
+  })
+
+  it('notes a grading where passing increases with sieve size', () => {
+    const r = classifyAASHTO({ passing10: 40, passing40: 60, passing200: 20, liquidLimit: 25, plasticityIndex: 4 })
+    expect(r.notes.join(' ')).toMatch(/must not increase with sieve size/)
+  })
+})
+
+describe('AASHTO and USCS answer different questions', () => {
+  it('disagrees on the fines boundary, and both are right', () => {
+    // 40% fines: AASHTO calls this silt-clay (>35%), USCS calls it
+    // coarse-grained (<50%). A report quoting both should not reconcile them.
+    const aashto = classifyAASHTO({ passing10: 100, passing40: 85, passing200: 40, liquidLimit: 35, plasticityIndex: 15 })
+    const uscs = classifyUSCS({ gravel: 10, sand: 50, fines: 40, liquidLimit: 35, plasticityIndex: 15 })
+
+    expect(aashto.granular).toBe(false)
+    expect(aashto.group).toBe('A-6')
+    expect(uscs.coarseGrained).toBe(true)
+    expect(uscs.symbol).toBe('SC')
+  })
+})

--- a/webapp/src/engine/soils/aashto.ts
+++ b/webapp/src/engine/soils/aashto.ts
@@ -1,0 +1,182 @@
+// ─────────────────────────────────────────────────────────────────────────
+// AASHTO soil classification. Layer 8. AASHTO M 145 Table 1.
+//
+// The highway-engineering counterpart to USCS, and it answers a different
+// question. USCS asks "what IS this soil"; AASHTO asks "how well will it
+// perform under a pavement", and ranks A-1 (best) through A-7 (worst) with a
+// GROUP INDEX that penalises fines and plasticity.
+//
+// The two systems disagree by design and both answers are correct. AASHTO puts
+// the silt/clay boundary at 35% passing the No. 200 sieve where USCS puts it at
+// 50%, so a soil with 40% fines is "granular" to AASHTO and "coarse-grained" to
+// USCS but sits in different families. A report that quotes both should not
+// try to reconcile them.
+//
+// THE TABLE IS READ LEFT TO RIGHT: M 145 is an elimination procedure, and the
+// first group whose criteria are all satisfied is the answer. Implementing it
+// as independent tests rather than in order gives the wrong group for soils
+// that satisfy more than one.
+//
+// UNITS: percentages 0–100; LL and PI in %.
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface AashtoInput {
+  /** Percent passing the 2.00 mm (No. 10) sieve, %. */
+  passing10: number
+  /** Percent passing the 0.425 mm (No. 40) sieve, %. */
+  passing40: number
+  /** Percent passing the 0.075 mm (No. 200) sieve, %. */
+  passing200: number
+  liquidLimit?: number
+  plasticityIndex?: number
+}
+
+export interface AashtoResult {
+  /** Group, e.g. 'A-2-6' or 'A-7-6'. Undefined when unclassifiable. */
+  group?: string
+  /**
+   * Group index, rounded to the nearest whole number and floored at zero.
+   * Printed in parentheses after the group: 'A-6 (12)'.
+   */
+  groupIndex: number
+  /** Group with its index, ready for a log: 'A-7-6 (18)'. */
+  label?: string
+  /** General rating as subgrade material. */
+  rating: 'excellent to good' | 'fair to poor' | 'unknown'
+  /** Granular when 35% or less passes the No. 200 sieve. */
+  granular: boolean
+  reason: string
+  notes: string[]
+}
+
+/**
+ * Group index, AASHTO M 145 Eq. 1:
+ *   GI = (F − 35)[0.2 + 0.005(LL − 40)] + 0.01(F − 15)(PI − 10)
+ * where F is percent passing the No. 200 sieve.
+ *
+ * The equation is evaluated SIGNED and only the TOTAL is floored at zero, which
+ * is what M 145 says: "when the calculated group index is negative, the group
+ * index shall be reported as zero". Clamping the individual terms at zero first
+ * is a different equation and gives a different answer — a soil with 40% fines
+ * at LL 20 / PI 2 comes out as 1 that way and as 0 the standard's way.
+ *
+ * DOMAIN: M 145 applies this to the silt-clay groups (F > 35) and, in its
+ * partial form, to A-2-6 and A-2-7. `classifyAASHTO` only calls it there.
+ * Evaluated far outside that domain the expression is simply meaningless —
+ * F = LL = PI = 0 returns 2, which is arithmetic, not a soil.
+ */
+export function groupIndex(passing200: number, LL: number, PI: number): number {
+  const F = Math.min(passing200, 100)
+  const gi = (F - 35) * (0.2 + 0.005 * (LL - 40)) + 0.01 * (F - 15) * (PI - 10)
+  return Math.max(Math.round(gi), 0)
+}
+
+/**
+ * Group index for the A-2-6 and A-2-7 subgroups, which use only the second
+ * (plasticity) term of the full equation — M 145 note.
+ */
+export function partialGroupIndex(passing200: number, PI: number): number {
+  const F = Math.min(passing200, 100)
+  return Math.max(Math.round(0.01 * (F - 15) * (PI - 10)), 0)
+}
+
+export function classifyAASHTO(i: AashtoInput): AashtoResult {
+  const notes: string[] = []
+  const { passing10, passing40, passing200 } = i
+  const LL = i.liquidLimit
+  const PI = i.plasticityIndex
+
+  if (passing200 > passing40 + 1e-9 || passing40 > passing10 + 1e-9) {
+    notes.push('Percent passing must not increase with sieve size — check the grading before relying on this.')
+  }
+
+  const granular = passing200 <= 35
+
+  // Plasticity is needed for everything except the coarsest granular groups,
+  // and guessing it would change the group outright.
+  const needsPlasticity = !granular || passing200 > 10
+  if (needsPlasticity && (LL == null || PI == null)) {
+    return {
+      groupIndex: 0, granular, notes, rating: 'unknown',
+      reason: 'AASHTO M 145 needs the liquid limit and plasticity index to place this soil — run ASTM D4318.',
+    }
+  }
+
+  // ── Granular: ≤ 35% passing No. 200 ──
+  if (granular) {
+    // A-1-a: ≤50 pass No.10, ≤30 pass No.40, ≤15 pass No.200, PI ≤ 6
+    if (passing10 <= 50 && passing40 <= 30 && passing200 <= 15 && (PI ?? 0) <= 6) {
+      return granularResult('A-1-a', 0, granular, notes,
+        'Predominantly stone fragments or gravel: ≤50% passing No. 10, ≤30% passing No. 40, ≤15% fines, PI ≤ 6.')
+    }
+    // A-1-b: ≤50 pass No.40, ≤25 pass No.200, PI ≤ 6
+    if (passing40 <= 50 && passing200 <= 25 && (PI ?? 0) <= 6) {
+      return granularResult('A-1-b', 0, granular, notes,
+        'Predominantly coarse sand: ≤50% passing No. 40, ≤25% fines, PI ≤ 6.')
+    }
+    // A-3: ≥51 pass No.40, ≤10 pass No.200, non-plastic
+    if (passing40 >= 51 && passing200 <= 10 && (PI ?? 0) === 0) {
+      return granularResult('A-3', 0, granular, notes,
+        'Fine sand: ≥51% passing No. 40, ≤10% fines, non-plastic.')
+    }
+    // A-2 family: granular with more fines or more plasticity than A-1 / A-3.
+    const ll = LL!, pi = PI!
+    const highLL = ll >= 41
+    const highPI = pi >= 11
+    const sub = highLL ? (highPI ? 'A-2-7' : 'A-2-5') : (highPI ? 'A-2-6' : 'A-2-4')
+    // Only the -6 and -7 subgroups carry a group index, from the partial equation.
+    const gi = sub === 'A-2-6' || sub === 'A-2-7' ? partialGroupIndex(passing200, pi) : 0
+    return granularResult(sub, gi, granular, notes,
+      `Granular with ${passing200.toFixed(0)}% fines: LL = ${ll.toFixed(0)} (${highLL ? '≥' : '<'} 41), PI = ${pi.toFixed(0)} (${highPI ? '≥' : '<'} 11) ⇒ ${sub}.`)
+  }
+
+  // ── Silt-clay: > 35% passing No. 200 ──
+  const ll = LL!, pi = PI!
+  const gi = groupIndex(passing200, ll, pi)
+  const highLL = ll >= 41
+  const highPI = pi >= 11
+
+  let group: string
+  let why: string
+  if (!highLL && !highPI) {
+    group = 'A-4'
+    why = 'Silty soil: LL < 41 and PI < 11.'
+  } else if (highLL && !highPI) {
+    group = 'A-5'
+    why = 'Elastic silt: LL ≥ 41 with PI < 11.'
+  } else if (!highLL && highPI) {
+    group = 'A-6'
+    why = 'Clayey soil: LL < 41 with PI ≥ 11.'
+  } else {
+    // A-7-5 vs A-7-6 turns on PI relative to LL − 30.
+    const a75 = pi <= ll - 30
+    group = a75 ? 'A-7-5' : 'A-7-6'
+    why = a75
+      ? `Highly plastic, PI = ${pi.toFixed(0)} ≤ LL − 30 = ${(ll - 30).toFixed(0)} ⇒ A-7-5.`
+      : `Highly plastic, PI = ${pi.toFixed(0)} > LL − 30 = ${(ll - 30).toFixed(0)} ⇒ A-7-6.`
+  }
+
+  return {
+    group,
+    groupIndex: gi,
+    label: `${group} (${gi})`,
+    granular: false,
+    rating: 'fair to poor',
+    notes,
+    reason: `${passing200.toFixed(0)}% passing the No. 200 sieve (> 35%) ⇒ silt-clay. ${why} Group index ${gi}.`,
+  }
+}
+
+function granularResult(
+  group: string, gi: number, granular: boolean, notes: string[], reason: string,
+): AashtoResult {
+  return {
+    group,
+    groupIndex: gi,
+    label: `${group} (${gi})`,
+    granular,
+    rating: 'excellent to good',
+    notes,
+    reason,
+  }
+}

--- a/webapp/src/engine/soils/atterberg.test.ts
+++ b/webapp/src/engine/soils/atterberg.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest'
+import {
+  atterberg, aLine, uLine, chartPosition, liquidLimitFromFlow, consistencyFromLI,
+} from './atterberg'
+
+describe('Casagrande chart lines (ASTM D2487 Fig. 3)', () => {
+  it('A-line passes through the published anchor points', () => {
+    // PI = 0.73(LL − 20): zero at LL = 20, and 29.2 at LL = 60.
+    expect(aLine(20)).toBeCloseTo(0, 10)
+    expect(aLine(60)).toBeCloseTo(29.2, 10)
+    expect(aLine(50)).toBeCloseTo(21.9, 10)
+  })
+
+  it('U-line passes through its anchor points and sits above the A-line', () => {
+    expect(uLine(8)).toBeCloseTo(0, 10)
+    expect(uLine(50)).toBeCloseTo(37.8, 10)
+    for (const LL of [20, 40, 60, 80, 100]) expect(uLine(LL)).toBeGreaterThan(aLine(LL))
+  })
+
+  it('treats a point ON the A-line as clay, per D2487', () => {
+    const on = chartPosition(50, aLine(50))
+    expect(on.aboveALine).toBe(true)
+  })
+
+  it('flags a point above the U-line as physically implausible', () => {
+    expect(chartPosition(40, uLine(40) + 1).aboveULine).toBe(true)
+    expect(chartPosition(40, uLine(40) - 1).aboveULine).toBe(false)
+  })
+
+  it('splits high and low plasticity at LL = 50', () => {
+    expect(chartPosition(49.9, 20).highPlasticity).toBe(false)
+    expect(chartPosition(50, 20).highPlasticity).toBe(true)
+  })
+})
+
+describe('atterberg — the worked case from the spec', () => {
+  it('LL 48, PL 25 gives PI 23 and plots as a clay', () => {
+    const r = atterberg({ liquidLimit: 48, plasticLimit: 25 })
+    expect(r.plasticityIndex).toBeCloseTo(23, 10)
+    expect(r.nonPlastic).toBe(false)
+    expect(r.chart.aboveALine).toBe(true)       // A-line at LL 48 is 20.4
+    expect(r.chart.highPlasticity).toBe(false)  // LL < 50 ⇒ the L suffix
+  })
+
+  it('LL 42, PL 23 gives PI 19', () => {
+    const r = atterberg({ liquidLimit: 42, plasticLimit: 23 })
+    expect(r.plasticityIndex).toBeCloseTo(19, 10)
+  })
+})
+
+describe('non-plastic is not PI = 0', () => {
+  it('marks a soil with no obtainable plastic limit as non-plastic', () => {
+    const r = atterberg({ liquidLimit: 22, nonPlastic: true })
+    expect(r.nonPlastic).toBe(true)
+    expect(r.notes.join(' ')).toMatch(/not the same as PI = 0/)
+  })
+
+  it('treats a missing plastic limit as non-plastic rather than assuming zero', () => {
+    expect(atterberg({ liquidLimit: 22 }).nonPlastic).toBe(true)
+  })
+
+  it('gives no liquidity index for a non-plastic soil', () => {
+    // LI = (w − PL)/PI would divide by zero; reporting a number would be worse.
+    const r = atterberg({ liquidLimit: 22, nonPlastic: true, naturalMoisture: 18 })
+    expect(r.liquidityIndex).toBeUndefined()
+  })
+})
+
+describe('liquidity index', () => {
+  it('computes (w − PL)/PI', () => {
+    const r = atterberg({ liquidLimit: 48, plasticLimit: 25, naturalMoisture: 36.5 })
+    expect(r.liquidityIndex).toBeCloseTo(0.5, 10)
+  })
+
+  it('warns when the soil is at or above its liquid limit', () => {
+    const r = atterberg({ liquidLimit: 42, plasticLimit: 23, naturalMoisture: 50 })
+    expect(r.liquidityIndex!).toBeGreaterThan(1)
+    expect(r.notes.join(' ')).toMatch(/sensitive or quick/)
+  })
+
+  it('warns when the soil is drier than its plastic limit', () => {
+    const r = atterberg({ liquidLimit: 42, plasticLimit: 23, naturalMoisture: 15 })
+    expect(r.liquidityIndex!).toBeLessThan(0)
+    expect(r.notes.join(' ')).toMatch(/desiccated|overconsolidated/)
+  })
+
+  it('maps LI onto a consistency description', () => {
+    expect(consistencyFromLI(1.2)).toMatch(/liquid/)
+    expect(consistencyFromLI(0.6)).toBe('firm')
+    expect(consistencyFromLI(-0.2)).toMatch(/hard/)
+  })
+})
+
+describe('liquid limit from a multipoint flow curve (D4318 Method A)', () => {
+  it('reads LL at 25 blows off a straight-line fit', () => {
+    // Constructed so the fit is exact: w = 50 − 10·log₁₀(N/25).
+    const pts = [15, 25, 35].map((blows) => ({
+      blows, moisture: 50 - 10 * Math.log10(blows / 25),
+    }))
+    const { liquidLimit, flowIndex } = liquidLimitFromFlow(pts)
+    expect(liquidLimit).toBeCloseTo(50, 6)
+    expect(flowIndex).toBeCloseTo(10, 6)
+  })
+
+  it('recovers the point value when a trial lands exactly on 25 blows', () => {
+    const pts = [
+      { blows: 20, moisture: 51.0 },
+      { blows: 25, moisture: 50.0 },
+      { blows: 31, moisture: 49.1 },
+    ]
+    expect(liquidLimitFromFlow(pts).liquidLimit).toBeCloseTo(50, 1)
+  })
+
+  it('warns when 25 blows is extrapolated rather than bracketed', () => {
+    const r = atterberg({
+      flowPoints: [{ blows: 30, moisture: 48 }, { blows: 38, moisture: 46 }],
+      plasticLimit: 22,
+    })
+    expect(r.notes.join(' ')).toMatch(/extrapolated/)
+  })
+
+  it('warns when a trial falls outside the 15–40 blow range D4318 asks for', () => {
+    const r = atterberg({
+      flowPoints: [{ blows: 12, moisture: 52 }, { blows: 25, moisture: 50 }, { blows: 44, moisture: 47 }],
+      plasticLimit: 22,
+    })
+    expect(r.notes.join(' ')).toMatch(/15 and 40/)
+  })
+
+  it('refuses a flow curve with fewer than two usable trials', () => {
+    expect(() => liquidLimitFromFlow([{ blows: 25, moisture: 50 }])).toThrow(/at least two/)
+    expect(() => liquidLimitFromFlow([])).toThrow(/at least two/)
+  })
+
+  it('falls back to the mean when every trial is at the same blow count', () => {
+    // No slope is defined; the mean is the best available estimate, and a
+    // divide-by-zero producing NaN would be far worse.
+    const { liquidLimit, flowIndex } = liquidLimitFromFlow([
+      { blows: 25, moisture: 50 }, { blows: 25, moisture: 52 },
+    ])
+    expect(liquidLimit).toBeCloseTo(51, 10)
+    expect(flowIndex).toBe(0)
+    expect(Number.isFinite(liquidLimit)).toBe(true)
+  })
+})
+
+describe('bad data is reported, not silently absorbed', () => {
+  it('clamps a negative PI to zero AND says why', () => {
+    const r = atterberg({ liquidLimit: 35, plasticLimit: 40 })
+    expect(r.plasticityIndex).toBe(0)
+    expect(r.notes.join(' ')).toMatch(/plastic limit exceeds the liquid limit/i)
+  })
+
+  it('flags a point above the U-line', () => {
+    const r = atterberg({ liquidLimit: 30, plasticLimit: 2 })   // PI 28 vs U-line 19.8
+    expect(r.chart.aboveULine).toBe(true)
+    expect(r.notes.join(' ')).toMatch(/above the U-line/)
+  })
+
+  it('refuses to run with neither a liquid limit nor a flow curve', () => {
+    expect(() => atterberg({ plasticLimit: 20 })).toThrow(/either a liquid limit or the flow-curve/)
+  })
+})

--- a/webapp/src/engine/soils/atterberg.ts
+++ b/webapp/src/engine/soils/atterberg.ts
@@ -1,0 +1,212 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Atterberg limits and the Casagrande plasticity chart. Layer 8.
+// ASTM D4318 (limits) · ASTM D2487 (chart lines).
+//
+// The limits are the water contents at which a fine-grained soil changes
+// behaviour: above the LIQUID LIMIT it flows, below the PLASTIC LIMIT it
+// crumbles, and the PLASTICITY INDEX between them measures how much water the
+// soil can absorb while still behaving plastically. That range is what
+// separates a clay from a silt on the Casagrande chart, and it is the input
+// the USCS classifier leans on hardest.
+//
+// NON-PLASTIC IS NOT PI = 0. A soil whose plastic limit cannot be obtained —
+// the thread will not roll at 3 mm — is reported NP. Recording that as PI = 0
+// would place it on the chart at the origin, where it would classify as a low
+// plasticity silt, which is a different claim from "this soil has no plastic
+// range at all". `AtterbergResult.nonPlastic` keeps the two apart.
+//
+// UNITS: all water contents in %, i.e. 0–100, not 0–1.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** One trial in a multipoint liquid-limit determination (D4318 Method A). */
+export interface FlowPoint {
+  /** Blow count at closure, 25 ± range. */
+  blows: number
+  /** Water content of the trial, %. */
+  moisture: number
+}
+
+export interface AtterbergInput {
+  /** Liquid limit, %. Omit when supplying `flowPoints` instead. */
+  liquidLimit?: number
+  /** Multipoint trials; LL is read off the flow curve at 25 blows. */
+  flowPoints?: FlowPoint[]
+  /** Plastic limit, %. Omit (or pass `nonPlastic`) when no thread could be rolled. */
+  plasticLimit?: number
+  /** The thread would not roll — the soil has no plastic range. */
+  nonPlastic?: boolean
+  shrinkageLimit?: number
+  /** Natural water content of the soil in place, % — gives the liquidity index. */
+  naturalMoisture?: number
+}
+
+export interface AtterbergResult {
+  liquidLimit: number
+  plasticLimit: number
+  /** LL − PL, %. Zero when non-plastic — read `nonPlastic` before using it. */
+  plasticityIndex: number
+  nonPlastic: boolean
+  /** Slope of the flow curve, % per log cycle of blows. Multipoint only. */
+  flowIndex?: number
+  /** (w − PL)/PI. Undefined when non-plastic or no natural moisture given. */
+  liquidityIndex?: number
+  shrinkageLimit?: number
+  /** Position relative to the A-line and U-line. */
+  chart: ChartPosition
+  /** Advisory notes — an LI above 1, a point above the U-line, and so on. */
+  notes: string[]
+}
+
+// ── Casagrande chart lines ────────────────────────────────────────────────
+
+/**
+ * A-line: PI = 0.73(LL − 20). Separates CLAYS (on or above) from SILTS and
+ * organic soils (below). ASTM D2487 Fig. 3.
+ */
+export const aLine = (LL: number): number => 0.73 * (LL - 20)
+
+/**
+ * U-line: PI = 0.9(LL − 8), the empirical UPPER BOUND on natural soils.
+ * A point above it has not been discovered — it has been mis-tested.
+ * ASTM D2487 §Fig. 3 note.
+ */
+export const uLine = (LL: number): number => 0.9 * (LL - 8)
+
+export interface ChartPosition {
+  /** PI on the A-line at this LL, %. */
+  aLinePI: number
+  /** PI on the U-line at this LL, %. */
+  uLinePI: number
+  /** On or above the A-line ⇒ clay behaviour. */
+  aboveALine: boolean
+  /** Above the U-line ⇒ physically implausible, re-run the test. */
+  aboveULine: boolean
+  /** LL ≥ 50 ⇒ high plasticity (the H suffix); below ⇒ low (L). */
+  highPlasticity: boolean
+}
+
+export function chartPosition(LL: number, PI: number): ChartPosition {
+  const aLinePI = aLine(LL)
+  const uLinePI = uLine(LL)
+  return {
+    aLinePI,
+    uLinePI,
+    // D2487 treats a point ON the A-line as clay, so the comparison is ≥.
+    aboveALine: PI >= aLinePI,
+    aboveULine: PI > uLinePI,
+    highPlasticity: LL >= 50,
+  }
+}
+
+// ── Liquid limit from a flow curve ────────────────────────────────────────
+
+/**
+ * Liquid limit from multipoint trials: the flow curve is a straight line on
+ * w vs log₁₀(N), and LL is its value at 25 blows (D4318 Method A).
+ *
+ * Returns the fitted LL and the flow index — the slope per log cycle, which is
+ * itself diagnostic: a steep flow curve means the soil loses strength quickly
+ * with added water.
+ */
+export function liquidLimitFromFlow(points: FlowPoint[]): { liquidLimit: number; flowIndex: number } {
+  const usable = points.filter((p) => p.blows > 0 && Number.isFinite(p.moisture))
+  if (usable.length < 2) {
+    throw new Error('A flow curve needs at least two trials with a positive blow count.')
+  }
+
+  // Least squares on w = a + b·log₁₀(N); the flow index is −b (w falls as N rises).
+  const xs = usable.map((p) => Math.log10(p.blows))
+  const ys = usable.map((p) => p.moisture)
+  const n = xs.length
+  const mx = xs.reduce((s, x) => s + x, 0) / n
+  const my = ys.reduce((s, y) => s + y, 0) / n
+  const sxx = xs.reduce((s, x) => s + (x - mx) ** 2, 0)
+  const sxy = xs.reduce((s, x, i) => s + (x - mx) * (ys[i] - my), 0)
+
+  // All trials at the same blow count: no slope is defined, so the mean water
+  // content is the best available estimate and the flow index is zero.
+  const b = sxx > 1e-12 ? sxy / sxx : 0
+  const a = my - b * mx
+  // `-b` on a zero slope yields negative zero, which prints as "-0" on a test
+  // sheet — cosmetic, but not something to hand an engineer.
+  return { liquidLimit: a + b * Math.log10(25), flowIndex: b === 0 ? 0 : -b }
+}
+
+// ── Main entry ────────────────────────────────────────────────────────────
+
+export function atterberg(i: AtterbergInput): AtterbergResult {
+  const notes: string[] = []
+
+  let flowIndex: number | undefined
+  let LL: number
+  if (i.flowPoints?.length) {
+    const fit = liquidLimitFromFlow(i.flowPoints)
+    LL = fit.liquidLimit
+    flowIndex = fit.flowIndex
+    const spread = i.flowPoints.map((p) => p.blows)
+    if (Math.min(...spread) > 25 || Math.max(...spread) < 25) {
+      notes.push('All trials fall on one side of 25 blows — the liquid limit is extrapolated, not interpolated.')
+    }
+    if (i.flowPoints.some((p) => p.blows < 15 || p.blows > 40)) {
+      notes.push('D4318 asks for trials between 15 and 40 blows; a point outside that range weakens the fit.')
+    }
+  } else if (i.liquidLimit != null) {
+    LL = i.liquidLimit
+  } else {
+    throw new Error('Supply either a liquid limit or the flow-curve trials it is read from.')
+  }
+
+  const nonPlastic = i.nonPlastic === true || i.plasticLimit == null
+  const PL = nonPlastic ? 0 : i.plasticLimit!
+  // PI is clamped at zero: a negative plasticity index is not a soil property,
+  // it is a failed test, and validateAtterberg reports it as an error.
+  const PI = nonPlastic ? 0 : Math.max(LL - PL, 0)
+
+  if (!nonPlastic && LL - PL < 0) {
+    notes.push('The plastic limit exceeds the liquid limit — one of the two determinations is wrong.')
+  }
+
+  let liquidityIndex: number | undefined
+  if (!nonPlastic && PI > 0 && i.naturalMoisture != null) {
+    liquidityIndex = (i.naturalMoisture - PL) / PI
+    if (liquidityIndex > 1) {
+      notes.push('Natural moisture is above the liquid limit (LI > 1) — the soil may be sensitive or quick.')
+    } else if (liquidityIndex < 0) {
+      notes.push('Natural moisture is below the plastic limit (LI < 0) — the soil is in a desiccated or overconsolidated state.')
+    }
+  }
+
+  const chart = chartPosition(LL, PI)
+  if (chart.aboveULine && !nonPlastic) {
+    notes.push('The point plots above the U-line, which no natural soil does — re-run the limits before classifying.')
+  }
+  if (nonPlastic) {
+    notes.push('Reported non-plastic: no thread could be rolled, so the soil has no plastic range. This is not the same as PI = 0.')
+  }
+
+  return {
+    liquidLimit: LL,
+    plasticLimit: PL,
+    plasticityIndex: PI,
+    nonPlastic,
+    flowIndex,
+    liquidityIndex,
+    shrinkageLimit: i.shrinkageLimit,
+    chart,
+    notes,
+  }
+}
+
+/**
+ * Consistency of a cohesive soil from its liquidity index — the descriptive
+ * term that goes on a borehole log. Ranges follow common practice rather than
+ * a code table, so the log should record how it was arrived at.
+ */
+export function consistencyFromLI(LI: number): string {
+  if (LI >= 1) return 'very soft / liquid'
+  if (LI >= 0.75) return 'soft'
+  if (LI >= 0.5) return 'firm'
+  if (LI >= 0.25) return 'stiff'
+  if (LI >= 0) return 'very stiff'
+  return 'hard (desiccated)'
+}

--- a/webapp/src/engine/soils/registry.test.ts
+++ b/webapp/src/engine/soils/registry.test.ts
@@ -41,7 +41,9 @@ describe('every registry entry is fully described', () => {
   it.each(IDS)('%s — every symbol description states its units', (id) => {
     // "mass of water" is not enough; "mass of water, g" is. A genuinely
     // dimensionless quantity says so by being a coefficient/index/ratio.
-    const HAS_UNIT = /,\s*[^,]*(%|\bg\b|\bmm\b|\bm\b|mm²|m²|m³|m\/s|kPa|MPa|kN\/m³|\bN\b|degrees|blows|°C)\s*$/i
+    // The unit follows the last comma but need not END the string: compound
+    // units like "% per log cycle" and "blows/300 mm" are legitimate.
+    const HAS_UNIT = /,\s*[^,]*(%|\bg\b|\bmm\b|\bm\b|mm²|m²|m³|m\/s|kPa|MPa|kN\/m³|\bN\b|degrees|blows|°C)/i
     const DIMENSIONLESS = /\b(coefficient|index|ratio|factor|correction|specific gravity|group symbol|strain)\b/i
     for (const [sym, desc] of Object.entries(calc(id).symbols)) {
       expect(desc.length, `${id}/${sym}`).toBeGreaterThan(5)

--- a/webapp/src/engine/soils/registry.ts
+++ b/webapp/src/engine/soils/registry.ts
@@ -174,7 +174,64 @@ export const CALCULATIONS = {
     limitations: ['Meaningless for a non-plastic soil (PI = 0 divides by zero).'],
   },
 
+  'atterberg.liquid-limit-flow': {
+    title: 'Liquid limit from the flow curve',
+    category: 'index',
+    equation: String.raw`w = a + b\log_{10} N \Rightarrow LL = w|_{N = 25}, \qquad I_f = -b`,
+    unit: '%',
+    symbols: {
+      w: 'water content of a trial, %',
+      N: 'blows to closure, blows',
+      LL: 'liquid limit, %',
+      I_f: 'flow index, % per log cycle',
+      a: 'intercept of the flow line, %',
+      b: 'slope of the flow line, % per log cycle',
+    },
+    standard: 'd4318',
+    assumptions: ['The flow curve is a straight line on water content vs log blows.'],
+    limitations: [
+      'D4318 asks for trials between 15 and 40 blows bracketing 25; outside that range the liquid limit is extrapolated.',
+    ],
+  },
+
   // ── Classification ──
+  'aashto.group-index': {
+    title: 'AASHTO group index',
+    category: 'classification',
+    equation: String.raw`GI = (F - 35)\left[0.2 + 0.005(LL - 40)\right] + 0.01(F - 15)(PI - 10)`,
+    unit: '—',
+    symbols: {
+      GI: 'group index, dimensionless',
+      F: 'percent passing the 0.075 mm (No. 200) sieve, %',
+      LL: 'liquid limit, %',
+      PI: 'plasticity index, %',
+    },
+    standard: 'm145',
+    limitations: [
+      'Evaluated signed; a negative result is reported as zero per M 145, not clamped term by term.',
+      'Defined for the silt-clay groups (F > 35) and, in partial form, for A-2-6 and A-2-7. Outside that domain the expression is arithmetic, not a soil property.',
+    ],
+  },
+
+  'aashto.classify': {
+    title: 'AASHTO group',
+    category: 'classification',
+    equation: String.raw`\text{gradation } (P_{10}, P_{40}, P_{200}) \text{ and plasticity } (LL, PI) \Rightarrow \text{A-group}`,
+    unit: '—',
+    symbols: {
+      P_10: 'percent passing the 2.00 mm (No. 10) sieve, %',
+      P_40: 'percent passing the 0.425 mm (No. 40) sieve, %',
+      P_200: 'percent passing the 0.075 mm (No. 200) sieve, %',
+      LL: 'liquid limit, %',
+      PI: 'plasticity index, %',
+    },
+    standard: 'm145',
+    assumptions: ['The table is read left to right — the first group whose criteria are all met is the answer.'],
+    limitations: [
+      'AASHTO puts the granular / silt-clay boundary at 35% fines where USCS puts the coarse / fine boundary at 50%. The two systems answer different questions and their results should not be reconciled.',
+    ],
+  },
+
   'uscs.classify': {
     title: 'USCS group symbol',
     category: 'classification',

--- a/webapp/src/engine/soils/sieve.test.ts
+++ b/webapp/src/engine/soils/sieve.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest'
+import {
+  gradation, interpolateD, passingAt, isWellGraded,
+  SIEVE_NO4, SIEVE_NO200, type SieveInput,
+} from './sieve'
+
+/** A well-graded sand: 500 g stack closing exactly. */
+const wellGradedSand: SieveInput = {
+  totalMass: 500,
+  readings: [
+    { size: 9.5, designation: '3/8 in', massRetained: 10 },
+    { size: 4.75, designation: 'No. 4', massRetained: 40 },
+    { size: 2.0, designation: 'No. 10', massRetained: 75 },
+    { size: 0.85, designation: 'No. 20', massRetained: 100 },
+    { size: 0.425, designation: 'No. 40', massRetained: 110 },
+    { size: 0.15, designation: 'No. 100', massRetained: 100 },
+    { size: 0.075, designation: 'No. 200', massRetained: 45 },
+  ],
+  panMass: 20,
+}
+
+describe('gradation table', () => {
+  const r = gradation(wellGradedSand)
+
+  it('computes percent retained, cumulative and passing', () => {
+    expect(r.rows[0].percentRetained).toBeCloseTo(2, 10)      // 10/500
+    expect(r.rows[0].percentPassing).toBeCloseTo(98, 10)
+    expect(r.rows[1].cumulativeRetained).toBeCloseTo(10, 10)  // (10+40)/500
+    expect(r.rows[1].percentPassing).toBeCloseTo(90, 10)
+  })
+
+  it('orders the stack coarse to fine regardless of input order', () => {
+    const shuffled = gradation({
+      ...wellGradedSand,
+      readings: [...wellGradedSand.readings].reverse(),
+    })
+    expect(shuffled.rows.map((x) => x.size)).toEqual([9.5, 4.75, 2.0, 0.85, 0.425, 0.15, 0.075])
+  })
+
+  it('closes the mass balance', () => {
+    expect(r.massError).toBeCloseTo(0, 10)
+    expect(r.notes.join(' ')).not.toMatch(/Mass balance/)
+  })
+
+  it('splits gravel, sand and fines at the D2487 boundaries', () => {
+    // Passing No.4 = 90%, passing No.200 = 4%.
+    expect(r.gravel).toBeCloseTo(10, 10)
+    expect(r.sand).toBeCloseTo(86, 10)
+    expect(r.fines).toBeCloseTo(4, 10)
+    expect(r.gravel + r.sand + r.fines + r.cobbles).toBeCloseTo(100, 8)
+  })
+})
+
+describe('mass balance is reported, never silently corrected', () => {
+  it('flags a stack that does not close within 1%', () => {
+    const r = gradation({ ...wellGradedSand, panMass: 60 })   // 40 g surplus = 8%
+    expect(Math.abs(r.massError)).toBeGreaterThan(1)
+    expect(r.notes.join(' ')).toMatch(/Mass balance is off by 8\.0%/)
+  })
+
+  it('never prints a negative percent passing', () => {
+    // An over-weighed stack would drive the cumulative past 100%; the reader
+    // would read a negative passing value as a data-entry error in the wrong
+    // place, so it is clamped and the mass error reported instead.
+    const r = gradation({
+      totalMass: 100,
+      readings: [{ size: 4.75, massRetained: 80 }, { size: 0.075, massRetained: 40 }],
+    })
+    expect(r.rows.every((x) => x.percentPassing >= 0)).toBe(true)
+    expect(r.notes.join(' ')).toMatch(/Mass balance/)
+  })
+
+  it('refuses a zero or negative total mass', () => {
+    expect(() => gradation({ totalMass: 0, readings: [] })).toThrow(/greater than zero/)
+  })
+})
+
+describe('D-sizes interpolate on a LOG scale', () => {
+  it('puts the midpoint at the geometric mean, not the arithmetic one', () => {
+    // 50% passing between 2 mm @ 60% and 0.2 mm @ 40%: the log midpoint is
+    // √(2 × 0.2) = 0.632 mm. Linear interpolation would give 1.1 mm — nearly
+    // double, which is why every grain-size curve is drawn on a log axis.
+    const rows = [
+      { size: 2.0, massRetained: 0, percentRetained: 0, cumulativeRetained: 40, percentPassing: 60 },
+      { size: 0.2, massRetained: 0, percentRetained: 0, cumulativeRetained: 60, percentPassing: 40 },
+    ]
+    const d50 = interpolateD(rows, 50)!
+    expect(d50).toBeCloseTo(Math.sqrt(2.0 * 0.2), 10)
+    expect(d50).toBeCloseTo(0.6325, 4)
+    expect(d50).toBeLessThan(1.1)
+  })
+
+  it('returns the exact sieve size when a reading lands on the percentage', () => {
+    const rows = [
+      { size: 2.0, massRetained: 0, percentRetained: 0, cumulativeRetained: 40, percentPassing: 60 },
+      { size: 0.5, massRetained: 0, percentRetained: 0, cumulativeRetained: 90, percentPassing: 10 },
+    ]
+    expect(interpolateD(rows, 60)).toBeCloseTo(2.0, 10)
+    expect(interpolateD(rows, 10)).toBeCloseTo(0.5, 10)
+  })
+
+  it('returns undefined when the curve never reaches the percentage', () => {
+    // "Unknown" is the honest answer — a soil with 15% fines has no D10 from
+    // sieving alone, and inventing one would flow straight into Cu and Cc.
+    const r = gradation({
+      totalMass: 100,
+      readings: [
+        { size: 4.75, massRetained: 20 },
+        { size: 0.425, massRetained: 45 },
+        { size: 0.075, massRetained: 20 },
+      ],
+      panMass: 15,
+    })
+    expect(r.fines).toBeCloseTo(15, 10)
+    expect(r.d10).toBeUndefined()
+    expect(r.cu).toBeUndefined()
+    expect(r.cc).toBeUndefined()
+    expect(r.notes.join(' ')).toMatch(/hydrometer/)
+  })
+})
+
+describe('passingAt', () => {
+  const r = gradation(wellGradedSand)
+
+  it('reads an exact sieve without interpolating', () => {
+    expect(passingAt(r.rows, SIEVE_NO4)).toBeCloseTo(90, 10)
+    expect(passingAt(r.rows, SIEVE_NO200)).toBeCloseTo(4, 10)
+  })
+
+  it('saturates above the coarsest and below the finest sieve', () => {
+    expect(passingAt(r.rows, 100)).toBe(100)
+    expect(passingAt(r.rows, 0.001)).toBeCloseTo(4, 10)
+  })
+})
+
+describe('Cu and Cc', () => {
+  it('computes the shape parameters from the D-sizes', () => {
+    const r = gradation(wellGradedSand)
+    expect(r.d10).toBeDefined()
+    expect(r.cu).toBeCloseTo(r.d60! / r.d10!, 10)
+    expect(r.cc).toBeCloseTo((r.d30! * r.d30!) / (r.d10! * r.d60!), 10)
+  })
+
+  it('applies the D2487 gradation criteria — Cu ≥ 6 for sand, ≥ 4 for gravel', () => {
+    expect(isWellGraded(6, 2, 'sand')).toBe(true)
+    expect(isWellGraded(5.9, 2, 'sand')).toBe(false)
+    expect(isWellGraded(5, 2, 'gravel')).toBe(true)
+    expect(isWellGraded(3.9, 2, 'gravel')).toBe(false)
+  })
+
+  it('requires Cc between 1 and 3 inclusive', () => {
+    expect(isWellGraded(10, 1, 'sand')).toBe(true)
+    expect(isWellGraded(10, 3, 'sand')).toBe(true)
+    expect(isWellGraded(10, 0.9, 'sand')).toBe(false)
+    expect(isWellGraded(10, 3.1, 'sand')).toBe(false)
+  })
+
+  it('says UNKNOWN rather than "poorly graded" when the parameters are missing', () => {
+    // The distinction matters: poorly graded is a finding, unknown is a gap.
+    expect(isWellGraded(undefined, 2, 'sand')).toBeUndefined()
+    expect(isWellGraded(8, undefined, 'sand')).toBeUndefined()
+  })
+})
+
+describe('cobbles', () => {
+  it('separates the plus-75 mm fraction and says D2487 excludes it', () => {
+    const r = gradation({
+      totalMass: 1000,
+      readings: [
+        { size: 100, massRetained: 150 },
+        { size: 75, massRetained: 50 },
+        { size: 4.75, massRetained: 500 },
+        { size: 0.075, massRetained: 250 },
+      ],
+      panMass: 50,
+    })
+    // Retained ON the 75 mm sieve and coarser: 150 + 50 = 200 g of 1000 g.
+    expect(r.cobbles).toBeCloseTo(20, 10)
+    expect(r.gravel).toBeCloseTo(50, 10)
+    expect(r.sand).toBeCloseTo(25, 10)
+    expect(r.fines).toBeCloseTo(5, 10)
+    expect(r.notes.join(' ')).toMatch(/coarser than 75 mm/)
+  })
+})

--- a/webapp/src/engine/soils/sieve.ts
+++ b/webapp/src/engine/soils/sieve.ts
@@ -1,0 +1,189 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Particle-size distribution from a sieve stack. Layer 8.
+// ASTM D6913 (sieving) · ASTM D2487 (fractions, Cu, Cc).
+//
+// The stack is weighed dry, mass retained per sieve, and the cumulative
+// passing curve follows. From it come the fractions that drive the USCS
+// classifier — gravel, sand and fines — and the shape parameters Cu and Cc
+// that separate well-graded from poorly graded material.
+//
+// D10, D30 and D60 ARE INTERPOLATED ON A LOG SCALE, which is the only thing
+// that makes them meaningful: particle sizes span four orders of magnitude, so
+// linear interpolation between 2 mm and 0.075 mm would put the midpoint at
+// roughly 1 mm rather than the 0.39 mm a log scale gives. Every published
+// grain-size curve is drawn on a log axis for the same reason.
+//
+// UNITS: sieve openings mm; masses g (any consistent unit — only ratios are
+// used); percentages 0–100.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Standard sieve boundaries used by ASTM D2487, mm. */
+export const SIEVE_75MM = 75      // gravel / cobble boundary
+export const SIEVE_NO4 = 4.75     // gravel / sand boundary
+export const SIEVE_NO200 = 0.075  // sand / fines boundary
+
+/** One sieve in the stack. */
+export interface SieveReading {
+  /** Clear opening, mm. */
+  size: number
+  /** Designation as it prints on the test sheet, e.g. 'No. 40'. */
+  designation?: string
+  /** Mass retained on this sieve, g. */
+  massRetained: number
+}
+
+export interface SieveInput {
+  /** Total dry mass of the specimen before sieving, g. */
+  totalMass: number
+  readings: SieveReading[]
+  /** Mass passing the finest sieve and caught in the pan, g. */
+  panMass?: number
+}
+
+export interface SieveRow {
+  size: number
+  designation?: string
+  massRetained: number
+  percentRetained: number
+  cumulativeRetained: number
+  percentPassing: number
+}
+
+export interface GradationResult {
+  rows: SieveRow[]
+  /** Percent by mass coarser than 4.75 mm, %. */
+  gravel: number
+  /** Percent between 4.75 mm and 0.075 mm, %. */
+  sand: number
+  /** Percent finer than 0.075 mm, %. */
+  fines: number
+  /** Percent coarser than 75 mm — excluded from the D2487 classification. */
+  cobbles: number
+  /** Grain sizes at 10 / 30 / 60% passing, mm. Undefined when off the curve. */
+  d10?: number
+  d30?: number
+  d60?: number
+  /** D60/D10. Undefined when D10 is off the curve. */
+  cu?: number
+  /** D30²/(D10·D60). Undefined when any of the three is off the curve. */
+  cc?: number
+  /** Mass balance error, % of the total. */
+  massError: number
+  notes: string[]
+}
+
+/**
+ * Grain size at a given percent passing, log-interpolated between the two
+ * bracketing sieves. Undefined when the curve never reaches that percentage,
+ * which is the honest answer: a soil with 15% fines has no D10 from sieving
+ * alone and needs a hydrometer.
+ */
+export function interpolateD(rows: SieveRow[], percent: number): number | undefined {
+  // Rows coarse → fine, so percentPassing decreases down the list.
+  const sorted = [...rows].sort((a, b) => b.size - a.size)
+  for (let i = 1; i < sorted.length; i++) {
+    const hi = sorted[i - 1], lo = sorted[i]
+    if (percent <= hi.percentPassing && percent >= lo.percentPassing) {
+      const span = hi.percentPassing - lo.percentPassing
+      if (span <= 1e-9) return lo.size
+      const f = (percent - lo.percentPassing) / span
+      // Log-linear: log D = log D_lo + f·(log D_hi − log D_lo)
+      return Math.pow(10, Math.log10(lo.size) + f * (Math.log10(hi.size) - Math.log10(lo.size)))
+    }
+  }
+  return undefined
+}
+
+/** Percent passing a given size, log-interpolated. Used for the D2487 fractions. */
+export function passingAt(rows: SieveRow[], size: number): number {
+  const sorted = [...rows].sort((a, b) => b.size - a.size)
+  const exact = sorted.find((r) => Math.abs(r.size - size) < 1e-9)
+  if (exact) return exact.percentPassing
+
+  if (!sorted.length) return 0
+  if (size >= sorted[0].size) return 100
+  if (size <= sorted[sorted.length - 1].size) return sorted[sorted.length - 1].percentPassing
+
+  for (let i = 1; i < sorted.length; i++) {
+    const hi = sorted[i - 1], lo = sorted[i]
+    if (size <= hi.size && size >= lo.size) {
+      const f = (Math.log10(size) - Math.log10(lo.size)) / (Math.log10(hi.size) - Math.log10(lo.size))
+      return lo.percentPassing + f * (hi.percentPassing - lo.percentPassing)
+    }
+  }
+  return 0
+}
+
+export function gradation(i: SieveInput): GradationResult {
+  const notes: string[] = []
+  if (!(i.totalMass > 0)) throw new Error('Total specimen mass must be greater than zero.')
+
+  const sorted = [...i.readings].sort((a, b) => b.size - a.size)
+  const pan = i.panMass ?? 0
+
+  const rows: SieveRow[] = []
+  let cumulative = 0
+  for (const r of sorted) {
+    const percentRetained = (r.massRetained / i.totalMass) * 100
+    cumulative += percentRetained
+    rows.push({
+      size: r.size,
+      designation: r.designation,
+      massRetained: r.massRetained,
+      percentRetained,
+      cumulativeRetained: cumulative,
+      // Clamped at zero: a mass-balance error must not print a negative
+      // percentage passing, which would be read as a data-entry mistake in the
+      // wrong place. The error itself is reported separately.
+      percentPassing: Math.max(100 - cumulative, 0),
+    })
+  }
+
+  const accounted = sorted.reduce((s, r) => s + r.massRetained, 0) + pan
+  const massError = ((accounted - i.totalMass) / i.totalMass) * 100
+  if (Math.abs(massError) > 1) {
+    notes.push(
+      `Mass balance is off by ${massError.toFixed(1)}% — D6913 requires closure within 1%. Re-weigh before using this grading.`,
+    )
+  }
+
+  const passing75 = passingAt(rows, SIEVE_75MM)
+  const passing4 = passingAt(rows, SIEVE_NO4)
+  const passing200 = passingAt(rows, SIEVE_NO200)
+
+  const cobbles = 100 - passing75
+  const gravel = passing75 - passing4
+  const sand = passing4 - passing200
+  const fines = passing200
+
+  const d10 = interpolateD(rows, 10)
+  const d30 = interpolateD(rows, 30)
+  const d60 = interpolateD(rows, 60)
+
+  const cu = d10 && d60 ? d60 / d10 : undefined
+  const cc = d10 && d30 && d60 ? (d30 * d30) / (d10 * d60) : undefined
+
+  if (d10 == null && fines > 10) {
+    notes.push(
+      `The curve does not reach 10% passing (${fines.toFixed(0)}% fines) — D₁₀, Cu and Cc need a hydrometer analysis to complete the grading.`,
+    )
+  }
+  if (cobbles > 0) {
+    notes.push(
+      `${cobbles.toFixed(0)}% is coarser than 75 mm. D2487 classifies the minus-75 mm fraction and reports cobbles and boulders separately.`,
+    )
+  }
+
+  return { rows, gravel, sand, fines, cobbles, d10, d30, d60, cu, cc, massError, notes }
+}
+
+/**
+ * Gradation criteria of ASTM D2487 Table 1. A gravel is well graded when
+ * Cu ≥ 4 and 1 ≤ Cc ≤ 3; a sand needs the stiffer Cu ≥ 6. Undefined when the
+ * shape parameters could not be computed — "unknown" is not "poorly graded".
+ */
+export function isWellGraded(cu: number | undefined, cc: number | undefined, kind: 'gravel' | 'sand'): boolean | undefined {
+  if (cu == null || cc == null) return undefined
+  const cuLimit = kind === 'gravel' ? 4 : 6
+  return cu >= cuLimit && cc >= 1 && cc <= 3
+}

--- a/webapp/src/engine/soils/uscs.test.ts
+++ b/webapp/src/engine/soils/uscs.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from 'vitest'
+import { classifyUSCS, overrideClassification } from './uscs'
+import { aLine } from './atterberg'
+
+// ─────────────────────────────────────────────────────────────────────────
+// Cases taken from the ASTM D2487 Table 1 decision tree, plus the two
+// worked examples in the module specification. The borderline bands are
+// where a simplified classifier goes quietly wrong, so they get the most
+// coverage: 5–12% fines, the CL-ML band, and the A-line itself.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('coarse-grained, clean (< 5% fines)', () => {
+  it('classifies a well-graded sand as SW', () => {
+    const r = classifyUSCS({ gravel: 10, sand: 87, fines: 3, cu: 8, cc: 1.5 })
+    expect(r.symbol).toBe('SW')
+    expect(r.name).toBe('Well-graded sand')
+    expect(r.dual).toBe(false)
+  })
+
+  it('classifies a uniform sand as SP — Cu below 6 fails the sand criterion', () => {
+    const r = classifyUSCS({ gravel: 2, sand: 95, fines: 3, cu: 3, cc: 1.2 })
+    expect(r.symbol).toBe('SP')
+    expect(r.reason).toMatch(/poorly graded/)
+  })
+
+  it('uses the gravel criterion (Cu ≥ 4) when gravel dominates', () => {
+    // Cu = 5 is well graded for a gravel but would fail for a sand.
+    expect(classifyUSCS({ gravel: 70, sand: 27, fines: 3, cu: 5, cc: 2 }).symbol).toBe('GW')
+    expect(classifyUSCS({ gravel: 27, sand: 70, fines: 3, cu: 5, cc: 2 }).symbol).toBe('SP')
+  })
+
+  it('adds "with gravel" when the secondary fraction reaches 15%', () => {
+    expect(classifyUSCS({ gravel: 20, sand: 77, fines: 3, cu: 8, cc: 1.5 }).name)
+      .toBe('Well-graded sand with gravel')
+    expect(classifyUSCS({ gravel: 10, sand: 87, fines: 3, cu: 8, cc: 1.5 }).name)
+      .toBe('Well-graded sand')
+  })
+
+  it('refuses to classify a clean sand without a gradation curve', () => {
+    const r = classifyUSCS({ gravel: 10, sand: 87, fines: 3 })
+    expect(r.symbol).toBeUndefined()
+    expect(r.reason).toMatch(/Cu and Cc/)
+  })
+})
+
+describe('coarse-grained with fines (> 12%)', () => {
+  it('classifies the specification example — 62% sand, 33% fines, LL 42, PI 19 — as SC', () => {
+    const r = classifyUSCS({ gravel: 5, sand: 62, fines: 33, liquidLimit: 42, plasticityIndex: 19 })
+    expect(r.symbol).toBe('SC')
+    expect(r.name).toMatch(/Clayey sand/)
+  })
+
+  it('classifies non-plastic fines as SM', () => {
+    // PI 4 at LL 25: below the A-line (16.1 → wait, A-line at 25 is 3.65) and
+    // PI ≤ 7, so it is not clayey.
+    const r = classifyUSCS({ gravel: 5, sand: 70, fines: 25, liquidLimit: 25, plasticityIndex: 2 })
+    expect(r.symbol).toBe('SM')
+    expect(r.name).toMatch(/Silty sand/)
+  })
+
+  it('takes the dual symbol SC-SM when the fines land in the CL-ML band', () => {
+    // PI 6 at LL 25: between 4 and 7, and above the A-line (3.65).
+    const r = classifyUSCS({ gravel: 5, sand: 70, fines: 25, liquidLimit: 25, plasticityIndex: 6 })
+    expect(r.symbol).toBe('SC-SM')
+    expect(r.dual).toBe(true)
+    expect(r.reason).toMatch(/CL-ML band/)
+  })
+
+  it('classifies a gravel with clayey fines as GC', () => {
+    const r = classifyUSCS({ gravel: 55, sand: 15, fines: 30, liquidLimit: 45, plasticityIndex: 25 })
+    expect(r.symbol).toBe('GC')
+  })
+
+  it('refuses to guess the fines plasticity from the fines content', () => {
+    const r = classifyUSCS({ gravel: 5, sand: 62, fines: 33 })
+    expect(r.symbol).toBeUndefined()
+    expect(r.reason).toMatch(/D4318/)
+  })
+})
+
+describe('the 5–12% fines band requires a DUAL symbol', () => {
+  it('gives SW-SC, not SW with a footnote', () => {
+    const r = classifyUSCS({ gravel: 5, sand: 87, fines: 8, cu: 8, cc: 1.5, liquidLimit: 40, plasticityIndex: 20 })
+    expect(r.symbol).toBe('SW-SC')
+    expect(r.dual).toBe(true)
+    expect(r.reason).toMatch(/5–12% band/)
+  })
+
+  it('gives SP-SM for a poorly graded sand with silty fines', () => {
+    const r = classifyUSCS({ gravel: 5, sand: 88, fines: 7, cu: 3, cc: 1.1, liquidLimit: 22, plasticityIndex: 2 })
+    expect(r.symbol).toBe('SP-SM')
+  })
+
+  it('gives GW-GM for a gravel', () => {
+    const r = classifyUSCS({ gravel: 70, sand: 20, fines: 10, cu: 6, cc: 2, liquidLimit: 20, plasticityIndex: 2 })
+    expect(r.symbol).toBe('GW-GM')
+  })
+
+  it('needs BOTH gradation and plasticity, and says so when one is missing', () => {
+    const noPlasticity = classifyUSCS({ gravel: 5, sand: 87, fines: 8, cu: 8, cc: 1.5 })
+    expect(noPlasticity.symbol).toBeUndefined()
+    expect(noPlasticity.reason).toMatch(/BOTH/)
+
+    const noGradation = classifyUSCS({ gravel: 5, sand: 87, fines: 8, liquidLimit: 40, plasticityIndex: 20 })
+    expect(noGradation.symbol).toBeUndefined()
+  })
+
+  it('boundary: 5% is dual, 4.9% is clean, 12% is dual, 12.1% is "with fines"', () => {
+    const g = { gravel: 5, cu: 8, cc: 1.5, liquidLimit: 40, plasticityIndex: 20 }
+    expect(classifyUSCS({ ...g, sand: 90.1, fines: 4.9 }).dual).toBe(false)
+    expect(classifyUSCS({ ...g, sand: 90, fines: 5 }).dual).toBe(true)
+    expect(classifyUSCS({ ...g, sand: 83, fines: 12 }).dual).toBe(true)
+    expect(classifyUSCS({ ...g, sand: 82.9, fines: 12.1 }).dual).toBe(false)
+  })
+})
+
+describe('fine-grained (≥ 50% fines)', () => {
+  it('classifies the specification example — LL 48, PI 23 — as CL', () => {
+    const r = classifyUSCS({ gravel: 0, sand: 10, fines: 90, liquidLimit: 48, plasticityIndex: 23 })
+    expect(r.symbol).toBe('CL')
+    expect(r.name).toMatch(/Lean clay/)
+  })
+
+  it('classifies a high-plasticity clay as CH', () => {
+    expect(classifyUSCS({ gravel: 0, sand: 5, fines: 95, liquidLimit: 65, plasticityIndex: 40 }).symbol).toBe('CH')
+  })
+
+  it('classifies silts below the A-line as ML and MH', () => {
+    expect(classifyUSCS({ gravel: 0, sand: 10, fines: 90, liquidLimit: 40, plasticityIndex: 10 }).symbol).toBe('ML')
+    expect(classifyUSCS({ gravel: 0, sand: 10, fines: 90, liquidLimit: 60, plasticityIndex: 20 }).symbol).toBe('MH')
+  })
+
+  it('puts a point exactly ON the A-line into the clay group', () => {
+    const LL = 45
+    const r = classifyUSCS({ gravel: 0, sand: 10, fines: 90, liquidLimit: LL, plasticityIndex: aLine(LL) })
+    expect(r.symbol).toBe('CL')
+  })
+
+  it('takes CL-ML in the 4–7 band above the A-line', () => {
+    // LL 25, A-line 3.65, PI 5 ⇒ in the band.
+    const r = classifyUSCS({ gravel: 0, sand: 10, fines: 90, liquidLimit: 25, plasticityIndex: 5 })
+    expect(r.symbol).toBe('CL-ML')
+    expect(r.dual).toBe(true)
+  })
+
+  it('classifies organic soils as OL / OH', () => {
+    expect(classifyUSCS({ gravel: 0, sand: 10, fines: 90, liquidLimit: 40, plasticityIndex: 15, organic: true }).symbol).toBe('OL')
+    expect(classifyUSCS({ gravel: 0, sand: 10, fines: 90, liquidLimit: 60, plasticityIndex: 25, organic: true }).symbol).toBe('OH')
+  })
+
+  it('adds sandy / gravelly modifiers at 30% coarse', () => {
+    expect(classifyUSCS({ gravel: 5, sand: 35, fines: 60, liquidLimit: 48, plasticityIndex: 23 }).name)
+      .toMatch(/^Sandy/)
+    expect(classifyUSCS({ gravel: 35, sand: 5, fines: 60, liquidLimit: 48, plasticityIndex: 23 }).name)
+      .toMatch(/^Gravelly/)
+  })
+
+  it('refuses to classify without Atterberg limits', () => {
+    const r = classifyUSCS({ gravel: 0, sand: 10, fines: 90 })
+    expect(r.symbol).toBeUndefined()
+    expect(r.reason).toMatch(/Atterberg limits/)
+    expect(r.reason).toMatch(/D4318/)
+  })
+
+  it('boundary: 50% fines is fine-grained, 49.9% is coarse', () => {
+    expect(classifyUSCS({ gravel: 5, sand: 45, fines: 50, liquidLimit: 48, plasticityIndex: 23 }).coarseGrained).toBe(false)
+    expect(classifyUSCS({ gravel: 5, sand: 45.1, fines: 49.9, liquidLimit: 48, plasticityIndex: 23 }).coarseGrained).toBe(true)
+  })
+})
+
+describe('the result always explains itself', () => {
+  const cases = [
+    { gravel: 10, sand: 87, fines: 3, cu: 8, cc: 1.5 },
+    { gravel: 5, sand: 62, fines: 33, liquidLimit: 42, plasticityIndex: 19 },
+    { gravel: 0, sand: 10, fines: 90, liquidLimit: 48, plasticityIndex: 23 },
+    { gravel: 0, sand: 10, fines: 90 },                       // unclassifiable
+    { gravel: 5, sand: 87, fines: 8, cu: 8, cc: 1.5, liquidLimit: 40, plasticityIndex: 20 },
+  ]
+
+  it.each(cases)('states a reason for %j', (input) => {
+    const r = classifyUSCS(input)
+    expect(r.reason.length).toBeGreaterThan(25)
+    // When it cannot classify, the reason must name the missing test.
+    if (!r.symbol) expect(r.reason).toMatch(/D4318|Cu and Cc|BOTH/)
+  })
+})
+
+describe('data sanity', () => {
+  it('notes fractions that do not sum to 100%', () => {
+    const r = classifyUSCS({ gravel: 10, sand: 50, fines: 30, liquidLimit: 40, plasticityIndex: 20 })
+    expect(r.notes.join(' ')).toMatch(/sum to 90%/)
+  })
+
+  it('notes a fine-grained point above the U-line', () => {
+    const r = classifyUSCS({ gravel: 0, sand: 10, fines: 90, liquidLimit: 30, plasticityIndex: 30 })
+    expect(r.notes.join(' ')).toMatch(/above the U-line/)
+  })
+})
+
+describe('engineer override', () => {
+  it('records both the computed value and the override', () => {
+    const r = classifyUSCS({ gravel: 5, sand: 62, fines: 33, liquidLimit: 42, plasticityIndex: 19 })
+    const o = overrideClassification(r, 'SM', 'Fines are non-plastic on re-test; the original PI was from a contaminated specimen.', 'RV')
+    expect(o.computed).toBe('SC')
+    expect(o.override).toBe('SM')
+    expect(o.by).toBe('RV')
+  })
+
+  it('refuses an override with no reason', () => {
+    // A silent override is the one thing worse than a wrong automatic answer:
+    // six months on it is indistinguishable from a typing error.
+    const r = classifyUSCS({ gravel: 5, sand: 62, fines: 33, liquidLimit: 42, plasticityIndex: 19 })
+    expect(() => overrideClassification(r, 'SM', '')).toThrow(/requires a stated reason/)
+    expect(() => overrideClassification(r, 'SM', '   ')).toThrow(/requires a stated reason/)
+  })
+})

--- a/webapp/src/engine/soils/uscs.ts
+++ b/webapp/src/engine/soils/uscs.ts
@@ -1,0 +1,240 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Unified Soil Classification System. Layer 8. ASTM D2487 Table 1.
+//
+// Gradation and plasticity in, group symbol and group name out. The decision
+// tree is D2487's, taken branch by branch rather than approximated, because the
+// borderline cases are where a classifier earns its keep and where a
+// simplified version quietly gets it wrong.
+//
+// TWO THINGS THIS CLASSIFIER WILL NOT DO:
+//
+//  1. It will not pick one symbol when D2487 requires a DUAL symbol. A sand
+//     with 5–12% fines is genuinely both — 'SW-SC' is the answer, not 'SW' with
+//     a footnote. Same for CL-ML, the silt-clay band between PI 4 and 7.
+//  2. It will not classify from incomplete data. No Atterberg limits on a
+//     fine-grained soil means no classification, not a guess from the fines
+//     content. `reason` says which test is missing.
+//
+// The engineer can override the result, and the override carries a required
+// reason (see `OverriddenClassification`). Visual-manual identification is
+// D2488 and is a different, lower-confidence claim than a D2487 classification
+// — the module keeps them apart rather than blurring them.
+// ─────────────────────────────────────────────────────────────────────────
+
+import { aLine, uLine } from './atterberg'
+import { isWellGraded } from './sieve'
+
+export interface UscsInput {
+  /** Percent coarser than 4.75 mm (of the minus-75 mm fraction), %. */
+  gravel: number
+  /** Percent between 4.75 and 0.075 mm, %. */
+  sand: number
+  /** Percent finer than 0.075 mm, %. */
+  fines: number
+  /** Shape parameters — needed for a clean coarse soil (< 5% fines). */
+  cu?: number
+  cc?: number
+  /** Atterberg limits — needed for any soil with ≥ 5% fines. */
+  liquidLimit?: number
+  plasticityIndex?: number
+  /** Field or loss-on-ignition evidence of organic content. */
+  organic?: boolean
+}
+
+export interface UscsResult {
+  /** Group symbol, e.g. 'SC' or 'SW-SM'. Undefined when unclassifiable. */
+  symbol?: string
+  /** Group name, e.g. 'Clayey sand with gravel'. */
+  name?: string
+  /** True when D2487 requires two symbols joined by a hyphen. */
+  dual: boolean
+  /** Coarse when more than half is retained on the No. 200 sieve. */
+  coarseGrained: boolean
+  /** Why the classification came out as it did, or what is missing. */
+  reason: string
+  notes: string[]
+}
+
+/** Fines plot as clay (on/above A-line, PI > 7) rather than silt. */
+function finesAreClayey(LL: number, PI: number): boolean {
+  return PI > 7 && PI >= aLine(LL)
+}
+
+/** The CL-ML band: PI between 4 and 7 inclusive AND on or above the A-line. */
+function isSiltClayBand(PI: number, LL: number): boolean {
+  return PI >= 4 && PI <= 7 && PI >= aLine(LL)
+}
+
+/** Descriptive modifier for the secondary coarse fraction (D2487 Table 1a). */
+function coarseModifier(primary: 'gravel' | 'sand', gravel: number, sand: number): string {
+  const secondary = primary === 'gravel' ? sand : gravel
+  const other = primary === 'gravel' ? 'sand' : 'gravel'
+  if (secondary >= 15) return ` with ${other}`
+  return ''
+}
+
+export function classifyUSCS(i: UscsInput): UscsResult {
+  const notes: string[] = []
+  const { gravel, sand, fines } = i
+  const total = gravel + sand + fines
+  if (Math.abs(total - 100) > 1) {
+    notes.push(`Fractions sum to ${total.toFixed(0)}%, not 100% — check the grading before relying on this.`)
+  }
+
+  const coarseGrained = fines < 50
+  const LL = i.liquidLimit
+  const PI = i.plasticityIndex
+
+  // ── Fine-grained: 50% or more passes the No. 200 sieve ──
+  if (!coarseGrained) {
+    if (LL == null || PI == null) {
+      return {
+        dual: false, coarseGrained: false, notes,
+        reason: 'Fine-grained soil (≥ 50% fines) cannot be classified without Atterberg limits — run ASTM D4318.',
+      }
+    }
+    return classifyFine(LL, PI, gravel, sand, i.organic === true, notes)
+  }
+
+  // ── Coarse-grained ──
+  const primary: 'gravel' | 'sand' = gravel > sand ? 'gravel' : 'sand'
+  const G = primary === 'gravel' ? 'G' : 'S'
+  const noun = primary === 'gravel' ? 'gravel' : 'sand'
+  const modifier = coarseModifier(primary, gravel, sand)
+
+  // Clean: < 5% fines — gradation alone decides.
+  if (fines < 5) {
+    const wellGraded = isWellGraded(i.cu, i.cc, primary)
+    if (wellGraded === undefined) {
+      return {
+        dual: false, coarseGrained: true, notes,
+        reason: `Clean ${noun} (< 5% fines) is classified on Cu and Cc, which need a complete grading curve.`,
+      }
+    }
+    const symbol = wellGraded ? `${G}W` : `${G}P`
+    const name = `${wellGraded ? 'Well-graded' : 'Poorly graded'} ${noun}${modifier}`
+    return {
+      symbol, name, dual: false, coarseGrained: true, notes,
+      reason: `Clean ${noun}: ${fines.toFixed(0)}% fines, Cu = ${i.cu?.toFixed(1)}, Cc = ${i.cc?.toFixed(2)} ⇒ ${wellGraded ? 'well' : 'poorly'} graded.`,
+    }
+  }
+
+  // With fines: > 12% — the fines' plasticity decides.
+  if (fines > 12) {
+    if (LL == null || PI == null) {
+      return {
+        dual: false, coarseGrained: true, notes,
+        reason: `${noun} with ${fines.toFixed(0)}% fines is classified on the plasticity of those fines — run ASTM D4318.`,
+      }
+    }
+    if (isSiltClayBand(PI, LL)) {
+      const symbol = `${G}C-${G}M`
+      return {
+        symbol,
+        name: `Silty, clayey ${noun}${modifier}`,
+        dual: true, coarseGrained: true, notes,
+        reason: `Fines plot in the CL-ML band (PI = ${PI.toFixed(0)}, between 4 and 7, on or above the A-line), so D2487 requires the dual symbol ${symbol}.`,
+      }
+    }
+    const clayey = finesAreClayey(LL, PI)
+    const symbol = `${G}${clayey ? 'C' : 'M'}`
+    return {
+      symbol,
+      name: `${clayey ? 'Clayey' : 'Silty'} ${noun}${modifier}`,
+      dual: false, coarseGrained: true, notes,
+      reason: `${fines.toFixed(0)}% fines plotting ${clayey ? 'on or above' : 'below'} the A-line (PI = ${PI.toFixed(0)}, A-line = ${aLine(LL).toFixed(1)}) ⇒ ${clayey ? 'clayey' : 'silty'} ${noun}.`,
+    }
+  }
+
+  // 5–12% fines — genuinely both, so D2487 requires a dual symbol.
+  const wellGraded = isWellGraded(i.cu, i.cc, primary)
+  if (wellGraded === undefined || LL == null || PI == null) {
+    return {
+      dual: true, coarseGrained: true, notes,
+      reason: `${noun} with ${fines.toFixed(0)}% fines needs a dual symbol, which requires BOTH the gradation (Cu, Cc) and the plasticity of the fines (LL, PI).`,
+    }
+  }
+  const first = wellGraded ? `${G}W` : `${G}P`
+  const clayey = finesAreClayey(LL, PI)
+  const second = `${G}${clayey ? 'C' : 'M'}`
+  const symbol = `${first}-${second}`
+  return {
+    symbol,
+    name: `${wellGraded ? 'Well-graded' : 'Poorly graded'} ${noun} with ${clayey ? 'clay' : 'silt'}${modifier}`,
+    dual: true, coarseGrained: true, notes,
+    reason: `${fines.toFixed(0)}% fines falls in the 5–12% band, where D2487 requires a dual symbol: ${first} from the gradation, ${second} from the plasticity of the fines.`,
+  }
+}
+
+function classifyFine(
+  LL: number, PI: number, gravel: number, sand: number, organic: boolean, notes: string[],
+): UscsResult {
+  if (PI > uLine(LL)) {
+    notes.push('The point plots above the U-line — no natural soil does. Re-run the limits before accepting this classification.')
+  }
+
+  const high = LL >= 50
+  const coarse = gravel + sand
+  // D2487 Table 1b: 15–29% coarse ⇒ "with sand/gravel"; ≥ 30% ⇒ "sandy/gravelly".
+  let modifier = ''
+  if (coarse >= 30) modifier = gravel > sand ? 'Gravelly ' : 'Sandy '
+  else if (coarse >= 15) modifier = ''
+  const suffix = coarse >= 15 && coarse < 30 ? (gravel > sand ? ' with gravel' : ' with sand') : ''
+
+  if (organic) {
+    const symbol = high ? 'OH' : 'OL'
+    const name = high ? 'Organic clay or silt of high plasticity' : 'Organic clay or silt of low plasticity'
+    return {
+      symbol, name, dual: false, coarseGrained: false, notes,
+      reason: `Organic fine-grained soil with LL = ${LL.toFixed(0)}% ⇒ ${symbol}. D2487 confirms O-groups by comparing the liquid limit oven-dried against not-dried (ratio < 0.75).`,
+    }
+  }
+
+  // CL-ML: the silt-clay band, a genuine dual classification.
+  if (!high && isSiltClayBand(PI, LL)) {
+    return {
+      symbol: 'CL-ML',
+      name: `${modifier}Silty clay${suffix}`.trim(),
+      dual: true, coarseGrained: false, notes,
+      reason: `PI = ${PI.toFixed(0)} lies in the 4–7 band on or above the A-line, which D2487 classifies as the dual symbol CL-ML.`,
+    }
+  }
+
+  const clayey = finesAreClayey(LL, PI)
+  const symbol = clayey ? (high ? 'CH' : 'CL') : (high ? 'MH' : 'ML')
+  const base = clayey
+    ? (high ? 'Fat clay' : 'Lean clay')
+    : (high ? 'Elastic silt' : 'Silt')
+  const name = `${modifier}${modifier ? base.toLowerCase() : base}${suffix}`
+
+  return {
+    symbol, name, dual: false, coarseGrained: false, notes,
+    reason: `LL = ${LL.toFixed(0)}% (${high ? 'high' : 'low'} plasticity), PI = ${PI.toFixed(0)} vs A-line ${aLine(LL).toFixed(1)} ⇒ ${clayey ? 'clay' : 'silt'} behaviour ⇒ ${symbol}.`,
+  }
+}
+
+// ── Engineer override ─────────────────────────────────────────────────────
+
+export interface OverriddenClassification {
+  /** What the classifier computed. Kept so the report can show both. */
+  computed?: string
+  /** What the engineer decided instead. */
+  override: string
+  /** Required — an override without a stated reason is indistinguishable
+   *  from a typing error six months later. */
+  reason: string
+  by?: string
+}
+
+/**
+ * Apply an engineer's override. Throws when no reason is supplied, because a
+ * silent override is the one thing worse than a wrong automatic answer.
+ */
+export function overrideClassification(
+  result: UscsResult, override: string, reason: string, by?: string,
+): OverriddenClassification {
+  if (!reason.trim()) {
+    throw new Error('An override of the computed classification requires a stated reason.')
+  }
+  return { computed: result.symbol, override: override.trim(), reason: reason.trim(), by }
+}


### PR DESCRIPTION
**Layer 8.** Phase 1 of the soil-investigation module (Phase 0 was #476). Four pure typed engines, **107 new tests**, validated against the ASTM D2487 decision tree, the AASHTO M 145 table and hand calculations. Still no UI — charts and pages follow.

## The engines

**`atterberg.ts`** — limits, Casagrande chart lines, flow-curve fitting.

*Non-plastic is kept distinct from PI = 0.* A soil whose thread won't roll at 3 mm has **no plastic range**; recording that as PI = 0 puts it at the chart origin where it classifies as a low-plasticity silt — a different claim entirely. `nonPlastic` keeps the two apart, and a non-plastic soil returns no liquidity index rather than dividing by zero.

LL can be given directly or read at 25 blows off a least-squares fit of *w* vs log *N*, which also yields the flow index.

**`sieve.ts`** — gradation table, D2487 fractions, D10/D30/D60, Cu, Cc.

*D-sizes interpolate on a log scale*, which is the only thing that makes them meaningful. Between 2 mm and 0.2 mm the log midpoint is **0.63 mm**; linear interpolation gives **1.1 mm** — nearly double. There's a test that pins exactly this.

It returns `undefined` rather than a number when the curve never reaches the percentage: a soil with 15% fines has no D10 from sieving alone and needs a hydrometer. Inventing one would flow straight into Cu and Cc and out into the classification.

**`uscs.ts`** — ASTM D2487 Table 1, branch by branch. Two things it refuses to do:

1. **It will not collapse a dual symbol.** A sand with 5–12% fines is genuinely `SW-SC`, not `SW` with a footnote. Same for `CL-ML` in the PI 4–7 band.
2. **It will not classify from incomplete data.** No Atterberg limits on a fine-grained soil means no classification — not a guess from the fines content. `reason` names the missing test.

An engineer override is supported and **requires a stated reason** — a silent override is indistinguishable from a typing error six months later.

**`aashto.ts`** — M 145 group index and A-groups. The table is read **left to right** because it's an elimination procedure; testing the groups independently gives the wrong answer for soils that satisfy more than one (there's a test for a soil that is A-1-b but would come out A-2-4 under independent tests).

AASHTO and USCS **disagree by design** — 35% fines boundary vs 50% — and a test pins that both answers stand rather than being reconciled.

## Two bugs the tests caught

- **`groupIndex` clamped each term of the M 145 equation at zero before summing.** The standard evaluates it signed and floors only the *total*. 40% fines at LL 20 / PI 2 is **0**, not 1. Fixed, with the equation's domain documented — outside the silt-clay groups it's arithmetic, not a soil property, and the classifier only calls it where M 145 applies it.
- **The flow index returned negative zero** on a flat flow curve, which prints as "−0" on a test sheet.

## Two of my test expectations were wrong; the engines were right

- Cobbles are the material retained *on* the 75 mm sieve and coarser — 200 g, not the 150 g I first wrote.
- LL 45 / PI 20 is **A-7-6**, not A-7-5, since PI > LL − 30.

Also loosened my own unit-check regex in the Phase 0 registry test: it required the unit at end-of-string, which rejected the legitimate compound unit "% per log cycle".

## Registry

Three new entries: `atterberg.liquid-limit-flow`, `aashto.group-index`, `aashto.classify` — each with equation, symbols, standard, assumptions and limitations, and each subject to the Phase 0 guards.

## Verification

`npm test` — **2388 passed / 161 files** (107 new) · `npx tsc -b` · `npm run lint` · `npm run build` all green.

## Honest limits

- **No hydrometer yet**, so soils with >10% fines have no D10 and the module says so rather than estimating. That's Phase 4.
- **Organic classification is taken on trust.** D2487 confirms O-groups by the oven-dried/not-dried LL ratio (< 0.75); the input is currently a boolean flag, and the reason string says what the standard actually requires.
- No `docs/ValidationMap.md` rows yet — these engines have no page, and the map tracks user-facing calculations. They land with the UI in Phase 3.

## Next

Phase 2 — SPT: N₆₀ corrections (C_B, C_S, C_R, E_R), (N₁)₆₀ with C_N, and the correlation library, every entry tagged `correlated` with its source and scatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_