### PR TITLE
Soil investigation Phase 5 — the parameter engine

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1329,9 +1329,10 @@ because flagging the unusual as an error trains people to ignore errors.
 | 3b — investigation UI, routes, profile editor | #480 | merged |
 | 4a — lab plumbing + index tests (moisture, Gs) | #481 | merged |
 | 4b — sieve + Atterberg wired, sample classification | #482 | merged |
-| 4c — direct shear + UCS | — | open |
+| 4c — direct shear + UCS | #483 | merged |
+| 5 — parameter engine (resolution + provenance) | — | open |
 | 4d… — compaction, triaxial, consolidation, permeability, CBR | — | |
-| 5 — parameter engine + wiring to existing analysis | — | the payoff |
+| 5b — wire parameters into the existing analysis pages | — | |
 | 6 — liquefaction, bearing methods, Coulomb | — | |
 | 7 — report document builder | — | |
 | 8 — Postgres, CPT, 3D subsurface | — | |

--- a/webapp/src/engine/soils/parameters.test.ts
+++ b/webapp/src/engine/soils/parameters.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect } from 'vitest'
+import {
+  resolveParameters, toLayerParameters, bearingInputs, samplesInLayer,
+  type ParameterKey,
+} from './parameters'
+import { sampleInvestigation } from './sample'
+import type { Borehole, LabTest, Sample } from './model'
+import type { LayerUnitWeight } from './sptProfile'
+
+const bh = (): Borehole => structuredClone(sampleInvestigation()).boreholes[0]
+
+const WEIGHTS: Record<string, LayerUnitWeight> = {
+  'bh1-l1': { gamma: 17, gammaSat: 19 },
+  'bh1-l2': { gamma: 18, gammaSat: 20 },
+  'bh1-l3': { gamma: 16, gammaSat: 18 },
+  'bh1-l4': { gamma: 19, gammaSat: 21 },
+}
+
+const lab = (over: Partial<LabTest> & Pick<LabTest, 'type'>): LabTest => ({
+  id: `t${Math.random().toString(36).slice(2, 8)}`,
+  standard: 'd3080', status: 'complete', ...over,
+})
+
+/** A direct shear placed exactly on c′ = 20 kPa, φ′ = 30°. */
+const shearTest = () => lab({
+  type: 'direct-shear', standard: 'd3080',
+  data: {
+    points: [
+      { normalStress: 50, peakShear: 20 + 50 * Math.tan(Math.PI / 6) },
+      { normalStress: 100, peakShear: 20 + 100 * Math.tan(Math.PI / 6) },
+      { normalStress: 200, peakShear: 20 + 200 * Math.tan(Math.PI / 6) },
+    ],
+  },
+})
+
+const gsTest = () => lab({
+  type: 'specific-gravity', standard: 'd854',
+  data: { solidMass: 25, pycWaterMass: 675, pycWaterSolidMass: 690.6 },
+})
+
+// Dated later than the fixture's own (empty) UCS on S-02, so the
+// most-recent-complete rule picks this one. Without the date the fixture's
+// test wins and no cu appears — which is the rule working, not a bug.
+const ucsTest = (soil?: string) => lab({
+  type: 'ucs', standard: 'd2166', testDate: '2026-07-01',
+  data: { diameter: 38, height: 76, failureLoad: 120, failureDeformation: 6, ...(soil ? { soil } : {}) },
+})
+
+const resolve = (b: Borehole, layerIdx: number, overrides = {}) =>
+  resolveParameters({ borehole: b, layer: b.layers[layerIdx], unitWeights: WEIGHTS, overrides })
+
+const find = (r: ReturnType<typeof resolve>, key: ParameterKey) =>
+  r.resolved.find((p) => p.key === key)
+
+// ── Evidence hierarchy ────────────────────────────────────────────────────
+
+describe('a measurement outranks a correlation', () => {
+  it('uses the direct-shear φ′, not the SPT one, and keeps the other as an alternative', () => {
+    const b = bh()
+    // Layer 2 (Silty Sand, 1.5-4.2 m) has SPT tests in it; add a shear test.
+    b.samples[0].tests.push(shearTest())
+
+    const r = resolve(b, 1)
+    const phi = find(r, 'effectiveFrictionAngle')!
+    expect(phi.value.provenance.kind).toBe('measured')
+    expect(phi.value.value).toBeCloseTo(30, 1)
+
+    // The SPT correlation is still reported, just not chosen.
+    const alt = phi.alternatives.find((a) => a.provenance.kind === 'correlated')
+    expect(alt).toBeDefined()
+    if (alt?.provenance.kind === 'correlated') {
+      expect(alt.provenance.source).toMatch(/Hatanaka/)
+    }
+  })
+
+  it('falls back to the correlation when there is no test', () => {
+    const r = resolve(bh(), 1)
+    const phi = find(r, 'effectiveFrictionAngle')!
+    expect(phi.value.provenance.kind).toBe('correlated')
+    expect(phi.alternatives).toEqual([])
+  })
+
+  it('SAYS SO when the correlation and the measurement disagree materially', () => {
+    const b = bh()
+    // A shear test giving φ′ ≈ 20°, well below what the SPT correlation gives.
+    b.samples[0].tests.push(lab({
+      type: 'direct-shear', standard: 'd3080',
+      data: {
+        points: [
+          { normalStress: 50, peakShear: 18.2 },
+          { normalStress: 100, peakShear: 36.4 },
+          { normalStress: 200, peakShear: 72.8 },
+        ],
+      },
+    }))
+    const r = resolve(b, 1)
+    expect(r.notes.join(' ')).toMatch(/the measured value is .* but the correlation gives/)
+    expect(r.notes.join(' ')).toMatch(/worth explaining in the report/)
+  })
+})
+
+describe('an engineer override beats everything, but only with a reason', () => {
+  it('wins over a measurement', () => {
+    const b = bh()
+    b.samples[0].tests.push(shearTest())
+    const r = resolve(b, 1, {
+      effectiveFrictionAngle: {
+        value: 28, unit: '°',
+        rationale: 'Shear box ran fast; adopting a conservative value pending a re-test.',
+        by: 'RV',
+      },
+    })
+    const phi = find(r, 'effectiveFrictionAngle')!
+    expect(phi.value.value).toBe(28)
+    expect(phi.value.provenance.kind).toBe('assumed')
+    // The measurement it displaced is kept.
+    expect(phi.alternatives.some((a) => a.provenance.kind === 'measured')).toBe(true)
+  })
+
+  it('is IGNORED when no rationale is given, and says why', () => {
+    const b = bh()
+    b.samples[0].tests.push(shearTest())
+    const r = resolve(b, 1, {
+      effectiveFrictionAngle: { value: 28, unit: '°', rationale: '   ' },
+    })
+    const phi = find(r, 'effectiveFrictionAngle')!
+    expect(phi.value.provenance.kind).toBe('measured')
+    expect(r.notes.join(' ')).toMatch(/indistinguishable from a typing error/)
+  })
+})
+
+// ── The absent parameter ──────────────────────────────────────────────────
+
+describe('a parameter with no evidence stays absent', () => {
+  it('is never defaulted to a textbook value', () => {
+    // An analysis running on invented numbers that look like measurements is
+    // the failure this whole module exists to prevent.
+    const b = bh()
+    b.samples = []
+    b.spt = []
+    const r = resolve(b, 2)
+    expect(r.resolved).toEqual([])
+    expect(r.absent).toContain('effectiveFrictionAngle')
+    expect(r.absent).toContain('undrainedShearStrength')
+    expect(r.absent).toContain('unitWeight')
+  })
+
+  it('reports absence to a downstream consumer rather than a plausible number', () => {
+    const b = bh()
+    b.samples = []
+    b.spt = []
+    const inputs = bearingInputs(resolve(b, 2))
+    expect(inputs.c).toBeUndefined()
+    expect(inputs.phiDeg).toBeUndefined()
+    expect(inputs.missing).toEqual(
+      expect.arrayContaining(['effectiveCohesion', 'effectiveFrictionAngle', 'unitWeight']),
+    )
+  })
+})
+
+// ── Soil-type gating ──────────────────────────────────────────────────────
+
+describe('correlations respect the soil they were fitted to', () => {
+  it('does not correlate φ′ or relative density in a clay', () => {
+    // Layer 3 is the Lean Clay, 4.2-8.5 m.
+    const r = resolve(bh(), 2)
+    expect(find(r, 'effectiveFrictionAngle')).toBeUndefined()
+    expect(find(r, 'relativeDensity')).toBeUndefined()
+    expect(r.notes.join(' ')).toMatch(/this layer is cohesive/)
+  })
+
+  it('correlates cu in a clay and not in a sand', () => {
+    const clay = resolve(bh(), 2)
+    expect(find(clay, 'undrainedShearStrength')?.value.provenance.kind).toBe('correlated')
+
+    const sand = resolve(bh(), 1)
+    expect(find(sand, 'undrainedShearStrength')).toBeUndefined()
+  })
+
+  it('reads the family from the group symbol when the description disagrees', () => {
+    const b = bh()
+    b.layers[1].symbol = 'CL'          // classified as clay despite "Silty Sand"
+    const r = resolve(b, 1)
+    expect(find(r, 'effectiveFrictionAngle')).toBeUndefined()
+    expect(r.notes.join(' ')).toMatch(/cohesive/)
+  })
+})
+
+describe('refusals are excluded from correlations', () => {
+  it('drops them and says how many', () => {
+    const b = bh()
+    // Two SPT results in layer 4 (the dense sand) hit refusal.
+    b.spt[5].penetration = [150, 150, 60]
+    b.spt[6].penetration = [150, 150, 40]
+    const r = resolve(b, 3)
+    expect(r.notes.join(' ')).toMatch(/2 SPT result\(s\) in this layer hit refusal/)
+    expect(r.notes.join(' ')).toMatch(/a lower bound is not a measurement/)
+  })
+
+  it('leaves the parameter absent when EVERY test in the layer refused', () => {
+    const b = bh()
+    for (const t of b.spt) t.penetration = [150, 150, 50]
+    b.samples = []
+    const r = resolve(b, 1)
+    expect(find(r, 'effectiveFrictionAngle')).toBeUndefined()
+  })
+})
+
+// ── Laboratory sources ────────────────────────────────────────────────────
+
+describe('laboratory measurements', () => {
+  it('takes c′ and φ′ from a direct shear, with the fitted stress range noted', () => {
+    const b = bh()
+    b.samples[0].tests.push(shearTest())
+    const r = resolve(b, 1)
+    expect(find(r, 'effectiveCohesion')!.value.value).toBeCloseTo(20, 1)
+    expect(find(r, 'effectiveCohesion')!.value.note).toMatch(/fitted over 50–200 kPa/)
+  })
+
+  it('takes cu from a UCS and records that it is a lower bound', () => {
+    const b = bh()
+    b.samples[1].tests.push(ucsTest())      // S-02 sits in the clay
+    const r = resolve(b, 2)
+    const cu = find(r, 'undrainedShearStrength')!
+    expect(cu.value.provenance.kind).toBe('measured')
+    expect(cu.value.value).toBeCloseTo(48.7, 0)
+    expect(cu.value.note).toMatch(/lower bound/)
+  })
+
+  it('does NOT take cu from a UCS the engine declined', () => {
+    const b = bh()
+    b.samples[1].tests.push(ucsTest('fissured'))
+    const r = resolve(b, 2)
+    const cu = find(r, 'undrainedShearStrength')
+    // The SPT correlation may still supply one, but not the UCS.
+    expect(cu?.value.provenance.kind).not.toBe('measured')
+    expect(r.notes.join(' ')).toMatch(/does not give cu/)
+  })
+
+  it('derives a void ratio from Gs and the entered unit weight', () => {
+    const b = bh()
+    b.samples[0].tests.push(gsTest())
+    const r = resolve(b, 1)
+    const e = find(r, 'voidRatio')!
+    expect(e.value.provenance.kind).toBe('derived')
+    // e = Gs·γw/γd − 1 = 2.6596 × 9.81 / 18 − 1
+    expect(e.value.value).toBeCloseTo(0.4494, 3)
+    expect(e.value.note).toMatch(/DRY value/)
+  })
+})
+
+// ── Sample attribution ────────────────────────────────────────────────────
+
+describe('samplesInLayer', () => {
+  const b = bh()
+
+  it('takes samples explicitly attributed to the layer', () => {
+    expect(samplesInLayer(b, b.layers[1]).map((s) => s.name)).toEqual(['S-01'])
+  })
+
+  it('takes an unattributed sample by its depth', () => {
+    const c = bh()
+    const orphan: Sample = {
+      id: 'orphan', name: 'S-99', type: 'split-spoon',
+      depthTop: 2.0, depthBottom: 2.45, tests: [],
+    }
+    c.samples.push(orphan)
+    expect(samplesInLayer(c, c.layers[1]).map((s) => s.name)).toContain('S-99')
+  })
+
+  it('does not steal a sample attributed to a different layer', () => {
+    const c = bh()
+    c.samples[0].layerId = 'bh1-l4'
+    expect(samplesInLayer(c, c.layers[1])).toEqual([])
+  })
+})
+
+// ── Output shaping ────────────────────────────────────────────────────────
+
+describe('toLayerParameters', () => {
+  it('produces the schema shape, keeping provenance on every value', () => {
+    const b = bh()
+    b.samples[0].tests.push(shearTest(), gsTest())
+    const p = toLayerParameters(resolve(b, 1))
+    expect(p.layerId).toBe('bh1-l2')
+    expect(p.boreholeId).toBe('bh1')
+    expect(p.effectiveFrictionAngle?.provenance.kind).toBe('measured')
+    expect(p.specificGravity?.value).toBeCloseTo(2.66, 2)
+    // JSON-serialisable, since it is stored.
+    expect(JSON.parse(JSON.stringify(p))).toEqual(p)
+  })
+})
+
+describe('bearingInputs', () => {
+  it('hands the geotech engine what it needs, in its units', () => {
+    const b = bh()
+    b.samples[0].tests.push(shearTest())
+    const inputs = bearingInputs(resolve(b, 1), 18)
+    expect(inputs.c).toBeCloseTo(20, 1)
+    expect(inputs.phiDeg).toBeCloseTo(30, 1)
+    expect(inputs.gamma).toBe(18)
+    expect(inputs.missing).toEqual([])
+  })
+
+  it('prefers effective parameters over total-stress ones', () => {
+    const b = bh()
+    b.samples[0].tests.push(shearTest())
+    const r = resolve(b, 1)
+    expect(find(r, 'effectiveCohesion')).toBeDefined()
+    expect(bearingInputs(r, 18).c).toBeCloseTo(find(r, 'effectiveCohesion')!.value.value, 6)
+  })
+})

