### PR TITLE
Soil investigation Phase 4d — consolidation

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1331,8 +1331,9 @@ because flagging the unusual as an error trains people to ignore errors.
 | 4b — sieve + Atterberg wired, sample classification | #482 | merged |
 | 4c — direct shear + UCS | #483 | merged |
 | 5 — parameter engine (resolution + provenance) | #484 | merged |
-| 5b — parameters wired into bearing capacity and slope | — | open |
-| 4d… — compaction, triaxial, consolidation, permeability, CBR | — | |
+| 5b — parameters wired into bearing capacity and slope | #485 | merged |
+| 4d — consolidation (Cc, Cr, σ′p, cv) | — | open |
+| 4e… — compaction, triaxial, permeability, CBR, hydrometer | — | |
 | 6 — liquefaction, bearing methods, Coulomb | — | |
 | 7 — report document builder | — | |
 | 8 — Postgres, CPT, 3D subsurface | — | |

--- a/webapp/src/engine/soils/lab/consolidation.test.ts
+++ b/webapp/src/engine/soils/lab/consolidation.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from 'vitest'
+import {
+  consolidation, heightOfSolids, fitBreak, overconsolidationRatio,
+  type ConsolidationData, type ConsolidationRow,
+} from './consolidation'
+
+// A 75 mm × 20 mm specimen, Gs 2.70, dry mass 79.5 g.
+// Hs = 79.5 / (2.70 × 0.001 × 4417.86) = 6.664 mm  ⇒  e0 = 20/6.664 − 1 = 2.001
+const SPECIMEN = { initialHeight: 20, diameter: 75, dryMass: 79.5, specificGravity: 2.70 }
+
+/**
+ * A curve with a deliberate break at 200 kPa: flat (Cr) below, steep (Cc)
+ * above. Void ratios are converted back to compressions so the engine has to
+ * do the work rather than being handed the answer.
+ */
+function curveWithBreak(): ConsolidationData {
+  const area = (Math.PI / 4) * SPECIMEN.diameter ** 2
+  const hs = heightOfSolids(SPECIMEN.dryMass, SPECIMEN.specificGravity, area)
+  const e0 = SPECIMEN.initialHeight / hs - 1
+  const CR = 0.04, CC = 0.40, SIGMA_P = 200
+
+  const stresses = [12.5, 25, 50, 100, 200, 400, 800, 1600]
+  const points = stresses.map((stress) => {
+    const e = stress <= SIGMA_P
+      ? e0 - CR * Math.log10(stress / stresses[0])
+      : e0 - CR * Math.log10(SIGMA_P / stresses[0]) - CC * Math.log10(stress / SIGMA_P)
+    const height = (1 + e) * hs
+    return { stress, compression: SPECIMEN.initialHeight - height, t50: 5 }
+  })
+  return { ...SPECIMEN, points }
+}
+
+describe('height of solids', () => {
+  it('is the datum every void ratio is measured against', () => {
+    const area = (Math.PI / 4) * 75 ** 2
+    expect(heightOfSolids(79.5, 2.70, area)).toBeCloseTo(6.664, 2)
+  })
+
+  it('refuses a zero specific gravity or area', () => {
+    expect(() => heightOfSolids(79.5, 0, 100)).toThrow(/greater than zero/)
+    expect(() => heightOfSolids(79.5, 2.7, 0)).toThrow(/greater than zero/)
+  })
+})
+
+describe('the e–log σ′ curve', () => {
+  const r = consolidation(curveWithBreak())
+
+  it('recovers the initial void ratio', () => {
+    expect(r.initialVoidRatio).toBeCloseTo(2.001, 2)
+  })
+
+  it('gives one row per increment, in stress order', () => {
+    expect(r.rows).toHaveLength(8)
+    expect(r.rows.map((x) => x.stress)).toEqual([12.5, 25, 50, 100, 200, 400, 800, 1600])
+  })
+
+  it('recovers Cc from the virgin branch', () => {
+    expect(r.cc).toBeCloseTo(0.40, 2)
+  })
+
+  it('recovers Cr from the recompression branch, and it is much smaller', () => {
+    expect(r.cr).toBeCloseTo(0.04, 2)
+    expect(r.cr!).toBeLessThan(r.cc / 5)
+  })
+
+  it('void ratio falls monotonically with stress', () => {
+    for (let i = 1; i < r.rows.length; i++) {
+      expect(r.rows[i].voidRatio).toBeLessThan(r.rows[i - 1].voidRatio)
+    }
+  })
+
+  it('computes cv from t50 when it was recorded', () => {
+    expect(r.rows.every((x) => x.cv != null && x.cv > 0)).toBe(true)
+  })
+})
+
+/** The same specimen with the break planted at an arbitrary stress. */
+function curveBreakingAt(sigmaP: number): ConsolidationData {
+  const area = (Math.PI / 4) * SPECIMEN.diameter ** 2
+  const hs = heightOfSolids(SPECIMEN.dryMass, SPECIMEN.specificGravity, area)
+  const e0 = SPECIMEN.initialHeight / hs - 1
+  const points = [12.5, 25, 50, 100, 200, 400, 800, 1600].map((stress) => {
+    const e = stress <= sigmaP
+      ? e0 - 0.04 * Math.log10(stress / 12.5)
+      : e0 - 0.04 * Math.log10(sigmaP / 12.5) - 0.40 * Math.log10(stress / sigmaP)
+    return { stress, compression: SPECIMEN.initialHeight - (1 + e) * hs }
+  })
+  return { ...SPECIMEN, points }
+}
+
+describe('preconsolidation pressure — an estimate, not a measurement', () => {
+  it('RECOVERS a planted break, wherever it sits', () => {
+    // The first version of this used a numerical Casagrande construction and
+    // returned 536 kPa for a break planted at 100 — wrong by a factor of five,
+    // and my tolerance was wide enough to hide it. A method that cannot recover
+    // a break it was handed cannot estimate one from real data.
+    for (const planted of [100, 200, 400]) {
+      const found = consolidation(curveBreakingAt(planted)).preconsolidationPressure
+      expect(found, `planted ${planted}`).toBeDefined()
+      expect(found!, `planted ${planted}`).toBeCloseTo(planted, 0)
+    }
+  })
+
+  it('recovers the two indices on either side of the break', () => {
+    const r = consolidation(curveBreakingAt(200))
+    expect(r.cc).toBeCloseTo(0.40, 6)
+    expect(r.cr).toBeCloseTo(0.04, 6)
+  })
+
+  it('says in as many words that it is an estimate, and not Casagrande', () => {
+    const r = consolidation(curveWithBreak())
+    expect(r.notes.join(' ')).toMatch(/ESTIMATE from a two-segment fit, not a measurement/)
+    expect(r.notes.join(' ')).toMatch(/not the graphical Casagrande construction/)
+    expect(r.notes.join(' ')).toMatch(/changes a prediction by a factor/)
+  })
+
+  it('returns undefined for a curve with no break, and explains both causes', () => {
+    // A normally consolidated clay: one straight virgin line throughout.
+    const area = (Math.PI / 4) * SPECIMEN.diameter ** 2
+    const hs = heightOfSolids(SPECIMEN.dryMass, SPECIMEN.specificGravity, area)
+    const e0 = SPECIMEN.initialHeight / hs - 1
+    const points = [12.5, 25, 50, 100, 200, 400, 800].map((stress) => {
+      const e = e0 - 0.35 * Math.log10(stress / 12.5)
+      return { stress, compression: SPECIMEN.initialHeight - (1 + e) * hs }
+    })
+    const r = consolidation({ ...SPECIMEN, points })
+    expect(r.preconsolidationPressure).toBeUndefined()
+    expect(r.notes.join(' ')).toMatch(/normally consolidated/)
+    expect(r.notes.join(' ')).toMatch(/too few increments were run below the break/)
+  })
+
+  it('will not report a σ′p outside the stresses actually applied', () => {
+    // A break beyond the tested range is an extrapolation the data cannot support.
+    const straight: ConsolidationRow[] = [100, 200, 400, 800, 1600].map((stress, i) => ({
+      stress, compression: 0, height: 20, voidRatio: 2.0 - 0.01 * i,
+    }))
+    expect(fitBreak(straight)).toBeUndefined()
+  })
+
+  it('needs enough points to fit two segments at all', () => {
+    expect(fitBreak([])).toBeUndefined()
+    expect(fitBreak([
+      { stress: 100, compression: 0, height: 20, voidRatio: 2.0 },
+      { stress: 200, compression: 0, height: 20, voidRatio: 1.9 },
+    ])).toBeUndefined()
+  })
+
+  it('refuses a break where the virgin branch is FLATTER than recompression', () => {
+    // Physically backwards; the fit must not report an intersection for it.
+    const backwards: ConsolidationRow[] = [12.5, 25, 50, 100, 200, 400].map((stress, i) => ({
+      stress, compression: 0, height: 20,
+      voidRatio: 2.0 - (i < 3 ? 0.4 : 0.02) * Math.log10(stress / 12.5),
+    }))
+    const f = fitBreak(backwards)
+    if (f) expect(f.cc).toBeGreaterThan(f.cr)
+  })
+})
+
+describe('overconsolidation ratio', () => {
+  it('is σ′p over the effective overburden', () => {
+    expect(overconsolidationRatio(200, 100)).toBeCloseTo(2, 10)
+  })
+
+  it('refuses a zero overburden rather than returning Infinity', () => {
+    expect(() => overconsolidationRatio(200, 0)).toThrow(/greater than zero/)
+  })
+})
+
+describe('impossible data is rejected, not absorbed', () => {
+  it('rejects a specimen with no voids', () => {
+    // Hs ≥ H means the solids alone fill the ring.
+    expect(() => consolidation({ ...SPECIMEN, initialHeight: 5, points: curveWithBreak().points }))
+      .toThrow(/leaves no voids/)
+  })
+
+  it('rejects compression past the height of solids', () => {
+    const d = curveWithBreak()
+    d.points = [...d.points, { stress: 3200, compression: 19.5 }]
+    expect(() => consolidation(d)).toThrow(/below its height of solids/)
+  })
+
+  it('rejects a zero height or diameter', () => {
+    expect(() => consolidation({ ...curveWithBreak(), initialHeight: 0 })).toThrow(/height must be greater/)
+    expect(() => consolidation({ ...curveWithBreak(), diameter: 0 })).toThrow(/diameter must be greater/)
+  })
+
+  it('refuses fewer than three increments', () => {
+    const d = curveWithBreak()
+    d.points = d.points.slice(0, 2)
+    expect(() => consolidation(d)).toThrow(/at least three load increments/)
+  })
+})
+
+describe('warnings that matter', () => {
+  it('flags Cr not smaller than Cc, which no real soil does', () => {
+    const area = (Math.PI / 4) * SPECIMEN.diameter ** 2
+    const hs = heightOfSolids(SPECIMEN.dryMass, SPECIMEN.specificGravity, area)
+    const e0 = SPECIMEN.initialHeight / hs - 1
+    // Steep first, flat later — the branches read the wrong way round.
+    const points = [12.5, 25, 50, 100, 200, 400].map((stress, i) => {
+      const e = e0 - (i < 3 ? 0.4 : 0.05) * Math.log10(stress / 12.5)
+      return { stress, compression: SPECIMEN.initialHeight - (1 + e) * hs }
+    })
+    const r = consolidation({ ...SPECIMEN, points })
+    expect(r.notes.join(' ')).toMatch(/wrong way round/)
+  })
+
+  it('says the RATE is unavailable without t50, but the magnitude is not', () => {
+    const d = curveWithBreak()
+    d.points = d.points.map(({ stress, compression }) => ({ stress, compression }))
+    const r = consolidation(d)
+    expect(r.rows.every((x) => x.cv === undefined)).toBe(true)
+    expect(r.notes.join(' ')).toMatch(/RATE of settlement — cannot be computed. The magnitude can/)
+  })
+
+  it('warns when too few increments were run', () => {
+    const d = curveWithBreak()
+    d.points = d.points.slice(0, 4)
+    expect(consolidation(d).notes.join(' ')).toMatch(/Only 4 increments/)
+  })
+})

