### PR TITLE
Soil investigation Phase 4a — lab test plumbing and the index tests

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1326,18 +1326,23 @@ because flagging the unusual as an error trains people to ignore errors.
 | 1 — classification (Atterberg, sieve, USCS, AASHTO) | #477 | merged |
 | 2 — SPT corrections, correlations, overburden | #478 | merged |
 | 3a — borehole log renderer (geometry) | #479 | open |
-| 3b — investigation UI, routes, profile editor | — | next |
-| 4 — laboratory suite | — | |
+| 3b — investigation UI, routes, profile editor | #480 | merged |
+| 4a — lab plumbing + index tests (moisture, Gs) | — | open |
+| 4b… — remaining lab tests | — | |
 | 5 — parameter engine + wiring to existing analysis | — | the payoff |
 | 6 — liquefaction, bearing methods, Coulomb | — | |
 | 7 — report document builder | — | |
 | 8 — Postgres, CPT, 3D subsurface | — | |
 
-**Everything so far is engine-only** — 364 tests across 12 modules, and not one
-line of it is reachable from the app yet. Phase 3b is the first with routes, and
-therefore the first to hit `docsContent.test.ts` (every route needs a docs
-entry) and `featureGate.ts` (`ROUTE_FEATURE` key-set equality with
-`trialQuota.GATED_PREFIXES`).
+**`/soils` is live**, gated behind the `soil-investigation` feature on pro and
+max. Six tabs: overview and integrity, boreholes with the graphical log,
+stratigraphy and samples, corrected SPT, laboratory tests, and a USCS
+classifier.
+
+**Storage decision, settled:** stay on the `SoilsStore` interface over
+localStorage; swap in a Supabase backend at Phase 8. Confirmed with the user
+before Phase 4 started, since that is the phase where lab-test shapes make a
+schema change expensive.
 
 **Two recurring lessons from these phases**, both worth remembering:
 
