### PR TITLE
Soil investigation Phase 4c — direct shear and unconfined compression

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1328,8 +1328,9 @@ because flagging the unusual as an error trains people to ignore errors.
 | 3a — borehole log renderer (geometry) | #479 | open |
 | 3b — investigation UI, routes, profile editor | #480 | merged |
 | 4a — lab plumbing + index tests (moisture, Gs) | #481 | merged |
-| 4b — sieve + Atterberg wired, sample classification | — | open |
-| 4c… — compaction, shear, UCS, triaxial, consolidation, k, CBR | — | |
+| 4b — sieve + Atterberg wired, sample classification | #482 | merged |
+| 4c — direct shear + UCS | — | open |
+| 4d… — compaction, triaxial, consolidation, permeability, CBR | — | |
 | 5 — parameter engine + wiring to existing analysis | — | the payoff |
 | 6 — liquefaction, bearing methods, Coulomb | — | |
 | 7 — report document builder | — | |

--- a/webapp/src/engine/soils/lab/directShear.ts
+++ b/webapp/src/engine/soils/lab/directShear.ts
@@ -1,0 +1,161 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Direct shear — Mohr–Coulomb failure envelope. Layer 8. ASTM D3080.
+//
+//   τf = c′ + σ′n · tan φ′
+//
+// Three or more specimens are sheared at different normal stresses, and the
+// envelope is the straight line through the peak shear stresses. c′ is its
+// intercept and φ′ its slope. That is the whole test, and every subtlety is in
+// how the line is fitted and how far it may be trusted.
+//
+// A NEGATIVE FITTED COHESION IS AN ARTEFACT, NOT A SOIL PROPERTY. Least squares
+// through three scattered points will happily produce c′ = −4 kPa, which would
+// then be carried into a bearing-capacity calculation as a real (and
+// unconservative in reverse) number. When the fit comes out negative this
+// module REFITS through the origin — the physically meaningful constraint for a
+// cohesionless soil — and says it did.
+//
+// c′ AND φ′ ARE ONLY VALID OVER THE STRESSES TESTED. The envelope of a real
+// soil is curved; a straight line through 50–200 kPa says nothing about
+// behaviour at 600 kPa under a raft. The module reports the tested range so a
+// caller can check the footing stress against it, and warns when asked.
+//
+// UNITS: stresses kPa; angles degrees.
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface ShearPoint {
+  /** Effective normal stress on the shear plane, kPa. */
+  normalStress: number
+  /** Peak shear stress at failure, kPa. */
+  peakShear: number
+  /** Residual (post-peak) shear stress, kPa. Optional. */
+  residualShear?: number
+}
+
+export interface DirectShearData {
+  points: ShearPoint[]
+  /** 'CD' consolidated drained (the usual) or 'UU'. */
+  testType?: 'CD' | 'CU' | 'UU'
+}
+
+export interface Envelope {
+  /** Cohesion intercept, kPa. Never negative — see the module header. */
+  cohesion: number
+  /** Friction angle, degrees. */
+  frictionAngle: number
+  /** Coefficient of determination of the fit. */
+  r2: number
+  /** True when the free fit gave a negative intercept and was refitted through the origin. */
+  refittedThroughOrigin: boolean
+}
+
+export interface DirectShearResult {
+  peak: Envelope
+  /** Residual envelope, when residual shear stresses were recorded. */
+  residual?: Envelope
+  /** Lowest and highest normal stress tested, kPa. */
+  stressRange: { min: number; max: number }
+  notes: string[]
+}
+
+/**
+ * Least-squares line τ = c + σ·m through the points, with the negative-intercept
+ * refit described in the module header.
+ */
+export function fitEnvelope(points: { x: number; y: number }[]): Envelope {
+  const n = points.length
+  if (n < 2) throw new Error('A failure envelope needs at least two specimens.')
+
+  const mx = points.reduce((s, p) => s + p.x, 0) / n
+  const my = points.reduce((s, p) => s + p.y, 0) / n
+  const sxx = points.reduce((s, p) => s + (p.x - mx) ** 2, 0)
+  const sxy = points.reduce((s, p) => s + (p.x - mx) * (p.y - my), 0)
+
+  if (sxx < 1e-12) {
+    throw new Error('Every specimen was sheared at the same normal stress — the envelope has no slope.')
+  }
+
+  let slope = sxy / sxx
+  let intercept = my - slope * mx
+  let refitted = false
+
+  if (intercept < 0) {
+    // Refit through the origin: slope = Σxy / Σx².
+    const sxy0 = points.reduce((s, p) => s + p.x * p.y, 0)
+    const sxx0 = points.reduce((s, p) => s + p.x * p.x, 0)
+    slope = sxx0 > 1e-12 ? sxy0 / sxx0 : 0
+    intercept = 0
+    refitted = true
+  }
+
+  // R² against the fitted line (through the origin when refitted).
+  const ssTot = points.reduce((s, p) => s + (p.y - my) ** 2, 0)
+  const ssRes = points.reduce((s, p) => s + (p.y - (intercept + slope * p.x)) ** 2, 0)
+  const r2 = ssTot > 1e-12 ? 1 - ssRes / ssTot : 1
+
+  return {
+    cohesion: intercept,
+    // A negative slope is not a friction angle. It means the specimens got
+    // weaker with confinement, which is a test problem, and atan would quietly
+    // return a negative angle that reads as a real result.
+    frictionAngle: (Math.atan(Math.max(slope, 0)) * 180) / Math.PI,
+    r2,
+    refittedThroughOrigin: refitted,
+  }
+}
+
+export function directShear(d: DirectShearData): DirectShearResult {
+  const notes: string[] = []
+  const pts = d.points.filter((p) => Number.isFinite(p.normalStress) && Number.isFinite(p.peakShear))
+
+  if (pts.length < 2) {
+    throw new Error('A direct-shear envelope needs at least two specimens with a normal and a peak shear stress.')
+  }
+  if (pts.length < 3) {
+    notes.push('Only two specimens. D3080 asks for at least three so the envelope can be seen to be straight — with two, any scatter is invisible.')
+  }
+
+  const peak = fitEnvelope(pts.map((p) => ({ x: p.normalStress, y: p.peakShear })))
+
+  const withResidual = pts.filter((p) => Number.isFinite(p.residualShear))
+  const residual = withResidual.length >= 2
+    ? fitEnvelope(withResidual.map((p) => ({ x: p.normalStress, y: p.residualShear! })))
+    : undefined
+
+  const stresses = pts.map((p) => p.normalStress)
+  const stressRange = { min: Math.min(...stresses), max: Math.max(...stresses) }
+
+  if (peak.refittedThroughOrigin) {
+    notes.push(
+      'The free fit gave a NEGATIVE cohesion intercept, which is a fitting artefact rather than a soil property. The envelope was refitted through the origin and c′ reported as 0.',
+    )
+  }
+  if (peak.r2 < 0.95) {
+    notes.push(
+      `The envelope fits poorly (R² = ${peak.r2.toFixed(3)}). Either the soil's envelope is curved over this stress range, or one specimen is an outlier — plot the points before trusting c′ and φ′.`,
+    )
+  }
+  if (peak.frictionAngle > 45) {
+    notes.push(`φ′ = ${peak.frictionAngle.toFixed(1)}° is above the range most soils reach. Verify the shear-box area correction.`)
+  }
+  if (residual && residual.frictionAngle > peak.frictionAngle + 0.5) {
+    notes.push('The residual friction angle exceeds the peak, which cannot happen in a real soil — check which column is which.')
+  }
+
+  notes.push(
+    `c′ and φ′ are fitted over ${stressRange.min.toFixed(0)}–${stressRange.max.toFixed(0)} kPa and are valid only there. A real envelope is curved; extrapolating to a much higher footing stress overestimates strength.`,
+  )
+
+  return { peak, residual, stressRange, notes }
+}
+
+/**
+ * Shear strength predicted by an envelope at a given normal stress, with a
+ * warning when that stress is outside the tested range.
+ */
+export function strengthAt(
+  env: Envelope, normalStress: number, range: { min: number; max: number },
+): { tau: number; extrapolated: boolean } {
+  const tau = env.cohesion + normalStress * Math.tan((env.frictionAngle * Math.PI) / 180)
+  return { tau, extrapolated: normalStress < range.min || normalStress > range.max }
+}

