### PR TITLE
Soil investigation Phase 2 — SPT corrections and correlations

### DIFF
--- a/webapp/src/engine/soils/overburden.test.ts
+++ b/webapp/src/engine/soils/overburden.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import {
+  verticalStress, effectiveStressAt, buoyantUnitWeight, GAMMA_W, type StressLayer,
+} from './overburden'
+
+const profile: StressLayer[] = [
+  { thickness: 3, gamma: 18, gammaSat: 20 },
+  { thickness: 6, gamma: 17, gammaSat: 19 },
+  { thickness: 6, gamma: 19, gammaSat: 21 },
+]
+
+describe('dry profile', () => {
+  it('accumulates γ·H with no pore pressure', () => {
+    const r = verticalStress(profile, 3)
+    expect(r.total).toBeCloseTo(3 * 18, 10)
+    expect(r.pore).toBe(0)
+    expect(r.effective).toBeCloseTo(54, 10)
+  })
+
+  it('sums across layers', () => {
+    const r = verticalStress(profile, 9)
+    expect(r.total).toBeCloseTo(3 * 18 + 6 * 17, 10)   // 54 + 102 = 156
+    expect(r.effective).toBeCloseTo(156, 10)
+  })
+
+  it('is zero at the surface', () => {
+    const r = verticalStress(profile, 0)
+    expect(r.total).toBe(0)
+    expect(r.effective).toBe(0)
+  })
+})
+
+describe('with a water table', () => {
+  it('uses saturated unit weight below the table and moist above', () => {
+    // Water table at 3 m; stress at 9 m.
+    // Total = 3(18) + 6(19) = 54 + 114 = 168
+    // Pore  = 6 × 9.81 = 58.86
+    // σ′    = 109.14
+    const r = verticalStress(profile, 9, 3)
+    expect(r.total).toBeCloseTo(168, 10)
+    expect(r.pore).toBeCloseTo(6 * GAMMA_W, 10)
+    expect(r.effective).toBeCloseTo(168 - 6 * GAMMA_W, 10)
+  })
+
+  it('splits a layer that straddles the water table', () => {
+    // Table at 5 m, inside the second layer (3–9 m).
+    // Total = 3(18) + 2(17) + 4(19) = 54 + 34 + 76 = 164
+    const r = verticalStress(profile, 9, 5)
+    expect(r.total).toBeCloseTo(164, 10)
+    expect(r.pore).toBeCloseTo(4 * GAMMA_W, 10)
+  })
+
+  it('does NOT use the midpoint unit weight for a straddling layer', () => {
+    // Taking whichever γ applies at the layer midpoint would give
+    // 3(18) + 6(19) = 168 (midpoint 6 m is below the 5 m table).
+    // The correct split gives 164 — a 4 kPa difference that grows with
+    // thickness and flows straight into (N₁)₆₀.
+    expect(verticalStress(profile, 9, 5).total).not.toBeCloseTo(168, 6)
+  })
+
+  it('gives buoyant unit weight below the table', () => {
+    // Effective stress increment per metre below the table is γsat − γw.
+    const a = verticalStress(profile, 4, 3).effective
+    const b = verticalStress(profile, 5, 3).effective
+    expect(b - a).toBeCloseTo(19 - GAMMA_W, 10)
+    expect(buoyantUnitWeight(19)).toBeCloseTo(19 - GAMMA_W, 10)
+  })
+
+  it('reads lower than the same profile dry — buoyancy is not optional', () => {
+    expect(verticalStress(profile, 15, 3).effective)
+      .toBeLessThan(verticalStress(profile, 15).effective)
+  })
+})
+
+describe('missing data is reported, not absorbed', () => {
+  it('warns when a submerged layer has no saturated unit weight', () => {
+    const noSat: StressLayer[] = [{ thickness: 10, gamma: 18 }]
+    const r = verticalStress(noSat, 8, 2)
+    expect(r.notes.join(' ')).toMatch(/no saturated unit weight/)
+    expect(r.notes.join(' ')).toMatch(/read low/)
+  })
+
+  it('does not warn when the layer never gets wet', () => {
+    const noSat: StressLayer[] = [{ thickness: 10, gamma: 18 }]
+    expect(verticalStress(noSat, 8).notes).toEqual([])
+  })
+
+  it('warns when asked below the logged profile', () => {
+    const r = verticalStress(profile, 25)
+    expect(r.notes.join(' ')).toMatch(/below the logged profile/)
+    // It still returns the stress at the base rather than throwing.
+    expect(r.total).toBeCloseTo(3 * 18 + 6 * 17 + 6 * 19, 10)
+  })
+
+  it('rejects a negative depth', () => {
+    expect(() => verticalStress(profile, -1)).toThrow(/must not be negative/)
+  })
+})
+
+describe('effectiveStressAt shorthand', () => {
+  it('matches the full result', () => {
+    expect(effectiveStressAt(profile, 9, 3)).toBeCloseTo(verticalStress(profile, 9, 3).effective, 10)
+  })
+
+  it('feeds a sensible C_N range for a real profile', () => {
+    // A shallow test in this profile should sit above the reference stress
+    // only near the surface; by 9 m σ′ is comfortably above 100 kPa.
+    expect(effectiveStressAt(profile, 2, 3)).toBeLessThan(100)
+    expect(effectiveStressAt(profile, 9, 3)).toBeGreaterThan(100)
+  })
+})