@@ -1350,3 +1355,7 @@ entry) and `featureGate.ts` (`ROUTE_FEATURE` key-set equality with
    each term of AASHTO M 145 at zero before summing, which is a different
    equation from the one the standard prints — 40% fines at LL 20 / PI 2 is 0,
    not 1.
+3. *One rule, one home.* The noun bug came back in Phase 3b because the page
+   grew its own `/clay|silt/` regex — a second independent reading of the same
+   field, which disagreed with the first within a day. `soilFamily` now lives in
+   `model.ts` and a test asserts the renderer and the page cannot drift apart.

--- a/webapp/src/engine/soils/lab/index.ts
+++ b/webapp/src/engine/soils/lab/index.ts
@@ -1,0 +1,193 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Laboratory-test registry: the typed bridge between `LabTest.data` and the
+// engine that understands it. Layer 8.
+//
+// `LabTest.data` is `Record<string, unknown>` in the schema, and deliberately
+// so — layer 1 cannot know the shape of every test without depending on every
+// test engine, which would invert the dependency. This module is where the
+// shapes are declared, so a caller gets `MoistureData` rather than `unknown`
+// without the schema growing a dozen imports.
+//
+// EVERY READER GOES THROUGH A GUARD. Stored investigations round-trip through
+// JSON and through an import file a user may have edited, so a `data` blob is
+// untrusted input, not a typed object that happens to be serialised. `readXxx`
+// returns undefined on anything malformed rather than handing back a
+// half-populated object that computes a plausible wrong answer.
+//
+// Adding a test: declare its Data type in its own module, add a case here, and
+// add a row to LAB_TESTS. The test suite asserts the three stay in step.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { LabTest, LabTestType } from '../model'
+import type { StandardId } from '../standards'
+import type { CalcId } from '../registry'
+import { type MoistureData, moistureContent, type MoistureResult } from './moisture'
+import {
+  type SpecificGravityData, specificGravity, type SpecificGravityResult,
+} from './specificGravity'
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v)
+
+const finite = (v: unknown): v is number => typeof v === 'number' && Number.isFinite(v)
+
+/** Every declared numeric field present and finite. */
+const hasNumbers = (o: Record<string, unknown>, keys: string[]): boolean =>
+  keys.every((k) => finite(o[k]))
+
+// ── Guards ────────────────────────────────────────────────────────────────
+
+export function readMoisture(test: LabTest): MoistureData | undefined {
+  const d = test.data
+  if (!isRecord(d) || !hasNumbers(d, ['containerMass', 'wetMass', 'dryMass'])) return undefined
+  return {
+    container: typeof d.container === 'string' ? d.container : undefined,
+    containerMass: d.containerMass as number,
+    wetMass: d.wetMass as number,
+    dryMass: d.dryMass as number,
+    temperature: finite(d.temperature) ? d.temperature : undefined,
+  }
+}
+
+export function readSpecificGravity(test: LabTest): SpecificGravityData | undefined {
+  const d = test.data
+  if (!isRecord(d) || !hasNumbers(d, ['solidMass', 'pycWaterMass', 'pycWaterSolidMass'])) return undefined
+  return {
+    pycnometer: typeof d.pycnometer === 'string' ? d.pycnometer : undefined,
+    solidMass: d.solidMass as number,
+    pycWaterMass: d.pycWaterMass as number,
+    pycWaterSolidMass: d.pycWaterSolidMass as number,
+    temperature: finite(d.temperature) ? d.temperature : undefined,
+  }
+}
+
+// ── Catalogue ─────────────────────────────────────────────────────────────
+
+/** One numeric input on a test form. */
+export interface LabField {
+  key: string
+  label: string
+  unit?: string
+  /** Optional when the standard allows it to be omitted. */
+  optional?: boolean
+  /** Sensible starting value for a blank form. */
+  placeholder?: number
+}
+
+export interface LabTestSpec {
+  type: LabTestType
+  label: string
+  standard: StandardId
+  /** Registry calculation this test's result is derived by. */
+  calculation?: CalcId
+  /** Whether the test needs an undisturbed specimen. */
+  needsUndisturbed: boolean
+  /** Raw measurements the form collects. */
+  fields: LabField[]
+  /** One line on what the test is for. */
+  purpose: string
+}
+
+/**
+ * Declared tests. Entries without `fields` are not yet implemented — they can
+ * still be BOOKED against a sample (status 'planned'), which is how a
+ * laboratory schedule works, but they have no data form until their engine
+ * lands. Saying so is better than hiding the test from the list and making the
+ * schedule look shorter than it is.
+ */
+export const LAB_TESTS: readonly LabTestSpec[] = [
+  {
+    type: 'moisture',
+    label: 'Water content',
+    standard: 'd2216',
+    calculation: 'moisture.water-content',
+    needsUndisturbed: false,
+    purpose: 'The water content every other index property leans on.',
+    fields: [
+      { key: 'containerMass', label: 'Container', unit: 'g', placeholder: 25 },
+      { key: 'wetMass', label: 'Container + wet soil', unit: 'g', placeholder: 85 },
+      { key: 'dryMass', label: 'Container + dry soil', unit: 'g', placeholder: 75 },
+      { key: 'temperature', label: 'Drying temperature', unit: '°C', optional: true, placeholder: 110 },
+    ],
+  },
+  {
+    type: 'specific-gravity',
+    label: 'Specific gravity',
+    standard: 'd854',
+    calculation: 'gs.specific-gravity',
+    needsUndisturbed: false,
+    purpose: 'Density of the solids, needed for void ratio, saturation and consolidation.',
+    fields: [
+      { key: 'solidMass', label: 'Oven-dry solids', unit: 'g', placeholder: 25 },
+      { key: 'pycWaterMass', label: 'Pycnometer + water', unit: 'g', placeholder: 675 },
+      { key: 'pycWaterSolidMass', label: 'Pycnometer + water + solids', unit: 'g', placeholder: 690.6 },
+      { key: 'temperature', label: 'Test temperature', unit: '°C', optional: true, placeholder: 20 },
+    ],
+  },
+  // Declared but not yet implemented — see the note above.
+  { type: 'sieve', label: 'Sieve analysis', standard: 'd6913', needsUndisturbed: false, fields: [], purpose: 'Grain-size distribution by sieving.' },
+  { type: 'hydrometer', label: 'Hydrometer', standard: 'd7928', needsUndisturbed: false, fields: [], purpose: 'Grain-size distribution of the fines by sedimentation.' },
+  { type: 'atterberg', label: 'Atterberg limits', standard: 'd4318', needsUndisturbed: false, fields: [], purpose: 'Liquid and plastic limits, which classify the fines.' },
+  { type: 'compaction', label: 'Compaction', standard: 'd698', needsUndisturbed: false, fields: [], purpose: 'Maximum dry density and optimum moisture content.' },
+  { type: 'direct-shear', label: 'Direct shear', standard: 'd3080', needsUndisturbed: true, fields: [], purpose: 'Effective cohesion and friction angle from the failure envelope.' },
+  { type: 'triaxial', label: 'Triaxial', standard: 'd4767', needsUndisturbed: true, fields: [], purpose: 'Shear strength under controlled drainage and confinement.' },
+  { type: 'ucs', label: 'Unconfined compression', standard: 'd2166', needsUndisturbed: true, fields: [], purpose: 'Undrained shear strength of a cohesive soil.' },
+  { type: 'consolidation', label: 'Consolidation', standard: 'd2435', needsUndisturbed: true, fields: [], purpose: 'Compressibility and the rate of settlement.' },
+  { type: 'permeability', label: 'Permeability', standard: 'd5084', needsUndisturbed: true, fields: [], purpose: 'Hydraulic conductivity.' },
+  { type: 'cbr', label: 'CBR', standard: 'd1883', needsUndisturbed: false, fields: [], purpose: 'Bearing ratio for pavement design.' },
+  { type: 'swell', label: 'Swell / collapse', standard: 'd4546', needsUndisturbed: true, fields: [], purpose: 'One-dimensional swell or collapse on wetting.' },
+]
+
+export const labSpec = (type: LabTestType): LabTestSpec | undefined =>
+  LAB_TESTS.find((t) => t.type === type)
+
+/** Tests that have a data form today. */
+export const implementedTests = (): LabTestSpec[] => LAB_TESTS.filter((t) => t.fields.length > 0)
+
+/** Whether a test type can currently accept results. */
+export const isImplemented = (type: LabTestType): boolean =>
+  (labSpec(type)?.fields.length ?? 0) > 0
+
+// ── Evaluation ────────────────────────────────────────────────────────────
+
+export type LabOutcome =
+  | { kind: 'moisture'; result: MoistureResult }
+  | { kind: 'specific-gravity'; result: SpecificGravityResult }
+
+/**
+ * Compute a test's result from its stored data.
+ *
+ * Returns undefined when the data is absent or malformed, and rethrows nothing:
+ * an engine that throws on impossible input (a dry mass above the wet mass) is
+ * reporting a data error, and the caller shows it rather than the page dying.
+ */
+export function evaluateTest(test: LabTest): { outcome?: LabOutcome; error?: string } {
+  try {
+    switch (test.type) {
+      case 'moisture': {
+        const d = readMoisture(test)
+        if (!d) return {}
+        return { outcome: { kind: 'moisture', result: moistureContent(d) } }
+      }
+      case 'specific-gravity': {
+        const d = readSpecificGravity(test)
+        if (!d) return {}
+        return { outcome: { kind: 'specific-gravity', result: specificGravity(d) } }
+      }
+      default:
+        return {}
+    }
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : String(e) }
+  }
+}
+
+/** The headline number a results table shows, with its unit. */
+export function summarise(outcome: LabOutcome): { label: string; value: number; unit: string } {
+  switch (outcome.kind) {
+    case 'moisture':
+      return { label: 'w', value: outcome.result.waterContent, unit: '%' }
+    case 'specific-gravity':
+      return { label: 'Gs', value: outcome.result.gs, unit: '' }
+  }
+}

