### PR TITLE
feat(soils): plot the three lab curves an engineer reads off a graph

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1325,30 +1325,31 @@ because flagging the unusual as an error trains people to ignore errors.
 | 0 — model, provenance, registry, store | #476 | merged |
 | 1 — classification (Atterberg, sieve, USCS, AASHTO) | #477 | merged |
 | 2 — SPT corrections, correlations, overburden | #478 | merged |
-| 3a — borehole log renderer (geometry) | #479 | open |
+| 3a — borehole log renderer (geometry) | #479 | merged |
 | 3b — investigation UI, routes, profile editor | #480 | merged |
 | 4a — lab plumbing + index tests (moisture, Gs) | #481 | merged |
 | 4b — sieve + Atterberg wired, sample classification | #482 | merged |
 | 4c — direct shear + UCS | #483 | merged |
 | 5 — parameter engine (resolution + provenance) | #484 | merged |
 | 5b — parameters wired into bearing capacity and slope | #485 | merged |
-| 4d — consolidation (Cc, Cr, σ′p, cv) | — | open |
-| 4e… — compaction, triaxial, permeability, CBR, hydrometer | — | |
+| 4d — consolidation (Cc, Cr, σ′p, cv) | #486 | merged |
+| 4e — lab charts (envelope, e–log σ′, grading) | #487 | open |
+| 4f… — compaction, triaxial, permeability, CBR, hydrometer | — | |
 | 6 — liquefaction, bearing methods, Coulomb | — | |
 | 7 — report document builder | — | |
 | 8 — Postgres, CPT, 3D subsurface | — | |
 
 **`/soils` is live**, gated behind the `soil-investigation` feature on pro and
-max. Six tabs: overview and integrity, boreholes with the graphical log,
-stratigraphy and samples, corrected SPT, laboratory tests, and a USCS
-classifier.
+max. Seven tabs: overview and integrity, boreholes with the graphical log,
+stratigraphy and samples, corrected SPT, laboratory tests (each test card now
+draws its own curve), interpreted parameters, and a USCS classifier.
 
 **Storage decision, settled:** stay on the `SoilsStore` interface over
 localStorage; swap in a Supabase backend at Phase 8. Confirmed with the user
 before Phase 4 started, since that is the phase where lab-test shapes make a
 schema change expensive.
 
-**Two recurring lessons from these phases**, both worth remembering:
+**Recurring lessons from these phases**, all worth remembering:
 
 1. *Tests can enshrine a bug.* The log renderer drew "Silty Sand" with silt
    hatching, and the test asserted that behaviour with a comment explaining it
@@ -1363,3 +1364,21 @@ schema change expensive.
    grew its own `/clay|silt/` regex — a second independent reading of the same
    field, which disagreed with the first within a day. `soilFamily` now lives in
    `model.ts` and a test asserts the renderer and the page cannot drift apart.
+4. *A loose tolerance hides a broken method.* Phase 4d's first σ′p used a
+   numerical Casagrande construction that returned 536 kPa for a break planted
+   at 100 — wrong by a factor of five — and the assertion (`120 < σ′p < 320` for
+   a planted 200) was wide enough to pass. The test now plants the break at
+   100, 200 and 400 and demands each one back. Where a range is the honest
+   assertion, probe the actual value once before trusting the range.
+5. *Render it and look at it.* Every visual defect in this module was found by
+   looking at output, never by a test: the silt hatching, the rock hatch
+   escaping its band, a fraction boundary struck through "sand 86%", and in
+   Phase 4e a rounded axis that clipped the extrapolated envelope off the top
+   of the frame. Each one is now covered by a test written *after* the render
+   showed it.
+
+**Chart conventions (Phase 4e), so the next chart matches:** log data gets a
+log axis; linear axes get 1–2–5 round ticks via `linearTicks`; extrapolation
+beyond the tested range is dashed; annotations sit on an opaque `plate` in the
+corner the curve structurally cannot reach. Charts are `PlanPrimitive` lists
+serialised by the shared `planToSvg` — no chart draws pixels of its own.