--- a/webapp/src/engine/soils/parameters.ts
+++ b/webapp/src/engine/soils/parameters.ts
@@ -1,0 +1,319 @@
+// ─────────────────────────────────────────────────────────────────────────
+// The parameter engine — resolve design parameters for a layer from every
+// piece of evidence available, each carrying its provenance. Layer 8.
+//
+// THIS IS THE PHASE THE REST OF THE MODULE EXISTS FOR. Everything before it
+// records data; this turns the record into the γ, c′, φ′, cu and Cc that the
+// bearing-capacity, settlement, slope and pile engines already take — so a
+// soil property is interpreted once, with its source attached, instead of
+// being retyped on five pages with no trail back to a test.
+//
+// THE RESOLUTION ORDER IS A HIERARCHY OF EVIDENCE, and it is deliberate:
+//
+//   1. ENGINEER OVERRIDE     — a stated decision beats everything.
+//   2. MEASURED              — a laboratory test on this soil.
+//   3. DERIVED               — computed from measurements by an exact relation.
+//   4. CORRELATED            — an empirical relation from a field test.
+//   5. (nothing)             — the parameter is absent, and stays absent.
+//
+// There is no step 6. A parameter with no evidence is NOT defaulted to a
+// textbook value: an analysis running on invented numbers that look like
+// measurements is exactly the failure this module was built to prevent. The
+// caller gets `undefined` and decides whether to assume something — which then
+// records itself as an ASSUMPTION with a rationale.
+//
+// The order is not a quality ranking. A well-run correlation over twenty SPT
+// points can be worth more than one UU triaxial on a disturbed sample, and the
+// engineer can override in either direction. What the order guarantees is that
+// nothing silently outranks a direct measurement.
+//
+// UNITS: unit weight kN/m³; stresses and strengths kPa; angles degrees.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { Borehole, SoilLayer, Sample, LayerParameters } from './model'
+import { soilFamily, isCohesive } from './model'
+import {
+  measured, derived, type SourcedValue, type Provenance,
+} from './provenance'
+import { evaluateTest } from './lab'
+import { governingTest } from './classifySample'
+import { sptProfile, type LayerUnitWeight } from './sptProfile'
+import { correlatePhi, correlateUndrainedStrength, correlateRelativeDensity } from './spt'
+import { voidRatio } from './lab/specificGravity'
+
+/** A value the engineer set by hand, with the reason that makes it defensible. */
+export interface ParameterOverride {
+  value: number
+  unit: string
+  rationale: string
+  by?: string
+}
+
+export interface ResolveInput {
+  borehole: Borehole
+  layer: SoilLayer
+  /** Unit weights per layer id, for the effective-stress profile. */
+  unitWeights: Record<string, LayerUnitWeight>
+  /** Engineer overrides, keyed by parameter name. */
+  overrides?: Partial<Record<ParameterKey, ParameterOverride>>
+}
+
+export type ParameterKey =
+  | 'unitWeight' | 'dryUnitWeight' | 'saturatedUnitWeight'
+  | 'cohesion' | 'frictionAngle'
+  | 'effectiveCohesion' | 'effectiveFrictionAngle' | 'undrainedShearStrength'
+  | 'specificGravity' | 'voidRatio' | 'relativeDensity'
+
+/**
+ * Readable names, kept HERE rather than in the page, because the engine writes
+ * notes that name a parameter and the page renders a table that names the same
+ * one. Two label maps would drift — the mistake this module has already made
+ * twice (see soilFamily).
+ */
+export const PARAMETER_LABEL: Record<ParameterKey, string> = {
+  unitWeight: 'Unit weight γ',
+  dryUnitWeight: 'Dry unit weight γd',
+  saturatedUnitWeight: 'Saturated unit weight γsat',
+  cohesion: 'Cohesion c',
+  frictionAngle: 'Friction angle φ',
+  effectiveCohesion: "Effective cohesion c'",
+  effectiveFrictionAngle: "Effective friction angle φ'",
+  undrainedShearStrength: 'Undrained shear strength cu',
+  specificGravity: 'Specific gravity Gs',
+  voidRatio: 'Void ratio e',
+  relativeDensity: 'Relative density Dr',
+}
+
+export interface ResolvedParameter {
+  key: ParameterKey
+  value: SourcedValue
+  /** Other candidates that were found but not chosen, best first. */
+  alternatives: SourcedValue[]
+}
+
+export interface ParameterResolution {
+  layerId: string
+  boreholeId: string
+  resolved: ResolvedParameter[]
+  /** Parameters with no evidence at all. Absent, not defaulted. */
+  absent: ParameterKey[]
+  notes: string[]
+}
+
+/** Rank of a provenance kind in the evidence hierarchy. Lower wins. */
+const RANK: Record<Provenance['kind'], number> = {
+  assumed: 0,      // an engineer's stated decision
+  measured: 1,
+  derived: 2,
+  correlated: 3,
+}
+
+/** Samples attributed to this layer, or falling inside its depth range. */
+export function samplesInLayer(bh: Borehole, layer: SoilLayer): Sample[] {
+  return bh.samples.filter((s) =>
+    s.layerId === layer.id
+    || (s.layerId == null && s.depthTop >= layer.depthTop && s.depthTop < layer.depthBottom))
+}
+
+/**
+ * Resolve every parameter this module can currently produce for one layer.
+ *
+ * Candidates are gathered from all sources, ranked, and the winner reported
+ * with the rest kept as `alternatives` — so a report can show that a
+ * correlated φ′ of 34° sat alongside a measured 31° and say which was used.
+ */
+export function resolveParameters(i: ResolveInput): ParameterResolution {
+  const { borehole: bh, layer } = i
+  const notes: string[] = []
+  const candidates = new Map<ParameterKey, SourcedValue[]>()
+
+  const add = (key: ParameterKey, v: SourcedValue) => {
+    const list = candidates.get(key) ?? []
+    list.push(v)
+    candidates.set(key, list)
+  }
+
+  const samples = samplesInLayer(bh, layer)
+  const family = soilFamily(layer.symbol, layer.name)
+  const cohesive = isCohesive(family)
+
+  // ── 1. Laboratory measurements ──
+  for (const s of samples) {
+    // Specific gravity.
+    const gsTest = governingTest(s, 'specific-gravity').test
+    if (gsTest) {
+      const { outcome } = evaluateTest(gsTest)
+      if (outcome?.kind === 'specific-gravity') {
+        add('specificGravity', measured(outcome.result.gs, '—', {
+          testId: gsTest.id, standard: 'd854', sampleId: s.name,
+        }))
+      }
+    }
+
+    // Direct shear → c′ and φ′ (effective, drained).
+    const dsTest = governingTest(s, 'direct-shear').test
+    if (dsTest) {
+      const { outcome } = evaluateTest(dsTest)
+      if (outcome?.kind === 'direct-shear') {
+        const e = outcome.result.peak
+        add('effectiveCohesion', measured(e.cohesion, 'kPa', {
+          testId: dsTest.id, standard: 'd3080', sampleId: s.name,
+        }, `fitted over ${outcome.result.stressRange.min.toFixed(0)}–${outcome.result.stressRange.max.toFixed(0)} kPa`))
+        add('effectiveFrictionAngle', measured(e.frictionAngle, '°', {
+          testId: dsTest.id, standard: 'd3080', sampleId: s.name,
+        }, e.refittedThroughOrigin ? 'envelope refitted through the origin' : undefined))
+      }
+    }
+
+    // UCS → cu, when the φ = 0 assumption holds.
+    const ucsTest = governingTest(s, 'ucs').test
+    if (ucsTest) {
+      const { outcome } = evaluateTest(ucsTest)
+      if (outcome?.kind === 'ucs') {
+        if (outcome.result.cu != null) {
+          add('undrainedShearStrength', measured(outcome.result.cu, 'kPa', {
+            testId: ucsTest.id, standard: 'd2166', sampleId: s.name,
+          }, 'cu = qu/2; a lower bound, since sampling only weakens a specimen'))
+        } else if (outcome.result.cuDeclined) {
+          notes.push(`UCS on ${s.name} does not give cu: ${outcome.result.cuDeclined}`)
+        }
+      }
+    }
+  }
+
+  // ── 2. Derived ──
+  const gs = best(candidates.get('specificGravity'))
+  const uw = i.unitWeights[layer.id]
+  if (gs && uw?.gamma != null) {
+    // Void ratio needs the DRY unit weight. Without a water content we cannot
+    // get it from the bulk value, so this only fires when one was supplied.
+    const dry = uw.gamma
+    try {
+      const e = voidRatio(gs.value, dry)
+      if (e > 0) {
+        add('voidRatio', derived(e, '—', {
+          calculation: 'consolidation.void-ratio',
+          from: [`Gs = ${gs.value.toFixed(3)}`, `γd = ${dry.toFixed(1)} kN/m³`],
+        }, 'assumes the entered unit weight is the DRY value'))
+      }
+    } catch { /* a non-physical combination simply yields no candidate */ }
+  }
+
+  // ── 3. SPT correlations ──
+  const profile = sptProfile(bh, i.unitWeights)
+  const inLayer = profile.rows.filter((r) => r.layerId === layer.id && !r.refusal)
+
+  if (inLayer.length) {
+    const n160s = inLayer.map((r) => r.n160).filter((v): v is number => v != null)
+    const n60s = inLayer.map((r) => r.n60)
+
+    if (n160s.length && !cohesive) {
+      const mean = n160s.reduce((a, b) => a + b, 0) / n160s.length
+      const phi = correlatePhi(mean, family === 'sand' ? 'clean-sand' : 'silty-sand')
+      if (phi.value) {
+        add('effectiveFrictionAngle', {
+          ...phi.value,
+          note: `${phi.value.note ? `${phi.value.note} ` : ''}mean of ${n160s.length} tests in this layer`,
+        })
+      }
+      const dr = correlateRelativeDensity(mean, 'clean-sand')
+      if (dr.value) add('relativeDensity', dr.value)
+    } else if (n160s.length && cohesive) {
+      notes.push('SPT correlations for φ′ and relative density were not applied — this layer is cohesive.')
+    }
+
+    if (cohesive && n60s.length) {
+      const mean = n60s.reduce((a, b) => a + b, 0) / n60s.length
+      const cu = correlateUndrainedStrength(mean, 'clay')
+      if (cu.value) add('undrainedShearStrength', cu.value)
+    }
+  }
+
+  const refused = profile.rows.filter((r) => r.layerId === layer.id && r.refusal).length
+  if (refused) {
+    notes.push(`${refused} SPT result(s) in this layer hit refusal and were excluded from the correlations — a lower bound is not a measurement.`)
+  }
+
+  // ── 4. Engineer overrides — applied last, ranked first ──
+  for (const [key, o] of Object.entries(i.overrides ?? {}) as [ParameterKey, ParameterOverride][]) {
+    if (!o?.rationale?.trim()) {
+      notes.push(`The override of ${PARAMETER_LABEL[key] ?? key} has no stated rationale and was ignored — an override without a reason is indistinguishable from a typing error.`)
+      continue
+    }
+    add(key, {
+      value: o.value,
+      unit: o.unit,
+      provenance: { kind: 'assumed', by: o.by, rationale: o.rationale.trim() },
+    })
+  }
+
+  // ── Resolve ──
+  const resolved: ResolvedParameter[] = []
+  for (const [key, list] of candidates) {
+    const sorted = [...list].sort((a, b) => RANK[a.provenance.kind] - RANK[b.provenance.kind])
+    resolved.push({ key, value: sorted[0], alternatives: sorted.slice(1) })
+  }
+  resolved.sort((a, b) => a.key.localeCompare(b.key))
+
+  const ALL: ParameterKey[] = [
+    'unitWeight', 'dryUnitWeight', 'saturatedUnitWeight',
+    'cohesion', 'frictionAngle', 'effectiveCohesion', 'effectiveFrictionAngle',
+    'undrainedShearStrength', 'specificGravity', 'voidRatio', 'relativeDensity',
+  ]
+  const absent = ALL.filter((k) => !candidates.has(k))
+
+  // The disagreement worth surfacing: a correlation that contradicts a test.
+  for (const r of resolved) {
+    const meas = r.value.provenance.kind === 'measured' ? r.value : undefined
+    const corr = r.alternatives.find((a) => a.provenance.kind === 'correlated')
+    if (meas && corr) {
+      const diff = Math.abs(corr.value - meas.value)
+      const rel = meas.value !== 0 ? diff / Math.abs(meas.value) : Infinity
+      if (rel > 0.15) {
+        notes.push(
+          `${PARAMETER_LABEL[r.key]}: the measured value is ${meas.value.toFixed(1)} ${meas.unit} but the correlation gives ${corr.value.toFixed(0)}. The measurement was used. A gap this wide is worth explaining in the report rather than leaving for a reader to notice.`,
+        )
+      }
+    }
+  }
+
+  return { layerId: layer.id, boreholeId: bh.id, resolved, absent, notes }
+}
+
+const best = (list: SourcedValue[] | undefined): SourcedValue | undefined =>
+  list?.length ? [...list].sort((a, b) => RANK[a.provenance.kind] - RANK[b.provenance.kind])[0] : undefined
+
+/** Shape the resolution into the `LayerParameters` the schema stores. */
+export function toLayerParameters(r: ParameterResolution): LayerParameters {
+  const out: LayerParameters = { layerId: r.layerId, boreholeId: r.boreholeId }
+  for (const p of r.resolved) {
+    (out as unknown as Record<string, SourcedValue>)[p.key] = p.value
+  }
+  return out
+}
+
+/**
+ * The parameters a bearing-capacity check needs, in the units that engine
+ * takes. Returns what is available and names what is not — the calculation
+ * belongs to `engine/geotech`, not here.
+ */
+export interface BearingInputs {
+  c?: number
+  phiDeg?: number
+  gamma?: number
+  missing: ParameterKey[]
+}
+
+export function bearingInputs(r: ParameterResolution, unitWeight?: number): BearingInputs {
+  const get = (k: ParameterKey) => r.resolved.find((p) => p.key === k)?.value.value
+  const c = get('effectiveCohesion') ?? get('cohesion')
+  const phiDeg = get('effectiveFrictionAngle') ?? get('frictionAngle')
+  const gamma = unitWeight ?? get('unitWeight')
+
+  const missing: ParameterKey[] = []
+  if (c == null) missing.push('effectiveCohesion')
+  if (phiDeg == null) missing.push('effectiveFrictionAngle')
+  if (gamma == null) missing.push('unitWeight')
+
+  return { c, phiDeg, gamma, missing }
+}

