### PR TITLE
Soil investigation Phase 5b — parameters wired into the analysis pages

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1330,9 +1330,9 @@ because flagging the unusual as an error trains people to ignore errors.
 | 4a — lab plumbing + index tests (moisture, Gs) | #481 | merged |
 | 4b — sieve + Atterberg wired, sample classification | #482 | merged |
 | 4c — direct shear + UCS | #483 | merged |
-| 5 — parameter engine (resolution + provenance) | — | open |
+| 5 — parameter engine (resolution + provenance) | #484 | merged |
+| 5b — parameters wired into bearing capacity and slope | — | open |
 | 4d… — compaction, triaxial, consolidation, permeability, CBR | — | |
-| 5b — wire parameters into the existing analysis pages | — | |
 | 6 — liquefaction, bearing methods, Coulomb | — | |
 | 7 — report document builder | — | |
 | 8 — Postgres, CPT, 3D subsurface | — | |

--- a/webapp/src/components/SoilLayerPicker.tsx
+++ b/webapp/src/components/SoilLayerPicker.tsx
@@ -1,0 +1,238 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { createStore, defaultBackend } from '../engine/soils/store'
+import { resolveParameters, PARAMETER_LABEL, type ParameterKey } from '../engine/soils/parameters'
+import { PROVENANCE_LABEL, describeProvenance, type SourcedValue } from '../engine/soils/provenance'
+import type { Investigation, Borehole, SoilLayer } from '../engine/soils/model'
+import { layerThickness } from '../engine/soils/model'
+import type { LayerUnitWeight } from '../engine/soils/sptProfile'
+
+// ─────────────────────────────────────────────────────────────────────────
+// Pull γ, c′ and φ′ for a calculator from a saved soil investigation.
+//
+// The point of the whole soils module in one component: a soil property is
+// interpreted once, on /soils, and read here — instead of being retyped on the
+// bearing, slope and pile pages with no trail back to the test it came from.
+//
+// IT NEVER FILLS IN WHAT IT DOES NOT HAVE. A layer with no evidence for φ′
+// offers no φ′, and the panel says which test would supply it. Silently
+// leaving the page's existing default in place while announcing "applied from
+// BH-01" would be worse than not offering the layer at all, so applied fields
+// are listed explicitly and the rest are left untouched.
+//
+// Read-only: it never writes to the investigation.
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface SoilParameterFill {
+  /** Effective cohesion c′, kPa. */
+  c?: number
+  /** Effective friction angle φ′, degrees. */
+  phiDeg?: number
+  /** Bulk unit weight γ, kN/m³. */
+  gamma?: number
+  /** Saturated unit weight, kN/m³. */
+  gammaSat?: number
+  /** Undrained shear strength cu, kPa. */
+  cu?: number
+}
+
+const PROVENANCE_STYLE: Record<string, string> = {
+  measured: 'bg-emerald-100 text-emerald-800',
+  derived: 'bg-sky-100 text-sky-800',
+  correlated: 'bg-amber-100 text-amber-900',
+  assumed: 'bg-violet-100 text-violet-800',
+}
+
+/**
+ * Decimal places a value's SOURCE supports. A correlation carries several
+ * degrees of scatter and is shown whole; a measurement keeps one.
+ */
+const dpFor = (v: SourcedValue): number =>
+  v.unit === '—' || v.unit === '' ? 3 : v.provenance.kind === 'correlated' ? 0 : 1
+
+/**
+ * The number to APPLY — rounded exactly as it is displayed.
+ *
+ * Without this the panel showed "20.0 kPa" and put 20.004999999999995 into the
+ * field, which is both ugly and a small lie: the two numbers a user sees should
+ * be the same number.
+ */
+const applyValue = (v: SourcedValue): number =>
+  Number(v.value.toFixed(dpFor(v)))
+
+/** Print to the precision the source supports. */
+const fmt = (v: SourcedValue): string =>
+  v.unit === '—' || v.unit === ''
+    ? v.value.toFixed(3)
+    : `${v.value.toFixed(dpFor(v))} ${v.unit}`
+
+/** Which of the picker's outputs a caller actually wants. */
+export type WantedParameter = keyof SoilParameterFill
+
+export function SoilLayerPicker({
+  want, onApply, title = 'Use a layer from a soil investigation',
+}: {
+  want: WantedParameter[]
+  onApply: (fill: SoilParameterFill) => void
+  title?: string
+}) {
+  const store = useMemo(() => createStore(defaultBackend()), [])
+  const [open, setOpen] = useState(false)
+  const [applied, setApplied] = useState<string | null>(null)
+
+  const investigations = useMemo(() => (open ? store.list() : []), [store, open])
+  const [id, setId] = useState<string | null>(null)
+  const inv: Investigation | null = useMemo(
+    () => (id ? store.load(id) : null), [store, id],
+  )
+
+  // Auto-select the only (or most recent) investigation when the panel opens.
+  const activeId = id ?? investigations[0]?.id ?? null
+  const active = inv ?? (activeId ? store.load(activeId) : null)
+
+  const rows = useMemo(() => {
+    if (!active) return []
+    const out: { bh: Borehole; layer: SoilLayer; fill: SoilParameterFill; resolved: { key: ParameterKey; value: SourcedValue }[]; missing: WantedParameter[] }[] = []
+    for (const bh of active.boreholes) {
+      for (const layer of bh.layers) {
+        const stored = active.parameters.find((p) => p.layerId === layer.id)
+        // Unit weights for the stress profile come from whatever was stored;
+        // this component does not invent them.
+        const unitWeights: Record<string, LayerUnitWeight> = {}
+        for (const l of bh.layers) {
+          const sp = active.parameters.find((p) => p.layerId === l.id)
+          const g = sp?.unitWeight?.value
+          if (g != null) unitWeights[l.id] = { gamma: g, gammaSat: sp?.saturatedUnitWeight?.value }
+        }
+
+        const r = resolveParameters({ borehole: bh, layer, unitWeights, stored })
+        const get = (k: ParameterKey) => r.resolved.find((p) => p.key === k)?.value
+
+        const pick = (...keys: ParameterKey[]) => {
+          for (const k of keys) { const v = get(k); if (v) return applyValue(v) }
+          return undefined
+        }
+        const fill: SoilParameterFill = {
+          c: pick('effectiveCohesion', 'cohesion'),
+          phiDeg: pick('effectiveFrictionAngle', 'frictionAngle'),
+          gamma: pick('unitWeight'),
+          gammaSat: pick('saturatedUnitWeight'),
+          cu: pick('undrainedShearStrength'),
+        }
+        const missing = want.filter((w) => fill[w] == null)
+        out.push({
+          bh, layer, fill, missing,
+          resolved: r.resolved.filter((p) => want.some((w) => WANT_KEYS[w].includes(p.key)))
+            .map((p) => ({ key: p.key, value: p.value })),
+        })
+      }
+    }
+    return out
+  }, [active, want])
+
+  if (!open) {
+    return (
+      <div className="flex flex-wrap items-center gap-2">
+        <button onClick={() => setOpen(true)}
+          className="rounded-md border border-slate-300 px-2.5 py-1 text-[12px] font-medium text-slate-700 hover:bg-slate-50">
+          {title}
+        </button>
+        {applied && (
+          <span className="text-[11px] text-emerald-700">Applied from {applied}.</span>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-[13px] font-bold text-[#0056b3]">{title}</h3>
+        <button onClick={() => setOpen(false)}
+          className="rounded px-1.5 py-0.5 text-[11px] text-slate-600 hover:bg-slate-200">close</button>
+      </div>
+
+      {!investigations.length ? (
+        <p className="text-[12px] text-slate-600">
+          No saved investigations in this browser.{' '}
+          <Link to="/soils" className="font-medium text-[#0056b3] underline">Create one</Link> to enter boreholes,
+          laboratory tests and parameters once and reuse them here.
+        </p>
+      ) : (
+        <>
+          {investigations.length > 1 && (
+            <select value={activeId ?? ''} onChange={(e) => setId(e.target.value)}
+              className="mb-2 rounded-md border border-slate-300 px-2 py-1 text-[12px]">
+              {investigations.map((s) => (
+                <option key={s.id} value={s.id}>{s.investigationNo || s.title}</option>
+              ))}
+            </select>
+          )}
+
+          {!rows.length && (
+            <p className="text-[12px] text-slate-600">That investigation has no logged layers yet.</p>
+          )}
+
+          <div className="space-y-2">
+            {rows.map(({ bh, layer, fill, resolved, missing }) => (
+              <div key={`${bh.id}-${layer.id}`} className="rounded-lg border border-slate-200 bg-white p-2.5">
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <span className="text-[12px] font-semibold text-slate-800">
+                    {bh.name} · {layer.name}
+                    <span className="ml-1.5 font-mono text-[10px] font-normal text-slate-500">
+                      {layer.depthTop.toFixed(2)}–{layer.depthBottom.toFixed(2)} m
+                      {layer.symbol ? ` · ${layer.symbol}` : ''}
+                      {` · ${layerThickness(layer).toFixed(2)} m thick`}
+                    </span>
+                  </span>
+                  <button
+                    disabled={!resolved.length}
+                    onClick={() => { onApply(fill); setApplied(`${bh.name} · ${layer.name}`); setOpen(false) }}
+                    className={`rounded-md px-2 py-0.5 text-[11px] font-semibold ${
+                      resolved.length
+                        ? 'bg-[#0056b3] text-white hover:bg-[#004a99]'
+                        : 'cursor-not-allowed bg-slate-200 text-slate-500'
+                    }`}>
+                    {resolved.length ? 'Use this layer' : 'nothing to apply'}
+                  </button>
+                </div>
+
+                {resolved.length > 0 && (
+                  <ul className="mt-1.5 space-y-0.5">
+                    {resolved.map((p) => (
+                      <li key={p.key} className="flex flex-wrap items-baseline gap-1.5 text-[11px]">
+                        <span className="text-slate-600">{PARAMETER_LABEL[p.key]}</span>
+                        <span className="font-mono font-semibold text-slate-800">{fmt(p.value)}</span>
+                        <span className={`rounded px-1 text-[9px] font-semibold ${PROVENANCE_STYLE[p.value.provenance.kind]}`}>
+                          {PROVENANCE_LABEL[p.value.provenance.kind]}
+                        </span>
+                        <span className="text-[10px] text-slate-500">{describeProvenance(p.value.provenance)}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+
+                {missing.length > 0 && (
+                  <p className="mt-1 text-[10px] text-amber-800">
+                    Not available for this layer: {missing.join(', ')}. Those fields are left as you have them —
+                    nothing is filled in that the investigation cannot support.
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+    </div>
+  )
+}
+
+/** Which resolved parameters back each requested field. */
+const WANT_KEYS: Record<WantedParameter, ParameterKey[]> = {
+  c: ['effectiveCohesion', 'cohesion'],
+  phiDeg: ['effectiveFrictionAngle', 'frictionAngle'],
+  gamma: ['unitWeight'],
+  gammaSat: ['saturatedUnitWeight'],
+  cu: ['undrainedShearStrength'],
+}

--- a/webapp/src/engine/soils/parameters.ts
+++ b/webapp/src/engine/soils/parameters.ts
@@ -54,6 +54,13 @@ export interface ResolveInput {
   layer: SoilLayer
   /** Unit weights per layer id, for the effective-stress profile. */
   unitWeights: Record<string, LayerUnitWeight>
+  /**
+   * Parameters already stored on the investigation for this layer. Each keeps
+   * the provenance it was saved with, so a unit weight the engineer typed
+   * enters the hierarchy as an ASSUMPTION rather than as a bare number with no
+   * source — which is what it is.
+   */
+  stored?: LayerParameters
   /** Engineer overrides, keyed by parameter name. */
   overrides?: Partial<Record<ParameterKey, ParameterOverride>>
 }
@@ -136,6 +143,14 @@ export function resolveParameters(i: ResolveInput): ParameterResolution {
   const samples = samplesInLayer(bh, layer)
   const family = soilFamily(layer.symbol, layer.name)
   const cohesive = isCohesive(family)
+
+  // ── 0. Stored parameters, each keeping the provenance it was saved with ──
+  if (i.stored) {
+    const { layerId: _l, boreholeId: _b, ...rest } = i.stored
+    for (const [key, v] of Object.entries(rest)) {
+      if (v && typeof v === 'object' && 'value' in v) add(key as ParameterKey, v as SourcedValue)
+    }
+  }
 
   // ── 1. Laboratory measurements ──
   for (const s of samples) {

--- a/webapp/src/pages/Geotech.tsx
+++ b/webapp/src/pages/Geotech.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { activeThrust, passiveThrust, bearingCapacity, infiniteSlopeFS, type FootingShape } from '../engine/geotech'
 import { ReportControls } from '../components/ReportControls'
+import { SoilLayerPicker } from '../components/SoilLayerPicker'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 
@@ -74,6 +75,15 @@ function Bearing() {
   const r = bearingCapacity({ c, phiDeg: phi, gamma, B, Df, shape, FS })
   return (
     <Card title="Bearing capacity — Terzaghi/Meyerhof (Vesić Nγ)" sub="qult = c·Nc·sc + q·Nq + ½·γ·B·Nγ·sγ,  q = γ·Df.">
+      <div className="mb-3">
+        <SoilLayerPicker
+          want={['c', 'phiDeg', 'gamma']}
+          onApply={(f) => {
+            if (f.c != null) setC(f.c)
+            if (f.phiDeg != null) setPhi(f.phiDeg)
+            if (f.gamma != null) setGamma(f.gamma)
+          }} />
+      </div>
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
         <Field label="Cohesion c" unit="kPa" value={c} onChange={setC} />
         <Field label="φ" unit="°" value={phi} onChange={setPhi} />
@@ -112,6 +122,16 @@ function Slope() {
   const fs = infiniteSlopeFS({ c, phiDeg: phi, gamma, z, betaDeg: beta, seepage, gammaSat })
   return (
     <Card title="Slope stability — infinite slope" sub="Planar failure at depth z; optional seepage parallel to the slope.">
+      <div className="mb-3">
+        <SoilLayerPicker
+          want={['c', 'phiDeg', 'gamma', 'gammaSat']}
+          onApply={(f) => {
+            if (f.c != null) setC(f.c)
+            if (f.phiDeg != null) setPhi(f.phiDeg)
+            if (f.gamma != null) setGamma(f.gamma)
+            if (f.gammaSat != null) setGammaSat(f.gammaSat)
+          }} />
+      </div>
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
         <Field label="Cohesion c" unit="kPa" value={c} onChange={setC} />
         <Field label="φ" unit="°" value={phi} onChange={setPhi} />

--- a/webapp/src/pages/SlopeStability.tsx
+++ b/webapp/src/pages/SlopeStability.tsx
@@ -5,6 +5,7 @@ import {
   type Pt, type SlopeSoil, type WaterModel, type CircleResult,
 } from '../engine/slopeStability'
 import { buildSlopeSolution } from '../lib/slopeSolution'
+import { SoilLayerPicker } from '../components/SoilLayerPicker'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -159,7 +160,17 @@ export default function SlopeStability() {
         Janbu&rsquo;s simplified — with a grid search for the critical (minimum-FS) circle. Pore pressure via ru.
       </p>
 
-      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+      <section className="mt-6">
+        <SoilLayerPicker
+          want={['c', 'phiDeg', 'gamma']}
+          onApply={(f) => {
+            if (f.c != null) setC(f.c)
+            if (f.phiDeg != null) setPhi(f.phiDeg)
+            if (f.gamma != null) setGamma(f.gamma)
+          }} />
+      </section>
+
+      <section className="mt-4 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
         <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Slope geometry</h2>
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           <Field label="Height H" unit="m" value={H} onChange={setH} />

--- a/webapp/src/pages/SoilInvestigation.tsx
+++ b/webapp/src/pages/SoilInvestigation.tsx
@@ -9,6 +9,7 @@ import { densityFromN60, consistencyFromN60 } from '../engine/soils/spt'
 import {
   layerThickness, recoveryRatio, soilFamily, isCohesive,
   type Borehole, type SoilLayer, type Sample, type LabTest, type LabTestType, type LabTestStatus,
+  type LayerParameters,
 } from '../engine/soils/model'
 import {
   LAB_TESTS, labSpec, isImplemented, evaluateTest, summarise,
@@ -141,11 +142,39 @@ export default function SoilInvestigation() {
   const issues = useMemo(() => (inv ? validateInvestigation(inv) : []), [inv])
   const bh: Borehole | undefined = inv?.boreholes[holeIdx]
 
-  // Unit weights entered per layer for the stress profile. They are an
-  // INTERPRETATION, not data, so they live in page state rather than in the
-  // stored investigation until the Phase 5 parameter engine gives them a home
-  // with provenance attached.
-  const [unitWeights, setUnitWeights] = useState<Record<string, LayerUnitWeight>>({})
+  // Unit weights are stored on the investigation as ASSUMED values with a
+  // rationale, not held in page state. They are an interpretation, which is
+  // exactly what `assumed` provenance is for — and storing them is what lets
+  // the analysis pages read a layer through SoilLayerPicker without the number
+  // arriving from nowhere.
+  const unitWeights: Record<string, LayerUnitWeight> = useMemo(() => {
+    const out: Record<string, LayerUnitWeight> = {}
+    for (const p of inv?.parameters ?? []) {
+      const g = p.unitWeight?.value
+      if (g != null) out[p.layerId] = { gamma: g, gammaSat: p.saturatedUnitWeight?.value }
+    }
+    return out
+  }, [inv])
+
+  const setUnitWeight = (layerId: string, key: 'gamma' | 'gammaSat', value: number) => api.update((d) => {
+    const bhId = d.boreholes[holeIdx]?.id
+    if (!bhId) return
+    let entry = d.parameters.find((p) => p.layerId === layerId)
+    if (!entry) {
+      entry = { layerId, boreholeId: bhId }
+      d.parameters.push(entry)
+    }
+    const field = key === 'gamma' ? 'unitWeight' : 'saturatedUnitWeight'
+    entry[field] = {
+      value, unit: 'kN/m³',
+      provenance: {
+        kind: 'assumed',
+        rationale: key === 'gamma'
+          ? 'Bulk unit weight entered by the engineer for the effective-stress profile.'
+          : 'Saturated unit weight entered by the engineer for the effective-stress profile.',
+      },
+    }
+  })
 
   const profile = useMemo(
     () => (bh ? sptProfile(bh, unitWeights) : null),
@@ -470,8 +499,10 @@ export default function SoilInvestigation() {
             <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Unit weights for the stress profile</h2>
             <p className="mb-3 text-[11px] text-slate-500">
               (N₁)₆₀ needs the effective stress at each test depth, which needs a unit weight per layer. These are an
-              interpretation, so they are entered here rather than stored as data. Layers left blank stop the stress
-              profile at that depth — the blow counts below are still corrected for equipment, just not for overburden.
+              interpretation, so they are stored as ASSUMED values with that stated on them — which is also what
+              lets the bearing-capacity and slope pages read this layer without the number arriving from nowhere.
+              Layers left blank stop the stress profile at that depth; the blow counts below are still corrected for
+              equipment, just not for overburden.
             </p>
             <div className="overflow-x-auto">
               <table className="w-full text-left text-[12px]">
@@ -487,18 +518,12 @@ export default function SoilInvestigation() {
                       <td className="py-0.5 pr-3">{l.name}</td>
                       <td className="py-0.5 pr-3">
                         <input type="number" step="0.5" value={unitWeights[l.id]?.gamma ?? ''}
-                          onChange={(e) => setUnitWeights((u) => ({
-                            ...u,
-                            [l.id]: { ...u[l.id], gamma: num(e.target.value) },
-                          }))}
+                          onChange={(e) => setUnitWeight(l.id, 'gamma', num(e.target.value))}
                           className="w-20 rounded border border-slate-200 px-1 py-0.5 text-right font-mono" />
                       </td>
                       <td className="py-0.5 pr-3">
                         <input type="number" step="0.5" value={unitWeights[l.id]?.gammaSat ?? ''}
-                          onChange={(e) => setUnitWeights((u) => ({
-                            ...u,
-                            [l.id]: { gamma: u[l.id]?.gamma ?? 18, gammaSat: num(e.target.value) },
-                          }))}
+                          onChange={(e) => setUnitWeight(l.id, 'gammaSat', num(e.target.value))}
                           className="w-20 rounded border border-slate-200 px-1 py-0.5 text-right font-mono" />
                       </td>
                     </tr>
@@ -607,7 +632,7 @@ export default function SoilInvestigation() {
 
       {tab === 'parameters' && bh && (
         <section className="mt-5">
-          <ParametersPanel bh={bh} unitWeights={unitWeights} />
+          <ParametersPanel bh={bh} unitWeights={unitWeights} stored={inv.parameters} />
         </section>
       )}
 
@@ -1126,14 +1151,21 @@ function formatParameter(v: SourcedValue): string {
 
 
 function ParametersPanel({
-  bh, unitWeights,
-}: { bh: Borehole; unitWeights: Record<string, LayerUnitWeight> }) {
+  bh, unitWeights, stored,
+}: {
+  bh: Borehole
+  unitWeights: Record<string, LayerUnitWeight>
+  stored: LayerParameters[]
+}) {
   const resolutions = useMemo(
     () => bh.layers.map((layer) => ({
       layer,
-      r: resolveParameters({ borehole: bh, layer, unitWeights }),
+      r: resolveParameters({
+        borehole: bh, layer, unitWeights,
+        stored: stored.find((p) => p.layerId === layer.id),
+      }),
     })),
-    [bh, unitWeights],
+    [bh, unitWeights, stored],
   )
 
   return (


### PR DESCRIPTION
**The payoff.** A soil property is interpreted once on `/soils` and **read** by the bearing-capacity and slope calculators — instead of being retyped there with no trail back to the test it came from.

Seven phases of the soils module have been building toward this one component.

## `SoilLayerPicker`

Read-only, dropped into an analysis page. Lists every layer in a saved investigation with its resolved parameters — each showing the source badge and the basis in words — and applies the ones it has.

**It never fills in what it does not have.** A layer with no evidence for φ′ offers no φ′ and names what's missing; the page's existing value is left alone rather than being silently kept while the panel announces *"applied from BH-01"*. A layer with nothing at all gets a disabled button rather than a live one that would do nothing.

Wired into `/geotech` (bearing capacity **and** infinite slope) and the full `/slope` method-of-slices page.

## Unit weights now have provenance

They were page state — the one number in a provenance table with no provenance, which I flagged as conspicuous in #484. They're now stored on the investigation as **`assumed`** values carrying a stated rationale, which is exactly what they are.

That's also what makes the picker possible: `resolveParameters` takes stored parameters as candidates, each keeping the provenance it was saved with.

## Two defects the browser caught, both the same shape

1. **The panel displayed `20.0 kPa` and applied `20.004999999999995`.** The two numbers a user sees should be the same number. One `dpFor()` now feeds both the display and the applied value.
2. **The "Applied from…" notice lived inside the panel that closes on apply** — so it could never be seen. Dead code that looked like a feature. It now sits beside the trigger.

## Verification

`npm test` — **2595 passed / 169 files** · `npx tsc -b` · `npm run lint` · `npm run build` all green.

End to end in headless Chromium:
- with no saved investigation, the picker **says so** and links to `/soils`
- entering unit weights on `/soils` **survives a reload** — they're stored, not page state
- back on `/geotech`, the picker offers **7 layers**, shows **φ′ = 30.0° Measured — ASTM D3080 on sample S-01**, and applying it puts **c = 20, φ = 30, γ = 18** into the bearing fields with the notice showing

Console clean.

## Honest limits

- **Only three calculators read it.** `/settlement`, `/lateral-pile`, `/retaining-wall` and the footing pages still take typed numbers. The component is generic — `want={['c','phiDeg','gamma']}` — so each is a small addition, but they aren't done.
- **The applied value loses its provenance at the boundary.** Once `c = 20` is in the field it's just a number; the calculator's own PDF won't say it came from a direct shear on S-01. Carrying provenance *into the report* is a bigger change to `ReportControls` and belongs in the reporting phase.
- **No layer is remembered.** Reopening the picker doesn't preselect what you used last, and re-running the calculator later gives no hint the numbers came from an investigation at all.
- **Settlement needs consolidation parameters** (Cc, Cr, σ′p) that no engine produces yet — that's the strongest argument for doing the consolidation test next.

## Next

Phase 4d — consolidation, which unblocks wiring `/settlement`. Then compaction, triaxial, permeability, CBR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_