--- a/webapp/src/engine/soils/lab/consolidation.ts
+++ b/webapp/src/engine/soils/lab/consolidation.ts
@@ -1,0 +1,280 @@
+// ─────────────────────────────────────────────────────────────────────────
+// One-dimensional consolidation (oedometer). Layer 8. ASTM D2435.
+//
+// A specimen is loaded in doubling increments and its compression recorded, and
+// the resulting e–log σ′ curve gives the three numbers settlement analysis
+// actually needs: the preconsolidation pressure σ′p, the compression index Cc
+// on the virgin branch, and the recompression index Cr below it.
+//
+// σ′p IS THE ONE THAT MATTERS MOST AND IS THE LEAST CERTAIN. It is not
+// measured, it is INFERRED from the shape of the curve. The classical method is
+// Casagrande's graphical construction, which turns on where the eye judges the
+// point of minimum radius to be — two engineers routinely differ by 20% on the
+// same curve. This module uses a two-segment fit instead (see fitBreak) and
+// says so, rather than claiming a construction it does not perform.
+//
+// The consequence is not academic: settlement below σ′p follows Cr, above it
+// follows Cc, and Cc is typically five to ten times larger. Placing σ′p wrongly
+// changes a predicted settlement by a factor, not a percentage.
+//
+// UNITS: stress kPa; heights mm; masses g; void ratio and indices dimensionless.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** One load increment held to the end of primary consolidation. */
+export interface ConsolidationPoint {
+  /** Applied effective vertical stress, kPa. */
+  stress: number
+  /** Cumulative compression of the specimen at the end of the increment, mm. */
+  compression: number
+  /** t50 or t90 from the increment's time curve, minutes. Optional. */
+  t50?: number
+}
+
+export interface ConsolidationData {
+  /** Initial specimen height, mm. */
+  initialHeight: number
+  /** Specimen diameter, mm — for the area, and so cv can be reported. */
+  diameter: number
+  /** Oven-dry mass of the specimen, g. */
+  dryMass: number
+  /** Specific gravity of solids. Needed for the height of solids. */
+  specificGravity: number
+  points: ConsolidationPoint[]
+}
+
+export interface ConsolidationRow {
+  stress: number
+  compression: number
+  height: number
+  voidRatio: number
+  /** Coefficient of consolidation from this increment, m²/year. Undefined without t50. */
+  cv?: number
+}
+
+export interface ConsolidationResult {
+  /** Equivalent height of solids, mm. */
+  solidHeight: number
+  initialVoidRatio: number
+  rows: ConsolidationRow[]
+  /** Compression index, from the steepest straight portion at high stress. */
+  cc: number
+  /** Recompression index, from the low-stress portion. Undefined with too few points. */
+  cr?: number
+  /**
+   * Preconsolidation pressure from the two-segment fit, kPa. An ESTIMATE, not a
+   * measurement, and not the graphical Casagrande value — see fitBreak.
+   */
+  preconsolidationPressure?: number
+  /** Points used for the Cc fit, for a plot to highlight. */
+  virginRange?: { from: number; to: number }
+  notes: string[]
+}
+
+/**
+ * Height of solids Hs = Ms / (Gs · ρw · A), the datum every void ratio is
+ * measured against. In consistent units with Ms in g, A in mm² and ρw as
+ * 1 g/cm³ = 0.001 g/mm³.
+ */
+export function heightOfSolids(dryMass: number, gs: number, areaMm2: number): number {
+  if (!(gs > 0) || !(areaMm2 > 0)) {
+    throw new Error('Specific gravity and specimen area must both be greater than zero.')
+  }
+  return dryMass / (gs * 0.001 * areaMm2)
+}
+
+/** Least-squares slope of e against log₁₀ σ′ over a set of rows. */
+function slope(rows: ConsolidationRow[]): number {
+  const n = rows.length
+  if (n < 2) return 0
+  const xs = rows.map((r) => Math.log10(r.stress))
+  const ys = rows.map((r) => r.voidRatio)
+  const mx = xs.reduce((a, b) => a + b, 0) / n
+  const my = ys.reduce((a, b) => a + b, 0) / n
+  const sxx = xs.reduce((s, x) => s + (x - mx) ** 2, 0)
+  const sxy = xs.reduce((s, x, i) => s + (x - mx) * (ys[i] - my), 0)
+  // e falls as σ′ rises, so the compression index is the NEGATIVE slope.
+  return sxx > 1e-12 ? -(sxy / sxx) : 0
+}
+
+/**
+ * Preconsolidation pressure by a TWO-SEGMENT (bilinear) fit of the e–log σ′
+ * curve: every candidate break is tried, each splitting the points into a
+ * recompression line and a virgin line, and the break with the smallest total
+ * residual wins. σ′p is where the two fitted lines intersect.
+ *
+ * THIS IS NOT THE CASAGRANDE CONSTRUCTION, and the difference is worth stating
+ * rather than glossing. Casagrande bisects the angle between the horizontal and
+ * the tangent at the point of minimum radius of curvature — a judgement made by
+ * eye on a plot, which no numerical rule reproduces faithfully. A bilinear fit
+ * is a different, more reproducible estimate that lands close to Casagrande on
+ * a curve with a sharp break and diverges from it on a rounded one.
+ *
+ * I tried the numerical-Casagrande route first and it was wrong by a factor of
+ * five on a synthetic curve with a planted break at 100 kPa. A method that
+ * cannot recover a break it was handed has no business estimating one from real
+ * data, so it was replaced rather than tuned.
+ *
+ * Returns undefined when no break improves on a single straight line — the
+ * honest answer for a normally consolidated clay.
+ */
+export interface BreakFit {
+  /** Preconsolidation pressure at the intersection, kPa. */
+  sigmaP: number
+  /** Compression index above the break. */
+  cc: number
+  /** Recompression index below it. */
+  cr: number
+  /** Index of the first point on the virgin branch. */
+  breakIndex: number
+}
+
+/** Least-squares fit of e against log₁₀ σ′; returns intercept and NEGATIVE slope. */
+function fitLine(rows: ConsolidationRow[]): { intercept: number; index: number; ssr: number } {
+  const n = rows.length
+  const xs = rows.map((r) => Math.log10(r.stress))
+  const ys = rows.map((r) => r.voidRatio)
+  const mx = xs.reduce((a, b) => a + b, 0) / n
+  const my = ys.reduce((a, b) => a + b, 0) / n
+  const sxx = xs.reduce((s, x) => s + (x - mx) ** 2, 0)
+  const sxy = xs.reduce((s, x, i) => s + (x - mx) * (ys[i] - my), 0)
+  const m = sxx > 1e-12 ? sxy / sxx : 0
+  const b = my - m * mx
+  const ssr = ys.reduce((s, y, i) => s + (y - (b + m * xs[i])) ** 2, 0)
+  return { intercept: b, index: -m, ssr }
+}
+
+export function fitBreak(rows: ConsolidationRow[]): BreakFit | undefined {
+  const pts = rows.filter((r) => r.stress > 0)
+  if (pts.length < 5) return undefined
+
+  const whole = fitLine(pts)
+  let best: (BreakFit & { ssr: number }) | undefined
+
+  // Each segment needs at least two points, so the break can sit anywhere from
+  // index 2 to n−2.
+  for (let k = 2; k <= pts.length - 2; k++) {
+    const lower = fitLine(pts.slice(0, k))
+    const upper = fitLine(pts.slice(k))
+    const ssr = lower.ssr + upper.ssr
+
+    // Intersection of e = b₁ − Cr·x and e = b₂ − Cc·x:
+    //   b₁ − Cr·x = b₂ − Cc·x  ⇒  x = (b₂ − b₁)/(Cc − Cr)
+    // The numerator's sign matters and I had it the wrong way round at first,
+    // which put σ′p at 0.005 kPa and made every break fall outside the tested
+    // range — so the fit silently returned "no break" on a curve built to have
+    // one.
+    const denom = upper.index - lower.index
+    if (denom <= 1e-9) continue            // virgin must be steeper than recompression
+    const x = (upper.intercept - lower.intercept) / denom
+    const sigmaP = Math.pow(10, x)
+
+    // A break outside the tested range is an extrapolation the data cannot support.
+    if (!Number.isFinite(sigmaP)) continue
+    if (sigmaP < pts[0].stress || sigmaP > pts[pts.length - 1].stress) continue
+
+    if (!best || ssr < best.ssr) {
+      best = { sigmaP, cc: upper.index, cr: lower.index, breakIndex: k, ssr }
+    }
+  }
+
+  // A break must explain the curve materially better than one straight line;
+  // otherwise the soil is normally consolidated and there is nothing to find.
+  if (!best || best.ssr > whole.ssr * 0.5) return undefined
+  return { sigmaP: best.sigmaP, cc: best.cc, cr: best.cr, breakIndex: best.breakIndex }
+}
+
+export function consolidation(d: ConsolidationData): ConsolidationResult {
+  const notes: string[] = []
+  if (!(d.initialHeight > 0)) throw new Error('Initial specimen height must be greater than zero.')
+  if (!(d.diameter > 0)) throw new Error('Specimen diameter must be greater than zero.')
+
+  const area = (Math.PI / 4) * d.diameter ** 2
+  const solidHeight = heightOfSolids(d.dryMass, d.specificGravity, area)
+
+  if (solidHeight >= d.initialHeight) {
+    throw new Error(
+      'The height of solids equals or exceeds the specimen height, which leaves no voids. Check the dry mass, the specific gravity and the specimen dimensions.',
+    )
+  }
+
+  const initialVoidRatio = d.initialHeight / solidHeight - 1
+
+  const pts = [...d.points]
+    .filter((p) => p.stress > 0 && Number.isFinite(p.compression))
+    .sort((a, b) => a.stress - b.stress)
+
+  if (pts.length < 3) {
+    throw new Error('A consolidation curve needs at least three load increments.')
+  }
+
+  const rows: ConsolidationRow[] = pts.map((p) => {
+    const height = d.initialHeight - p.compression
+    const voidRatio = height / solidHeight - 1
+    // cv = T50·Hdr²/t50, T50 = 0.197, Hdr = half the specimen (drained both faces).
+    // mm²/min → m²/year: ×(1e-6)×(525600)
+    const hdr = height / 2
+    const cv = p.t50 && p.t50 > 0
+      ? (0.197 * hdr * hdr / p.t50) * 1e-6 * 525600
+      : undefined
+    return { stress: p.stress, compression: p.compression, height, voidRatio, cv }
+  })
+
+  if (rows.some((r) => r.voidRatio < 0)) {
+    throw new Error('A load increment compressed the specimen below its height of solids, which is impossible. Check the compression readings.')
+  }
+
+  // The break decides both branches: fitting Cc over an arbitrary "upper half"
+  // drags recompression points into it and flattens the index.
+  const fit = fitBreak(rows)
+  const virgin = fit ? rows.slice(fit.breakIndex) : rows.slice(Math.floor(rows.length / 2))
+  const cc = fit ? fit.cc : slope(virgin)
+  // Without a break the branches are not separable, but a recompression index
+  // over the lower half is still worth computing so the sanity check below can
+  // catch a curve whose branches were entered the wrong way round.
+  const cr = fit ? fit.cr : slope(rows.slice(0, Math.max(Math.floor(rows.length / 2), 2)))
+  const preconsolidationPressure = fit?.sigmaP
+
+  if (preconsolidationPressure == null) {
+    notes.push(
+      'No break in the curve fits materially better than a single straight line. That is the honest result for a normally consolidated clay, where σ′p sits at or below the lowest stress applied — but it also happens when too few increments were run below the break, so check the plot before concluding either.',
+    )
+  } else {
+    notes.push(
+      `σ′p = ${preconsolidationPressure.toFixed(0)} kPa is an ESTIMATE from a two-segment fit, not a measurement, and not the graphical Casagrande construction — the two agree on a sharp break and diverge on a rounded one. Settlement below σ′p follows Cr and above it follows Cc, which is several times larger, so where the break is placed changes a prediction by a factor rather than a percentage. Check it against the plotted curve.`,
+    )
+  }
+
+  if (cr != null && cr >= cc) {
+    notes.push('The recompression index is not smaller than the compression index, which no real soil does — the two branches have probably been read the wrong way round.')
+  }
+  if (cc <= 0) {
+    notes.push('The compression index came out zero or negative: the specimen did not compress with increasing stress. Check the compression column.')
+  }
+  if (rows.length < 6) {
+    notes.push(`Only ${rows.length} increments. D2435 asks for enough to define both branches and the break between them; with this few the Casagrande construction is poorly constrained.`)
+  }
+  if (!rows.some((r) => r.cv != null)) {
+    notes.push('No t50 recorded on any increment, so cv — and therefore the RATE of settlement — cannot be computed. The magnitude can.')
+  }
+
+  return {
+    solidHeight,
+    initialVoidRatio,
+    rows,
+    cc,
+    cr,
+    preconsolidationPressure,
+    virginRange: { from: virgin[0].stress, to: virgin[virgin.length - 1].stress },
+    notes,
+  }
+}
+
+/**
+ * Overconsolidation ratio, σ′p / σ′v0. Above about 1.2 the soil is
+ * overconsolidated and will settle on the much flatter Cr branch until the new
+ * load pushes it past σ′p.
+ */
+export function overconsolidationRatio(sigmaP: number, effectiveOverburden: number): number {
+  if (!(effectiveOverburden > 0)) throw new Error('Effective overburden must be greater than zero.')
+  return sigmaP / effectiveOverburden
+}

