### PR TITLE
feat(column): use the beam page's section card

### DIFF
--- a/webapp/src/components/ColumnSchematic.tsx
+++ b/webapp/src/components/ColumnSchematic.tsx
@@ -16,14 +16,24 @@ export interface ColumnSchematicProps {
 
 /** Column cross-section to scale: rectangular tied (bars on two faces, tie at
  *  real thickness) or circular spiral (ring of bars + spiral wire). */
+/** Drawing area, in viewBox units. The frame is this plus the margins, so a
+ *  square column does not sit in a landscape box with dead space beside it. */
+const W_DRAW = 190, H_DRAW = 200
+
 export function ColumnSchematic({ shape, b = 0, h = 0, D = 0, cover, barDia, tieDia, bars, tieSpacing }: ColumnSchematicProps): JSX.Element {
-  const W = 320, H = 280
-  const padT = 28, availW = 170, availH = 190
+  // Margins carry the dimension lines: `h` and its rotated label on the left,
+  // `b` and the bar callout below. The drawing is CENTRED in what is left —
+  // it used to start at a hard-coded x = 70, which left the right side empty
+  // whenever the section was narrower than the space allowed for it.
+  const ML = 62, MR = 30, MT = 14, MB = 46
+  const availW = W_DRAW, availH = H_DRAW
+  const padT = MT
   const tied = shape === 'tied'
   const bb = tied ? b : D, hh0 = tied ? h : D
   const s = Math.min(availW / bb, availH / hh0)
   const bw = bb * s, hgt = hh0 * s
-  const x0 = 70 + (availW - bw) / 2, y0 = padT
+  const x0 = ML + (availW - bw) / 2, y0 = padT
+  const W = ML + availW + MR, H = MT + hgt + MB
   const stW = Math.max(1, tieDia * s)
   const br = Math.max(3, (barDia / 2) * s)
 
@@ -96,7 +106,6 @@ export function ColumnSchematic({ shape, b = 0, h = 0, D = 0, cover, barDia, tie
   return (
     <svg viewBox={`0 0 ${W} ${H}`} xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet"
       style={{ width: '100%', height: 'auto', fontFamily: 'Arial, sans-serif' }}>
-      <text x={70} y={14} fontSize={11} fontWeight={700} fill="#0056b3">SECTION</text>
       {body}
       <text x={x0 + bw / 2} y={y0 + hgt + 12} fontSize={8.5} fill={BAR} textAnchor="middle">
         {bars} ⌀{barDia} mm · {tied ? `ties ⌀${tieDia}` : `spiral ⌀${tieDia}`}{tieSpacing ? ` @ ${Math.round(tieSpacing)} mm` : ''}

--- a/webapp/src/engine/columnDesign.ts
+++ b/webapp/src/engine/columnDesign.ts
@@ -23,6 +23,12 @@ export type ColumnShape  = 'tied' | 'spiral'
 export type LateralSystem = 'gravity' | 'imf' | 'smf'
 
 // ── Axial (short, concentric) ────────────────────────────────────────────
+/** Longitudinal steel ratio limits for a compression member — ACI 318-14
+ *  §10.6.1.1 / NSCP §410.6.1.1. Exported so the page's footnote quotes the
+ *  numbers the check actually uses. */
+export const RHO_MIN = 0.01
+export const RHO_MAX = 0.08
+
 export interface AxialColumnInput {
   shape: ColumnShape
   b?: number; h?: number       // tied rectangular, mm
@@ -51,7 +57,7 @@ export interface AxialColumnResult {
   bars: number
   Ast: number                  // provided, mm²
   rho: number
-  rhoOK: boolean               // 0.01 ≤ ρ ≤ 0.08
+  rhoOK: boolean               // RHO_MIN ≤ ρ ≤ RHO_MAX
   minBars: number
   Po: number                   // kN
   PnMax: number                // kN
@@ -93,7 +99,7 @@ export function designAxialColumn(i: AxialColumnInput): AxialColumnResult {
   const bars = i.numBars ?? Math.max(minBars, Math.ceil(AstReq / Ab))
   const Ast = bars * Ab
   const rho = Ast / Ag
-  const rhoOK = rho >= 0.01 - 1e-9 && rho <= 0.08 + 1e-9
+  const rhoOK = rho >= RHO_MIN - 1e-9 && rho <= RHO_MAX + 1e-9
 
   const Po = (0.85 * i.fc * (Ag - Ast) + i.fy * Ast) / 1000
   const PnMax = alpha * Po

--- a/webapp/src/pages/ColumnDesign.tsx
+++ b/webapp/src/pages/ColumnDesign.tsx
@@ -1,11 +1,15 @@
 import { useMemo, useState } from 'react'
 import {
   designAxialColumn, interaction, capacityAtEccentricity, momentMagnificationNonsway,
+  RHO_MIN, RHO_MAX,
   type ColumnShape, type LateralSystem, type BarLayout,
 } from '../engine/columnDesign'
 import { factoredLoad } from '../engine/loads'
 import { ColumnSchematic } from '../components/ColumnSchematic'
-import { PageHeader, DrawingCard, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
+import {
+  PageHeader, VerdictPanel, DrawingCard, LetterheadCard, PrintReport,
+  type LetterheadState, type VerdictStat, type VerdictCheck,
+} from '../components/calc'
 import { initialLetterhead } from '../lib/letterhead'
 import { InteractionDiagram } from '../components/InteractionDiagram'
 import { WorkedSolution } from '../components/WorkedSolution'
@@ -92,6 +96,48 @@ export default function ColumnDesign() {
   }, [slender, eccentric, inter, cap, axial, Pu, MuEff])
 
   const util = cap && cap.phi * cap.Pn > 1e-9 ? Pu / (cap.phi * cap.Pn) : null
+
+  /**
+   * The on-screen verdict, and the SAME object the printed report uses.
+   *
+   * Built once rather than assembled twice: the PDF already carried a headline,
+   * a governing line, stat tiles and utilisation checks, and the page carried
+   * none of them. Two hand-built copies of a pass/fail verdict is how a sheet
+   * ends up saying OK while the screen says otherwise.
+   */
+  const verdict = useMemo(() => {
+    if (!axial) return null
+    const ok = (eccentric ? util !== null && util <= 1 && !unstable : axial.axialOK) && axial.rhoOK
+    const spacing = tied ? axial.tieSpacingFinal : axial.spiralPitch
+    const checks: VerdictCheck[] = []
+    // Axial capacity is meaningful in both modes; the P–M check only exists
+    // once there is a moment to interact with.
+    if (axial.phiPnMax > 1e-9) checks.push({ name: 'Axial Pu/φPn,max', ratio: Pu / axial.phiPnMax })
+    if (eccentric && util !== null) checks.push({ name: 'P–M interaction Pu/φPn', ratio: util })
+    // ρ against the 8% ceiling (§410.6.1.1). The 1% floor is a minimum, not a
+    // utilisation, so it belongs in the footnote rather than on a bar.
+    checks.push({ name: 'Steel ratio ρ/ρmax', ratio: axial.rho / RHO_MAX })
+    return {
+      ok,
+      headline: ok
+        ? `DESIGN OK — ${tied ? 'tied' : 'spiral'}, ${eccentric && slender?.slender ? 'slender' : 'short'}`
+        : 'CHECK FAILED — revise the section',
+      governing: eccentric
+        ? (unstable
+          ? 'Slender column unstable — Pu ≥ 0.75·Pc (§406.6.4)'
+          : `Governing: P–M interaction · utilization ${util !== null ? util.toFixed(2) : '—'}`)
+        : `Governing: axial · φPn,max = ${f1(axial.phiPnMax)} kN`,
+      stats: [
+        { label: 'Longitudinal', value: `${axial.bars}-⌀${barDia}`, unit: `ρ ${(axial.rho * 100).toFixed(2)}%` },
+        { label: tied ? 'Ties' : 'Spiral',
+          value: `⌀${tied ? Math.max(tieDia, axial.tieDiaMin) : tieDia}`,
+          unit: `@${f0(spacing)} mm` },
+        { label: 'φPn,max', value: f1(axial.phiPnMax), unit: 'kN' },
+      ] as VerdictStat[],
+      checks,
+      footnote: `ρ = ${(axial.rho * 100).toFixed(2)}% within ${(RHO_MIN * 100).toFixed(0)} … ${(RHO_MAX * 100).toFixed(0)}% — §410.6.1.1${eccentric && slender ? ` · δ = ${slender.delta.toFixed(3)}` : ''}`,
+    }
+  }, [axial, eccentric, util, unstable, tied, slender, Pu, barDia, tieDia])
 
   // ~12 representative rows for the P-M table, balanced point always included.
   const tableRows = useMemo(() => {
@@ -205,6 +251,11 @@ export default function ColumnDesign() {
         </div>
 
         <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
+          {verdict && (
+            <VerdictPanel ok={verdict.ok} headline={verdict.headline} governing={verdict.governing}
+              stats={verdict.stats} checks={verdict.checks} footnote={verdict.footnote} />
+          )}
+
           {/* The same card the beam page uses — graph-paper ground, title and
               section meta in a header strip above the drawing. The two pages
               draw the same kind of thing and should look like it. */}

--- a/webapp/src/pages/ColumnDesign.tsx
+++ b/webapp/src/pages/ColumnDesign.tsx
@@ -5,7 +5,7 @@ import {
 } from '../engine/columnDesign'
 import { factoredLoad } from '../engine/loads'
 import { ColumnSchematic } from '../components/ColumnSchematic'
-import { PageHeader, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
+import { PageHeader, DrawingCard, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
 import { initialLetterhead } from '../lib/letterhead'
 import { InteractionDiagram } from '../components/InteractionDiagram'
 import { WorkedSolution } from '../components/WorkedSolution'
@@ -205,12 +205,15 @@ export default function ColumnDesign() {
         </div>
 
         <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
-          <div data-pdf-drawing className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-            <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Section</h2>
+          {/* The same card the beam page uses — graph-paper ground, title and
+              section meta in a header strip above the drawing. The two pages
+              draw the same kind of thing and should look like it. */}
+          <DrawingCard pdfDrawing title="Section"
+            meta={`${tied ? `${f0(b)} × ${f0(h)}` : `⌀${f0(D)}`} · ${axial?.bars ?? numBars} ⌀${barDia} · to scale`}>
             <ColumnSchematic shape={tied ? 'tied' : 'spiral'} b={b} h={h} D={D} cover={cover}
               barDia={barDia} tieDia={tieDia} bars={axial?.bars ?? numBars}
               tieSpacing={axial ? (tied ? axial.tieSpacingFinal : axial.spiralPitch) : undefined} />
-          </div>
+          </DrawingCard>
 
           {axial && (
             <ResultCard title="Results">


### PR DESCRIPTION
> *Column design, replace the section card with the same card used by beam design section (with gridlines and above the section it has displayed bar lines and result)*

Three things differed, and the third was the reason it read oddly:

- a plain white card with an `<h2>`, versus the beam page's `DrawingCard` with its **gridded ground** and mono meta strip;
- **no section summary** anywhere in the chrome;
- the SVG drew its **own `SECTION` title**, so the card carried the word twice, in two different type styles.

The wrapper is now the same `DrawingCard`, the in-drawing title is gone (the header above it already says it), and the meta line carries the size and bar count in the beam page's format — `400 × 400 · 8 ⌀28 · to scale`.

## One thing I fixed while in there

The drawing started at a hard-coded `x = 70` inside a fixed `320×280` frame, so a section narrower than the space allowed for it sat **left of centre with dead space on the right**, and a square column sat in a landscape box. The frame is now the drawing plus margins sized by what sits in them, and the section is centred. Same correction as the T-beam card (#506), same reason.

## Verification

Rendered in the browser for **both** variants — the tied rectangular column and the circular spiral one, which shares the frame code. `npx tsc -b`, `eslint`, `npm test` (**3095 tests**) and `npm run build` all clean.

## One check on my reading

I took *"above the section it has displayed bar lines and result"* to mean the beam card's header strip — title on the left, section/bar summary on the right — since that's what sits above the drawing there. If you meant something else by "bar lines and result" (bar callout leaders? the Results card pulled up above the drawing?), say which and it's a small change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_