### PR TITLE
Soil investigation Phase 4b — sample classification from the lab record

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1327,8 +1327,9 @@ because flagging the unusual as an error trains people to ignore errors.
 | 2 — SPT corrections, correlations, overburden | #478 | merged |
 | 3a — borehole log renderer (geometry) | #479 | open |
 | 3b — investigation UI, routes, profile editor | #480 | merged |
-| 4a — lab plumbing + index tests (moisture, Gs) | — | open |
-| 4b… — remaining lab tests | — | |
+| 4a — lab plumbing + index tests (moisture, Gs) | #481 | merged |
+| 4b — sieve + Atterberg wired, sample classification | — | open |
+| 4c… — compaction, shear, UCS, triaxial, consolidation, k, CBR | — | |
 | 5 — parameter engine + wiring to existing analysis | — | the payoff |
 | 6 — liquefaction, bearing methods, Coulomb | — | |
 | 7 — report document builder | — | |

--- a/webapp/src/engine/soils/classifySample.test.ts
+++ b/webapp/src/engine/soils/classifySample.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect } from 'vitest'
+import { classifySample, governingTest } from './classifySample'
+import { readSieve, readAtterberg, evaluateTest } from './lab'
+import type { Sample, LabTest } from './model'
+import type { SieveInput } from './sieve'
+
+// A 500 g stack that classifies as SC when paired with LL 42 / PL 23:
+// gravel 5%, sand 62%, fines 33%.
+const SIEVE_DATA: SieveInput = {
+  totalMass: 500,
+  readings: [
+    { size: 4.75, designation: 'No. 4', massRetained: 25 },
+    { size: 2.0, designation: 'No. 10', massRetained: 60 },
+    { size: 0.425, designation: 'No. 40', massRetained: 130 },
+    { size: 0.075, designation: 'No. 200', massRetained: 120 },
+  ],
+  panMass: 165,
+}
+
+const test = (over: Partial<LabTest> & Pick<LabTest, 'type'>): LabTest => ({
+  id: `t${Math.random().toString(36).slice(2, 8)}`,
+  standard: 'd6913', status: 'complete', ...over,
+})
+
+const sample = (tests: LabTest[]): Sample => ({
+  id: 's1', name: 'S-01', type: 'split-spoon',
+  depthTop: 1.5, depthBottom: 1.95, tests,
+})
+
+const sieveTest = (data: SieveInput = SIEVE_DATA, over: Partial<LabTest> = {}) =>
+  test({ type: 'sieve', standard: 'd6913', data: data as unknown as Record<string, unknown>, ...over })
+
+const atterbergTest = (data: Record<string, unknown>, over: Partial<LabTest> = {}) =>
+  test({ type: 'atterberg', standard: 'd4318', data, ...over })
+
+// ── Readers ───────────────────────────────────────────────────────────────
+
+describe('reading a sieve stack from stored data', () => {
+  it('reads a well-formed stack', () => {
+    const d = readSieve(sieveTest())!
+    expect(d.totalMass).toBe(500)
+    expect(d.readings).toHaveLength(4)
+    expect(d.panMass).toBe(165)
+  })
+
+  it('DROPS a malformed row rather than reading it as zero', () => {
+    // A zero mass retained is a real measurement; an absent one is not.
+    const d = readSieve(sieveTest({
+      ...SIEVE_DATA,
+      readings: [
+        { size: 4.75, massRetained: 25 },
+        { size: 2.0 } as unknown as { size: number; massRetained: number },
+        { massRetained: 60 } as unknown as { size: number; massRetained: number },
+        { size: 0.075, massRetained: 120 },
+      ],
+    }))!
+    expect(d.readings.map((r) => r.size)).toEqual([4.75, 0.075])
+  })
+
+  it('keeps a genuine zero mass', () => {
+    const d = readSieve(sieveTest({
+      ...SIEVE_DATA, readings: [{ size: 9.5, massRetained: 0 }, { size: 4.75, massRetained: 25 }],
+    }))!
+    expect(d.readings).toHaveLength(2)
+    expect(d.readings[0].massRetained).toBe(0)
+  })
+
+  it('returns undefined when there is nothing usable', () => {
+    expect(readSieve(sieveTest({ ...SIEVE_DATA, readings: [] }))).toBeUndefined()
+    expect(readSieve(test({ type: 'sieve' }))).toBeUndefined()
+    expect(readSieve(sieveTest({ totalMass: NaN, readings: SIEVE_DATA.readings } as never))).toBeUndefined()
+  })
+})
+
+describe('reading Atterberg limits', () => {
+  it('reads limits and keeps a missing plastic limit as NON-PLASTIC', () => {
+    // Absent PL is a different claim from PI = 0.
+    const d = readAtterberg(atterbergTest({ liquidLimit: 22 }))!
+    expect(d.liquidLimit).toBe(22)
+    expect(d.plasticLimit).toBeUndefined()
+
+    const r = evaluateTest(atterbergTest({ liquidLimit: 22 })).outcome!
+    expect(r.kind).toBe('atterberg')
+    if (r.kind === 'atterberg') expect(r.result.nonPlastic).toBe(true)
+  })
+
+  it('requires a liquid limit', () => {
+    expect(readAtterberg(atterbergTest({ plasticLimit: 23 }))).toBeUndefined()
+  })
+})
+
+// ── Governing test ────────────────────────────────────────────────────────
+
+describe('choosing which test counts', () => {
+  it('ignores a void test entirely', () => {
+    // A specimen that failed on a seating error stays in the record but must
+    // not classify the soil.
+    const s = sample([sieveTest(SIEVE_DATA, { status: 'void' })])
+    expect(governingTest(s, 'sieve').test).toBeUndefined()
+    expect(classifySample(s).missing).toContain('sieve')
+  })
+
+  it('prefers a COMPLETE test over an in-progress one', () => {
+    const inProgress = sieveTest(SIEVE_DATA, { status: 'in-progress', testDate: '2026-06-30' })
+    const complete = sieveTest(SIEVE_DATA, { status: 'complete', testDate: '2026-06-01' })
+    const s = sample([inProgress, complete])
+    expect(governingTest(s, 'sieve').test!.id).toBe(complete.id)
+  })
+
+  it('takes the most recent when several are complete, and SAYS it chose', () => {
+    const older = sieveTest(SIEVE_DATA, { testDate: '2026-06-01' })
+    const newer = sieveTest(SIEVE_DATA, { testDate: '2026-06-20' })
+    const s = sample([older, newer, atterbergTest({ liquidLimit: 42, plasticLimit: 23 })])
+    expect(governingTest(s, 'sieve').test!.id).toBe(newer.id)
+    expect(classifySample(s).notes.join(' ')).toMatch(/2 sieve analyses.*most recent complete one was used/)
+  })
+
+  it('falls back to a non-void test when none is complete', () => {
+    const s = sample([sieveTest(SIEVE_DATA, { status: 'in-progress' })])
+    expect(governingTest(s, 'sieve').test).toBeDefined()
+  })
+})
+
+// ── Classification ────────────────────────────────────────────────────────
+
+describe('classifying from the laboratory record', () => {
+  const full = sample([sieveTest(), atterbergTest({ liquidLimit: 42, plasticLimit: 23 })])
+
+  it('produces a USCS symbol from the tests, not from typed numbers', () => {
+    const c = classifySample(full)
+    expect(c.gradation!.fines).toBeCloseTo(33, 0)
+    expect(c.atterberg!.plasticityIndex).toBeCloseTo(19, 10)
+    expect(c.uscs!.symbol).toBe('SC')
+    expect(c.missing).toEqual([])
+  })
+
+  it('produces an AASHTO group too', () => {
+    const c = classifySample(full)
+    expect(c.aashto!.group).toBeTruthy()
+    expect(c.aashto!.groupIndex).toBeGreaterThanOrEqual(0)
+  })
+
+  it('carries the gradation and limit notes up', () => {
+    const c = classifySample(full)
+    // The stack has >10% fines, so D10 is off the curve and the gradation
+    // module says a hydrometer would complete it.
+    expect(c.notes.join(' ')).toMatch(/hydrometer/)
+  })
+
+  it('does NOT list a hydrometer as missing when it would not change the symbol', () => {
+    // With 33% fines, D2487 classifies on the plasticity of the fines, not on
+    // Cu and Cc. `missing` is for tests that block or change the answer, not
+    // every test that would tell you something.
+    expect(classifySample(full).missing).not.toContain('hydrometer')
+  })
+
+  it('DOES list it when the gradation shape is what governs', () => {
+    // The narrow band where it actually matters: 10-12% fines. D2487 needs a
+    // dual symbol there, which needs Cu and Cc — but with more than 10% fines
+    // the sieve curve never reaches 10% passing, so D10 does not exist and
+    // sieving alone cannot finish the job.
+    //
+    // Below 10% fines the curve DOES reach D10, which is why the 9%-fines
+    // stack above classifies as SW-SC with no hydrometer needed.
+    const s = sample([
+      sieveTest({
+        totalMass: 500,
+        readings: [
+          { size: 4.75, massRetained: 25 },
+          { size: 2.0, massRetained: 150 },
+          { size: 0.425, massRetained: 180 },
+          { size: 0.075, massRetained: 90 },
+        ],
+        panMass: 55,
+      }),
+      atterbergTest({ liquidLimit: 30, plasticLimit: 22 }),
+    ])
+    const c = classifySample(s)
+    expect(c.gradation!.fines).toBeCloseTo(11, 6)
+    expect(c.gradation!.d10).toBeUndefined()
+    expect(c.uscs!.symbol).toBeUndefined()
+    expect(c.uscs!.reason).toMatch(/BOTH/)
+    expect(c.missing).toContain('hydrometer')
+  })
+})
+
+describe('it will not invent a missing input', () => {
+  it('declines without a sieve analysis and names it', () => {
+    const c = classifySample(sample([atterbergTest({ liquidLimit: 42, plasticLimit: 23 })]))
+    expect(c.uscs).toBeUndefined()
+    expect(c.missing).toContain('sieve')
+    expect(c.notes.join(' ')).toMatch(/gravel\/sand\/fines split is unknown/)
+  })
+
+  it('names the Atterberg test when a fine-grained soil lacks it', () => {
+    // 33% fines with no limits: D2487 needs the plasticity of the fines.
+    const c = classifySample(sample([sieveTest()]))
+    expect(c.missing).toContain('atterberg')
+    expect(c.uscs!.symbol).toBeUndefined()
+    expect(c.uscs!.reason).toMatch(/D4318/)
+  })
+
+  it('reports an evaluation error rather than classifying around it', () => {
+    const broken = sample([
+      sieveTest({ ...SIEVE_DATA, totalMass: 0 }),
+      atterbergTest({ liquidLimit: 42, plasticLimit: 23 }),
+    ])
+    const c = classifySample(broken)
+    expect(c.notes.join(' ')).toMatch(/could not be evaluated/)
+    expect(c.uscs).toBeUndefined()
+  })
+})
+
+describe('non-plastic fines are a finding, not a gap', () => {
+  it('passes PI = 0 through so the classifier can call the fines silty', () => {
+    // A clean-ish sand with non-plastic fines should come out SM, not refuse.
+    const s = sample([
+      sieveTest({
+        totalMass: 500,
+        readings: [
+          { size: 4.75, massRetained: 25 },
+          { size: 2.0, massRetained: 60 },
+          { size: 0.425, massRetained: 130 },
+          { size: 0.075, massRetained: 120 },
+        ],
+        panMass: 165,
+      }),
+      atterbergTest({ liquidLimit: 22 }),   // no plastic limit ⇒ non-plastic
+    ])
+    const c = classifySample(s)
+    expect(c.atterberg!.nonPlastic).toBe(true)
+    expect(c.uscs!.symbol).toBe('SM')
+  })
+})
+
+describe('an empty sample', () => {
+  it('returns both tests as missing without throwing', () => {
+    const c = classifySample(sample([]))
+    expect(c.uscs).toBeUndefined()
+    expect(c.missing).toEqual(expect.arrayContaining(['sieve', 'atterberg']))
+  })
+})

