### PR TITLE
Soil investigation Phase 3b — the investigation UI

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -36,6 +36,7 @@ import Micropile from './pages/Micropile'
 import SlopeStability from './pages/SlopeStability'
 import Settlement from './pages/Settlement'
 import LateralPile from './pages/LateralPile'
+import SoilInvestigation from './pages/SoilInvestigation'
 import Pricing from './pages/Pricing'
 import SignIn from './pages/auth/SignIn'
 import SignUp from './pages/auth/SignUp'
@@ -115,6 +116,7 @@ export default function App() {
         <Route path="/slope" element={<SlopeStability />} />
         <Route path="/settlement" element={<Settlement />} />
         <Route path="/lateral-pile" element={<LateralPile />} />
+        <Route path="/soils" element={<RequireAuth><SoilInvestigation /></RequireAuth>} />
         <Route path="/pricing" element={<Pricing />} />
         <Route path="/signin" element={<SignIn />} />
         <Route path="/signup" element={<SignUp />} />

--- a/webapp/src/engine/soils/logRenderer.ts
+++ b/webapp/src/engine/soils/logRenderer.ts
@@ -23,7 +23,7 @@
 
 import type { PlanPrimitive, Drawing } from '../planRenderer'
 import type { Borehole, SoilLayer } from './model'
-import { layerThickness } from './model'
+import { layerThickness, soilFamily, type SoilFamily } from './model'
 import { fieldN } from './model'
 
 /** Column x-positions and widths, mm of paper. */
@@ -58,34 +58,15 @@ export const DEFAULT_LAYOUT: LogLayout = {
  * get dense lines — the convention on a hand-drafted log, kept because an
  * engineer reads the column before reading the words.
  */
-export type HatchKind = 'gravel' | 'sand' | 'silt' | 'clay' | 'organic' | 'fill' | 'rock' | 'unknown'
+export type HatchKind = SoilFamily
 
-export function hatchFor(symbol: string | undefined, name: string): HatchKind {
-  const s = (symbol ?? '').toUpperCase()
-  const n = name.toLowerCase()
-  if (n.includes('fill')) return 'fill'
-  if (n.includes('rock') || n.includes('bedrock')) return 'rock'
-  if (s.startsWith('G')) return 'gravel'
-  if (s.startsWith('S')) return 'sand'
-  if (s.startsWith('O') || n.includes('organic') || n.includes('peat')) return 'organic'
-  if (s.startsWith('C')) return 'clay'
-  if (s.startsWith('M')) return 'silt'
-
-  // No group symbol: fall back to the description, where THE NOUN GOVERNS.
-  // "Silty Sand" is a sand that happens to be silty — SM, drawn as sand. A
-  // first-match scan returns silt and draws the wrong column, which misleads
-  // an engineer who reads the strata before the words. Soil names put the
-  // adjective first and the noun last, so the LAST match wins.
-  const nouns: [string, HatchKind][] = [
-    ['gravel', 'gravel'], ['sand', 'sand'], ['silt', 'silt'], ['clay', 'clay'],
-  ]
-  let best: { at: number; kind: HatchKind } | undefined
-  for (const [word, kind] of nouns) {
-    const at = n.lastIndexOf(word)
-    if (at >= 0 && (!best || at > best.at)) best = { at, kind }
-  }
-  return best?.kind ?? 'unknown'
-}
+/**
+ * Hatch family for a layer. Delegates to `soilFamily` so the drawing and the
+ * SPT table cannot disagree about what a layer is — they did once, and a
+ * "Silty Sand" came out drawn as silt and described as "firm".
+ */
+export const hatchFor = (symbol: string | undefined, name: string): HatchKind =>
+  soilFamily(symbol, name)
 
 const HATCH_FILL: Record<HatchKind, string> = {
   gravel: '#d6d3d1',

--- a/webapp/src/engine/soils/model.ts
+++ b/webapp/src/engine/soils/model.ts
@@ -309,6 +309,46 @@ export function parameterValues(p: LayerParameters): SourcedValue[] {
 
 // ── Derived views ─────────────────────────────────────────────────────────
 
+/**
+ * Broad soil family of a layer, from its USCS symbol when classified and
+ * otherwise from its description.
+ *
+ * IN A SOIL NAME THE NOUN GOVERNS. "Silty Sand" is a sand that happens to be
+ * silty (SM); "Sandy Clay" is a clay. A first-match scan of the description
+ * gets both backwards, which then propagates: the log draws the wrong hatch,
+ * and an SPT of 6 in a silty sand gets described as "firm" — a cohesive
+ * consistency term — instead of "loose". So the rule lives here, once, and
+ * both the renderer and the SPT table read it.
+ */
+export type SoilFamily = 'gravel' | 'sand' | 'silt' | 'clay' | 'organic' | 'fill' | 'rock' | 'unknown'
+
+export function soilFamily(symbol: string | undefined, name: string): SoilFamily {
+  const s = (symbol ?? '').toUpperCase()
+  const n = name.toLowerCase()
+  if (n.includes('fill')) return 'fill'
+  if (n.includes('rock') || n.includes('bedrock')) return 'rock'
+  if (s.startsWith('G')) return 'gravel'
+  if (s.startsWith('S')) return 'sand'
+  if (s.startsWith('O') || n.includes('organic') || n.includes('peat')) return 'organic'
+  if (s.startsWith('C')) return 'clay'
+  if (s.startsWith('M')) return 'silt'
+
+  // Description fallback: the LAST noun wins.
+  const nouns: [string, SoilFamily][] = [
+    ['gravel', 'gravel'], ['sand', 'sand'], ['silt', 'silt'], ['clay', 'clay'],
+  ]
+  let best: { at: number; family: SoilFamily } | undefined
+  for (const [word, family] of nouns) {
+    const at = n.lastIndexOf(word)
+    if (at >= 0 && (!best || at > best.at)) best = { at, family }
+  }
+  return best?.family ?? 'unknown'
+}
+
+/** Whether a family is described by consistency (cohesive) or density (granular). */
+export const isCohesive = (f: SoilFamily): boolean =>
+  f === 'clay' || f === 'silt' || f === 'organic'
+
 /** Layer thickness, m. */
 export const layerThickness = (l: SoilLayer): number => l.depthBottom - l.depthTop
 

--- a/webapp/src/engine/soils/soilFamily.test.ts
+++ b/webapp/src/engine/soils/soilFamily.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { soilFamily, isCohesive } from './model'
+import { hatchFor } from './logRenderer'
+
+// ─────────────────────────────────────────────────────────────────────────
+// The noun rule, tested once and shared by everything that needs it.
+//
+// This exists because the same mistake was made twice: the log renderer drew
+// "Silty Sand" as silt, and — after that was fixed — the SPT table described an
+// N of 6 in the same layer as "firm", a COHESIVE consistency term, because the
+// page had its own /clay|silt/ regex. Two independent readings of the same
+// field will eventually disagree, so there is now one function and this file
+// pins its behaviour.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('the group symbol wins when there is one', () => {
+  it('reads the USCS family', () => {
+    expect(soilFamily('GW', 'anything')).toBe('gravel')
+    expect(soilFamily('SP-SM', 'anything')).toBe('sand')
+    expect(soilFamily('CL', 'anything')).toBe('clay')
+    expect(soilFamily('MH', 'anything')).toBe('silt')
+    expect(soilFamily('OH', 'anything')).toBe('organic')
+  })
+
+  it('outranks a contradictory description', () => {
+    // The symbol is a classification; the name is prose.
+    expect(soilFamily('SM', 'Silty Sand')).toBe('sand')
+    expect(soilFamily('CL', 'Sandy Clay')).toBe('clay')
+  })
+
+  it('still puts fill and rock first — they are histories, not soil types', () => {
+    expect(soilFamily('SM', 'Sand Fill')).toBe('fill')
+    expect(soilFamily('GW', 'Weathered bedrock')).toBe('rock')
+  })
+})
+
+describe('without a symbol, the NOUN governs', () => {
+  it.each([
+    ['Silty Sand', 'sand'],
+    ['Clayey Sand', 'sand'],
+    ['Sandy Clay', 'clay'],
+    ['Silty Clay', 'clay'],
+    ['Gravelly Silt', 'silt'],
+    ['Sandy Gravel', 'gravel'],
+    ['Lean Clay', 'clay'],
+    ['Poorly Graded Sand', 'sand'],
+    ['Soft to firm lean CLAY with sand', 'sand'],
+  ] as const)('%s → %s', (name, expected) => {
+    expect(soilFamily(undefined, name)).toBe(expected)
+  })
+
+  it('returns unknown rather than guessing', () => {
+    expect(soilFamily(undefined, 'Something else')).toBe('unknown')
+    expect(soilFamily(undefined, '')).toBe('unknown')
+  })
+})
+
+describe('cohesive vs granular', () => {
+  it('picks the scale a description term belongs to', () => {
+    // Consistency (soft/firm/stiff) and density (loose/dense) are different
+    // scales; the wrong one turns an N of 6 in a silty sand into "firm".
+    expect(isCohesive(soilFamily('SM', 'Silty Sand'))).toBe(false)
+    expect(isCohesive(soilFamily(undefined, 'Silty Sand'))).toBe(false)
+    expect(isCohesive(soilFamily('CL', 'Lean Clay'))).toBe(true)
+    expect(isCohesive(soilFamily('MH', 'Elastic Silt'))).toBe(true)
+    expect(isCohesive(soilFamily('OL', 'Organic silt'))).toBe(true)
+    expect(isCohesive(soilFamily('GW', 'Well-graded gravel'))).toBe(false)
+  })
+})
+
+describe('the renderer and the family rule cannot drift apart', () => {
+  it('hatchFor delegates rather than re-implementing', () => {
+    const cases = [
+      ['SM', 'Silty Sand'], [undefined, 'Silty Sand'], ['CL', 'Sandy Clay'],
+      [undefined, 'Gravelly Silt'], ['SM', 'Sand Fill'], [undefined, 'Mystery'],
+    ] as const
+    for (const [sym, name] of cases) {
+      expect(hatchFor(sym, name), `${sym ?? '—'} / ${name}`).toBe(soilFamily(sym, name))
+    }
+  })
+})

--- a/webapp/src/lib/docsContentAnalysis.ts
+++ b/webapp/src/lib/docsContentAnalysis.ts
@@ -370,4 +370,75 @@ export const ANALYSIS_TOOLS: DocTool[] = [
       },
     ],
   },
