### PR TITLE
fix(tbeam): apply the lone-bar pairing rule to T-beam layering

### DIFF
--- a/webapp/src/engine/barLayers.test.ts
+++ b/webapp/src/engine/barLayers.test.ts
@@ -1,0 +1,91 @@
+// The rule under test: no layer carries a single bar. It lived only inside
+// `beamDesign`, so the T-beam engine — which stacked bars with its own greedy
+// loop — could detail one bar sitting alone in the top layer with nothing to
+// tie to on either side. These tests belong to the rule, not to either engine.
+
+import { describe, it, expect } from 'vitest'
+import { splitLayers, centroidRise } from './barLayers'
+
+const total = (l: number[]) => l.reduce((s, k) => s + k, 0)
+
+describe('splitLayers', () => {
+  it('keeps everything in one layer while it fits', () => {
+    expect(splitLayers(4, 4)).toEqual({ bars: 4, layers: [4] })
+    expect(splitLayers(2, 5)).toEqual({ bars: 2, layers: [2] })
+  })
+
+  it('fills the bottom layer first', () => {
+    // The extreme layer is the one doing the work; a half-full bottom layer
+    // would raise the group centroid and cost effective depth for nothing.
+    expect(splitLayers(7, 4).layers).toEqual([4, 3])
+  })
+
+  it('pairs a lone bar in the upper layer — the bug this exists to stop', () => {
+    // 5 bars, 4 per layer, is [4, 1] naively. The 1 has no neighbour to sit
+    // beside the stirrup leg with, so it becomes [4, 2] and the count goes up.
+    expect(splitLayers(5, 4)).toEqual({ bars: 6, layers: [4, 2] })
+    expect(splitLayers(3, 2)).toEqual({ bars: 4, layers: [2, 2] })
+    expect(splitLayers(9, 4)).toEqual({ bars: 10, layers: [4, 4, 2] })
+  })
+
+  it('never returns a layer of one, for any count or width', () => {
+    for (let per = 2; per <= 8; per++) {
+      for (let n = 2; n <= 60; n++) {
+        const r = splitLayers(n, per)
+        expect(r.layers.every((k) => k >= 2)).toBe(true)
+        expect(total(r.layers)).toBe(r.bars)
+      }
+    }
+  })
+
+  it('only ever ADDS steel — pairing is conservative on As', () => {
+    // Never the other direction. A section detailed with fewer bars than the
+    // strength calculation demanded is the one failure mode that matters here.
+    for (let per = 2; per <= 8; per++) {
+      for (let n = 2; n <= 60; n++) {
+        expect(splitLayers(n, per).bars).toBeGreaterThanOrEqual(n)
+        expect(splitLayers(n, per).bars).toBeLessThanOrEqual(n + 1)
+      }
+    }
+  })
+
+  it('leaves a one-bar-wide web alone', () => {
+    // maxPerLayer < 2 means the web cannot hold two bars side by side at all.
+    // The honest answer is that the section is too narrow, not that it wants
+    // another bar — so pairing is skipped rather than looping forever.
+    expect(splitLayers(3, 1)).toEqual({ bars: 3, layers: [1, 1, 1] })
+  })
+
+  it('handles a single bar and none at all', () => {
+    expect(splitLayers(1, 4)).toEqual({ bars: 1, layers: [1] })
+    expect(splitLayers(0, 4)).toEqual({ bars: 0, layers: [] })
+  })
+
+  it('rounds a fractional demand up', () => {
+    expect(splitLayers(4.2, 4).bars).toBe(6)   // 5 → paired to 6
+  })
+})
+
+describe('centroidRise', () => {
+  it('is zero for a single layer — d is unaffected', () => {
+    expect(centroidRise([4], 45)).toBe(0)
+  })
+
+  it('is the Varignon average of the layer heights', () => {
+    // [4, 2] at 45 mm pitch: (4·0 + 2·45) / 6 = 15 mm.
+    expect(centroidRise([4, 2], 45)).toBeCloseTo(15, 9)
+    // [4, 4] is symmetric about the gap: exactly half the pitch.
+    expect(centroidRise([4, 4], 45)).toBeCloseTo(22.5, 9)
+  })
+
+  it('always raises the centroid as layers are added, never lowers it', () => {
+    // Stacking must REDUCE effective depth. A rise that went the other way
+    // would silently overstate capacity.
+    expect(centroidRise([4, 4, 2], 45)).toBeGreaterThan(centroidRise([4, 4], 45))
+    expect(centroidRise([4, 4], 45)).toBeGreaterThan(centroidRise([4], 45))
+  })
+
+  it('is safe on an empty group', () => {
+    expect(centroidRise([], 45)).toBe(0)
+  })
+})

