### PR TITLE
Soil investigation Phase 3a — borehole log renderer

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1317,3 +1317,36 @@ because flagging the unusual as an error trains people to ignore errors.
 8. **Postgres, CPT, 3D subsurface.**
 
 **Open for the user:** which plan tier gates this (suggest `pro`+).
+
+## Soil investigation — progress
+
+| Phase | PR | State |
+|---|---|---|
+| 0 — model, provenance, registry, store | #476 | merged |
+| 1 — classification (Atterberg, sieve, USCS, AASHTO) | #477 | merged |
+| 2 — SPT corrections, correlations, overburden | #478 | merged |
+| 3a — borehole log renderer (geometry) | #479 | open |
+| 3b — investigation UI, routes, profile editor | — | next |
+| 4 — laboratory suite | — | |
+| 5 — parameter engine + wiring to existing analysis | — | the payoff |
+| 6 — liquefaction, bearing methods, Coulomb | — | |
+| 7 — report document builder | — | |
+| 8 — Postgres, CPT, 3D subsurface | — | |
+
+**Everything so far is engine-only** — 364 tests across 12 modules, and not one
+line of it is reachable from the app yet. Phase 3b is the first with routes, and
+therefore the first to hit `docsContent.test.ts` (every route needs a docs
+entry) and `featureGate.ts` (`ROUTE_FEATURE` key-set equality with
+`trialQuota.GATED_PREFIXES`).
+
+**Two recurring lessons from these phases**, both worth remembering:
+
+1. *Tests can enshrine a bug.* The log renderer drew "Silty Sand" with silt
+   hatching, and the test asserted that behaviour with a comment explaining it
+   ("'silt' matches first") — I had written down what the code did rather than
+   what was right. Only rendering the log and looking at it caught it. In a soil
+   name the adjective comes first and the noun governs.
+2. *Check the standard, not the plausible reading of it.* `groupIndex` clamped
+   each term of AASHTO M 145 at zero before summing, which is a different
+   equation from the one the standard prints — 40% fines at LL 20 / PI 2 is 0,
+   not 1.