+  {
+    id: 'soil-investigation',
+    name: 'Soil Investigation',
+    route: '/soils',
+    group: 'Foundations & geotechnical',
+    summary: 'Manage a site investigation — boreholes, strata, samples, SPT — and classify the soil, so parameters are entered once instead of retyped on every geotechnical page.',
+    basis: 'ASTM D1586 (SPT), D2487 (USCS), D4318 (Atterberg), D6913 (gradation); AASHTO M 145; Skempton (1986) and Youd et al. (2001) corrections.',
+    sections: [
+      {
+        id: 'si-overview',
+        title: 'Investigation',
+        body: 'An investigation is stored in this browser, not on a server. Export the JSON to keep a copy — that is '
+          + 'the backup mechanism, not a convenience. Every edit saves immediately, because field and laboratory data '
+          + 'is expensive to re-enter and an edit lost to a refresh is not a minor annoyance here.',
+        controls: [
+          { kind: 'field', name: 'Reference', what: 'Investigation number as it appears on the report cover, e.g. SI-2026-014.' },
+          { kind: 'field', name: 'Project / Client / Location', what: 'Site identity carried onto the report cover and the borehole logs.' },
+          { kind: 'choice', name: 'Status', what: 'Draft, fieldwork, laboratory, analysis, review or completed — the stage the investigation has reached.' },
+          { kind: 'output', name: 'Data integrity', what: 'Errors are the physically impossible: overlapping layers, groundwater below the hole, a plastic limit above the liquid limit. Warnings are the merely unusual, which is often perfectly real. Nothing is repaired automatically — an unlogged interval may be a logging error or an unrecovered run, and only whoever was on the rig knows which.' },
+        ],
+      },
+      {
+        id: 'si-boreholes',
+        title: 'Boreholes',
+        body: 'Each hole carries its collar elevation, termination depth, diameter and groundwater level. The '
+          + 'diameter feeds the SPT borehole-diameter correction C_B, so it is data rather than description.',
+        controls: [
+          { kind: 'field', name: 'Ground elevation', unit: 'm', what: 'Collar elevation. Optional — without it the log shows depths only, not elevations.' },
+          { kind: 'field', name: 'Depth', unit: 'm', what: 'Termination depth. A profile logged deeper than this is an error; one that stops short is a warning.' },
+          { kind: 'field', name: 'Diameter', unit: 'mm', what: 'Hole diameter, which sets C_B: 1.00 up to 115 mm, 1.05 at 150 mm, 1.15 at 200 mm.' },
+          { kind: 'field', name: 'Groundwater', unit: 'm', what: 'Depth to the water table. Leave blank when it was not encountered — the log then says so rather than drawing a table at an assumed depth.' },
+          { kind: 'output', name: 'Borehole log', what: 'Graphical log with the strata column, hatching, depth scale, water table and SPT values. Hatching follows the USCS symbol where one is entered, otherwise the description, in which the noun governs — "Silty Sand" is drawn as a sand.' },
+        ],
+      },
+      {
+        id: 'si-profile',
+        title: 'Soil profile',
+        controls: [
+          { kind: 'field', name: 'Layer top / base', unit: 'm', what: 'Layer boundaries. Overlaps are an error — two soils cannot occupy the same ground. Gaps are a warning, since an unrecovered run is a real thing to record.' },
+          { kind: 'field', name: 'USCS symbol', what: 'Group symbol once the soil has been classified. Left blank until then: an unclassified layer is an honest state and a guessed symbol is not.' },
+          { kind: 'field', name: 'Description', what: 'Full log description, printed in the log column and wrapped to fit its band.' },
+          { kind: 'output', name: 'Samples', what: 'Samples with their type, depth, recovery ratio and the laboratory tests booked against them. Recovery below 50% is flagged, since results on a poorly recovered sample carry reduced confidence.' },
+        ],
+      },
+      {
+        id: 'si-spt',
+        title: 'SPT',
+        body: 'The raw blow count is not a soil property — it is the response of one hammer, on one rig, through one '
+          + 'length of rod, at one depth. N60 removes the equipment; (N1)60 additionally removes the overburden so '
+          + 'tests at 3 m and 15 m in the same sand can be compared.',
+        controls: [
+          { kind: 'field', name: 'Unit weights γ, γsat', unit: 'kN/m³', what: 'Entered per layer to build the effective-stress profile that (N1)60 needs. They are an interpretation rather than measured data, so they live on the page rather than in the stored investigation. Layers left blank stop the stress profile there — the blow counts below are still corrected for equipment, just not for overburden.' },
+          { kind: 'output', name: 'N60', what: 'Field N corrected for hammer energy, borehole diameter, sampler and rod length.' },
+          { kind: 'output', name: '(N1)60', what: 'N60 further corrected to a 100 kPa reference overburden, with C_N capped at 1.7 so a shallow test is not inflated without limit.' },
+          { kind: 'output', name: 'Refusal', what: 'A drive that did not achieve full penetration is marked with an asterisk and shaded. Its N is a LOWER BOUND, not a measurement, and correlations are declined on it — correcting a lower bound makes it look more precise without making it more accurate.' },
+        ],
+      },
+      {
+        id: 'si-classification',
+        title: 'Classification',
+        body: 'USCS to ASTM D2487, taken branch by branch. It will not collapse a dual symbol — a sand with 5-12% '
+          + 'fines is genuinely SW-SC, not SW with a footnote — and it will not classify from incomplete data.',
+        controls: [
+          { kind: 'field', name: 'Gravel / Sand / Fines', unit: '%', what: 'Fractions from the gradation curve, split at 4.75 mm and 0.075 mm.' },
+          { kind: 'field', name: 'Cu, Cc', what: 'Gradation shape parameters. A gravel is well graded at Cu ≥ 4, a sand needs Cu ≥ 6, and both need 1 ≤ Cc ≤ 3.' },
+          { kind: 'field', name: 'LL, PL', unit: '%', what: 'Atterberg limits. PI = LL − PL decides whether the fines behave as clay or silt, against the Casagrande A-line.' },
+          { kind: 'output', name: 'Group symbol and name', what: 'The D2487 result, with the reasoning printed underneath. Where a needed test has not been run the classifier says which one rather than picking the likeliest symbol.' },
+        ],
+      },
+    ],
+  },
 ]

