### PR TITLE
refactor(brand): rename CivEng → CivEngg, from one constant

### DIFF
--- a/webapp/src/components/AppShell.tsx
+++ b/webapp/src/components/AppShell.tsx
@@ -5,6 +5,7 @@ import { CommandPalette } from './CommandPalette'
 import { usePaletteHotkey } from '../lib/usePaletteHotkey'
 import { SiteFooter } from './SiteFooter'
 import { AccountMenu } from './AccountMenu'
+import { BRAND_MARK, BRAND_TAIL } from '../lib/brand'
 
 // Workbench shell (docs/design/uiux-2026-07): persistent ink-navy sidebar with
 // the grouped tool catalog + ⌘K search, and a slim breadcrumb header. Wraps
@@ -30,8 +31,8 @@ function Sidebar({ onOpenPalette }: { onOpenPalette: () => void }) {
     <aside className="no-print sticky top-0 hidden h-screen w-[230px] flex-none flex-col overflow-y-auto bg-[#0f1b2a] text-[#e8eaed] lg:flex">
       <div className="border-b border-white/10 p-4 pb-3.5">
         <Link to="/" className="flex items-baseline gap-2">
-          <span className="text-[15px] font-extrabold tracking-[.14em] text-white">CIVENG</span>
-          <span className="text-[9px] font-semibold uppercase tracking-[.22em] text-[#7d8ea3]">Toolkit</span>
+          <span className="text-[15px] font-extrabold tracking-[.14em] text-white">{BRAND_MARK}</span>
+          <span className="text-[9px] font-semibold uppercase tracking-[.22em] text-[#7d8ea3]">{BRAND_TAIL}</span>
         </Link>
         <div className="mt-3"><SearchBox onOpen={onOpenPalette} compact /></div>
       </div>
@@ -84,7 +85,7 @@ export function AppShell({ children }: { children: ReactNode }) {
         <header className="no-print sticky top-0 z-40 border-b border-[#e3e1da] bg-white/95 backdrop-blur">
           <div className="flex h-11 items-center gap-3 px-4 sm:px-6">
             <Link to="/" className="flex items-baseline gap-1.5 lg:hidden">
-              <span className="text-[13px] font-extrabold tracking-[.14em] text-[#0f1b2a]">CIVENG</span>
+              <span className="text-[13px] font-extrabold tracking-[.14em] text-[#0f1b2a]">{BRAND_MARK}</span>
             </Link>
             <div className="flex min-w-0 items-center gap-2 text-[11px] text-[#7a7568]">
               <Link to="/" className="hover:text-[#0f4c92]">Workbench</Link>

--- a/webapp/src/components/ReportControls.tsx
+++ b/webapp/src/components/ReportControls.tsx
@@ -2,6 +2,7 @@ import { useState, type JSX } from 'react'
 import type { CalcPdfInput } from '../lib/calcPdf'
 import { ExportPdfButton } from './ExportPdfButton'
 import { loadProfile, letterheadDefaults } from '../lib/auth/profile'
+import { BRAND_MARK, BRAND_TAIL, docLabel } from '../lib/brand'
 
 /**
  * A page's report payload, minus the parts this component already owns.
@@ -31,7 +32,7 @@ export interface ReportControlsProps {
  * Report letterhead for every calculator page (docs/design/uiux-2026-07,
  * Report Print): on screen a letterhead card (Project / Sheet / Prepared by /
  * Date) with the ⎙ Export action; in print, the calc-sheet header — mono
- * document strip, CIVENG brand block, title, code badges and the letterhead
+ * document strip, wordmark block, title, code badges and the letterhead
  * grid — ahead of the page's themed content. Pages with structured results
  * use the full PrintReport instead (components/calc.tsx).
  */
@@ -93,12 +94,12 @@ export function ReportControls({ title, badges = ['NSCP 2015', 'ACI 318-14'], re
       {/* Print: calc-sheet letterhead header */}
       <div className="print-only mb-4">
         <div className="flex items-baseline justify-between border-b border-[#eeece5] pb-1.5 font-mono text-[9px] text-[#a39d8d]">
-          <span>CIVENG TOOLKIT · {title.toUpperCase()}</span>
+          <span>{docLabel(title)}</span>
           <span>{sheet || '—'} · {today}</span>
         </div>
         <div className="mt-3 flex items-baseline gap-2">
-          <span className="text-[14px] font-extrabold tracking-[.14em]">CIVENG</span>
-          <span className="text-[8px] font-semibold uppercase tracking-[.22em] text-[#7a7568]">Toolkit</span>
+          <span className="text-[14px] font-extrabold tracking-[.14em]">{BRAND_MARK}</span>
+          <span className="text-[8px] font-semibold uppercase tracking-[.22em] text-[#7a7568]">{BRAND_TAIL}</span>
         </div>
         <h1 className="mt-2 text-[24px] font-extrabold tracking-tight text-[#0f1b2a]">{title}</h1>
         <div className="mt-2 flex gap-2">

--- a/webapp/src/components/SiteFooter.tsx
+++ b/webapp/src/components/SiteFooter.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
 import { SITE, businessName, addressLines, missingSiteFields } from '../lib/siteConfig'
+import { BRAND_MARK, BRAND_TAIL } from '../lib/brand'
 
 /**
  * Public footer.
@@ -17,8 +18,8 @@ export function SiteFooter() {
       <div className="mx-auto grid max-w-[1200px] gap-6 px-6 py-8 sm:grid-cols-2 lg:grid-cols-4">
         <div>
           <div className="flex items-baseline gap-2">
-            <span className="text-[13px] font-extrabold tracking-[.14em] text-[#0f1b2a]">CIVENG</span>
-            <span className="text-[8.5px] font-semibold uppercase tracking-[.22em] text-[#7a7568]">Toolkit</span>
+            <span className="text-[13px] font-extrabold tracking-[.14em] text-[#0f1b2a]">{BRAND_MARK}</span>
+            <span className="text-[8.5px] font-semibold uppercase tracking-[.22em] text-[#7a7568]">{BRAND_TAIL}</span>
           </div>
           <p className="mt-2 text-[12px] leading-5 text-slate-500">
             Structural and geotechnical calculation software to NSCP 2015, ACI 318-14 and AISC 360-16.

--- a/webapp/src/components/calc.tsx
+++ b/webapp/src/components/calc.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import { ExportPdfButton } from './ExportPdfButton'
 import type { SolutionStep } from '../lib/solution'
 import { Math as KTex } from '../lib/math'
+import { BRAND_MARK, BRAND_TAIL, COMPUTED_BY, docLabel } from '../lib/brand'
 
 // Calculator-template building blocks (docs/design/uiux-2026-07, Foundation /
 // Beam mockups): numbered input sections on the left, a sticky verdict panel
@@ -196,14 +197,14 @@ export function PrintReport({ docTitle, docCode, badges, ok, governing, lh, stat
     </div>
     <div className="print-only">
       <div className="flex items-baseline justify-between border-b border-[#eeece5] pb-1.5 font-mono text-[9px] text-[#a39d8d]">
-        <span>CIVENG TOOLKIT · {docTitle.toUpperCase()} — CALCULATION REPORT</span>
+        <span>{docLabel(`${docTitle} — Calculation Report`)}</span>
         <span>{lh.sheet || docCode} · {today}</span>
       </div>
       <div className="mt-3 flex items-start justify-between gap-4">
         <div>
           <div className="flex items-baseline gap-2">
-            <span className="text-[14px] font-extrabold tracking-[.14em]">CIVENG</span>
-            <span className="text-[8px] font-semibold uppercase tracking-[.22em] text-[#7a7568]">Toolkit</span>
+            <span className="text-[14px] font-extrabold tracking-[.14em]">{BRAND_MARK}</span>
+            <span className="text-[8px] font-semibold uppercase tracking-[.22em] text-[#7a7568]">{BRAND_TAIL}</span>
           </div>
           <h1 className="mt-2 text-[24px] font-extrabold tracking-tight">{docTitle} — Design Calculation</h1>
           <div className="mt-2 flex gap-2">
@@ -296,7 +297,7 @@ export function PrintReport({ docTitle, docCode, badges, ok, governing, lh, stat
         <div><div className="h-11 border-b border-[#0f1b2a]" /><p className="mt-1.5 text-[10px] font-bold">{lh.preparedBy || '\u00a0'}</p><p className="text-[9px] text-[#7a7568]">Prepared by</p></div>
         <div><div className="h-11 border-b border-[#0f1b2a]" /><p className="mt-1.5 text-[10px] font-bold">{'\u00a0'}</p><p className="text-[9px] text-[#7a7568]">Reviewed by · Date</p></div>
       </div>
-      <p className="mt-4 text-[8.5px] leading-relaxed text-[#a39d8d]">Computed client-side by the CivEng Toolkit engine · verify before construction use. Load factors per NSCP 2015 §203.3; strength reduction factors per ACI 318-14 Table 21.2.1. Project: {lh.project || '—'}.</p>
+      <p className="mt-4 text-[8.5px] leading-relaxed text-[#a39d8d]">{COMPUTED_BY} Load factors per NSCP 2015 §203.3; strength reduction factors per ACI 318-14 Table 21.2.1. Project: {lh.project || '—'}.</p>
     </div>
     </>
   )

--- a/webapp/src/lib/brand.test.ts
+++ b/webapp/src/lib/brand.test.ts
@@ -1,0 +1,46 @@
+// The brand was previously typed out by hand in twelve files across three
+// casings, and nothing failed when they disagreed. These tests exist so the
+// next rename cannot leave a stale spelling behind in a PDF nobody reopened.
+
+import { describe, it, expect } from 'vitest'
+import { BRAND_NAME, BRAND_UPPER, BRAND_MARK, BRAND_TAIL, COMPUTED_BY, docLabel } from './brand'
+import { SITE } from './siteConfig'
+
+describe('brand', () => {
+  it('is the trade name — the brand is a business fact, not a UI string', () => {
+    expect(BRAND_NAME).toBe(SITE.tradeName)
+    expect(BRAND_NAME).toBe('CivEngg Toolkit')
+  })
+
+  it('splits into a wordmark that reassembles into the whole name', () => {
+    // The invariant that matters: rename the trade name and BOTH halves of the
+    // wordmark follow. A test on the literals alone would pass while the mark
+    // still read CIVENG.
+    expect([BRAND_MARK, BRAND_TAIL].filter(Boolean).join(' ')).toBe(BRAND_UPPER)
+    expect(BRAND_MARK).toBe('CIVENGG')
+    expect(BRAND_TAIL).toBe('TOOLKIT')
+  })
+
+  it('builds document strips in the shared house style', () => {
+    expect(docLabel('Structure — Calculation Report'))
+      .toBe('CIVENGG TOOLKIT · STRUCTURE — CALCULATION REPORT')
+    // Every sheet in the set uses the same separator, so the calc sheets, the
+    // structure report and the soils report read as one document.
+    expect(docLabel('anything')).toMatch(/^CIVENGG TOOLKIT · /)
+  })
+
+  it('names itself in the engine attribution', () => {
+    expect(COMPUTED_BY).toContain(BRAND_NAME)
+    expect(COMPUTED_BY).toContain('verify before construction use')
+  })
+
+  it('leaves no trace of the old spelling', () => {
+    // `CivEngg` contains `CivEng` as a prefix, so a naive substring check would
+    // pass on the old name too. Match the old name only where it is NOT
+    // followed by the second g.
+    const stale = /CivEng(?!g)|CIVENG(?!G)/
+    for (const s of [BRAND_NAME, BRAND_UPPER, BRAND_MARK, BRAND_TAIL, COMPUTED_BY, docLabel('x')]) {
+      expect(s).not.toMatch(stale)
+    }
+  })
+})

--- a/webapp/src/lib/brand.ts
+++ b/webapp/src/lib/brand.ts
@@ -1,0 +1,50 @@
+// ─────────────────────────────────────────────────────────────────────────
+// THE BRAND, IN ONE PLACE.
+//
+// The name was previously typed out in twelve files across three casings —
+// `CivEngg Toolkit` in prose, `CIVENGG TOOLKIT` in the PDF document strip, and
+// `CIVENGG` as the wordmark — so renaming it meant finding every one of them
+// and getting each casing right. Everything now derives from
+// `SITE.tradeName`, which is where a business fact belongs.
+//
+// The derivation is deliberately dumb: the wordmark is the FIRST word and the
+// tail is the rest. That covers a two-word trade name and degrades sensibly for
+// a one-word one (empty tail). `brand.test.ts` asserts the pieces reassemble
+// into the trade name, so a future rename cannot leave the wordmark behind.
+// ─────────────────────────────────────────────────────────────────────────
+
+import { SITE } from './siteConfig'
+
+/** The trade name as written in prose: `CivEngg Toolkit`.
+ *  Named `BRAND_NAME`, not `BRAND`, because `pdfKit` already exports `BRAND`
+ *  as the brand COLOUR — two different things must not share one name. */
+export const BRAND_NAME = SITE.tradeName
+
+/** The whole name in caps, for the PDF document strip: `CIVENGG TOOLKIT`. */
+export const BRAND_UPPER = BRAND_NAME.toUpperCase()
+
+const words = BRAND_NAME.trim().split(/\s+/)
+
+/** The heavy half of the wordmark: `CIVENGG`. */
+export const BRAND_MARK = (words[0] ?? '').toUpperCase()
+
+/** The light half that sits beside it: `TOOLKIT`. Empty for a one-word name. */
+export const BRAND_TAIL = words.slice(1).join(' ').toUpperCase()
+
+/**
+ * A PDF/report document-strip label: `CIVENGG TOOLKIT · STRUCTURE — CALCULATION REPORT`.
+ *
+ * Every sheet in the set is built from this, so the separator and casing cannot
+ * drift between the calc sheets, the structure report and the soils report —
+ * they are meant to look like pages from one document.
+ */
+export const docLabel = (sheet: string): string => `${BRAND_UPPER} · ${sheet.toUpperCase()}`
+
+/**
+ * The engine attribution printed under every calculation.
+ *
+ * Kept here rather than repeated at each call site because it is a CLAIM about
+ * where the numbers came from — three copies of it is three chances for one to
+ * go stale and say something no longer true.
+ */
+export const COMPUTED_BY = `Computed client-side by the ${BRAND_NAME} engine · verify before construction use.`

--- a/webapp/src/lib/calcPdf.ts
+++ b/webapp/src/lib/calcPdf.ts
@@ -22,6 +22,7 @@
 import type { LetterheadState, VerdictStat } from '../components/calc'
 import type { SolutionStep } from './solution'
 import { createSheet, autoTable, MUTED } from './pdfKit'
+import { COMPUTED_BY, docLabel as brandDocLabel } from './brand'
 
 export interface CalcCheckRow { name: string; ratio: number; ok: boolean }
 
@@ -59,7 +60,7 @@ export async function generateCalcPdf(input: CalcPdfInput): Promise<void> {
   const { doc } = s
   const today = new Date().toISOString().slice(0, 10)
   const sheet = lh.sheet || docCode
-  const docLabel = `CIVENG TOOLKIT · ${docTitle.toUpperCase()} — CALCULATION REPORT`
+  const docLabel = brandDocLabel(`${docTitle} — Calculation Report`)
 
   s.brandHeader({ docLabel, title: `${docTitle} — Design Calculation`, sheet, today, ok, governing, badges })
   s.letterheadGrid([
@@ -125,7 +126,7 @@ export async function generateCalcPdf(input: CalcPdfInput): Promise<void> {
 
   s.signatures(lh.preparedBy)
   s.disclaimer(
-    'Computed client-side by the CivEng Toolkit engine · verify before construction use. '
+    COMPUTED_BY + ' '
     + 'Load factors per NSCP 2015 §203.3; strength reduction factors per ACI 318-14 Table 21.2.1. '
     + `Project: ${lh.project || '—'}.`,
   )

--- a/webapp/src/lib/modelPdf.ts
+++ b/webapp/src/lib/modelPdf.ts
@@ -1,6 +1,6 @@
 // Direct PDF export of the Model Space structure report — A4 portrait calc
-// sheet built from the SHARED chrome in `pdfKit` (mono header strip, CIVENG
-// brand, verdict chip, letterhead grid, numbered section rules, PASS/FAIL
+// sheet built from the SHARED chrome in `pdfKit` (mono header strip, the
+// wordmark, verdict chip, letterhead grid, numbered section rules, PASS/FAIL
 // chips, equation boxes, signature blocks, per-page footer). The calculator
 // pages' `calcPdf` is built from the same kit, which is what keeps the two
 // reports looking like sheets from one set instead of two lookalikes that
@@ -13,6 +13,7 @@
 // loaded lazily via dynamic import.
 import type { LetterheadState } from '../components/calc'
 import type { ModelReport, ReportSection } from './modelReport'
+import { COMPUTED_BY, docLabel as brandDocLabel } from './brand'
 import {
   createSheet, autoTable,
   INK, MUTED, FAINT, BRAND, HAIR, M, CONTENT_W,
@@ -37,7 +38,7 @@ export async function generateModelPdf({ lh, report, modelImg, badges, fileName 
 
   const today = new Date().toISOString().slice(0, 10)
   const sheet = lh.sheet || 'S-3D'
-  const docLabel = 'CIVENG TOOLKIT · STRUCTURE — CALCULATION REPORT'
+  const docLabel = brandDocLabel('Structure — Calculation Report')
 
   const CONC: [number, number, number] = [238, 243, 248]
   /** Vector cross-section (bar layout + stirrup hooks + dimension lines) drawn
@@ -306,7 +307,7 @@ export async function generateModelPdf({ lh, report, modelImg, badges, fileName 
 
   sh.signatures(lh.preparedBy)
   sh.disclaimer(
-    'Computed client-side by the CivEng Toolkit engine · verify before construction use. '
+    COMPUTED_BY + ' '
     + 'Load factors per NSCP 2015 §203.3; strength reduction factors per ACI 318-14 Table 21.2.1; '
     + `steel design per AISC 360-16 LRFD. Project: ${lh.project || '—'}.`,
   )

--- a/webapp/src/lib/pdfKit.ts
+++ b/webapp/src/lib/pdfKit.ts
@@ -2,7 +2,7 @@
 // PDF CALC-SHEET KIT — the shared chrome behind every generated report.
 //
 // The Model Space structure report and the calculator-page reports are meant to
-// look like sheets from the same set: mono document strip, CIVENG brand block,
+// look like sheets from the same set: mono document strip, the wordmark,
 // verdict chip, letterhead grid, numbered section rules, PASS/FAIL chips,
 // equation boxes, signature blocks, per-page footer. This module owns all of
 // that, ONCE, so "similar" survives the next edit to either report. Two copies
@@ -21,6 +21,7 @@ import { jsPDF } from 'jspdf'
 import autoTable from 'jspdf-autotable'
 import type { SolutionStep } from './solution'
 import { texToPlain } from './texText'
+import { BRAND_NAME, BRAND_MARK, BRAND_TAIL } from './brand'
 import { SANS, SANS_BOLD, MONO, MONO_BOLD } from './pdfFonts'
 
 export type RGB = [number, number, number]
@@ -140,7 +141,7 @@ export interface Sheet {
 }
 
 export interface BrandHeader {
-  /** Mono strip text, e.g. 'CIVENG TOOLKIT · STRUCTURE — CALCULATION REPORT'. */
+  /** Mono strip text — build it with `docLabel()` from `brand.ts`. */
   docLabel: string
   /** Large heading, e.g. 'Structure — Design Calculation'. */
   title: string
@@ -235,9 +236,9 @@ export function createSheet(): Sheet {
       doc.line(M, s.y, M + CONTENT_W, s.y)
       s.y += 7
       s.setF('sans', 'bold', 11.5, INK)
-      doc.text('CIVENG', M, s.y, { charSpace: 0.9 })
+      doc.text(BRAND_MARK, M, s.y, { charSpace: 0.9 })
       s.setF('sans', 'bold', 5.4, SUBTLE)
-      doc.text('TOOLKIT', M + doc.getTextWidth('CIVENG') + 13, s.y, { charSpace: 0.7 })
+      doc.text(BRAND_TAIL, M + doc.getTextWidth(BRAND_MARK) + 13, s.y, { charSpace: 0.7 })
       s.y += 8
       // The verdict chip occupies the top-right 52 mm, so the title has to fit
       // in what is left or it runs underneath it. Model Space's title is short
@@ -421,7 +422,7 @@ export function createSheet(): Sheet {
         doc.setDrawColor(...HAIR_SOFT); doc.setLineWidth(0.15)
         doc.line(M, FOOT_Y + 3, M + CONTENT_W, FOOT_Y + 3)
         s.setF('mono', 'normal', 5.6, FAINT)
-        doc.text(`${sheet} · ${project || 'CivEng Toolkit'}`, M, FOOT_Y + 6.5)
+        doc.text(`${sheet} · ${project || BRAND_NAME}`, M, FOOT_Y + 6.5)
         doc.text(`page ${p} / ${pages}`, M + CONTENT_W, FOOT_Y + 6.5, { align: 'right' })
       }
     },

--- a/webapp/src/lib/scheduleExcel.ts
+++ b/webapp/src/lib/scheduleExcel.ts
@@ -2,6 +2,7 @@
 // Loaded lazily via dynamic import so ExcelJS stays out of the main bundle.
 import ExcelJS from 'exceljs'
 import type { ScheduleReport } from './scheduleReport'
+import { BRAND_NAME } from './brand'
 
 /** Excel sheet names: ≤31 chars, none of : \ / ? * [ ]. */
 const sheetName = (t: string): string => t.replace(/[:\\/?*[\]]/g, ' ').slice(0, 31)
@@ -9,7 +10,7 @@ const sheetName = (t: string): string => t.replace(/[:\\/?*[\]]/g, ' ').slice(0,
 /** Build the report workbook (no I/O — node-testable). */
 export function buildScheduleWorkbook(report: ScheduleReport): ExcelJS.Workbook {
   const wb = new ExcelJS.Workbook()
-  wb.creator = 'CivEng Toolkit'
+  wb.creator = BRAND_NAME
 
   const summary = wb.addWorksheet('Summary')
   summary.addRow([report.title]).font = { bold: true, size: 13 }

--- a/webapp/src/lib/schedulePdf.ts
+++ b/webapp/src/lib/schedulePdf.ts
@@ -3,6 +3,7 @@
 import { jsPDF } from 'jspdf'
 import autoTable from 'jspdf-autotable'
 import type { ScheduleReport } from './scheduleReport'
+import { BRAND_NAME } from './brand'
 
 const BRAND: [number, number, number] = [15, 76, 146]
 const INK: [number, number, number] = [15, 27, 42]
@@ -49,7 +50,7 @@ export function buildSchedulePdf(report: ScheduleReport): jsPDF {
   for (let p = 1; p <= pages; p++) {
     doc.setPage(p)
     doc.setFont('helvetica', 'normal').setFontSize(8).setTextColor(163, 157, 141)
-    doc.text(`CivEng Toolkit · schedule report · ${today}`, 14, doc.internal.pageSize.getHeight() - 8)
+    doc.text(`${BRAND_NAME} · schedule report · ${today}`, 14, doc.internal.pageSize.getHeight() - 8)
     doc.text(`${p} / ${pages}`, pageW - 14, doc.internal.pageSize.getHeight() - 8, { align: 'right' })
   }
   return doc

--- a/webapp/src/lib/siteConfig.ts
+++ b/webapp/src/lib/siteConfig.ts
@@ -47,7 +47,7 @@ export interface SiteConfig {
 }
 
 export const SITE: SiteConfig = {
-  tradeName: 'CivEng Toolkit',
+  tradeName: 'CivEngg Toolkit',
 
   // ── FILL THESE IN ────────────────────────────────────────────────────
   legalName: '',

--- a/webapp/src/lib/soilsPdf.ts
+++ b/webapp/src/lib/soilsPdf.ts
@@ -25,6 +25,7 @@
 
 import type { SoilsReport, ReportSection } from '../engine/soils/report'
 import { createSheet, autoTable, MUTED, INK, BRAND, FAIL_FG, OK_FG, CONTENT_W, M, PAGE_W } from './pdfKit'
+import { docLabel as brandDocLabel } from './brand'
 import { paintDrawing, paintedSize } from './drawingPdf'
 
 const STATUS_LABEL = {
@@ -53,7 +54,7 @@ export function renderSoilsReport(
   const today = new Date().toISOString().slice(0, 10)
 
   s.brandHeader({
-    docLabel: 'CIVENG TOOLKIT · GEOTECHNICAL INVESTIGATION REPORT',
+    docLabel: brandDocLabel('Geotechnical Investigation Report'),
     title: r.title,
     sheet: r.investigationNo || 'GI-01',
     today: r.reportDate,

--- a/webapp/src/pages/Home.tsx
+++ b/webapp/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { AccountMenu } from '../components/AccountMenu'
 import { Link } from 'react-router-dom'
+import { BRAND_MARK, BRAND_TAIL } from '../lib/brand'
 import { SIDEBAR_GROUPS, ALL_TOOLS } from '../lib/tools'
 import { CommandPalette } from '../components/CommandPalette'
 import { usePaletteHotkey } from '../lib/usePaletteHotkey'
@@ -52,8 +53,8 @@ export default function Home({ onAuth }: { onAuth: (mode: 'login' | 'signup') =>
       <nav className="no-print sticky top-0 z-50 border-b border-white/10 bg-[#0f1b2a]">
         <div className="mx-auto flex h-[52px] max-w-[1200px] items-center gap-5 px-6">
           <Link to="/" className="flex items-baseline gap-2">
-            <span className="text-[15px] font-extrabold tracking-[.14em] text-white">CIVENG</span>
-            <span className="text-[9px] font-semibold uppercase tracking-[.22em] text-[#7d8ea3]">Toolkit</span>
+            <span className="text-[15px] font-extrabold tracking-[.14em] text-white">{BRAND_MARK}</span>
+            <span className="text-[9px] font-semibold uppercase tracking-[.22em] text-[#7d8ea3]">{BRAND_TAIL}</span>
           </Link>
           <div className="hidden items-center gap-0.5 md:flex">
             <a href="#tools" className="rounded-md px-2.5 py-1.5 text-[12.5px] font-semibold text-[#b6c2d0] hover:bg-white/5 hover:text-white">Tools</a>


### PR DESCRIPTION
Renames the app from **CivEng** to **CivEngg**.

## The rename was the easy half

The name was typed out by hand in **twelve files across three casings** — `CivEng Toolkit` in prose, `CIVENG TOOLKIT` in the PDF document strip, and `CIVENG` as the wordmark — and nothing failed when they disagreed. Doing the rename as twelve find-and-replaces would have set it up to happen again.

Everything now derives from `SITE.tradeName` through a new `lib/brand.ts`:

| constant | value | used by |
|---|---|---|
| `BRAND_NAME` | `CivEngg Toolkit` | prose, Excel `creator`, PDF footer |
| `BRAND_UPPER` | `CIVENGG TOOLKIT` | document strip |
| `BRAND_MARK` | `CIVENGG` | wordmark, heavy half |
| `BRAND_TAIL` | `TOOLKIT` | wordmark, light half |
| `docLabel(sheet)` | strip builder | calc / structure / soils sheets |
| `COMPUTED_BY` | engine attribution | printed under every calculation |

Named `BRAND_NAME` rather than `BRAND` because `pdfKit` already exports `BRAND` as the brand **colour**. Two different things must not share one name.

## One thing that wasn't just text

`pdfKit` placed the light half of the wordmark with `getTextWidth('CIVENG')` — the hard-coded string was **load-bearing for layout**. A plain find-and-replace on the visible text would have left the tail positioned for a word one character shorter. It now measures `BRAND_MARK`.

## Test

`brand.test.ts` pins the invariant that actually matters: `BRAND_MARK + ' ' + BRAND_TAIL === BRAND_UPPER`, so a future rename can't leave half the wordmark behind. It also asserts the old spelling is gone using `/CivEng(?!g)|CIVENG(?!G)/` — a naive substring check would match `CivEngg` too and pass on a failed rename.

## Verification

Browser, dev server: `/`, `/beam-design` and `/pricing` render `CIVENGG` / `CivEngg` with **no occurrence of the old name**. `npx tsc -b`, `eslint`, `npm test` (**2974 tests, 187 files**) and `npm run build` all clean.

## Flagged, not changed

`index.html` sets `<title>Civil Engineering</title>` — not the old brand, so not part of this rename, but it does mean the browser tab doesn't carry the product name. Say the word and I'll point it at `BRAND_NAME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_