--- a/webapp/src/engine/soils/overburden.ts
+++ b/webapp/src/engine/soils/overburden.ts
@@ -1,0 +1,102 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Vertical stress in a layered profile. Layer 8.
+//
+// Total stress is the weight of everything above; pore pressure is the head of
+// water above; effective stress is the difference, and it is the one that
+// governs strength, compressibility and the SPT overburden correction.
+//
+// SUBMERGED SOIL USES ITS SATURATED UNIT WEIGHT, NOT ITS BULK ONE. A layer
+// below the water table weighs more (it is full of water) but pushes less (that
+// water carries part of the load). Using the moist γ below the table
+// double-counts the buoyancy and reads σ′ high, which flows straight into an
+// unconservative (N₁)₆₀ and from there into an unconservative friction angle.
+//
+// This module takes unit weights EXPLICITLY rather than reading them from the
+// parameter engine, so it stays usable before parameters have been interpreted
+// and so its tests do not depend on that layer.
+//
+// UNITS: depth m; unit weight kN/m³; stress kPa.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Unit weight of water, kN/m³. */
+export const GAMMA_W = 9.81
+
+/** One stratum for a stress profile. */
+export interface StressLayer {
+  /** Thickness, m. */
+  thickness: number
+  /** Moist/bulk unit weight above the water table, kN/m³. */
+  gamma: number
+  /** Saturated unit weight below the water table, kN/m³. Falls back to gamma. */
+  gammaSat?: number
+}
+
+export interface StressAtDepth {
+  depth: number
+  /** Total vertical stress, kPa. */
+  total: number
+  /** Pore water pressure, kPa. */
+  pore: number
+  /** Effective vertical stress σ′v0 = total − pore, kPa. */
+  effective: number
+  notes: string[]
+}
+
+/**
+ * Vertical stress at a depth in a layered profile.
+ *
+ * `waterTable` is the depth to the water table, m below ground; omit it (or
+ * pass Infinity) for a dry profile. A layer straddling the table is integrated
+ * in two parts, moist above and saturated below, rather than taking whichever
+ * unit weight happens to apply at its midpoint.
+ */
+export function verticalStress(
+  layers: StressLayer[], depth: number, waterTable = Infinity,
+): StressAtDepth {
+  const notes: string[] = []
+  if (depth < 0) throw new Error('Depth must not be negative.')
+
+  let total = 0
+  let z = 0        // running depth at the top of the current layer
+  let remaining = depth
+
+  for (const l of layers) {
+    if (remaining <= 0) break
+    const slice = Math.min(l.thickness, remaining)
+    const sat = l.gammaSat ?? l.gamma
+    if (l.gammaSat == null && z + slice > waterTable) {
+      notes.push(
+        `A submerged layer has no saturated unit weight, so its moist γ = ${l.gamma} kN/m³ was used. Effective stress will read low.`,
+      )
+    }
+
+    // Split the slice at the water table when it straddles it.
+    const dryPart = Math.max(Math.min(slice, waterTable - z), 0)
+    const wetPart = slice - dryPart
+    total += dryPart * l.gamma + wetPart * sat
+
+    z += slice
+    remaining -= slice
+  }
+
+  if (remaining > 1e-9) {
+    notes.push(
+      `The profile is ${(depth - remaining).toFixed(2)} m deep but the stress was asked for at ${depth.toFixed(2)} m — the stress below the logged profile is not computed.`,
+    )
+  }
+
+  const pore = Math.max(depth - waterTable, 0) * GAMMA_W
+  const effective = total - pore
+  return { depth, total, pore, effective, notes }
+}
+
+/** Effective vertical stress only — the common case. */
+export const effectiveStressAt = (
+  layers: StressLayer[], depth: number, waterTable = Infinity,
+): number => verticalStress(layers, depth, waterTable).effective
+
+/**
+ * Buoyant (submerged) unit weight γ′ = γsat − γw. The weight a submerged soil
+ * actually contributes to effective stress.
+ */
+export const buoyantUnitWeight = (gammaSat: number): number => gammaSat - GAMMA_W

--- a/webapp/src/engine/soils/registry.ts
+++ b/webapp/src/engine/soils/registry.ts
@@ -314,6 +314,27 @@ export const CALCULATIONS = {
     ],
   },
 