--- a/webapp/src/lib/featureGate.ts
+++ b/webapp/src/lib/featureGate.ts
@@ -127,6 +127,7 @@ export const ROUTE_FEATURE: Record<string, Feature> = {
   '/seismic-wizard': 'model-space',
   '/estimate': 'estimating',
   '/schedule': 'scheduling',
+  '/soils': 'soil-investigation',
 }
 
 /**

--- a/webapp/src/lib/plans.ts
+++ b/webapp/src/lib/plans.ts
@@ -40,6 +40,8 @@ export type Feature =
   | 'nonlinear'
   /** Save projects to the account. */
   | 'saved-projects'
+  /** Soil-investigation management: boreholes, lab tests, parameters, report. */
+  | 'soil-investigation'
 
 /** How often a paid plan is billed. */
 export type BillingPeriod = 'monthly' | 'annual'
@@ -86,7 +88,7 @@ export interface Plan {
 /** Everything a paid tier unlocks — listed once so the tiers cannot drift. */
 const ALL_FEATURES: readonly Feature[] = [
   'model-space', 'design-pipeline', 'optimizer', 'reports',
-  'estimating', 'scheduling', 'nonlinear', 'saved-projects',
+  'estimating', 'scheduling', 'nonlinear', 'saved-projects', 'soil-investigation',
 ]
 
 /**
@@ -140,7 +142,7 @@ export const PLANS: readonly Plan[] = [
     priceMonthly: 1_399,
     priceAnnual: 15_099,
     tagline: 'The 3D Model Space and the tools built on it.',
-    features: ['model-space', 'design-pipeline', 'optimizer', 'reports', 'estimating', 'saved-projects'],
+    features: ['model-space', 'design-pipeline', 'optimizer', 'reports', 'estimating', 'saved-projects', 'soil-investigation'],
     maxMembers: 400,
     calculatorRuns: null,
     maxProjects: null,
@@ -281,6 +283,7 @@ export function featureLabel(f: Feature): string {
     case 'scheduling': return 'construction scheduling'
     case 'nonlinear': return 'nonlinear analysis'
     case 'saved-projects': return 'saved projects'
+    case 'soil-investigation': return 'the soil-investigation module'
   }
 }
 

--- a/webapp/src/lib/tools.ts
+++ b/webapp/src/lib/tools.ts
@@ -46,6 +46,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
       { to: '/slope',            name: 'Slope Stability',  sub: 'Slices · Bishop/Fellenius/Janbu', group: 'Geotechnical' },
       { to: '/settlement',       name: 'Settlement',       sub: 'Boussinesq · Terzaghi · Schmertmann', group: 'Geotechnical' },
       { to: '/lateral-pile',     name: 'Lateral Pile',     sub: 'Broms · p-y (Matlock/API)', group: 'Geotechnical' },
+      { to: '/soils',            name: 'Soil Investigation', sub: 'Boreholes · SPT · USCS',  group: 'Geotechnical' },
       { to: '/seismic-wizard',   name: 'Seismic Wizard',   sub: 'NSCP 208 Ca/Cv/I/R',       group: 'Seismic & Loads' },
       { to: '/load-combinations', name: 'Load Combinations', sub: 'NSCP 2015 §203.3 LRFD',  group: 'Seismic & Loads' },
       { to: '/wood-slab',        name: 'Wood Slab',        sub: 'Deck-on-joist · NDS §3 / NSCP §6', group: 'Timber' },

--- a/webapp/src/lib/trialQuota.ts
+++ b/webapp/src/lib/trialQuota.ts
@@ -49,7 +49,7 @@ export const GUEST_TRIAL_ROUTES: readonly string[] = [
  * behind a counter.
  */
 export const GATED_PREFIXES: readonly string[] = [
-  '/model', '/frame', '/truss', '/schedule', '/estimate', '/seismic-wizard',
+  '/model', '/frame', '/truss', '/schedule', '/estimate', '/seismic-wizard', '/soils',
 ]
 
 /** Freely readable by anyone, signed in or not — no counter, no gate. */

--- a/webapp/src/lib/useInvestigation.ts
+++ b/webapp/src/lib/useInvestigation.ts
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { Investigation } from '../engine/soils/model'
+import { emptyInvestigation } from '../engine/soils/model'
+import {
+  createStore, defaultBackend, exportJSON as serialise, importJSON as parse,
+  type InvestigationSummary,
+} from '../engine/soils/store'
+import { sampleInvestigation } from '../engine/soils/sample'
+
+// Shared active-investigation state for the /soils routes. Each page calls this
+// hook; the store is the single source of truth, so an edit on the borehole
+// page is visible when the profile page mounts — the same arrangement the
+// scheduling routes use.
+//
+// EVERY MUTATION PERSISTS IMMEDIATELY. Field and laboratory data is expensive
+// to re-enter and, until the backend swap lands, it lives in one browser: an
+// unsaved edit lost to a refresh is not a minor annoyance here.
+
+const ACTIVE_KEY = 'soils:active'
+
+const newId = (): string => `si_${Date.now().toString(36)}`
+
+export interface InvestigationApi {
+  investigation: Investigation | null
+  activeId: string | null
+  investigations: InvestigationSummary[]
+  /** Mutate a structural copy; auto-persists. */
+  update(mutate: (draft: Investigation) => void): void
+  replace(next: Investigation): void
+  loadSample(): void
+  newInvestigation(title?: string): void
+  open(id: string): void
+  remove(id: string): void
+  importJSON(json: string): void
+  exportJSON(): string
+}
+
+export function useInvestigation(): InvestigationApi {
+  const backend = useMemo(() => defaultBackend(), [])
+  const store = useMemo(() => createStore(backend), [backend])
+
+  const [activeId, setActiveId] = useState<string | null>(() => backend.getItem(ACTIVE_KEY))
+  const [investigation, setInvestigation] = useState<Investigation | null>(() => {
+    const id = backend.getItem(ACTIVE_KEY)
+    return id ? store.load(id) : null
+  })
+  const [investigations, setInvestigations] = useState<InvestigationSummary[]>(() => store.list())
+
+  const refreshList = useCallback(() => setInvestigations(store.list()), [store])
+
+  useEffect(() => {
+    if (activeId) backend.setItem(ACTIVE_KEY, activeId)
+    else backend.removeItem(ACTIVE_KEY)
+  }, [activeId, backend])
+
+  const persist = useCallback((id: string, next: Investigation) => {
+    store.save(id, next)
+    setInvestigation(next)
+    refreshList()
+  }, [store, refreshList])
+
+  const activate = useCallback((id: string, next: Investigation) => {
+    setActiveId(id)
+    persist(id, next)
+  }, [persist])
+
+  const update = useCallback((mutate: (draft: Investigation) => void) => {
+    if (!investigation || !activeId) return
+    const draft = structuredClone(investigation)
+    mutate(draft)
+    persist(activeId, draft)
+  }, [investigation, activeId, persist])
+
+  const replace = useCallback((next: Investigation) => {
+    activate(activeId ?? newId(), next)
+  }, [activeId, activate])
+
+  const loadSample = useCallback(() => activate(newId(), sampleInvestigation()), [activate])
+  const newInvestigation = useCallback(
+    (title?: string) => activate(newId(), emptyInvestigation(title)), [activate],
+  )
+
+  const open = useCallback((id: string) => {
+    const found = store.load(id)
+    if (found) { setActiveId(id); setInvestigation(found) }
+  }, [store])
+
+  const remove = useCallback((id: string) => {
+    store.remove(id)
+    refreshList()
+    if (id === activeId) {
+      const next = store.list()[0]
+      if (next) open(next.id)
+      else { setActiveId(null); setInvestigation(null) }
+    }
+  }, [store, activeId, refreshList, open])
+
+  const importJSON = useCallback((json: string) => {
+    // Throws on malformed JSON or an integrity error; the caller surfaces it
+    // rather than this hook swallowing a failed import.
+    activate(newId(), parse(json))
+  }, [activate])
+
+  const exportJSON = useCallback(() => (investigation ? serialise(investigation) : ''), [investigation])
+
+  return {
+    investigation, activeId, investigations,
+    update, replace, loadSample, newInvestigation, open, remove, importJSON, exportJSON,
+  }
+}

--- a/webapp/src/pages/SoilInvestigation.tsx
+++ b/webapp/src/pages/SoilInvestigation.tsx
@@ -1,0 +1,629 @@
+import { useMemo, useState } from 'react'
+import { useInvestigation } from '../lib/useInvestigation'
+import { buildBoreholeLog } from '../engine/soils/logRenderer'
+import { planToSvg } from '../engine/planRenderer'
+import { validateInvestigation, type ValidationIssue } from '../engine/soils/validate'
+import { sptProfile, type LayerUnitWeight } from '../engine/soils/sptProfile'
+import { classifyUSCS } from '../engine/soils/uscs'
+import { densityFromN60, consistencyFromN60 } from '../engine/soils/spt'
+import {
+  layerThickness, recoveryRatio, soilFamily, isCohesive,
+  type Borehole, type SoilLayer,
+} from '../engine/soils/model'
+
+const f2 = (n: number | undefined) => (n == null || !Number.isFinite(n) ? '—' : n.toFixed(2))
+const f1 = (n: number | undefined) => (n == null || !Number.isFinite(n) ? '—' : n.toFixed(1))
+const f0 = (n: number | undefined) => (n == null || !Number.isFinite(n) ? '—' : Math.round(n).toString())
+
+function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
+
+// ── Small shared bits ─────────────────────────────────────────────────────
+
+function IssueList({ issues }: { issues: ValidationIssue[] }) {
+  if (!issues.length) {
+    return (
+      <p className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-[12px] text-emerald-800">
+        No integrity issues.
+      </p>
+    )
+  }
+  const errors = issues.filter((i) => i.severity === 'error')
+  const warnings = issues.filter((i) => i.severity === 'warning')
+  return (
+    <div className="space-y-1.5">
+      {errors.map((i, k) => (
+        <p key={`e${k}`} className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-800">
+          <strong className="font-semibold">Error</strong> — {i.message}
+        </p>
+      ))}
+      {warnings.map((i, k) => (
+        <p key={`w${k}`} className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] text-amber-900">
+          <strong className="font-semibold">Check</strong> — {i.message}
+        </p>
+      ))}
+    </div>
+  )
+}
+
+function Stat({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+      <p className="text-[10px] font-bold uppercase tracking-[0.14em] text-slate-500">{label}</p>
+      <p className="mt-0.5 font-mono text-[15px] font-semibold text-slate-800">{value}</p>
+      {sub && <p className="text-[10px] text-slate-500">{sub}</p>}
+    </div>
+  )
+}
+
+// ── Borehole log ──────────────────────────────────────────────────────────
+
+function LogView({ bh }: { bh: Borehole }) {
+  // The drawing is pure geometry (engine/soils/logRenderer) serialised by the
+  // same planToSvg the structural drawings use — no painting code here.
+  const svg = useMemo(() => planToSvg(buildBoreholeLog(bh), 640), [bh])
+  return <div className="overflow-x-auto" dangerouslySetInnerHTML={{ __html: svg }} />
+}
+
+// ── Layer editor ──────────────────────────────────────────────────────────
+
+function LayerRow({
+  layer, onChange, onRemove,
+}: { layer: SoilLayer; onChange: (patch: Partial<SoilLayer>) => void; onRemove: () => void }) {
+  return (
+    <tr className="border-b border-slate-100">
+      <td className="py-0.5 pr-2">
+        <input type="number" step="0.1" value={layer.depthTop}
+          onChange={(e) => onChange({ depthTop: num(e.target.value) })}
+          className="w-16 rounded border border-slate-200 px-1 py-0.5 text-right font-mono" />
+      </td>
+      <td className="py-0.5 pr-2">
+        <input type="number" step="0.1" value={layer.depthBottom}
+          onChange={(e) => onChange({ depthBottom: num(e.target.value) })}
+          className="w-16 rounded border border-slate-200 px-1 py-0.5 text-right font-mono" />
+      </td>
+      <td className="py-0.5 pr-2 text-right font-mono text-slate-500">{f2(layerThickness(layer))}</td>
+      <td className="py-0.5 pr-2">
+        <input value={layer.symbol ?? ''} placeholder="—"
+          onChange={(e) => onChange({ symbol: e.target.value.toUpperCase() || undefined })}
+          className="w-16 rounded border border-slate-200 px-1 py-0.5 font-mono uppercase" />
+      </td>
+      <td className="py-0.5 pr-2">
+        <input value={layer.name}
+          onChange={(e) => onChange({ name: e.target.value })}
+          className="w-full min-w-[8rem] rounded border border-slate-200 px-1 py-0.5" />
+      </td>
+      <td className="py-0.5 pr-2">
+        <input value={layer.description ?? ''}
+          onChange={(e) => onChange({ description: e.target.value || undefined })}
+          className="w-full min-w-[12rem] rounded border border-slate-200 px-1 py-0.5" />
+      </td>
+      <td className="py-0.5 text-right">
+        <button onClick={onRemove} className="rounded px-1.5 py-0.5 text-[11px] text-red-600 hover:bg-red-50">
+          remove
+        </button>
+      </td>
+    </tr>
+  )
+}
+
+/**
+ * Descriptive term for a corrected blow count. Cohesive soils take a
+ * CONSISTENCY (soft/firm/stiff), granular ones a DENSITY (loose/dense) — they
+ * are different scales, and using the wrong one turns an N of 6 in a silty sand
+ * into "firm" when it is "loose". The family comes from `soilFamily`, which the
+ * log renderer also uses, so the drawing and the table cannot disagree.
+ */
+function describeN60(n60: number, layer: SoilLayer | undefined): string {
+  if (!layer) return densityFromN60(n60)
+  return isCohesive(soilFamily(layer.symbol, layer.name))
+    ? consistencyFromN60(n60)
+    : densityFromN60(n60)
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────
+
+type Tab = 'overview' | 'boreholes' | 'profile' | 'spt' | 'classification'
+
+export default function SoilInvestigation() {
+  const api = useInvestigation()
+  const { investigation: inv } = api
+  const [tab, setTab] = useState<Tab>('overview')
+  const [holeIdx, setHoleIdx] = useState(0)
+  const [importError, setImportError] = useState<string | null>(null)
+
+  const issues = useMemo(() => (inv ? validateInvestigation(inv) : []), [inv])
+  const bh: Borehole | undefined = inv?.boreholes[holeIdx]
+
+  // Unit weights entered per layer for the stress profile. They are an
+  // INTERPRETATION, not data, so they live in page state rather than in the
+  // stored investigation until the Phase 5 parameter engine gives them a home
+  // with provenance attached.
+  const [unitWeights, setUnitWeights] = useState<Record<string, LayerUnitWeight>>({})
+
+  const profile = useMemo(
+    () => (bh ? sptProfile(bh, unitWeights) : null),
+    [bh, unitWeights],
+  )
+
+  if (!inv) {
+    return (
+      <main className="mx-auto max-w-3xl px-5 py-10">
+        <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
+        <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Soil investigation</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          Enter a site investigation once — boreholes, strata, samples and field tests — and reuse it across the
+          bearing-capacity, settlement, slope and pile calculators instead of retyping soil properties on each.
+        </p>
+
+        <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 className="text-[1.05rem] font-bold text-[#0056b3]">Start</h2>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button onClick={() => api.newInvestigation()}
+              className="rounded-md bg-[#0056b3] px-3 py-1.5 text-sm font-semibold text-white hover:bg-[#004a99]">
+              New investigation
+            </button>
+            <button onClick={api.loadSample}
+              className="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50">
+              Load the example
+            </button>
+          </div>
+          <p className="mt-3 text-[11px] text-slate-500">
+            Investigations are stored in this browser only. Export the JSON to keep a copy — it is the backup, not a
+            convenience.
+          </p>
+        </section>
+      </main>
+    )
+  }
+
+  const set = api.update
+
+  return (
+    <main className="mx-auto max-w-5xl px-5 py-10">
+      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
+      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">
+        {inv.meta.title || 'Untitled investigation'}
+      </h1>
+      <p className="mt-1 text-sm text-slate-600">
+        {inv.meta.investigationNo || 'no reference'} · {inv.meta.site.projectName || 'no project name'}
+        {inv.meta.site.location ? ` · ${inv.meta.site.location}` : ''}
+      </p>
+
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        <button onClick={() => api.newInvestigation()}
+          className="rounded-md border border-slate-300 px-2.5 py-1 text-[12px] font-medium text-slate-700 hover:bg-slate-50">
+          New
+        </button>
+        <button onClick={api.loadSample}
+          className="rounded-md border border-slate-300 px-2.5 py-1 text-[12px] font-medium text-slate-700 hover:bg-slate-50">
+          Load example
+        </button>
+        <button
+          onClick={() => {
+            const blob = new Blob([api.exportJSON()], { type: 'application/json' })
+            const a = document.createElement('a')
+            a.href = URL.createObjectURL(blob)
+            a.download = `${inv.meta.investigationNo || 'investigation'}.json`
+            a.click()
+            URL.revokeObjectURL(a.href)
+          }}
+          className="rounded-md border border-slate-300 px-2.5 py-1 text-[12px] font-medium text-slate-700 hover:bg-slate-50">
+          Export JSON
+        </button>
+        <label className="cursor-pointer rounded-md border border-slate-300 px-2.5 py-1 text-[12px] font-medium text-slate-700 hover:bg-slate-50">
+          Import JSON
+          <input type="file" accept="application/json" className="hidden"
+            onChange={async (e) => {
+              const file = e.target.files?.[0]
+              if (!file) return
+              setImportError(null)
+              try { api.importJSON(await file.text()) }
+              catch (err) { setImportError(err instanceof Error ? err.message : String(err)) }
+              e.target.value = ''
+            }} />
+        </label>
+        {api.investigations.length > 1 && (
+          <select value={api.activeId ?? ''} onChange={(e) => api.open(e.target.value)}
+            className="rounded-md border border-slate-300 px-2 py-1 text-[12px]">
+            {api.investigations.map((s) => (
+              <option key={s.id} value={s.id}>{s.investigationNo || s.title}</option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      {importError && (
+        <p className="mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-800">
+          {importError}
+        </p>
+      )}
+
+      <nav className="mt-6 flex flex-wrap gap-1 border-b border-slate-200">
+        {(['overview', 'boreholes', 'profile', 'spt', 'classification'] as Tab[]).map((t) => (
+          <button key={t} onClick={() => setTab(t)}
+            className={`rounded-t-md px-3 py-1.5 text-[13px] font-medium capitalize ${
+              tab === t ? 'border-b-2 border-[#0056b3] text-[#0056b3]' : 'text-slate-600 hover:text-slate-900'
+            }`}>
+            {t === 'spt' ? 'SPT' : t}
+          </button>
+        ))}
+      </nav>
+
+      {/* ── Overview ── */}
+      {tab === 'overview' && (
+        <section className="mt-5 space-y-5">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <Stat label="Boreholes" value={String(inv.boreholes.length)} />
+            <Stat label="Samples" value={String(inv.boreholes.reduce((n, b) => n + b.samples.length, 0))} />
+            <Stat label="SPT tests" value={String(inv.boreholes.reduce((n, b) => n + b.spt.length, 0))} />
+            <Stat label="Lab tests"
+              value={String(inv.boreholes.reduce((n, b) => n + b.samples.reduce((m, s) => m + s.tests.length, 0), 0))} />
+          </div>
+
+          <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Investigation</h2>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {([
+                ['Reference', inv.meta.investigationNo, (v: string) => set((d) => { d.meta.investigationNo = v })],
+                ['Title', inv.meta.title, (v: string) => set((d) => { d.meta.title = v })],
+                ['Project', inv.meta.site.projectName, (v: string) => set((d) => { d.meta.site.projectName = v })],
+                ['Client', inv.meta.site.client ?? '', (v: string) => set((d) => { d.meta.site.client = v })],
+                ['Location', inv.meta.site.location ?? '', (v: string) => set((d) => { d.meta.site.location = v })],
+                ['Engineer', inv.meta.engineer ?? '', (v: string) => set((d) => { d.meta.engineer = v })],
+              ] as [string, string, (v: string) => void][]).map(([label, value, onChange]) => (
+                <label key={label} className="flex flex-col text-sm">
+                  <span className="mb-1 font-medium text-slate-600">{label}</span>
+                  <input value={value} onChange={(e) => onChange(e.target.value)}
+                    className="rounded-md border border-slate-300 px-2.5 py-1.5" />
+                </label>
+              ))}
+              <label className="flex flex-col text-sm">
+                <span className="mb-1 font-medium text-slate-600">Status</span>
+                <select value={inv.meta.status}
+                  onChange={(e) => set((d) => { d.meta.status = e.target.value as typeof d.meta.status })}
+                  className="rounded-md border border-slate-300 px-2.5 py-1.5">
+                  {['draft', 'fieldwork', 'laboratory', 'analysis', 'review', 'completed'].map((s) => (
+                    <option key={s} value={s}>{s}</option>
+                  ))}
+                </select>
+              </label>
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Data integrity</h2>
+            <IssueList issues={issues} />
+            <p className="mt-3 text-[11px] text-slate-500">
+              Errors are the physically impossible — overlapping layers, groundwater below the hole, a plastic limit
+              above the liquid limit. Warnings are the merely unusual, which is often perfectly real. Nothing here is
+              repaired automatically: an unlogged interval may be a logging error or an unrecovered run, and only
+              whoever was on the rig knows which.
+            </p>
+          </div>
+        </section>
+      )}
+
+      {/* ── Boreholes ── */}
+      {tab === 'boreholes' && (
+        <section className="mt-5 space-y-4">
+          <div className="flex flex-wrap items-center gap-2">
+            {inv.boreholes.map((b, i) => (
+              <button key={b.id} onClick={() => setHoleIdx(i)}
+                className={`rounded-md px-2.5 py-1 text-[12px] font-medium ${
+                  i === holeIdx ? 'bg-[#0056b3] text-white' : 'border border-slate-300 text-slate-700 hover:bg-slate-50'
+                }`}>
+                {b.name}
+              </button>
+            ))}
+            <button
+              onClick={() => {
+                const n = inv.boreholes.length + 1
+                set((d) => {
+                  d.boreholes.push({
+                    id: `bh_${Date.now().toString(36)}`,
+                    name: `BH-${String(n).padStart(2, '0')}`,
+                    kind: 'borehole', actualDepth: 10,
+                    layers: [], samples: [], spt: [],
+                  })
+                })
+                setHoleIdx(inv.boreholes.length)
+              }}
+              className="rounded-md border border-dashed border-slate-300 px-2.5 py-1 text-[12px] text-slate-600 hover:bg-slate-50">
+              + borehole
+            </button>
+          </div>
+
+          {bh && (
+            <>
+              <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+                <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">{bh.name}</h2>
+                <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+                  {([
+                    ['Name', bh.name, 'text', (v: string) => set((d) => { d.boreholes[holeIdx].name = v })],
+                    ['Ground elevation (m)', bh.groundElevation ?? '', 'number',
+                      (v: string) => set((d) => { d.boreholes[holeIdx].groundElevation = v === '' ? undefined : num(v) })],
+                    ['Depth (m)', bh.actualDepth, 'number',
+                      (v: string) => set((d) => { d.boreholes[holeIdx].actualDepth = num(v) })],
+                    ['Diameter (mm)', bh.diameter ?? '', 'number',
+                      (v: string) => set((d) => { d.boreholes[holeIdx].diameter = v === '' ? undefined : num(v) })],
+                    ['Groundwater (m)', bh.groundwaterDepth ?? '', 'number',
+                      (v: string) => set((d) => { d.boreholes[holeIdx].groundwaterDepth = v === '' ? undefined : num(v) })],
+                  ] as [string, string | number, string, (v: string) => void][]).map(([label, value, type, onChange]) => (
+                    <label key={label} className="flex flex-col text-sm">
+                      <span className="mb-1 font-medium text-slate-600">{label}</span>
+                      <input type={type} step="any" value={value}
+                        onChange={(e) => onChange(e.target.value)}
+                        className="rounded-md border border-slate-300 px-2.5 py-1.5" />
+                    </label>
+                  ))}
+                </div>
+                <p className="mt-3 text-[11px] text-slate-500">
+                  Leave groundwater blank when it was not encountered — the log then says so rather than drawing a
+                  table at an assumed depth.
+                </p>
+              </div>
+
+              <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+                <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Borehole log</h2>
+                <LogView bh={bh} />
+                <p className="mt-2 text-[11px] text-slate-500">
+                  Strata hatching follows the USCS group symbol where one has been entered, otherwise the description —
+                  in which the noun governs, so &ldquo;Silty Sand&rdquo; is drawn as a sand. A refusal blow count is
+                  marked with an asterisk so it cannot be read as a measurement.
+                </p>
+              </div>
+            </>
+          )}
+        </section>
+      )}
+
+      {/* ── Soil profile ── */}
+      {tab === 'profile' && bh && (
+        <section className="mt-5 space-y-4">
+          <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-[1.05rem] font-bold text-[#0056b3]">{bh.name} — stratigraphy</h2>
+              <button
+                onClick={() => set((d) => {
+                  const layers = d.boreholes[holeIdx].layers
+                  const top = layers.length ? layers[layers.length - 1].depthBottom : 0
+                  layers.push({
+                    id: `l_${Date.now().toString(36)}`,
+                    depthTop: top, depthBottom: top + 1, name: 'New layer',
+                  })
+                })}
+                className="rounded-md border border-dashed border-slate-300 px-2.5 py-1 text-[12px] text-slate-600 hover:bg-slate-50">
+                + layer
+              </button>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full text-left text-[12px]">
+                <thead className="text-slate-500">
+                  <tr className="border-b border-slate-200">
+                    <th className="py-1 pr-2">Top (m)</th><th className="py-1 pr-2">Base (m)</th>
+                    <th className="py-1 pr-2 text-right">Thk</th><th className="py-1 pr-2">USCS</th>
+                    <th className="py-1 pr-2">Name</th><th className="py-1 pr-2">Description</th><th />
+                  </tr>
+                </thead>
+                <tbody>
+                  {bh.layers.map((l, i) => (
+                    <LayerRow key={l.id} layer={l}
+                      onChange={(patch) => set((d) => {
+                        Object.assign(d.boreholes[holeIdx].layers[i], patch)
+                      })}
+                      onRemove={() => set((d) => { d.boreholes[holeIdx].layers.splice(i, 1) })} />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {!bh.layers.length && (
+              <p className="mt-3 text-[12px] text-slate-500">No layers logged yet.</p>
+            )}
+          </div>
+
+          <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="mb-2 text-[1.05rem] font-bold text-[#0056b3]">Samples</h2>
+            <div className="overflow-x-auto">
+              <table className="w-full text-left text-[12px]">
+                <thead className="text-slate-500">
+                  <tr className="border-b border-slate-200">
+                    <th className="py-1 pr-3">Sample</th><th className="py-1 pr-3">Type</th>
+                    <th className="py-1 pr-3">Depth (m)</th><th className="py-1 pr-3 text-right">Recovery</th>
+                    <th className="py-1 pr-3">Tests</th>
+                  </tr>
+                </thead>
+                <tbody className="font-mono">
+                  {bh.samples.map((s) => (
+                    <tr key={s.id} className="border-b border-slate-100">
+                      <td className="py-0.5 pr-3">{s.name}</td>
+                      <td className="py-0.5 pr-3">{s.type}</td>
+                      <td className="py-0.5 pr-3">{f2(s.depthTop)}–{f2(s.depthBottom)}</td>
+                      <td className="py-0.5 pr-3 text-right">
+                        {recoveryRatio(s) == null ? '—' : `${f0(recoveryRatio(s))} %`}
+                      </td>
+                      <td className="py-0.5 pr-3 font-sans">
+                        {s.tests.length
+                          ? s.tests.map((t) => `${t.type}${t.status === 'complete' ? '' : ` (${t.status})`}`).join(', ')
+                          : '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {!bh.samples.length && <p className="mt-3 text-[12px] text-slate-500">No samples recorded.</p>}
+          </div>
+        </section>
+      )}
+
+      {/* ── SPT ── */}
+      {tab === 'spt' && bh && profile && (
+        <section className="mt-5 space-y-4">
+          <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Unit weights for the stress profile</h2>
+            <p className="mb-3 text-[11px] text-slate-500">
+              (N₁)₆₀ needs the effective stress at each test depth, which needs a unit weight per layer. These are an
+              interpretation, so they are entered here rather than stored as data. Layers left blank stop the stress
+              profile at that depth — the blow counts below are still corrected for equipment, just not for overburden.
+            </p>
+            <div className="overflow-x-auto">
+              <table className="w-full text-left text-[12px]">
+                <thead className="text-slate-500">
+                  <tr className="border-b border-slate-200">
+                    <th className="py-1 pr-3">Layer</th><th className="py-1 pr-3">γ (kN/m³)</th>
+                    <th className="py-1 pr-3">γsat (kN/m³)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {bh.layers.map((l) => (
+                    <tr key={l.id} className="border-b border-slate-100">
+                      <td className="py-0.5 pr-3">{l.name}</td>
+                      <td className="py-0.5 pr-3">
+                        <input type="number" step="0.5" value={unitWeights[l.id]?.gamma ?? ''}
+                          onChange={(e) => setUnitWeights((u) => ({
+                            ...u,
+                            [l.id]: { ...u[l.id], gamma: num(e.target.value) },
+                          }))}
+                          className="w-20 rounded border border-slate-200 px-1 py-0.5 text-right font-mono" />
+                      </td>
+                      <td className="py-0.5 pr-3">
+                        <input type="number" step="0.5" value={unitWeights[l.id]?.gammaSat ?? ''}
+                          onChange={(e) => setUnitWeights((u) => ({
+                            ...u,
+                            [l.id]: { gamma: u[l.id]?.gamma ?? 18, gammaSat: num(e.target.value) },
+                          }))}
+                          className="w-20 rounded border border-slate-200 px-1 py-0.5 text-right font-mono" />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Corrected blow counts</h2>
+            <div className="overflow-x-auto">
+              <table className="w-full text-right text-[12px]">
+                <thead className="text-slate-500">
+                  <tr className="border-b border-slate-200">
+                    <th className="py-1 pr-3 text-left">Depth (m)</th><th className="py-1 pr-3 text-left">Layer</th>
+                    <th className="py-1 pr-3">N</th><th className="py-1 pr-3">C_R</th>
+                    <th className="py-1 pr-3">N₆₀</th><th className="py-1 pr-3">σ′ᵥ₀</th>
+                    <th className="py-1 pr-3">C_N</th><th className="py-1 pr-3">(N₁)₆₀</th>
+                    <th className="py-1 pr-3 text-left">Description</th>
+                  </tr>
+                </thead>
+                <tbody className="font-mono">
+                  {profile.rows.map((r) => (
+                    <tr key={r.testId} className={`border-b border-slate-100 ${r.refusal ? 'bg-amber-50' : ''}`}>
+                      <td className="py-0.5 pr-3 text-left">{f2(r.depth)}</td>
+                      <td className="py-0.5 pr-3 text-left font-sans">{r.layerName ?? '—'}</td>
+                      <td className="py-0.5 pr-3">{r.N}{r.refusal ? '*' : ''}</td>
+                      <td className="py-0.5 pr-3">{f2(r.cr)}</td>
+                      <td className="py-0.5 pr-3 font-semibold">{f1(r.n60)}</td>
+                      <td className="py-0.5 pr-3">{f0(r.effectiveStress)}</td>
+                      <td className="py-0.5 pr-3">{f2(r.cn)}</td>
+                      <td className="py-0.5 pr-3 font-semibold">{f1(r.n160)}</td>
+                      <td className="py-0.5 pr-3 text-left font-sans text-slate-600">
+                        {r.refusal
+                          ? 'refusal'
+                          : describeN60(r.n60, bh.layers.find((l) => l.id === r.layerId))}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {!profile.rows.length && <p className="mt-3 text-[12px] text-slate-500">No SPT results recorded.</p>}
+            {profile.notes.map((n, k) => (
+              <p key={k} className="mt-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[11px] text-amber-900">
+                {n}
+              </p>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* ── Classification ── */}
+      {tab === 'classification' && (
+        <section className="mt-5">
+          <ClassificationPanel />
+        </section>
+      )}
+
+    </main>
+  )
+}
+
+// ── Classification calculator ─────────────────────────────────────────────
+// A standalone USCS check driven by typed gradation and plasticity, so a
+// classification can be worked out before the sample data model carries the
+// laboratory results (Phase 4).
+
+function ClassificationPanel() {
+  const [gravel, setGravel] = useState(5)
+  const [sand, setSand] = useState(62)
+  const [fines, setFines] = useState(33)
+  const [cu, setCu] = useState(8)
+  const [cc, setCc] = useState(1.5)
+  const [ll, setLl] = useState(42)
+  const [pl, setPl] = useState(23)
+  const [organic, setOrganic] = useState(false)
+
+  const pi = Math.max(ll - pl, 0)
+  const result = useMemo(
+    () => classifyUSCS({ gravel, sand, fines, cu, cc, liquidLimit: ll, plasticityIndex: pi, organic }),
+    [gravel, sand, fines, cu, cc, ll, pi, organic],
+  )
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Gradation and plasticity</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          {([
+            ['Gravel (%)', gravel, setGravel], ['Sand (%)', sand, setSand], ['Fines (%)', fines, setFines],
+            ['Cu', cu, setCu], ['Cc', cc, setCc], ['LL (%)', ll, setLl], ['PL (%)', pl, setPl],
+          ] as [string, number, (v: number) => void][]).map(([label, value, onChange]) => (
+            <label key={label} className="flex flex-col text-sm">
+              <span className="mb-1 font-medium text-slate-600">{label}</span>
+              <input type="number" step="any" value={value}
+                onChange={(e) => onChange(num(e.target.value))}
+                className="rounded-md border border-slate-300 px-2.5 py-1.5" />
+            </label>
+          ))}
+          <label className="flex items-end gap-2 text-sm">
+            <input type="checkbox" checked={organic} onChange={(e) => setOrganic(e.target.checked)}
+              className="mb-2 h-4 w-4" />
+            <span className="mb-1.5 font-medium text-slate-600">Organic</span>
+          </label>
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-2 text-[1.05rem] font-bold text-[#0056b3]">USCS — ASTM D2487</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Stat label="Group symbol" value={result.symbol ?? '—'} sub={result.dual ? 'dual symbol' : undefined} />
+          <Stat label="PI" value={f0(pi)} sub="LL − PL" />
+          <Stat label="Fines" value={`${f0(fines)} %`} sub={result.coarseGrained ? 'coarse-grained' : 'fine-grained'} />
+          <Stat label="Group name" value={result.name ?? '—'} />
+        </div>
+        <p className="mt-3 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-[12px] text-slate-700">
+          {result.reason}
+        </p>
+        {result.notes.map((n, k) => (
+          <p key={k} className="mt-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[11px] text-amber-900">
+            {n}
+          </p>
+        ))}
+        {!result.symbol && (
+          <p className="mt-2 text-[11px] text-slate-500">
+            The classifier will not guess. Where D2487 needs a test that has not been run, it says which one rather
+            than picking the likeliest symbol.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
**The first phase of the module that is reachable from the app.** `/soils` is a five-tab workbench over the Phase 0–3a engines (#476, #477, #478, #479): investigation details and integrity, boreholes with the graphical log, a stratigraphy and sample editor, corrected SPT blow counts, and a USCS classifier.

## Gating

- New feature **`soil-investigation` on pro and max**. It produces a client-deliverable report, which is the line `reports` and `estimating` already sit on.
- `/soils` added to **`ROUTE_FEATURE` and `GATED_PREFIXES` together** — the guard test requires the key sets to be equal. I checked it bites by removing one and watching it fail.
- Docs entry added, since `docsContent.test.ts` refuses a route that has none.
- Nav entry under Geotechnical.

## Persistence

`useInvestigation` mirrors `useScheduleProject`: the store is the single source of truth, and **every mutation persists immediately**. Field and laboratory data is expensive to re-enter and, until the backend swap, lives in one browser — an edit lost to a refresh is not a minor annoyance here. Import surfaces its error rather than the hook swallowing a failed parse.

Unit weights for the stress profile are entered **on the page rather than stored**, because they're an interpretation rather than measured data. They get a home with provenance attached when the Phase 5 parameter engine lands.

## Three defects found by rendering the page and looking at it

**1. The same noun bug, again — and this one is the interesting failure.**

The SPT table described an N of 6 in a silty sand as **"firm"** — a *cohesive* consistency term for a granular soil. I'd fixed exactly this class of bug in the log renderer one PR ago, then reintroduced it by writing the page's own `/clay|silt/` regex: a second, independent reading of the same field.

Fixed properly this time. `soilFamily` now lives in `model.ts`, `hatchFor` delegates to it, the page reads it, and a test asserts the renderer and the rule cannot drift apart. Two readings of one field will eventually disagree; there is now one.

**2. The footer rendered twice** — `AppShell` already provides it.

**3. The group-name tile** printed an empty value with the name in its subtitle.

## Verification

`npm test` — **2485 passed / 166 files** · `npx tsc -b` · `npm run lint` · `npm run build` all green.

In headless Chromium: the example investigation loads, the borehole log draws, layers edit, entering unit weights produces (N₁)₆₀, the classifier returns SC with its reasoning, the investigation survives a reload, and the console is clean. The SPT table now reads *loose / medium dense* for the silty sand, *soft / firm* for the lean clay and *dense / very dense* for the poorly graded sand — the right scale for each.

## Honest limits

- **Auth is unconfigured in this environment**, so `RequireAuth` and `usePlan` both fail open and I verified the page rather than the paywall. The gating logic is unit-tested; the actual pro-plan redirect needs your Supabase project to exercise.
- **No laboratory test entry yet.** Samples show their booked tests, but the results themselves have no form — that's Phase 4. The classifier tab therefore takes typed gradation and plasticity rather than reading them from a sample.
- **The USCS symbol is not written back to the layer.** You can classify, but the result doesn't yet populate `layer.symbol`; wiring that needs the sample→test→layer path that Phase 4 builds.
- **Unit weights reset on navigation**, being page state by design. Mildly annoying, and deliberate — storing them would mean storing an interpretation with no provenance.

## Next

Phase 4 — the laboratory suite: moisture, Gs, compaction, direct shear, UCS, triaxial, consolidation, permeability, CBR. That's also the point where the localStorage-vs-Postgres decision gets expensive to reverse, since it adds a dozen test shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_