--- a/webapp/src/pages/SoilInvestigation.tsx
+++ b/webapp/src/pages/SoilInvestigation.tsx
@@ -14,6 +14,8 @@ import {
   LAB_TESTS, labSpec, isImplemented, evaluateTest, summarise,
 } from '../engine/soils/lab'
 import { classifySample } from '../engine/soils/classifySample'
+import { resolveParameters, bearingInputs, PARAMETER_LABEL } from '../engine/soils/parameters'
+import { describeProvenance, PROVENANCE_LABEL, type SourcedValue } from '../engine/soils/provenance'
 import { cite } from '../engine/soils/standards'
 
 const f2 = (n: number | undefined) => (n == null || !Number.isFinite(n) ? '—' : n.toFixed(2))
@@ -127,7 +129,7 @@ function describeN60(n60: number, layer: SoilLayer | undefined): string {
 
 // ── Page ──────────────────────────────────────────────────────────────────
 
-type Tab = 'overview' | 'boreholes' | 'profile' | 'spt' | 'lab' | 'classification'
+type Tab = 'overview' | 'boreholes' | 'profile' | 'spt' | 'lab' | 'classification' | 'parameters'
 
 export default function SoilInvestigation() {
   const api = useInvestigation()
@@ -244,7 +246,7 @@ export default function SoilInvestigation() {
       )}
 
       <nav className="mt-6 flex flex-wrap gap-1 border-b border-slate-200">
-        {(['overview', 'boreholes', 'profile', 'spt', 'lab', 'classification'] as Tab[]).map((t) => (
+        {(['overview', 'boreholes', 'profile', 'spt', 'lab', 'parameters', 'classification'] as Tab[]).map((t) => (
           <button key={t} onClick={() => setTab(t)}
             className={`rounded-t-md px-3 py-1.5 text-[13px] font-medium capitalize ${
               tab === t ? 'border-b-2 border-[#0056b3] text-[#0056b3]' : 'text-slate-600 hover:text-slate-900'
@@ -600,6 +602,12 @@ export default function SoilInvestigation() {
               sample.tests = sample.tests.filter((x) => x.id !== testId)
             })}
           />
+        </section>
+      )}
+
+      {tab === 'parameters' && bh && (
+        <section className="mt-5">
+          <ParametersPanel bh={bh} unitWeights={unitWeights} />
         </section>
       )}
 
@@ -1089,6 +1097,139 @@ function ShearPoints({
         className="mt-1 rounded border border-dashed border-slate-300 px-2 py-0.5 text-[10px] text-slate-600 hover:bg-slate-50">
         + specimen
       </button>
+    </div>
+  )
+}
+
+// ── Design parameters ─────────────────────────────────────────────────────
+
+const PROVENANCE_STYLE: Record<string, string> = {
+  measured: 'bg-emerald-100 text-emerald-800',
+  derived: 'bg-sky-100 text-sky-800',
+  correlated: 'bg-amber-100 text-amber-900',
+  assumed: 'bg-violet-100 text-violet-800',
+}
+
+/**
+ * A parameter printed to the precision its SOURCE supports.
+ *
+ * A correlated friction angle carries roughly ±3° of scatter — the registry
+ * entry says so in as many words — so printing "46.6°" claims a precision the
+ * relation does not have and invites a reader to treat it like a measurement.
+ * Correlations are shown whole; measurements keep a decimal.
+ */
+function formatParameter(v: SourcedValue): string {
+  if (v.unit === '—' || v.unit === '') return v.value.toFixed(3)
+  const dp = v.provenance.kind === 'correlated' ? 0 : 1
+  return `${v.value.toFixed(dp)} ${v.unit}`
+}
+
+
+function ParametersPanel({
+  bh, unitWeights,
+}: { bh: Borehole; unitWeights: Record<string, LayerUnitWeight> }) {
+  const resolutions = useMemo(
+    () => bh.layers.map((layer) => ({
+      layer,
+      r: resolveParameters({ borehole: bh, layer, unitWeights }),
+    })),
+    [bh, unitWeights],
+  )
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Design parameters</h2>
+        <p className="text-[11px] text-slate-500">
+          Resolved once per layer from every piece of evidence available, each carrying where it came from. A stated
+          engineer override beats a measurement, a measurement beats a correlation, and a parameter with no evidence
+          at all stays <strong>absent</strong> — it is never filled in with a textbook value, because a number that
+          looks measured but is not is the failure this module exists to prevent.
+        </p>
+        <div className="mt-3 flex flex-wrap gap-2 text-[10px]">
+          {(['measured', 'derived', 'correlated', 'assumed'] as const).map((k) => (
+            <span key={k} className={`rounded px-1.5 py-0.5 font-semibold ${PROVENANCE_STYLE[k]}`}>
+              {PROVENANCE_LABEL[k]}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {resolutions.map(({ layer, r }) => {
+        const bearing = bearingInputs(r, unitWeights[layer.id]?.gamma)
+        return (
+          <div key={layer.id} className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <div className="mb-3 flex flex-wrap items-baseline justify-between gap-2">
+              <h3 className="text-[1rem] font-bold text-[#0056b3]">
+                {layer.name}
+                <span className="ml-2 font-mono text-[12px] font-normal text-slate-500">
+                  {f2(layer.depthTop)}–{f2(layer.depthBottom)} m{layer.symbol ? ` · ${layer.symbol}` : ''}
+                </span>
+              </h3>
+            </div>
+
+            {r.resolved.length ? (
+              <div className="overflow-x-auto">
+                <table className="w-full text-left text-[12px]">
+                  <thead className="text-slate-500">
+                    <tr className="border-b border-slate-200">
+                      <th className="py-1 pr-3">Parameter</th>
+                      <th className="py-1 pr-3 text-right">Value</th>
+                      <th className="py-1 pr-3">Source</th>
+                      <th className="py-1 pr-3">Basis</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {r.resolved.map((p) => (
+                      <tr key={p.key} className="border-b border-slate-100 align-top">
+                        <td className="py-1 pr-3">{PARAMETER_LABEL[p.key] ?? p.key}</td>
+                        <td className="py-1 pr-3 text-right font-mono font-semibold">
+                          {formatParameter(p.value)}
+                        </td>
+                        <td className="py-1 pr-3">
+                          <span className={`rounded px-1.5 py-0.5 text-[10px] font-semibold ${PROVENANCE_STYLE[p.value.provenance.kind]}`}>
+                            {PROVENANCE_LABEL[p.value.provenance.kind]}
+                          </span>
+                        </td>
+                        <td className="py-1 pr-3 text-[11px] text-slate-600">
+                          {describeProvenance(p.value.provenance)}
+                          {p.value.note && <span className="block text-slate-500">{p.value.note}</span>}
+                          {p.alternatives.length > 0 && (
+                            <span className="mt-0.5 block text-[10px] text-slate-500">
+                              Also available: {p.alternatives.map((a) =>
+                                `${formatParameter(a)} (${PROVENANCE_LABEL[a.provenance.kind].toLowerCase()})`,
+                              ).join(', ')}
+                            </span>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="text-[12px] text-slate-600">
+                No evidence for any parameter in this layer yet — no laboratory tests on its samples and no usable
+                field tests within it.
+              </p>
+            )}
+
+            {bearing.missing.length > 0 && (
+              <p className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[11px] text-amber-900">
+                A bearing-capacity check on this layer still needs:{' '}
+                <strong>{bearing.missing.map((k) => PARAMETER_LABEL[k] ?? k).join(', ')}</strong>. Nothing has been
+                assumed on your behalf.
+              </p>
+            )}
+
+            {r.notes.map((n, k) => (
+              <p key={k} className="mt-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-[11px] text-slate-700">
+                {n}
+              </p>
+            ))}
+          </div>
+        )
+      })}
     </div>
   )
 }


### PR DESCRIPTION
**This is the phase the rest of the module exists for.** Everything before it records data; this turns the record into the γ, c′, φ′ and cu that the bearing, settlement, slope and pile engines already take — interpreted **once**, with the source attached, instead of retyped on five pages with no trail back to a test. **22 new tests.**

I jumped here ahead of the remaining lab tests (compaction, triaxial, consolidation, permeability, CBR) because five phases of data entry only become worth anything once something consumes them. Those follow.

## The resolution order is a hierarchy of evidence

```
engineer override → measured → derived → correlated → absent
```

**There is no step after absent.** A parameter with no evidence is *not* defaulted to a textbook value — an analysis running on invented numbers that look like measurements is precisely the failure this module was built to prevent. The caller gets `undefined`, and `bearingInputs` **names what's missing** rather than handing the geotech engine a plausible number.

The order is not a quality ranking. A well-run correlation over twenty SPT points can beat one UU triaxial on a disturbed sample, and the engineer can override in either direction. What it guarantees is that nothing *silently* outranks a direct measurement. Displaced candidates are kept as `alternatives`, so the sheet shows that a correlated φ′ of 36° sat beside the measured 30° that was used.

## Three refusals

- **An override with no rationale is ignored**, and says why. Six months on it would be indistinguishable from a typing error.
- **A sand correlation is not applied to a cohesive layer** — and the family comes from the group symbol when the description disagrees with it.
- **Refusal blow counts are excluded from correlations**, with a count, because a lower bound is not a measurement.

It also surfaces the disagreement worth explaining: when a correlation differs from a measurement by more than 15%, the note says so rather than leaving a reader to spot it.

## UI

A **Parameters** tab: per-layer table with value, colour-coded source badge, and the basis in words — plus what a bearing check still needs from that layer.

## Three inconsistencies the rendered page caught

1. **Correlated values printed to a decimal place** — which flatly contradicts the registry entry I wrote in Phase 0 saying a correlated φ′ carries ±3° and *"should never be quoted to a decimal place"*. Correlations now print whole; measurements keep a decimal.
2. **Provenance named the raw sample id** (`bh1-s1`) rather than `S-01`.
3. **Structural:** the parameter labels lived in the page while the engine wrote notes naming the same parameters — so a note read `effectiveFrictionAngle: the measured value is…`. `PARAMETER_LABEL` now lives in the engine and both read it.

That third one is the same one-rule-one-home lesson as `soilFamily`, for the third time in this module. I'm now treating "the engine and the page both name this thing" as a signal to put the naming in the engine by default.

## Verification

`npm test` — **2595 passed / 169 files** · `npx tsc -b` · `npm run lint` · `npm run build` all green.

In headless Chromium:
- with no unit weights, three layers show **no evidence** and four bearing notices say **nothing was assumed**
- entering unit weights brings the SPT correlations alive — φ′ 36°, Dr 47%, cu 21 kPa — with the clay correctly **refusing** φ′ and relative density
- adding a direct shear flips φ′ to **30.0° Measured** with *"Also available: 36° (correlated)"*, and raises the disagreement note

Console clean.

## Honest limits

- **Nothing is written back to the investigation yet.** `toLayerParameters` produces the stored shape but the UI doesn't persist it — resolution is recomputed on view. That's fine while it's cheap and keeps a stale copy from existing, but it means the parameters aren't in the exported JSON.
- **The analysis pages still don't read this.** `bearingInputs` exists and is tested, but `/geotech`, `/settlement` and `/slope` are untouched. That wiring is Phase 5b and is the actual user-visible payoff.
- **Unit weight is never resolved, only passed through.** It comes from the SPT tab's page state, so it has no provenance — which is conspicuous in a table whose whole point is provenance. It needs a field-density or a derivation from Gs and water content.
- **Overrides have no UI.** The engine takes them and tests them; there's no way to enter one yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_