### PR TITLE
fix(prestressed): draw the UDL uniformly, and land it on the beam

### DIFF
--- a/webapp/src/components/BeamElevation.tsx
+++ b/webapp/src/components/BeamElevation.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from 'react'
+import { udlStations } from './udl'
 import type { Support, BeamLoad } from '../engine/beamAnalysis'
 
 const BEAM = '#37526e'
@@ -82,13 +83,12 @@ export function BeamElevation({ L, supports, loads }: {
     const xa = sx(ld.x1), xb = sx(ld.x2)
     const h1 = ld.type === 'udl' ? 26 : Math.max(8, 26 * (Math.abs(ld.w1) / Math.max(Math.abs(ld.w1), Math.abs(ld.w2), 1e-9)))
     const h2 = ld.type === 'udl' ? 26 : Math.max(8, 26 * (Math.abs(ld.w2) / Math.max(Math.abs(ld.w1), Math.abs(ld.w2), 1e-9)))
-    const nA = Math.max(3, Math.floor((xb - xa) / 26))
+    const stations = udlStations(xb - xa)
     const label = ld.type === 'udl' ? `${ld.w} kN/m (${ld.cat})` : `${ld.w1}→${ld.w2} kN/m (${ld.cat})`
     return (
       <g key={`l${i}`}>
         <line x1={xa} y1={by - 4 - h1} x2={xb} y2={by - 4 - h2} stroke={LOAD} strokeWidth={1.2} />
-        {Array.from({ length: nA + 1 }, (_, j) => {
-          const t = j / nA
+        {stations.map((t) => {
           const x = xa + (xb - xa) * t
           const hh = h1 + (h2 - h1) * t
           return arrow(x, by - 4 - hh, by - 3, LOAD)

--- a/webapp/src/components/udl.test.ts
+++ b/webapp/src/components/udl.test.ts
@@ -1,0 +1,63 @@
+// The prestressed-beam elevation drew its uniformly distributed load from a
+// hand-typed list of fractions that was neither uniform nor symmetric. These
+// tests are the reason it cannot come back: they state, as arithmetic, what
+// "uniformly distributed" means for a drawing.
+
+import { describe, it, expect } from 'vitest'
+import { udlStations } from './udl'
+
+const gaps = (t: number[]) => t.slice(1).map((v, i) => v - t[i])
+
+describe('udlStations', () => {
+  it.each([60, 120, 248, 400, 1000])('spans the whole loaded length at %i px', (len) => {
+    const t = udlStations(len)
+    // An arrow at each end. The old list started 8% in and stopped 4% short,
+    // so the load looked like it missed the supports — and missed them by
+    // different amounts at each end.
+    expect(t[0]).toBe(0)
+    expect(t[t.length - 1]).toBe(1)
+  })
+
+  it.each([60, 120, 248, 400, 1000])('is evenly spaced at %i px', (len) => {
+    const g = gaps(udlStations(len))
+    for (const x of g) expect(x).toBeCloseTo(g[0], 12)
+  })
+
+  it.each([60, 120, 248, 400, 1000])('is symmetric about mid-span at %i px', (len) => {
+    const t = udlStations(len)
+    for (let i = 0; i < t.length; i++) {
+      expect(t[i]).toBeCloseTo(1 - t[t.length - 1 - i], 12)
+    }
+  })
+
+  it('adds arrows as the span grows', () => {
+    expect(udlStations(1000).length).toBeGreaterThan(udlStations(200).length)
+  })
+
+  it('never drops below three arrows, however short the span', () => {
+    // Two arrows read as a pair of point loads, not as a distributed one.
+    for (const len of [0, 1, 10, 25, 26]) {
+      expect(udlStations(len).length).toBeGreaterThanOrEqual(4)
+    }
+  })
+
+  it('keeps the arrows from becoming a comb on a long span', () => {
+    const len = 1000
+    const t = udlStations(len)
+    const spacingPx = (t[1] - t[0]) * len
+    expect(spacingPx).toBeGreaterThanOrEqual(26 - 1e-9)
+  })
+
+  it('honours a custom minimum spacing', () => {
+    expect(udlStations(240, 60).length).toBe(5)   // 4 gaps of 60
+    expect(udlStations(240, 20).length).toBe(13)  // 12 gaps of 20
+  })
+
+  it('rejects nothing — a degenerate length still yields a drawable set', () => {
+    for (const len of [NaN, -5, Infinity]) {
+      const t = udlStations(len)
+      expect(t.length).toBeGreaterThanOrEqual(4)
+      expect(t.every((v) => Number.isFinite(v))).toBe(true)
+    }
+  })
+})

--- a/webapp/src/components/udl.ts
+++ b/webapp/src/components/udl.ts
@@ -1,0 +1,29 @@
+// Arrow placement for a distributed-load glyph. Its own file because `dims`
+// exports components and this is arithmetic — and because two elevations now
+// share it (BeamElevation and the prestressed-beam page), which is exactly
+// how the hand-typed version drifted out of being uniform in the first place.
+
+/**
+ * Where the arrows of a distributed load go, as fractions of the loaded length.
+ *
+ * ALWAYS INCLUSIVE OF BOTH ENDS AND ALWAYS EVENLY SPACED. That is the whole
+ * point of the helper: the prestressed-beam elevation used to carry a
+ * hand-typed list, `[0.08, 0.26, 0.44, 0.62, 0.8, 0.96]`, which was neither.
+ * Its last gap was 11% shorter than the rest and it sat 19.8 units from the
+ * left end of the beam but 9.9 from the right — a uniformly distributed load
+ * drawn non-uniformly, and off-centre.
+ *
+ * `minSpacing` is a floor on the gap in viewBox units, so a short span does
+ * not become a comb; three arrows is the fewest that still reads as a UDL
+ * rather than as point loads.
+ */
+export function udlStations(lengthPx: number, minSpacing = 26): number[] {
+  // Total by construction. A NaN or Infinity length went straight into
+  // `Array.from({ length })`, which yields an EMPTY array — the load would
+  // vanish from the drawing rather than fail loudly. The upper cap stops an
+  // absurd length emitting thousands of arrows.
+  const span = Number.isFinite(lengthPx) ? Math.max(0, lengthPx) : 0
+  const step = Number.isFinite(minSpacing) && minSpacing > 0 ? minSpacing : 26
+  const n = Math.min(64, Math.max(3, Math.floor(span / step)))
+  return Array.from({ length: n + 1 }, (_, j) => j / n)
+}

--- a/webapp/src/pages/PrestressedBeam.tsx
+++ b/webapp/src/pages/PrestressedBeam.tsx
@@ -7,6 +7,7 @@ import { initialLetterhead } from '../lib/letterhead'
 import { Num, Pick, Card } from '../components/qty'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { DimBelow, DimSide } from '../components/dims'
+import { udlStations } from '../components/udl'
 
 const f1 = (v: number) => v.toFixed(1)
 
@@ -17,15 +18,17 @@ function PSElevation({ h, e, span }: { h: number; e: number; span: number }) {
   const x0 = 46, bw = 248
   const y0 = 74, H = 56
   const yc = y0 + H / 2, yTendon = Math.min(y0 + H - 5, yc + (e / h) * H)
-  const arrows = [0.08, 0.26, 0.44, 0.62, 0.8, 0.96].map((f) => x0 + f * bw)
+  const arrows = udlStations(bw).map((t) => x0 + t * bw)
   return (
     <svg viewBox={`0 0 ${W} ${HT}`} className="mx-auto block w-full max-w-[380px]" style={{ fontFamily: 'Arial, sans-serif' }}>
       {/* UDL: top line + arrows touching the beam's top edge */}
       <line x1={x0} y1={y0 - 26} x2={x0 + bw} y2={y0 - 26} stroke="#5c6675" strokeWidth="1.4" />
       {arrows.map((x) => (
         <g key={x} stroke="#5c6675" strokeWidth="1.4">
-          <line x1={x} y1={y0 - 26} x2={x} y2={y0 - 5} />
-          <path d={`M${x - 3.2} ${y0 - 6.5} L${x} ${y0 - 0.5} L${x + 3.2} ${y0 - 6.5} z`} fill="#5c6675" stroke="none" />
+          {/* The tip lands ON the top edge (y0). It used to stop at y0 − 0.5,
+              which with a 1.4 stroke reads as a load floating above the beam. */}
+          <line x1={x} y1={y0 - 26} x2={x} y2={y0 - 6} />
+          <path d={`M${x - 3.2} ${y0 - 6} L${x} ${y0} L${x + 3.2} ${y0 - 6} z`} fill="#5c6675" stroke="none" />
         </g>
       ))}
       <text x={x0 + bw / 2} y={y0 - 32} fontSize="8.5" fill="#5c6675" textAnchor="middle">w (D + L)</text>


### PR DESCRIPTION
> *Prestressed Beam, the uniformly distributed load is not rendered correctly*

It was drawn from a hand-typed list of fractions:

```js
const arrows = [0.08, 0.26, 0.44, 0.62, 0.8, 0.96].map((f) => x0 + f * bw)
```

which is neither uniform nor symmetric. Measured off the live page:

| | before | after |
|---|---|---|
| gaps between arrows | 44.64, 44.64, 44.64, 44.64, **39.68** | 27.56 × 9 |
| inset from beam ends | **19.84 left, 9.92 right** | 0, 0 |
| arrow tip *y* | 73.5 (beam top edge is **74.0**) | 74.0 |

So: a uniformly distributed load drawn non-uniformly, not centred on the span it loads, and not quite touching the member it acts on — which is what made it read as floating.

## The fix, and why it shouldn't recur

`BeamElevation` has drawn this **correctly all along** — a count derived from the loaded length, arrows at both ends, evenly spaced. The prestressed page had its own copy of the idea, typed by hand, and that copy drifted.

That construction is now `udlStations()` in its own module, and **both** elevations call it. Deduplicating is the part that stops this coming back; fixing the numbers in place would just have reset the clock.

## One thing the first version got wrong

`udlStations` is total by construction. My first draft put the computed count straight into `Array.from({ length })` — so a `NaN` or `Infinity` length yields an **empty array**, and the load would silently vanish from the drawing rather than fail loudly. There's a cap at the other end too, so an absurd length can't emit thousands of arrows.

## Test

`udl.test.ts` states as arithmetic what "uniformly distributed" means for a drawing: an arrow at each end, equal gaps, symmetric about mid-span, never fewer than three (two reads as a pair of point loads), never denser than the minimum spacing, and total for degenerate input.

## Verification

Before/after screenshots from the running page, plus the DOM measurements in the table above. `npx tsc -b`, `eslint`, `npm test` (**3080 tests, 194 files**) and `npm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_