--- a/webapp/src/engine/soils/lab/index.ts
+++ b/webapp/src/engine/soils/lab/index.ts
@@ -31,6 +31,10 @@ import {
   type DirectShearData, type ShearPoint, directShear, type DirectShearResult,
 } from './directShear'
 import { type UcsData, type UcsSoil, ucs, type UcsResult } from './ucs'
+import {
+  type ConsolidationData, type ConsolidationPoint, consolidation,
+  type ConsolidationResult,
+} from './consolidation'
 
 const isRecord = (v: unknown): v is Record<string, unknown> =>
   typeof v === 'object' && v !== null && !Array.isArray(v)
@@ -158,6 +162,33 @@ export function readUcs(test: LabTest): { data: UcsData; soil: UcsSoil } | undef
   }
 }
 
+/** Oedometer increments — another variable-length table; malformed rows drop. */
+export function readConsolidation(test: LabTest): ConsolidationData | undefined {
+  const d = test.data
+  if (!isRecord(d)) return undefined
+  if (!hasNumbers(d, ['initialHeight', 'diameter', 'dryMass', 'specificGravity'])) return undefined
+  if (!Array.isArray(d.points)) return undefined
+
+  const points: ConsolidationPoint[] = []
+  for (const r of d.points) {
+    if (!isRecord(r) || !finite(r.stress) || !finite(r.compression)) continue
+    points.push({
+      stress: r.stress,
+      compression: r.compression,
+      t50: finite(r.t50) ? r.t50 : undefined,
+    })
+  }
+  if (points.length < 3) return undefined
+
+  return {
+    initialHeight: d.initialHeight as number,
+    diameter: d.diameter as number,
+    dryMass: d.dryMass as number,
+    specificGravity: d.specificGravity as number,
+    points,
+  }
+}
+
 // ── Catalogue ─────────────────────────────────────────────────────────────
 
 /** One numeric input on a test form. */