--- a/webapp/src/engine/soils/logRenderer.test.ts
+++ b/webapp/src/engine/soils/logRenderer.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildBoreholeLog, hatchFor, hatchLines, wrapText, yOf, thinnestLayer,
+  layerAtLogDepth, logHeight, DEFAULT_LAYOUT,
+} from './logRenderer'
+import { planToSvg } from '../planRenderer'
+import { sampleInvestigation } from './sample'
+import type { Borehole } from './model'
+
+const bh = (): Borehole => structuredClone(sampleInvestigation()).boreholes[0]
+
+const texts = (d: { primitives: { kind: string }[] }) =>
+  d.primitives.filter((p): p is { kind: 'text'; text: string } & typeof p => p.kind === 'text')
+    .map((p) => (p as unknown as { text: string }).text)
+
+describe('depth scale', () => {
+  it('maps ground depth to paper millimetres linearly below the header', () => {
+    const L = DEFAULT_LAYOUT
+    expect(yOf(0, L)).toBe(L.headerH)
+    expect(yOf(1, L)).toBe(L.headerH + L.mmPerMetre)
+    expect(yOf(10, L) - yOf(5, L)).toBeCloseTo(5 * L.mmPerMetre, 10)
+  })
+
+  it('honours an overridden scale', () => {
+    const d = buildBoreholeLog(bh(), { layout: { mmPerMetre: 20 } })
+    const shallow = buildBoreholeLog(bh(), { layout: { mmPerMetre: 8 } })
+    expect(logHeight(d)).toBeGreaterThan(logHeight(shallow))
+  })
+})
+
+describe('hatch selection', () => {
+  it('reads the USCS family from the group symbol', () => {
+    expect(hatchFor('GW', 'anything')).toBe('gravel')
+    expect(hatchFor('SP-SM', 'anything')).toBe('sand')
+    expect(hatchFor('CL', 'anything')).toBe('clay')
+    expect(hatchFor('MH', 'anything')).toBe('silt')
+    expect(hatchFor('OH', 'anything')).toBe('organic')
+  })
+
+  it('falls back to the description, where the NOUN governs', () => {
+    // Found by looking at a rendered log, not by reading the code: my first
+    // version scanned for the first matching word, so "Silty Sand" drew as
+    // silt. A soil name puts the adjective first and the noun last — "Silty
+    // Sand" is a sand (SM), "Sandy Clay" is a clay.
+    expect(hatchFor(undefined, 'Silty Sand')).toBe('sand')
+    expect(hatchFor(undefined, 'Clayey Sand')).toBe('sand')
+    expect(hatchFor(undefined, 'Sandy Clay')).toBe('clay')
+    expect(hatchFor(undefined, 'Gravelly Silt')).toBe('silt')
+    expect(hatchFor(undefined, 'Lean Clay')).toBe('clay')
+    expect(hatchFor(undefined, 'Poorly Graded Sand')).toBe('sand')
+    expect(hatchFor(undefined, 'Something else')).toBe('unknown')
+  })
+
+  it('still prefers the group symbol over the description', () => {
+    // The symbol is a classification; the name is prose. SM is a sand even if
+    // somebody typed "clay" in the description field.
+    expect(hatchFor('SM', 'Silty Sand')).toBe('sand')
+    expect(hatchFor('CL', 'Sandy Clay')).toBe('clay')
+  })
+
+  it('recognises fill and rock ahead of the symbol', () => {
+    // A fill logged as SM is still drawn as fill — it is a construction
+    // history, not a soil type, and the log column should say so.
+    expect(hatchFor('SM', 'Sand Fill')).toBe('fill')
+    expect(hatchFor('GW', 'Weathered bedrock')).toBe('rock')
+  })
+
+  it('emits strokes for every hatched family and none for unknown', () => {
+    for (const k of ['clay', 'silt', 'sand', 'gravel', 'organic', 'fill', 'rock'] as const) {
+      expect(hatchLines(k, 0, 0, 26, 40).length, k).toBeGreaterThan(0)
+    }
+    expect(hatchLines('unknown', 0, 0, 26, 40)).toEqual([])
+  })
+
+  it('keeps hatching inside the band it was given', () => {
+    const h = hatchLines('clay', 10, 20, 26, 30)
+    for (const p of h) {
+      if (p.kind === 'line') {
+        expect(p.y1).toBeGreaterThanOrEqual(20)
+        expect(p.y1).toBeLessThanOrEqual(50)
+        expect(p.x1).toBeGreaterThanOrEqual(10)
+        expect(p.x2).toBeLessThanOrEqual(36)
+      }
+    }
+  })
+
+  it('scales the number of strokes with the band height', () => {
+    expect(hatchLines('clay', 0, 0, 26, 60).length)
+      .toBeGreaterThan(hatchLines('clay', 0, 0, 26, 20).length)
+  })
+
+  it('terminates on a zero-height band instead of looping forever', () => {
+    for (const k of ['clay', 'silt', 'sand', 'gravel', 'organic', 'fill', 'rock'] as const) {
+      expect(hatchLines(k, 0, 0, 26, 0).length, k).toBe(0)
+    }
+  })
+})
+
+describe('wrapText', () => {
+  it('breaks on word boundaries', () => {
+    expect(wrapText('Medium dense silty fine to medium SAND', 20))
+      .toEqual(['Medium dense silty', 'fine to medium SAND'])
+  })
+
+  it('leaves a word longer than the limit intact', () => {
+    // Cutting "poorly-graded" mid-word makes a log harder to read, not easier.
+    expect(wrapText('overconsolidated clay', 8)).toEqual(['overconsolidated', 'clay'])
+  })
+
+  it('handles empty and whitespace-only input', () => {
+    expect(wrapText('', 20)).toEqual([])
+    expect(wrapText('   ', 20)).toEqual([])
+  })
+})
+
+describe('a real borehole log', () => {
+  const d = buildBoreholeLog(bh())
+
+  it('titles itself and reports the drawn depth', () => {
+    expect(d.title).toBe('BH-01 — borehole log')
+    expect(d.maxDepth).toBe(20)
+  })
+
+  it('draws one strata rectangle per layer', () => {
+    const rects = d.primitives.filter((p) => p.kind === 'rect')
+    expect(rects).toHaveLength(4)
+  })
+
+  it('prints every layer-top depth', () => {
+    const t = texts(d)
+    for (const depth of ['0.00', '1.50', '4.20', '8.50']) expect(t).toContain(depth)
+    expect(t).toContain('20.00')   // base of the profile
+  })
+
+  it('prints the hole header — elevation, depth and groundwater', () => {
+    const header = texts(d).find((x) => x.includes('EL'))!
+    expect(header).toMatch(/EL 1450\.35 m/)
+    expect(header).toMatch(/depth 20\.00 m/)
+    expect(header).toMatch(/GWT 7\.80 m/)
+  })
+
+  it('draws the water table at the right depth, with its triangle', () => {
+    const L = DEFAULT_LAYOUT
+    const y = yOf(7.8, L)
+    const line = d.primitives.find((p) => p.kind === 'line' && Math.abs((p as { y1: number }).y1 - y) < 1e-9 && (p as { stroke?: string }).stroke === '#0284c7')
+    expect(line).toBeDefined()
+    expect(d.primitives.some((p) => p.kind === 'path')).toBe(true)
+  })
+
+  it('says so when there is no water table rather than drawing one', () => {
+    const dry = bh()
+    dry.groundwaterDepth = undefined
+    const dd = buildBoreholeLog(dry)
+    expect(texts(dd).find((x) => x.includes('GWT'))).toMatch(/not encountered/)
+    expect(dd.primitives.some((p) => p.kind === 'path')).toBe(false)
+  })
+
+  it('prints the SPT N values', () => {
+    const t = texts(d)
+    expect(t).toContain('8')    // 4/4 at 1.5 m
+    expect(t).toContain('35')   // 16/19 at 9 m
+  })
+
+  it('marks a refusal so it cannot be read as a measurement', () => {
+    const refused = bh()
+    refused.spt[7].penetration = [150, 150, 60]
+    const dd = buildBoreholeLog(refused)
+    const t = texts(dd)
+    expect(t).toContain('62*')
+    expect(t.join(' ')).toMatch(/refusal — N is a lower bound/)
+  })
+
+  it('omits the SPT column for a hole with no tests', () => {
+    const noSpt = bh()
+    noSpt.spt = []
+    const dd = buildBoreholeLog(noSpt)
+    expect(texts(dd)).not.toContain('SPT N')
+    expect(dd.bounds.maxX).toBeLessThan(buildBoreholeLog(bh()).bounds.maxX)
+  })
+
+  it('anchors description text inside its own layer band', () => {
+    // Centring would let a thin layer's label drift into the next one.
+    const L = DEFAULT_LAYOUT
+    // Below the header rule — the "DESCRIPTION" column label sits above it.
+    const descTexts = d.primitives.filter(
+      (p) => p.kind === 'text'
+        && (p as unknown as { x: number }).x === L.descX
+        && (p as unknown as { y: number }).y > L.headerH,
+    ) as unknown as { y: number }[]
+    expect(descTexts.length).toBeGreaterThan(3)
+    for (const t of descTexts) {
+      const layer = bh().layers.find((l) => t.y >= yOf(l.depthTop, L) && t.y <= yOf(l.depthBottom, L) + 3.2)
+      expect(layer, `text at y=${t.y} is outside every layer band`).toBeDefined()
+    }
+  })
+
+  it('bounds enclose everything drawn', () => {
+    const xs: number[] = []
+    const ys: number[] = []
+    for (const p of d.primitives) {
+      if (p.kind === 'line') { xs.push(p.x1, p.x2); ys.push(p.y1, p.y2) }
+      else if (p.kind === 'rect') { xs.push(p.x, p.x + p.w); ys.push(p.y, p.y + p.h) }
+      else if (p.kind === 'circle') { xs.push(p.cx); ys.push(p.cy) }
+      else if (p.kind === 'text') { xs.push(p.x); ys.push(p.y) }
+    }
+    expect(Math.min(...xs)).toBeGreaterThanOrEqual(d.bounds.minX)
+    expect(Math.max(...ys)).toBeLessThanOrEqual(d.bounds.maxY)
+  })
+})
+
+describe('it serialises through the existing plan serialiser', () => {
+  it('produces valid SVG with no new painting code', () => {
+    // The point of emitting PlanPrimitive: planToSvg already knows how to
+    // paint every one of these.
+    const svg = planToSvg(buildBoreholeLog(bh()))
+    expect(svg.startsWith('<svg')).toBe(true)
+    expect(svg).toContain('</svg>')
+    expect(svg).toContain('BH-01')
+    expect(svg).not.toMatch(/NaN|undefined/)
+  })
+})
+
+describe('degenerate holes', () => {
+  it('draws a hole with no layers without throwing', () => {
+    const empty = bh()
+    empty.layers = []
+    empty.spt = []
+    const d = buildBoreholeLog(empty)
+    expect(d.primitives.length).toBeGreaterThan(0)
+    expect(planToSvg(d)).not.toMatch(/NaN/)
+  })
+
+  it('reports the thinnest layer, so a caller can pick a scale that shows it', () => {
+    expect(thinnestLayer(bh())).toBeCloseTo(1.5, 10)
+    const none = bh(); none.layers = []
+    expect(thinnestLayer(none)).toBeUndefined()
+  })
+
+  it('finds the layer at a depth, with the contact belonging to the lower layer', () => {
+    expect(layerAtLogDepth(bh(), 0)!.name).toBe('Fill')
+    expect(layerAtLogDepth(bh(), 1.5)!.name).toBe('Silty Sand')
+    expect(layerAtLogDepth(bh(), 100)).toBeUndefined()
+  })
+})

