### PR TITLE
feat(soils): put the correlated section in the report and the profile tab

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1344,13 +1344,19 @@ because flagging the unusual as an error trains people to ignore errors.
 | 8a — async remote store, sync, Supabase adapter + SQL | #494 | merged |
 | 8b — sync UI (status, conflict resolution) | — | BLOCKED: apply the migration to the live project first |
 | 8c — CPT (Robertson SBT, correlations) | #495 | merged |
-| 8d — subsurface cross-sections | — | open |
+| 8d — subsurface cross-sections | #496 | merged |
+| 8e — section wired into the report and the profile tab | — | open |
 
 **`/soils` is live**, gated behind the `soil-investigation` feature on pro and
 max. Eight tabs: overview and integrity, boreholes with the graphical log,
-stratigraphy and samples, corrected SPT, laboratory tests (each test card draws
-its own curve), liquefaction triggering with an FS profile, interpreted
-parameters, and a USCS classifier.
+stratigraphy and samples with the correlated section, corrected SPT, laboratory
+tests (each test card draws its own curve), liquefaction triggering with an FS
+profile, interpreted parameters, and a USCS classifier. A "Report PDF" button
+generates the 22-section investigation report.
+
+**Engines built but not yet reachable from the UI:** `cpt.ts` (Phase 8c). The
+model has no field for cone readings — `Borehole` would need `cpt?: CptReading[]`
+plus a `meshValidation` rule — so wiring it is a schema change, not a page.
 
 **Storage decision, settled:** the local `SoilsStore` over localStorage stays;
 Phase 8a adds an ASYNC `RemoteStore` beside it rather than behind it, because a

--- a/webapp/src/engine/soils/report.test.ts
+++ b/webapp/src/engine/soils/report.test.ts
@@ -216,12 +216,33 @@ describe('metadata and headers', () => {
   })
 })
 