--- a/webapp/src/engine/soils/lab/lab.test.ts
+++ b/webapp/src/engine/soils/lab/lab.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect } from 'vitest'
+import { moistureContent, meanWaterContent } from './moisture'
+import {
+  specificGravity, waterDensity, temperatureCorrection, voidRatio, saturation,
+} from './specificGravity'
+import {
+  LAB_TESTS, labSpec, isImplemented, implementedTests,
+  readMoisture, readSpecificGravity, evaluateTest, summarise,
+} from './index'
+import { STANDARDS } from '../standards'
+import { CALCULATIONS } from '../registry'
+import type { LabTest, LabTestType } from '../model'
+
+const test = (type: LabTestType, data?: Record<string, unknown>): LabTest => ({
+  id: 't1', type, standard: 'd2216', status: 'complete', data,
+})
+
+// ── Water content ─────────────────────────────────────────────────────────
+
+describe('water content (ASTM D2216)', () => {
+  it('matches a hand calculation', () => {
+    // Container 25.00 g, wet 85.00 g, dry 75.00 g
+    // water 10.00 g, solids 50.00 g ⇒ w = 20.00%
+    const r = moistureContent({ containerMass: 25, wetMass: 85, dryMass: 75 })
+    expect(r.waterMass).toBeCloseTo(10, 10)
+    expect(r.solidMass).toBeCloseTo(50, 10)
+    expect(r.waterContent).toBeCloseTo(20, 10)
+  })
+
+  it('is a ratio to the DRY mass, so above 100% is legitimate', () => {
+    // A soft organic clay holding more water than solids by mass.
+    const r = moistureContent({ containerMass: 20, wetMass: 140, dryMass: 70 })
+    expect(r.waterContent).toBeCloseTo(140, 10)
+    expect(r.notes.join(' ')).toMatch(/organic/)
+  })
+
+  it('does not clamp a high water content', () => {
+    const r = moistureContent({ containerMass: 0, wetMass: 300, dryMass: 100 })
+    expect(r.waterContent).toBeCloseTo(200, 10)
+  })
+
+  it('rejects a dry mass at or below the tare', () => {
+    expect(() => moistureContent({ containerMass: 25, wetMass: 30, dryMass: 25 }))
+      .toThrow(/check the tare/i)
+    expect(() => moistureContent({ containerMass: 25, wetMass: 30, dryMass: 20 }))
+      .toThrow(/check the tare/i)
+  })
+
+  it('rejects a dry mass above the wet mass', () => {
+    expect(() => moistureContent({ containerMass: 25, wetMass: 70, dryMass: 75 }))
+      .toThrow(/impossible/i)
+  })
+
+  it('notes a non-standard drying temperature', () => {
+    const r = moistureContent({ containerMass: 25, wetMass: 85, dryMass: 75, temperature: 90 })
+    expect(r.notes.join(' ')).toMatch(/110 ± 5 °C/)
+  })
+
+  it('does not complain about 60 °C, which D2216 allows for organics', () => {
+    const r = moistureContent({ containerMass: 25, wetMass: 85, dryMass: 75, temperature: 60 })
+    expect(r.notes.join(' ')).not.toMatch(/110 ± 5/)
+  })
+
+  it('notes a specimen too small to weigh reliably', () => {
+    const r = moistureContent({ containerMass: 25, wetMass: 31, dryMass: 30 })
+    expect(r.notes.join(' ')).toMatch(/proportional weighing error/)
+  })
+})
+
+describe('averaging determinations', () => {
+  const at = (w: number) => moistureContent({ containerMass: 0, wetMass: 100 + w, dryMass: 100 })
+
+  it('averages and reports the spread', () => {
+    const r = meanWaterContent([at(20), at(22)])
+    expect(r.mean).toBeCloseTo(21, 10)
+    expect(r.range).toBeCloseTo(2, 10)
+    expect(r.notes).toEqual([])
+  })
+
+  it('flags duplicates that disagree instead of averaging them silently', () => {
+    // Usually a tare or transcription error rather than natural variation.
+    const r = meanWaterContent([at(20), at(28)])
+    expect(r.notes.join(' ')).toMatch(/check the tare masses before averaging/)
+  })
+
+  it('refuses an empty set', () => {
+    expect(() => meanWaterContent([])).toThrow(/No determinations/)
+  })
+})
+
+// ── Specific gravity ──────────────────────────────────────────────────────
+
+describe('water density and the D854 temperature correction', () => {
+  it('reproduces the standard table', () => {
+    expect(waterDensity(4)).toBeCloseTo(1.0000, 4)
+    expect(waterDensity(20)).toBeCloseTo(0.99821, 4)
+    expect(waterDensity(25)).toBeCloseTo(0.99705, 4)
+  })
+
+  it('is 1.0 at the 20 °C reference and below 1 when warmer', () => {
+    expect(temperatureCorrection(20)).toBeCloseTo(1, 12)
+    expect(temperatureCorrection(25)).toBeLessThan(1)
+    expect(temperatureCorrection(15)).toBeGreaterThan(1)
+  })
+})
+
+describe('specific gravity (ASTM D854)', () => {
+  it('matches a hand calculation', () => {
+    // Ms 25.00, Mpw 675.00, Mpws 690.60 ⇒ displaced 9.40 ⇒ Gs 2.6596
+    const r = specificGravity({ solidMass: 25, pycWaterMass: 675, pycWaterSolidMass: 690.6 })
+    expect(r.displacedMass).toBeCloseTo(9.4, 10)
+    expect(r.gsAtTest).toBeCloseTo(2.6596, 4)
+    expect(r.gs).toBeCloseTo(2.6596, 4)     // no correction at 20 °C
+  })
+
+  it('corrects to 20 °C and says it did', () => {
+    const warm = specificGravity({
+      solidMass: 25, pycWaterMass: 675, pycWaterSolidMass: 690.6, temperature: 25,
+    })
+    expect(warm.k).toBeLessThan(1)
+    expect(warm.gs).toBeLessThan(warm.gsAtTest)
+    expect(warm.notes.join(' ')).toMatch(/Corrected from 25\.0 °C to 20 °C/)
+  })
+
+  it('rejects solids that displaced no water', () => {
+    expect(() => specificGravity({ solidMass: 25, pycWaterMass: 675, pycWaterSolidMass: 700 }))
+      .toThrow(/physically impossible/)
+  })
+
+  it('rejects a zero dry mass', () => {
+    expect(() => specificGravity({ solidMass: 0, pycWaterMass: 675, pycWaterSolidMass: 680 }))
+      .toThrow(/greater than zero/)
+  })
+
+  it('flags a Gs outside the usual mineral range, and says which way it errs', () => {
+    // Under-de-aired suspensions trap air, displace too little, and read LOW.
+    const low = specificGravity({ solidMass: 25, pycWaterMass: 675, pycWaterSolidMass: 689 })
+    expect(low.gs).toBeLessThan(2.4)
+    expect(low.notes.join(' ')).toMatch(/de-airing.*reads low/i)
+  })
+
+  it('notes a specimen small enough to magnify the weighing error', () => {
+    const r = specificGravity({ solidMass: 5, pycWaterMass: 675, pycWaterSolidMass: 678.1 })
+    expect(r.notes.join(' ')).toMatch(/magnifies every weighing error/)
+  })
+})
+
+describe('what Gs is actually for', () => {
+  it('gives the void ratio from the dry unit weight', () => {
+    // e = Gs·γw/γd − 1 = 2.68 × 9.81 / 16.0 − 1 = 0.6432
+    expect(voidRatio(2.68, 16)).toBeCloseTo(0.6432, 4)
+  })
+
+  it('gives the degree of saturation', () => {
+    // S = w·Gs/e = 20 × 2.68 / 0.6432 = 83.3%
+    expect(saturation(20, 2.68, voidRatio(2.68, 16))).toBeCloseTo(83.33, 1)
+  })
+
+  it('rejects degenerate inputs rather than returning Infinity', () => {
+    expect(() => voidRatio(2.68, 0)).toThrow(/greater than zero/)
+    expect(() => saturation(20, 2.68, 0)).toThrow(/greater than zero/)
+  })
+})
+
+// ── Registry ──────────────────────────────────────────────────────────────
+
+describe('the lab catalogue stays in step with the schema', () => {
+  it('names a real standard for every test', () => {
+    for (const t of LAB_TESTS) {
+      expect(STANDARDS[t.standard], t.type).toBeDefined()
+    }
+  })
+
+  it('names a real registry calculation where it claims one', () => {
+    for (const t of LAB_TESTS) {
+      if (t.calculation) expect(CALCULATIONS[t.calculation], t.type).toBeDefined()
+    }
+  })
+
+  it('has no duplicate test types', () => {
+    const types = LAB_TESTS.map((t) => t.type)
+    expect(new Set(types).size).toBe(types.length)
+  })
+
+  it('declares every test the schema knows about', () => {
+    // A LabTestType with no catalogue entry would be un-bookable.
+    const declared = new Set(LAB_TESTS.map((t) => t.type))
+    const schemaTypes: LabTestType[] = [
+      'moisture', 'specific-gravity', 'sieve', 'hydrometer', 'atterberg',
+      'compaction', 'direct-shear', 'triaxial', 'ucs', 'consolidation',
+      'permeability', 'cbr', 'swell',
+    ]
+    for (const t of schemaTypes) expect(declared.has(t), t).toBe(true)
+  })
+
+  it('distinguishes implemented tests from merely declared ones', () => {
+    // A test with no engine can still be BOOKED — that is how a laboratory
+    // schedule works — but it has no data form, and the list says so rather
+    // than hiding it and making the schedule look shorter than it is.
+    expect(isImplemented('moisture')).toBe(true)
+    expect(isImplemented('specific-gravity')).toBe(true)
+    expect(isImplemented('triaxial')).toBe(false)
+    expect(implementedTests().map((t) => t.type)).toEqual(['moisture', 'specific-gravity'])
+  })
+
+  it('gives every implemented test a field for each of its engine inputs', () => {
+    for (const t of implementedTests()) {
+      expect(t.fields.length, t.type).toBeGreaterThanOrEqual(3)
+      for (const f of t.fields) {
+        expect(f.label.length, `${t.type}/${f.key}`).toBeGreaterThan(2)
+        expect(f.key, `${t.type}/${f.key}`).toMatch(/^[a-zA-Z]+$/)
+      }
+    }
+  })
+
+  it('marks the tests that need an undisturbed specimen', () => {
+    expect(labSpec('triaxial')!.needsUndisturbed).toBe(true)
+    expect(labSpec('consolidation')!.needsUndisturbed).toBe(true)
+    expect(labSpec('moisture')!.needsUndisturbed).toBe(false)
+  })
+})
+
+// ── Guards ────────────────────────────────────────────────────────────────
+
+describe('stored data is untrusted input', () => {
+  it('reads a well-formed blob', () => {
+    const d = readMoisture(test('moisture', { containerMass: 25, wetMass: 85, dryMass: 75 }))
+    expect(d).toEqual({ container: undefined, containerMass: 25, wetMass: 85, dryMass: 75, temperature: undefined })
+  })
+
+  it('returns undefined rather than a half-populated object', () => {
+    // An investigation round-trips through JSON and through a file a user may
+    // have edited, so a missing field must not become NaN downstream.
+    expect(readMoisture(test('moisture', { containerMass: 25, wetMass: 85 }))).toBeUndefined()
+    expect(readMoisture(test('moisture', {}))).toBeUndefined()
+    expect(readMoisture(test('moisture'))).toBeUndefined()
+    expect(readMoisture(test('moisture', { containerMass: 'x', wetMass: 85, dryMass: 75 }))).toBeUndefined()
+  })
+
+  it('rejects NaN and Infinity, which survive JSON round trips as null or numbers', () => {
+    expect(readMoisture(test('moisture', { containerMass: NaN, wetMass: 85, dryMass: 75 }))).toBeUndefined()
+    expect(readMoisture(test('moisture', { containerMass: Infinity, wetMass: 85, dryMass: 75 }))).toBeUndefined()
+  })
+
+  it('ignores an array or a primitive where an object is expected', () => {
+    expect(readMoisture({ ...test('moisture'), data: [] as unknown as Record<string, unknown> })).toBeUndefined()
+  })
+
+  it('reads specific gravity the same way', () => {
+    expect(readSpecificGravity(test('specific-gravity', {
+      solidMass: 25, pycWaterMass: 675, pycWaterSolidMass: 690.6,
+    }))).toBeTruthy()
+    expect(readSpecificGravity(test('specific-gravity', { solidMass: 25 }))).toBeUndefined()
+  })
+})
+
+describe('evaluateTest', () => {
+  it('computes an implemented test', () => {
+    const { outcome, error } = evaluateTest(test('moisture', { containerMass: 25, wetMass: 85, dryMass: 75 }))
+    expect(error).toBeUndefined()
+    expect(outcome!.kind).toBe('moisture')
+    expect(summarise(outcome!)).toEqual({ label: 'w', value: 20, unit: '%' })
+  })
+
+  it('returns an ERROR for impossible data rather than throwing', () => {
+    // The page shows the message; it does not die.
+    const { outcome, error } = evaluateTest(test('moisture', { containerMass: 25, wetMass: 70, dryMass: 75 }))
+    expect(outcome).toBeUndefined()
+    expect(error).toMatch(/impossible/)
+  })
+
+  it('returns nothing for a test with no data or no engine', () => {
+    expect(evaluateTest(test('moisture'))).toEqual({})
+    expect(evaluateTest(test('triaxial', { anything: 1 }))).toEqual({})
+  })
+
+  it('summarises specific gravity', () => {
+    const { outcome } = evaluateTest(test('specific-gravity', {
+      solidMass: 25, pycWaterMass: 675, pycWaterSolidMass: 690.6,
+    }))
+    const s = summarise(outcome!)
+    expect(s.label).toBe('Gs')
+    expect(s.value).toBeCloseTo(2.6596, 3)
+  })
+})