--- a/webapp/src/engine/soils/logRenderer.ts
+++ b/webapp/src/engine/soils/logRenderer.ts
@@ -1,0 +1,343 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Borehole log drawing — pure geometry. Layer 8.
+//
+// Emits the same typed `PlanPrimitive` list the structural plan renderer uses,
+// so `planToSvg` serialises a borehole log with no new painting code. That is
+// the whole reason this is a geometry module and not JSX: the column positions,
+// the depth scale, the hatch spacing and the label collision handling are all
+// arithmetic, and arithmetic belongs somewhere it can be tested.
+//
+// LAYOUT (x to the right, y DOWNWARD = increasing depth, drafting convention):
+//
+//     depth   symbol   strata column        description        SPT N
+//     ────────────────────────────────────────────────────────────────
+//     0.00 ─  [SM]     ▓▓▓▓▓▓▓▓▓▓▓▓         Silty SAND          8
+//     1.50 ─  [CL]     ░░░░░░░░░░░░         Lean CLAY          14
+//
+// The drawing is in MILLIMETRES of paper, not metres of ground: a log is a
+// drafted sheet, and fixing the paper geometry here keeps the depth scale
+// explicit (`mmPerMetre`) rather than hidden in a viewBox.
+//
+// UNITS: ground depth m; drawing coordinates mm of paper.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { PlanPrimitive, Drawing } from '../planRenderer'
+import type { Borehole, SoilLayer } from './model'
+import { layerThickness } from './model'
+import { fieldN } from './model'
+
+/** Column x-positions and widths, mm of paper. */
+export interface LogLayout {
+  depthColX: number
+  symbolColX: number
+  strataX: number
+  strataW: number
+  descX: number
+  descW: number
+  sptX: number
+  /** Paper millimetres per metre of depth. */
+  mmPerMetre: number
+  /** Header height above depth zero, mm. */
+  headerH: number
+}
+
+export const DEFAULT_LAYOUT: LogLayout = {
+  depthColX: 0,
+  symbolColX: 22,
+  strataX: 42,
+  strataW: 26,
+  descX: 74,
+  descW: 88,
+  sptX: 172,
+  mmPerMetre: 8,
+  headerH: 14,
+}
+
+/**
+ * Hatch pattern per USCS family. Coarse soils get sparse dots/rings, fine soils
+ * get dense lines — the convention on a hand-drafted log, kept because an
+ * engineer reads the column before reading the words.
+ */
+export type HatchKind = 'gravel' | 'sand' | 'silt' | 'clay' | 'organic' | 'fill' | 'rock' | 'unknown'
+
+export function hatchFor(symbol: string | undefined, name: string): HatchKind {
+  const s = (symbol ?? '').toUpperCase()
+  const n = name.toLowerCase()
+  if (n.includes('fill')) return 'fill'
+  if (n.includes('rock') || n.includes('bedrock')) return 'rock'
+  if (s.startsWith('G')) return 'gravel'
+  if (s.startsWith('S')) return 'sand'
+  if (s.startsWith('O') || n.includes('organic') || n.includes('peat')) return 'organic'
+  if (s.startsWith('C')) return 'clay'
+  if (s.startsWith('M')) return 'silt'
+
+  // No group symbol: fall back to the description, where THE NOUN GOVERNS.
+  // "Silty Sand" is a sand that happens to be silty — SM, drawn as sand. A
+  // first-match scan returns silt and draws the wrong column, which misleads
+  // an engineer who reads the strata before the words. Soil names put the
+  // adjective first and the noun last, so the LAST match wins.
+  const nouns: [string, HatchKind][] = [
+    ['gravel', 'gravel'], ['sand', 'sand'], ['silt', 'silt'], ['clay', 'clay'],
+  ]
+  let best: { at: number; kind: HatchKind } | undefined
+  for (const [word, kind] of nouns) {
+    const at = n.lastIndexOf(word)
+    if (at >= 0 && (!best || at > best.at)) best = { at, kind }
+  }
+  return best?.kind ?? 'unknown'
+}
+
+const HATCH_FILL: Record<HatchKind, string> = {
+  gravel: '#d6d3d1',
+  sand: '#fde68a',
+  silt: '#d9f99d',
+  clay: '#bfdbfe',
+  organic: '#a8a29e',
+  fill: '#e7e5e4',
+  rock: '#a1a1aa',
+  unknown: '#f5f5f4',
+}
+
+export interface LogDrawing extends Drawing {
+  title: string
+  /** Depth of the deepest thing drawn, m — for a caller sizing a page. */
+  maxDepth: number
+}
+
+export interface LogOptions {
+  layout?: Partial<LogLayout>
+  /** Draw the SPT column. Off for a hole with no tests. */
+  showSpt?: boolean
+  /** Description text wraps at this many characters. */
+  wrapChars?: number
+}
+
+/** Y coordinate (mm of paper) for a ground depth (m). */
+export const yOf = (depth: number, L: LogLayout): number => L.headerH + depth * L.mmPerMetre
+
+/**
+ * Break a description onto lines of at most `max` characters, on word
+ * boundaries. A word longer than the limit is left intact rather than cut —
+ * splitting "poorly-graded" mid-word makes a log harder to read, not easier.
+ */
+export function wrapText(text: string, max: number): string[] {
+  if (max <= 0) return [text]
+  const words = text.split(/\s+/).filter(Boolean)
+  if (!words.length) return []
+  const lines: string[] = []
+  let line = ''
+  for (const w of words) {
+    if (!line) line = w
+    else if (line.length + 1 + w.length <= max) line += ` ${w}`
+    else { lines.push(line); line = w }
+  }
+  if (line) lines.push(line)
+  return lines
+}
+
+export function buildBoreholeLog(bh: Borehole, opts: LogOptions = {}): LogDrawing {
+  const L: LogLayout = { ...DEFAULT_LAYOUT, ...opts.layout }
+  const wrapChars = opts.wrapChars ?? 30
+  const showSpt = opts.showSpt ?? bh.spt.length > 0
+  const p: PlanPrimitive[] = []
+
+  const layers = [...bh.layers].sort((a, b) => a.depthTop - b.depthTop)
+  const maxDepth = Math.max(
+    bh.actualDepth,
+    layers.length ? layers[layers.length - 1].depthBottom : 0,
+    ...bh.spt.map((t) => t.depth),
+  )
+  const bottomY = yOf(maxDepth, L)
+  const rightX = showSpt ? L.sptX + 18 : L.descX + L.descW
+
+  // ── Header ──
+  p.push({ kind: 'text', x: L.depthColX, y: 6, text: bh.name, size: 4.5, weight: 700 })
+  const headerBits = [
+    bh.groundElevation != null ? `EL ${bh.groundElevation.toFixed(2)} m` : null,
+    `depth ${bh.actualDepth.toFixed(2)} m`,
+    bh.groundwaterDepth != null ? `GWT ${bh.groundwaterDepth.toFixed(2)} m` : 'GWT not encountered',
+  ].filter(Boolean)
+  p.push({ kind: 'text', x: L.strataX, y: 6, text: headerBits.join('  ·  '), size: 2.6, color: '#475569' })
+
+  for (const [x, label] of [
+    [L.depthColX, 'DEPTH (m)'], [L.symbolColX, 'USCS'],
+    [L.strataX, 'STRATA'], [L.descX, 'DESCRIPTION'],
+    ...(showSpt ? [[L.sptX, 'SPT N'] as [number, string]] : []),
+  ] as [number, string][]) {
+    p.push({ kind: 'text', x, y: L.headerH - 3, text: label, size: 2.4, weight: 700, color: '#334155' })
+  }
+  p.push({ kind: 'line', x1: L.depthColX, y1: L.headerH, x2: rightX, y2: L.headerH, stroke: '#334155', width: 0.5 })
+
+  // ── Strata column ──
+  for (const l of layers) {
+    const y1 = yOf(l.depthTop, L)
+    const y2 = yOf(l.depthBottom, L)
+    const h = y2 - y1
+    const kind = hatchFor(l.symbol, l.name)
+
+    p.push({
+      kind: 'rect', x: L.strataX, y: y1, w: L.strataW, h,
+      fill: HATCH_FILL[kind], stroke: '#334155', width: 0.3,
+    })
+    p.push(...hatchLines(kind, L.strataX, y1, L.strataW, h))
+
+    // Depth tick + label at the TOP of every layer.
+    p.push({ kind: 'line', x1: L.depthColX + 14, y1, x2: L.strataX, y2: y1, stroke: '#94a3b8', width: 0.25 })
+    p.push({ kind: 'text', x: L.depthColX, y: y1 + 1, text: l.depthTop.toFixed(2), size: 2.6 })
+
+    if (l.symbol) {
+      p.push({ kind: 'text', x: L.symbolColX, y: y1 + 3.2, text: l.symbol, size: 2.8, weight: 700, color: '#0056b3' })
+    }
+
+    const desc = l.description ?? l.name
+    const lines = wrapText(desc, wrapChars)
+    // Text is anchored to the layer top rather than centred, so a thin layer's
+    // label still lands inside its own band instead of drifting into the next.
+    lines.slice(0, Math.max(1, Math.floor(h / 3.2))).forEach((ln, k) => {
+      p.push({ kind: 'text', x: L.descX, y: y1 + 3.2 + k * 3.2, text: ln, size: 2.6 })
+    })
+  }
+
+  // Base of the logged profile.
+  const baseY = layers.length ? yOf(layers[layers.length - 1].depthBottom, L) : L.headerH
+  p.push({ kind: 'text', x: L.depthColX, y: baseY + 1, text: (layers.length ? layers[layers.length - 1].depthBottom : 0).toFixed(2), size: 2.6 })
+
+  // ── Groundwater ──
+  if (bh.groundwaterDepth != null) {
+    const y = yOf(bh.groundwaterDepth, L)
+    p.push({ kind: 'line', x1: L.strataX - 6, y1: y, x2: L.descX + L.descW, y2: y, stroke: '#0284c7', width: 0.5, dash: [3, 1.5] })
+    // Standard water-table triangle.
+    p.push({
+      kind: 'path', closed: true, fill: '#0284c7', stroke: '#0284c7', width: 0.3,
+      cmds: [
+        { c: 'M', x: L.strataX - 6, y: y - 2.2 },
+        { c: 'L', x: L.strataX - 2, y: y - 2.2 },
+        { c: 'L', x: L.strataX - 4, y },
+      ],
+    })
+  }
+
+  // ── SPT column ──
+  if (showSpt) {
+    for (const t of [...bh.spt].sort((a, b) => a.depth - b.depth)) {
+      const y = yOf(t.depth, L)
+      const N = fieldN(t)
+      const refusal = t.penetration?.some((v) => v < 150) ?? false
+      p.push({ kind: 'line', x1: L.descX + L.descW, y1: y, x2: L.sptX - 2, y2: y, stroke: '#cbd5e1', width: 0.25 })
+      p.push({
+        kind: 'text', x: L.sptX, y: y + 1,
+        // A refusal prints as "50/75mm"-style notation, never as a bare number:
+        // the log must not let a lower bound read as a measurement.
+        text: refusal ? `${N}*` : String(N),
+        size: 2.8, weight: refusal ? 700 : 400,
+        color: refusal ? '#b45309' : '#0f172a',
+      })
+    }
+    if (bh.spt.some((t) => t.penetration?.some((v) => v < 150))) {
+      p.push({
+        kind: 'text', x: L.sptX - 4, y: bottomY + 6,
+        text: '* refusal — N is a lower bound', size: 2.2, color: '#b45309',
+      })
+    }
+  }
+
+  // ── Frame ──
+  p.push({ kind: 'line', x1: L.depthColX, y1: bottomY, x2: rightX, y2: bottomY, stroke: '#334155', width: 0.5 })
+  for (const x of [L.strataX, L.strataX + L.strataW, L.descX + L.descW]) {
+    p.push({ kind: 'line', x1: x, y1: L.headerH, x2: x, y2: bottomY, stroke: '#cbd5e1', width: 0.25 })
+  }
+
+  return {
+    primitives: p,
+    bounds: { minX: L.depthColX - 2, minY: 0, maxX: rightX + 2, maxY: bottomY + 10 },
+    title: `${bh.name} — borehole log`,
+    maxDepth,
+  }
+}
+
+/**
+ * Hatch strokes for a strata band. Kept separate and pure so the pattern for a
+ * given soil can be tested without building a whole log.
+ */
+export function hatchLines(kind: HatchKind, x: number, y: number, w: number, h: number): PlanPrimitive[] {
+  const out: PlanPrimitive[] = []
+  const stroke = '#64748b'
+  const width = 0.2
+
+  switch (kind) {
+    case 'clay':
+      // Dense horizontal lines.
+      for (let yy = y + 1.5; yy < y + h; yy += 1.5) {
+        out.push({ kind: 'line', x1: x + 1, y1: yy, x2: x + w - 1, y2: yy, stroke, width })
+      }
+      break
+    case 'silt':
+      // Horizontal lines with a dash, sparser than clay.
+      for (let yy = y + 2.5; yy < y + h; yy += 2.5) {
+        out.push({ kind: 'line', x1: x + 1, y1: yy, x2: x + w - 1, y2: yy, stroke, width, dash: [2, 1.5] })
+      }
+      break
+    case 'sand':
+      // Stippling on a staggered grid.
+      for (let yy = y + 2, row = 0; yy < y + h; yy += 2.6, row++) {
+        for (let xx = x + 2.5 + (row % 2 ? 1.6 : 0); xx < x + w - 1.5; xx += 3.2) {
+          out.push({ kind: 'circle', cx: xx, cy: yy, r: 0.28, fill: stroke })
+        }
+      }
+      break
+    case 'gravel':
+      // Larger rings among the stipple.
+      for (let yy = y + 2.5, row = 0; yy < y + h; yy += 3.4, row++) {
+        for (let xx = x + 3 + (row % 2 ? 2.2 : 0); xx < x + w - 2; xx += 4.4) {
+          out.push({ kind: 'circle', cx: xx, cy: yy, r: 0.85, stroke, width })
+        }
+      }
+      break
+    case 'organic':
+      // Short vertical tufts.
+      for (let yy = y + 2.5, row = 0; yy < y + h; yy += 3, row++) {
+        for (let xx = x + 3 + (row % 2 ? 2 : 0); xx < x + w - 2; xx += 4) {
+          out.push({ kind: 'line', x1: xx, y1: yy - 1, x2: xx, y2: yy + 1, stroke, width })
+        }
+      }
+      break
+    case 'fill':
+      // Irregular cross-hatch, drawn as opposing diagonals.
+      for (let yy = y + 3; yy < y + h; yy += 3) {
+        out.push({ kind: 'line', x1: x + 1, y1: yy, x2: x + w - 1, y2: yy - 2.5, stroke, width })
+      }
+      break
+    case 'rock': {
+      // Diagonal hatch one way only, the drafting convention for rock. Each
+      // line x + y = c is CLIPPED to the band; the earlier version walked y
+      // past the band height and drew outside it, which showed up as strokes
+      // on a zero-height layer.
+      const x0 = x + 1, x1e = x + w - 1, y0 = y + 1, y1e = y + h - 1
+      if (x1e <= x0 || y1e <= y0) break
+      for (let c = x0 + y0 + 2.5; c < x1e + y1e; c += 2.5) {
+        const ax = Math.max(x0, c - y1e)
+        const bx = Math.min(x1e, c - y0)
+        if (bx <= ax) continue
+        out.push({ kind: 'line', x1: ax, y1: c - ax, x2: bx, y2: c - bx, stroke, width })
+      }
+      break
+    }
+    case 'unknown':
+      break
+  }
+  return out
+}
+
+/** Layer at a depth, for a click-through on the drawn column. */
+export function layerAtLogDepth(bh: Borehole, depth: number): SoilLayer | undefined {
+  return bh.layers.find((l) => depth >= l.depthTop && depth < l.depthBottom)
+}
+
+/** Total drawn height in mm, for a caller sizing a page. */
+export const logHeight = (d: LogDrawing): number => d.bounds.maxY - d.bounds.minY
+
+/** Thickness of the thinnest layer, m — a log needs a bigger scale to show it. */
+export function thinnestLayer(bh: Borehole): number | undefined {
+  if (!bh.layers.length) return undefined
+  return Math.min(...bh.layers.map(layerThickness))
+}


