### PR TITLE
fix(tbeam): the section drawing fills its card

### DIFF
--- a/webapp/src/components/TSection.tsx
+++ b/webapp/src/components/TSection.tsx
@@ -1,4 +1,5 @@
 import { DimBelow, DimSide } from './dims'
+import { sectionFrame } from './sectionLayout'
 
 /** Flanged (T / L) beam cross-section to scale: outline, optional compression
  *  stress block, stirrup + tension-bar layers in the web, and the shared
@@ -8,11 +9,11 @@ export function TSection({ bf, bw, h, hf, a = 0, bars = 0, barDia = 0, layers = 
   bf: number; bw: number; h: number; hf: number; a?: number
   bars?: number; barDia?: number; layers?: number[]; cover?: number; stirrupDia?: number; legs?: number
 }) {
-  const W = 340, HT = 285
-  const availW = 210, availH = 200
-  const S = Math.min(availW / bf, availH / h)
-  const w = bf * S, ht = h * S, wf = bw * S, hff = hf * S, A = Math.min(a, h) * S
-  const x0 = (W - w) / 2, y0 = 40
+  // Frame arithmetic lives in `sectionLayout` so it can be tested — the
+  // complaint that started this ("too small, area not fully used") is a
+  // statement about these numbers and nothing else.
+  const { scale: S, W, HT, x0, y0, w, ht } = sectionFrame(bf, h, bars)
+  const wf = bw * S, hff = hf * S, A = Math.min(a, h) * S
   const xw = x0 + (w - wf) / 2
   const inset = (cover + stirrupDia / 2) * S
   const br = Math.max(2.5, (barDia / 2) * S)
@@ -23,14 +24,17 @@ export function TSection({ bf, bw, h, hf, a = 0, bars = 0, barDia = 0, layers = 
   const bx1 = xw + (cover + stirrupDia + barDia / 2) * S
   const bx2 = xw + wf - (cover + stirrupDia + barDia / 2) * S
   return (
-    <svg viewBox={`0 0 ${W} ${HT}`} className="mx-auto block w-full max-w-[360px]" style={{ fontFamily: 'Arial, sans-serif' }}>
+    <svg viewBox={`0 0 ${W} ${HT}`} className="mx-auto block h-auto max-h-[440px] w-full max-w-[560px]" style={{ fontFamily: 'Arial, sans-serif' }}>
       <path d={`M${x0} ${y0} h${w} v${hff} h${-(w - wf) / 2} v${ht - hff} h${-wf} v${-(ht - hff)} h${-(w - wf) / 2} z`}
         fill="#eef3f8" stroke="#37526e" strokeWidth="1.6" />
       {a > 0 && <>
         <rect x={x0} y={y0} width={w} height={Math.min(A, hff)} fill="#0f4c92" opacity="0.16" />
         {A > hff && <rect x={xw} y={y0 + hff} width={wf} height={A - hff} fill="#0f4c92" opacity="0.16" />}
         <line x1={x0 - 6} y1={y0 + A} x2={x0 + w + 6} y2={y0 + A} stroke="#0f4c92" strokeWidth="1.2" strokeDasharray="5 3" />
-        <text x={x0 + w - 4} y={y0 + A + 11} fontSize="8.5" fontFamily="IBM Plex Mono, monospace" fill="#0f4c92" textAnchor="end">a = {a.toFixed(0)}</text>
+        {/* Anchored at the LEFT end of the block. On the right it sat on top of
+            the `hf` dimension line, which only became visible once the section
+            grew to fill the card. */}
+        <text x={x0 + 5} y={y0 + A + 11} fontSize="8.5" fontFamily="IBM Plex Mono, monospace" fill="#0f4c92" textAnchor="start">a = {a.toFixed(0)}</text>
       </>}
       {/* stirrup in the web */}
       <rect x={xw + inset} y={y0 + hff * 0.35} width={wf - 2 * inset} height={ht - hff * 0.35 - inset}