--- a/webapp/src/engine/soils/lab/index.ts
+++ b/webapp/src/engine/soils/lab/index.ts
@@ -27,6 +27,10 @@ import {
 } from './specificGravity'
 import { type SieveInput, type SieveReading, gradation, type GradationResult } from '../sieve'
 import { type AtterbergInput, atterberg, type AtterbergResult } from '../atterberg'
+import {
+  type DirectShearData, type ShearPoint, directShear, type DirectShearResult,
+} from './directShear'
+import { type UcsData, type UcsSoil, ucs, type UcsResult } from './ucs'
 
 const isRecord = (v: unknown): v is Record<string, unknown> =>
   typeof v === 'object' && v !== null && !Array.isArray(v)
@@ -107,6 +111,53 @@ export function readAtterberg(test: LabTest): AtterbergInput | undefined {
   }
 }
 
+/**
+ * Direct shear. Like the sieve stack this carries a variable-length table —
+ * one row per specimen — and a row missing either stress is DROPPED, because a
+ * specimen with no recorded normal stress cannot sit on an envelope.
+ */
+export function readDirectShear(test: LabTest): DirectShearData | undefined {
+  const d = test.data
+  if (!isRecord(d) || !Array.isArray(d.points)) return undefined
+
+  const points: ShearPoint[] = []
+  for (const r of d.points) {
+    if (!isRecord(r) || !finite(r.normalStress) || !finite(r.peakShear)) continue
+    points.push({
+      normalStress: r.normalStress,
+      peakShear: r.peakShear,
+      residualShear: finite(r.residualShear) ? r.residualShear : undefined,
+    })
+  }
+  if (points.length < 2) return undefined
+
+  const t = d.testType
+  return {
+    points,
+    testType: t === 'CD' || t === 'CU' || t === 'UU' ? t : undefined,
+  }
+}
+
+const UCS_SOILS: UcsSoil[] = ['saturated-cohesive', 'fissured', 'partly-saturated', 'granular']
+
+export function readUcs(test: LabTest): { data: UcsData; soil: UcsSoil } | undefined {
+  const d = test.data
+  if (!isRecord(d) || !hasNumbers(d, ['diameter', 'height', 'failureLoad', 'failureDeformation'])) {
+    return undefined
+  }
+  const soil = UCS_SOILS.find((s) => s === d.soil) ?? 'saturated-cohesive'
+  return {
+    soil,
+    data: {
+      diameter: d.diameter as number,
+      height: d.height as number,
+      failureLoad: d.failureLoad as number,
+      failureDeformation: d.failureDeformation as number,
+      unitWeight: finite(d.unitWeight) ? d.unitWeight : undefined,
+    },
+  }
+}
+
 // ── Catalogue ─────────────────────────────────────────────────────────────
 
 /** One numeric input on a test form. */