--- a/webapp/src/engine/soils/classifySample.ts
+++ b/webapp/src/engine/soils/classifySample.ts
@@ -1,0 +1,160 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Classify a SAMPLE from the tests actually run on it. Layer 8.
+//
+// `classifyUSCS` takes gradation and plasticity as numbers. This finds those
+// numbers among a sample's laboratory tests and hands them over — which is the
+// difference between a classifier an engineer retypes into and one that reads
+// the laboratory record.
+//
+// THREE THINGS IT REFUSES TO DO:
+//
+//  1. It will not read a VOID test. A specimen that failed on a seating error
+//     is kept in the record (see model.ts) but must not classify the soil.
+//  2. It will not silently pick between two tests of the same kind. Two sieve
+//     analyses on one sample means somebody re-ran it, and which one counts is
+//     a decision — so the most recent COMPLETE test wins and the sheet says it
+//     chose.
+//  3. It will not invent a missing input. No Atterberg test on a fine-grained
+//     sample means no classification, and `missing` names the test to run
+//     rather than the classifier guessing from the fines content.
+//
+// UNITS: as the underlying engines — percentages 0–100, sizes mm.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { Sample, LabTest, LabTestType } from './model'
+import { classifyUSCS, type UscsResult } from './uscs'
+import { classifyAASHTO, type AashtoResult } from './aashto'
+import { evaluateTest } from './lab'
+import type { GradationResult } from './sieve'
+import type { AtterbergResult } from './atterberg'
+
+export interface SampleClassification {
+  uscs?: UscsResult
+  aashto?: AashtoResult
+  /** The gradation the classification used, when one was found. */
+  gradation?: GradationResult
+  /** The limits the classification used, when they were found. */
+  atterberg?: AtterbergResult
+  /** Tests that would complete or improve the classification. */
+  missing: LabTestType[]
+  /** How the inputs were chosen, and anything odd about them. */
+  notes: string[]
+}
+
+/**
+ * The test of a kind that should count: the most recent COMPLETE one, falling
+ * back to the most recent non-void one when none is complete yet. Ties break on
+ * array order, which is entry order.
+ */
+export function governingTest(sample: Sample, type: LabTestType): {
+  test?: LabTest; superseded: number
+} {
+  const candidates = sample.tests.filter((t) => t.type === type && t.status !== 'void')
+  if (!candidates.length) return { superseded: 0 }
+
+  const complete = candidates.filter((t) => t.status === 'complete')
+  const pool = complete.length ? complete : candidates
+
+  // Most recent by test date where dates exist; otherwise the last entered.
+  const sorted = [...pool].sort((a, b) => (a.testDate ?? '').localeCompare(b.testDate ?? ''))
+  return { test: sorted[sorted.length - 1], superseded: candidates.length - 1 }
+}
+
+export function classifySample(sample: Sample): SampleClassification {
+  const notes: string[] = []
+  const missing: LabTestType[] = []
+
+  // ── Gradation ──
+  const sieve = governingTest(sample, 'sieve')
+  let grad: GradationResult | undefined
+  if (sieve.test) {
+    const { outcome, error } = evaluateTest(sieve.test)
+    if (error) notes.push(`Sieve analysis could not be evaluated: ${error}`)
+    else if (outcome?.kind === 'sieve') grad = outcome.result
+    if (sieve.superseded > 0) {
+      notes.push(
+        `${sieve.superseded + 1} sieve analyses on this sample — the most recent complete one was used. Void the others if they should not count.`,
+      )
+    }
+  } else {
+    missing.push('sieve')
+  }
+
+  // ── Plasticity ──
+  const atter = governingTest(sample, 'atterberg')
+  let limits: AtterbergResult | undefined
+  if (atter.test) {
+    const { outcome, error } = evaluateTest(atter.test)
+    if (error) notes.push(`Atterberg limits could not be evaluated: ${error}`)
+    else if (outcome?.kind === 'atterberg') limits = outcome.result
+    if (atter.superseded > 0) {
+      notes.push(
+        `${atter.superseded + 1} Atterberg determinations on this sample — the most recent complete one was used.`,
+      )
+    }
+  } else {
+    missing.push('atterberg')
+  }
+
+  if (!grad) {
+    return {
+      atterberg: limits, missing, notes: [
+        ...notes,
+        'No usable sieve analysis on this sample, so the gravel/sand/fines split is unknown and neither system can classify it.',
+      ],
+    }
+  }
+
+  // Carry the limits through only when the soil is plastic. A non-plastic
+  // result is a real finding — it tells the classifier the fines are silty —
+  // so it is passed as PI = 0 with the LL, not withheld.
+  const LL = limits?.liquidLimit
+  const PI = limits?.plasticityIndex
+
+  const uscs = classifyUSCS({
+    gravel: grad.gravel,
+    sand: grad.sand,
+    fines: grad.fines,
+    cu: grad.cu,
+    cc: grad.cc,
+    liquidLimit: LL,
+    plasticityIndex: PI,
+  })
+
+  // AASHTO needs percent passing at three sieves rather than the fractions.
+  const aashto = classifyAASHTO({
+    passing10: passingAtSize(grad, 2.0),
+    passing40: passingAtSize(grad, 0.425),
+    passing200: grad.fines,
+    liquidLimit: LL,
+    plasticityIndex: PI,
+  })
+
+  if (grad.notes.length) notes.push(...grad.notes)
+  if (limits?.notes.length) notes.push(...limits.notes)
+
+  if (!uscs.symbol && !missing.includes('atterberg') && grad.d10 == null) {
+    notes.push('The gradation curve does not reach 10% passing, so Cu and Cc are unavailable — a hydrometer analysis would complete it.')
+    if (!missing.includes('hydrometer')) missing.push('hydrometer')
+  }
+
+  return { uscs, aashto, gradation: grad, atterberg: limits, missing, notes }
+}
+
+/** Percent passing a sieve size, read off the computed gradation rows. */
+function passingAtSize(g: GradationResult, size: number): number {
+  const sorted = [...g.rows].sort((a, b) => b.size - a.size)
+  const exact = sorted.find((r) => Math.abs(r.size - size) < 1e-9)
+  if (exact) return exact.percentPassing
+  if (!sorted.length) return 0
+  if (size >= sorted[0].size) return 100
+  if (size <= sorted[sorted.length - 1].size) return sorted[sorted.length - 1].percentPassing
+  for (let i = 1; i < sorted.length; i++) {
+    const hi = sorted[i - 1], lo = sorted[i]
+    if (size <= hi.size && size >= lo.size) {
+      const f = (Math.log10(size) - Math.log10(lo.size)) / (Math.log10(hi.size) - Math.log10(lo.size))
+      return lo.percentPassing + f * (hi.percentPassing - lo.percentPassing)
+    }
+  }
+  return 0
+}