--- a/webapp/src/engine/soils/lab/moisture.ts
+++ b/webapp/src/engine/soils/lab/moisture.ts
@@ -1,0 +1,100 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Water content by oven drying. Layer 8. ASTM D2216.
+//
+// The simplest test in the laboratory and the one every other index property
+// leans on: the liquid and plastic limits are water contents, the void ratio
+// comes from it, and the unit weight cannot be split into dry and saturated
+// without it.
+//
+// WATER CONTENT IS A RATIO TO THE DRY MASS, NOT THE TOTAL. w = Mw/Ms, so a
+// water content above 100% is perfectly ordinary in a soft organic clay — it
+// means the soil holds more water than solids by mass. Clamping it at 100
+// would be wrong, and the module does not.
+//
+// The RAW MASSES are what the test records and what this takes: container,
+// container + wet soil, container + dry soil. Storing only the answer would
+// make a transcription error undetectable, and the tare mass is exactly where
+// those errors happen.
+//
+// UNITS: masses g (any consistent unit — only ratios are used); w in %.
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface MoistureData {
+  /** Specimen identifier on the tin, e.g. 'A-14'. */
+  container?: string
+  /** Mass of the empty container, g. */
+  containerMass: number
+  /** Mass of container + wet soil, g. */
+  wetMass: number
+  /** Mass of container + oven-dried soil, g. */
+  dryMass: number
+  /** Drying temperature, °C. Default 110 per D2216. */
+  temperature?: number
+}
+
+export interface MoistureResult {
+  /** Mass of water driven off, g. */
+  waterMass: number
+  /** Mass of dry solids, g. */
+  solidMass: number
+  /** Water content, %. Can legitimately exceed 100. */
+  waterContent: number
+  notes: string[]
+}
+
+export function moistureContent(d: MoistureData): MoistureResult {
+  const notes: string[] = []
+
+  const waterMass = d.wetMass - d.dryMass
+  const solidMass = d.dryMass - d.containerMass
+
+  if (!(solidMass > 0)) {
+    throw new Error(
+      'Dry mass must exceed the container mass — check the tare. Without solids there is no water content.',
+    )
+  }
+  if (waterMass < 0) {
+    throw new Error(
+      'The dry mass exceeds the wet mass, which is impossible. One of the two weighings is wrong.',
+    )
+  }
+
+  const waterContent = (waterMass / solidMass) * 100
+
+  const temp = d.temperature ?? 110
+  if (temp > 60 && waterContent > 100) {
+    notes.push(
+      'Water content above 100% — ordinary in a soft or organic clay, where the soil holds more water than solids by mass. If the soil is organic, D2216 asks for drying at 60 °C instead; structural water is lost at 110 °C and the result reads high.',
+    )
+  }
+  if (temp < 105 && temp !== 60) {
+    notes.push(`Dried at ${temp} °C. D2216 specifies 110 ± 5 °C unless the soil is organic or gypsiferous, in which case 60 °C and a stated deviation.`)
+  }
+  if (solidMass < 10) {
+    notes.push(`Only ${solidMass.toFixed(1)} g of solids — D2216 asks for a minimum specimen mass that grows with particle size, and a small specimen carries a large proportional weighing error.`)
+  }
+
+  return { waterMass, solidMass, waterContent, notes }
+}
+
+/**
+ * Mean water content of several determinations, with the spread reported.
+ * Averaging silently would hide a pair of results that disagree, which is
+ * usually a tare or a transcription error rather than natural variation.
+ */
+export function meanWaterContent(results: MoistureResult[]): {
+  mean: number; range: number; notes: string[]
+} {
+  if (!results.length) throw new Error('No determinations to average.')
+  const ws = results.map((r) => r.waterContent)
+  const mean = ws.reduce((s, w) => s + w, 0) / ws.length
+  const range = Math.max(...ws) - Math.min(...ws)
+  const notes: string[] = []
+  // 2 percentage points is a common repeatability expectation for duplicates.
+  if (ws.length > 1 && range > 2) {
+    notes.push(
+      `The determinations spread ${range.toFixed(1)} percentage points. That is wider than duplicate repeatability — check the tare masses before averaging.`,
+    )
+  }
+  return { mean, range, notes }
+}