@@ -175,7 +206,7 @@ export interface LabField {
  * How a test's form is laid out. Most tests are a flat list of numbers; a sieve
  * stack is a variable-length table, which no `LabField[]` can express.
  */
-export type LabFormKind = 'fields' | 'sieve-stack' | 'shear-points'
+export type LabFormKind = 'fields' | 'sieve-stack' | 'shear-points' | 'load-increments'
 
 export interface LabTestSpec {
   type: LabTestType
@@ -285,7 +316,21 @@ export const LAB_TESTS: readonly LabTestSpec[] = [
       { key: 'unitWeight', label: 'Bulk unit weight', unit: 'kN/m³', optional: true, placeholder: 18 },
     ],
   },
-  { type: 'consolidation', label: 'Consolidation', standard: 'd2435', needsUndisturbed: true, fields: [], purpose: 'Compressibility and the rate of settlement.' },
+  {
+    type: 'consolidation',
+    label: 'Consolidation',
+    standard: 'd2435',
+    formKind: 'load-increments',
+    calculation: 'consolidation.cc',
+    needsUndisturbed: true,
+    purpose: 'Cc, Cr and σ′p — the three numbers a settlement analysis runs on.',
+    fields: [
+      { key: 'initialHeight', label: 'Initial height', unit: 'mm', placeholder: 20 },
+      { key: 'diameter', label: 'Diameter', unit: 'mm', placeholder: 75 },
+      { key: 'dryMass', label: 'Oven-dry mass', unit: 'g', placeholder: 79.5 },
+      { key: 'specificGravity', label: 'Specific gravity Gs', placeholder: 2.7 },
+    ],
+  },
   { type: 'permeability', label: 'Permeability', standard: 'd5084', needsUndisturbed: true, fields: [], purpose: 'Hydraulic conductivity.' },
   { type: 'cbr', label: 'CBR', standard: 'd1883', needsUndisturbed: false, fields: [], purpose: 'Bearing ratio for pavement design.' },
   { type: 'swell', label: 'Swell / collapse', standard: 'd4546', needsUndisturbed: true, fields: [], purpose: 'One-dimensional swell or collapse on wetting.' },
@@ -321,6 +366,7 @@ export type LabOutcome =
   | { kind: 'atterberg'; result: AtterbergResult }
   | { kind: 'direct-shear'; result: DirectShearResult }
   | { kind: 'ucs'; result: UcsResult }
+  | { kind: 'consolidation'; result: ConsolidationResult }
 
 /**
  * Compute a test's result from its stored data.
@@ -362,6 +408,11 @@ export function evaluateTest(test: LabTest): { outcome?: LabOutcome; error?: str
         if (!d) return {}
         return { outcome: { kind: 'ucs', result: ucs(d.data, d.soil) } }
       }
+      case 'consolidation': {
+        const d = readConsolidation(test)
+        if (!d) return {}
+        return { outcome: { kind: 'consolidation', result: consolidation(d) } }
+      }
       default:
         return {}
     }
@@ -385,5 +436,7 @@ export function summarise(outcome: LabOutcome): { label: string; value: number; 
       return { label: "φ'", value: outcome.result.peak.frictionAngle, unit: '°' }
     case 'ucs':
       return { label: 'qu', value: outcome.result.qu, unit: 'kPa' }
+    case 'consolidation':
+      return { label: 'Cc', value: outcome.result.cc, unit: '' }
   }
 }

--- a/webapp/src/engine/soils/lab/lab.test.ts
+++ b/webapp/src/engine/soils/lab/lab.test.ts
@@ -205,10 +205,11 @@ describe('the lab catalogue stays in step with the schema', () => {
     // fields-only check reported it as unimplemented.
     expect(isImplemented('direct-shear')).toBe(true)
     expect(isImplemented('ucs')).toBe(true)
+    expect(isImplemented('consolidation')).toBe(true)
     expect(isImplemented('triaxial')).toBe(false)
-    expect(isImplemented('consolidation')).toBe(false)
+    expect(isImplemented('permeability')).toBe(false)
     expect(implementedTests().map((t) => t.type))
-      .toEqual(['moisture', 'specific-gravity', 'sieve', 'atterberg', 'direct-shear', 'ucs'])
+      .toEqual(['moisture', 'specific-gravity', 'sieve', 'atterberg', 'direct-shear', 'ucs', 'consolidation'])
   })
 
   it('gives every implemented test enough fields to drive its engine', () => {
@@ -235,6 +236,7 @@ describe('the lab catalogue stays in step with the schema', () => {
       atterberg: ['liquidLimit'],
       'direct-shear': [],
       ucs: ['diameter', 'height', 'failureLoad', 'failureDeformation'],
+      consolidation: ['initialHeight', 'diameter', 'dryMass', 'specificGravity'],
     }
     for (const t of implementedTests()) {
       const declared = t.fields.filter((f) => !f.optional).map((f) => f.key).sort()

--- a/webapp/src/engine/soils/parameters.ts
+++ b/webapp/src/engine/soils/parameters.ts
@@ -70,6 +70,8 @@ export type ParameterKey =
   | 'cohesion' | 'frictionAngle'
   | 'effectiveCohesion' | 'effectiveFrictionAngle' | 'undrainedShearStrength'
   | 'specificGravity' | 'voidRatio' | 'relativeDensity'
+  | 'compressionIndex' | 'recompressionIndex' | 'preconsolidationPressure'
+  | 'coefficientOfConsolidation'
 
 /**
  * Readable names, kept HERE rather than in the page, because the engine writes
@@ -89,6 +91,10 @@ export const PARAMETER_LABEL: Record<ParameterKey, string> = {
   specificGravity: 'Specific gravity Gs',
   voidRatio: 'Void ratio e',
   relativeDensity: 'Relative density Dr',
+  compressionIndex: 'Compression index Cc',
+  recompressionIndex: 'Recompression index Cr',
+  preconsolidationPressure: "Preconsolidation pressure σ'p",
+  coefficientOfConsolidation: 'Coefficient of consolidation cv',
 }
 
 export interface ResolvedParameter {
@@ -177,6 +183,35 @@ export function resolveParameters(i: ResolveInput): ParameterResolution {
         add('effectiveFrictionAngle', measured(e.frictionAngle, '°', {
           testId: dsTest.id, standard: 'd3080', sampleId: s.name,
         }, e.refittedThroughOrigin ? 'envelope refitted through the origin' : undefined))
+      }
+    }
+
+    // Consolidation → Cc, Cr, σ′p and cv.
+    const consTest = governingTest(s, 'consolidation').test
+    if (consTest) {
+      const { outcome, error } = evaluateTest(consTest)
+      if (error) notes.push(`Consolidation on ${s.name} could not be evaluated: ${error}`)
+      else if (outcome?.kind === 'consolidation') {
+        const c = outcome.result
+        const p = { testId: consTest.id, standard: 'd2435' as const, sampleId: s.name }
+        add('compressionIndex', measured(c.cc, '—', p))
+        if (c.cr != null) add('recompressionIndex', measured(c.cr, '—', p))
+        if (c.preconsolidationPressure != null) {
+          // σ′p is inferred from the curve's shape, not read off a dial, so it
+          // enters as DERIVED rather than measured — the distinction is the
+          // whole point of the provenance model.
+          add('preconsolidationPressure', derived(c.preconsolidationPressure, 'kPa', {
+            calculation: 'consolidation.cc',
+            from: [`${c.rows.length} load increments on ${s.name}`],
+          }, 'two-segment fit of the e–log σ′ curve; check against the plotted curve'))
+        }
+        const cvs = c.rows.map((r) => r.cv).filter((v): v is number => v != null)
+        if (cvs.length) {
+          add('coefficientOfConsolidation', measured(
+            cvs.reduce((a, b) => a + b, 0) / cvs.length, 'm²/yr', p,
+            `mean of ${cvs.length} increments`,
+          ))
+        }
       }
     }
 
@@ -274,6 +309,8 @@ export function resolveParameters(i: ResolveInput): ParameterResolution {
     'unitWeight', 'dryUnitWeight', 'saturatedUnitWeight',
     'cohesion', 'frictionAngle', 'effectiveCohesion', 'effectiveFrictionAngle',
     'undrainedShearStrength', 'specificGravity', 'voidRatio', 'relativeDensity',
+    'compressionIndex', 'recompressionIndex', 'preconsolidationPressure',
+    'coefficientOfConsolidation',
   ]
   const absent = ALL.filter((k) => !candidates.has(k))
 

--- a/webapp/src/pages/SoilInvestigation.tsx
+++ b/webapp/src/pages/SoilInvestigation.tsx
@@ -789,6 +789,12 @@ function TestCard({
               onChange={(rows) => onPoints(rows)} />
           )}
 
+          {spec!.formKind === 'load-increments' && (
+            <LoadIncrements
+              rows={(test.data?.points as LoadRow[] | undefined) ?? []}
+              onChange={(rows) => onPoints(rows as unknown as ShearRow[])} />
+          )}
+
           {test.type === 'ucs' && (
             <label className="mt-2 flex flex-col text-[11px]">
               <span className="mb-0.5 text-slate-600">Soil condition</span>
@@ -1262,6 +1268,63 @@ function ParametersPanel({
           </div>
         )
       })}
+    </div>
+  )
+}
+
+// ── Oedometer increments ──────────────────────────────────────────────────
+
+interface LoadRow { stress: number; compression: number; t50?: number }
+
+const DEFAULT_INCREMENTS = [12.5, 25, 50, 100, 200, 400, 800]
+
+function LoadIncrements({
+  rows, onChange,
+}: { rows: LoadRow[]; onChange: (rows: LoadRow[]) => void }) {
+  const pts: LoadRow[] = rows.length ? rows : DEFAULT_INCREMENTS.map((stress) => ({ stress, compression: 0 }))
+  const set = (i: number, patch: Partial<LoadRow>) =>
+    onChange(pts.map((r, k) => (k === i ? { ...r, ...patch } : r)))
+
+  return (
+    <div className="mt-2">
+      <table className="w-full text-left text-[11px]">
+        <thead className="text-slate-500">
+          <tr className="border-b border-slate-200">
+            <th className="py-1 pr-2 text-right">σ′ (kPa)</th>
+            <th className="py-1 pr-2 text-right">Compression (mm)</th>
+            <th className="py-1 pr-2 text-right">t₅₀ (min)</th>
+            <th />
+          </tr>
+        </thead>
+        <tbody>
+          {pts.map((r, i) => (
+            <tr key={i} className="border-b border-slate-100">
+              {([['stress', r.stress] as const, ['compression', r.compression] as const, ['t50', r.t50] as const])
+                .map(([key, v]) => (
+                  <td key={key} className="py-0.5 pr-2 text-right">
+                    <input type="number" step="any" value={v ?? ''}
+                      placeholder={key === 't50' ? 'optional' : ''}
+                      onChange={(e) => set(i, {
+                        [key]: e.target.value === '' ? undefined : num(e.target.value),
+                      } as Partial<LoadRow>)}
+                      className="w-24 rounded border border-slate-200 px-1 py-0.5 text-right font-mono" />
+                  </td>
+                ))}
+              <td className="py-0.5 text-right">
+                <button onClick={() => onChange(pts.filter((_, k) => k !== i))}
+                  className="rounded px-1 text-[10px] text-red-600 hover:bg-red-50">×</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p className="mt-1 text-[10px] text-slate-500">
+        Without t₅₀ the magnitude of settlement can be computed but not its rate.
+      </p>
+      <button onClick={() => onChange([...pts, { stress: 0, compression: 0 }])}
+        className="mt-1 rounded border border-dashed border-slate-300 px-2 py-0.5 text-[10px] text-slate-600 hover:bg-slate-50">
+        + increment
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
**Layer 8.** Cc, Cr, σ′p and cv from an oedometer test — the three numbers a settlement analysis actually runs on, plus the rate. **24 new tests.**

## The preconsolidation pressure is the number that matters most and is the least certain

Settlement below σ′p follows Cr; above it follows Cc, which is several times larger. Placing the break wrongly changes a prediction by a **factor**, not a percentage.

## I got this wrong twice, and the second time is the more interesting one

**First attempt: a numerical Casagrande construction** — bend detection, tangent bisection, intersection with the virgin line. It returned **536 kPa for a break planted at 100**. Wrong by a factor of five.

My test tolerance was `120 < σ′p < 320` for a planted 200. Wide enough to pass. I only caught it because I probed the actual numbers before writing the PR, out of a habit of not trusting a tolerance I chose myself.

A method that cannot recover a break it was *handed* has no business estimating one from real data, so I replaced it rather than tuning it.

**Second attempt: a two-segment fit.** Every candidate break is tried, each splitting the points into a recompression line and a virgin line; the one with the smallest total residual wins, and σ′p is where the fitted lines intersect.

That version *also* failed at first — a sign error: `x = (b₂ − b₁)/(Cc − Cr)`, and I had the numerator reversed. σ′p landed at **0.005 kPa**, fell outside the tested range, and the out-of-range guard correctly rejected it — so the fit reported *"no break"* on a curve built to have one. The guard was doing its job; the algebra behind it wasn't.

It now recovers planted breaks at 100, 200 and 400 kPa **to within 0.5 kPa**, and the test asserts that rather than a band.

## It is not Casagrande, and says so

The docstring, the result note and this PR all state it: a two-segment fit and the graphical Casagrande construction agree on a sharp break and diverge on a rounded one. Claiming a construction the code does not perform would be worse than naming what it does.

## Provenance

σ′p enters the parameter engine as **`derived`**, not measured — it's inferred from the curve's *shape*, not read off a dial. Cc, Cr and cv are measured. That distinction is exactly what the provenance model exists for.

## Verification

`npm test` — **2619 passed / 170 files** · `npx tsc -b` · `npm run lint` · `npm run build` all green.

End to end in headless Chromium: entering a specimen and eight load increments on the Laboratory tab gives **Cc = 0.400** and **Cr = 0.040** against the planted 0.40 and 0.04, **σ′p = 200 kPa** against the planted 200, and all three reach the Parameters tab with σ′p correctly badged *Derived*.

(My first browser run showed Cc = 0.134 — the scripted compressions didn't correspond to the specimen I'd typed in. I recomputed them rather than explaining away the discrepancy.)

## Honest limits

- **No e–log σ′ plot.** Same gap as the direct-shear envelope: the note says *"check it against the plotted curve"* and there is no plotted curve. For a test whose key output is read off a graph, that's the weakest part of this PR.
- **cv uses T₅₀ = 0.197 and assumes double drainage.** A specimen drained on one face only has four times the drainage path and the module doesn't ask which it was.
- **`/settlement` is still not wired**, even though this unblocks it — that page takes a layered profile rather than single-layer parameters, so the picker doesn't fit it as-is. It needs its own shape.
- **Secondary compression (Cα) isn't computed**, so long-term creep settlement is out of reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_