### PR TITLE
feat(slab): bar-arrangement section — top, bottom and temperature steel

### DIFF
--- a/webapp/src/components/SlabBarSection.tsx
+++ b/webapp/src/components/SlabBarSection.tsx
@@ -1,0 +1,165 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Longitudinal section through one slab span, showing where each mat runs.
+//
+// Answers the three questions the page could not: which bars are at the TOP,
+// which at the BOTTOM, and where each one stops. The shrinkage/temperature
+// mat runs the other way, so in a section it is seen end-on and draws as a row
+// of dots sitting inside each flexural mat — which is also the honest picture
+// of where it actually sits.
+//
+// The cut-off arithmetic is in `engine/slabBarDetail`; this file only turns
+// metres into pixels. The extension fractions are PRINTED on the drawing on
+// purpose — see the warning in that module about their provenance.
+// ─────────────────────────────────────────────────────────────────────────
+
+import { slabBarRuns, DEFAULT_EXT, type SlabBarExtensions } from '../engine/slabBarDetail'
+
+const INK = '#37526e'
+const CONC = '#eef3f8'
+const TOPBAR = '#c2402a'      // negative moment — the mat nearest the top face
+const BOTBAR = '#0f4c92'      // positive moment
+const TEMP = '#7c6f5a'        // shrinkage / temperature, seen end-on
+const DIM = '#1f77b4'
+const FAINT = '#a39d8d'
+
+export interface SlabBarSectionProps {
+  /** Centre-to-centre span, m. */
+  l1: number
+  /** Support width, m. */
+  support: number
+  /** Slab thickness, mm. */
+  h: number
+  /** Clear cover, mm. */
+  cover: number
+  /** Which strip this section is taken through. */
+  strip: 'column' | 'middle'
+  /** Bar callouts, when the design has produced them. */
+  topBars?: string
+  bottomBars?: string
+  tempBars?: string
+  /** Override the code extensions; defaults to the figure values. */
+  ext?: SlabBarExtensions
+}
+
+export function SlabBarSection({
+  l1, support, h, cover, strip, topBars, bottomBars, tempBars, ext,
+}: SlabBarSectionProps) {
+  const L = slabBarRuns(l1, support, h, cover, ext ?? DEFAULT_EXT[strip])
+
+  // Frame: the slab runs the full drawing width; the thickness is drawn
+  // EXAGGERATED, because a 200 mm slab over a 6 m span is 1:30 and would be a
+  // hairline. Stated on the drawing so nobody scales off it.
+  // Enough slab depth for the two mats to read as separate layers, and enough
+  // margin below for the callouts — the first version stacked the two bottom
+  // labels on the same baseline and they printed on top of each other.
+  const ML = 26, MR = 26, MT = 58, MB = 96
+  const DRAW_W = 620, SLAB_H = 62
+  const sx = (m: number) => ML + (m / Math.max(l1, 1e-9)) * DRAW_W
+  const W = ML + DRAW_W + MR, HT = MT + SLAB_H + MB
+
+  const yTop = MT
+  const yBot = MT + SLAB_H
+  // Mats sit at the cover faces, scaled into the exaggerated thickness so the
+  // top mat is visibly above the bottom one.
+  const yMatTop = yTop + Math.max(5, (L.topCover / h) * SLAB_H)
+  const yMatBot = yTop + Math.min(SLAB_H - 5, (L.bottomCover / h) * SLAB_H)
+
+  const supW = Math.max(6, (support / Math.max(l1, 1e-9)) * DRAW_W)
+  const faceL = sx(support / 2), faceR = sx(l1 - support / 2)
+
+  const tops = L.runs.filter((r) => r.mat === 'top')
+  const bots = L.runs.filter((r) => r.mat === 'bottom')
+
+  return (
+    <svg viewBox={`0 0 ${W} ${HT}`} className="mx-auto block h-auto w-full"
+      style={{ fontFamily: 'Arial, sans-serif' }}>
+      {/* supports, drawn below the soffit so the slab reads as continuous */}
+      {[0, l1].map((m) => (
+        <rect key={m} x={sx(m) - supW / 2} y={yBot} width={supW} height={22}
+          fill="#e2e5ea" stroke={INK} strokeWidth={1.2} />
+      ))}
+
+      {/* the slab */}
+      <rect x={ML} y={yTop} width={DRAW_W} height={SLAB_H} fill={CONC} stroke={INK} strokeWidth={1.6} />
+
+      {/* face-of-support lines — every cut-off below is measured from these */}
+      {[faceL, faceR].map((x, i) => (
+        <line key={i} x1={x} y1={yTop - 8} x2={x} y2={yBot + 24}
+          stroke={FAINT} strokeWidth={0.8} strokeDasharray="3 3" />
+      ))}
+
+      {/* ── top mat: over the supports, cut off in the span ──────────────── */}
+      {tops.map((r, i) => {
+        const pair = Math.floor(i / 2)
+        const y = yMatTop + pair * 5
+        return (
+          <g key={`t${i}`}>
+            <line x1={sx(r.x1)} y1={y} x2={sx(r.x2)} y2={y} stroke={TOPBAR} strokeWidth={2.4} strokeLinecap="round" />
+            {/* the hooked end at the free end of a top bar — 90° down into the
+                slab, which is what stops it lifting during the pour */}
+            {!r.continuesRight && <line x1={sx(r.x2)} y1={y} x2={sx(r.x2)} y2={y + 9} stroke={TOPBAR} strokeWidth={2.4} strokeLinecap="round" />}
+            {!r.continuesLeft && <line x1={sx(r.x1)} y1={y} x2={sx(r.x1)} y2={y + 9} stroke={TOPBAR} strokeWidth={2.4} strokeLinecap="round" />}
+            {/* Label the LEFT run of each pair only; the right end mirrors it,
+                and two labels per length is noise. Stagger by pair so the
+                0.30ℓn and 0.20ℓn callouts do not land on one baseline. */}
+            {r.x1 === 0 && (
+              <text x={sx(r.x2)} y={y - 6 - pair * 11} fontSize={8} fill={TOPBAR} textAnchor="end"
+                paintOrder="stroke" stroke="#fff" strokeWidth={2.6}>{r.label} →|</text>
+            )}
+          </g>
+        )
+      })}
+
+      {/* ── bottom mat ───────────────────────────────────────────────────── */}
+      {bots.map((r, i) => {
+        const y = yMatBot - i * 6
+        // i = 0 is the continuous run (labelled under the soffit, where there
+        // is room for a long sentence); i = 1 is the short run, labelled just
+        // above its own line. Sharing a baseline was the collision.
+        const ly = i === 0 ? yBot + 34 : y - 6
+        return (
+          <g key={`b${i}`}>
+            <line x1={sx(r.x1)} y1={y} x2={sx(r.x2)} y2={y} stroke={BOTBAR} strokeWidth={2.4} strokeLinecap="round" />
+            {i === 0 && <line x1={sx(r.x1) + 8} y1={y} x2={sx(r.x1) + 8} y2={ly - 8} stroke={BOTBAR} strokeWidth={0.7} />}
+            <text x={i === 0 ? sx(r.x1) + 12 : (sx(r.x1) + sx(r.x2)) / 2} y={ly}
+              fontSize={8} fill={BOTBAR} textAnchor={i === 0 ? 'start' : 'middle'}
+              paintOrder="stroke" stroke="#fff" strokeWidth={2.6}>{r.label}</text>
+          </g>
+        )
+      })}
+
+      {/* ── shrinkage / temperature steel, seen END-ON ───────────────────── */}
+      {Array.from({ length: 17 }, (_, i) => {
+        const x = ML + 18 + (i * (DRAW_W - 36)) / 16
+        return <circle key={`s${i}`} cx={x} cy={yMatTop + 7} r={2.1} fill={TEMP} />
+      })}
+      <text x={W - MR} y={yBot + 34} fontSize={7.5} fill={TEMP} textAnchor="end"
+        paintOrder="stroke" stroke="#fff" strokeWidth={2.4}>
+        ⊙ shrinkage / temperature bars — perpendicular, seen end-on (§424.4.3)
+      </text>
+
+      {/* ── legend and dimensions ────────────────────────────────────────── */}
+      <g fontSize={8.5}>
+        <line x1={ML} y1={18} x2={ML + 16} y2={18} stroke={TOPBAR} strokeWidth={2.4} />
+        <text x={ML + 21} y={21} fill={TOPBAR}>Top — negative moment{topBars ? ` · ${topBars}` : ''}</text>
+        <line x1={ML} y1={33} x2={ML + 16} y2={33} stroke={BOTBAR} strokeWidth={2.4} />
+        <text x={ML + 21} y={36} fill={BOTBAR}>Bottom — positive moment{bottomBars ? ` · ${bottomBars}` : ''}</text>
+        {tempBars && <text x={W - MR} y={21} fill={TEMP} textAnchor="end">Temp · {tempBars}</text>}
+      </g>
+
+      {/* clear span, face to face */}
+      <g>
+        <line x1={faceL} y1={HT - 28} x2={faceR} y2={HT - 28} stroke={DIM} strokeWidth={0.9} />
+        {[faceL, faceR].map((x, i) => (
+          <line key={i} x1={x - 4} y1={HT - 24} x2={x + 4} y2={HT - 32} stroke={DIM} strokeWidth={1.2} />
+        ))}
+        <text x={(faceL + faceR) / 2} y={HT - 32} fontSize={9} fill={DIM} textAnchor="middle"
+          paintOrder="stroke" stroke="#fff" strokeWidth={2.6}>ℓn = {L.ln.toFixed(2)} m</text>
+      </g>
+      <text x={W / 2} y={HT - 8} fontSize={7.5} fill={FAINT} textAnchor="middle">
+        {strip === 'column' ? 'Column strip' : 'Middle strip'} · slab {h} mm, cover {cover} mm ·
+        thickness exaggerated, do not scale · extensions per ACI 318-14 Fig. 8.7.4.1.3(a)
+      </text>
+    </svg>
+  )
+}