--- a/webapp/src/engine/soils/lab/specificGravity.ts
+++ b/webapp/src/engine/soils/lab/specificGravity.ts
@@ -1,0 +1,112 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Specific gravity of soil solids by water pycnometer. Layer 8. ASTM D854.
+//
+//   Gs = Ms / (Ms + Mpw − Mpws)
+//
+// where the denominator is the mass of water the solids displaced. The
+// measurement is a difference between two nearly equal masses, which is why it
+// is delicate: a 0.1 g error in Mpws on a 25 g specimen moves Gs by about 0.01,
+// and de-airing is the dominant error source — an under-de-aired suspension
+// traps air, displaces too little water, and reads LOW.
+//
+// TEMPERATURE MATTERS AND IS NOT OPTIONAL. Water density falls with
+// temperature, so a test run at 25 °C displaces less mass than the same solids
+// at 20 °C. D854 reports Gs at 20 °C, and the correction K = ρw(T)/ρw(20) is
+// applied here rather than left to the engineer to remember.
+//
+// UNITS: masses g; temperature °C; Gs dimensionless.
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface SpecificGravityData {
+  /** Pycnometer identifier. */
+  pycnometer?: string
+  /** Oven-dry mass of the soil solids, g. */
+  solidMass: number
+  /** Mass of pycnometer + water at the test temperature, g. */
+  pycWaterMass: number
+  /** Mass of pycnometer + water + solids at the test temperature, g. */
+  pycWaterSolidMass: number
+  /** Test temperature, °C. Default 20 (no correction). */
+  temperature?: number
+}
+
+export interface SpecificGravityResult {
+  /** Mass of water displaced by the solids, g. */
+  displacedMass: number
+  /** Gs at the test temperature, before the correction to 20 °C. */
+  gsAtTest: number
+  /** Temperature correction K = ρw(T)/ρw(20). */
+  k: number
+  /** Gs corrected to 20 °C — the reported value. */
+  gs: number
+  notes: string[]
+}
+
+/**
+ * Density of water, g/cm³, over the range a soils laboratory works in.
+ * Fitted to the standard table; accurate to about 1e-6 over 15–30 °C, which is
+ * an order of magnitude finer than the mass weighings.
+ */
+export function waterDensity(tempC: number): number {
+  // Thiesen–Scheel–Diesselhorst form, the usual expression for pure water.
+  const t = tempC
+  return (1 - ((t + 288.9414) / (508929.2 * (t + 68.12963))) * (t - 3.9863) ** 2)
+}
+
+/** D854 temperature correction K = ρw(T)/ρw(20 °C). */
+export const temperatureCorrection = (tempC: number): number =>
+  waterDensity(tempC) / waterDensity(20)
+
+export function specificGravity(d: SpecificGravityData): SpecificGravityResult {
+  const notes: string[] = []
+  const { solidMass: Ms, pycWaterMass: Mpw, pycWaterSolidMass: Mpws } = d
+
+  if (!(Ms > 0)) throw new Error('The oven-dry mass of solids must be greater than zero.')
+
+  const displacedMass = Ms + Mpw - Mpws
+  if (!(displacedMass > 0)) {
+    throw new Error(
+      'The solids displaced no water (Ms + Mpw ≤ Mpws), which is physically impossible. Check the two pycnometer weighings.',
+    )
+  }
+
+  const gsAtTest = Ms / displacedMass
+  const temp = d.temperature ?? 20
+  const k = temperatureCorrection(temp)
+  const gs = gsAtTest * k
+
+  if (gs < 2.4 || gs > 2.9) {
+    notes.push(
+      `Gs = ${gs.toFixed(3)} falls outside the 2.60–2.80 range most mineral soils occupy. Below it suggests organic matter or trapped air from incomplete de-airing, which reads low; above it suggests heavy minerals. Verify before using this in a void-ratio calculation.`,
+    )
+  }
+  if (Math.abs(temp - 20) > 0.1) {
+    notes.push(
+      `Corrected from ${temp.toFixed(1)} °C to 20 °C with K = ${k.toFixed(5)}. D854 reports Gs at 20 °C.`,
+    )
+  }
+  if (Ms < 10) {
+    notes.push(
+      `Only ${Ms.toFixed(1)} g of solids. Gs is a difference between two nearly equal masses, so a small specimen magnifies every weighing error.`,
+    )
+  }
+
+  return { displacedMass, gsAtTest, k, gs, notes }
+}
+
+/**
+ * Void ratio from the dry unit weight and Gs:  e = (Gs·γw / γd) − 1.
+ *
+ * Kept here because it is the reason Gs is measured at all — the number is
+ * rarely of interest by itself, and pairing them makes the dependency obvious.
+ */
+export function voidRatio(gs: number, dryUnitWeight: number, gammaW = 9.81): number {
+  if (!(dryUnitWeight > 0)) throw new Error('Dry unit weight must be greater than zero.')
+  return (gs * gammaW) / dryUnitWeight - 1
+}
+
+/** Degree of saturation, %:  S = w·Gs / e. */
+export function saturation(waterContent: number, gs: number, e: number): number {
+  if (!(e > 0)) throw new Error('Void ratio must be greater than zero.')
+  return (waterContent * gs) / e
+}

