### PR TITLE
fix(pages): show the worked solution that nine pages already computed

### DIFF
--- a/webapp/src/pages/DevLength.tsx
+++ b/webapp/src/pages/DevLength.tsx
@@ -5,6 +5,7 @@ import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { ReportControls } from '../components/ReportControls'
 import { buildDevLengthSolution } from '../lib/devLengthSolution'
 import { f0, f1, f2 } from '../lib/format'
+import { WorkedSolution } from '../components/WorkedSolution'
 
 const BAR_SIZES: [string, string][] = [
   ['10', '10 mm (ø10)'],
@@ -172,6 +173,12 @@ export default function DevLength() {
           </p>
         )}
       </div>
+      {/* The step-by-step already existed and only ever reached the PDF. */}
+      {solution && solution.length > 0 && (
+        <div className="mt-5">
+          <WorkedSolution steps={solution} title="Calculation report — worked solution" />
+        </div>
+      )}
     </div>
   )
 }

--- a/webapp/src/pages/LateralPile.tsx
+++ b/webapp/src/pages/LateralPile.tsx
@@ -5,6 +5,7 @@ import {
   type PileHead, type SoilModel, type PyResult, type BromsResult,
 } from '../engine/lateralPile'
 import { buildLateralPileSolution } from '../lib/lateralPileSolution'
+import { WorkedSolution } from '../components/WorkedSolution'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -253,6 +254,10 @@ export default function LateralPile() {
           visible rather than silently presented as an answer. Deflections are relative to the undeflected pile axis.
         </p>
       </section>
+      {/* The step-by-step already existed and only ever reached the PDF. */}
+      <div className="mt-5">
+        <WorkedSolution steps={solution} title="Calculation report — worked solution" />
+      </div>
     </main>
   )
 }

--- a/webapp/src/pages/Micropile.tsx
+++ b/webapp/src/pages/Micropile.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { designMicropile } from '../engine/micropile'
 import { ReportControls } from '../components/ReportControls'
 import { buildMicropileSolution } from '../lib/geotechSolutions'
+import { WorkedSolution } from '../components/WorkedSolution'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -137,6 +138,10 @@ export default function Micropile() {
           π·Dbond·Lbond·αbond / FS. Verify buckling in very soft soils and group/settlement effects separately.
         </p>
       </section>
+      {/* The step-by-step already existed and only ever reached the PDF. */}
+      <div className="mt-5">
+        <WorkedSolution steps={solution} title="Calculation report — worked solution" />
+      </div>
     </main>
   )
 }

--- a/webapp/src/pages/PunchingShear.tsx
+++ b/webapp/src/pages/PunchingShear.tsx
@@ -5,6 +5,7 @@ import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { ReportControls } from '../components/ReportControls'
 import { buildPunchingSolution } from '../lib/punchingSolution'
 import { f0, f1, f2, f3 } from '../lib/format'
+import { WorkedSolution } from '../components/WorkedSolution'
 
 interface FormState {
   c1: number; c2: number         // column dimensions, mm
@@ -167,6 +168,12 @@ export default function PunchingShear() {
           </p>
         )}
       </div>
+      {/* The step-by-step already existed and only ever reached the PDF. */}
+      {solution && solution.length > 0 && (
+        <div className="mt-5">
+          <WorkedSolution steps={solution} title="Calculation report — worked solution" />
+        </div>
+      )}
     </div>
   )
 }

--- a/webapp/src/pages/RockAnchor.tsx
+++ b/webapp/src/pages/RockAnchor.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { designRockAnchor } from '../engine/rockAnchor'
 import { ReportControls } from '../components/ReportControls'
 import { buildRockAnchorSolution } from '../lib/geotechSolutions'
+import { WorkedSolution } from '../components/WorkedSolution'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -107,6 +108,10 @@ export default function RockAnchor() {
           min(1.33·T, 0.80·GUTS). Provide the unbonded (free) length and corrosion protection separately.
         </p>
       </section>
+      {/* The step-by-step already existed and only ever reached the PDF. */}
+      <div className="mt-5">
+        <WorkedSolution steps={solution} title="Calculation report — worked solution" />
+      </div>
     </main>
   )
 }