--- a/webapp/src/engine/soils/lab/index.ts
+++ b/webapp/src/engine/soils/lab/index.ts
@@ -25,6 +25,8 @@ import { type MoistureData, moistureContent, type MoistureResult } from './moist
 import {
   type SpecificGravityData, specificGravity, type SpecificGravityResult,
 } from './specificGravity'
+import { type SieveInput, type SieveReading, gradation, type GradationResult } from '../sieve'
+import { type AtterbergInput, atterberg, type AtterbergResult } from '../atterberg'
 
 const isRecord = (v: unknown): v is Record<string, unknown> =>
   typeof v === 'object' && v !== null && !Array.isArray(v)
@@ -61,6 +63,50 @@ export function readSpecificGravity(test: LabTest): SpecificGravityData | undefi
   }
 }
 
+/**
+ * Sieve stack. The readings are a variable-length array rather than a fixed set
+ * of fields, so the guard walks them: a row missing its size or its mass is
+ * DROPPED rather than read as zero, because a zero mass retained is a real
+ * measurement and an absent one is not.
+ */
+export function readSieve(test: LabTest): SieveInput | undefined {
+  const d = test.data
+  if (!isRecord(d) || !finite(d.totalMass) || !Array.isArray(d.readings)) return undefined
+
+  const readings: SieveReading[] = []
+  for (const r of d.readings) {
+    if (!isRecord(r) || !finite(r.size) || !finite(r.massRetained)) continue
+    readings.push({
+      size: r.size,
+      designation: typeof r.designation === 'string' ? r.designation : undefined,
+      massRetained: r.massRetained,
+    })
+  }
+  if (!readings.length) return undefined
+
+  return {
+    totalMass: d.totalMass,
+    readings,
+    panMass: finite(d.panMass) ? d.panMass : undefined,
+  }
+}
+
+/**
+ * Atterberg limits. A liquid limit is required; the plastic limit may be
+ * absent, which means NON-PLASTIC and is a different claim from PI = 0.
+ */
+export function readAtterberg(test: LabTest): AtterbergInput | undefined {
+  const d = test.data
+  if (!isRecord(d) || !finite(d.liquidLimit)) return undefined
+  return {
+    liquidLimit: d.liquidLimit,
+    plasticLimit: finite(d.plasticLimit) ? d.plasticLimit : undefined,
+    nonPlastic: d.nonPlastic === true,
+    shrinkageLimit: finite(d.shrinkageLimit) ? d.shrinkageLimit : undefined,
+    naturalMoisture: finite(d.naturalMoisture) ? d.naturalMoisture : undefined,
+  }
+}
+
 // ── Catalogue ─────────────────────────────────────────────────────────────
 
 /** One numeric input on a test form. */