--- a/webapp/src/engine/barLayers.ts
+++ b/webapp/src/engine/barLayers.ts
@@ -1,0 +1,59 @@
+// ─────────────────────────────────────────────────────────────────────────
+// STACKING TENSION BARS INTO LAYERS — one rule, one home.
+//
+// Lifted out of `beamDesign.ts` when the T-beam engine turned out to have its
+// own greedy loop with no pairing, so a T-beam could be detailed with a single
+// bar sitting alone in its top layer. The rectangular-beam page had never
+// drawn one; the T-beam page had, since it shipped.
+//
+// THE DETAILING RULE. No layer carries a single bar. A lone bar in the upper
+// (least-full) layer has nothing to tie to on either side, so it is paired
+// with a second and the two sit beside the stirrup legs. Pairing ADDS a bar,
+// which is conservative on As — the section ends up with slightly more steel
+// than the strength calculation demanded, never less.
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface BarLayers {
+  /** Total bars after any pairing bump — use THIS for As provided, not the
+   *  count that went in, or the section is reported with steel it does not have. */
+  bars: number
+  /** Bars per layer, extreme (bottom) layer first. */
+  layers: number[]
+}
+
+/**
+ * Split `n` bars into layers of at most `maxPerLayer`, fullest at the bottom.
+ *
+ * `maxPerLayer < 2` means the web cannot hold two bars side by side at all;
+ * pairing is then meaningless and the stack is left as it comes out, because
+ * the honest answer is that the section is too narrow, not that it needs
+ * another bar.
+ */
+export function splitLayers(n: number, maxPerLayer: number): BarLayers {
+  let total = Math.max(0, Math.ceil(n))
+  const build = (m: number): number[] => {
+    const out: number[] = []
+    let left = m
+    while (left > 0) { const take = Math.min(left, maxPerLayer); out.push(take); left -= take }
+    return out
+  }
+  let layers = build(total)
+  if (maxPerLayer >= 2 && layers.length > 1 && layers[layers.length - 1] === 1) {
+    total += 1
+    layers = build(total)
+  }
+  return { bars: total, layers }
+}
+
+/**
+ * Centroid rise of the bar group above the extreme (bottom) layer — Varignon.
+ *
+ * `pitch` is the layer-to-layer centre distance, db + 25 mm clear per
+ * ACI 318-14 §25.2.2 / NSCP §425.2.2. The result is subtracted from dt to give
+ * the effective depth of the group, so stacking layers always REDUCES d.
+ */
+export function centroidRise(layers: number[], pitch: number): number {
+  const n = layers.reduce((s, k) => s + k, 0)
+  const sum = layers.reduce((s, k, i) => s + k * i * pitch, 0)
+  return n > 0 ? sum / n : 0
+}

--- a/webapp/src/engine/beamDesign.ts
+++ b/webapp/src/engine/beamDesign.ts
@@ -15,6 +15,7 @@ import { rhoMin } from './flexure'
 import { beta1 } from './loads'
 import { Ec as concreteEc } from './slabDeflection'
 import { crackedInertia, deflCoeff, longTermMultiplier, minBeamThickness, type BeamSupport } from './beamDeflection'