@@ -124,7 +175,7 @@ export interface LabField {
  * How a test's form is laid out. Most tests are a flat list of numbers; a sieve
  * stack is a variable-length table, which no `LabField[]` can express.
  */
-export type LabFormKind = 'fields' | 'sieve-stack'
+export type LabFormKind = 'fields' | 'sieve-stack' | 'shear-points'
 
 export interface LabTestSpec {
   type: LabTestType
@@ -208,9 +259,32 @@ export const LAB_TESTS: readonly LabTestSpec[] = [
     ],
   },
   { type: 'compaction', label: 'Compaction', standard: 'd698', needsUndisturbed: false, fields: [], purpose: 'Maximum dry density and optimum moisture content.' },
-  { type: 'direct-shear', label: 'Direct shear', standard: 'd3080', needsUndisturbed: true, fields: [], purpose: 'Effective cohesion and friction angle from the failure envelope.' },
+  {
+    type: 'direct-shear',
+    label: 'Direct shear',
+    standard: 'd3080',
+    formKind: 'shear-points',
+    calculation: 'directshear.envelope',
+    needsUndisturbed: true,
+    purpose: 'Effective cohesion and friction angle from the Mohr–Coulomb failure envelope.',
+    fields: [],
+  },
   { type: 'triaxial', label: 'Triaxial', standard: 'd4767', needsUndisturbed: true, fields: [], purpose: 'Shear strength under controlled drainage and confinement.' },
-  { type: 'ucs', label: 'Unconfined compression', standard: 'd2166', needsUndisturbed: true, fields: [], purpose: 'Undrained shear strength of a cohesive soil.' },
+  {
+    type: 'ucs',
+    label: 'Unconfined compression',
+    standard: 'd2166',
+    calculation: 'ucs.qu',
+    needsUndisturbed: true,
+    purpose: 'Undrained shear strength of a saturated cohesive soil.',
+    fields: [
+      { key: 'diameter', label: 'Diameter', unit: 'mm', placeholder: 38 },
+      { key: 'height', label: 'Height', unit: 'mm', placeholder: 76 },
+      { key: 'failureLoad', label: 'Load at failure', unit: 'N', placeholder: 120 },
+      { key: 'failureDeformation', label: 'Deformation at failure', unit: 'mm', placeholder: 6 },
+      { key: 'unitWeight', label: 'Bulk unit weight', unit: 'kN/m³', optional: true, placeholder: 18 },
+    ],
+  },
   { type: 'consolidation', label: 'Consolidation', standard: 'd2435', needsUndisturbed: true, fields: [], purpose: 'Compressibility and the rate of settlement.' },
   { type: 'permeability', label: 'Permeability', standard: 'd5084', needsUndisturbed: true, fields: [], purpose: 'Hydraulic conductivity.' },
   { type: 'cbr', label: 'CBR', standard: 'd1883', needsUndisturbed: false, fields: [], purpose: 'Bearing ratio for pavement design.' },
@@ -220,12 +294,23 @@ export const LAB_TESTS: readonly LabTestSpec[] = [
 export const labSpec = (type: LabTestType): LabTestSpec | undefined =>
   LAB_TESTS.find((t) => t.type === type)
 
+/**
+ * Whether a spec has a data form. Flat forms declare `fields`; table-driven
+ * ones (a sieve stack, a set of shear specimens) carry their inputs in a table
+ * and may declare none, so counting fields alone reports them as unimplemented
+ * — which it did for direct shear until a test caught it.
+ */
+const hasForm = (t: LabTestSpec): boolean =>
+  t.fields.length > 0 || (t.formKind != null && t.formKind !== 'fields')
+
 /** Tests that have a data form today. */
-export const implementedTests = (): LabTestSpec[] => LAB_TESTS.filter((t) => t.fields.length > 0)
+export const implementedTests = (): LabTestSpec[] => LAB_TESTS.filter(hasForm)
 
 /** Whether a test type can currently accept results. */
-export const isImplemented = (type: LabTestType): boolean =>
-  (labSpec(type)?.fields.length ?? 0) > 0
+export const isImplemented = (type: LabTestType): boolean => {
+  const spec = labSpec(type)
+  return spec ? hasForm(spec) : false
+}
 
 // ── Evaluation ────────────────────────────────────────────────────────────
 
@@ -234,6 +319,8 @@ export type LabOutcome =
   | { kind: 'specific-gravity'; result: SpecificGravityResult }
   | { kind: 'sieve'; result: GradationResult }
   | { kind: 'atterberg'; result: AtterbergResult }
+  | { kind: 'direct-shear'; result: DirectShearResult }
+  | { kind: 'ucs'; result: UcsResult }
 
 /**
  * Compute a test's result from its stored data.
@@ -265,6 +352,16 @@ export function evaluateTest(test: LabTest): { outcome?: LabOutcome; error?: str
         if (!d) return {}
         return { outcome: { kind: 'atterberg', result: atterberg(d) } }
       }
+      case 'direct-shear': {
+        const d = readDirectShear(test)
+        if (!d) return {}
+        return { outcome: { kind: 'direct-shear', result: directShear(d) } }
+      }
+      case 'ucs': {
+        const d = readUcs(test)
+        if (!d) return {}
+        return { outcome: { kind: 'ucs', result: ucs(d.data, d.soil) } }
+      }
       default:
         return {}
     }
@@ -284,5 +381,9 @@ export function summarise(outcome: LabOutcome): { label: string; value: number; 
       return { label: 'fines', value: outcome.result.fines, unit: '%' }
     case 'atterberg':
       return { label: 'PI', value: outcome.result.plasticityIndex, unit: '%' }
+    case 'direct-shear':
+      return { label: "φ'", value: outcome.result.peak.frictionAngle, unit: '°' }
+    case 'ucs':
+      return { label: 'qu', value: outcome.result.qu, unit: 'kPa' }
   }
 }

--- a/webapp/src/engine/soils/lab/lab.test.ts
+++ b/webapp/src/engine/soils/lab/lab.test.ts
@@ -201,10 +201,14 @@ describe('the lab catalogue stays in step with the schema', () => {
     expect(isImplemented('specific-gravity')).toBe(true)
     expect(isImplemented('sieve')).toBe(true)
     expect(isImplemented('atterberg')).toBe(true)
+    // Direct shear declares no flat fields — its specimens are a table — so a
+    // fields-only check reported it as unimplemented.
+    expect(isImplemented('direct-shear')).toBe(true)
+    expect(isImplemented('ucs')).toBe(true)
     expect(isImplemented('triaxial')).toBe(false)
     expect(isImplemented('consolidation')).toBe(false)
     expect(implementedTests().map((t) => t.type))
-      .toEqual(['moisture', 'specific-gravity', 'sieve', 'atterberg'])
+      .toEqual(['moisture', 'specific-gravity', 'sieve', 'atterberg', 'direct-shear', 'ucs'])
   })
 
   it('gives every implemented test enough fields to drive its engine', () => {
@@ -213,7 +217,7 @@ describe('the lab catalogue stays in step with the schema', () => {
     // fields — the earlier version of this test demanded three from everything
     // and failed the sieve for being shaped correctly.
     for (const t of implementedTests()) {
-      const floor = t.formKind === 'sieve-stack' ? 1 : 3
+      const floor = t.formKind && t.formKind !== 'fields' ? 0 : 3
       expect(t.fields.length, t.type).toBeGreaterThanOrEqual(floor)
       for (const f of t.fields) {
         expect(f.label.length, `${t.type}/${f.key}`).toBeGreaterThan(2)
@@ -229,6 +233,8 @@ describe('the lab catalogue stays in step with the schema', () => {
       'specific-gravity': ['solidMass', 'pycWaterMass', 'pycWaterSolidMass'],
       sieve: ['totalMass'],
       atterberg: ['liquidLimit'],
+      'direct-shear': [],
+      ucs: ['diameter', 'height', 'failureLoad', 'failureDeformation'],
     }
     for (const t of implementedTests()) {
       const declared = t.fields.filter((f) => !f.optional).map((f) => f.key).sort()

--- a/webapp/src/engine/soils/lab/strength.test.ts
+++ b/webapp/src/engine/soils/lab/strength.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect } from 'vitest'
+import { directShear, fitEnvelope, strengthAt } from './directShear'
+import { ucs, consistencyFromQu } from './ucs'
+import { readDirectShear, readUcs, evaluateTest, summarise, isImplemented } from './index'
+import type { LabTest } from '../model'
+
+const asData = (o: unknown) => o as Record<string, unknown>
+const test = (type: LabTest['type'], data?: unknown): LabTest => ({
+  id: 't1', type, standard: 'd3080', status: 'complete', data: data == null ? undefined : asData(data),
+})
+
+// ── Failure envelope ──────────────────────────────────────────────────────
+
+describe('fitEnvelope', () => {
+  it('recovers a line placed exactly on c = 20, φ = 30°', () => {
+    const tan30 = Math.tan(Math.PI / 6)
+    const pts = [50, 100, 200].map((x) => ({ x, y: 20 + x * tan30 }))
+    const e = fitEnvelope(pts)
+    expect(e.cohesion).toBeCloseTo(20, 8)
+    expect(e.frictionAngle).toBeCloseTo(30, 8)
+    expect(e.r2).toBeCloseTo(1, 8)
+    expect(e.refittedThroughOrigin).toBe(false)
+  })
+
+  it('REFITS through the origin when the free fit gives a negative intercept', () => {
+    // Least squares through scattered points will happily report c′ = −4 kPa,
+    // which would then be carried into a bearing calculation as real.
+    const pts = [{ x: 50, y: 28 }, { x: 100, y: 60 }, { x: 200, y: 122 }]
+    const free = { intercept: -4 }   // roughly what an unconstrained fit gives
+    expect(free.intercept).toBeLessThan(0)
+
+    const e = fitEnvelope(pts)
+    expect(e.refittedThroughOrigin).toBe(true)
+    expect(e.cohesion).toBe(0)
+    expect(e.frictionAngle).toBeGreaterThan(25)
+  })
+
+  it('never reports a negative friction angle', () => {
+    // Specimens getting weaker with confinement is a test problem, and atan
+    // would quietly return a negative angle that reads as a real result.
+    const e = fitEnvelope([{ x: 50, y: 100 }, { x: 200, y: 40 }])
+    expect(e.frictionAngle).toBe(0)
+  })
+
+  it('refuses fewer than two specimens, or all at one stress', () => {
+    expect(() => fitEnvelope([{ x: 50, y: 30 }])).toThrow(/at least two/)
+    expect(() => fitEnvelope([{ x: 100, y: 30 }, { x: 100, y: 60 }])).toThrow(/no slope/)
+  })
+})
+
+describe('direct shear (ASTM D3080)', () => {
+  const clean = {
+    points: [
+      { normalStress: 50, peakShear: 48.9 },
+      { normalStress: 100, peakShear: 77.7 },
+      { normalStress: 200, peakShear: 135.5 },
+    ],
+  }
+
+  it('reports c′, φ′ and the stress range they are valid over', () => {
+    const r = directShear(clean)
+    expect(r.peak.cohesion).toBeCloseTo(20, 0)
+    expect(r.peak.frictionAngle).toBeCloseTo(30, 0)
+    expect(r.stressRange).toEqual({ min: 50, max: 200 })
+    expect(r.notes.join(' ')).toMatch(/valid only there/)
+  })
+
+  it('warns when only two specimens were run', () => {
+    const r = directShear({ points: clean.points.slice(0, 2) })
+    expect(r.notes.join(' ')).toMatch(/at least three/)
+  })
+
+  it('says when it refitted through the origin', () => {
+    const r = directShear({
+      points: [
+        { normalStress: 50, peakShear: 28 },
+        { normalStress: 100, peakShear: 60 },
+        { normalStress: 200, peakShear: 122 },
+      ],
+    })
+    expect(r.peak.cohesion).toBe(0)
+    expect(r.notes.join(' ')).toMatch(/NEGATIVE cohesion intercept.*fitting artefact/)
+  })
+
+  it('warns on a poor fit rather than reporting c′ and φ′ as if they were solid', () => {
+    const r = directShear({
+      points: [
+        { normalStress: 50, peakShear: 90 },
+        { normalStress: 100, peakShear: 60 },
+        { normalStress: 200, peakShear: 140 },
+      ],
+    })
+    expect(r.peak.r2).toBeLessThan(0.95)
+    expect(r.notes.join(' ')).toMatch(/plot the points before trusting/)
+  })
+
+  it('fits a residual envelope when residual stresses were recorded', () => {
+    const r = directShear({
+      points: clean.points.map((p, i) => ({ ...p, residualShear: [30, 55, 105][i] })),
+    })
+    expect(r.residual).toBeDefined()
+    expect(r.residual!.frictionAngle).toBeLessThan(r.peak.frictionAngle + 1)
+  })
+
+  it('flags a residual angle above the peak, which cannot happen', () => {
+    const r = directShear({
+      points: [
+        { normalStress: 50, peakShear: 40, residualShear: 20 },
+        { normalStress: 200, peakShear: 60, residualShear: 160 },
+      ],
+    })
+    expect(r.notes.join(' ')).toMatch(/cannot happen in a real soil/)
+  })
+
+  it('refuses a single specimen', () => {
+    expect(() => directShear({ points: [{ normalStress: 50, peakShear: 30 }] }))
+      .toThrow(/at least two specimens/)
+  })
+})
+
+describe('using an envelope outside the stresses it was fitted over', () => {
+  it('flags extrapolation, because a real envelope is curved', () => {
+    const r = directShear({
+      points: [
+        { normalStress: 50, peakShear: 48.9 },
+        { normalStress: 100, peakShear: 77.7 },
+        { normalStress: 200, peakShear: 135.5 },
+      ],
+    })
+    expect(strengthAt(r.peak, 150, r.stressRange).extrapolated).toBe(false)
+    expect(strengthAt(r.peak, 600, r.stressRange).extrapolated).toBe(true)
+    expect(strengthAt(r.peak, 10, r.stressRange).extrapolated).toBe(true)
+  })
+})
+
+// ── UCS ───────────────────────────────────────────────────────────────────
+
+describe('unconfined compression (ASTM D2166)', () => {
+  const spec = { diameter: 38, height: 76, failureLoad: 120, failureDeformation: 6 }
+
+  it('applies the area correction, which lowers qu', () => {
+    // A0 = π/4 × 38² = 1134.115 mm²; ε = 6/76 = 0.078947
+    // Ac = 1134.115 / 0.921053 = 1231.325 mm²
+    // qu = 120 / 1231.325 × 1000 = 97.455 kPa
+    const r = ucs(spec)
+    expect(r.initialArea).toBeCloseTo(1134.11, 1)
+    expect(r.strain).toBeCloseTo(0.07895, 5)
+    expect(r.correctedArea).toBeCloseTo(1231.325, 2)
+    expect(r.qu).toBeCloseTo(97.45, 1)
+    expect(r.quUncorrected).toBeCloseTo(105.81, 1)
+    expect(r.qu).toBeLessThan(r.quUncorrected)
+  })
+
+  it('says how much the correction moved the answer', () => {
+    // Omitting it would overstate the strength — always unconservatively.
+    const r = ucs(spec)
+    expect(r.notes.join(' ')).toMatch(/lowering qu from 106 to 97 kPa/)
+  })
+
+  it('halves qu for a saturated cohesive soil and states the assumption', () => {
+    const r = ucs(spec)
+    expect(r.cu).toBeCloseTo(r.qu / 2, 10)
+    expect(r.notes.join(' ')).toMatch(/assumes φ = 0/)
+    expect(r.notes.join(' ')).toMatch(/LOWER BOUND/)
+  })
+
+  it('DECLINES cu when the φ = 0 assumption does not hold', () => {
+    for (const soil of ['fissured', 'partly-saturated', 'granular'] as const) {
+      const r = ucs(spec, soil)
+      expect(r.cu, soil).toBeUndefined()
+      expect(r.cuDeclined, soil).toBeTruthy()
+      expect(r.qu, soil).toBeCloseTo(97.45, 1)   // qu is still a measurement
+    }
+    expect(ucs(spec, 'fissured').cuDeclined).toMatch(/discontinuity/)
+    expect(ucs(spec, 'granular').cuDeclined).toMatch(/triaxial or direct shear/)
+  })
+
+  it('warns about a specimen outside the 2.0–2.5 slenderness range', () => {
+    expect(ucs({ ...spec, height: 60 }).notes.join(' ')).toMatch(/restrained by the platens/)
+    expect(ucs({ ...spec, height: 76 }).notes.join(' ')).not.toMatch(/2\.0–2\.5/)
+  })
+
+  it('warns past 20% strain, where the specimen is barrelling not shearing', () => {
+    expect(ucs({ ...spec, failureDeformation: 18 }).notes.join(' ')).toMatch(/barrelling/)
+  })
+
+  it('rejects impossible geometry rather than returning nonsense', () => {
+    expect(() => ucs({ ...spec, diameter: 0 })).toThrow(/greater than zero/)
+    expect(() => ucs({ ...spec, failureDeformation: 76 })).toThrow(/units on the dial gauge/)
+    expect(() => ucs({ ...spec, failureDeformation: 100 })).toThrow(/units on the dial gauge/)
+    expect(() => ucs({ ...spec, failureLoad: -1 })).toThrow(/must not be negative/)
+  })
+
+  it('describes the consistency from qu (Terzaghi & Peck)', () => {
+    expect(consistencyFromQu(20)).toBe('very soft')
+    expect(consistencyFromQu(75)).toBe('medium stiff')
+    expect(consistencyFromQu(150)).toBe('stiff')
+    expect(consistencyFromQu(500)).toBe('hard')
+    expect(ucs(spec).consistency).toBe('medium stiff')
+  })
+})
+
+// ── Readers and evaluation ────────────────────────────────────────────────
+
+describe('reading strength tests from stored data', () => {
+  it('drops a shear row missing either stress', () => {
+    const d = readDirectShear(test('direct-shear', {
+      points: [
+        { normalStress: 50, peakShear: 48 },
+        { normalStress: 100 },
+        { peakShear: 77 },
+        { normalStress: 200, peakShear: 135 },
+      ],
+    }))!
+    expect(d.points.map((p) => p.normalStress)).toEqual([50, 200])
+  })
+
+  it('returns undefined when fewer than two rows survive', () => {
+    expect(readDirectShear(test('direct-shear', { points: [{ normalStress: 50, peakShear: 48 }] })))
+      .toBeUndefined()
+    expect(readDirectShear(test('direct-shear'))).toBeUndefined()
+  })
+
+  it('keeps only a recognised test type', () => {
+    expect(readDirectShear(test('direct-shear', {
+      points: [{ normalStress: 50, peakShear: 48 }, { normalStress: 200, peakShear: 135 }],
+      testType: 'CD',
+    }))!.testType).toBe('CD')
+    expect(readDirectShear(test('direct-shear', {
+      points: [{ normalStress: 50, peakShear: 48 }, { normalStress: 200, peakShear: 135 }],
+      testType: 'nonsense',
+    }))!.testType).toBeUndefined()
+  })
+
+  it('defaults an unrecognised UCS soil to saturated cohesive', () => {
+    const r = readUcs(test('ucs', {
+      diameter: 38, height: 76, failureLoad: 120, failureDeformation: 6, soil: 'made-up',
+    }))!
+    expect(r.soil).toBe('saturated-cohesive')
+  })
+
+  it('honours a stated UCS soil condition', () => {
+    expect(readUcs(test('ucs', {
+      diameter: 38, height: 76, failureLoad: 120, failureDeformation: 6, soil: 'fissured',
+    }))!.soil).toBe('fissured')
+  })
+})
+
+describe('evaluateTest covers the new tests', () => {
+  it('summarises direct shear by φ′', () => {
+    const { outcome } = evaluateTest(test('direct-shear', {
+      points: [
+        { normalStress: 50, peakShear: 48.9 },
+        { normalStress: 100, peakShear: 77.7 },
+        { normalStress: 200, peakShear: 135.5 },
+      ],
+    }))
+    expect(outcome!.kind).toBe('direct-shear')
+    const s = summarise(outcome!)
+    expect(s.label).toBe("φ'")
+    expect(s.value).toBeCloseTo(30, 0)
+  })
+
+  it('summarises UCS by qu', () => {
+    const { outcome } = evaluateTest(test('ucs', {
+      diameter: 38, height: 76, failureLoad: 120, failureDeformation: 6,
+    }))
+    expect(summarise(outcome!)).toEqual({ label: 'qu', value: expect.closeTo(97.45, 1), unit: 'kPa' })
+  })
+
+  it('surfaces an impossible specimen as an error, not a crash', () => {
+    const { error } = evaluateTest(test('ucs', {
+      diameter: 38, height: 76, failureLoad: 120, failureDeformation: 80,
+    }))
+    expect(error).toMatch(/dial gauge/)
+  })
+
+  it('marks both as implemented now', () => {
+    expect(isImplemented('direct-shear')).toBe(true)
+    expect(isImplemented('ucs')).toBe(true)
+    expect(isImplemented('triaxial')).toBe(false)
+  })
+})

--- a/webapp/src/engine/soils/lab/ucs.ts
+++ b/webapp/src/engine/soils/lab/ucs.ts
@@ -1,0 +1,125 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Unconfined compressive strength. Layer 8. ASTM D2166.
+//
+//   qu = P / Ac     and, for a saturated cohesive soil,     cu ≈ qu / 2
+//
+// THE AREA CORRECTION IS NOT OPTIONAL. A specimen shortens as it is loaded and
+// bulges to compensate, so the area carrying the load grows: Ac = A0/(1 − ε).
+// At 15% axial strain — a routine failure strain for a soft clay — the
+// corrected area is 18% larger than the initial one, so using A0 overstates qu
+// by 18%. That error goes straight into cu and from there into a bearing
+// capacity, and it always errs unconservatively.
+//
+// cu = qu/2 ASSUMES φ = 0. The total-stress Mohr circle through the origin is
+// only a fair picture of a SATURATED COHESIVE soil sheared undrained. In a
+// fissured clay, a partly saturated soil, or anything granular the assumption
+// fails and cu comes out unconservative — so the caller states the soil and the
+// module declines rather than dividing regardless.
+//
+// A UCS IS ALSO A LOWER BOUND ON THE IN-SITU SOIL. Sampling disturbance only
+// ever weakens a specimen, so a low qu may be the sample rather than the ground.
+//
+// UNITS: dimensions mm; load N; stresses kPa; strain as a fraction.
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface UcsData {
+  /** Initial specimen diameter, mm. */
+  diameter: number
+  /** Initial specimen height, mm. */
+  height: number
+  /** Axial load at failure, N. */
+  failureLoad: number
+  /** Axial deformation at failure, mm. */
+  failureDeformation: number
+  /** Bulk unit weight of the specimen, kN/m³. Optional, for the record. */
+  unitWeight?: number
+}
+
+export type UcsSoil = 'saturated-cohesive' | 'fissured' | 'partly-saturated' | 'granular'
+
+export interface UcsResult {
+  /** Initial cross-sectional area, mm². */
+  initialArea: number
+  /** Axial strain at failure, as a fraction. */
+  strain: number
+  /** Corrected area at failure, mm². */
+  correctedArea: number
+  /** Unconfined compressive strength, kPa. */
+  qu: number
+  /** qu computed on the INITIAL area — for comparison only. */
+  quUncorrected: number
+  /** Undrained shear strength, kPa. Undefined when the assumption does not hold. */
+  cu?: number
+  /** Why cu was not reported, when it was not. */
+  cuDeclined?: string
+  /** Descriptive consistency from qu (Terzaghi & Peck). */
+  consistency: string
+  notes: string[]
+}
+
+/** Consistency of a cohesive soil from qu, kPa (Terzaghi & Peck). */
+export function consistencyFromQu(qu: number): string {
+  if (qu < 25) return 'very soft'
+  if (qu < 50) return 'soft'
+  if (qu < 100) return 'medium stiff'
+  if (qu < 200) return 'stiff'
+  if (qu < 400) return 'very stiff'
+  return 'hard'
+}
+
+export function ucs(d: UcsData, soil: UcsSoil = 'saturated-cohesive'): UcsResult {
+  const notes: string[] = []
+
+  if (!(d.diameter > 0) || !(d.height > 0)) {
+    throw new Error('Specimen diameter and height must both be greater than zero.')
+  }
+  if (d.failureLoad < 0) throw new Error('Failure load must not be negative.')
+  if (d.failureDeformation < 0) throw new Error('Failure deformation must not be negative.')
+  if (d.failureDeformation >= d.height) {
+    throw new Error('The axial deformation equals or exceeds the specimen height — check the units on the dial gauge.')
+  }
+
+  const initialArea = (Math.PI / 4) * d.diameter ** 2
+  const strain = d.failureDeformation / d.height
+  const correctedArea = initialArea / (1 - strain)
+
+  // N / mm² = MPa; ×1000 → kPa.
+  const qu = (d.failureLoad / correctedArea) * 1000
+  const quUncorrected = (d.failureLoad / initialArea) * 1000
+
+  const ratio = d.height / d.diameter
+  if (ratio < 2 || ratio > 2.5) {
+    notes.push(
+      `Height/diameter is ${ratio.toFixed(2)}. D2166 asks for 2.0–2.5: a squatter specimen is restrained by the platens and reads high, a slenderer one can buckle.`,
+    )
+  }
+  if (strain > 0.20) {
+    notes.push(
+      `Failure strain is ${(strain * 100).toFixed(1)}%. Beyond about 20% the specimen is barrelling rather than shearing, and the area correction stops describing it.`,
+    )
+  }
+  if (strain > 0.05) {
+    notes.push(
+      `The area correction raised the area by ${(((correctedArea / initialArea) - 1) * 100).toFixed(1)}%, lowering qu from ${quUncorrected.toFixed(0)} to ${qu.toFixed(0)} kPa. Omitting it would overstate the strength.`,
+    )
+  }
+
+  let cu: number | undefined
+  let cuDeclined: string | undefined
+  if (soil === 'saturated-cohesive') {
+    cu = qu / 2
+    notes.push('cu = qu/2 assumes φ = 0 — a saturated cohesive soil sheared undrained. A UCS is also a LOWER BOUND on the in-situ strength, since sampling disturbance only ever weakens a specimen.')
+  } else {
+    cuDeclined = {
+      fissured: 'The specimen is fissured, so it fails on a discontinuity rather than through the matrix. qu/2 would overstate the operational strength.',
+      'partly-saturated': 'The soil is partly saturated, so suction contributes to the measured strength and φ = 0 does not hold. qu/2 would be unconservative.',
+      granular: 'A granular soil has no unconfined strength to speak of, and φ = 0 does not apply. Use a triaxial or direct shear test.',
+    }[soil]
+    notes.push(cuDeclined)
+  }
+
+  return {
+    initialArea, strain, correctedArea, qu, quUncorrected,
+    cu, cuDeclined, consistency: consistencyFromQu(qu), notes,
+  }
+}

--- a/webapp/src/pages/SoilInvestigation.tsx
+++ b/webapp/src/pages/SoilInvestigation.tsx
@@ -569,6 +569,16 @@ export default function SoilInvestigation() {
                 .find((x) => x.id === sampleId)?.tests.find((x) => x.id === testId)
               if (t) t.data = { ...t.data, readings: rows }
             })}
