### PR TITLE
feat(projects): saved projects — store, database ceiling, and the Model Space tab

### DIFF
--- a/supabase/migrations/20260804010000_projects.sql
+++ b/supabase/migrations/20260804010000_projects.sql
@@ -1,0 +1,122 @@
+-- ─────────────────────────────────────────────────────────────────────────
+-- Saved projects — durable storage for Model Space.
+--
+-- Until now the 3D model lived in `sessionStorage`, so it survived a reload
+-- and nothing else: close the tab and the work was gone. `saved-projects` has
+-- been listed on every plan since pricing was written, with no store behind it.
+--
+-- ONE ROW PER PROJECT, the document in a jsonb column, not a normalised
+-- schema. The argument is the same one made for soil investigations and is set
+-- out at length in webapp/src/engine/projects/remoteStore.ts: nothing queries
+-- across projects, the document shape is still moving, and normalising later
+-- is a migration rather than a rewrite.
+--
+-- ROW LEVEL SECURITY IS THE SECURITY BOUNDARY. The browser holds the anon key
+-- and the user's session; the `.eq('user_id', …)` filters in the client are an
+-- optimisation, not a control.
+--
+-- AND IT IS ALSO THE PAYWALL. The insert policy counts existing rows against
+-- the plan in the caller's JWT, so the project ceiling is enforced HERE rather
+-- than by a check in the browser that devtools could talk out of. That makes
+-- the saved-project limit the first entitlement in this app that is a real
+-- boundary rather than a product promise.
+-- ─────────────────────────────────────────────────────────────────────────
+
+create table if not exists public.projects (
+  id             text        primary key,
+  user_id        uuid        not null references auth.users (id) on delete cascade,
+  project        jsonb       not null,
+  -- Mirrors PROJECT_SCHEMA_VERSION in the client. A row written by a newer
+  -- client is refused by the reader rather than parsed.
+  schema_version integer     not null default 1,
+  updated_at     timestamptz not null default now(),
+  created_at     timestamptz not null default now()
+);
+
+-- The listing is "my projects, newest first" and nothing else. The insert
+-- policy's count runs on the same index.
+create index if not exists projects_user_updated_idx
+  on public.projects (user_id, updated_at desc);
+
+alter table public.projects enable row level security;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- How many projects may this account keep?
+--
+-- THIS DUPLICATES `maxProjects` IN webapp/src/lib/plans.ts, and there is no way
+-- around that: the server cannot import TypeScript and the browser cannot be
+-- trusted to enforce its own ceiling. The mitigation is a test —
+-- `plans.limits.test.ts` reads THIS FILE and fails if the two disagree — so the
+-- copies cannot drift silently.
+--
+-- The plan is read from app_metadata, which only the service-role key can
+-- write (migration 20260731120000). Reading it from user_metadata would let an
+-- account raise its own ceiling with one call from a browser console.
+--
+-- NULL means no limit. An unknown or absent plan falls to the free allowance,
+-- never to unlimited: the failure direction has to cost the business nothing.
+-- ─────────────────────────────────────────────────────────────────────────
+create or replace function public.project_limit()
+returns integer
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select case coalesce(auth.jwt() -> 'app_metadata' ->> 'plan', 'free')
+           when 'pro' then null
+           when 'max' then null
+           when 'free' then 3
+           else 3
+         end::integer;
+$$;
+
+grant execute on function public.project_limit() to authenticated;
+
+create or replace function public.project_count()
+returns integer
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select count(*)::integer from public.projects where user_id = auth.uid();
+$$;
+
+grant execute on function public.project_count() to authenticated;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Policies. Four rather than one FOR ALL, so a reader can see at a glance that
+-- INSERT cannot plant a row under another user_id and that only INSERT carries
+-- the ceiling.
+-- ─────────────────────────────────────────────────────────────────────────
+
+drop policy if exists "own projects are readable" on public.projects;
+create policy "own projects are readable"
+  on public.projects for select
+  using (auth.uid() = user_id);
+
+-- The ceiling applies to CREATING a project, never to saving one that already
+-- exists. A plan that lapses must not make existing work unsavable — meeting a
+-- paywall mid-edit, holding changes you cannot store, is the worst possible
+-- moment for it.
+drop policy if exists "own projects are insertable within the plan limit" on public.projects;
+create policy "own projects are insertable within the plan limit"
+  on public.projects for insert
+  with check (
+    auth.uid() = user_id
+    and (public.project_limit() is null or public.project_count() < public.project_limit())
+  );
+
+-- USING controls which rows may be updated; WITH CHECK stops an update from
+-- reassigning the row to somebody else. Both are needed, and neither counts.
+drop policy if exists "own projects are updatable" on public.projects;
+create policy "own projects are updatable"
+  on public.projects for update
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+drop policy if exists "own projects are deletable" on public.projects;
+create policy "own projects are deletable"
+  on public.projects for delete
+  using (auth.uid() = user_id);