@@ -74,9 +120,17 @@ export interface LabField {
   placeholder?: number
 }
 
+/**
+ * How a test's form is laid out. Most tests are a flat list of numbers; a sieve
+ * stack is a variable-length table, which no `LabField[]` can express.
+ */
+export type LabFormKind = 'fields' | 'sieve-stack'
+
 export interface LabTestSpec {
   type: LabTestType
   label: string
+  /** Defaults to 'fields'. */
+  formKind?: LabFormKind
   standard: StandardId
   /** Registry calculation this test's result is derived by. */
   calculation?: CalcId
@@ -125,9 +179,34 @@ export const LAB_TESTS: readonly LabTestSpec[] = [
     ],
   },
   // Declared but not yet implemented — see the note above.
-  { type: 'sieve', label: 'Sieve analysis', standard: 'd6913', needsUndisturbed: false, fields: [], purpose: 'Grain-size distribution by sieving.' },
+  {
+    type: 'sieve',
+    label: 'Sieve analysis',
+    standard: 'd6913',
+    formKind: 'sieve-stack',
+    calculation: 'sieve.percent-passing',
+    needsUndisturbed: false,
+    purpose: 'Grain-size distribution by sieving — the fractions the USCS classifier needs.',
+    fields: [
+      { key: 'totalMass', label: 'Total dry specimen', unit: 'g', placeholder: 500 },
+      { key: 'panMass', label: 'Pan', unit: 'g', optional: true, placeholder: 20 },
+    ],
+  },
   { type: 'hydrometer', label: 'Hydrometer', standard: 'd7928', needsUndisturbed: false, fields: [], purpose: 'Grain-size distribution of the fines by sedimentation.' },