--- a/webapp/src/pages/Settlement.tsx
+++ b/webapp/src/pages/Settlement.tsx
@@ -7,6 +7,7 @@ import {
   type SoilLayer,
 } from '../engine/settlement'
 import { buildSettlementSolution } from '../lib/settlementSolution'
+import { WorkedSolution } from '../components/WorkedSolution'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -281,6 +282,10 @@ export default function Settlement() {
           about 1% — not the series itself.
         </p>
       </section>
+      {/* The step-by-step already existed and only ever reached the PDF. */}
+      <div className="mt-5">
+        <WorkedSolution steps={solution} title="Calculation report — worked solution" />
+      </div>
     </main>
   )
 }

--- a/webapp/src/pages/ShotcreteFacing.tsx
+++ b/webapp/src/pages/ShotcreteFacing.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { designFacing } from '../engine/shotcreteFacing'
 import { ReportControls } from '../components/ReportControls'
 import { buildFacingSolution } from '../lib/geotechSolutions'
+import { WorkedSolution } from '../components/WorkedSolution'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -123,6 +124,10 @@ export default function ShotcreteFacing() {
           tension (permanent facing) and temporary-vs-final facing stages are checked separately.
         </p>
       </section>
+      {/* The step-by-step already existed and only ever reached the PDF. */}
+      <div className="mt-5">
+        <WorkedSolution steps={solution} title="Calculation report — worked solution" />
+      </div>
     </main>
   )
 }

--- a/webapp/src/pages/SlabDesign.tsx
+++ b/webapp/src/pages/SlabDesign.tsx
@@ -9,6 +9,7 @@ import { SlabBarSection } from '../components/SlabBarSection'
 import { tempSteelArea, tempSpacingMax } from '../engine/slabBarDetail'
 import { f0, f1, f2 } from '../lib/format'
 import 'katex/dist/katex.min.css'
+import { WorkedSolution } from '../components/WorkedSolution'
 
 interface FormState {
   lx: number; ly: number
@@ -283,6 +284,12 @@ export default function SlabDesign() {
           )}
         </div>
       </div>
+      {/* The step-by-step already existed and only ever reached the PDF. */}
+      {solution && solution.length > 0 && (
+        <div className="mt-5">
+          <WorkedSolution steps={solution} title="Calculation report — worked solution" />
+        </div>
+      )}
     </div>
   )
 }

--- a/webapp/src/pages/SoilNail.tsx
+++ b/webapp/src/pages/SoilNail.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { designSoilNail } from '../engine/soilNail'
 import { ReportControls } from '../components/ReportControls'
 import { buildSoilNailSolution } from '../lib/geotechSolutions'
+import { WorkedSolution } from '../components/WorkedSolution'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -127,6 +128,10 @@ export default function SoilNail() {
           This is a preliminary component check — verify global stability separately.
         </p>
       </section>
+      {/* The step-by-step already existed and only ever reached the PDF. */}
+      <div className="mt-5">
+        <WorkedSolution steps={solution} title="Calculation report — worked solution" />
+      </div>
     </main>
   )
 }


### PR DESCRIPTION
While adding a step-by-step to the stair page (#511) I found it **already had one**. Same on the water tank (#512). Same on torsion (#513). Three in a row is a pattern, so I swept every page.

## Nine more

These were building a **full worked solution on every render**, passing it to `report.steps`, and never putting it on screen. The derivation reached the PDF and nothing else:

`/dev-length` · `/lateral-pile` · `/micropile` · `/punching-shear` · `/rock-anchor` · `/settlement` · `/shotcrete-facing` · `/slab-design` · `/soil-nail`

Every one already imported its builder, already called it, already had the steps in hand. The fix is one `<WorkedSolution>` per page.

The three whose builder returns `null` on invalid input (dev-length, punching shear, slab) are guarded; the rest always have steps.

## Why no test caught it

Every solution builder was covered and every one was correct. The output just went nowhere. A unit test on `buildPunchingSolution` passes whether or not anything renders it — this is only visible by opening the page.

## Verification

Browser sweep of all twelve routes (these nine plus the three fixed in the earlier PRs): the solution renders on every one, no page errors. `npx tsc -b`, `eslint src/pages/`, `npm test` (**3109 tests**) and `npm run build` all clean.

## Note for the backlog

This closes the "add solution" half of items #30 (dev & splice) and #31 (punching shear) outright — both already had the calculation. The drawing and hint-button halves are still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_