--- a/webapp/src/components/ProjectsPanel.tsx
+++ b/webapp/src/components/ProjectsPanel.tsx
@@ -1,0 +1,257 @@
+// ─────────────────────────────────────────────────────────────────────────
+// The Projects tab in Model Space: save, open, rename, delete, and sync.
+//
+// Self-contained on purpose. Model Space is already ~4,500 lines; folding a
+// listing, a rename field, a delete confirm and a conflict resolver into it
+// would have made the page harder to read for the sake of avoiding one import.
+// The page hands over two things — the model and the design inputs — and gets
+// back a callback when the engineer opens something.
+//
+// The two rules that shape this panel:
+//   • DELETE ASKS. A structural model is a day's work and there is no undo.
+//   • CONFLICTS ARE THE ENGINEER'S TO SETTLE. The panel shows both sides and
+//     the two buttons; it never picks. See `useProjects.resolve`.
+// ─────────────────────────────────────────────────────────────────────────
+
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useProjects, conflictsIn } from '../lib/useProjects'
+import { readSession, writeSession, readOpenId, writeOpenId } from '../lib/modelSpaceSession'
+
+const when = (iso: string): string => {
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? '—' : d.toLocaleString()
+}
+
+// No props. The panel reads and writes the page's own session snapshot
+// (`lib/modelSpaceSession`), which means it never holds a second copy of the
+// sixty design fields Model Space keeps in component state.
+
+const BTN = 'rounded border border-[#cddcf0] bg-[#eaf1f9] px-2.5 py-1 text-[11.5px] font-semibold text-[#0f4c92] hover:bg-[#dbe8f5] disabled:cursor-not-allowed disabled:opacity-50'
+const BTN_QUIET = 'rounded border border-[#d6d3c9] px-2 py-1 text-[11px] font-semibold text-[#5b5648] hover:border-[#0056b3] hover:text-[#0056b3]'
+
+export function ProjectsPanel() {
+  const api = useProjects()
+  const [openId, setOpenId] = useState<string | null>(() => readOpenId())
+  const [name, setName] = useState('')
+  const [renaming, setRenaming] = useState<string | null>(null)
+  const [renameTo, setRenameTo] = useState('')
+  const [confirming, setConfirming] = useState<string | null>(null)
+
+  const conflicts = api.report ? conflictsIn(api.report) : []
+
+  const attach = (id: string | null) => { setOpenId(id); writeOpenId(id) }
+
+  const saveCurrent = () => {
+    const snap = readSession()
+    if (openId) {
+      const existing = api.load(openId)
+      if (existing) { api.save(openId, { ...existing, ...snap }); return }
+    }
+    const id = api.create(name.trim() || 'Untitled project', snap)
+    if (id) { attach(id); setName('') }
+  }
+
+  /**
+   * Opening writes the project into the session the page reads at mount and
+   * reloads. See `lib/modelSpaceSession` for why this beats calling sixty
+   * setters — in short, the setter list would be a third copy of the design
+   * inputs and would miss whichever field was added last.
+   */
+  const open = (id: string) => {
+    const p = api.load(id)
+    if (!p) return
+    writeSession({ model: p.model, inputs: p.inputs })
+    writeOpenId(id)
+    window.location.reload()
+  }
+
+  const del = (id: string) => {
+    api.remove(id)
+    if (openId === id) attach(null)
+    setConfirming(null)
+  }
+
+  return (
+    <div className="space-y-4 p-4">
+      {/* ── Save the open model ─────────────────────────────────────── */}
+      <div>
+        <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-[#7a7568]">Save this project</p>
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          <input
+            value={openId ? (api.load(openId)?.meta.name ?? '') : name}
+            onChange={(e) => (openId ? api.rename(openId, e.target.value) : setName(e.target.value))}
+            placeholder="Project name"
+            className="min-w-[180px] flex-1 rounded border border-[#d6d3c9] px-2 py-1 text-[12.5px]"
+          />
+          <button type="button" onClick={saveCurrent} className={BTN}
+            disabled={!openId && !api.canCreate.ok}>
+            {openId ? 'Save changes' : 'Save as new'}
+          </button>
+          {openId && (
+            <button type="button" onClick={() => attach(null)} className={BTN_QUIET}>
+              Detach
+            </button>
+          )}
+        </div>
+        {!openId && !api.canCreate.ok && (
+          <p className="mt-1.5 text-[11.5px] leading-5 text-amber-800">
+            🔒 {api.canCreate.message}{' '}
+            <Link to="/pricing" className="font-semibold underline">See plans</Link>
+          </p>
+        )}
+        {!readSession().model && (
+          <p className="mt-1.5 text-[11.5px] text-[#7a7568]">
+            No model yet — saving now keeps the name and the design inputs, and the
+            model joins it the next time you save.
+          </p>
+        )}
+      </div>
+
+      {/* ── The listing ─────────────────────────────────────────────── */}
+      <div>
+        <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-[#7a7568]">
+          Saved projects ({api.list.length})
+        </p>
+        {api.list.length === 0 ? (
+          <p className="mt-2 text-[12px] text-[#7a7568]">Nothing saved on this browser yet.</p>
+        ) : (
+          <ul className="mt-2 divide-y divide-[#eeece5] border-y border-[#eeece5]">
+            {api.list.map((p) => (
+              <li key={p.id} className="py-2">
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="truncate text-[13px] font-semibold text-[#0f1b2a]">
+                      {p.name}
+                      {p.id === openId && <span className="ml-2 rounded bg-[#eaf1f9] px-1.5 py-px text-[9.5px] font-bold uppercase tracking-wider text-[#0f4c92]">Open</span>}
+                    </p>
+                    <p className="text-[11px] text-[#7a7568]">
+                      {p.memberCount} member{p.memberCount === 1 ? '' : 's'} · {p.nodeCount} node{p.nodeCount === 1 ? '' : 's'} · saved {when(p.updatedAt)}
+                      {p.client && ` · ${p.client}`}
+                    </p>
+                  </div>
+                  <div className="flex flex-none gap-1.5">
+                    <button type="button" onClick={() => open(p.id)} className={BTN_QUIET}>Open</button>
+                    <button type="button" className={BTN_QUIET}
+                      onClick={() => { setRenaming(p.id); setRenameTo(p.name) }}>Rename</button>
+                    <button type="button"
+                      onClick={() => setConfirming(p.id)}
+                      className="rounded border border-red-200 px-2 py-1 text-[11px] font-semibold text-red-700 hover:bg-red-50">
+                      Delete
+                    </button>
+                  </div>
+                </div>
+
+                {renaming === p.id && (
+                  <div className="mt-2 flex gap-1.5">
+                    <input value={renameTo} onChange={(e) => setRenameTo(e.target.value)} autoFocus
+                      className="flex-1 rounded border border-[#d6d3c9] px-2 py-1 text-[12px]" />
+                    <button type="button" className={BTN}
+                      onClick={() => { api.rename(p.id, renameTo); setRenaming(null) }}>Save</button>
+                    <button type="button" className={BTN_QUIET} onClick={() => setRenaming(null)}>Cancel</button>
+                  </div>
+                )}
+
+                {/* Deleting asks. A structural model is a day's work and there
+                    is no undo — not even a sync will bring it back, because a
+                    sync never resurrects what you deleted on purpose. */}
+                {confirming === p.id && (
+                  <div className="mt-2 rounded border border-red-200 bg-red-50 px-2.5 py-2">
+                    <p className="text-[12px] text-red-900">
+                      Delete “{p.name}” from this browser? This cannot be undone.
+                    </p>
+                    <div className="mt-1.5 flex gap-1.5">
+                      <button type="button"
+                        onClick={() => del(p.id)}
+                        className="rounded bg-red-600 px-2.5 py-1 text-[11.5px] font-semibold text-white hover:bg-red-700">
+                        Delete it
+                      </button>
+                      <button type="button" className={BTN_QUIET} onClick={() => setConfirming(null)}>Keep it</button>
+                    </div>
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* ── Cloud ───────────────────────────────────────────────────── */}
+      <div>
+        <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-[#7a7568]">Your account</p>
+        {api.cloud === 'not-configured' && (
+          <p className="mt-2 text-[12px] text-[#7a7568]">
+            Sign-in is not set up on this deployment, so projects stay on this browser.
+          </p>
+        )}
+        {api.cloud === 'signed-out' && (
+          <p className="mt-2 text-[12px] text-[#7a7568]">
+            <Link to="/signin" className="font-semibold underline">Sign in</Link> to keep projects
+            on your account and open them on another machine.
+          </p>
+        )}
+        {api.cloud === 'ready' && (
+          <>
+            <div className="mt-2 flex items-center gap-2">
+              <button type="button" onClick={() => void api.sync()} disabled={api.busy} className={BTN}>
+                {api.busy ? 'Syncing…' : 'Sync with my account'}
+              </button>
+              <span className="text-[11px] text-[#7a7568]">Manual — nothing uploads on its own.</span>
+            </div>
+            {api.report && conflicts.length === 0 && (
+              <p className="mt-1.5 text-[11.5px] text-[#7a7568]">
+                {summarise(api.report.outcomes.map((o) => o.kind))}
+              </p>
+            )}
+            {api.report?.outcomes.filter((o) => o.kind === 'failed').map((o) => (
+              <p key={o.id} className="mt-1.5 text-[11.5px] text-amber-800">
+                ⚠ {o.kind === 'failed' && o.message}
+              </p>
+            ))}
+          </>
+        )}
+        {api.error && <p className="mt-1.5 text-[11.5px] text-red-700">{api.error}</p>}
+      </div>
+
+      {/* ── Conflicts ───────────────────────────────────────────────── */}
+      {conflicts.length > 0 && (
+        <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2.5">
+          <p className="text-[12.5px] font-semibold text-amber-900">
+            {conflicts.length} project{conflicts.length === 1 ? '' : 's'} changed in two places
+          </p>
+          <p className="mt-1 text-[11.5px] leading-5 text-amber-900">
+            Nothing has been overwritten. Choose which version to keep — there is no
+            field-by-field merge, because deciding which member size is right is yours to make.
+          </p>
+          <ul className="mt-2 space-y-2">
+            {conflicts.map((c) => (
+              <li key={c.id} className="rounded border border-amber-200 bg-white px-2.5 py-2">
+                <p className="text-[12px] font-semibold text-[#0f1b2a]">{c.local.meta.name}</p>
+                <p className="text-[11px] text-[#7a7568]">
+                  This browser: saved {when(c.local.meta.updatedAt)}, {c.local.model?.members.length ?? 0} members ·
+                  {' '}Your account: saved {when(c.remote.updatedAt)}, {c.remote.project.model?.members.length ?? 0} members
+                </p>
+                <div className="mt-1.5 flex gap-1.5">
+                  <button type="button" className={BTN_QUIET}
+                    onClick={() => void api.resolve(c.id, 'local')}>Keep this browser’s</button>
+                  <button type="button" className={BTN_QUIET}
+                    onClick={() => void api.resolve(c.id, 'remote')}>Keep my account’s</button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** "2 uploaded, 1 downloaded" — or plain reassurance when nothing moved. */
+function summarise(kinds: string[]): string {
+  const n = (k: string) => kinds.filter((x) => x === k).length
+  const parts = [
+    n('uploaded') && `${n('uploaded')} uploaded`,
+    n('downloaded') && `${n('downloaded')} downloaded`,
+  ].filter(Boolean) as string[]
+  return parts.length ? `Synced — ${parts.join(', ')}.` : 'Synced — everything was already up to date.'
+}

--- a/webapp/src/engine/projects/model.ts
+++ b/webapp/src/engine/projects/model.ts
@@ -1,0 +1,122 @@
+// ─────────────────────────────────────────────────────────────────────────
+// SAVED PROJECTS — the document a paid account keeps. Layer 1.
+//
+// Until now Model Space kept its work in `sessionStorage` under
+// `model-space-autosave`, which means it survived a reload and NOTHING ELSE.
+// Close the tab and a day's modelling was gone; open it on another machine and
+// there was nothing there. The `saved-projects` feature has been listed on
+// every plan since `plans.ts` was written, with no store behind it.
+//
+// WHAT A PROJECT IS. The structural model plus the design inputs that produced
+// it — soil, seismic, wind, prices, material choices. The model alone is not
+// enough: reopening it with the inputs reset to defaults gives an engineer a
+// structure whose design basis silently changed.
+//
+// WHY `inputs` IS AN OPAQUE BAG. Model Space keeps roughly sixty design fields
+// in component state and already writes them out as one object. Restating that
+// list as a typed interface here would be a second copy that drifts the first
+// time a field is added, and the page already reads them defensively (each
+// field falls back to its default). So the shape is checked, the contents are
+// not — and the page, which owns the fields, stays the only place that knows
+// them. Stated here so this reads as a decision rather than laziness.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { StructuralModel } from '../model'
+
+/** On-disk schema version. Bump and add a migration when the shape changes. */
+export const PROJECT_SCHEMA_VERSION = 1
+
+/** Longest project name we will store — long enough for a real one, short
+ *  enough that a listing stays readable and the column cannot be abused. */
+export const NAME_MAX = 120
+
+export interface ProjectMeta {
+  /** What the engineer calls it. The only field they must supply. */
+  name: string
+  client: string
+  location: string
+  notes: string
+  /** ISO timestamps, written by the store rather than the caller. */
+  createdAt: string
+  updatedAt: string
+}
+
+export interface Project {
+  meta: ProjectMeta
+  /**
+   * The 3D model, or null.
+   *
+   * Null is a real state, not a placeholder: a project can be named and given
+   * a client before a grid is generated, and refusing to save that would mean
+   * the first thing an engineer does is the one thing they cannot keep.
+   */
+  model: StructuralModel | null
+  /** Model Space's design inputs. Opaque here — see the header. */
+  inputs: Record<string, unknown>
+}
+
+/** Listing entry — enough for a picker without parsing every full document. */
+export interface ProjectSummary {
+  id: string
+  name: string
+  client: string
+  location: string
+  updatedAt: string
+  /** 0 when the project has no model yet. */
+  nodeCount: number
+  memberCount: number
+}
+
+const str = (v: unknown): v is string => typeof v === 'string'
+
+/**
+ * Structural check, used on every read from disk and from the network.
+ *
+ * Deliberately shallow on `model`: it asks whether the arrays are there, not
+ * whether every member references a live node. Deep validation belongs to
+ * `meshValidation`, which the solver runs anyway, and duplicating it here
+ * would mean a project that fails a NEW rule becomes unopenable rather than
+ * openable-and-flagged.
+ */
+export function isProject(v: unknown): v is Project {
+  if (!v || typeof v !== 'object') return false
+  const p = v as Partial<Project>
+  const m = p.meta as Partial<ProjectMeta> | undefined
+  if (!m || typeof m !== 'object') return false
+  if (!str(m.name) || !str(m.client) || !str(m.location) || !str(m.notes)) return false
+  if (!str(m.createdAt) || !str(m.updatedAt)) return false
+  if (!p.inputs || typeof p.inputs !== 'object' || Array.isArray(p.inputs)) return false
+  if (p.model === null || p.model === undefined) return true
+  const mo = p.model as Partial<StructuralModel>
+  return Array.isArray(mo.nodes) && Array.isArray(mo.members)
+}
+
+/** A project's display name, never blank — an untitled row is unclickable. */
+export const displayName = (p: Project): string => p.meta.name.trim() || 'Untitled project'
+
+/**
+ * Trim and cap a name on the way in.
+ *
+ * Applied at the store boundary rather than in the form, so a name that
+ * arrives from an import or from another client is capped too.
+ */
+export const cleanName = (raw: string): string => raw.trim().slice(0, NAME_MAX)
+
+export const summaryOf = (id: string, p: Project): ProjectSummary => ({
+  id,
+  name: displayName(p),
+  client: p.meta.client,
+  location: p.meta.location,
+  updatedAt: p.meta.updatedAt,
+  nodeCount: p.model?.nodes.length ?? 0,
+  memberCount: p.model?.members.length ?? 0,
+})
+
+/** A fresh, empty project. `now` is injectable so tests are not clock-bound. */
+export function emptyProject(name: string, now: string = new Date().toISOString()): Project {
+  return {
+    meta: { name: cleanName(name), client: '', location: '', notes: '', createdAt: now, updatedAt: now },
+    model: null,
+    inputs: {},
+  }
+}

--- a/webapp/src/engine/projects/remoteStore.test.ts
+++ b/webapp/src/engine/projects/remoteStore.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest'
+import { createStore, memoryBackend, type ProjectStore } from './store'
+import { emptyProject, type Project } from './model'
+import {
+  memoryRemote, syncProjects, contentHash, conflictsIn,
+  ConflictError, ProjectLimitError, type SyncMark, type SyncMarks, type RemoteStore,
+} from './remoteStore'
+
+const T = (n: number) => new Date(Date.UTC(2026, 0, 1, 0, 0, n)).toISOString()
+
+function marksIn(): SyncMarks & { all: Map<string, SyncMark> } {
+  const all = new Map<string, SyncMark>()
+  return { all, get: (id) => all.get(id), set: (id, m) => void all.set(id, m), forget: (id) => void all.delete(id) }
+}
+
+const named = (name: string, n = 0): Project => emptyProject(name, T(n))
+
+async function settled(local: ProjectStore, remote: RemoteStore, marks: SyncMarks) {
+  const r = await syncProjects(local, remote, marks)
+  return r.outcomes.map((o) => `${o.id}:${o.kind}`).sort()
+}
+
+describe('contentHash', () => {
+  it('ignores key order — two structurally equal projects hash the same', () => {
+    const a = named('Tower', 0)
+    const reordered = JSON.parse(JSON.stringify({ inputs: a.inputs, model: a.model, meta: a.meta })) as Project
+    expect(contentHash(reordered)).toBe(contentHash(a))
+  })
+
+  it('notices a real edit', () => {
+    const a = named('Tower', 0)
+    const b: Project = { ...a, meta: { ...a.meta, client: 'ACME' } }
+    expect(contentHash(b)).not.toBe(contentHash(a))
+  })
+})
+
+describe('memoryRemote', () => {
+  it('refuses a stale write and hands back the version it refused for', async () => {
+    const r = memoryRemote()
+    const first = await r.save('a', named('One'))
+    await r.save('a', named('Two'), first.updatedAt)
+    await expect(r.save('a', named('Three'), first.updatedAt)).rejects.toThrow(ConflictError)
+  })
+
+  it('stamps two writes in the same millisecond differently', async () => {
+    // Wall-clock stamps collide when the app is fast, and optimistic
+    // concurrency silently stops working the moment two versions share one.
+    const r = memoryRemote()
+    const a = await r.save('a', named('a'))
+    const b = await r.save('b', named('b'))
+    expect(a.updatedAt).not.toBe(b.updatedAt)
+  })
+
+  it('enforces a ceiling on new rows only', async () => {
+    const r = memoryRemote([], 2)
+    const a = await r.save('a', named('a'))
+    await r.save('b', named('b'))
+    await expect(r.save('c', named('c'))).rejects.toThrow(ProjectLimitError)
+    // The one that exists can still be saved — a lapsed plan must not make
+    // existing work unsavable.
+    await expect(r.save('a', named('a2'), a.updatedAt)).resolves.toBeTruthy()
+  })
+})
+
+describe('syncProjects', () => {
+  it('uploads a project the server has never seen', async () => {
+    const local = createStore(memoryBackend()), remote = memoryRemote(), marks = marksIn()
+    local.save('a', named('Tower'), T(0))
+    expect(await settled(local, remote, marks)).toEqual(['a:uploaded'])
+    expect((await remote.load('a'))?.project.meta.name).toBe('Tower')
+  })
+
+  it('downloads a project this machine has never seen — the point of the feature', async () => {
+    const local = createStore(memoryBackend()), remote = memoryRemote(), marks = marksIn()
+    await remote.save('a', named('From the office'))
+    expect(await settled(local, remote, marks)).toEqual(['a:downloaded'])
+    expect(local.load('a')?.meta.name).toBe('From the office')
+  })
+
+  it('is a no-op the second time — nothing re-uploads on every sync', async () => {
+    const local = createStore(memoryBackend()), remote = memoryRemote(), marks = marksIn()
+    local.save('a', named('Tower'), T(0))
+    await settled(local, remote, marks)
+    expect(await settled(local, remote, marks)).toEqual(['a:unchanged'])
+  })
+
+  it('uploads a local edit and downloads a remote one', async () => {
+    const local = createStore(memoryBackend()), remote = memoryRemote(), marks = marksIn()
+    local.save('a', named('Tower'), T(0))
+    await settled(local, remote, marks)
+
+    local.save('a', { ...local.load('a')!, meta: { ...local.load('a')!.meta, client: 'ACME' } }, T(10))
+    expect(await settled(local, remote, marks)).toEqual(['a:uploaded'])
+    expect((await remote.load('a'))?.project.meta.client).toBe('ACME')
+
+    const cur = await remote.load('a')
+    await remote.save('a', { ...cur!.project, meta: { ...cur!.project.meta, location: 'Cebu' } }, cur!.updatedAt)
+    expect(await settled(local, remote, marks)).toEqual(['a:downloaded'])
+    expect(local.load('a')?.meta.location).toBe('Cebu')
+  })
+
+  it('reports both-sides-changed as a conflict and touches neither', async () => {
+    const local = createStore(memoryBackend()), remote = memoryRemote(), marks = marksIn()
+    local.save('a', named('Tower'), T(0))
+    await settled(local, remote, marks)
+
+    local.save('a', { ...local.load('a')!, meta: { ...local.load('a')!.meta, client: 'LOCAL' } }, T(10))
+    const cur = await remote.load('a')
+    await remote.save('a', { ...cur!.project, meta: { ...cur!.project.meta, client: 'REMOTE' } }, cur!.updatedAt)
+
+    const report = await syncProjects(local, remote, marks)
+    expect(conflictsIn(report)).toHaveLength(1)
+    // Neither side was overwritten. The caller decides; the machine does not
+    // guess which column size is right.
+    expect(local.load('a')?.meta.client).toBe('LOCAL')
+    expect((await remote.load('a'))?.project.meta.client).toBe('REMOTE')
+  })
+
+  it('does not decide by timestamp', async () => {
+    // A laptop whose clock is an hour slow would otherwise lose every race.
+    // The local document here is stamped in 1999 and still wins, because it is
+    // the side that CHANGED.
+    const local = createStore(memoryBackend()), remote = memoryRemote(), marks = marksIn()
+    local.save('a', named('Tower'), T(0))
+    await settled(local, remote, marks)
+    local.save('a', { ...local.load('a')!, meta: { ...local.load('a')!.meta, client: 'ACME' } },
+      new Date(Date.UTC(1999, 0, 1)).toISOString())
+    expect(await settled(local, remote, marks)).toEqual(['a:uploaded'])
+    expect((await remote.load('a'))?.project.meta.client).toBe('ACME')
+  })
+
+  it('never deletes — a project missing from one side comes back', async () => {
+    // Resurrection is the safe failure; silent deletion is not. Deleting is an
+    // explicit act through `remove`, not something a sync infers.
+    const local = createStore(memoryBackend()), remote = memoryRemote(), marks = marksIn()
+    local.save('a', named('Tower'), T(0))
+    await settled(local, remote, marks)
+    await remote.remove('a')
+    expect(await settled(local, remote, marks)).toEqual(['a:uploaded'])
+    expect(await remote.load('a')).not.toBeNull()
+  })
+
+  it('keeps going when one project fails', async () => {
+    const local = createStore(memoryBackend()), remote = memoryRemote(), marks = marksIn()
+    local.save('ok', named('Fine'), T(0))
+    local.save('bad', named('Broken'), T(0))
+    const failing: RemoteStore = {
+      ...remote,
+      save: async (id, p, exp) => {
+        if (id === 'bad') throw new Error('network went away')
+        return remote.save(id, p, exp)
+      },
+    }
+    const outcomes = await settled(local, failing, marks)
+    expect(outcomes).toEqual(['bad:failed', 'ok:uploaded'])
+    // The one that worked is marked, so it does not re-upload next time.
+    expect(marks.all.has('ok')).toBe(true)
+    expect(marks.all.has('bad')).toBe(false)
+  })
+
+  it('surfaces the plan ceiling as a failure rather than losing the project', async () => {
+    const local = createStore(memoryBackend()), marks = marksIn()
+    const remote = memoryRemote([], 1)
+    local.save('a', named('One'), T(0))
+    local.save('b', named('Two'), T(1))
+
+    // WHICH one is refused depends on the order the listing happens to yield,
+    // and that is not the invariant. The invariant is that exactly one gets
+    // through, the other is reported, and BOTH are still on this machine — a
+    // quota must never be the reason work disappears.
+    const report = await syncProjects(local, remote, marks)
+    const kinds = report.outcomes.map((o) => o.kind).sort()
+    expect(kinds).toEqual(['failed', 'uploaded'])
+    const refused = report.outcomes.find((o) => o.kind === 'failed')!
+    expect(refused.kind === 'failed' && refused.message).toContain('plan')
+    expect(local.load('a')).not.toBeNull()
+    expect(local.load('b')).not.toBeNull()
+  })
+})

--- a/webapp/src/engine/projects/remoteStore.ts
+++ b/webapp/src/engine/projects/remoteStore.ts
@@ -1,0 +1,235 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Durable project storage — the async half. Layer 1.
+//
+// `store.ts` is synchronous because localStorage is. A database is not, and no
+// amount of wrapping makes it so, which is why this is a separate interface
+// rather than a fourth `StorageBackend`.
+//
+// CONFLICTS ARE REPORTED, NEVER RESOLVED SILENTLY. Two machines editing one
+// project is the reason an engineer wanted cloud storage in the first place. A
+// save that would overwrite a version the caller has not seen fails with both
+// versions attached, and the caller decides which to keep. There is no
+// field-by-field merge: two versions of a structural model are not mergeable
+// without someone deciding which column size is right, and a machine guessing
+// at that is worse than asking.
+//
+// One row per project, the document in a `jsonb` column — the same call the
+// soils module made, argued at length in `engine/soils/remoteStore.ts`. Nothing
+// queries across projects, so normalising now would be thirty tables of
+// guesses; normalising later is a migration rather than a rewrite.
+// ─────────────────────────────────────────────────────────────────────────
+
+import { contentHash as hashOf } from '../../lib/contentHash'
+import { summaryOf, type Project, type ProjectSummary } from './model'
+import type { ProjectStore } from './store'
+
+export interface RemoteRecord {
+  id: string
+  project: Project
+  schemaVersion: number
+  /** Server timestamp of the last write, ISO. */
+  updatedAt: string
+}
+
+/** Raised when a save would clobber a version the caller has not seen. */
+export class ConflictError extends Error {
+  readonly id: string
+  readonly remote: RemoteRecord
+  readonly expectedUpdatedAt: string | undefined
+
+  constructor(id: string, remote: RemoteRecord, expectedUpdatedAt: string | undefined) {
+    super(
+      `"${remote.project.meta.name || id}" was changed elsewhere at ${remote.updatedAt}. Saving now would discard that version.`,
+    )
+    this.name = 'ConflictError'
+    this.id = id
+    this.remote = remote
+    this.expectedUpdatedAt = expectedUpdatedAt
+  }
+}
+
+/** Raised when the account is already at its plan's project ceiling. */
+export class ProjectLimitError extends Error {
+  readonly limit: number
+  constructor(limit: number) {
+    super(
+      limit === 0
+        ? 'Your plan does not include saved projects.'
+        : `Your plan keeps ${limit} saved project${limit === 1 ? '' : 's'}. Delete one, or move to a plan without a limit.`,
+    )
+    this.name = 'ProjectLimitError'
+    this.limit = limit
+  }
+}
+
+export interface RemoteStore {
+  list(): Promise<ProjectSummary[]>
+  load(id: string): Promise<RemoteRecord | null>
+  /**
+   * Write. `expectedUpdatedAt` is the version the caller last read; a mismatch
+   * raises ConflictError rather than overwriting. Omit it only when creating.
+   */
+  save(id: string, project: Project, expectedUpdatedAt?: string): Promise<RemoteRecord>
+  remove(id: string): Promise<void>
+}
+
+/** Content fingerprint of a project — the shared rule, narrowed to this type. */
+export const contentHash = (p: Project): string => hashOf(p)
+
+// ── In-memory implementation, for tests and the offline case ──────────────
+
+export function memoryRemote(seed: RemoteRecord[] = [], limit: number | null = null): RemoteStore {
+  const rows = new Map<string, RemoteRecord>(seed.map((r) => [r.id, r]))
+  // A counter, not Date.now(): two saves inside the same millisecond must still
+  // produce different versions, or optimistic concurrency stops working exactly
+  // when the app is fast.
+  let tick = 0
+  const stamp = () => new Date(Date.UTC(2026, 0, 1) + ++tick * 1000).toISOString()
+
+  const self: RemoteStore = {
+    async list() {
+      return [...rows.values()]
+        .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+        .map((r) => summaryOf(r.id, r.project))
+    },
+    async load(id) {
+      return rows.get(id) ?? null
+    },
+    async save(id, project, expectedUpdatedAt) {
+      const current = rows.get(id)
+      if (current && current.updatedAt !== expectedUpdatedAt) {
+        throw new ConflictError(id, current, expectedUpdatedAt)
+      }
+      if (!current && expectedUpdatedAt) {
+        throw new Error(`Project "${id}" no longer exists on the server.`)
+      }
+      if (!current && limit !== null && rows.size >= limit) throw new ProjectLimitError(limit)
+      const rec: RemoteRecord = { id, project, schemaVersion: 1, updatedAt: stamp() }
+      rows.set(id, rec)
+      return rec
+    },
+    async remove(id) {
+      rows.delete(id)
+    },
+  }
+  return self
+}
+
+// ── Reconciliation ────────────────────────────────────────────────────────
+
+/**
+ * The watermark for one project as of the last reconciliation: what the local
+ * document HASHED to, and what the server's version stamp was.
+ *
+ * Two tokens because the two sides answer to different clocks. Storing one
+ * timestamp for both — the obvious first version — makes `localChanged`
+ * permanently true and re-uploads on every sync.
+ */
+export interface SyncMark {
+  localHash: string
+  remote: string
+}
+
+export interface SyncMarks {
+  get(id: string): SyncMark | undefined
+  set(id: string, mark: SyncMark): void
+  forget(id: string): void
+}
+
+/** What one reconciliation did, per project. */
+export type SyncOutcome =
+  | { id: string; kind: 'uploaded' }
+  | { id: string; kind: 'downloaded' }
+  | { id: string; kind: 'unchanged' }
+  | { id: string; kind: 'conflict'; local: Project; remote: RemoteRecord }
+  | { id: string; kind: 'failed'; message: string }
+
+export interface SyncReport {
+  outcomes: SyncOutcome[]
+  at: string
+}
+
+/**
+ * Reconcile every local and remote project once.
+ *
+ * The decision for each id is made from three facts — did the local document
+ * change since the mark, did the remote stamp change since the mark, does each
+ * side exist — and NOTHING ELSE. In particular not "which is newer": wall
+ * clocks on two machines disagree, and a laptop an hour behind would quietly
+ * win every race.
+ *
+ * Both-changed is a CONFLICT and is reported, not resolved. Nothing is deleted
+ * on either side: a project missing from one side is treated as new to it, so
+ * a failed sync can never be the reason work disappeared. Deleting is an
+ * explicit act through `remove`.
+ */
+export async function syncProjects(
+  local: ProjectStore, remote: RemoteStore, marks: SyncMarks,
+): Promise<SyncReport> {
+  const at = new Date().toISOString()
+  const outcomes: SyncOutcome[] = []
+
+  const remoteList = await remote.list()
+  const remoteIds = new Set(remoteList.map((r) => r.id))
+  const localIds = new Set(local.list().map((r) => r.id))
+
+  for (const id of new Set([...localIds, ...remoteIds])) {
+    try {
+      outcomes.push(await reconcile(id, local, remote, marks))
+    } catch (e) {
+      outcomes.push({ id, kind: 'failed', message: e instanceof Error ? e.message : String(e) })
+    }
+  }
+
+  return { outcomes, at }
+}
+
+async function reconcile(
+  id: string, local: ProjectStore, remote: RemoteStore, marks: SyncMarks,
+): Promise<SyncOutcome> {
+  const mine = local.load(id)
+  const theirs = await remote.load(id)
+  const mark = marks.get(id)
+
+  if (!mine && !theirs) return { id, kind: 'unchanged' }
+
+  // Only on the server: take it. This also covers a machine that has never
+  // seen the project, which is the whole point of storing it centrally.
+  if (!mine && theirs) {
+    local.save(id, theirs.project, theirs.project.meta.updatedAt)
+    marks.set(id, { localHash: contentHash(theirs.project), remote: theirs.updatedAt })
+    return { id, kind: 'downloaded' }
+  }
+
+  // Only local: push it. Note this is also what happens after someone deletes
+  // the project on another machine — it comes back rather than vanishing here.
+  // Resurrection is the safe failure; silent deletion is not.
+  if (mine && !theirs) {
+    const saved = await remote.save(id, mine)
+    marks.set(id, { localHash: contentHash(mine), remote: saved.updatedAt })
+    return { id, kind: 'uploaded' }
+  }
+
+  // Both sides exist from here.
+  const localChanged = !mark || contentHash(mine!) !== mark.localHash
+  const remoteChanged = !mark || theirs!.updatedAt !== mark.remote
+
+  if (localChanged && remoteChanged) {
+    return { id, kind: 'conflict', local: mine!, remote: theirs! }
+  }
+  if (localChanged) {
+    const saved = await remote.save(id, mine!, theirs!.updatedAt)
+    marks.set(id, { localHash: contentHash(mine!), remote: saved.updatedAt })
+    return { id, kind: 'uploaded' }
+  }
+  if (remoteChanged) {
+    local.save(id, theirs!.project, theirs!.project.meta.updatedAt)
+    marks.set(id, { localHash: contentHash(theirs!.project), remote: theirs!.updatedAt })
+    return { id, kind: 'downloaded' }
+  }
+  return { id, kind: 'unchanged' }
+}
+
+/** The conflicts in a report — the only outcome the UI must act on. */
+export const conflictsIn = (r: SyncReport): Extract<SyncOutcome, { kind: 'conflict' }>[] =>
+  r.outcomes.filter((o): o is Extract<SyncOutcome, { kind: 'conflict' }> => o.kind === 'conflict')

--- a/webapp/src/engine/projects/store.test.ts
+++ b/webapp/src/engine/projects/store.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest'
+import { createStore, memoryBackend, canSaveNew } from './store'
+import { emptyProject, isProject, cleanName, summaryOf, NAME_MAX, type Project } from './model'
+import type { StructuralModel } from '../model'
+
+const T = (n: number) => new Date(Date.UTC(2026, 0, 1, 0, 0, n)).toISOString()
+
+const withModel = (p: Project, nodes: number, members: number): Project => ({
+  ...p,
+  model: {
+    nodes: Array.from({ length: nodes }, (_, i) => ({ id: `n${i}`, x: i, y: 0, z: 0 })),
+    members: Array.from({ length: members }, (_, i) => ({ id: `m${i}`, i: 'n0', j: 'n1', role: 'beam' })),
+  } as unknown as StructuralModel,
+})
+
+describe('isProject', () => {
+  it('accepts a project with no model — that is a real state, not a placeholder', () => {
+    // A project can be named and given a client before a grid exists. Refusing
+    // to save that means the first thing an engineer does is the one thing
+    // they cannot keep.
+    expect(isProject(emptyProject('Bridge B', T(0)))).toBe(true)
+  })
+
+  it('rejects records missing the fields a listing depends on', () => {
+    const good = emptyProject('x', T(0))
+    expect(isProject({ ...good, meta: { ...good.meta, name: 42 } })).toBe(false)
+    expect(isProject({ ...good, meta: { ...good.meta, updatedAt: undefined } })).toBe(false)
+    expect(isProject({ ...good, inputs: [] })).toBe(false)
+    expect(isProject({ ...good, model: { nodes: [] } })).toBe(false)
+    expect(isProject(null)).toBe(false)
+    expect(isProject('a project')).toBe(false)
+  })
+
+  it('does not judge the model deeply', () => {
+    // Deep validation is meshValidation's job and the solver runs it anyway.
+    // Duplicating it here would make a project that fails a NEW rule
+    // unopenable rather than openable-and-flagged.
+    const dangling = withModel(emptyProject('x', T(0)), 1, 1)
+    expect(isProject(dangling)).toBe(true)
+  })
+})
+
+describe('cleanName', () => {
+  it('trims and caps', () => {
+    expect(cleanName('  Tower 3  ')).toBe('Tower 3')
+    expect(cleanName('x'.repeat(NAME_MAX + 40))).toHaveLength(NAME_MAX)
+  })
+})
+
+describe('the local store', () => {
+  it('round-trips a project', () => {
+    const s = createStore(memoryBackend())
+    const p = withModel(emptyProject('Tower 3', T(0)), 8, 12)
+    s.save('a', p, T(5))
+    const back = s.load('a')
+    expect(back?.meta.name).toBe('Tower 3')
+    expect(back?.model?.members).toHaveLength(12)
+  })
+
+  it('stamps updatedAt on every save, and leaves createdAt alone', () => {
+    const s = createStore(memoryBackend())
+    s.save('a', emptyProject('x', T(0)), T(0))
+    const later = s.save('a', s.load('a')!, T(90))
+    expect(later.meta.createdAt).toBe(T(0))
+    expect(later.meta.updatedAt).toBe(T(90))
+  })
+
+  it('lists newest first', () => {
+    const s = createStore(memoryBackend())
+    s.save('old', emptyProject('Old', T(0)), T(0))
+    s.save('new', emptyProject('New', T(60)), T(60))
+    s.save('mid', emptyProject('Mid', T(30)), T(30))
+    expect(s.list().map((r) => r.id)).toEqual(['new', 'mid', 'old'])
+  })
+
+  it('survives a corrupt entry rather than losing the whole listing', () => {
+    const b = memoryBackend({
+      'projects:good': JSON.stringify({ version: 1, project: emptyProject('Fine', T(0)) }),
+      'projects:broken': '{not json',
+      'projects:wrong-shape': JSON.stringify({ version: 1, project: { meta: {} } }),
+    })
+    const s = createStore(b)
+    expect(s.list().map((r) => r.id)).toEqual(['good'])
+    expect(s.count()).toBe(1)
+    expect(s.load('broken')).toBeNull()
+  })
+
+  it('ignores keys that are not ours', () => {
+    const b = memoryBackend({
+      'soils:investigation:x': '{}',
+      'model-space-autosave': '{}',
+      'projects:mine': JSON.stringify({ version: 1, project: emptyProject('Mine', T(0)) }),
+    })
+    expect(createStore(b).list().map((r) => r.id)).toEqual(['mine'])
+  })
+
+  it('removes', () => {
+    const s = createStore(memoryBackend())
+    s.save('a', emptyProject('x', T(0)), T(0))
+    expect(s.exists('a')).toBe(true)
+    s.remove('a')
+    expect(s.exists('a')).toBe(false)
+    expect(s.count()).toBe(0)
+  })
+})
+
+describe('summaryOf', () => {
+  it('counts an absent model as zero rather than omitting the fields', () => {
+    const s = summaryOf('a', emptyProject('x', T(0)))
+    expect(s.nodeCount).toBe(0)
+    expect(s.memberCount).toBe(0)
+  })
+
+  it('never yields a blank name — an untitled row is unclickable', () => {
+    expect(summaryOf('a', emptyProject('   ', T(0))).name).toBe('Untitled project')
+  })
+})
+
+describe('canSaveNew', () => {
+  it('lets Free keep three and refuses the fourth', () => {
+    expect(canSaveNew('free', 2).ok).toBe(true)
+    expect(canSaveNew('free', 3).ok).toBe(false)
+  })
+
+  it('never blocks re-saving a project that already exists', () => {
+    // A Free account at its limit must still be able to keep an edit to a
+    // project it already has. Meeting a paywall mid-edit, holding changes you
+    // cannot store, is the worst possible moment for it.
+    expect(canSaveNew('free', 99, 'existing-id').ok).toBe(true)
+    expect(canSaveNew('guest', 99, 'existing-id').ok).toBe(true)
+  })
+
+  it('lets the paid tiers save without limit', () => {
+    expect(canSaveNew('pro', 5_000).ok).toBe(true)
+    expect(canSaveNew('max', 5_000).ok).toBe(true)
+  })
+
+  it('names the plan and the numbers in the refusal', () => {
+    const v = canSaveNew('free', 3)
+    expect(v.ok).toBe(false)
+    if (v.ok) return
+    expect(v.limit).toBe(3)
+    expect(v.saved).toBe(3)
+    expect(v.message).toContain('Free')
+    expect(v.message).toContain('3')
+  })
+
+  it('tells a guest to make an account rather than to pay', () => {
+    const v = canSaveNew('guest', 0)
+    expect(v.ok).toBe(false)
+    if (v.ok) return
+    expect(v.message).toContain('free account')
+  })
+})

--- a/webapp/src/engine/projects/store.ts
+++ b/webapp/src/engine/projects/store.ts
@@ -1,0 +1,170 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Local project storage. Layer 1.
+//
+// The same `StorageBackend` seam the soils module uses, and for the same
+// reason: the app gets localStorage, tests get a Map, and neither knows about
+// the other. LOCALSTORAGE, NOT sessionStorage — the bug this replaces is that
+// Model Space's autosave died with the tab.
+//
+// One key per project under `projects:<id>`, wrapped with a schema version so
+// a future format change migrates on read instead of corrupting old saves.
+//
+// PLAN LIMITS ARE NOT ENFORCED HERE. `canSaveNew` reports whether a save would
+// exceed the plan, and the caller decides what to say about it; the store
+// itself never refuses. Two reasons: a plan that lapses must not make existing
+// projects unreadable, and the real enforcement point is the database policy
+// in the migration, not a check the browser could be talked out of.
+// ─────────────────────────────────────────────────────────────────────────
+
+import { isProject, cleanName, summaryOf, PROJECT_SCHEMA_VERSION, type Project, type ProjectSummary } from './model'
+import { withinProjectLimit, planOf, type Plan, type PlanId } from '../../lib/plans'
+
+const KEY_PREFIX = 'projects:'
+
+/** Minimal storage contract (a subset of the Web Storage API). */
+export interface StorageBackend {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+  keys(): string[]
+}
+
+/** In-memory backend for tests / non-browser environments. */
+export function memoryBackend(seed?: Record<string, string>): StorageBackend {
+  const map = new Map<string, string>(seed ? Object.entries(seed) : [])
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k)! : null),
+    setItem: (k, v) => void map.set(k, v),
+    removeItem: (k) => void map.delete(k),
+    keys: () => [...map.keys()],
+  }
+}
+
+/** Browser localStorage backend, or an in-memory fallback when unavailable. */
+export function defaultBackend(): StorageBackend {
+  const ls = typeof globalThis !== 'undefined' ? (globalThis as { localStorage?: Storage }).localStorage : undefined
+  if (!ls) return memoryBackend()
+  return {
+    getItem: (k) => ls.getItem(k),
+    setItem: (k, v) => ls.setItem(k, v),
+    removeItem: (k) => ls.removeItem(k),
+    keys: () => Array.from({ length: ls.length }, (_, i) => ls.key(i)).filter((k): k is string => k !== null),
+  }
+}
+
+export interface StoredProject {
+  version: number
+  project: Project
+}
+
+/** Why a save was refused, or that it may go ahead. */
+export type SaveVerdict =
+  | { ok: true }
+  | { ok: false; reason: 'plan-limit'; limit: number; saved: number; message: string }
+
+export interface ProjectStore {
+  /** Newest first — the order a picker wants. */
+  list(): ProjectSummary[]
+  load(id: string): Project | null
+  /** Writes, stamping `updatedAt`. Never refuses on plan grounds — see the header. */
+  save(id: string, project: Project, now?: string): Project
+  remove(id: string): void
+  exists(id: string): boolean
+  count(): number
+}
+
+/**
+ * A quota is only worth reporting when it would actually bite.
+ *
+ * `existingId` matters: re-saving a project you already have must never be
+ * blocked, or a Free account at its limit could open a project and then not be
+ * allowed to keep the edit — the worst possible moment to meet a paywall.
+ */
+export function canSaveNew(
+  plan: PlanId | Plan, saved: number, existingId?: string,
+): SaveVerdict {
+  if (existingId) return { ok: true }
+  const p = typeof plan === 'string' ? planOf(plan) : plan
+  if (withinProjectLimit(p, saved)) return { ok: true }
+  const limit = p.maxProjects ?? 0
+  return {
+    ok: false, reason: 'plan-limit', limit, saved,
+    message: limit === 0
+      ? `The ${p.name} plan cannot save projects. Create a free account to keep up to 3.`
+      : `The ${p.name} plan keeps ${limit} saved project${limit === 1 ? '' : 's'}; you have ${saved}. Delete one, or move to a plan without a limit.`,
+  }
+}
+
+export function createStore(backend: StorageBackend = defaultBackend()): ProjectStore {
+  const keyOf = (id: string) => KEY_PREFIX + id
+  const idOf = (key: string) => key.slice(KEY_PREFIX.length)
+
+  const readStored = (key: string): StoredProject | null => {
+    const raw = backend.getItem(key)
+    if (raw == null) return null
+    try {
+      const parsed = JSON.parse(raw) as StoredProject
+      // One corrupt entry must not take the whole listing down, so the shape is
+      // checked here rather than trusted from the key prefix alone.
+      if (!parsed || typeof parsed !== 'object' || !isProject(parsed.project)) return null
+      return migrate(parsed)
+    } catch {
+      return null
+    }
+  }
+
+  return {
+    list() {
+      const out: ProjectSummary[] = []
+      for (const key of backend.keys()) {
+        if (!key.startsWith(KEY_PREFIX)) continue
+        const stored = readStored(key)
+        if (!stored) continue
+        out.push(summaryOf(idOf(key), stored.project))
+      }
+      return out.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+    },
+
+    load(id) {
+      return readStored(keyOf(id))?.project ?? null
+    },
+
+    save(id, project, now = new Date().toISOString()) {
+      const stamped: Project = {
+        ...project,
+        meta: { ...project.meta, name: cleanName(project.meta.name), updatedAt: now },
+      }
+      backend.setItem(keyOf(id), JSON.stringify({ version: PROJECT_SCHEMA_VERSION, project: stamped }))
+      return stamped
+    },
+
+    remove(id) {
+      backend.removeItem(keyOf(id))
+    },
+
+    exists(id) {
+      return readStored(keyOf(id)) !== null
+    },
+
+    count() {
+      let n = 0
+      for (const key of backend.keys()) {
+        if (key.startsWith(KEY_PREFIX) && readStored(key)) n++
+      }
+      return n
+    },
+  }
+}
+
+/**
+ * Bring an older record up to the current shape.
+ *
+ * A no-op at version 1 — it exists so the first real format change has an
+ * obvious place to go, rather than being bolted onto the read path under
+ * pressure. A record from a NEWER client is returned untouched and will fail
+ * `isProject` if the shape moved, which is the safe direction: refusing to
+ * open beats silently dropping fields this build does not know about.
+ */
+function migrate(stored: StoredProject): StoredProject {
+  return stored
+}

--- a/webapp/src/engine/projects/supabaseRemote.ts
+++ b/webapp/src/engine/projects/supabaseRemote.ts
@@ -1,0 +1,156 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Supabase-backed `RemoteStore` for projects.
+//
+// Deliberately thin: it maps rows to `RemoteRecord` and translates the two
+// errors that matter — a version mismatch and a plan ceiling — into typed
+// exceptions. All the reconciliation logic lives in `remoteStore.ts`, which is
+// testable without a database.
+//
+// SECURITY. Every query goes through the ANON key with the user's session, so
+// Row Level Security is what enforces ownership; the `.eq('user_id', …)`
+// filters are an optimisation and a readability aid, not a control. The
+// project CEILING is enforced by the same policy — see the migration — which
+// is the difference between a paywall and a suggestion. A browser that skips
+// this file entirely still cannot insert row four on a Free plan.
+//
+// SCHEMA VERSION. A row written by a newer client is REFUSED rather than
+// parsed: a partial read of a shape this client does not understand is worse
+// than an error the engineer can act on.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { isProject, summaryOf, PROJECT_SCHEMA_VERSION, type Project, type ProjectSummary } from './model'
+import { ConflictError, ProjectLimitError, type RemoteRecord, type RemoteStore } from './remoteStore'
+
+export const TABLE = 'projects'
+
+const COLUMNS = 'id, user_id, project, schema_version, updated_at'
+
+interface Row {
+  id: string
+  user_id: string
+  project: unknown
+  schema_version: number
+  updated_at: string
+}
+
+function toRecord(row: Row): RemoteRecord {
+  if (row.schema_version > PROJECT_SCHEMA_VERSION) {
+    throw new Error(
+      `Project "${row.id}" was saved by a newer version of the app (format ${row.schema_version}, this client reads ${PROJECT_SCHEMA_VERSION}). Update before opening it — reading it with this version could silently drop data.`,
+    )
+  }
+  if (!isProject(row.project)) {
+    throw new Error(`Project "${row.id}" did not come back in a shape this client recognises.`)
+  }
+  return {
+    id: row.id,
+    project: row.project,
+    schemaVersion: row.schema_version,
+    updatedAt: row.updated_at,
+  }
+}
+
+/**
+ * Postgres tells us the ceiling was hit by refusing the INSERT.
+ *
+ * A row blocked by a `with check` clause comes back as 42501
+ * (insufficient_privilege) with a row-level-security message — indistinguishable
+ * from any other policy refusal by code alone, hence the message sniff. The
+ * fallback is a plain error, so a genuine permission problem is never
+ * mislabelled as "buy a bigger plan".
+ */
+function isLimitRefusal(error: { code?: string; message?: string }): boolean {
+  if (error.code !== '42501') return false
+  const m = (error.message ?? '').toLowerCase()
+  return m.includes('row-level security') || m.includes('row level security')
+}
+
+export function supabaseRemote(client: SupabaseClient, userId: string): RemoteStore {
+  const self: RemoteStore = {
+    async list(): Promise<ProjectSummary[]> {
+      const { data, error } = await client
+        .from(TABLE).select(COLUMNS)
+        .eq('user_id', userId)
+        .order('updated_at', { ascending: false })
+      if (error) throw new Error(error.message)
+
+      const out: ProjectSummary[] = []
+      for (const row of (data ?? []) as unknown as Row[]) {
+        // One unreadable row must not take the whole listing down — the same
+        // rule the local store follows for a corrupt entry.
+        try { const r = toRecord(row); out.push(summaryOf(r.id, r.project)) } catch { continue }
+      }
+      return out
+    },
+
+    async load(id): Promise<RemoteRecord | null> {
+      const { data, error } = await client
+        .from(TABLE).select(COLUMNS)
+        .eq('user_id', userId).eq('id', id)
+        .maybeSingle()
+      if (error) throw new Error(error.message)
+      return data ? toRecord(data as unknown as Row) : null
+    },
+
+    async save(id, project: Project, expectedUpdatedAt): Promise<RemoteRecord> {
+      // Optimistic concurrency: the UPDATE is conditional on the version the
+      // caller read. Zero rows back means someone else got there first.
+      if (expectedUpdatedAt) {
+        const { data, error } = await client
+          .from(TABLE)
+          .update({ project, schema_version: PROJECT_SCHEMA_VERSION, updated_at: new Date().toISOString() })
+          .eq('user_id', userId).eq('id', id).eq('updated_at', expectedUpdatedAt)
+          .select(COLUMNS)
+          .maybeSingle()
+        if (error) throw new Error(error.message)
+        if (!data) {
+          const current = await self.load(id)
+          if (current) throw new ConflictError(id, current, expectedUpdatedAt)
+          throw new Error(`Project "${id}" no longer exists on the server.`)
+        }
+        return toRecord(data as unknown as Row)
+      }
+
+      const { data, error } = await client
+        .from(TABLE)
+        .insert({
+          id, user_id: userId, project,
+          schema_version: PROJECT_SCHEMA_VERSION, updated_at: new Date().toISOString(),
+        })
+        .select(COLUMNS)
+        .single()
+      if (error) {
+        const e = error as { code?: string; message?: string }
+        // 23505 = unique violation: the row exists, so this is a create racing
+        // an existing record rather than a transport failure.
+        if (e.code === '23505') {
+          const current = await self.load(id)
+          if (current) throw new ConflictError(id, current, undefined)
+        }
+        if (isLimitRefusal(e)) throw new ProjectLimitError(await countFor(client, userId))
+        throw new Error(error.message)
+      }
+      return toRecord(data as unknown as Row)
+    },
+
+    async remove(id) {
+      const { error } = await client.from(TABLE).delete().eq('user_id', userId).eq('id', id)
+      if (error) throw new Error(error.message)
+    },
+  }
+  return self
+}
+
+/**
+ * How many projects the account already has, for the limit message.
+ *
+ * Asked only when a save has ALREADY been refused, so the extra round trip
+ * costs nothing on the path that matters. Returns 0 if even the count fails —
+ * a vague message beats an error swallowing the real one.
+ */
+async function countFor(client: SupabaseClient, userId: string): Promise<number> {
+  const { count, error } = await client
+    .from(TABLE).select('id', { count: 'exact', head: true }).eq('user_id', userId)
+  return error ? 0 : (count ?? 0)
+}

--- a/webapp/src/engine/soils/remoteStore.ts
+++ b/webapp/src/engine/soils/remoteStore.ts
@@ -29,6 +29,7 @@
 
 import type { Investigation } from './model'
 import { SOILS_SCHEMA_VERSION, isInvestigation, type InvestigationSummary, type SoilsStore } from './store'
+import { contentHash as hashOf } from '../../lib/contentHash'
 
 
 export interface RemoteRecord {
@@ -127,38 +128,12 @@ export interface SyncReport {
 }
 
 /**
- * Stable JSON — keys sorted at every level, so two structurally equal
- * investigations hash the same regardless of the order their fields were set.
+ * Content fingerprint of an investigation — the shared rule from
+ * `lib/contentHash`, re-exported so this module's callers keep one import.
+ * The argument is narrowed to `Investigation` on purpose: hashing anything
+ * else here would be a call-site mistake, not a feature.
  */
-function stableStringify(v: unknown): string {
-  if (v === null || typeof v !== 'object') return JSON.stringify(v) ?? 'null'
-  if (Array.isArray(v)) return `[${v.map(stableStringify).join(',')}]`
-  const keys = Object.keys(v as Record<string, unknown>).sort()
-  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify((v as Record<string, unknown>)[k])}`).join(',')}}`
-}
-
-/**
- * Content fingerprint of an investigation (FNV-1a over its stable JSON).
- *
- * Local change is detected by CONTENT, not by timestamp. The local store
- * stamps `savedAt` from the wall clock, so two saves inside one millisecond
- * are indistinguishable — and a genuine edit that collided with the previous
- * stamp would never be uploaded. Silent data loss is the one outcome this
- * module cannot accept, and a hash removes the clock from the question
- * entirely. It also means a no-op save does not cause a pointless upload.
- *
- * Not cryptographic, and does not need to be: it detects accidental sameness,
- * not adversarial collisions.
- */
-export function contentHash(inv: Investigation): string {
-  const s = stableStringify(inv)
-  let h = 0x811c9dc5
-  for (let i = 0; i < s.length; i++) {
-    h ^= s.charCodeAt(i)
-    h = Math.imul(h, 0x01000193) >>> 0
-  }
-  return h.toString(16).padStart(8, '0') + ':' + s.length
-}
+export const contentHash = (inv: Investigation): string => hashOf(inv)
 
 /**
  * The watermark for one investigation, as of the last reconciliation: what the

--- a/webapp/src/lib/contentHash.ts
+++ b/webapp/src/lib/contentHash.ts
@@ -1,0 +1,43 @@
+// ─────────────────────────────────────────────────────────────────────────
+// CONTENT FINGERPRINTING — "has this document actually changed?"
+//
+// Extracted from `engine/soils/remoteStore.ts` when the project store needed
+// the same answer. The rule is payload-agnostic, so it has one home; the
+// alternative was a second copy that would drift from the first exactly when
+// it mattered, which is the failure this file exists to prevent.
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Stable JSON — keys sorted at every level, so two structurally equal values
+ * hash the same regardless of the order their fields happened to be set.
+ */
+export function stableStringify(v: unknown): string {
+  if (v === null || typeof v !== 'object') return JSON.stringify(v) ?? 'null'
+  if (Array.isArray(v)) return `[${v.map(stableStringify).join(',')}]`
+  const keys = Object.keys(v as Record<string, unknown>).sort()
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify((v as Record<string, unknown>)[k])}`).join(',')}}`
+}
+
+/**
+ * Content fingerprint (FNV-1a over the stable JSON, with the length appended).
+ *
+ * Change is detected by CONTENT, not by timestamp. A local store stamps
+ * `savedAt` from the wall clock, so two saves inside one millisecond are
+ * indistinguishable — and a genuine edit that collided with the previous stamp
+ * would never be uploaded. Silent data loss is the one outcome a sync cannot
+ * accept, and a hash removes the clock from the question entirely. It also
+ * means a no-op save does not cause a pointless upload.
+ *
+ * Not cryptographic, and does not need to be: it detects accidental sameness,
+ * not adversarial collisions. The length suffix is cheap insurance against the
+ * 32-bit hash space, since a wrong "unchanged" is the expensive direction.
+ */
+export function contentHash(value: unknown): string {
+  const s = stableStringify(value)
+  let h = 0x811c9dc5
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i)
+    h = Math.imul(h, 0x01000193) >>> 0
+  }
+  return h.toString(16).padStart(8, '0') + ':' + s.length
+}

--- a/webapp/src/lib/modelSpaceSession.ts
+++ b/webapp/src/lib/modelSpaceSession.ts
@@ -1,0 +1,71 @@
+// ─────────────────────────────────────────────────────────────────────────
+// The Model Space session snapshot — the two sessionStorage keys the page
+// writes on every change and reads once at mount.
+//
+// Pulled out of the page so the Projects panel can save and restore a project
+// WITHOUT a second copy of the design-input list. Model Space keeps roughly
+// sixty design fields in individual `useState` hooks; restoring a project by
+// calling sixty setters would duplicate that list a third time and silently
+// miss whichever field was added last. Writing these two keys and letting the
+// page's own restore path run means a field added to the autosave is restored
+// for free.
+//
+// That is also why opening a project RELOADS the page. The alternative is the
+// sixty setters. A reload is legible — the engineer just asked to swap the
+// whole document — and it cannot drift.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { StructuralModel } from '../engine/model'
+
+export const AUTOSAVE_KEY = 'model-space-autosave'
+export const INPUTS_KEY = 'model-space-inputs'
+
+/** Which saved project the open session belongs to, if any. Survives the
+ *  reload that opening performs, which is the only reason it is stored. */
+export const OPEN_ID_KEY = 'projects:open-id'
+
+export interface SessionSnapshot {
+  model: StructuralModel | null
+  inputs: Record<string, unknown>
+}
+
+const store = (): Storage | undefined =>
+  typeof globalThis !== 'undefined' ? (globalThis as { sessionStorage?: Storage }).sessionStorage : undefined
+
+/** What Model Space currently has open. Missing or corrupt reads as empty. */
+export function readSession(): SessionSnapshot {
+  const s = store()
+  let model: StructuralModel | null = null
+  let inputs: Record<string, unknown> = {}
+  try {
+    const raw = s?.getItem(AUTOSAVE_KEY)
+    if (raw) model = JSON.parse(raw) as StructuralModel
+  } catch { /* a corrupt autosave is a fresh page, not a crash */ }
+  try {
+    const raw = s?.getItem(INPUTS_KEY)
+    const v = raw ? JSON.parse(raw) : null
+    if (v && typeof v === 'object' && !Array.isArray(v)) inputs = v as Record<string, unknown>
+  } catch { /* as above */ }
+  return { model, inputs }
+}
+
+/** Load a snapshot into the session the page reads at mount. */
+export function writeSession(snap: SessionSnapshot): void {
+  const s = store()
+  try {
+    if (snap.model) s?.setItem(AUTOSAVE_KEY, JSON.stringify(snap.model))
+    else s?.removeItem(AUTOSAVE_KEY)
+    s?.setItem(INPUTS_KEY, JSON.stringify(snap.inputs))
+  } catch { /* quota — the caller reloads either way and gets what fitted */ }
+}
+
+export function readOpenId(): string | null {
+  try { return store()?.getItem(OPEN_ID_KEY) ?? null } catch { return null }
+}
+
+export function writeOpenId(id: string | null): void {
+  try {
+    if (id) store()?.setItem(OPEN_ID_KEY, id)
+    else store()?.removeItem(OPEN_ID_KEY)
+  } catch { /* ignore */ }
+}

--- a/webapp/src/lib/plans.limits.test.ts
+++ b/webapp/src/lib/plans.limits.test.ts
@@ -1,0 +1,81 @@
+// The project ceiling exists in TWO places and has to: `plans.ts` drives what
+// the UI says, and the RLS policy in the migration is what actually stops the
+// insert. The server cannot import TypeScript and the browser cannot be trusted
+// to enforce its own paywall, so duplication is the price.
+//
+// This test is what stops them drifting. It reads the SQL and checks every
+// branch of `project_limit()` against `PLANS`, so raising a limit in one place
+// and not the other fails here rather than in production, where the symptom
+// would be a customer who paid for unlimited projects being refused the fourth.
+
+import { describe, it, expect } from 'vitest'
+import migration from '../../../supabase/migrations/20260804010000_projects.sql?raw'
+import { PLANS, planOf } from './plans'
+
+/**
+ * SQL with `--` comments removed.
+ *
+ * The assertions below are about what the database EXECUTES. Matching raw file
+ * text instead fails on a comment that merely names the thing it is warning
+ * you against — which is exactly what happened the first time this ran.
+ */
+const code = (sql: string): string =>
+  sql.split('\n').map((l) => l.replace(/--.*$/, '')).join('\n')
+
+/** The `when '<plan>' then <null|N>` branches of `project_limit()`. */
+function sqlLimits(sql: string): Record<string, number | null> {
+  const fn = sql.slice(sql.indexOf('function public.project_limit()'))
+  const body = fn.slice(0, fn.indexOf('$$;'))
+  const out: Record<string, number | null> = {}
+  for (const m of body.matchAll(/when\s+'([a-z]+)'\s+then\s+(null|\d+)/gi)) {
+    out[m[1]] = m[2].toLowerCase() === 'null' ? null : Number(m[2])
+  }
+  return out
+}
+
+describe('the SQL project ceiling matches plans.ts', () => {
+  const limits = sqlLimits(code(migration))
+
+  it('found the branches at all — a silent zero here would pass everything', () => {
+    expect(Object.keys(limits).sort()).toEqual(['free', 'max', 'pro'])
+  })
+
+  it.each(['free', 'pro', 'max'])('agrees for the %s plan', (id) => {
+    expect(limits[id]).toBe(planOf(id).maxProjects)
+  })
+
+  it('defaults an unknown plan to the free allowance, never to unlimited', () => {
+    // `else 3` in the SQL. The failure direction has to cost the business
+    // nothing: an unrecognised plan string must not read as "no limit".
+    const fallback = /else\s+(null|\d+)/i.exec(
+      code(migration).slice(code(migration).indexOf('function public.project_limit()')),
+    )
+    expect(fallback?.[1]).toBe(String(planOf('free').maxProjects))
+  })
+
+  it('reads the plan from app_metadata, not user_metadata', () => {
+    // user_metadata is writable by the account itself — see migration
+    // 20260731120000. Reading it here would let anyone raise their own ceiling
+    // from a browser console.
+    expect(code(migration)).toContain("auth.jwt() -> 'app_metadata' ->> 'plan'")
+    expect(code(migration)).not.toContain('user_metadata')
+  })
+
+  it('applies the ceiling to INSERT only', () => {
+    // A lapsed plan must not make existing projects unsavable. If the UPDATE
+    // policy ever grows a count, an engineer mid-edit is holding changes they
+    // cannot store.
+    const sql = code(migration)
+    const update = sql.slice(sql.indexOf('for update'))
+    expect(update).not.toContain('project_count')
+    const insert = sql.slice(sql.indexOf('for insert'), sql.indexOf('for update'))
+    expect(insert).toContain('project_count')
+  })
+
+  it('every plan that offers saved-projects has a limit the SQL knows about', () => {
+    for (const p of PLANS) {
+      if (!p.features.includes('saved-projects')) continue
+      expect(Object.keys(limits)).toContain(p.id)
+    }
+  })
+})

--- a/webapp/src/lib/useProjects.ts
+++ b/webapp/src/lib/useProjects.ts
@@ -1,0 +1,184 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Projects, from a component's point of view.
+//
+// EVERYTHING REMOTE IS MANUAL, DELIBERATELY — the same rule the soils sync
+// follows. Nothing uploads on a timer or on every keystroke. A structural
+// model is expensive to rebuild and a two-sided edit is a real scenario, so
+// the moment work moves between machines is a moment the engineer chose.
+//
+// LOCAL SAVING IS NOT. `save()` writes to localStorage immediately, because
+// the bug this module replaces is that Model Space's autosave died with the
+// tab. Losing a day's modelling to a closed window is not a trade-off worth
+// keeping for tidiness.
+//
+// The sync marks live in localStorage beside the projects. They are a CACHE,
+// not a source of truth: losing them makes the next sync treat everything as
+// changed on both sides, which surfaces conflicts rather than destroying
+// anything.
+// ─────────────────────────────────────────────────────────────────────────
+
+import { useCallback, useMemo, useState } from 'react'
+import { getClient, isAuthConfigured } from './auth/authClient'
+import { useAuth } from './auth/authContext'
+import { usePlan } from './auth/usePlan'
+import { createStore, defaultBackend, canSaveNew, type SaveVerdict } from '../engine/projects/store'
+import { emptyProject, type Project, type ProjectSummary } from '../engine/projects/model'
+import { supabaseRemote } from '../engine/projects/supabaseRemote'
+import {
+  syncProjects, contentHash, conflictsIn,
+  type SyncReport, type SyncMark, type SyncMarks,
+} from '../engine/projects/remoteStore'
+
+const MARKS_KEY = 'projects:sync-marks'
+
+/** Marks persisted in localStorage. A corrupt blob is discarded, not thrown. */
+function storedMarks(): SyncMarks {
+  const read = (): Record<string, SyncMark> => {
+    try {
+      const raw = localStorage.getItem(MARKS_KEY)
+      const v = raw ? JSON.parse(raw) : {}
+      return v && typeof v === 'object' ? (v as Record<string, SyncMark>) : {}
+    } catch { return {} }
+  }
+  const write = (all: Record<string, SyncMark>) => {
+    try { localStorage.setItem(MARKS_KEY, JSON.stringify(all)) } catch { /* quota — next sync re-detects */ }
+  }
+  return {
+    get: (id) => read()[id],
+    set: (id, mark) => { const all = read(); all[id] = mark; write(all) },
+    forget: (id) => { const all = read(); delete all[id]; write(all) },
+  }
+}
+
+/** A short, sortable, collision-resistant id. Not a UUID — it is a key in one
+ *  account's namespace, and a readable prefix helps when reading the table. */
+const newId = (): string =>
+  'p_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 8)
+
+export interface ProjectsApi {
+  /** Local listing, newest first. */
+  list: ProjectSummary[]
+  /** Whether cloud sync is even possible right now. */
+  cloud: 'ready' | 'signed-out' | 'not-configured'
+  busy: boolean
+  error: string | null
+  report: SyncReport | null
+  /** Whether a NEW project may be saved under the current plan. */
+  canCreate: SaveVerdict
+  create(name: string, seed?: Partial<Project>): string | null
+  load(id: string): Project | null
+  save(id: string, project: Project): void
+  rename(id: string, name: string): void
+  remove(id: string): void
+  sync(): Promise<void>
+  /** Resolve one conflict by keeping one side whole. */
+  resolve(id: string, keep: 'local' | 'remote'): Promise<void>
+}
+
+export function useProjects(): ProjectsApi {
+  const { user } = useAuth()
+  const plan = usePlan()
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [report, setReport] = useState<SyncReport | null>(null)
+  // Bumped after every mutation so the listing re-reads. The store is
+  // synchronous, so a version counter is honest about where the truth lives —
+  // mirroring the list into React state would give two answers to one question.
+  const [rev, setRev] = useState(0)
+
+  const local = useMemo(() => createStore(defaultBackend()), [])
+  const marks = useMemo(() => storedMarks(), [])
+
+  const list = useMemo(() => {
+    void rev
+    return local.list()
+  }, [local, rev])
+
+  const cloud: ProjectsApi['cloud'] = !isAuthConfigured()
+    ? 'not-configured' : user ? 'ready' : 'signed-out'
+
+  const remote = useMemo(() => {
+    const client = getClient()
+    if (!client || !user) return null
+    return supabaseRemote(client, user.id)
+  }, [user])
+
+  const canCreate = canSaveNew(plan, list.length)
+
+  const run = useCallback(async (fn: () => Promise<void>) => {
+    setBusy(true); setError(null)
+    try { await fn() } catch (e) { setError(e instanceof Error ? e.message : String(e)) }
+    finally { setBusy(false); setRev((n) => n + 1) }
+  }, [])
+
+  const create = useCallback((name: string, seed?: Partial<Project>): string | null => {
+    // The plan check is read from the CURRENT listing rather than the stale
+    // `canCreate` above, so two quick clicks cannot both pass.
+    if (!canSaveNew(plan, local.list().length).ok) return null
+    const id = newId()
+    local.save(id, { ...emptyProject(name), ...seed, meta: { ...emptyProject(name).meta, ...seed?.meta } })
+    setRev((n) => n + 1)
+    return id
+  }, [local, plan])
+
+  const load = useCallback((id: string) => local.load(id), [local])
+
+  const save = useCallback((id: string, project: Project) => {
+    local.save(id, project)
+    setRev((n) => n + 1)
+  }, [local])
+
+  const rename = useCallback((id: string, name: string) => {
+    const p = local.load(id)
+    if (!p) return
+    local.save(id, { ...p, meta: { ...p.meta, name } })
+    setRev((n) => n + 1)
+  }, [local])
+
+  const remove = useCallback((id: string) => {
+    local.remove(id)
+    // Forget the watermark too. Leaving it would make the next sync read
+    // "local is gone but unchanged" and quietly pull the project back.
+    marks.forget(id)
+    setRev((n) => n + 1)
+  }, [local, marks])
+
+  const sync = useCallback(async () => {
+    if (!remote) return
+    await run(async () => { setReport(await syncProjects(local, remote, marks)) })
+  }, [remote, local, marks, run])
+
+  /**
+   * Resolve a conflict by KEEPING ONE SIDE WHOLE.
+   *
+   * There is no merge. Two versions of a structural model are not mergeable
+   * field-by-field without an engineer deciding which member size is right,
+   * and a machine guessing at that is worse than asking.
+   */
+  const resolve = useCallback(async (id: string, keep: 'local' | 'remote') => {
+    if (!remote) return
+    await run(async () => {
+      const current = await remote.load(id)
+      if (!current) return
+      if (keep === 'remote') {
+        local.save(id, current.project, current.project.meta.updatedAt)
+        // Mark BOTH sides as seen, or the next sync treats the copy it just
+        // took as a local edit and pushes it straight back.
+        marks.set(id, { localHash: contentHash(current.project), remote: current.updatedAt })
+      } else {
+        const mine = local.load(id)
+        if (!mine) return
+        const saved = await remote.save(id, mine, current.updatedAt)
+        marks.set(id, { localHash: contentHash(mine), remote: saved.updatedAt })
+      }
+      // Re-run so the panel reflects the new state rather than a stale report.
+      setReport(await syncProjects(local, remote, marks))
+    })
+  }, [remote, local, marks, run])
+
+  return { list, cloud, busy, error, report, canCreate, create, load, save, rename, remove, sync, resolve }
+}
+
+/** Conflicts in the latest report, for the panel. Re-exported so the component
+ *  imports one module rather than reaching into the engine. */
+export { conflictsIn }

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -3,6 +3,10 @@ import { Link } from 'react-router-dom'
 import { Canvas, useFrame } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 import { SceneText } from '../components/SceneText'
+import { ProjectsPanel } from '../components/ProjectsPanel'
+// The session keys are shared with the Projects panel, which saves and
+// restores exactly what the page autosaves — see lib/modelSpaceSession.
+import { AUTOSAVE_KEY, INPUTS_KEY } from '../lib/modelSpaceSession'
 import * as THREE from 'three'
 import { generateGridModel, removeElements, removeNode, buildGravityLoads, splitSharedSections } from '../engine/modelBuilder'
 import type { StructuralModel, Member, Plate, RectSection, ModelLoad, MemberRole, MemberReleases, NodeSupport, SupportFixity, WoodDeck } from '../engine/model'
@@ -87,8 +91,6 @@ const DEFAULT_DECK: WoodDeck = {
   joistSupport: 'simple', deckMaterial: 'plank', deckThickness: 25, deckSupport: 'continuous',
 }
 
-const AUTOSAVE_KEY = 'model-space-autosave'
-const INPUTS_KEY = 'model-space-inputs'
 
 
 /** The design inputs persisted alongside the autosaved model so a reload keeps
@@ -742,7 +744,7 @@ function DirPicker({ value, onChange }: { value: string[]; onChange: (v: string[
 }
 
 // ── Right-panel tabs ────────────────────────────────────────────────────────
-type Tab = 'geometry' | 'properties' | 'supports' | 'loading' | 'analysis' | 'modal' | 'pushover' | 'nonlinear' | 'design' | 'plans'
+type Tab = 'geometry' | 'properties' | 'supports' | 'loading' | 'analysis' | 'modal' | 'pushover' | 'nonlinear' | 'design' | 'plans' | 'projects'
 const TABS: { id: Tab; label: string }[] = [
   { id: 'geometry', label: 'Geometry' },
   { id: 'properties', label: 'Properties' },
@@ -754,6 +756,7 @@ const TABS: { id: Tab; label: string }[] = [
   { id: 'nonlinear', label: 'Nonlinear' },
   { id: 'design', label: 'Design' },
   { id: 'plans', label: 'Plans' },
+  { id: 'projects', label: 'Projects' },
 ]
 /** Flat panel section (3D Model Space mockup): uppercase mini-title, no card
  *  chrome — hairline separation comes from the parent's divide-y. */
@@ -4296,6 +4299,8 @@ export default function ModelSpace() {
               </Sec>
             </div>
           )}
+          {tab === 'projects' && <ProjectsPanel />}
+
           {tab === 'plans' && model && (
             <div className="px-4 py-3">
               <PlansPanel model={model} design={design} soil={soil} />


### PR DESCRIPTION
The project storage module for paid accounts, end to end.

## What was there

`saved-projects` has been listed on every plan since `plans.ts` was written, with **no store behind it**. Model Space kept its work in `sessionStorage` under `model-space-autosave` — which survives a reload and nothing else. Close the tab and a day's modelling is gone; open it on another machine and there's nothing there.

Verified that exact failure in a browser, then verified it fixed: generate a model → save it as a project → clear `sessionStorage` (what closing the tab does) → reload → the page falls back to *"Set the grid and hit Regenerate grid model"* → open the saved project → **all 26 members and the canvas come back**.

## What a project is

The structural model **plus the design inputs that produced it** — soil, seismic, wind, prices, material choices. The model alone isn't enough: reopening it with the inputs reset to defaults hands an engineer a structure whose design basis silently changed.

## The plan limit is enforced by the database

```sql
create policy "own projects are insertable within the plan limit"
  on public.projects for insert
  with check (
    auth.uid() = user_id
    and (public.project_limit() is null or public.project_count() < public.project_limit())
  );
```

`project_limit()` reads the plan from **`app_metadata`** — the field only the service-role key can write (migration `20260731120000`). A browser that skips the client code entirely still cannot insert row four on a Free plan. That makes the saved-project ceiling **the first entitlement in this app that is a real boundary rather than a product promise**; `featureGate.ts` is careful to say why the others aren't, and this doesn't change that.

It **duplicates `maxProjects` from `plans.ts`**, unavoidably — the server can't import TypeScript and the browser can't be trusted to enforce its own paywall. `plans.limits.test.ts` reads the `.sql` and checks: every branch against `PLANS`; that an unknown plan falls to the **free** allowance, never unlimited; that the plan is read from `app_metadata`; and that the ceiling applies to **INSERT only** — a lapsed plan must not make existing work unsavable.

*(That test caught its own first draft: it asserted on raw file text and failed on a comment that merely names the thing it warns against. It now strips `--` comments and asserts on what Postgres executes.)*

## Opening reloads the page — the interesting decision

Model Space holds ~60 design fields in individual `useState` hooks. Restoring a project by calling sixty setters would be a **third** copy of that list — after the state declarations and the autosave effect — and would silently miss whichever field was added last.

Instead `lib/modelSpaceSession.ts` owns the two session keys, the panel writes them, and **the page's own restore path runs**. A field added to the autosave is restored for free. For the same reason `<ProjectsPanel />` takes **no props**: it reads the session snapshot rather than being handed a copy.

## Two rules shaped the panel

- **Delete asks.** A structural model is a day's work and there's no undo — not even a sync, which never resurrects what you deleted on purpose. Removing a project also **forgets its sync mark**; leaving it would make the next sync read *"local is gone but unchanged"* and quietly pull the project back.
- **Conflicts are the engineer's.** Both versions are shown with member counts and save times, and two buttons. No field-by-field merge: deciding which member size is right isn't a machine's call.

Sync is manual — nothing uploads on a timer. Local saving is **not**: it writes immediately, because losing a day's modelling to a closed window isn't a trade-off worth keeping for tidiness.

## The reconciler

Decides from three facts: did the local document change since the mark, did the remote stamp change, does each side exist. **Not "which is newer"** — wall clocks on two machines disagree and a laptop an hour behind would quietly win every race. A test pins that with a document stamped in 1999 that still uploads, because it's the side that *changed*.

Both changed → conflict, reported not resolved. **Nothing is ever deleted by a sync.** One project failing doesn't stop the rest. A save refused by the plan ceiling is reported and the project **stays on the machine** — a quota must never be the reason work disappears.

## Also

`contentHash` / `stableStringify` moved to `lib/contentHash.ts`; the rule is payload-agnostic and the project store needed the same answer. Soils re-exports it under its own narrowed signature, so no call site changed.

## Verification

Browser, dev server: save two projects, the "Open" badge tracks which is attached, rename inline, delete asks and then removes, and the listing count follows. No page errors. Plus the session-loss scenario above.

`npx tsc -b`, `eslint`, `npm test` (**3013 tests, 190 files**) and `npm run build` all clean.

## After merging

Run migration `20260804010000_projects.sql`. Without it the panel still works — projects save locally and the cloud section says sign-in isn't set up or you're signed out.

## Known limit, flagged

Projects are keyed per browser until you sync. Two machines that have never synced will both see "nothing saved here" — which is correct, but worth knowing before it surprises someone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)