--- a/webapp/src/engine/slabBarDetail.test.ts
+++ b/webapp/src/engine/slabBarDetail.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest'
+import {
+  slabBarRuns, tempSteelArea, tempSpacingMax, DEFAULT_EXT, type BarRun,
+} from './slabBarDetail'
+
+// 6 m centres, 400 mm columns → ℓn = 5.6 m, faces at 0.2 and 5.8 m.
+const L1 = 6, C = 0.4, H = 200, COVER = 20
+const layout = (strip: 'column' | 'middle' = 'column') =>
+  slabBarRuns(L1, C, H, COVER, DEFAULT_EXT[strip])
+
+const top = (r: BarRun[]) => r.filter((x) => x.mat === 'top')
+const bottom = (r: BarRun[]) => r.filter((x) => x.mat === 'bottom')
+
+describe('slabBarRuns', () => {
+  it('derives the clear span from centres and support width', () => {
+    const l = layout()
+    expect(l.ln).toBeCloseTo(5.6, 9)
+    expect(l.support).toBe(C)
+  })
+
+  it('measures top-bar cut-offs from the FACE of support, not the centreline', () => {
+    // The distinction is the whole point of the figure. Measuring from the
+    // centreline would put every cut-off 200 mm further into the span here.
+    const t = top(layout().runs)
+    const long = t.find((r) => r.x1 === 0)!
+    expect(long.x2).toBeCloseTo(0.2 + 0.30 * 5.6, 9)   // face + 0.30ℓn
+  })
+
+  it('puts a top run at each end, mirrored about mid-span', () => {
+    const t = top(layout().runs)
+    expect(t).toHaveLength(4)
+    for (const r of t) {
+      const mirrored = t.find((o) => Math.abs((L1 - o.x2) - r.x1) < 1e-9 && Math.abs((L1 - o.x1) - r.x2) < 1e-9)
+      expect(mirrored).toBeTruthy()
+    }
+  })
+
+  it('leaves the middle of the span with no top steel', () => {
+    // A flat plate's top mat stops in the span; if the runs met at mid-span the
+    // drawing would be showing a continuous top mat, which is a different detail.
+    const t = top(layout().runs)
+    const reachRight = Math.max(...t.filter((r) => r.x1 === 0).map((r) => r.x2))
+    const reachLeft = Math.min(...t.filter((r) => r.x2 === L1).map((r) => r.x1))
+    expect(reachRight).toBeLessThan(reachLeft)
+  })
+
+  it('runs the continuous bottom bar through both supports', () => {
+    const b = bottom(layout().runs)
+    const cont = b.find((r) => r.label.startsWith('continuous'))!
+    // 150 mm past the face, i.e. into the support, at both ends.
+    expect(cont.x1).toBeCloseTo(0.2 - 0.15, 9)
+    expect(cont.x2).toBeCloseTo(5.8 + 0.15, 9)
+  })
+
+  it('never lets the embedment overshoot the support centreline', () => {
+    // A 100 mm wall with 150 mm of embedment would otherwise draw the bar
+    // sticking out the far side of its own support.
+    const l = slabBarRuns(6, 0.1, H, COVER, DEFAULT_EXT.column)
+    const cont = bottom(l.runs).find((r) => r.label.startsWith('continuous'))!
+    expect(cont.x1).toBeGreaterThanOrEqual(0)
+    expect(cont.x2).toBeLessThanOrEqual(6)
+  })
+
+  it('stops the discontinuous bottom bars short of the supports', () => {
+    const b = bottom(layout().runs)
+    const short = b.find((r) => r.label.includes('from face'))!
+    expect(short.x1).toBeCloseTo(0.2 + 0.20 * 5.6, 9)
+    expect(short.x2).toBeCloseTo(5.8 - 0.20 * 5.6, 9)
+    // …and that they still overlap mid-span rather than leaving a gap.
+    expect(short.x1).toBeLessThan(short.x2)
+  })
+
+  it('gives the middle strip shorter top runs than the column strip', () => {
+    // Column strip 0.30ℓn versus middle strip 0.22ℓn — the reason the two
+    // strips are drawn separately at all.
+    const col = Math.max(...top(layout('column').runs).map((r) => r.x2 - r.x1))
+    const mid = Math.max(...top(layout('middle').runs).map((r) => r.x2 - r.x1))
+    expect(mid).toBeLessThan(col)
+  })
+
+  it('places the mats at the cover faces', () => {
+    const l = layout()
+    expect(l.topCover).toBe(COVER)
+    expect(l.bottomCover).toBe(H - COVER)
+  })
+
+  it('survives a degenerate span without producing negative geometry', () => {
+    const l = slabBarRuns(0.3, 0.4, H, COVER, DEFAULT_EXT.column)
+    expect(l.ln).toBe(0)
+    for (const r of l.runs) expect(Number.isFinite(r.x1) && Number.isFinite(r.x2)).toBe(true)
+  })
+})
+
+describe('tempSteelArea — §24.4.3.2', () => {
+  it('uses 0.0020 for Grade 280 and 350', () => {
+    expect(tempSteelArea(200, 280).rho).toBeCloseTo(0.0020, 9)
+    expect(tempSteelArea(200, 350).rho).toBeCloseTo(0.0020, 9)
+  })
+
+  it('uses 0.0018 for Grade 420 — the common case', () => {
+    const t = tempSteelArea(200, 420)
+    expect(t.rho).toBeCloseTo(0.0018, 9)
+    expect(t.As).toBeCloseTo(0.0018 * 1000 * 200, 6)   // mm² per metre width
+  })
+
+  it('scales above Grade 420 but never below the 0.0014 floor', () => {
+    expect(tempSteelArea(200, 520).rho).toBeCloseTo((0.0018 * 420) / 520, 9)
+    // 0.0018·420/fy falls under 0.0014 at fy = 540; the floor takes over.
+    expect(tempSteelArea(200, 700).rho).toBeCloseTo(0.0014, 9)
+    expect(tempSteelArea(200, 5000).rho).toBeCloseTo(0.0014, 9)
+  })
+})
+
+describe('tempSpacingMax — §24.4.3.3', () => {
+  it('is the lesser of 5h and 450 mm', () => {
+    expect(tempSpacingMax(80)).toBe(400)    // 5h governs on a thin slab
+    expect(tempSpacingMax(200)).toBe(450)   // the 450 cap governs
+    expect(tempSpacingMax(90)).toBe(450)    // 5h = 450, the boundary
+  })
+})