+import { splitLayers, centroidRise } from './barLayers'
 
 export interface BeamDesignInput {
   b: number            // web width, mm
@@ -93,36 +94,11 @@ export interface BeamDesignResult {
 const PHI_FLEX = 0.90
 const PHI_SHEAR = 0.75
 const LAYER_CLEAR = 25       // §407.7.2 clear distance between layers, mm
+// The lone-bar pairing rule and the Varignon centroid live in `barLayers` so
+// the T-beam engine uses the SAME rule — it used to have its own greedy loop
+// and could detail a single bar alone in the top layer.
 const roundDown = (v: number, step: number) => Math.floor(v / step) * step
 
-/** Split n bars into layers of at most maxPerLayer, fullest at the bottom.
- *  Detailing rule: no layer carries a single bar — a lone bar in the top
- *  (least-full) layer is paired with a second so the two sit beside the
- *  stirrup legs on each side. Pairing adds one bar (conservative on As).
- *  Returns the (possibly bumped) total count alongside the layer vector. */
-function splitLayers(n: number, maxPerLayer: number): { bars: number; layers: number[] } {
-  let total = n
-  const build = (m: number): number[] => {
-    const out: number[] = []
-    let left = m
-    while (left > 0) { const take = Math.min(left, maxPerLayer); out.push(take); left -= take }
-    return out
-  }
-  let layers = build(total)
-  // pair a lone top-layer bar (only meaningful once the section holds ≥ 2/layer)
-  if (maxPerLayer >= 2 && layers.length > 1 && layers[layers.length - 1] === 1) {
-    total += 1
-    layers = build(total)
-  }
-  return { bars: total, layers }
-}
-
-/** Centroid rise of the bar group above the extreme (bottom) layer — Varignon. */
-function centroidRise(layers: number[], pitch: number): number {
-  const n = layers.reduce((s, k) => s + k, 0)
-  const sum = layers.reduce((s, k, i) => s + k * i * pitch, 0)
-  return n > 0 ? sum / n : 0
-}
 
 /** Minimum practical stirrup spacing, mm — the tightest a designer will place
  *  transverse steel before adding legs instead (placement / congestion). Used as

--- a/webapp/src/engine/tbeam.test.ts
+++ b/webapp/src/engine/tbeam.test.ts
@@ -104,3 +104,39 @@ describe('tension-controlled cap', () => {
     expect(r.notes.join(' ')).toContain('tension-controlled')
   })
 })
+
+describe('bar layering — no layer carries a single bar', () => {
+  // This engine used to stack bars with its own greedy loop and had no pairing
+  // rule, so a T-beam could be detailed with one bar sitting alone in the top
+  // layer with nothing to tie to on either side. `beamDesign` had the rule all
+  // along; both now share `barLayers.splitLayers`.
+  it('never produces a lone bar, across a sweep of moments and bar sizes', () => {
+    for (const barDia of [16, 20, 25, 28, 32]) {
+      for (let Mu = 60; Mu <= 900; Mu += 20) {
+        const r = designTBeam({ ...base, barDia, Mu })
+        expect(r.layers.every((n) => n >= 2)).toBe(true)
+        expect(r.layers.reduce((s, n) => s + n, 0)).toBe(r.bars)
+      }
+    }
+  })
+
+  it('narrow webs too, where layers stack fastest', () => {
+    for (const bw of [200, 250, 300, 400]) {
+      for (let Mu = 100; Mu <= 700; Mu += 50) {
+        const r = designTBeam({ ...base, bw, Mu })
+        expect(r.layers.every((n) => n >= 2)).toBe(true)
+      }
+    }
+  })
+
+  it('details at least the steel the strength calculation asked for', () => {
+    // Pairing ADDS a bar, so the detailed count can only exceed the demand.
+    // The direction that would matter is the other one: a schedule showing
+    // fewer bars than the section needs.
+    const Ab = (Math.PI / 4) * base.barDia ** 2
+    for (let Mu = 200; Mu <= 800; Mu += 25) {
+      const r = designTBeam({ ...base, Mu })
+      expect(r.bars * Ab).toBeGreaterThanOrEqual(r.As - 1e-6)
+    }
+  })
+})

--- a/webapp/src/engine/tbeam.ts
+++ b/webapp/src/engine/tbeam.ts
@@ -9,6 +9,8 @@
 // (§22.2); φ from εt (§21.2.2); As,min per §9.6.1.2 (with the 2bw rule when a
 // flange is in tension on statically determinate spans).
 
+import { splitLayers, centroidRise } from './barLayers'
+
 export type TBeamKind = 'interior' | 'edge' | 'isolated'
 
 export interface TBeamInput {
@@ -146,19 +148,19 @@ export function designTBeam(i: TBeamInput): TBeamResult {
   const minGoverns = !(i.AsGiven && i.AsGiven > 0) && As <= AsMin + 1e-9
 
   // bar layout in the web: fit per layer with §25.2.1 clear spacing
-  const bars = Math.max(2, Math.ceil(As / Ab))
   const sClearMin = Math.max(25, i.barDia)
   const web = i.bw - 2 * (i.cover + i.stirrupDia)
   const perLayer = Math.max(2, Math.floor((web + sClearMin) / (i.barDia + sClearMin)))
-  const layers: number[] = []
-  for (let left = bars; left > 0; left -= perLayer) layers.push(Math.min(perLayer, left))
+  // `splitLayers` — the SAME rule the rectangular-beam engine uses — pairs a
+  // lone bar in the upper layer. This engine used to stack them greedily, so a
+  // T-beam could be detailed with one bar sitting alone with nothing to tie to
+  // on either side. The pairing bumps the count, so `bars` (not the strength
+  // demand) is what As-provided must be computed from.
+  const { bars, layers } = splitLayers(Math.max(2, Math.ceil(As / Ab)), perLayer)
   const sClear = layers[0] > 1 ? (web - layers[0] * i.barDia) / (layers[0] - 1) : web
   if (layers.length > 1) {
-    // shift d to the group centroid (25 mm clear between layers)
-    const pitch = i.barDia + 25
-    const n = layers.reduce((s, x) => s + x, 0)
-    const yBar = layers.reduce((s, x, k) => s + x * k * pitch, 0) / n
-    d = dt - yBar
+    // shift d to the group centroid (25 mm clear between layers, §425.2.2)
+    d = dt - centroidRise(layers, i.barDia + 25)
     notes.push(`${layers.length} bar layers — d reduced to the group centroid`)
   }
 


### PR DESCRIPTION
> *for the t-beam, i noticed that the second layer of bar is only one. we have a rule in beam layering that the minimum bars on next layer is two. check how the beam page does the layering*

You were right, and the beam page was the right place to look.

## What was wrong

`beamDesign.ts` has enforced the rule since it was written — a lone bar in the upper layer gets paired, so the two sit beside the stirrup legs:

```js
if (maxPerLayer >= 2 && layers.length > 1 && layers[layers.length - 1] === 1) {
  total += 1
  layers = build(total)
}
```

`tbeam.ts` never got it. It stacked bars with its own greedy loop:

```js
for (let left = bars; left > 0; left -= perLayer)
  layers.push(Math.min(perLayer, left))
```

so 5 bars at 4 per layer came out as **`[4, 1]`**. The page's own default inputs — 300×600 web, ⌀25, Mu = 400 kN·m — land exactly on that case, which is why it was visible on first load.

## The fix

The rule now lives in `engine/barLayers.ts` and **both** engines call it, along with the Varignon `centroidRise` they had also each implemented separately. Two copies of a detailing rule is precisely how one of them ends up not having it.

## Effect on results, stated plainly

Pairing **adds** a bar, so As-provided rises slightly where the rule bites:

| Mu (kN·m) | before | after |
|---|---|---|
| 300–380 | 4 → `[4]` | 4 → `[4]` |
| **400–560** | **5 → `[4, 1]`** | **6 → `[4, 2]`** |
| 600 | 7 → `[4, 3]` | 7 → `[4, 3]` |
| 700 | 8 → `[4, 4]` | 8 → `[4, 4]` |

That's the conservative direction, and it matches what the rectangular-beam engine has always done. Capacity is computed from the **detailed** count, so the schedule and the capacity check agree about how much steel is in the section.

## Tests

- `barLayers.test.ts` owns the rule: no layer of one **for any count 2–60 across web capacities 2–8**; pairing only ever adds steel and never more than one bar; a web too narrow for two bars side by side is left alone rather than looping forever (the honest answer there is "the section is too narrow", not "add a bar").
- `tbeam.test.ts` sweeps Mu 60–900 kN·m across five bar sizes and four web widths and asserts the engine itself never emits a lone bar, and that the detailed steel always meets the demand.

## Verification

Rendered on the page: the default case now shows **6 ⌀25 in `[4, 2]`** instead of 5 in `[4, 1]`. `npx tsc -b`, `eslint`, `npm test` (**3075 tests, 194 files**) and `npm run build` all clean.

## Layer

L6 — design pipeline. No solver change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_