-  { type: 'atterberg', label: 'Atterberg limits', standard: 'd4318', needsUndisturbed: false, fields: [], purpose: 'Liquid and plastic limits, which classify the fines.' },
+  {
+    type: 'atterberg',
+    label: 'Atterberg limits',
+    standard: 'd4318',
+    calculation: 'atterberg.plasticity-index',
+    needsUndisturbed: false,
+    purpose: 'Liquid and plastic limits, which decide whether the fines behave as clay or silt.',
+    fields: [
+      { key: 'liquidLimit', label: 'Liquid limit', unit: '%', placeholder: 42 },
+      { key: 'plasticLimit', label: 'Plastic limit', unit: '%', optional: true, placeholder: 23 },
+      { key: 'naturalMoisture', label: 'Natural moisture', unit: '%', optional: true, placeholder: 30 },
+      { key: 'shrinkageLimit', label: 'Shrinkage limit', unit: '%', optional: true, placeholder: 12 },
+    ],
+  },
   { type: 'compaction', label: 'Compaction', standard: 'd698', needsUndisturbed: false, fields: [], purpose: 'Maximum dry density and optimum moisture content.' },
   { type: 'direct-shear', label: 'Direct shear', standard: 'd3080', needsUndisturbed: true, fields: [], purpose: 'Effective cohesion and friction angle from the failure envelope.' },
   { type: 'triaxial', label: 'Triaxial', standard: 'd4767', needsUndisturbed: true, fields: [], purpose: 'Shear strength under controlled drainage and confinement.' },
@@ -153,6 +232,8 @@ export const isImplemented = (type: LabTestType): boolean =>
 export type LabOutcome =
   | { kind: 'moisture'; result: MoistureResult }
   | { kind: 'specific-gravity'; result: SpecificGravityResult }