--- a/webapp/src/components/sectionLayout.test.ts
+++ b/webapp/src/components/sectionLayout.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { sectionFrame, fillRatio, DRAW, MARGIN, MIN_DRAW_W } from './sectionLayout'
+
+/** What the old fixed frame did, for comparison. 340×285 outer, 210×200 inner. */
+const OLD = (bf: number, h: number) => {
+  const s = Math.min(210 / bf, 200 / h)
+  return { w: bf * s, ht: h * s, W: 340, HT: 285 }
+}
+const oldFill = (bf: number, h: number) => {
+  const o = OLD(bf, h)
+  return (o.w * o.ht) / (o.W * o.HT)
+}
+
+// Real sections, not invented ones: the page's own defaults, a slab-and-joist
+// flange, and a deep narrow beam.
+const CASES: [string, number, number][] = [
+  ['page default', 1800, 600],
+  ['wide flange', 2400, 500],
+  ['modest flange', 900, 550],
+  ['deep, narrow flange', 500, 900],
+  ['nearly square', 600, 600],
+]
+
+describe('sectionFrame', () => {
+  it.each(CASES)('%s: uses more of the frame than the old fixed one', (_n, bf, h) => {
+    const f = sectionFrame(bf, h, 4)
+    expect(fillRatio(f)).toBeGreaterThan(oldFill(bf, h))
+  })
+
+  it.each(CASES)('%s: fills the drawing area on its limiting axis', (_n, bf, h) => {
+    // THE invariant, and a better statement than any ratio. The section is
+    // scaled until it hits one edge of the drawing area; the frame is then that
+    // section plus fixed margins, and nothing else. So there is no dead space
+    // anywhere except the margins that carry the dimension lines.
+    //
+    // A ratio would have been a statement about those margins instead: a
+    // 2400×500 flange draws 54 units tall, so the 94 units of top-and-bottom
+    // margin dominate its area no matter how well the drawing is placed.
+    const f = sectionFrame(bf, h, 4)
+    const atWidth = Math.abs(f.w - DRAW.width) < 1e-9
+    const atHeight = Math.abs(f.ht - DRAW.height) < 1e-9
+    expect(atWidth || atHeight).toBe(true)
+  })
+
+  it('draws a wide section at the full drawing width', () => {
+    // 1800×600 is width-limited, so it should use every unit of DRAW.width.
+    const f = sectionFrame(1800, 600, 4)
+    expect(f.w).toBeCloseTo(DRAW.width, 6)
+    expect(f.W).toBeCloseTo(MARGIN.left + DRAW.width + MARGIN.right, 6)
+  })
+
+  it('caps the height rather than letting a deep beam run off', () => {
+    const f = sectionFrame(400, 3000, 4)
+    expect(f.ht).toBeLessThanOrEqual(DRAW.height + 1e-9)
+  })
+
+  it('shrinks the frame around a narrow section instead of padding it', () => {
+    // The old failure rotated 90°: a narrow section floating in side margins.
+    const narrow = sectionFrame(300, 900, 4)
+    const wide = sectionFrame(2400, 500, 4)
+    expect(narrow.W).toBeLessThan(wide.W)
+  })
+
+  it('never goes narrower than the bw label needs', () => {
+    const f = sectionFrame(50, 900, 4)
+    expect(f.W).toBeGreaterThanOrEqual(MARGIN.left + MIN_DRAW_W + MARGIN.right)
+    // …and the section stays centred in whatever floor was applied.
+    expect(f.x0 + f.w / 2).toBeCloseTo(MARGIN.left + MIN_DRAW_W / 2, 6)
+  })
+
+  it('gives the bar callout its own room, and takes it back when there is none', () => {
+    const withBars = sectionFrame(1800, 600, 4)
+    const without = sectionFrame(1800, 600, 0)
+    expect(withBars.HT - without.HT).toBe(MARGIN.bottomWithBars - MARGIN.bottom)
+  })
+
+  it('keeps the frame aspect close to the section aspect', () => {
+    // The old frame was 340×285 (1.19) whatever the beam looked like. This is
+    // the property that killed the dead band: the frame now follows the shape.
+    for (const [, bf, h] of CASES) {
+      const f = sectionFrame(bf, h, 4)
+      const section = f.w / f.ht, frame = f.W / f.HT
+      expect(frame / section).toBeGreaterThan(0.35)
+      expect(frame / section).toBeLessThan(3.2)
+    }
+  })
+
+  it('scales uniformly — a section is never stretched', () => {
+    const f = sectionFrame(1800, 600, 4)
+    expect(f.w / 1800).toBeCloseTo(f.scale, 12)
+    expect(f.ht / 600).toBeCloseTo(f.scale, 12)
+  })
+})