+            onPoints={(sampleId, testId, rows) => set((d) => {
+              const t = d.boreholes[holeIdx].samples
+                .find((x) => x.id === sampleId)?.tests.find((x) => x.id === testId)
+              if (t) t.data = { ...t.data, points: rows }
+            })}
+            onChoice={(sampleId, testId, key, value) => set((d) => {
+              const t = d.boreholes[holeIdx].samples
+                .find((x) => x.id === sampleId)?.tests.find((x) => x.id === testId)
+              if (t) t.data = { ...t.data, [key]: value }
+            })}
             onApplySymbol={(layerId, symbol) => set((d) => {
               const l = d.boreholes[holeIdx].layers.find((x) => x.id === layerId)
               if (l) l.symbol = symbol
@@ -677,12 +687,27 @@ function ClassificationPanel() {
 
 // ── Laboratory ────────────────────────────────────────────────────────────
 
+/**
+ * A laboratory result printed to the precision the measurement supports. A
+ * strength read off a proving ring is not known to three decimal places, and
+ * "qu = 97.456 kPa" claims a precision the test does not have. Only the
+ * dimensionless ratios (Gs) earn three.
+ */
+function formatOutcome(s: { label: string; value: number; unit: string }): string {
+  const dp = s.unit === '' ? 3 : 1
+  // No space before a degree sign; one before every other unit.
+  const gap = s.unit === '°' ? '' : ' '
+  return `${s.label} = ${s.value.toFixed(dp)}${s.unit ? gap + s.unit : ''}`
+}
+
 function TestCard({
-  test, onData, onRows, onStatus, onRemove,
+  test, onData, onRows, onPoints, onChoice, onStatus, onRemove,
 }: {
   test: LabTest
   onData: (key: string, value: number) => void
   onRows: (rows: StackRow[]) => void
+  onPoints: (rows: ShearRow[]) => void
+  onChoice: (key: string, value: string) => void
   onStatus: (s: LabTestStatus) => void
   onRemove: () => void
 }) {
@@ -725,6 +750,30 @@ function TestCard({
               onChange={(rows) => onRows(rows)} />
           )}
 
+          {spec!.formKind === 'shear-points' && (
+            <ShearPoints
+              rows={(test.data?.points as ShearRow[] | undefined) ?? []}
+              onChange={(rows) => onPoints(rows)} />
+          )}
+
+          {test.type === 'ucs' && (
+            <label className="mt-2 flex flex-col text-[11px]">
+              <span className="mb-0.5 text-slate-600">Soil condition</span>
+              <select
+                value={(test.data?.soil as string | undefined) ?? 'saturated-cohesive'}
+                onChange={(e) => onChoice('soil', e.target.value)}
+                className="rounded border border-slate-300 px-1.5 py-1">
+                <option value="saturated-cohesive">Saturated cohesive (cu = qu/2 applies)</option>
+                <option value="fissured">Fissured</option>
+                <option value="partly-saturated">Partly saturated</option>
+                <option value="granular">Granular</option>
+              </select>
+              <span className="mt-0.5 text-[10px] text-slate-500">
+                cu = qu/2 assumes φ = 0. Outside a saturated cohesive soil the module reports qu and declines cu.
+              </span>
+            </label>
+          )}
+
           <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-4">
             {spec!.fields.map((f) => (
               <label key={f.key} className="flex flex-col text-[11px]">
@@ -749,9 +798,7 @@ function TestCard({
           {outcome && (
             <div className="mt-2 rounded border border-emerald-200 bg-emerald-50 px-2 py-1.5">
               <p className="font-mono text-[13px] font-semibold text-emerald-900">
-                {summarise(outcome).label} = {summarise(outcome).value.toFixed(
-                  summarise(outcome).unit === '%' ? 1 : 3,
-                )}{summarise(outcome).unit ? ` ${summarise(outcome).unit}` : ''}
+                {formatOutcome(summarise(outcome))}
               </p>
               {outcome.result.notes.map((n, k) => (
                 <p key={k} className="mt-1 text-[10px] text-amber-900">{n}</p>
@@ -769,12 +816,14 @@ function TestCard({
 }
 
 function LabPanel({
-  bh, onAdd, onData, onRows, onStatus, onRemove, onApplySymbol,
+  bh, onAdd, onData, onRows, onPoints, onChoice, onStatus, onRemove, onApplySymbol,
 }: {
   bh: Borehole
   onAdd: (sampleId: string, type: LabTestType) => void
   onData: (sampleId: string, testId: string, key: string, value: number) => void
   onRows: (sampleId: string, testId: string, rows: StackRow[]) => void
+  onPoints: (sampleId: string, testId: string, rows: ShearRow[]) => void
+  onChoice: (sampleId: string, testId: string, key: string, value: string) => void
   onStatus: (sampleId: string, testId: string, status: LabTestStatus) => void
   onRemove: (sampleId: string, testId: string) => void
   onApplySymbol: (layerId: string, symbol: string) => void
@@ -827,6 +876,8 @@ function LabPanel({
                 <TestCard key={t.id} test={t}
                   onData={(key, value) => onData(s.id, t.id, key, value)}
                   onRows={(rows) => onRows(s.id, t.id, rows)}
+                  onPoints={(rows) => onPoints(s.id, t.id, rows)}
+                  onChoice={(key, value) => onChoice(s.id, t.id, key, value)}
                   onStatus={(status) => onStatus(s.id, t.id, status)}
                   onRemove={() => onRemove(s.id, t.id)} />
               ))}
@@ -977,6 +1028,67 @@ function SampleClassificationCard({
           This sample is not attributed to a layer, so there is nothing to apply the symbol to.
         </p>
       )}
+    </div>
+  )
+}
+
+// ── Direct-shear specimens ────────────────────────────────────────────────
+
+interface ShearRow { normalStress: number; peakShear: number; residualShear?: number }
+
+function ShearPoints({
+  rows, onChange,
+}: { rows: ShearRow[]; onChange: (rows: ShearRow[]) => void }) {
+  const pts = rows.length ? rows : [
+    { normalStress: 50, peakShear: 0 },
+    { normalStress: 100, peakShear: 0 },
+    { normalStress: 200, peakShear: 0 },
+  ]
+  const set = (i: number, patch: Partial<ShearRow>) =>
+    onChange(pts.map((r, k) => (k === i ? { ...r, ...patch } : r)))
+
+  return (
+    <div className="mt-2">
+      <table className="w-full text-left text-[11px]">
+        <thead className="text-slate-500">
+          <tr className="border-b border-slate-200">
+            <th className="py-1 pr-2">Specimen</th>
+            <th className="py-1 pr-2 text-right">σ′n (kPa)</th>
+            <th className="py-1 pr-2 text-right">τ peak (kPa)</th>
+            <th className="py-1 pr-2 text-right">τ residual (kPa)</th>
+            <th />
+          </tr>
+        </thead>
+        <tbody>
+          {pts.map((r, i) => (
+            <tr key={i} className="border-b border-slate-100">
+              <td className="py-0.5 pr-2 text-slate-600">{i + 1}</td>
+              {([
+                ['normalStress', r.normalStress] as const,
+                ['peakShear', r.peakShear] as const,
+                ['residualShear', r.residualShear] as const,
+              ]).map(([key, v]) => (
+                <td key={key} className="py-0.5 pr-2 text-right">
+                  <input type="number" step="any" value={v ?? ''}
+                    placeholder={key === 'residualShear' ? 'optional' : ''}
+                    onChange={(e) => set(i, {
+                      [key]: e.target.value === '' ? undefined : num(e.target.value),
+                    } as Partial<ShearRow>)}
+                    className="w-24 rounded border border-slate-200 px-1 py-0.5 text-right font-mono" />
+                </td>
+              ))}
+              <td className="py-0.5 text-right">
+                <button onClick={() => onChange(pts.filter((_, k) => k !== i))}
+                  className="rounded px-1 text-[10px] text-red-600 hover:bg-red-50">×</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button onClick={() => onChange([...pts, { normalStress: 0, peakShear: 0 }])}
+        className="mt-1 rounded border border-dashed border-slate-300 px-2 py-0.5 text-[10px] text-slate-600 hover:bg-slate-50">
+        + specimen
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
**Layer 8.** The two strength tests that feed **c′, φ′ and cu** — the parameters every bearing, slope and pile calculation in the app already takes. **29 new tests.**

## `lab/directShear.ts` — Mohr–Coulomb envelope, ASTM D3080

**A negative fitted cohesion is an artefact, not a soil property.** Least squares through three scattered points will happily report c′ = −4 kPa, which would then be carried into a bearing capacity as a real number. When the free fit comes out negative, the envelope is **refitted through the origin** — the physically meaningful constraint — and the sheet says so.

A negative slope is likewise not a friction angle. Specimens getting *weaker* with confinement is a test problem, and `atan` would quietly return a negative angle that reads as a result.

**c′ and φ′ are reported with the stress range they were fitted over.** A real envelope is curved; a straight line through 50–200 kPa says nothing about a raft at 600 kPa. `strengthAt` flags extrapolation in both directions.

## `lab/ucs.ts` — unconfined compression, ASTM D2166

**The area correction is not optional.** A specimen bulges as it shortens, so Ac = A0/(1−ε). At the routine 8% failure strain in the test case that lowers qu from **106 to 97 kPa** — and omitting it overstates the strength *every* time, always unconservatively. The note states before and after rather than applying it silently.

**cu = qu/2 assumes φ = 0** — a saturated cohesive soil sheared undrained. For a fissured, partly saturated or granular specimen the module reports qu (still a measurement) and **declines cu with the reason**. It also states that a UCS is a *lower bound* on the in-situ soil, since sampling disturbance only ever weakens a specimen.

## A design flaw the tests caught

`isImplemented` keyed off the flat `fields` array — so **direct shear, whose specimens are a table rather than fields, reported as unimplemented and could not be filled in at all.** Both it and `implementedTests` now go through a shared `hasForm` that accounts for table-driven forms.

This is the second time a table-shaped test has tripped a fields-shaped assumption (the sieve did it in 4b). The abstraction is now explicit rather than incidental.

## Also fixed

Results printed to three decimals, so a strength read off a proving ring appeared as `qu = 97.456 kPa` — claiming a precision the test does not have. Only dimensionless ratios (Gs) earn three now.

## Verification

`npm test` — **2573 passed / 169 files** · `npx tsc -b` · `npm run lint` · `npm run build` all green.

In headless Chromium:
- **qu = 97.5 kPa**, matching the hand calculation
- switching the soil condition to *granular* **declines cu while keeping qu**
- the shear envelope gives **φ′ = 30.0°** from points placed on c = 20 / φ = 30
- the stress-range caveat renders
- dropping the shear stresses to force a negative intercept produces the refit notice

Console clean.

## Honest limits

- **The envelope is fitted, never plotted.** An engineer checking a direct shear normally *looks* at the points against the line; there's no chart yet, only R² and a warning when it's poor. That's the weakest part of this PR.
- **Residual strength is fitted but unused.** It's computed and reported when residual stresses are entered, but nothing downstream consumes it — residual φ′ matters for a reactivated landslide, which the slope module doesn't yet distinguish.
- **Still seven tests without engines**: compaction, triaxial, consolidation, permeability, CBR, hydrometer, swell.
- **No provenance trail yet** — a measured φ′ still can't flow into a layer's parameters as a `SourcedValue`. That's Phase 5, and it's what makes all of this worth having.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_