+  | { kind: 'sieve'; result: GradationResult }
+  | { kind: 'atterberg'; result: AtterbergResult }
 
 /**
  * Compute a test's result from its stored data.
@@ -174,6 +255,16 @@ export function evaluateTest(test: LabTest): { outcome?: LabOutcome; error?: str
         if (!d) return {}
         return { outcome: { kind: 'specific-gravity', result: specificGravity(d) } }
       }
+      case 'sieve': {
+        const d = readSieve(test)
+        if (!d) return {}
+        return { outcome: { kind: 'sieve', result: gradation(d) } }
+      }
+      case 'atterberg': {
+        const d = readAtterberg(test)
+        if (!d) return {}
+        return { outcome: { kind: 'atterberg', result: atterberg(d) } }
+      }
       default:
         return {}
     }
@@ -189,5 +280,9 @@ export function summarise(outcome: LabOutcome): { label: string; value: number; 
       return { label: 'w', value: outcome.result.waterContent, unit: '%' }
     case 'specific-gravity':
       return { label: 'Gs', value: outcome.result.gs, unit: '' }
+    case 'sieve':
+      return { label: 'fines', value: outcome.result.fines, unit: '%' }
+    case 'atterberg':
+      return { label: 'PI', value: outcome.result.plasticityIndex, unit: '%' }
   }
 }

--- a/webapp/src/engine/soils/lab/lab.test.ts
+++ b/webapp/src/engine/soils/lab/lab.test.ts
@@ -199,17 +199,40 @@ describe('the lab catalogue stays in step with the schema', () => {
     // than hiding it and making the schedule look shorter than it is.
     expect(isImplemented('moisture')).toBe(true)
     expect(isImplemented('specific-gravity')).toBe(true)
+    expect(isImplemented('sieve')).toBe(true)
+    expect(isImplemented('atterberg')).toBe(true)
     expect(isImplemented('triaxial')).toBe(false)
-    expect(implementedTests().map((t) => t.type)).toEqual(['moisture', 'specific-gravity'])
+    expect(isImplemented('consolidation')).toBe(false)
+    expect(implementedTests().map((t) => t.type))
+      .toEqual(['moisture', 'specific-gravity', 'sieve', 'atterberg'])
   })
 
-  it('gives every implemented test a field for each of its engine inputs', () => {
+  it('gives every implemented test enough fields to drive its engine', () => {
+    // A plain form carries every input in `fields`. A sieve stack carries its
+    // readings in a variable-length table instead, so it needs fewer flat
+    // fields — the earlier version of this test demanded three from everything
+    // and failed the sieve for being shaped correctly.
     for (const t of implementedTests()) {
-      expect(t.fields.length, t.type).toBeGreaterThanOrEqual(3)
+      const floor = t.formKind === 'sieve-stack' ? 1 : 3
+      expect(t.fields.length, t.type).toBeGreaterThanOrEqual(floor)
       for (const f of t.fields) {
         expect(f.label.length, `${t.type}/${f.key}`).toBeGreaterThan(2)
         expect(f.key, `${t.type}/${f.key}`).toMatch(/^[a-zA-Z]+$/)
       }
+    }
+  })
+
+  it('every required field is one the engine actually reads', () => {
+    // A required field the reader ignores would block a form for no reason.
+    const required: Record<string, string[]> = {
+      moisture: ['containerMass', 'wetMass', 'dryMass'],
+      'specific-gravity': ['solidMass', 'pycWaterMass', 'pycWaterSolidMass'],
+      sieve: ['totalMass'],
+      atterberg: ['liquidLimit'],
+    }
+    for (const t of implementedTests()) {
+      const declared = t.fields.filter((f) => !f.optional).map((f) => f.key).sort()
+      expect(declared, t.type).toEqual(required[t.type].sort())
     }
   })
 

--- a/webapp/src/pages/SoilInvestigation.tsx
+++ b/webapp/src/pages/SoilInvestigation.tsx
@@ -8,11 +8,12 @@ import { classifyUSCS } from '../engine/soils/uscs'
 import { densityFromN60, consistencyFromN60 } from '../engine/soils/spt'
 import {
   layerThickness, recoveryRatio, soilFamily, isCohesive,
-  type Borehole, type SoilLayer, type LabTest, type LabTestType, type LabTestStatus,
+  type Borehole, type SoilLayer, type Sample, type LabTest, type LabTestType, type LabTestStatus,
 } from '../engine/soils/model'
 import {
   LAB_TESTS, labSpec, isImplemented, evaluateTest, summarise,
 } from '../engine/soils/lab'
+import { classifySample } from '../engine/soils/classifySample'
 import { cite } from '../engine/soils/standards'
 
 const f2 = (n: number | undefined) => (n == null || !Number.isFinite(n) ? '—' : n.toFixed(2))
@@ -563,6 +564,15 @@ export default function SoilInvestigation() {
                 status: isImplemented(type) ? 'in-progress' : 'planned',
               })
             })}
+            onRows={(sampleId, testId, rows) => set((d) => {
+              const t = d.boreholes[holeIdx].samples
+                .find((x) => x.id === sampleId)?.tests.find((x) => x.id === testId)
+              if (t) t.data = { ...t.data, readings: rows }
+            })}
+            onApplySymbol={(layerId, symbol) => set((d) => {
+              const l = d.boreholes[holeIdx].layers.find((x) => x.id === layerId)
+              if (l) l.symbol = symbol
+            })}
             onData={(sampleId, testId, key, value) => set((d) => {
               const t = d.boreholes[holeIdx].samples
                 .find((x) => x.id === sampleId)?.tests.find((x) => x.id === testId)
@@ -668,10 +678,11 @@ function ClassificationPanel() {
 // ── Laboratory ────────────────────────────────────────────────────────────
 
 function TestCard({
-  test, onData, onStatus, onRemove,
+  test, onData, onRows, onStatus, onRemove,
 }: {
   test: LabTest
   onData: (key: string, value: number) => void
+  onRows: (rows: StackRow[]) => void
   onStatus: (s: LabTestStatus) => void
   onRemove: () => void
 }) {
@@ -708,6 +719,12 @@ function TestCard({
         </p>
       ) : (
         <>
+          {spec!.formKind === 'sieve-stack' && (
+            <SieveStack
+              rows={(test.data?.readings as StackRow[] | undefined) ?? []}
+              onChange={(rows) => onRows(rows)} />
+          )}
+
           <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-4">
             {spec!.fields.map((f) => (
               <label key={f.key} className="flex flex-col text-[11px]">
@@ -752,13 +769,15 @@ function TestCard({
 }
 
 function LabPanel({
-  bh, onAdd, onData, onStatus, onRemove,
+  bh, onAdd, onData, onRows, onStatus, onRemove, onApplySymbol,
 }: {
   bh: Borehole
   onAdd: (sampleId: string, type: LabTestType) => void
   onData: (sampleId: string, testId: string, key: string, value: number) => void
+  onRows: (sampleId: string, testId: string, rows: StackRow[]) => void
   onStatus: (sampleId: string, testId: string, status: LabTestStatus) => void
   onRemove: (sampleId: string, testId: string) => void
+  onApplySymbol: (layerId: string, symbol: string) => void
 }) {
   if (!bh.samples.length) {
     return (
@@ -807,6 +826,7 @@ function LabPanel({
               {s.tests.map((t) => (
                 <TestCard key={t.id} test={t}
                   onData={(key, value) => onData(s.id, t.id, key, value)}
+                  onRows={(rows) => onRows(s.id, t.id, rows)}
                   onStatus={(status) => onStatus(s.id, t.id, status)}
                   onRemove={() => onRemove(s.id, t.id)} />
               ))}
@@ -814,8 +834,149 @@ function LabPanel({
           ) : (
             <p className="text-[12px] text-slate-500">No tests booked on this sample.</p>
           )}
+
+          <SampleClassificationCard sample={s} layers={bh.layers} onApply={onApplySymbol} />
         </div>
       ))}
+    </div>
+  )
+}
+
+// ── Sieve stack ───────────────────────────────────────────────────────────
+
+/** Standard stack a blank sieve test starts from. */
+const DEFAULT_STACK: { size: number; designation: string }[] = [
+  { size: 9.5, designation: '3/8 in' },
+  { size: 4.75, designation: 'No. 4' },
+  { size: 2.0, designation: 'No. 10' },
+  { size: 0.85, designation: 'No. 20' },
+  { size: 0.425, designation: 'No. 40' },
+  { size: 0.15, designation: 'No. 100' },
+  { size: 0.075, designation: 'No. 200' },
+]
+
+interface StackRow { size: number; designation?: string; massRetained: number }
+
+function SieveStack({
+  rows, onChange,
+}: { rows: StackRow[]; onChange: (rows: StackRow[]) => void }) {
+  const stack = rows.length ? rows : DEFAULT_STACK.map((r) => ({ ...r, massRetained: 0 }))
+  const set = (i: number, patch: Partial<StackRow>) =>
+    onChange(stack.map((r, k) => (k === i ? { ...r, ...patch } : r)))
+
+  return (
+    <div className="mt-2">
+      <table className="w-full text-left text-[11px]">
+        <thead className="text-slate-500">
+          <tr className="border-b border-slate-200">
+            <th className="py-1 pr-2">Sieve</th>
+            <th className="py-1 pr-2">Opening (mm)</th>
+            <th className="py-1 pr-2 text-right">Mass retained (g)</th>
+            <th />
+          </tr>
+        </thead>
+        <tbody>
+          {stack.map((r, i) => (
+            <tr key={i} className="border-b border-slate-100">
+              <td className="py-0.5 pr-2">
+                <input value={r.designation ?? ''} placeholder="—"
+                  onChange={(e) => set(i, { designation: e.target.value || undefined })}
+                  className="w-20 rounded border border-slate-200 px-1 py-0.5" />
+              </td>
+              <td className="py-0.5 pr-2">
+                <input type="number" step="any" value={r.size}
+                  onChange={(e) => set(i, { size: num(e.target.value) })}
+                  className="w-20 rounded border border-slate-200 px-1 py-0.5 text-right font-mono" />
+              </td>
+              <td className="py-0.5 pr-2 text-right">
+                <input type="number" step="any" value={r.massRetained}
+                  onChange={(e) => set(i, { massRetained: num(e.target.value) })}
+                  className="w-24 rounded border border-slate-200 px-1 py-0.5 text-right font-mono" />
+              </td>
+              <td className="py-0.5 text-right">
+                <button onClick={() => onChange(stack.filter((_, k) => k !== i))}
+                  className="rounded px-1 text-[10px] text-red-600 hover:bg-red-50">×</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button
+        onClick={() => onChange([...stack, { size: 0.075, massRetained: 0 }])}
+        className="mt-1 rounded border border-dashed border-slate-300 px-2 py-0.5 text-[10px] text-slate-600 hover:bg-slate-50">
+        + sieve
+      </button>
+    </div>
+  )
+}
+
+// ── Sample classification ─────────────────────────────────────────────────
+
+function SampleClassificationCard({
+  sample, layers, onApply,
+}: {
+  sample: Sample
+  layers: SoilLayer[]
+  onApply: (layerId: string, symbol: string) => void
+}) {
+  const c = useMemo(() => classifySample(sample), [sample])
+  const layer = layers.find((l) => l.id === sample.layerId)
+  const symbol = c.uscs?.symbol
+
+  return (
+    <div className="mt-3 rounded-lg border border-slate-200 bg-slate-50 p-3">
+      <p className="text-[11px] font-bold uppercase tracking-[0.14em] text-slate-500">
+        Classification from this sample
+      </p>
+
+      {symbol ? (
+        <div className="mt-1 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          <span className="font-mono text-[16px] font-semibold text-[#0056b3]">{symbol}</span>
+          <span className="text-[12px] text-slate-700">{c.uscs!.name}</span>
+          {c.aashto?.label && (
+            <span className="font-mono text-[11px] text-slate-500">AASHTO {c.aashto.label}</span>
+          )}
+        </div>
+      ) : (
+        <p className="mt-1 text-[12px] text-slate-600">
+          {c.uscs?.reason ?? 'Not enough laboratory data to classify this sample yet.'}
+        </p>
+      )}
+
+      {c.missing.length > 0 && (
+        <p className="mt-1.5 text-[11px] text-slate-600">
+          Run to complete it: <strong>{c.missing.join(', ')}</strong>
+        </p>
+      )}
+
+      {symbol && c.uscs!.reason && (
+        <p className="mt-1.5 text-[11px] text-slate-600">{c.uscs!.reason}</p>
+      )}
+
+      {c.notes.map((n, k) => (
+        <p key={k} className="mt-1 text-[10px] text-amber-900">{n}</p>
+      ))}
+
+      {symbol && layer && (
+        layer.symbol === symbol ? (
+          <p className="mt-2 text-[11px] text-emerald-700">
+            Layer &ldquo;{layer.name}&rdquo; already carries {symbol}.
+          </p>
+        ) : (
+          <button onClick={() => onApply(layer.id, symbol)}
+            className="mt-2 rounded-md bg-[#0056b3] px-2.5 py-1 text-[11px] font-semibold text-white hover:bg-[#004a99]">
+            {layer.symbol
+              ? `Replace ${layer.symbol} with ${symbol} on “${layer.name}”`
+              : `Apply ${symbol} to “${layer.name}”`}
+          </button>
+        )
+      )}
+
+      {symbol && !layer && (
+        <p className="mt-2 text-[11px] text-slate-500">
+          This sample is not attributed to a layer, so there is nothing to apply the symbol to.
+        </p>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
**Layer 8.** Wires sieve and Atterberg into `LabTest.data` and adds `classifySample`, so the USCS symbol comes from **the tests actually run on a sample** rather than numbers retyped into a calculator.

**This closes the gap left open since 3b** — the borehole log's USCS column now populates.

## `classifySample.ts` — three refusals, each with a test

1. **It will not read a void test.** A specimen that failed on a seating error stays in the record (that's deliberate, per Phase 0) but must not classify the soil.
2. **It will not silently pick between two tests of the same kind.** Two sieve analyses on one sample means somebody re-ran it, and which one counts is a decision — the most recent *complete* one wins, and the sheet says it chose.
3. **It will not invent a missing input.** No Atterberg test on a fine-grained sample means no classification, and `missing` names the test to run.

### `missing` means "blocks or changes the answer", not "would tell you something"

A hydrometer does **not** appear for a soil with 33% fines, because D2487 classifies that on the plasticity of the fines — the hydrometer wouldn't move the symbol. It **does** appear in the 10–12% band, where a dual symbol needs Cu and Cc but the sieve curve can't reach D10.

That distinction cost me a test iteration: my first attempt at the "hydrometer needed" case used 9% fines, where the curve *does* reach D10 and SW-SC is the correct answer.

### Non-plastic is passed through, not withheld

A non-plastic result goes to the classifier as PI = 0 *with* the liquid limit, because it's a finding — it tells D2487 the fines are silty, which is how a clean-ish sand comes out **SM** instead of unclassifiable.

## Readers

`readSieve` walks a variable-length array and **drops a malformed row rather than reading it as zero** — a zero mass retained is a real measurement; an absent one is not. `LabTestSpec` gains `formKind`, since no flat `LabField[]` can express a sieve stack.

## UI

A sieve-stack table on the test card, and a per-sample classification card showing the symbol, group name, AASHTO group, the reasoning and what's still missing — with a button that applies the symbol to the sample's layer, labelled **"Replace X with Y"** when the layer already carries one.

## Two of my own assertions were outdated by this work

`implementedTests()` is now four rather than two. And the "at least three fields" check **failed the sieve for being shaped correctly** — a sieve-stack form carries its inputs in a table, not in flat fields. The replacement checks each test's required fields against what its reader actually reads, which is the thing worth pinning.

## Verification

`npm test` — **2544 passed / 168 files** · `npx tsc -b` · `npm run lint` · `npm run build` all green.

End to end in headless Chromium, on one sample: the stack computes **fines = 13.0%**, the limits give **PI = 19.0%**, the card reads **SC / Clayey sand / AASHTO A-2-7 (0)**, *"Apply SC to Silty Sand"* writes the symbol, the card then reads *"already carries SC"*, and the borehole log's USCS column — **empty before** — shows SC. Console clean.

The mass-balance warning also fired during that run (my browser-script masses didn't close on the total), which incidentally confirms that check reaches the UI.

## Honest limits

- **A field description and a lab symbol can disagree without comment.** A layer named "Silty Sand" classified SC is normal — field descriptions are D2488 visual-manual and carry lower confidence than a D2487 lab result — but a genuine conflict (a layer named "Clay" classified SW) currently applies silently. Worth a cross-check note later.
- **Applying a symbol has no provenance trail.** `layer.symbol` is a plain string; it doesn't record which sample or which tests produced it. That wants the Phase 5 parameter engine, where `SourcedValue` already exists for exactly this.
- **Still nine tests without engines** — compaction, direct shear, UCS, triaxial, consolidation, permeability, CBR, hydrometer, swell. All bookable, all saying "no form yet".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_