--- a/webapp/src/pages/SoilInvestigation.tsx
+++ b/webapp/src/pages/SoilInvestigation.tsx
@@ -8,8 +8,12 @@ import { classifyUSCS } from '../engine/soils/uscs'
 import { densityFromN60, consistencyFromN60 } from '../engine/soils/spt'
 import {
   layerThickness, recoveryRatio, soilFamily, isCohesive,
-  type Borehole, type SoilLayer,
+  type Borehole, type SoilLayer, type LabTest, type LabTestType, type LabTestStatus,
 } from '../engine/soils/model'
+import {
+  LAB_TESTS, labSpec, isImplemented, evaluateTest, summarise,
+} from '../engine/soils/lab'
+import { cite } from '../engine/soils/standards'
 
 const f2 = (n: number | undefined) => (n == null || !Number.isFinite(n) ? '—' : n.toFixed(2))
 const f1 = (n: number | undefined) => (n == null || !Number.isFinite(n) ? '—' : n.toFixed(1))
@@ -122,7 +126,7 @@ function describeN60(n60: number, layer: SoilLayer | undefined): string {
 
 // ── Page ──────────────────────────────────────────────────────────────────
 
-type Tab = 'overview' | 'boreholes' | 'profile' | 'spt' | 'classification'
+type Tab = 'overview' | 'boreholes' | 'profile' | 'spt' | 'lab' | 'classification'
 
 export default function SoilInvestigation() {
   const api = useInvestigation()
@@ -239,12 +243,12 @@ export default function SoilInvestigation() {
       )}
 
       <nav className="mt-6 flex flex-wrap gap-1 border-b border-slate-200">
-        {(['overview', 'boreholes', 'profile', 'spt', 'classification'] as Tab[]).map((t) => (
+        {(['overview', 'boreholes', 'profile', 'spt', 'lab', 'classification'] as Tab[]).map((t) => (
           <button key={t} onClick={() => setTab(t)}
             className={`rounded-t-md px-3 py-1.5 text-[13px] font-medium capitalize ${
               tab === t ? 'border-b-2 border-[#0056b3] text-[#0056b3]' : 'text-slate-600 hover:text-slate-900'
             }`}>
-            {t === 'spt' ? 'SPT' : t}
+            {t === 'spt' ? 'SPT' : t === 'lab' ? 'Laboratory' : t}
           </button>
         ))}
       </nav>
@@ -546,6 +550,39 @@ export default function SoilInvestigation() {
       )}
 
       {/* ── Classification ── */}
+      {tab === 'lab' && bh && (
+        <section className="mt-5">
+          <LabPanel
+            bh={bh}
+            onAdd={(sampleId, type) => set((d) => {
+              const spec = labSpec(type)!
+              const sample = d.boreholes[holeIdx].samples.find((x) => x.id === sampleId)
+              sample?.tests.push({
+                id: `t_${Date.now().toString(36)}`,
+                type, standard: spec.standard,
+                status: isImplemented(type) ? 'in-progress' : 'planned',
+              })
+            })}
+            onData={(sampleId, testId, key, value) => set((d) => {
+              const t = d.boreholes[holeIdx].samples
+                .find((x) => x.id === sampleId)?.tests.find((x) => x.id === testId)
+              if (!t) return
+              t.data = { ...t.data, [key]: value }
+            })}
+            onStatus={(sampleId, testId, status) => set((d) => {
+              const t = d.boreholes[holeIdx].samples
+                .find((x) => x.id === sampleId)?.tests.find((x) => x.id === testId)
+              if (t) t.status = status
+            })}
+            onRemove={(sampleId, testId) => set((d) => {
+              const sample = d.boreholes[holeIdx].samples.find((x) => x.id === sampleId)
+              if (!sample) return
+              sample.tests = sample.tests.filter((x) => x.id !== testId)
+            })}
+          />
+        </section>
+      )}
+
       {tab === 'classification' && (
         <section className="mt-5">
           <ClassificationPanel />
@@ -624,6 +661,161 @@ function ClassificationPanel() {
           </p>
         )}
       </div>
+    </div>
+  )
+}
+
+// ── Laboratory ────────────────────────────────────────────────────────────
+
+function TestCard({
+  test, onData, onStatus, onRemove,
+}: {
+  test: LabTest
+  onData: (key: string, value: number) => void
+  onStatus: (s: LabTestStatus) => void
+  onRemove: () => void
+}) {
+  const spec = labSpec(test.type)
+  const { outcome, error } = evaluateTest(test)
+  const implemented = isImplemented(test.type)
+
+  return (
+    <div className={`rounded-lg border p-3 ${test.status === 'void' ? 'border-slate-200 bg-slate-50 opacity-70' : 'border-slate-200 bg-white'}`}>
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <div>
+          <span className="text-[13px] font-semibold text-slate-800">{spec?.label ?? test.type}</span>
+          <span className="ml-2 font-mono text-[10px] text-slate-500">{cite(test.standard)}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <select value={test.status} onChange={(e) => onStatus(e.target.value as LabTestStatus)}
+            className="rounded border border-slate-300 px-1.5 py-0.5 text-[11px]">
+            {(['planned', 'in-progress', 'complete', 'void'] as LabTestStatus[]).map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+          <button onClick={onRemove} className="rounded px-1.5 py-0.5 text-[11px] text-red-600 hover:bg-red-50">
+            remove
+          </button>
+        </div>
+      </div>
+
+      {spec?.purpose && <p className="mt-1 text-[11px] text-slate-500">{spec.purpose}</p>}
+
+      {!implemented ? (
+        <p className="mt-2 rounded border border-slate-200 bg-slate-50 px-2 py-1.5 text-[11px] text-slate-600">
+          Booked against this sample. No data form yet — this test&rsquo;s engine has not shipped, and the schedule
+          shows it rather than hiding it.
+        </p>
+      ) : (
+        <>
+          <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-4">
+            {spec!.fields.map((f) => (
+              <label key={f.key} className="flex flex-col text-[11px]">
+                <span className="mb-0.5 text-slate-600">
+                  {f.label}{f.unit ? ` (${f.unit})` : ''}{f.optional ? '' : ' *'}
+                </span>
+                <input type="number" step="any"
+                  value={(test.data?.[f.key] as number | undefined) ?? ''}
+                  placeholder={f.placeholder != null ? String(f.placeholder) : ''}
+                  onChange={(e) => onData(f.key, num(e.target.value))}
+                  className="rounded border border-slate-300 px-1.5 py-1 text-right font-mono" />
+              </label>
+            ))}
+          </div>
+
+          {error && (
+            <p className="mt-2 rounded border border-red-200 bg-red-50 px-2 py-1.5 text-[11px] text-red-800">
+              {error}
+            </p>
+          )}
+
+          {outcome && (
+            <div className="mt-2 rounded border border-emerald-200 bg-emerald-50 px-2 py-1.5">
+              <p className="font-mono text-[13px] font-semibold text-emerald-900">
+                {summarise(outcome).label} = {summarise(outcome).value.toFixed(
+                  summarise(outcome).unit === '%' ? 1 : 3,
+                )}{summarise(outcome).unit ? ` ${summarise(outcome).unit}` : ''}
+              </p>
+              {outcome.result.notes.map((n, k) => (
+                <p key={k} className="mt-1 text-[10px] text-amber-900">{n}</p>
+              ))}
+            </div>
+          )}
+
+          {!outcome && !error && (
+            <p className="mt-2 text-[11px] text-slate-500">Enter every required field to compute a result.</p>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+function LabPanel({
+  bh, onAdd, onData, onStatus, onRemove,
+}: {
+  bh: Borehole
+  onAdd: (sampleId: string, type: LabTestType) => void
+  onData: (sampleId: string, testId: string, key: string, value: number) => void
+  onStatus: (sampleId: string, testId: string, status: LabTestStatus) => void
+  onRemove: (sampleId: string, testId: string) => void
+}) {
+  if (!bh.samples.length) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <p className="text-[12px] text-slate-600">
+          No samples in {bh.name}. Laboratory tests are booked against a sample, not a layer — a sample recovered
+          across a stratigraphic boundary belongs to the hole at a depth.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {bh.samples.map((s) => (
+        <div key={s.id} className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div className="mb-3 flex flex-wrap items-baseline justify-between gap-2">
+            <h2 className="text-[1.05rem] font-bold text-[#0056b3]">
+              {s.name}
+              <span className="ml-2 font-mono text-[12px] font-normal text-slate-500">
+                {f2(s.depthTop)}–{f2(s.depthBottom)} m · {s.type}
+              </span>
+            </h2>
+            <select value="" onChange={(e) => { if (e.target.value) onAdd(s.id, e.target.value as LabTestType) }}
+              className="rounded-md border border-slate-300 px-2 py-1 text-[12px]">
+              <option value="">+ add a test…</option>
+              {LAB_TESTS.map((t) => (
+                <option key={t.type} value={t.type}>
+                  {t.label}{isImplemented(t.type) ? '' : ' (no form yet)'}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* A strength or compressibility test needs an undisturbed specimen. */}
+          {s.tests.some((t) => labSpec(t.type)?.needsUndisturbed && t.status !== 'void')
+            && !['undisturbed', 'shelby-tube', 'core'].includes(s.type) && (
+            <p className="mb-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[11px] text-amber-900">
+              A strength or compressibility test is booked on a <strong>{s.type}</strong> sample. Those need an
+              undisturbed specimen — the result will understate the in-situ soil.
+            </p>
+          )}
+
+          {s.tests.length ? (
+            <div className="space-y-2">
+              {s.tests.map((t) => (
+                <TestCard key={t.id} test={t}
+                  onData={(key, value) => onData(s.id, t.id, key, value)}
+                  onStatus={(status) => onStatus(s.id, t.id, status)}
+                  onRemove={() => onRemove(s.id, t.id)} />
+              ))}
+            </div>
+          ) : (
+            <p className="text-[12px] text-slate-500">No tests booked on this sample.</p>
+          )}
+        </div>
+      ))}
     </div>
   )
 }


### PR DESCRIPTION
**Layer 8.** The typed bridge between `LabTest.data` and the engines that understand it, plus the first two tests. **38 new tests.** Follows #476, #477, #478, #479, #480.

**Storage decision confirmed before starting:** stay on the `SoilsStore` interface over localStorage, swap in a Supabase backend at Phase 8. Phase 4 is the point where lab-test shapes would make a schema change expensive, so it was settled rather than drifted into.

## `lab/moisture.ts` — ASTM D2216

Water content is a ratio to the **dry** mass, so above 100% is ordinary in a soft organic clay — and is not clamped. The **raw masses** are what the test records and what the module takes: storing only the answer makes a transcription error undetectable, and the tare mass is exactly where those happen.

A dry mass above the wet mass, or at or below the tare, **throws** rather than producing a plausible wrong number.

## `lab/specificGravity.ts` — ASTM D854

Gs is a difference between two nearly equal masses, so the module says when a specimen is small enough to magnify the weighing error — and when the result falls outside the 2.60–2.80 mineral range it says **which way it errs**: an under-de-aired suspension traps air, displaces too little water, and reads *low*.

Temperature correction to 20 °C is applied rather than left to the engineer to remember. Water density follows the Thiesen form and is tested against the standard table (1.0000 at 4 °C, 0.99821 at 20 °C, 0.99705 at 25 °C). `voidRatio` and `saturation` live alongside, since they're the reason Gs is measured at all.

## `lab/index.ts` — the registry

`LabTest.data` stays `Record<string, unknown>` in the schema, because layer 1 can't know the shape of every test without depending on every test engine — that inverts the dependency. The shapes are declared here instead.

**Every reader goes through a guard.** An investigation round-trips through JSON *and* through a file a user may have edited, so a `data` blob is untrusted input, not a typed object that happens to be serialised. `readXxx` returns `undefined` on anything malformed rather than handing back a half-populated object that computes a plausible wrong answer — including on `NaN` and `Infinity`, which survive a JSON round trip.

**Unimplemented tests are declared, not hidden.** They can be *booked* against a sample — that's how a laboratory schedule works — and the list says "no form yet" rather than making the schedule look shorter than it is.

## UI

A **Laboratory** tab on `/soils`. Tests are booked per sample, results compute live, impossible data surfaces as a message rather than a crash, and a strength or compressibility test booked on a disturbed sample gets a banner saying the result will understate the in-situ soil.

## Verification

`npm test` — **2523 passed / 167 files** · `npx tsc -b` · `npm run lint` · `npm run build` all green.

In headless Chromium: **w = 20.0%** and **Gs = 2.660** both match the hand calculations, an impossible dry mass shows its message, results survive a reload, console clean.

I also confirmed the undisturbed-sample banner actually renders, by booking a triaxial on a split-spoon sample and watching the count go 0 → 1. Zero occurrences on the example data is correct behaviour, and without that check it would have been indistinguishable from dead code.

## Honest limits

- **Only two of thirteen tests have engines.** The other eleven are bookable and say so. Sieve and Atterberg already *have* engines from Phase 1 but aren't wired to `LabTest.data` yet — that's deliberate, since wiring them is what lets the classifier read from a sample instead of typed numbers, and that belongs in one coherent PR rather than half here.
- **The USCS symbol still isn't written back to the layer**, so the log's USCS column stays empty. Unblocked by the sieve/Atterberg wiring above.
- **Placeholders look like values.** An empty moisture form shows greyed 25/85/75 hints next to "Enter every required field" — standard placeholder behaviour, but mildly ambiguous on a form where the numbers matter.

## Next

Phase 4b — wire sieve and Atterberg into `LabTest.data` and have the classifier read a sample, which closes the USCS-symbol gap. Then compaction, direct shear, UCS, triaxial, consolidation, permeability, CBR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_