--- a/webapp/src/engine/slabBarDetail.ts
+++ b/webapp/src/engine/slabBarDetail.ts
@@ -1,0 +1,146 @@
+// ─────────────────────────────────────────────────────────────────────────
+// SLAB BAR ARRANGEMENT — where each mat starts and stops along a strip.
+//
+// Produces the geometry for a longitudinal SECTION through one span of a
+// two-way slab: the top mat over each support, the bottom mat through
+// mid-span, and the shrinkage/temperature mat running the other way (seen
+// end-on, so it draws as a row of dots).
+//
+// ⚠ THE EXTENSION FRACTIONS ARE NOT VERIFIED AGAINST THE PRINTED FIGURE.
+//
+// They are meant to be ACI 318-14 Fig. 8.7.4.1.3(a) / NSCP 2015
+// Fig. 408.7.4.1.3(a) — "minimum extensions for deformed reinforcement in
+// two-way slabs without beams" — for the case WITHOUT drop panels. I could not
+// open the figure from the environment this was written in, so `DEFAULT_EXT`
+// is written from memory and MUST be checked against a copy of the code before
+// anyone details from it.
+//
+// That is why the fractions are an INPUT with a default rather than a constant
+// buried in a drawing: the numbers are printed on the drawing itself, next to
+// the clause, so an engineer sees exactly what was assumed and can change it.
+// A wrong cut-off length that nobody can see is the failure mode worth
+// designing against here.
+//
+// Units: metres for spans, millimetres for the slab and its cover.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Fractions of the clear span ℓn, measured from the FACE of support. */
+export interface SlabBarExtensions {
+  /** Top mat, the bars that run furthest — at least half of them. */
+  topLong: number
+  /** Top mat, the remainder. */
+  topShort: number
+  /** Bottom mat, the bars that stop short — the remainder that is not continuous. */
+  bottomShort: number
+  /** Minimum embedment of a continuous bottom bar into the support, mm. */
+  supportEmbed: number
+}
+
+/**
+ * Defaults for a flat plate — no beams, no drop panels.
+ *
+ * See the warning at the top of this file: unverified. The column strip and
+ * middle strip differ in the figure, which is why `slabBarRuns` takes the set
+ * to use rather than choosing one.
+ */
+export const DEFAULT_EXT: Record<'column' | 'middle', SlabBarExtensions> = {
+  column: { topLong: 0.30, topShort: 0.20, bottomShort: 0.20, supportEmbed: 150 },
+  middle: { topLong: 0.22, topShort: 0.22, bottomShort: 0.15, supportEmbed: 150 },
+}
+
+/** One drawn bar run, in metres along the span from the left support centre. */
+export interface BarRun {
+  /** Which mat it belongs to. */
+  mat: 'top' | 'bottom'
+  /** Start and end, metres from the left support CENTRELINE. */
+  x1: number
+  x2: number
+  /** What to call it on the drawing. */
+  label: string
+  /** True when the run continues past the drawn span rather than stopping. */
+  continuesLeft: boolean
+  continuesRight: boolean
+}
+
+export interface SlabBarLayout {
+  /** Clear span used, m. */
+  ln: number
+  /** Support width, m — the span is drawn between support centrelines. */
+  support: number
+  /** Overall drawn length, support centre to support centre, m. */
+  total: number
+  runs: BarRun[]
+  /** Depth of each mat below the top face, mm. Temperature bars share the mats. */
+  topCover: number
+  bottomCover: number
+}
+
+/**
+ * Bar runs for one span of one strip.
+ *
+ * `l1` is centre-to-centre, `c` the support width, so ℓn = l1 − c and the face
+ * of support sits at c/2 from each centreline. Everything is returned in the
+ * same coordinate — metres from the left support centre — so the drawing does
+ * no arithmetic of its own.
+ */
+export function slabBarRuns(
+  l1: number, c: number, slabH: number, cover: number, ext: SlabBarExtensions,
+): SlabBarLayout {
+  const support = Math.max(0, c)
+  const ln = Math.max(0, l1 - support)
+  const face = support / 2
+  const right = l1 - face          // right face of support, from left centreline
+
+  const runs: BarRun[] = []
+
+  // ── Top mat: over each support, cut off in the span ────────────────────
+  // Drawn as two bands at each end because the figure splits the steel: the
+  // longer run carries at least half the bars, the shorter one the rest.
+  for (const [frac, label] of [[ext.topLong, `0.${(ext.topLong * 100).toFixed(0)}ℓn`],
+                               [ext.topShort, `0.${(ext.topShort * 100).toFixed(0)}ℓn`]] as [number, string][]) {
+    runs.push({ mat: 'top', x1: 0, x2: face + frac * ln, label, continuesLeft: true, continuesRight: false })
+    runs.push({ mat: 'top', x1: right - frac * ln, x2: l1, label, continuesLeft: false, continuesRight: true })
+  }
+
+  // ── Bottom mat ────────────────────────────────────────────────────────
+  // At least half continuous through the support; the remainder stops short of
+  // it. The continuous bars are what stop a mid-span crack from becoming a
+  // hinge, so they are drawn running the whole way with the embedment noted.
+  const embed = ext.supportEmbed / 1000
+  runs.push({
+    mat: 'bottom', x1: face - Math.min(embed, face), x2: right + Math.min(embed, face),
+    label: `continuous · ${ext.supportEmbed} mm into support`,
+    continuesLeft: false, continuesRight: false,
+  })
+  runs.push({
+    mat: 'bottom', x1: face + ext.bottomShort * ln, x2: right - ext.bottomShort * ln,
+    label: `0.${(ext.bottomShort * 100).toFixed(0)}ℓn from face`,
+    continuesLeft: false, continuesRight: false,
+  })
+
+  return {
+    ln, support, total: l1, runs,
+    topCover: cover,
+    bottomCover: Math.max(0, slabH - cover),
+  }
+}
+
+/**
+ * Shrinkage and temperature steel — ACI 318-14 §24.4.3.2 / NSCP §424.4.3.2.
+ *
+ * Ratio of gross area: 0.0020 for Grade 280/350 deformed bars, 0.0018 for
+ * Grade 420, and 0.0018 × 420/fy for higher grades but never below 0.0014.
+ * Returned as area per metre width so it can sit beside the flexural steel.
+ */
+export function tempSteelArea(slabH: number, fy: number): { rho: number; As: number } {
+  const rho = fy <= 350 ? 0.0020
+    : fy <= 420 ? 0.0018
+    : Math.max(0.0014, (0.0018 * 420) / fy)
+  return { rho, As: rho * 1000 * slabH }
+}
+
+/**
+ * Maximum spacing of shrinkage and temperature bars — §24.4.3.3:
+ * the lesser of 5h and 450 mm.
+ */
+export const tempSpacingMax = (slabH: number): number => Math.min(5 * slabH, 450)