### PR DESCRIPTION
**Layer 8.** Phase 3a of the soil-investigation module (#476, #477, #478). Pure geometry for the graphical borehole log — depth scale, strata column with per-soil hatching, groundwater symbol, description text, SPT column. **28 tests.**

It emits the same typed `PlanPrimitive` list the structural plan renderer already uses, so **`planToSvg` serialises a borehole log with no new painting code** — there's a test asserting the round trip produces valid SVG. That's the reason this is a geometry module rather than JSX: column positions, depth scale, hatch spacing and text placement are all arithmetic, and arithmetic belongs somewhere it can be tested.

Coordinates are **millimetres of paper**, not metres of ground. A log is a drafted sheet, and fixing the paper geometry keeps the depth scale explicit (`mmPerMetre`) instead of hidden in a viewBox.

## Two things the drawing refuses to blur

- **A refusal N prints as `62*` with a footnote**, never as a bare number. The strata column is the first thing an engineer reads, and a lower bound must not sit in it looking like a measurement.
- **A hole with no groundwater says "GWT not encountered"** rather than drawing a table at an assumed depth.

Description text is anchored to the layer **top** rather than centred, so a thin layer's label stays inside its own band instead of drifting into the next. A test walks every description string and asserts it lands within its layer.

## Two defects found by rendering the log and looking at it

Neither was caught by the tests on their own:

1. **The rock hatch drew outside its rectangle.** The loop walked `y` past the band height — visible as strokes on a zero-height layer. Rewritten as diagonals clipped to the band.

2. **"Silty Sand" drew with silt hatching.** The description fallback scanned for the *first* matching word — and I had written the wrong behaviour into a test comment (`// 'silt' matches first`) rather than questioning it. In a soil name the adjective comes first and the **noun governs**: "Silty Sand" is a sand (SM), "Sandy Clay" is a clay. Now the last noun wins, and the group symbol still outranks the prose.

The second one is the more instructive failure: the test wasn't wrong by accident, it was wrong because I encoded my implementation's behaviour as the specification. Only pixels caught it.

## Verification

`npm test` — **2470 passed / 165 files** (28 new) · `npx tsc -b` · `npm run lint` · `npm run build` all green. BH-01 rendered to SVG and inspected as pixels before and after both fixes.

## Honest limits

- **The USCS column renders empty on the sample fixture**, because Phase 0 deliberately leaves `symbol` blank until a layer is classified. That's the honest state, not a bug — it fills in once Phase 1's classifier is wired to the data in the UI phase.
- **Hatch patterns are drawn, not tiled.** Each band emits its own strokes rather than referencing an SVG `<pattern>`, which keeps `planToSvg` unchanged but means a very deep log emits a lot of primitives. Fine at sheet scale; worth revisiting if logs get long.
- **No page yet.** This is the geometry only — the borehole page, profile editor and routes are Phase 3b, which is where the docs and feature-gate guards start to apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_