--- a/webapp/src/components/sectionLayout.ts
+++ b/webapp/src/components/sectionLayout.ts
@@ -1,0 +1,71 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Frame arithmetic for the flanged-section drawing.
+//
+// Pulled out of `TSection.tsx` so it can be tested: the whole complaint was
+// "the drawing is too small and the drawing area is not fully used", which is
+// a statement about these numbers and nothing else. Rendering the component to
+// check would need a DOM the test setup does not have; the numbers do not.
+//
+// THE OLD FRAME WAS FIXED at 340×285 with a 210×200 drawing area, so:
+//   • the section could never use more than 62% of the frame's width, and
+//   • a flanged section is WIDE AND SHORT — bf 1800, h 600 is ordinary — so
+//     scaling to fit left roughly half the frame empty below the beam.
+// Both come from one mistake: a frame whose shape has nothing to do with the
+// shape of the thing inside it.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Margins, sized by what sits in them: the `h` dimension and its rotated
+ *  label on the left, `hf` on the right, `bf` above, `bw` (plus the bar
+ *  callout, when there is one) below. */
+export const MARGIN = { left: 54, right: 50, top: 40, bottom: 40, bottomWithBars: 54 } as const
+
+/** The largest the drawing itself is allowed to get, in viewBox units. The
+ *  SVG scales to its container, so these set the frame's PROPORTIONS, not the
+ *  rendered size. */
+export const DRAW = { width: 260, height: 235 } as const
+
+/** Frames never narrower than this, so the `bw` label has somewhere to go. */
+export const MIN_DRAW_W = 120
+
+export interface SectionFrame {
+  /** mm → viewBox units. */
+  scale: number
+  /** viewBox dimensions. */
+  W: number
+  HT: number
+  /** Top-left of the flange. */
+  x0: number
+  y0: number
+  /** Drawn flange width and overall depth. */
+  w: number
+  ht: number
+}
+
+/**
+ * Frame for a flanged section of `bf × h`, with `bars` deciding whether the
+ * bottom margin has to carry the bar callout as well as the `bw` dimension.
+ *
+ * Fills the width, caps the height, then sizes the FRAME from the result — so
+ * the viewBox's aspect ratio matches the beam's and there is no dead band in
+ * either direction.
+ */
+export function sectionFrame(bf: number, h: number, bars = 0): SectionFrame {
+  const mb = bars > 0 ? MARGIN.bottomWithBars : MARGIN.bottom
+  const scale = Math.min(DRAW.width / bf, DRAW.height / h)
+  const w = bf * scale, ht = h * scale
+  const drawW = Math.max(w, MIN_DRAW_W)
+  return {
+    scale,
+    W: MARGIN.left + drawW + MARGIN.right,
+    HT: MARGIN.top + ht + mb,
+    x0: MARGIN.left + (drawW - w) / 2,
+    y0: MARGIN.top,
+    w,
+    ht,
+  }
+}
+
+/** Share of the frame's area the section itself occupies — the number the old
+ *  frame got wrong. Exported for the test rather than computed inline there,
+ *  so the definition of "well used" lives with the thing it judges. */
+export const fillRatio = (f: SectionFrame): number => (f.w * f.ht) / (f.W * f.HT)


### PR DESCRIPTION
> *T-beam design, rescale the rendered drawing because the drawing is too small and the drawing area is not fully used*

Both symptoms come from one mistake: **a frame whose shape had nothing to do with the shape of the thing inside it.**

The frame was fixed at `340×285` with a `210×200` drawing area, and capped at `360px` on screen. So:

- the section could never use more than **62% of the frame's width**, whatever the beam looked like;
- a flanged section is **wide and short** — the page's own default is 1800×600 — so scaling to fit a near-square frame left roughly **45% of the card empty** below the beam.

## The fix

The section is scaled until it reaches one edge of the drawing area, and the **frame is that section plus fixed margins. Nothing else.** Margins are sized by what sits in them: the `h` dimension and its rotated label on the left, `hf` on the right, `bf` above, `bw` plus the bar callout below.

Measured on the page: the SVG went from **360×302 → 493×245**, and the section inside it from **222px wide → 352px** — 1.6× linear, dead band gone.

The frame adapts in **both** directions. Fixing the width would leave a tall narrow section floating in side margins — the same dead space, rotated 90°. A floor keeps the frame wide enough for the `bw` label.

## Test

The arithmetic moved to `sectionLayout.ts` so it can be tested — the complaint is a statement about these numbers and nothing else, and the test setup has no DOM to render a component into. `sectionLayout.test.ts` asserts the real invariant across five real sections: **every geometry fills the drawing area on its limiting axis**, and each beats the old fixed frame.

An area-fill threshold was the obvious test and it was **wrong**: a 2400×500 flange draws 54 units tall, so the 94 units of margin carrying the dimension lines dominate its area however well the drawing is placed. That assertion would have been about dimension lines, not about the drawing. Noted in the test so nobody re-introduces it.

## Also

Moved the `a = …` stress-block label to the left end of the block. On the right it sat on top of the `hf` dimension — a collision that existed before but only became visible once the section grew to fill the card.

## Scope note

`TSection` is shared with the Model Space beam schedule, which gets the same improvement. It's width-responsive, so it still scales down in the narrower rail.

## Verification

Before/after screenshots captured from the running page (attached in the conversation). `npx tsc -b`, `eslint`, `npm test` (**2991 tests, 188 files**) and `npm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_