--- a/webapp/src/pages/SlabDesign.tsx
+++ b/webapp/src/pages/SlabDesign.tsx
@@ -5,6 +5,8 @@ import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { ReportControls } from '../components/ReportControls'
 import { buildSlabSolution } from '../lib/slabSolution'
 import { Math as KTex } from '../lib/math'
+import { SlabBarSection } from '../components/SlabBarSection'
+import { tempSteelArea, tempSpacingMax } from '../engine/slabBarDetail'
 import { f0, f1, f2 } from '../lib/format'
 import 'katex/dist/katex.min.css'
 
@@ -101,6 +103,9 @@ export default function SlabDesign() {
   }, [f])
 
   const r = useMemo(() => (valid ? designSlabDDM(input) : null), [valid, input])
+  // §424.4.3 shrinkage and temperature steel — a slab detail the DDM result
+  // does not carry, because it is not a flexural demand.
+  const temp = useMemo(() => tempSteelArea(r?.h ?? 0, f.fy), [r, f.fy])
 
   const defl = r?.deflection
 
@@ -225,6 +230,34 @@ export default function SlabDesign() {
 
               {/* Y direction */}
               <DirCard title={`Direction y (l₁ = ${f2(r.y.l1)} m)`} dir={r.y} barDia={f.barDia} />
+
+              {/* ── Bar arrangement ─────────────────────────────────── */}
+              <ResultCard title="Bar arrangement — section through the span">
+                <div className="-mx-1 space-y-4">
+                  {(['column', 'middle'] as const).map((strip) => {
+                    const loc = r.x.locations.find((l) => l.name === '+M') ?? r.x.locations[0]
+                    const neg = r.x.locations.find((l) => l.name.includes('−M')) ?? loc
+                    const sec = strip === 'column' ? loc.column : loc.middle
+                    const negSec = strip === 'column' ? neg.column : neg.middle
+                    return (
+                      <SlabBarSection key={strip} strip={strip}
+                        l1={r.x.l1} support={f.colWidth / 1000} h={r.h} cover={f.cover}
+                        topBars={`⌀${f.barDia} @ ${f0(negSec.spacing)} mm`}
+                        bottomBars={`⌀${f.barDia} @ ${f0(sec.spacing)} mm`}
+                        tempBars={`As ${f0(temp.As)} mm²/m · max s ${f0(tempSpacingMax(r.h))} mm`} />
+                    )
+                  })}
+                </div>
+                <p className="mt-2 text-[11px] leading-5 text-slate-500">
+                  Sections are taken along <KTex tex="l_1" /> in the x-direction. Top steel is the
+                  negative-moment mat over the supports; bottom steel is the positive-moment mat
+                  through mid-span. The shrinkage and temperature bars run perpendicular, so a
+                  section cuts them end-on.{' '}
+                  <strong className="font-semibold text-amber-800">
+                    Check the cut-off fractions against ACI 318-14 Fig. 8.7.4.1.3(a) before detailing.
+                  </strong>
+                </p>
+              </ResultCard>
 
               {/* Deflection */}
               {defl && (


### PR DESCRIPTION
> *Slab design, add detailed drawing that shows the orientation of bars (top bot and temp bars) and how its bent or terminated in mid span*

The slab page had **no drawing at all** — it reported As, bar counts and spacing per strip and location, and never showed where any of it goes.

## What's drawn

A longitudinal section through one span, once for the **column strip** and once for the **middle strip**:

- the **top mat** over each support, cut off in the span, with the 90° hooked end that stops it lifting during the pour;
- the **bottom mat** — the continuous run through the support with its embedment noted, and the remainder that stops short of the face;
- the **shrinkage / temperature bars**, which run the other way and so are cut end-on by a section: a row of dots inside the top mat, which is also where they actually sit;
- **ℓn dimensioned face to face**, because every cut-off is measured from a *face* of support, not a centreline. Measuring from the centreline would put each one 200 mm further into the span on the default panel.

`engine/slabBarDetail.ts` holds the arithmetic — cut-off positions, the §424.4.3.2 temperature-steel ratio (including the 0.0014 floor above Grade 420) and the §424.4.3.3 spacing cap. 14 tests, including: the top runs never meet at mid-span (that would be a different detail); the support embedment can't overshoot a narrow support's centreline; the middle strip's top runs are shorter than the column strip's.

## ⚠ One thing you must check before this is usable

**The cut-off fractions are not verified.** They're meant to be **ACI 318-14 Fig. 8.7.4.1.3(a)** for a flat plate without drop panels, but web access is blocked from this environment (403 from the proxy on every source I tried), so I could not open the figure. **They are written from memory.**

| | top, long run | top, remainder | bottom, remainder | support embed |
|---|---|---|---|---|
| column strip | 0.30ℓn | 0.20ℓn | 0.20ℓn | 150 mm |
| middle strip | 0.22ℓn | 0.22ℓn | 0.15ℓn | 150 mm |

I'm reasonably confident about the column-strip top runs and the middle-strip 0.22ℓn; **less so about the two bottom-remainder values.**

That uncertainty shaped the design rather than being hidden by it:

- the fractions are an **input with a default**, not a constant buried in the drawing;
- they're **printed on the drawing itself**, next to the clause reference, so an engineer sees exactly what was assumed;
- the card carries a **bold "check against Fig. 8.7.4.1.3(a) before detailing"** line.

If you have the figure to hand, correcting `DEFAULT_EXT` is a two-line change and the tests will follow.

## Found by rendering, not by testing

Two label collisions the test suite couldn't see: the two bottom callouts shared a baseline and printed on top of each other, and the 0.30ℓn / 0.20ℓn top callouts were staggered by `i % 2` — but the runs come out `[longL, longR, shortL, shortR]`, so that offset separated *left from right* rather than *long from short*.

## Verification

Rendered on the page for both strips, no console errors. `npx tsc -b`, `eslint`, `npm test` (**3109 tests**) and `npm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_