+  'stress.effective-vertical': {
+    title: 'Effective vertical stress',
+    category: 'field',
+    equation: String.raw`\sigma'_{v0} = \sum \gamma_i h_i - \gamma_w \max(z - z_w,\ 0)`,
+    unit: 'kPa',
+    symbols: {
+      "\\sigma'_{v0}": 'effective vertical stress, kPa',
+      '\\gamma_i': 'unit weight of layer i — moist above the water table, saturated below, kN/m³',
+      h_i: 'thickness of layer i contributing above the depth, m',
+      '\\gamma_w': 'unit weight of water, 9.81 kN/m³',
+      z: 'depth of interest, m',
+      z_w: 'depth to the water table, m',
+    },
+    reference: 'Terzaghi effective-stress principle',
+    assumptions: ['Hydrostatic pore pressure below a static water table.'],
+    limitations: [
+      'A layer straddling the water table must be integrated in two parts. Taking whichever unit weight applies at its midpoint reads the stress high and flows straight into an unconservative (N₁)₆₀.',
+      'Artesian or perched conditions are not hydrostatic and need a measured piezometric profile.',
+    ],
+  },
+
   // ── Strength ──
   'ucs.qu': {
     title: 'Unconfined compressive strength',

--- a/webapp/src/engine/soils/spt.test.ts
+++ b/webapp/src/engine/soils/spt.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from 'vitest'
+import {
+  sptCorrections, correctionCB, correctionCS, correctionCR, correctionCN,
+  correlatePhi, correlateRelativeDensity, correlateUndrainedStrength,
+  densityFromN60, consistencyFromN60, HAMMER_ENERGY, P_ATM,
+} from './spt'
+import type { SptTest } from './model'
+
+const test = (over: Partial<SptTest> = {}): SptTest => ({
+  id: 't1', depth: 6, blows: [4, 7, 8], penetration: [150, 150, 150],
+  hammer: 'safety', rodLength: 7.5, ...over,
+})
+
+describe('individual corrections', () => {
+  it('C_B by borehole diameter (Skempton 1986)', () => {
+    expect(correctionCB(100)).toBe(1.0)
+    expect(correctionCB(115)).toBe(1.0)
+    expect(correctionCB(150)).toBe(1.05)
+    expect(correctionCB(200)).toBe(1.15)
+    expect(correctionCB(undefined)).toBe(1.0)
+  })
+
+  it('C_S is above 1 when a liner-ready sampler is used without one', () => {
+    expect(correctionCS('standard')).toBe(1.0)
+    expect(correctionCS('liner-absent')).toBe(1.2)
+    expect(correctionCS(undefined)).toBe(1.0)
+  })
+
+  it('C_R rises with rod length to 1.0 beyond 10 m (Youd et al. 2001)', () => {
+    expect(correctionCR(2)).toBe(0.75)
+    expect(correctionCR(3.5)).toBe(0.8)
+    expect(correctionCR(5)).toBe(0.85)
+    expect(correctionCR(8)).toBe(0.95)
+    expect(correctionCR(12)).toBe(1.0)
+    expect(correctionCR(undefined)).toBe(1.0)
+  })
+
+  it('C_N is 1.0 at the reference overburden and capped at 1.7', () => {
+    expect(correctionCN(P_ATM)).toBeCloseTo(1.0, 10)
+    expect(correctionCN(400)).toBeCloseTo(0.5, 10)
+    // Without the cap a shallow test inflates without limit as σ′ → 0.
+    expect(correctionCN(1)).toBe(1.7)
+    expect(correctionCN(0)).toBe(1.7)
+    expect(correctionCN(-5)).toBe(1.7)
+  })
+})
+
+describe('N60', () => {
+  it('matches a hand calculation', () => {
+    // N = 7 + 8 = 15; safety hammer 60%; 100 mm hole C_B = 1.0;
+    // standard sampler C_S = 1.0; 7.5 m rods C_R = 0.95.
+    // N60 = 15 × (60/60) × 1.0 × 1.0 × 0.95 = 14.25
+    const r = sptCorrections({ test: test(), boreholeDiameter: 100 })
+    expect(r.N).toBe(15)
+    expect(r.n60).toBeCloseTo(14.25, 10)
+  })
+
+  it('uses the seating drive for nothing — N is the 2nd + 3rd increments', () => {
+    // Changing only the seating blows must not move N.
+    const a = sptCorrections({ test: test({ blows: [4, 7, 8] }) })
+    const b = sptCorrections({ test: test({ blows: [25, 7, 8] }) })
+    expect(a.N).toBe(b.N)
+  })
+
+  it('scales with a measured energy ratio and says it was measured', () => {
+    const r = sptCorrections({ test: test({ energyRatio: 80 }), boreholeDiameter: 100 })
+    expect(r.energyMeasured).toBe(true)
+    expect(r.n60).toBeCloseTo(15 * (80 / 60) * 0.95, 10)
+    expect(r.notes.join(' ')).not.toMatch(/default/)
+  })
+
+  it('falls back to a hammer default AND warns that it is weak', () => {
+    const r = sptCorrections({ test: test({ hammer: 'automatic' }), boreholeDiameter: 100 })
+    expect(r.energyMeasured).toBe(false)
+    expect(r.energyRatio).toBe(HAMMER_ENERGY.automatic)
+    expect(r.notes.join(' ')).toMatch(/vary widely between nominally identical rigs/)
+  })
+
+  it('warns when no rod length was recorded', () => {
+    const r = sptCorrections({ test: test({ rodLength: undefined }) })
+    expect(r.cr).toBe(1.0)
+    expect(r.notes.join(' ')).toMatch(/Shallow tests are over-estimated/)
+  })
+})
+
+describe('(N1)60', () => {
+  it('applies C_N only when an effective stress is supplied', () => {
+    const without = sptCorrections({ test: test(), boreholeDiameter: 100 })
+    expect(without.cn).toBeUndefined()
+    expect(without.n160).toBeUndefined()
+
+    const with_ = sptCorrections({ test: test(), boreholeDiameter: 100, effectiveStress: 100 })
+    expect(with_.cn).toBeCloseTo(1.0, 10)
+    expect(with_.n160).toBeCloseTo(with_.n60, 10)
+  })
+
+  it('normalises two depths in the same sand to comparable values', () => {
+    // The point of (N1)60: a shallow N and a deep N in the same material
+    // should come out closer after normalising than before.
+    const shallow = sptCorrections({ test: test({ blows: [2, 4, 5], rodLength: 4 }), boreholeDiameter: 100, effectiveStress: 40 })
+    const deep = sptCorrections({ test: test({ blows: [6, 10, 12], rodLength: 15 }), boreholeDiameter: 100, effectiveStress: 250 })
+
+    const rawGap = Math.abs(deep.N - shallow.N)
+    const normalisedGap = Math.abs(deep.n160! - shallow.n160!)
+    expect(normalisedGap).toBeLessThan(rawGap)
+  })
+
+  it('says when the overburden correction hit its cap', () => {
+    const r = sptCorrections({ test: test(), boreholeDiameter: 100, effectiveStress: 20 })
+    expect(r.cn).toBe(1.7)
+    expect(r.notes.join(' ')).toMatch(/1\.7 cap/)
+  })
+})
+
+describe('refusal is a lower bound, not a measurement', () => {
+  const refused = test({ blows: [30, 50, 25], penetration: [150, 150, 75] })
+
+  it('is flagged and explained', () => {
+    const r = sptCorrections({ test: refused, boreholeDiameter: 100 })
+    expect(r.refusal).toBe(true)
+    expect(r.notes.join(' ')).toMatch(/LOWER BOUND/)
+    expect(r.notes.join(' ')).toMatch(/correlations must not be applied/)
+  })
+
+  it('makes every correlation decline rather than return a number', () => {
+    // Correcting a lower bound produces a more precise-looking lower bound,
+    // not a better estimate.
+    expect(correlatePhi(40, 'clean-sand', true).value).toBeUndefined()
+    expect(correlatePhi(40, 'clean-sand', true).declined).toMatch(/refusal/)
+    expect(correlateRelativeDensity(40, 'clean-sand', true).declined).toBeTruthy()
+    expect(correlateUndrainedStrength(40, 'clay', 20, true).declined).toBeTruthy()
+  })
+})
+
+describe('correlations carry their provenance, never a bare number', () => {
+  it('φ from (N1)60 names the source and the scatter', () => {
+    const out = correlatePhi(18, 'clean-sand')
+    const v = out.value!
+    expect(v.value).toBeCloseTo(Math.sqrt(20 * 18) + 20, 10)
+    expect(v.unit).toBe('°')
+    expect(v.provenance.kind).toBe('correlated')
+    if (v.provenance.kind === 'correlated') {
+      expect(v.provenance.source).toMatch(/Hatanaka/)
+      expect(v.provenance.scatter).toBe('±3°')
+      expect(v.provenance.basis).toMatch(/\(N₁\)₆₀ = 18/)
+    }
+  })
+
+  it('declines φ for a clay and says what to run instead', () => {
+    const out = correlatePhi(18, 'clay')
+    expect(out.value).toBeUndefined()
+    expect(out.declined).toMatch(/triaxial or direct shear/)
+  })
+
+  it('notes when φ is applied to a silty sand — outside the fitted data', () => {
+    const out = correlatePhi(18, 'silty-sand')
+    expect(out.value!.note).toMatch(/outside the clean-sand data/)
+  })
+
+  it('relative density is capped at 100% and declined for clay', () => {
+    expect(correlateRelativeDensity(60, 'clean-sand').value!.value).toBeCloseTo(100, 10)
+    expect(correlateRelativeDensity(200, 'clean-sand').value!.value).toBe(100)
+    expect(correlateRelativeDensity(20, 'clay').declined).toMatch(/not defined for a cohesive soil/)
+  })
+
+  it('cu from N60 varies f with plasticity and states the band', () => {
+    const low = correlateUndrainedStrength(10, 'clay', 15).value!
+    const mid = correlateUndrainedStrength(10, 'clay', 25).value!
+    expect(low.value).toBeCloseTo(45, 10)     // f = 4.5
+    expect(mid.value).toBeCloseTo(60, 10)     // f = 6
+    if (mid.provenance.kind === 'correlated') {
+      expect(mid.provenance.scatter).toMatch(/4–6 kPa/)
+    }
+  })
+
+  it('warns that SPT is a poor test in soft clay', () => {
+    expect(correlateUndrainedStrength(3, 'clay', 25).value!.note).toMatch(/vane, UCS or triaxial/)
+    expect(correlateUndrainedStrength(20, 'clay', 25).value!.note).toBeUndefined()
+  })
+
+  it('declines cu for a granular soil', () => {
+    expect(correlateUndrainedStrength(20, 'clean-sand').declined).toMatch(/granular/)
+  })
+
+  it('declines a negative or non-finite blow count', () => {
+    expect(correlatePhi(-1, 'clean-sand').declined).toBeTruthy()
+    expect(correlateRelativeDensity(NaN, 'clean-sand').declined).toBeTruthy()
+  })
+})
+
+describe('descriptive terms', () => {
+  it('maps N60 onto density and consistency (Terzaghi & Peck)', () => {
+    expect(densityFromN60(2)).toBe('very loose')
+    expect(densityFromN60(8)).toBe('loose')
+    expect(densityFromN60(20)).toBe('medium dense')
+    expect(densityFromN60(40)).toBe('dense')
+    expect(densityFromN60(60)).toBe('very dense')
+
+    expect(consistencyFromN60(1)).toBe('very soft')
+    expect(consistencyFromN60(6)).toBe('firm')
+    expect(consistencyFromN60(20)).toBe('very stiff')
+    expect(consistencyFromN60(40)).toBe('hard')
+  })
+})

--- a/webapp/src/engine/soils/spt.ts
+++ b/webapp/src/engine/soils/spt.ts
@@ -1,0 +1,255 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Standard Penetration Test corrections and correlations. Layer 8.
+// ASTM D1586 · Skempton (1986) · Youd et al. (2001) NCEER.
+//
+// The raw SPT blow count is not a soil property. It is the response of one
+// particular hammer, on one particular rig, through one particular length of
+// rod, at one particular depth — and every one of those changes the number.
+// N60 removes the equipment; (N1)60 additionally removes the overburden, so
+// that two tests at 3 m and 15 m in the same sand can be compared.
+//
+// WHAT THIS MODULE WILL NOT DO:
+//
+//  • It will not correct a REFUSAL. A drive that stopped short of 450 mm gives
+//    a blow count that is a lower bound, not a measurement, and multiplying a
+//    lower bound by C_N produces a more precise-looking lower bound rather than
+//    a better estimate. `sptCorrections` reports it and refuses the correlations.
+//
+//  • It will not apply a sand correlation to a clay. Every correlation here
+//    carries the soil it was fitted to, and `correlate*` returns a warning
+//    rather than a number when asked outside that range.
+//
+// Every correlated value comes back as a `SourcedValue` with
+// `kind: 'correlated'`, its basis, its source AND its scatter — a correlation
+// quoted bare reads exactly like a measurement, which is the misreading the
+// whole module exists to prevent.
+//
+// UNITS: depth m; rod length m; borehole diameter mm; stress kPa; angles degrees.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { SptTest, HammerType, SamplerType } from './model'
+import { fieldN, isRefusal } from './model'
+import { correlated, type SourcedValue } from './provenance'
+
+/** Atmospheric pressure used as the reference overburden, kPa. */
+export const P_ATM = 100
+
+/**
+ * Hammer energy ratios, %. These are DEFAULTS, and weak ones: measured energy
+ * ratios for nominally identical hammers span a wide band in practice, so a
+ * measured E_R is worth far more than the correction it replaces.
+ * Ranges after Skempton (1986) / NCEER.
+ */
+export const HAMMER_ENERGY: Record<HammerType, number> = {
+  donut: 45,
+  safety: 60,
+  automatic: 80,
+}
+
+/** Borehole-diameter correction C_B (Skempton 1986). */
+export function correctionCB(diameterMm: number | undefined): number {
+  if (diameterMm == null) return 1.0
+  if (diameterMm <= 115) return 1.0    // 65–115 mm
+  if (diameterMm <= 150) return 1.05
+  return 1.15                          // 200 mm
+}
+
+/**
+ * Sampler correction C_S. A sampler built for a liner but used WITHOUT one
+ * gives a lower blow count, so the correction is above 1.
+ */
+export function correctionCS(sampler: SamplerType | undefined): number {
+  return sampler === 'liner-absent' ? 1.2 : 1.0
+}
+
+/** Rod-length correction C_R (Youd et al. 2001, Table 2). */
+export function correctionCR(rodLengthM: number | undefined): number {
+  if (rodLengthM == null) return 1.0
+  if (rodLengthM < 3) return 0.75
+  if (rodLengthM < 4) return 0.8
+  if (rodLengthM < 6) return 0.85
+  if (rodLengthM < 10) return 0.95
+  return 1.0
+}
+
+/**
+ * Overburden correction C_N = √(Pa/σ′v0), capped at 1.7 (Liao & Whitman 1986,
+ * cap per Youd et al. 2001). Without the cap a shallow test would be inflated
+ * without limit as σ′v0 → 0.
+ */
+export function correctionCN(effectiveStress: number): number {
+  if (!(effectiveStress > 0)) return 1.7
+  return Math.min(Math.sqrt(P_ATM / effectiveStress), 1.7)
+}
+
+export interface SptCorrectionInput {
+  test: SptTest
+  /** Hole diameter, mm. Falls back to the borehole's own value upstream. */
+  boreholeDiameter?: number
+  /** Effective vertical stress at the test depth, kPa. Needed for (N1)60. */
+  effectiveStress?: number
+}
+
+export interface SptCorrections {
+  /** Field N — second plus third increment. */
+  N: number
+  energyRatio: number
+  /** True when E_R came from a measurement rather than a hammer-type default. */
+  energyMeasured: boolean
+  cb: number
+  cs: number
+  cr: number
+  n60: number
+  /** Overburden correction. Undefined without an effective stress. */
+  cn?: number
+  /** (N1)60. Undefined without an effective stress. */
+  n160?: number
+  /** The drive did not achieve full penetration — N is a lower bound. */
+  refusal: boolean
+  notes: string[]
+}
+
+export function sptCorrections(i: SptCorrectionInput): SptCorrections {
+  const t = i.test
+  const notes: string[] = []
+  const N = fieldN(t)
+  const refusal = isRefusal(t)
+
+  const energyMeasured = t.energyRatio != null
+  const energyRatio = t.energyRatio ?? HAMMER_ENERGY[t.hammer ?? 'safety']
+  if (!energyMeasured) {
+    notes.push(
+      `Hammer energy taken as the ${t.hammer ?? 'safety'}-hammer default of ${energyRatio}%. Measured energy ratios vary widely between nominally identical rigs — a measured value is worth more than this correction.`,
+    )
+  }
+
+  const cb = correctionCB(i.boreholeDiameter)
+  const cs = correctionCS(t.sampler)
+  const cr = correctionCR(t.rodLength)
+  if (t.rodLength == null) {
+    notes.push('No rod length recorded, so C_R is taken as 1.0. Shallow tests are over-estimated without it.')
+  }
+
+  const n60 = N * (energyRatio / 60) * cb * cs * cr
+
+  let cn: number | undefined
+  let n160: number | undefined
+  if (i.effectiveStress != null) {
+    cn = correctionCN(i.effectiveStress)
+    n160 = cn * n60
+    if (cn >= 1.7) {
+      notes.push('The overburden correction is at its 1.7 cap — the test is shallow and (N₁)₆₀ is a capped estimate.')
+    }
+  }
+
+  if (refusal) {
+    notes.push(
+      'The drive did not achieve full penetration. N is a LOWER BOUND, not a measurement: corrections make it look more precise without making it more accurate, and correlations must not be applied to it.',
+    )
+  }
+
+  return { N, energyRatio, energyMeasured, cb, cs, cr, n60, cn, n160, refusal, notes }
+}
+
+// ── Correlations ──────────────────────────────────────────────────────────
+// Each returns a SourcedValue tagged `correlated`, or a refusal explaining why
+// it does not apply. Returning a bare number would strip exactly the context
+// that stops a correlation being read as a measurement.
+
+export type SoilKind = 'clean-sand' | 'silty-sand' | 'clay' | 'unknown'
+
+export interface CorrelationOutput {
+  value?: SourcedValue
+  /** Present when the correlation was declined; says why. */
+  declined?: string
+}
+
+/**
+ * Effective friction angle from (N₁)₆₀ — Hatanaka & Uchida (1996):
+ *   φ′ = √(20·(N₁)₆₀) + 20
+ * Fitted to CLEAN SANDS, scatter roughly ±3°.
+ */
+export function correlatePhi(n160: number, soil: SoilKind, refusal = false): CorrelationOutput {
+  if (refusal) return { declined: 'The blow count is a refusal lower bound; a friction angle from it would be meaningless.' }
+  if (soil === 'clay') {
+    return { declined: 'Hatanaka & Uchida is fitted to clean sands. A drained friction angle for clay needs a triaxial or direct shear test.' }
+  }
+  if (!(n160 >= 0)) return { declined: 'A negative or non-finite blow count cannot be correlated.' }
+
+  const phi = Math.sqrt(20 * n160) + 20
+  const note = soil === 'silty-sand'
+    ? 'Applied to a silty sand — outside the clean-sand data the relation was fitted to.'
+    : undefined
+  return {
+    value: correlated(phi, '°', {
+      basis: `corrected SPT (N₁)₆₀ = ${n160.toFixed(0)}`,
+      source: 'Hatanaka & Uchida (1996)',
+      scatter: '±3°',
+    }, note),
+  }
+}
+
+/**
+ * Relative density from (N₁)₆₀ — Skempton (1986):
+ *   D_r = √((N₁)₆₀ / 60) × 100
+ * Fitted to normally consolidated clean sand.
+ */
+export function correlateRelativeDensity(n160: number, soil: SoilKind, refusal = false): CorrelationOutput {
+  if (refusal) return { declined: 'The blow count is a refusal lower bound.' }
+  if (soil === 'clay') return { declined: 'Relative density is not defined for a cohesive soil.' }
+  if (!(n160 >= 0)) return { declined: 'A negative or non-finite blow count cannot be correlated.' }
+
+  const dr = Math.min(Math.sqrt(n160 / 60) * 100, 100)
+  return {
+    value: correlated(dr, '%', {
+      basis: `corrected SPT (N₁)₆₀ = ${n160.toFixed(0)}`,
+      source: 'Skempton (1986), normally consolidated clean sand',
+      scatter: 'overconsolidated or aged deposits read high',
+    }),
+  }
+}
+
+/**
+ * Undrained shear strength from N₆₀ — Stroud (1974): c_u ≈ f·N₆₀ with f
+ * between about 4 and 6 kPa depending on plasticity. This is an
+ * order-of-magnitude estimate, and SPT in soft clay is a poor test outright.
+ */
+export function correlateUndrainedStrength(
+  n60: number, soil: SoilKind, plasticityIndex?: number, refusal = false,
+): CorrelationOutput {
+  if (refusal) return { declined: 'The blow count is a refusal lower bound.' }
+  if (soil !== 'clay' && soil !== 'unknown') {
+    return { declined: 'Undrained shear strength applies to cohesive soils; this layer is granular.' }
+  }
+  if (!(n60 >= 0)) return { declined: 'A negative or non-finite blow count cannot be correlated.' }
+
+  // f rises with plasticity across Stroud's band; 6 kPa at PI ≈ 20–30.
+  const f = plasticityIndex == null ? 5 : plasticityIndex < 20 ? 4.5 : plasticityIndex <= 30 ? 6 : 5
+  const cu = f * n60
+  return {
+    value: correlated(cu, 'kPa', {
+      basis: `N₆₀ = ${n60.toFixed(0)}${plasticityIndex != null ? `, PI = ${plasticityIndex.toFixed(0)}%` : ''}`,
+      source: `Stroud (1974), f = ${f} kPa`,
+      scatter: 'f ranges 4–6 kPa with plasticity; an order-of-magnitude estimate',
+    }, n60 < 5 ? 'SPT is a poor test in soft clay — prefer a vane, UCS or triaxial where one exists.' : undefined),
+  }
+}
+
+/** Descriptive density of a granular soil from N₆₀ (Terzaghi & Peck). */
+export function densityFromN60(n60: number): string {
+  if (n60 < 4) return 'very loose'
+  if (n60 < 10) return 'loose'
+  if (n60 < 30) return 'medium dense'
+  if (n60 < 50) return 'dense'
+  return 'very dense'
+}
+
+/** Descriptive consistency of a cohesive soil from N₆₀ (Terzaghi & Peck). */
+export function consistencyFromN60(n60: number): string {
+  if (n60 < 2) return 'very soft'
+  if (n60 < 4) return 'soft'
+  if (n60 < 8) return 'firm'
+  if (n60 < 15) return 'stiff'
+  if (n60 < 30) return 'very stiff'
+  return 'hard'
+}

--- a/webapp/src/engine/soils/sptProfile.test.ts
+++ b/webapp/src/engine/soils/sptProfile.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest'
+import { sptProfile, type LayerUnitWeight } from './sptProfile'
+import { sampleInvestigation } from './sample'
+import { effectiveStressAt } from './overburden'
+
+const bh = () => structuredClone(sampleInvestigation()).boreholes[0]
+
+/** Unit weights for every layer of BH-01. */
+const allWeights: Record<string, LayerUnitWeight> = {
+  'bh1-l1': { gamma: 17, gammaSat: 19 },
+  'bh1-l2': { gamma: 18, gammaSat: 20 },
+  'bh1-l3': { gamma: 16, gammaSat: 18 },
+  'bh1-l4': { gamma: 19, gammaSat: 21 },
+}
+
+describe('a fully specified hole', () => {
+  const p = sptProfile(bh(), allWeights)
+
+  it('returns every test, in depth order', () => {
+    expect(p.rows).toHaveLength(8)
+    const depths = p.rows.map((r) => r.depth)
+    expect([...depths].sort((a, b) => a - b)).toEqual(depths)
+  })
+
+  it('attributes each test to the layer it falls in', () => {
+    const at6 = p.rows.find((r) => r.depth === 6)!
+    expect(at6.layerName).toBe('Lean Clay')       // 4.2–8.5 m
+    const at12 = p.rows.find((r) => r.depth === 12)!
+    expect(at12.layerName).toBe('Poorly Graded Sand')
+  })
+
+  it('computes effective stress consistent with the standalone helper', () => {
+    const at9 = p.rows.find((r) => r.depth === 9)!
+    const expected = effectiveStressAt(
+      [
+        { thickness: 1.5, gamma: 17, gammaSat: 19 },
+        { thickness: 2.7, gamma: 18, gammaSat: 20 },
+        { thickness: 4.3, gamma: 16, gammaSat: 18 },
+        { thickness: 11.5, gamma: 19, gammaSat: 21 },
+      ],
+      9, 7.8,
+    )
+    expect(at9.effectiveStress).toBeCloseTo(expected, 8)
+  })
+
+  it('gives (N1)60 everywhere the stress is known', () => {
+    expect(p.rows.every((r) => r.n160 != null)).toBe(true)
+    expect(p.missingUnitWeights).toEqual([])
+  })
+
+  it('applies the hole diameter to C_B', () => {
+    // BH-01 is a 100 mm hole ⇒ C_B = 1.0.
+    expect(p.rows.every((r) => r.cb === 1.0)).toBe(true)
+  })
+
+  it('normalises the deep dense sand below its raw blow count', () => {
+    // At 18 m the effective stress is well above 100 kPa, so C_N < 1.
+    const at18 = p.rows.find((r) => r.depth === 18)!
+    expect(at18.effectiveStress!).toBeGreaterThan(100)
+    expect(at18.cn!).toBeLessThan(1)
+    expect(at18.n160!).toBeLessThan(at18.n60)
+  })
+})
+
+describe('missing unit weights are reported, never defaulted', () => {
+  it('stops computing stress below the first layer with no unit weight', () => {
+    // A wrong γ moves σ′v0, which moves C_N, which moves (N₁)₆₀, which moves φ′.
+    const partial = { 'bh1-l1': allWeights['bh1-l1'], 'bh1-l2': allWeights['bh1-l2'] }
+    const p = sptProfile(bh(), partial)
+
+    // Layers 1–2 cover 0–4.2 m.
+    const shallow = p.rows.filter((r) => r.depth <= 4.2)
+    const deep = p.rows.filter((r) => r.depth > 4.2)
+    expect(shallow.every((r) => r.effectiveStress != null)).toBe(true)
+    expect(deep.every((r) => r.effectiveStress === undefined)).toBe(true)
+    expect(deep.every((r) => r.n160 === undefined)).toBe(true)
+  })
+
+  it('still reports N60, which needs no stress', () => {
+    const p = sptProfile(bh(), {})
+    expect(p.rows.every((r) => r.n60 > 0)).toBe(true)
+    expect(p.rows.every((r) => r.n160 === undefined)).toBe(true)
+  })
+
+  it('names the layers it is missing and the depth it stopped at', () => {
+    const p = sptProfile(bh(), { 'bh1-l1': allWeights['bh1-l1'] })
+    expect(p.missingUnitWeights).toEqual(['Silty Sand', 'Lean Clay', 'Poorly Graded Sand'])
+    expect(p.notes.join(' ')).toMatch(/not computed below 1\.50 m/)
+  })
+})
+
+describe('groundwater', () => {
+  it('warns when no water table was recorded', () => {
+    const dry = bh()
+    dry.groundwaterDepth = undefined
+    const p = sptProfile(dry, allWeights)
+    expect(p.notes.join(' ')).toMatch(/treated as dry/)
+  })
+
+  it('a dry profile gives a higher effective stress than a wet one', () => {
+    const dry = bh()
+    dry.groundwaterDepth = undefined
+    const wet = sptProfile(bh(), allWeights).rows.find((r) => r.depth === 18)!
+    const dryRow = sptProfile(dry, allWeights).rows.find((r) => r.depth === 18)!
+    expect(dryRow.effectiveStress!).toBeGreaterThan(wet.effectiveStress!)
+  })
+})
+
+describe('refusals', () => {
+  it('counts them and says the blow counts are lower bounds', () => {
+    const withRefusal = bh()
+    withRefusal.spt[7].penetration = [150, 150, 60]
+    const p = sptProfile(withRefusal, allWeights)
+    expect(p.notes.join(' ')).toMatch(/1 of 8 tests hit refusal/)
+    expect(p.rows.find((r) => r.depth === 18)!.refusal).toBe(true)
+  })
+})
+
+describe('an empty hole', () => {
+  it('returns an empty profile rather than throwing', () => {
+    const empty = bh()
+    empty.spt = []
+    const p = sptProfile(empty, allWeights)
+    expect(p.rows).toEqual([])
+    expect(p.notes.join(' ')).not.toMatch(/refusal/)
+  })
+})

--- a/webapp/src/engine/soils/sptProfile.ts
+++ b/webapp/src/engine/soils/sptProfile.ts
@@ -1,0 +1,117 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Whole-borehole SPT profile: every test corrected, in depth order. Layer 8.
+//
+// `spt.ts` corrects one test. This walks a hole, computes the effective stress
+// at each test depth from the supplied unit weights, and returns the corrected
+// profile the log plot and the parameter engine both read.
+//
+// Unit weights come in EXPLICITLY, keyed by layer id. They are an
+// interpretation — usually correlated from the very blow counts being corrected
+// — so the caller owns that judgement and this module stays a pure
+// transformation. Where a layer has no unit weight the profile says so instead
+// of substituting a default, because a wrong γ moves σ′v0, which moves C_N,
+// which moves (N₁)₆₀, which moves φ′.
+//
+// UNITS: depth m; unit weight kN/m³; stress kPa.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { Borehole } from './model'
+import { layerThickness } from './model'
+import { sptCorrections, type SptCorrections } from './spt'
+import { verticalStress, type StressLayer } from './overburden'
+
+/** Unit weights for one layer, kN/m³. */
+export interface LayerUnitWeight {
+  gamma: number
+  gammaSat?: number
+}
+
+export interface SptProfileRow extends SptCorrections {
+  testId: string
+  depth: number
+  /** Effective vertical stress at the test depth, kPa. Undefined when unknown. */
+  effectiveStress?: number
+  /** Layer the test falls in, when the profile covers that depth. */
+  layerId?: string
+  layerName?: string
+}
+
+export interface SptProfile {
+  rows: SptProfileRow[]
+  /** Layers with no unit weight supplied — every stress below them is unknown. */
+  missingUnitWeights: string[]
+  notes: string[]
+}
+
+/**
+ * Correct every SPT in a hole.
+ *
+ * `unitWeights` is keyed by layer id. When any layer above a test lacks a unit
+ * weight, that test's effective stress and (N₁)₆₀ come back undefined rather
+ * than guessed — N₆₀ is still reported, since it needs no stress.
+ */
+export function sptProfile(
+  bh: Borehole, unitWeights: Record<string, LayerUnitWeight>,
+): SptProfile {
+  const notes: string[] = []
+  const ordered = [...bh.layers].sort((a, b) => a.depthTop - b.depthTop)
+
+  const missingUnitWeights = ordered
+    .filter((l) => unitWeights[l.id] == null)
+    .map((l) => l.name)
+
+  // Depth above which every layer has a unit weight; below it, stress is unknown.
+  let knownTo = 0
+  for (const l of ordered) {
+    if (unitWeights[l.id] == null) break
+    knownTo = l.depthBottom
+  }
+
+  const stressLayers: StressLayer[] = []
+  for (const l of ordered) {
+    const uw = unitWeights[l.id]
+    if (uw == null) break
+    stressLayers.push({ thickness: layerThickness(l), gamma: uw.gamma, gammaSat: uw.gammaSat })
+  }
+
+  if (missingUnitWeights.length) {
+    notes.push(
+      `No unit weight for ${missingUnitWeights.join(', ')}. Effective stress — and therefore (N₁)₆₀ — is not computed below ${knownTo.toFixed(2)} m.`,
+    )
+  }
+
+  const rows: SptProfileRow[] = [...bh.spt]
+    .sort((a, b) => a.depth - b.depth)
+    .map((t) => {
+      const layer = ordered.find((l) => t.depth >= l.depthTop && t.depth < l.depthBottom)
+      const canStress = t.depth <= knownTo + 1e-9
+      const effectiveStress = canStress
+        ? verticalStress(stressLayers, t.depth, bh.groundwaterDepth ?? Infinity).effective
+        : undefined
+
+      const corrections = sptCorrections({
+        test: t,
+        boreholeDiameter: bh.diameter,
+        effectiveStress,
+      })
+
+      return {
+        ...corrections,
+        testId: t.id,
+        depth: t.depth,
+        effectiveStress,
+        layerId: layer?.id,
+        layerName: layer?.name,
+      }
+    })
+
+  const refusals = rows.filter((r) => r.refusal).length
+  if (refusals) {
+    notes.push(`${refusals} of ${rows.length} tests hit refusal — those blow counts are lower bounds.`)
+  }
+  if (bh.groundwaterDepth == null && rows.some((r) => r.effectiveStress != null)) {
+    notes.push('No groundwater depth recorded, so the profile is treated as dry. Effective stress reads high if it is not.')
+  }
+
+  return { rows, missingUnitWeights, notes }
+}


### PR DESCRIPTION
**Layer 8.** Phase 2 of the soil-investigation module (#476 Phase 0, #477 Phase 1). N₆₀, (N₁)₆₀ and the correlation library, plus the effective-stress profile they depend on. **54 new tests** against Skempton (1986), Youd et al. (2001) NCEER, and hand calculations.

## `spt.ts` — corrections and correlations

The raw blow count is not a soil property. It's the response of one hammer, on one rig, through one length of rod, at one depth — and every one of those changes the number. N₆₀ removes the equipment (E_R, C_B, C_S, C_R); (N₁)₆₀ additionally removes the overburden (C_N, capped at 1.7) so tests at 3 m and 15 m in the same sand can be compared. A test pins that normalising actually brings two such tests *closer together* than their raw counts.

**Two things it refuses to do**, both deliberate:

1. **It will not correct a refusal.** A drive that stopped short of 450 mm gives a lower bound, not a measurement — multiplying a lower bound by C_N produces a more precise-*looking* lower bound, not a better estimate. Every correlation declines on a refusal.
2. **It will not apply a sand correlation to a clay.** Each correlation carries the soil it was fitted to and returns a stated refusal rather than a number when asked outside it: *"Hatanaka & Uchida is fitted to clean sands. A drained friction angle for clay needs a triaxial or direct shear test."*

Correlations return a `SourcedValue` tagged `correlated` with **basis, source and scatter**. A correlation quoted bare reads exactly like a measurement — the misreading the whole module exists to prevent.

Hammer-type energy defaults carry a note saying they're weak: measured energy ratios vary widely between nominally identical rigs, and a measured E_R is worth more than the correction it replaces.

## `overburden.ts` — vertical stress in a layered profile

Submerged soil uses its **saturated** unit weight, and a layer straddling the water table is integrated in **two parts**. Taking whichever unit weight applies at the layer midpoint gives 168 kPa against the correct 164 kPa in the test case — and that error flows straight into C_N, then (N₁)₆₀, then φ′. There's a test that pins the two apart explicitly.

Missing saturated unit weights are reported ("effective stress will read low"), not substituted.

## `sptProfile.ts` — whole-borehole profile

Unit weights come in **explicitly**, keyed by layer id, because they're an interpretation — usually correlated from the very blow counts being corrected — and belong to the caller, not to this module.

Where a layer has no unit weight, the stress and (N₁)₆₀ below it come back `undefined` rather than guessed. N₆₀ is still reported, since it needs no stress. The profile names which layers it's missing and the depth it stopped at.

## Registry

One new entry: `stress.effective-vertical`, with the straddling-layer trap recorded as a limitation.

## Verification

`npm test` — **2442 passed / 164 files** (54 new) · `npx tsc -b` · `npm run lint` · `npm run build` all green.

## Honest limits

- **The correlations are still just correlations.** The scatter is stated on every one, but a φ′ from SPT is not a measured φ′, and the module can only label that — it can't fix it.
- **Hydrostatic pore pressure only.** Artesian or perched conditions need a measured piezometric profile; the limitation is recorded in the registry entry.
- **`sptProfile` needs unit weights it can't supply itself.** Closing that loop — correlate γ, feed it back, recompute — is the Phase 5 parameter engine's job, and doing it here would make this module depend on the thing that depends on it.
- No `ValidationMap.md` rows yet; these engines have no page until Phase 3.

## Next

Phase 3 — the investigation UI: borehole page, graphical log column (as a testable geometry module like `planRenderer`, not JSX math), and the soil-profile editor. That's the first phase with routes, so the docs and feature-gate guards start applying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_