--- a/webapp/src/engine/soils/lab/plots.test.ts
+++ b/webapp/src/engine/soils/lab/plots.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect } from 'vitest'
+import { shearEnvelopeChart, consolidationChart, gradingChart, decadeTicks, linearTicks, tickDp } from './plots'
+import { directShear } from './directShear'
+import { consolidation, heightOfSolids } from './consolidation'
+import { gradation } from '../sieve'
+import { planToSvg } from '../../planRenderer'
+import type { PlanPrimitive } from '../../planRenderer'
+
+const texts = (d: { primitives: PlanPrimitive[] }) =>
+  d.primitives.filter((p): p is Extract<PlanPrimitive, { kind: 'text' }> => p.kind === 'text')
+    .map((p) => p.text)
+
+const dots = (d: { primitives: PlanPrimitive[] }) =>
+  d.primitives.filter((p) => p.kind === 'circle')
+
+const SHEAR = [
+  { normalStress: 50, peakShear: 48.87 },
+  { normalStress: 100, peakShear: 77.74 },
+  { normalStress: 200, peakShear: 135.47 },
+]
+
+const SPECIMEN = { initialHeight: 20, diameter: 75, dryMass: 79.5, specificGravity: 2.70 }
+
+function consolidationCurve() {
+  const hs = heightOfSolids(SPECIMEN.dryMass, SPECIMEN.specificGravity, (Math.PI / 4) * SPECIMEN.diameter ** 2)
+  const e0 = SPECIMEN.initialHeight / hs - 1
+  const points = [12.5, 25, 50, 100, 200, 400, 800, 1600].map((stress) => {
+    const e = stress <= 200
+      ? e0 - 0.04 * Math.log10(stress / 12.5)
+      : e0 - 0.04 * Math.log10(200 / 12.5) - 0.40 * Math.log10(stress / 200)
+    return { stress, compression: SPECIMEN.initialHeight - (1 + e) * hs }
+  })
+  return consolidation({ ...SPECIMEN, points })
+}
+
+const GRADING = gradation({
+  totalMass: 500,
+  readings: [
+    { size: 9.5, massRetained: 10 },
+    { size: 4.75, massRetained: 40 },
+    { size: 2.0, massRetained: 75 },
+    { size: 0.85, massRetained: 100 },
+    { size: 0.425, massRetained: 110 },
+    { size: 0.15, massRetained: 100 },
+    { size: 0.075, massRetained: 45 },
+  ],
+  panMass: 20,
+})
+
+describe('decade ticks', () => {
+  it('gives 1-2-5 ticks across the range', () => {
+    expect(decadeTicks(10, 1000)).toEqual([10, 20, 50, 100, 200, 500, 1000])
+  })
+
+  it('is empty for a degenerate range rather than looping', () => {
+    expect(decadeTicks(0, 100)).toEqual([])
+    expect(decadeTicks(-1, 100)).toEqual([])
+    expect(decadeTicks(100, 100)).toEqual([])
+  })
+})
+
+describe('linear ticks', () => {
+  it('gives ROUND numbers, not quarters of the data range', () => {
+    // The first version divided the range in four: an envelope to 230 kPa was
+    // labelled 57 / 115 / 172 / 230, which no one draws and no one can read a
+    // footing stress off.
+    expect(linearTicks(0, 230).ticks).toEqual([0, 50, 100, 150, 200, 250])
+    expect(linearTicks(0, 163).ticks).toEqual([0, 50, 100, 150, 200])
+  })
+
+  it('snaps BOTH ends out, so no data point lands on the frame', () => {
+    const a = linearTicks(1.56, 2.01)
+    expect(a.lo).toBeLessThanOrEqual(1.56)
+    expect(a.hi).toBeGreaterThanOrEqual(2.01)
+    expect(a.ticks).toEqual([1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1])
+  })
+
+  it('keeps ticks evenly spaced', () => {
+    for (const [lo, hi] of [[0, 7], [0, 0.03], [12, 4800], [-5, 5]] as [number, number][]) {
+      const { ticks } = linearTicks(lo, hi)
+      expect(ticks.length).toBeGreaterThan(2)
+      const step = ticks[1] - ticks[0]
+      for (let i = 1; i < ticks.length; i++) {
+        expect(ticks[i] - ticks[i - 1]).toBeCloseTo(step, 9)
+      }
+    }
+  })
+
+  it('is empty for a degenerate range rather than looping forever', () => {
+    expect(linearTicks(5, 5).ticks).toEqual([])
+    expect(linearTicks(10, 1).ticks).toEqual([])
+    expect(linearTicks(NaN, 10).ticks).toEqual([])
+  })
+
+  it('prints a 2.5 step as 2.5, not 2', () => {
+    expect(tickDp(2.5)).toBe(1)
+    expect(tickDp(50)).toBe(0)
+    expect(tickDp(0.05)).toBe(2)
+  })
+})
+
+describe('failure envelope chart', () => {
+  const r = directShear({ points: SHEAR })
+  const d = shearEnvelopeChart(r, SHEAR)
+
+  it('plots one dot per specimen', () => {
+    expect(dots(d)).toHaveLength(3)
+  })
+
+  it('prints c′, φ′ and R² on the chart', () => {
+    const t = texts(d).join(' ')
+    expect(t).toMatch(/c' = 20\.0 kPa/)
+    expect(t).toMatch(/φ' = 30\.0°/)
+    expect(t).toMatch(/R² = /)
+  })
+
+  it('DASHES the line outside the tested stress range', () => {
+    // Extrapolation should be visible rather than implied — the whole reason
+    // the result carries a stress-range caveat.
+    const dashed = d.primitives.filter((p) => p.kind === 'line' && p.dash != null && p.stroke === '#0056b3')
+    expect(dashed.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('says so on the chart when the fit is poor', () => {
+    const bad = directShear({
+      points: [
+        { normalStress: 50, peakShear: 90 },
+        { normalStress: 100, peakShear: 60 },
+        { normalStress: 200, peakShear: 140 },
+      ],
+    })
+    const chart = shearEnvelopeChart(bad, [
+      { normalStress: 50, peakShear: 90 },
+      { normalStress: 100, peakShear: 60 },
+      { normalStress: 200, peakShear: 140 },
+    ])
+    expect(texts(chart).join(' ')).toMatch(/check for an outlier/)
+  })
+
+  it('serialises through the shared plan serialiser', () => {
+    const svg = planToSvg(d)
+    expect(svg.startsWith('<svg')).toBe(true)
+    expect(svg).not.toMatch(/NaN|undefined/)
+  })
+})
+
+describe('consolidation chart', () => {
+  const r = consolidationCurve()
+  const d = consolidationChart(r)
+
+  it('plots every load increment', () => {
+    expect(dots(d)).toHaveLength(8)
+  })
+
+  it('marks the fitted break, which is what the result note tells you to check', () => {
+    const t = texts(d).join(' ')
+    expect(t).toMatch(/σ'p ≈ 200 kPa/)
+    const marker = d.primitives.filter((p) => p.kind === 'line' && p.stroke === '#b45309' && p.dash != null)
+    expect(marker.length).toBe(1)
+  })
+
+  it('prints Cc and Cr', () => {
+    expect(texts(d).join(' ')).toMatch(/Cc = 0\.400\s+Cr = 0\.040/)
+  })
+
+  it('uses a LOG stress axis', () => {
+    // A linear axis hides the straight-line behaviour the reading depends on.
+    // Equal decades must occupy equal width: 12.5→125 and 125→1250.
+    const ticks = texts(d)
+    expect(ticks).toContain('100')
+    expect(ticks).toContain('1000')
+    const xs = d.primitives
+      .filter((p): p is Extract<PlanPrimitive, { kind: 'text' }> => p.kind === 'text')
+      .filter((p) => ['10', '100', '1000'].includes(p.text))
+      .sort((a, b) => Number(a.text) - Number(b.text))
+      .map((p) => p.x)
+    expect(xs).toHaveLength(3)
+    expect(xs[1] - xs[0]).toBeCloseTo(xs[2] - xs[1], 4)
+  })
+
+  it('draws void ratio falling DOWN the page, the drafting convention', () => {
+    const circles = d.primitives.filter((p): p is Extract<PlanPrimitive, { kind: 'circle' }> => p.kind === 'circle')
+    // Points are emitted in increasing stress, and e falls as σ′ rises, so y
+    // must increase along the series.
+    for (let i = 1; i < circles.length; i++) {
+      expect(circles[i].cy).toBeGreaterThan(circles[i - 1].cy)
+    }
+  })
+
+  it('survives a result with no rows', () => {
+    const empty = { ...r, rows: [] }
+    const chart = consolidationChart(empty)
+    expect(planToSvg(chart)).not.toMatch(/NaN/)
+  })
+})
+
+describe('grading chart', () => {
+  const d = gradingChart(GRADING)
+
+  it('plots every sieve', () => {
+    expect(dots(d)).toHaveLength(7)
+  })
+
+  it('runs COARSE TO FINE left to right', () => {
+    // The convention on every published grading chart, which is why the size
+    // axis runs backwards.
+    const circles = d.primitives.filter((p): p is Extract<PlanPrimitive, { kind: 'circle' }> => p.kind === 'circle')
+    for (let i = 1; i < circles.length; i++) {
+      expect(circles[i].cx).toBeGreaterThan(circles[i - 1].cx)
+    }
+  })
+
+  it('marks the D2487 fraction boundaries', () => {
+    const t = texts(d).join(' ')
+    expect(t).toMatch(/gravel \| sand/)
+    expect(t).toMatch(/sand \| fines/)
+  })
+
+  it('prints the fractions and the shape parameters', () => {
+    const t = texts(d).join(' ')
+    expect(t).toMatch(/gravel 10%\s+sand 86%\s+fines 4%/)
+    expect(t).toMatch(/Cu = /)
+  })
+
+  it('says when Cu and Cc are unavailable rather than omitting them', () => {
+    const fines = gradation({
+      totalMass: 100,
+      readings: [
+        { size: 4.75, massRetained: 20 },
+        { size: 0.425, massRetained: 45 },
+        { size: 0.075, massRetained: 20 },
+      ],
+      panMass: 15,
+    })
+    expect(texts(gradingChart(fines)).join(' ')).toMatch(/does not reach 10% passing/)
+  })
+
+  it('survives an empty grading', () => {
+    const empty = gradation({ totalMass: 100, readings: [{ size: 1, massRetained: 100 }] })
+    expect(planToSvg(gradingChart(empty))).not.toMatch(/NaN/)
+  })
+})
+
+describe('nothing drawn escapes the frame', () => {
+  // Two separate defects, both found by looking at a render rather than by a
+  // passing test: rounding the axes to nice ticks sent the extrapolated
+  // envelope off the TOP (τ = 164 kPa at the right edge, y-axis to 150), and
+  // the opaque annotation plates hung far enough below their anchor to white
+  // out a section of the bottom axis.
+  const BOX = { left: 18, top: 8, w: 96, h: 62 }
+
+  const extent = (d: { primitives: PlanPrimitive[] }) => {
+    const xs: number[] = []
+    const ys: number[] = []
+    for (const p of d.primitives) {
+      if (p.kind === 'line') { xs.push(p.x1, p.x2); ys.push(p.y1, p.y2) }
+      else if (p.kind === 'rect') { xs.push(p.x, p.x + p.w); ys.push(p.y, p.y + p.h) }
+      else if (p.kind === 'circle') { xs.push(p.cx - p.r, p.cx + p.r); ys.push(p.cy - p.r, p.cy + p.r) }
+    }
+    return { xs, ys }
+  }
+
+  const charts: [string, { primitives: PlanPrimitive[] }][] = [
+    ['failure envelope', shearEnvelopeChart(directShear({ points: SHEAR }), SHEAR)],
+    ['consolidation', consolidationChart(consolidationCurve())],
+    ['grading', gradingChart(GRADING)],
+  ]
+
+  for (const [name, chart] of charts) {
+    it(`stays inside the plot area — ${name}`, () => {
+      const { xs, ys } = extent(chart)
+      expect(Math.min(...xs), 'left').toBeGreaterThanOrEqual(BOX.left - 1e-6)
+      expect(Math.max(...xs), 'right').toBeLessThanOrEqual(BOX.left + BOX.w + 1e-6)
+      expect(Math.min(...ys), 'top').toBeGreaterThanOrEqual(BOX.top - 1e-6)
+      expect(Math.max(...ys), 'bottom').toBeLessThanOrEqual(BOX.top + BOX.h + 1e-6)
+    })
+  }
+})
+
+describe('all three serialise cleanly', () => {
+  it('produce valid SVG with no new painting code', () => {
+    const charts = [
+      shearEnvelopeChart(directShear({ points: SHEAR }), SHEAR),
+      consolidationChart(consolidationCurve()),
+      gradingChart(GRADING),
+    ]
+    for (const c of charts) {
+      const svg = planToSvg(c)
+      expect(svg.startsWith('<svg')).toBe(true)
+      expect(svg).toContain('</svg>')
+      expect(svg).not.toMatch(/NaN|undefined|Infinity/)
+    }
+  })
+})

--- a/webapp/src/engine/soils/lab/plots.ts
+++ b/webapp/src/engine/soils/lab/plots.ts
@@ -1,0 +1,357 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Laboratory-test charts — pure geometry. Layer 8.
+//
+// Three tests in this module produce a number that an engineer traditionally
+// reads OFF A GRAPH, and until now the module printed the number and told the
+// reader to "check it against the plotted curve" while providing no curve:
+//
+//   • the direct-shear failure envelope — is the line straight, or is one
+//     specimen an outlier?
+//   • the e–log σ′ consolidation curve — is the break where the fit put it?
+//   • the grain-size distribution — the shape, not just D10/D30/D60.
+//
+// A stated caveat that cannot be acted on is worse than no caveat: it looks
+// like diligence while leaving the reader exactly where they were. So these
+// emit the same typed `PlanPrimitive` list the borehole log and the structural
+// drawings use, and `planToSvg` paints them.
+//
+// LOG AXES ARE DRAWN AS LOG AXES. Both the consolidation curve and the grading
+// curve span orders of magnitude, and a linear axis on either is not merely
+// ugly — it hides the straight-line behaviour the whole reading depends on.
+//
+// UNITS: chart coordinates are millimetres of paper, as with the borehole log.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { PlanPrimitive, Drawing } from '../../planRenderer'
+import type { DirectShearResult } from './directShear'
+import type { ConsolidationResult } from './consolidation'
+import type { GradationResult } from '../sieve'
+
+const AXIS = '#334155'
+const GRID = '#e2e8f0'
+const INK = '#0f172a'
+const ACCENT = '#0056b3'
+const WARN = '#b45309'
+
+export interface ChartBox {
+  /** Plot area, mm of paper. */
+  w: number
+  h: number
+  left: number
+  top: number
+}
+
+const BOX: ChartBox = { w: 96, h: 62, left: 18, top: 8 }
+
+/** Nice round decade ticks spanning [lo, hi] on a log axis. */
+export function decadeTicks(lo: number, hi: number): number[] {
+  if (!(lo > 0) || !(hi > lo)) return []
+  const out: number[] = []
+  const first = Math.floor(Math.log10(lo))
+  const last = Math.ceil(Math.log10(hi))
+  for (let d = first; d <= last; d++) {
+    for (const m of [1, 2, 5]) {
+      const v = m * Math.pow(10, d)
+      if (v >= lo / 1.001 && v <= hi * 1.001) out.push(v)
+    }
+  }
+  return out
+}
+
+/**
+ * `raw` rounded to the NEAREST step in the 1–2–5 series.
+ *
+ * Nearest, not up: rounding a raw step of 57.5 up to 100 leaves an axis with
+ * three labels on it, which is not more readable than the arithmetic it was
+ * meant to replace.
+ */
+function niceStep(raw: number): number {
+  if (!(raw > 0) || !Number.isFinite(raw)) return 1
+  const mag = Math.pow(10, Math.floor(Math.log10(raw)))
+  const f = raw / mag
+  return (f < 1.5 ? 1 : f < 3 ? 2 : f < 7 ? 5 : 10) * mag
+}
+
+/** Decimal places that print `step` exactly, so a 0.05 step is not labelled "0". */
+export function tickDp(step: number): number {
+  for (let d = 0; d < 6; d++) {
+    const scaled = step * Math.pow(10, d)
+    if (Math.abs(scaled - Math.round(scaled)) < 1e-9) return d
+  }
+  return 6
+}
+
+/**
+ * Round ticks for a LINEAR axis spanning [lo, hi], with both ends snapped out
+ * to a multiple of the step.
+ *
+ * Dividing the data range into four equal parts is arithmetically fine and
+ * reads as an error: an envelope labelled 57 / 115 / 172 / 230 kPa is not a
+ * chart anyone draws, and a reader trying to place a 150 kPa footing stress on
+ * it has to do mental arithmetic against the axis instead of reading it.
+ */
+export function linearTicks(lo: number, hi: number, target = 4): { lo: number; hi: number; ticks: number[] } {
+  if (!Number.isFinite(lo) || !Number.isFinite(hi) || !(hi > lo)) return { lo: 0, hi: 1, ticks: [] }
+  const step = niceStep((hi - lo) / target)
+  const from = Math.floor(lo / step + 1e-9) * step
+  const to = Math.ceil(hi / step - 1e-9) * step
+  const dp = tickDp(step)
+  const ticks: number[] = []
+  for (let k = 0; from + k * step <= to + step * 1e-6; k++) {
+    ticks.push(Number((from + k * step).toFixed(dp + 2)))
+  }
+  return { lo: from, hi: to, ticks }
+}
+
+/**
+ * An annotation block on an opaque plate.
+ *
+ * Grid lines and the D2487 fraction boundaries run behind these, and a dashed
+ * boundary struck through "sand 86%" is exactly the detail that makes a printed
+ * sheet look careless. The width is estimated from the character count, which
+ * is approximate but only ever slightly generous.
+ *
+ * The plate is opaque, so where it goes matters: each caller puts it in the
+ * corner its own curve cannot reach. A grading curve and an e–log σ′ curve both
+ * descend left to right (bottom-left is free); a failure envelope ascends
+ * (top-left is free). Those are properties of the plots, not of the fixtures.
+ */
+function plate(
+  x: number, y: number, size: number, lines: { text: string; color?: string }[],
+): PlanPrimitive[] {
+  const gap = size * 1.5
+  const w = Math.max(...lines.map((l) => l.text.length)) * size * 0.52 + 1.4
+  const h = (lines.length - 1) * gap + size * 1.9
+  const out: PlanPrimitive[] = [{ kind: 'rect', x: x - 0.7, y: y - size * 0.95, w, h, fill: '#ffffff' }]
+  lines.forEach((l, i) => out.push({
+    kind: 'text', x, y: y + i * gap, text: l.text, size, color: l.color ?? INK,
+  }))
+  return out
+}
+
+/** Axis frame plus labels. Shared by all three charts. */
+function frame(
+  box: ChartBox, xLabel: string, yLabel: string, title: string,
+): PlanPrimitive[] {
+  const { left, top, w, h } = box
+  return [
+    { kind: 'text', x: left, y: top - 2.5, text: title, size: 3.2, weight: 700, color: ACCENT },
+    { kind: 'line', x1: left, y1: top, x2: left, y2: top + h, stroke: AXIS, width: 0.4 },
+    { kind: 'line', x1: left, y1: top + h, x2: left + w, y2: top + h, stroke: AXIS, width: 0.4 },
+    { kind: 'text', x: left + w / 2, y: top + h + 9, text: xLabel, size: 2.6, anchor: 'middle', color: AXIS },
+    {
+      kind: 'text', x: left - 13, y: top + h / 2, text: yLabel, size: 2.6,
+      anchor: 'middle', rotate: -90, color: AXIS,
+    },
+  ]
+}
+
+// ── Direct shear ──────────────────────────────────────────────────────────
+
+/**
+ * Failure envelope with the specimens plotted on it. The point of drawing this
+ * is to make an outlier visible — an R² of 0.93 says something is off but not
+ * WHICH point, and a straight line through three dots answers that instantly.
+ */
+export function shearEnvelopeChart(r: DirectShearResult, points: { normalStress: number; peakShear: number }[]): Drawing {
+  const box = BOX
+  const p: PlanPrimitive[] = frame(box, "σ'n  (kPa)", 'τ  (kPa)', 'Failure envelope')
+
+  const tan = Math.tan((r.peak.frictionAngle * Math.PI) / 180)
+  const tau = (s: number) => r.peak.cohesion + s * tan
+
+  // Both axes start at the ORIGIN: c′ is the intercept at σ′n = 0, so an axis
+  // that begins part-way up hides the quantity the chart exists to show.
+  //
+  // The vertical range covers the ENVELOPE at the right-hand edge, not just the
+  // specimens — the extrapolated segment is drawn all the way across, and an
+  // axis sized to the data alone sends it off the top of the frame.
+  const xa = linearTicks(0, Math.max(...points.map((q) => q.normalStress), r.stressRange.max) * 1.1)
+  const xMax = xa.hi
+  const ya = linearTicks(0, Math.max(...points.map((q) => q.peakShear), r.peak.cohesion, tau(xMax)))
+  const yMax = ya.hi
+  const X = (v: number) => box.left + (v / xMax) * box.w
+  const Y = (v: number) => box.top + box.h - (v / yMax) * box.h
+
+  for (const t of xa.ticks) {
+    if (t <= 0) continue
+    p.push({ kind: 'line', x1: X(t), y1: box.top, x2: X(t), y2: box.top + box.h, stroke: GRID, width: 0.2 })
+    p.push({ kind: 'text', x: X(t), y: box.top + box.h + 4, text: String(t), size: 2.2, anchor: 'middle', color: AXIS })
+  }
+  for (const t of ya.ticks) {
+    if (t <= 0) continue
+    p.push({ kind: 'line', x1: box.left, y1: Y(t), x2: box.left + box.w, y2: Y(t), stroke: GRID, width: 0.2 })
+    p.push({ kind: 'text', x: box.left - 1.5, y: Y(t) + 0.8, text: String(t), size: 2.2, anchor: 'end', color: AXIS })
+  }
+
+  // The fitted line across the whole axis, dashed outside the tested range so
+  // extrapolation is visible rather than implied.
+  p.push({
+    kind: 'line',
+    x1: X(r.stressRange.min), y1: Y(tau(r.stressRange.min)),
+    x2: X(r.stressRange.max), y2: Y(tau(r.stressRange.max)),
+    stroke: ACCENT, width: 0.6,
+  })
+  p.push({
+    kind: 'line',
+    x1: X(r.stressRange.max), y1: Y(tau(r.stressRange.max)),
+    x2: X(xMax), y2: Y(tau(xMax)),
+    stroke: ACCENT, width: 0.4, dash: [2, 1.5],
+  })
+  if (r.stressRange.min > 0) {
+    p.push({
+      kind: 'line', x1: X(0), y1: Y(tau(0)), x2: X(r.stressRange.min), y2: Y(tau(r.stressRange.min)),
+      stroke: ACCENT, width: 0.4, dash: [2, 1.5],
+    })
+  }
+
+  for (const q of points) {
+    p.push({ kind: 'circle', cx: X(q.normalStress), cy: Y(q.peakShear), r: 1.1, fill: INK })
+  }
+
+  p.push(...plate(box.left + 2, box.top + 4, 2.4, [
+    { text: `c' = ${r.peak.cohesion.toFixed(1)} kPa   φ' = ${r.peak.frictionAngle.toFixed(1)}°   R² = ${r.peak.r2.toFixed(3)}` },
+    ...(r.peak.r2 < 0.95
+      ? [{ text: 'poor fit — check for an outlier or a curved envelope', color: WARN }]
+      : []),
+  ]))
+
+  return {
+    primitives: p,
+    bounds: { minX: 0, minY: 0, maxX: box.left + box.w + 4, maxY: box.top + box.h + 13 },
+  }
+}
+
+// ── Consolidation ─────────────────────────────────────────────────────────
+
+/**
+ * e–log σ′ with the fitted break marked. The note on the result says "check it
+ * against the plotted curve"; this is that curve.
+ */
+export function consolidationChart(r: ConsolidationResult): Drawing {
+  const box = BOX
+  const p: PlanPrimitive[] = frame(box, "σ'  (kPa, log)", 'void ratio  e', 'e – log σ′')
+
+  const rows = r.rows.filter((x) => x.stress > 0)
+  if (!rows.length) return { primitives: p, bounds: { minX: 0, minY: 0, maxX: box.left + box.w + 4, maxY: box.top + box.h + 13 } }
+
+  const sLo = rows[0].stress / 1.6
+  const sHi = rows[rows.length - 1].stress * 1.6
+  const eLo = Math.min(...rows.map((x) => x.voidRatio))
+  const eHi = Math.max(...rows.map((x) => x.voidRatio))
+  const ePad = Math.max((eHi - eLo) * 0.08, 0.005)
+  const ea = linearTicks(eLo - ePad, eHi + ePad)
+  const eDp = tickDp((ea.hi - ea.lo) / Math.max(ea.ticks.length - 1, 1))
+
+  const X = (v: number) =>
+    box.left + ((Math.log10(v) - Math.log10(sLo)) / (Math.log10(sHi) - Math.log10(sLo))) * box.w
+  // Void ratio falls down the page, the drafting convention for this plot.
+  const Y = (v: number) => box.top + ((ea.hi - v) / (ea.hi - ea.lo)) * box.h
+
+  for (const t of decadeTicks(sLo, sHi)) {
+    p.push({ kind: 'line', x1: X(t), y1: box.top, x2: X(t), y2: box.top + box.h, stroke: GRID, width: 0.2 })
+    p.push({ kind: 'text', x: X(t), y: box.top + box.h + 4, text: String(t), size: 2.1, anchor: 'middle', color: AXIS })
+  }
+  for (const e of ea.ticks) {
+    p.push({ kind: 'line', x1: box.left, y1: Y(e), x2: box.left + box.w, y2: Y(e), stroke: GRID, width: 0.2 })
+    p.push({ kind: 'text', x: box.left - 1.5, y: Y(e) + 0.8, text: e.toFixed(eDp), size: 2.1, anchor: 'end', color: AXIS })
+  }
+
+  for (let i = 1; i < rows.length; i++) {
+    p.push({
+      kind: 'line',
+      x1: X(rows[i - 1].stress), y1: Y(rows[i - 1].voidRatio),
+      x2: X(rows[i].stress), y2: Y(rows[i].voidRatio),
+      stroke: ACCENT, width: 0.6,
+    })
+  }
+  for (const row of rows) {
+    p.push({ kind: 'circle', cx: X(row.stress), cy: Y(row.voidRatio), r: 1.0, fill: INK })
+  }
+
+  if (r.preconsolidationPressure != null) {
+    const x = X(r.preconsolidationPressure)
+    p.push({ kind: 'line', x1: x, y1: box.top, x2: x, y2: box.top + box.h, stroke: WARN, width: 0.5, dash: [2.5, 1.5] })
+    const label = `σ'p ≈ ${r.preconsolidationPressure.toFixed(0)} kPa`
+    // Flip the label to the left of the marker when it would run off the frame.
+    const w = label.length * 2.3 * 0.52 + 1.4
+    const at = x + 1.5 + w > box.left + box.w ? x - 1.5 - w : x + 1.5
+    p.push(...plate(at, box.top + 4, 2.3, [{ text: label, color: WARN }]))
+  }
+
+  p.push(...plate(box.left + 2, box.top + box.h - 3.2, 2.4, [{
+    text: `Cc = ${r.cc.toFixed(3)}${r.cr != null ? `   Cr = ${r.cr.toFixed(3)}` : ''}`,
+  }]))
+
+  return {
+    primitives: p,
+    bounds: { minX: 0, minY: 0, maxX: box.left + box.w + 4, maxY: box.top + box.h + 13 },
+  }
+}
+
+// ── Grain-size distribution ───────────────────────────────────────────────
+
+/**
+ * Percent passing against log particle size, drawn coarse-to-fine LEFT TO
+ * RIGHT — the convention on every published grading chart, and the reason the
+ * size axis runs backwards.
+ */
+export function gradingChart(g: GradationResult): Drawing {
+  const box = BOX
+  const p: PlanPrimitive[] = frame(box, 'particle size  (mm, log)', '% passing', 'Grain-size distribution')
+
+  const rows = [...g.rows].filter((r) => r.size > 0).sort((a, b) => b.size - a.size)
+  if (!rows.length) return { primitives: p, bounds: { minX: 0, minY: 0, maxX: box.left + box.w + 4, maxY: box.top + box.h + 13 } }
+
+  const dHi = rows[0].size * 1.5
+  const dLo = rows[rows.length - 1].size / 1.5
+  // Coarse on the left: size decreases as x increases.
+  const X = (v: number) =>
+    box.left + ((Math.log10(dHi) - Math.log10(v)) / (Math.log10(dHi) - Math.log10(dLo))) * box.w
+  const Y = (v: number) => box.top + box.h - (v / 100) * box.h
+
+  for (const t of decadeTicks(dLo, dHi)) {
+    p.push({ kind: 'line', x1: X(t), y1: box.top, x2: X(t), y2: box.top + box.h, stroke: GRID, width: 0.2 })
+    p.push({ kind: 'text', x: X(t), y: box.top + box.h + 4, text: t < 1 ? t.toFixed(t < 0.1 ? 3 : 2) : String(t), size: 2.0, anchor: 'middle', color: AXIS })
+  }
+  for (const pc of [0, 25, 50, 75, 100]) {
+    p.push({ kind: 'line', x1: box.left, y1: Y(pc), x2: box.left + box.w, y2: Y(pc), stroke: GRID, width: 0.2 })
+    p.push({ kind: 'text', x: box.left - 1.5, y: Y(pc) + 0.8, text: String(pc), size: 2.1, anchor: 'end', color: AXIS })
+  }
+
+  // The D2487 fraction boundaries, which is where a reader's eye goes first.
+  for (const [size, label] of [[4.75, 'gravel | sand'], [0.075, 'sand | fines']] as [number, string][]) {
+    if (size <= dHi && size >= dLo) {
+      p.push({ kind: 'line', x1: X(size), y1: box.top, x2: X(size), y2: box.top + box.h, stroke: WARN, width: 0.4, dash: [2, 1.5] })
+      p.push({ kind: 'text', x: X(size), y: box.top - 0.5, text: label, size: 1.9, anchor: 'middle', color: WARN })
+    }
+  }
+
+  for (let i = 1; i < rows.length; i++) {
+    p.push({
+      kind: 'line',
+      x1: X(rows[i - 1].size), y1: Y(rows[i - 1].percentPassing),
+      x2: X(rows[i].size), y2: Y(rows[i].percentPassing),
+      stroke: ACCENT, width: 0.6,
+    })
+  }
+  for (const r of rows) {
+    p.push({ kind: 'circle', cx: X(r.size), cy: Y(r.percentPassing), r: 0.9, fill: INK })
+  }
+
+  // The statistics go BOTTOM-left. A grading curve descends left to right, so
+  // the top-left corner is exactly where the curve and the gravel/sand boundary
+  // label already are — putting text there overlapped both.
+  const shape = g.cu != null && g.cc != null
+    ? `Cu = ${g.cu.toFixed(1)}   Cc = ${g.cc.toFixed(2)}`
+    : 'Cu, Cc unavailable — the curve does not reach 10% passing'
+  p.push(...plate(box.left + 2, box.top + box.h - 6.6, 2.3, [
+    { text: shape, color: g.cu != null ? INK : WARN },
+    { text: `gravel ${g.gravel.toFixed(0)}%   sand ${g.sand.toFixed(0)}%   fines ${g.fines.toFixed(0)}%` },
+  ]))
+
+  return {
+    primitives: p,
+    bounds: { minX: 0, minY: 0, maxX: box.left + box.w + 4, maxY: box.top + box.h + 13 },
+  }
+}

--- a/webapp/src/pages/SoilInvestigation.tsx
+++ b/webapp/src/pages/SoilInvestigation.tsx
@@ -12,9 +12,13 @@ import {
   type LayerParameters,
 } from '../engine/soils/model'
 import {
-  LAB_TESTS, labSpec, isImplemented, evaluateTest, summarise,
+  LAB_TESTS, labSpec, isImplemented, evaluateTest, summarise, readDirectShear,
+  type LabOutcome,
 } from '../engine/soils/lab'
 import { classifySample } from '../engine/soils/classifySample'
+import {
+  shearEnvelopeChart, consolidationChart, gradingChart,
+} from '../engine/soils/lab/plots'
 import { resolveParameters, bearingInputs, PARAMETER_LABEL } from '../engine/soils/parameters'
 import { describeProvenance, PROVENANCE_LABEL, type SourcedValue } from '../engine/soils/provenance'
 import { cite } from '../engine/soils/standards'
@@ -834,6 +838,8 @@ function TestCard({
             </p>
           )}
 
+          {outcome && <TestChart test={test} outcome={outcome} />}
+
           {outcome && (
             <div className="mt-2 rounded border border-emerald-200 bg-emerald-50 px-2 py-1.5">
               <p className="font-mono text-[13px] font-semibold text-emerald-900">
@@ -1327,4 +1333,35 @@ function LoadIncrements({
       </button>
     </div>
   )
+}
+
+// ── Test charts ───────────────────────────────────────────────────────────
+
+/**
+ * The plot for a test whose key number is traditionally read off a graph.
+ *
+ * The consolidation result tells the reader to "check σ′p against the plotted
+ * curve" and the shear result warns about a poor fit; both were unactionable
+ * until there was a curve to look at.
+ */
+function TestChart({ test, outcome }: { test: LabTest; outcome: LabOutcome }) {
+  const svg = useMemo(() => {
+    switch (outcome.kind) {
+      // The envelope needs the specimens themselves, which live on the test
+      // data rather than the fitted result — plotting the fit without the
+      // points it was fitted through is exactly the picture that hides an
+      // outlier.
+      case 'direct-shear':
+        return planToSvg(shearEnvelopeChart(outcome.result, readDirectShear(test)?.points ?? []), 460)
+      case 'consolidation':
+        return planToSvg(consolidationChart(outcome.result), 460)
+      case 'sieve':
+        return planToSvg(gradingChart(outcome.result), 460)
+      default:
+        return null
+    }
+  }, [test, outcome])
+
+  if (!svg) return null
+  return <div className="mt-2 overflow-x-auto" dangerouslySetInnerHTML={{ __html: svg }} />
 }


### PR DESCRIPTION
**Soil Investigation module — Phase 4e.** Engine layer **8 (geotech)**: pure chart geometry, no new painting code.

## Why

Three of the laboratory engines shipped in 4c/4d produce a number that is traditionally read **off a curve**, and the module printed the number while telling the reader to *"check it against the plotted curve"* — with no curve to check against. I flagged this in both #483 and #486 and it stayed open. A caveat that cannot be acted on looks like diligence while leaving the reader exactly where they were, so this is the gap I closed before adding an eighth lab test.

## What

`webapp/src/engine/soils/lab/plots.ts` emits the same typed `PlanPrimitive` list the borehole log and the structural drawings use, so `planToSvg` paints it and nothing new draws pixels.

| Chart | What it makes visible |
|---|---|
| `shearEnvelopeChart` | The specimens **on** the fitted envelope. An R² of 0.93 says something is off; the dots say *which* specimen. Extrapolation outside the tested stress range is **dashed**, so it is visible rather than implied. |
| `consolidationChart` | e–log σ′ with the fitted **σ′p marked** — literally the check the result note asks the reader to perform — plus Cc and Cr. |
| `gradingChart` | The curve *shape*, not just D10/D30/D60, with the D2487 gravel\|sand and sand\|fines boundaries drawn. |

**Log axes are drawn as log axes.** A linear axis on either the consolidation or the grading curve is not merely ugly — it hides the straight-line behaviour the whole reading depends on. Linear axes get 1–2–5 round ticks via `linearTicks`.

Wired into the **Laboratory tab of `/soils`**: each test card renders its own chart above its result. The envelope reads its specimens from the test data through `readDirectShear`, so it plots what was actually entered rather than only the fit.

## Verification

`npx tsc -b`, `npm run lint` and `npm test` (**2647 tests, 172 files**) all pass. `npm run build` clean.

All three charts were rendered in a headless browser on the Laboratory tab and **read**, not just asserted on. That found three defects, each now fixed and covered:

1. **Rounding the axes to nice ticks clipped the envelope.** τ at the right-hand edge is 164 kPa; a y-axis sized to the specimens alone topped out at 150, so the extrapolated segment ran off the top of the frame. The vertical range now covers the envelope at the edge, not just the data.
2. **The opaque annotation plates punched a hole in the bottom axis** — they hung a fraction of a millimetre below their anchor.
3. **The gravel\|sand boundary struck through "sand 86%".** Annotations now sit on an opaque plate, in the corner each curve structurally cannot reach.

A frame-containment test over lines, rects *and* circles covers (1) and (2) for all three charts, at zero tolerance rather than a slack margin.

Two of my own test expectations were wrong on the way and the engine was right in one, wrong in the other — `niceStep` originally rounded the step **up**, turning a raw 57.5 into 100 and leaving three labels on the axis. It now rounds to the nearest of the 1–2–5 series.

## Not in this PR

- Compaction, triaxial, permeability, CBR, hydrometer and swell still have no engine, so no chart.
- These charts are on screen only; carrying them into the calculator PDFs needs `ReportControls` changes.

## Remaining phases

**6** liquefaction (NCEER) + bearing depth/inclination factors + Coulomb earth pressure · **7** the 22-section report builder · **8** Postgres backend swap, CPT, 3D subsurface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_