+describe('the section is presented as an interpretation', () => {
+  it('follows the logs rather than leading, and says what is measured', () => {
+    // A reader should meet the measured holes before the drawing that guesses
+    // between them.
+    const s = section(buildSoilsReport(sampleInvestigation()), 5)
+    expect(s.figures.at(-1)!.caption).toMatch(/Correlated section/)
+    expect(s.paragraphs.join(' ')).toMatch(/is an INTERPRETATION/)
+    expect(s.paragraphs.join(' ')).toMatch(/dashed to say so/)
+  })
+
+  it('omits it entirely when there is only one hole', () => {
+    const inv = sampleInvestigation()
+    inv.boreholes = inv.boreholes.slice(0, 1)
+    const s = section(buildSoilsReport(inv), 5)
+    expect(s.figures.every((f) => !/Correlated section/.test(f.caption))).toBe(true)
+    expect(s.paragraphs.join(' ')).not.toMatch(/is an INTERPRETATION/)
+  })
+})
+
 describe('figures come from the shared drawing engines', () => {
   it('includes a borehole log per logged hole and an FS profile per hole with SPT', () => {
     const r = buildSoilsReport(sampleInvestigation(), { seismic: SEISMIC })
     const logs = section(r, 5).figures
     const fs = section(r, 12).figures
-    expect(logs.length).toBe(2)
+    // Two borehole logs plus the correlated section between them.
+    expect(logs.length).toBe(3)
+    expect(logs.at(-1)!.caption).toMatch(/dashed where it is inferred/)
     expect(fs.length).toBeGreaterThan(0)
     for (const f of [...logs, ...fs]) {
       expect(f.drawing.primitives.length).toBeGreaterThan(0)

--- a/webapp/src/engine/soils/report.ts
+++ b/webapp/src/engine/soils/report.ts
@@ -28,6 +28,7 @@ import type { Drawing } from '../planRenderer'
 import type { Investigation, Borehole } from './model'
 import { layerThickness, soilFamily, isCohesive } from './model'
 import { buildBoreholeLog } from './logRenderer'
+import { buildSection, sectionDrawing } from './section'
 import { sptProfile, type LayerUnitWeight } from './sptProfile'
 import { liquefactionProfile, type LiquefactionProfileInput } from './liquefaction'
 import { liquefactionChart } from './liquefactionPlot'
@@ -157,6 +158,7 @@ function s4FieldWork(inv: Investigation): ReportSection {
 
 function s5Stratigraphy(inv: Investigation): ReportSection {
   const layers = inv.boreholes.flatMap((b) => b.layers.map((l) => ({ b, l })))
+  const section = buildSection(inv.boreholes)
   if (!layers.length) {
     return missing(5, 'Subsurface conditions', 'No strata have been logged. Stratigraphy is the basis of every other section, so nothing downstream can be reported either.')
   }
@@ -167,7 +169,12 @@ function s5Stratigraphy(inv: Investigation): ReportSection {
     gap: unclassified.length
       ? `${unclassified.length} layer${unclassified.length === 1 ? ' has' : 's have'} no USCS group symbol (${unclassified.slice(0, 4).join(', ')}${unclassified.length > 4 ? ', …' : ''}). A described layer without a classification cannot be correlated between holes with confidence.`
       : undefined,
-    paragraphs: ['The strata encountered in each exploration are logged below. Descriptions follow the visual-manual procedure, confirmed by laboratory classification where samples were tested.'],
+    paragraphs: [
+      'The strata encountered in each exploration are logged below. Descriptions follow the visual-manual procedure, confirmed by laboratory classification where samples were tested.',
+      ...(section.holes.length > 1
+        ? ['The correlated section that follows the logs is an INTERPRETATION. Only the vertical hole traces on it are measured; every boundary drawn between holes is inferred, and is dashed to say so.']
+        : []),
+    ],
     tables: inv.boreholes.filter((b) => b.layers.length).map((b) => ({
       title: `${b.name} — stratigraphy`,
       head: ['From (m)', 'To (m)', 'Thickness (m)', 'Symbol', 'Description'],
@@ -177,11 +184,21 @@ function s5Stratigraphy(inv: Investigation): ReportSection {
       ]),
       right: [0, 1, 2],
     })),
-    figures: inv.boreholes.filter((b) => b.layers.length).map((b) => ({
-      caption: `${b.name} — borehole log`,
-      drawing: buildBoreholeLog(b),
-    })),
-    notes: [],
+    figures: [
+      ...inv.boreholes.filter((b) => b.layers.length).map((b) => ({
+        caption: `${b.name} — borehole log`,
+        drawing: buildBoreholeLog(b),
+      })),
+      // The section is an INTERPRETATION between the logs, so it follows them
+      // rather than leading — a reader should meet the measured holes first.
+      ...(section.holes.length > 1
+        ? [{
+            caption: 'Correlated section — solid where a hole proves a boundary, dashed where it is inferred',
+            drawing: sectionDrawing(section),
+          }]
+        : []),
+    ],
+    notes: section.holes.length > 1 ? section.notes : [],
   }
 }
 

--- a/webapp/src/pages/SoilInvestigation.tsx
+++ b/webapp/src/pages/SoilInvestigation.tsx
@@ -19,6 +19,7 @@ import { classifySample } from '../engine/soils/classifySample'
 import {
   shearEnvelopeChart, consolidationChart, gradingChart,
 } from '../engine/soils/lab/plots'
+import { buildSection, sectionDrawing } from '../engine/soils/section'
 import { liquefactionProfile } from '../engine/soils/liquefaction'
 import { liquefactionChart, skipText } from '../engine/soils/liquefactionPlot'
 import { finesByLayer, finesMap } from '../engine/soils/finesContent'
@@ -444,6 +445,7 @@ export default function SoilInvestigation() {
       {/* ── Soil profile ── */}
       {tab === 'profile' && bh && (
         <section className="mt-5 space-y-4">
+          <SectionPanel boreholes={inv.boreholes} />
           <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
             <div className="mb-3 flex items-center justify-between">
               <h2 className="text-[1.05rem] font-bold text-[#0056b3]">{bh.name} — stratigraphy</h2>
@@ -677,6 +679,44 @@ export default function SoilInvestigation() {
       )}
 
     </main>
+  )
+}
+
+// ── Correlated section ────────────────────────────────────────────────────
+// The one drawing in this module that is an INTERPRETATION rather than a
+// record, so the caption says which parts are measured before the reader
+// scrolls to it.
+
+function SectionPanel({ boreholes }: { boreholes: Borehole[] }) {
+  const section = useMemo(() => buildSection(boreholes), [boreholes])
+  const svg = useMemo(
+    () => (section.holes.length > 1 ? planToSvg(sectionDrawing(section), 720) : null),
+    [section],
+  )
+  if (!svg) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Correlated section</h2>
+        <p className="text-[12px] text-slate-600">
+          A section needs at least two boreholes. With one there is nothing to correlate.
+        </p>
+      </div>
+    )
+  }
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+      <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Correlated section</h2>
+      <p className="mb-3 text-[11px] text-slate-500">
+        Only the vertical hole traces are measured. Every boundary between holes is inferred and is drawn
+        dashed to say so — this is the most over-read drawing in a geotechnical report, and it is an
+        interpretation, not a record. Layers are correlated by USCS symbol or name, never by their position
+        in the sequence.
+      </p>
+      <div className="overflow-x-auto" dangerouslySetInnerHTML={{ __html: svg }} />
+      {section.notes.map((n, k) => (
+        <p key={k} className="mt-2 text-[11px] text-amber-900">{n}</p>
+      ))}
+    </div>
   )
 }
 


### PR DESCRIPTION
**Phase 8e.** The section engine from #496 shipped **unreachable from the app** — an engine nobody can open is half a job.

## Report §5

The section now follows the borehole logs, **never precedes them**: a reader should meet the measured holes before the drawing that interpolates between them. It comes with a paragraph saying in as many words that it is an **interpretation**, that only the hole traces are measured, and that every boundary between holes is dashed to say so.

With a single hole, both the figure and the paragraph are **omitted** rather than printing a "section" of one.

## `/soils` profile tab

The same drawing, with the same framing above it and the correlation notes below.

## Verification

`npx tsc -b`, `npm run lint`, `npm test` (**2934 tests**), `npm run build` — all clean.

Rendered in the browser against the sample investigation with coordinates added. The section draws to scale at real Baguio elevations (~1450 m), the water-table marks appear, inferred boundaries are dashed, and the notes report that **three correlations rested on layer name** because the sample's layers carry no USCS symbols.

That last part is worth noting: it's the *same* gap §5 of the report already states independently. Two parts of the module reaching the same conclusion about the same data is a good sign they agree.

## One existing test changed

§5 now has three figures for the two-hole sample rather than two. That's the new behaviour — asserted, not accommodated, with two further tests pinning that the section follows the logs and disappears for a single hole.

## Still unreachable

`cpt.ts` (Phase 8c). The model has no field for cone readings — `Borehole` would need `cpt?: CptReading[]` plus a `meshValidation` rule — so wiring it is a schema change rather than a page, and belongs in its own PR. Recorded in `HANDOFF.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_