### PR TITLE
fix(auth): read the plan from app_metadata, closing the self-grant hole

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1348,7 +1348,8 @@ because flagging the unusual as an error trains people to ignore errors.
 | 8e — section wired into the report and the profile tab | #497 | merged |
 | 8f — CPT in the model, validation and a UI tab | #498 | merged |
 | fix — remove the mixed-method `bearingCapacity()` | #499 | merged |
-| 8b — sync UI + live connection self-test | — | open |
+| 8b — sync UI + live connection self-test | #500 | merged |
+| fix — plan moved to `app_metadata` (self-grant closed) | — | open |
 
 **`/soils` is live**, gated behind the `soil-investigation` feature on pro and
 max. Eight tabs: overview and integrity, boreholes with the graphical log,

--- a/supabase/functions/billing-webhook/index.ts
+++ b/supabase/functions/billing-webhook/index.ts
@@ -82,13 +82,19 @@ Deno.serve(async (req: Request): Promise<Response> => {
     console.error('no such user:', outcome.userId, readErr?.message ?? '')
     return deny(404)
   }
-  const meta = (existing.user.user_metadata ?? {}) as Record<string, unknown>
+  // THE PLAN LIVES IN app_metadata. `updateUser({ data })` from the browser
+  // writes user_metadata, so a plan kept there could be granted by the account
+  // itself; app_metadata is writable only with the service-role key, which is
+  // held here and nowhere else. The client reads app_metadata with no fallback.
+  const meta = (existing.user.app_metadata ?? {}) as Record<string, unknown>
   if (meta.billing_event_id === outcome.eventId) {
     return new Response('already applied', { status: 200 })
   }
 
   const { error } = await admin.auth.admin.updateUserById(outcome.userId, {
-    user_metadata: {
+    // SPREAD, never replace: app_metadata also carries Supabase's own
+    // `provider` and `providers` fields, and dropping those breaks sign-in.
+    app_metadata: {
       ...meta,
       plan: outcome.plan,
       billing_event_id: outcome.eventId,

--- a/supabase/migrations/20260731120000_plan_to_app_metadata.sql
+++ b/supabase/migrations/20260731120000_plan_to_app_metadata.sql
@@ -1,0 +1,45 @@
+-- ─────────────────────────────────────────────────────────────────────────
+-- Move the subscription plan from user_metadata to app_metadata.
+--
+-- WHY. `raw_user_meta_data` is writable by the account itself — a signed-in
+-- user can run `supabase.auth.updateUser({ data: { plan: 'max' } })` from a
+-- browser console and the app would believe them. `raw_app_meta_data` is
+-- writable only with the service-role key, which lives in the billing webhook
+-- and nowhere else.
+--
+-- The client now reads app_metadata with NO FALLBACK to user_metadata, so this
+-- migration must run for existing paying users to keep their plan.
+--
+-- Safe to re-run: it copies only where a plan exists and app_metadata does not
+-- already carry one, so a second run is a no-op.
+-- ─────────────────────────────────────────────────────────────────────────
+
+update auth.users
+set raw_app_meta_data =
+      coalesce(raw_app_meta_data, '{}'::jsonb)
+      || jsonb_strip_nulls(jsonb_build_object(
+           'plan',               raw_user_meta_data->>'plan',
+           'billing_event_id',   raw_user_meta_data->>'billing_event_id',
+           'billing_updated_at', raw_user_meta_data->>'billing_updated_at'
+         ))
+where raw_user_meta_data ? 'plan'
+  and coalesce(raw_app_meta_data->>'plan', '') = '';
+
+-- Then remove the old copy, so nothing reads a stale plan and no user can
+-- resurrect one by editing their own metadata.
+--
+-- Runs SECOND and separately: if the copy above failed, this would otherwise
+-- delete the only record of what people had paid for.
+update auth.users
+set raw_user_meta_data = raw_user_meta_data - 'plan' - 'billing_event_id' - 'billing_updated_at'
+where raw_user_meta_data ? 'plan'
+  and raw_app_meta_data->>'plan' is not null;
+
+-- Check afterwards — every row should show the plan under app, and nothing
+-- under user:
+--
+--   select email,
+--          raw_app_meta_data->>'plan'  as app_plan,
+--          raw_user_meta_data->>'plan' as user_plan
+--   from auth.users
+--   order by email;

--- a/webapp/src/lib/auth/authClient.test.ts
+++ b/webapp/src/lib/auth/authClient.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import type { Session } from '@supabase/supabase-js'
+import { toUser } from './authClient'
+
+/** Minimal session stand-in — only the fields `toUser` reads. */
+const session = (
+  app: Record<string, unknown>, user: Record<string, unknown> = {},
+): Session => ({
+  user: {
+    id: 'u1', email: 'a@b.c', email_confirmed_at: '2026-01-01T00:00:00Z',
+    app_metadata: app, user_metadata: user,
+  },
+} as unknown as Session)
+
+describe('where the plan comes from', () => {
+  it('reads the plan from APP metadata', () => {
+    expect(toUser(session({ plan: 'pro' }))!.plan).toBe('pro')
+  })
+
+  it('IGNORES a plan planted in user metadata', () => {
+    // The security property. `updateUser({ data })` writes user_metadata, so an
+    // account could set this itself; if it were honoured, the paywall would be
+    // a suggestion and any signed-in user could grant themselves `max` from a
+    // browser console.
+    expect(toUser(session({}, { plan: 'max' }))!.plan).toBeNull()
+  })
+
+  it('takes app metadata even when user metadata disagrees', () => {
+    expect(toUser(session({ plan: 'free' }, { plan: 'max' }))!.plan).toBe('free')
+  })
+
+  it('is null when no plan has been granted', () => {
+    expect(toUser(session({}))!.plan).toBeNull()
+  })
+
+  it('ignores a non-string plan rather than coercing it', () => {
+    expect(toUser(session({ plan: 42 }))!.plan).toBeNull()
+    expect(toUser(session({ plan: { tier: 'max' } }))!.plan).toBeNull()
+  })
+})
+
+describe('the rest of the mapping', () => {
+  it('still takes the display NAME from user metadata, which the user owns', () => {
+    // Deliberate: a name is the user's to set. A plan is not.
+    const u = toUser(session({ plan: 'pro' }, { name: 'A. Engineer' }))!
+    expect(u.name).toBe('A. Engineer')
+    expect(u.plan).toBe('pro')
+  })
+
+  it('carries id, email and verification through', () => {
+    const u = toUser(session({}))!
+    expect(u.id).toBe('u1')
+    expect(u.email).toBe('a@b.c')
+    expect(u.emailVerified).toBe(true)
+  })
+
+  it('is null for no session', () => {
+    expect(toUser(null)).toBeNull()
+  })
+
+  it('survives metadata being absent entirely', () => {
+    const s = { user: { id: 'u2', email: null } } as unknown as Session
+    const u = toUser(s)!
+    expect(u.plan).toBeNull()
+    expect(u.name).toBeNull()
+    expect(u.emailVerified).toBe(false)
+  })
+})

--- a/webapp/src/lib/auth/authClient.ts
+++ b/webapp/src/lib/auth/authClient.ts
@@ -28,7 +28,7 @@ export interface AuthUser {
   /** True once the address has been confirmed. */
   emailVerified: boolean
   /**
-   * Subscription plan id from user metadata.
+   * Subscription plan id, read from APP METADATA.
    *
    * Read-only here, and null until something sets it. Nothing in the browser
    * may grant itself a plan — that has to come from the server side (a
@@ -115,12 +115,26 @@ export function classifyError(message: string, status?: number): AuthError {
   return { kind: 'unknown', message: 'Something went wrong. Please try again.' }
 }
 
-const toUser = (s: Session | null): AuthUser | null => {
+/**
+ * Map a session to the app's user. Exported so the plan's provenance can be
+ * pinned by a test — that it comes from app_metadata and that a plan planted
+ * in user_metadata is ignored is a SECURITY property, not a detail.
+ */
+export const toUser = (s: Session | null): AuthUser | null => {
   const u = s?.user
   if (!u) return null
   const meta = (u.user_metadata ?? {}) as Record<string, unknown>
   const name = typeof meta.name === 'string' ? meta.name : null
-  const plan = typeof meta.plan === 'string' ? meta.plan : null
+
+  // THE PLAN COMES FROM app_metadata, NOT user_metadata, and there is
+  // deliberately NO FALLBACK to user_metadata. `updateUser({ data })` writes
+  // user_metadata, so a signed-in account could set its own plan there; a
+  // fallback "for the transition" would leave that door open permanently.
+  // app_metadata is writable only with the service-role key, which lives in
+  // the billing webhook and nowhere else.
+  const appMeta = (u.app_metadata ?? {}) as Record<string, unknown>
+  const plan = typeof appMeta.plan === 'string' ? appMeta.plan : null
+
   return { id: u.id, email: u.email ?? null, name, emailVerified: !!u.email_confirmed_at, plan }
 }
 

--- a/webapp/src/lib/auth/profile.ts
+++ b/webapp/src/lib/auth/profile.ts
@@ -5,13 +5,19 @@
 // page: their name, their licence number, their firm. This holds them once so
 // the letterhead can start filled in.
 //
-// STORED LOCALLY, NOT IN THE ACCOUNT — deliberately. Writing to Supabase
-// `user_metadata` from the browser is possible, but that is the SAME field the
-// billing webhook writes `plan` into, and a client that can PATCH its own
-// metadata is a client that can try to set `plan: 'max'`. Row-level security
-// would be the answer, and until that exists these preferences are worth far
-// less than the risk of opening that door. They are cosmetic — a name printed
-// on a sheet — so localStorage is the honest place for them.
+// STORED LOCALLY, NOT IN THE ACCOUNT — deliberately.
+//
+// The original reason was that `user_metadata` was also where the billing
+// webhook wrote `plan`, so a client able to PATCH its own metadata was a client
+// able to try `plan: 'max'`. THAT REASON IS GONE: the plan moved to
+// `app_metadata`, which only the service-role key can write, and a test pins
+// that a plan planted in user_metadata is ignored.
+//
+// These stay local anyway, for a plainer reason: they are cosmetic and
+// per-machine — a name and a firm printed on a sheet — and syncing them would
+// buy a round trip and a conflict case for no benefit. If they ever need to
+// follow an engineer between devices, user_metadata is now a safe home for
+// them.
 //
 // The consequence is stated in the UI: these follow the browser, not the login.
 // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
`authClient.ts` claimed:

> *Nothing in the browser may grant itself a plan — or the paywall would be a suggestion.*

That wasn't true. The plan was read from `user_metadata`, which the account itself can write:

```js
await supabase.auth.updateUser({ data: { plan: 'max' } })
```

…and the app believed it.

## The fix

The plan now lives in **`app_metadata`**, writable only with the service-role key — which the billing webhook holds and nothing else does.

**There is no fallback to `user_metadata`.** A fallback "for the transition" would leave the door open permanently, so existing plans move by migration instead.

- `toUser` reads `app_metadata.plan` and is now **exported**, so the provenance can be pinned. Tests assert a plan planted in `user_metadata` is **ignored**, and that `app_metadata` wins when the two disagree.
- The webhook writes `app_metadata` and **spreads rather than replaces** it — `app_metadata` also carries Supabase's own `provider`/`providers`, and dropping those breaks sign-in. That one's easy to get wrong.
- The idempotency key moved with it, so a retried webhook is still a no-op.
- **Migration `20260731120000`** copies existing plans across, then strips the old copy — in **two separate statements**, because if the copy failed, a single combined statement would delete the only record of what people had paid for.

The display **name** deliberately stays in `user_metadata`. A name is the user's to set; a plan is not — and there's a test saying so.

## A stale rationale, also corrected

`profile.ts` justified keeping preferences in localStorage because `user_metadata` was "the SAME field the billing webhook writes `plan` into". That reason is now gone. I replaced it with the honest one — they're cosmetic and per-machine — and noted that `user_metadata` is now a safe home for them if they ever need to follow an engineer between devices. A comment that justifies a decision with a reason that no longer exists is worse than no comment.

## Scope, stated plainly

This was **never a data-access hole**. Investigations are protected by RLS, which is separate and sound, and self-granting a plan unlocked UI whose code already ships in the browser bundle.

What it *did* make was **paid tiers trivially bypassable by anyone who read the source** — a commercial problem, and a real one the moment anything server-side starts trusting that field.

## After merging

Run the migration (SQL Editor, or `supabase db push`). Then verify:

```sql
select email,
       raw_app_meta_data->>'plan'  as app_plan,
       raw_user_meta_data->>'plan' as user_plan
from auth.users order by email;
```

Every row should show the plan under `app_plan` and **nothing** under `user_plan`. Users need to sign out and back in for the new session to carry it.

To grant yourself `max` from now on:

```sql
update auth.users
set raw_app_meta_data =
  coalesce(raw_app_meta_data, '{}'::jsonb) || jsonb_build_object('plan', 'max')
where email = 'raymval246@gmail.com';
```

## Verification

`npx tsc -b`, `npm run lint`, `npm test` (**2966 tests**), `npm run build` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_