### PR TITLE
fix(pile-cap): draw piles and column as line work, and show the crack paths

### DIFF
--- a/webapp/src/components/PileCapSchematic.tsx
+++ b/webapp/src/components/PileCapSchematic.tsx
@@ -5,6 +5,15 @@ import { DimBelow, DimSide } from './dims'
 const BLUE  = '#0056b3'
 const STEEL = '#37526e'
 const FILL  = '#eef3f8'
+const CRACK = '#c2402a'
+
+// Piles and the column are drawn as LINE WORK, not as filled shapes.
+//
+// A pile in a cap plan is BELOW the cap — you are looking at it through
+// concrete — so a broken line is the drafting convention and a solid disc is
+// simply wrong. The column is above the cut, so it is an outline. Filling
+// either one also fought the crack paths for attention, and the cracks are the
+// thing an engineer needs to see.
 
 interface Props {
   capBx: number        // mm
@@ -14,10 +23,14 @@ interface Props {
   colX: number         // mm
   colY: number         // mm
   reactions: number[]  // service, kN
+  /** Effective depth, mm — sets where the punching cone is drawn (d/2 from
+   *  the column face). Optional so existing callers keep working; the cone is
+   *  omitted rather than guessed when it is not supplied. */
+  d?: number
 }
 
 /** Top-view (plan) schematic of the pile cap with pile reactions. */
-export function PileCapSchematic({ capBx, capBy, coords, pileDia, colX, colY, reactions }: Props): JSX.Element {
+export function PileCapSchematic({ capBx, capBy, coords, pileDia, colX, colY, reactions, d }: Props): JSX.Element {
   const W = 320
   const PAD = 40
   const availW = W - 2 * PAD
@@ -41,10 +54,12 @@ export function PileCapSchematic({ capBx, capBy, coords, pileDia, colX, colY, re
   // Pile radius in pixels
   const pr = Math.max(4, pileDia * s / 2)
 
-  const maxR = Math.max(...reactions)
+  // Punching cone at d/2 from the column face — the same critical section
+  // the punching check uses. Omitted when d is not supplied.
+  const punchOff = d && d > 0 ? (d / 2) * s : 0
 
   return (
-    <svg viewBox={`0 0 ${W} ${availH + PAD}`} xmlns="http://www.w3.org/2000/svg"
+    <svg viewBox={`0 0 ${W} ${availH + PAD + 46}`} xmlns="http://www.w3.org/2000/svg"
       preserveAspectRatio="xMidYMid meet" style={{ width: '100%', height: 'auto', fontFamily: 'Arial, sans-serif' }}>
 
       {/* Title */}
@@ -58,11 +73,12 @@ export function PileCapSchematic({ capBx, capBy, coords, pileDia, colX, colY, re
       {coords.map((p, i) => {
         const px = cx + p.x * s
         const py = cy - p.y * s  // SVG y-down → invert y
-        const intensity = maxR > 0 ? reactions[i] / maxR : 1
-        const fill = `rgba(0, 86, 179, ${(0.25 + 0.65 * intensity).toFixed(2)})`
+        // The reaction is carried by the LABEL, not by a fill: a shade of blue
+        // cannot be read back as a number, and the number is printed anyway.
         return (
           <g key={i}>
-            <circle cx={px} cy={py} r={pr} fill={fill} stroke={STEEL} strokeWidth={1} />
+            <circle cx={px} cy={py} r={pr} fill="none" stroke={BLUE} strokeWidth={1.3}
+              strokeDasharray="5 3" />
             <text x={px} y={py + pr + 9} fontSize={8} fill={STEEL} textAnchor="middle"
               paintOrder="stroke" stroke="#fff" strokeWidth={2}>
               {reactions[i].toFixed(0)} kN
@@ -71,9 +87,40 @@ export function PileCapSchematic({ capBx, capBy, coords, pileDia, colX, colY, re
         )
       })}
 
-      {/* Column (on top of piles) */}
+      {/* Column — outline only. It is above the cut, and a solid block hid the
+          cracks that radiate from its face. */}
       <rect x={cx - colW / 2} y={cy - colH / 2} width={colW} height={colH}
-        fill={STEEL} opacity={0.85} />
+        fill="none" stroke={STEEL} strokeWidth={1.6} />
+
+      {/* ── Likely cracking ──────────────────────────────────────────────
+          Two mechanisms, both starting at the column and both what the cap's
+          reinforcement is there to control:
+
+          • FLEXURAL cracks on the underside, running between the column face
+            and each pile — the cap spans as a deep member from the column out
+            to the pile heads, so the tension face cracks along those lines.
+            This is why the main mat runs pile-to-pile rather than uniformly.
+          • A PUNCHING cone around the column, drawn at d/2 from its face — the
+            same critical section the punching check uses.
+
+          Drawn faint and dashed: these are expected crack PATHS, not a
+          prediction that the cap has failed. */}
+      <g stroke={CRACK} strokeWidth={1.1} strokeDasharray="4 3" fill="none" opacity={0.85}>
+        {coords.map((p, i) => {
+          const px = cx + p.x * s, py = cy - p.y * s
+          // Start at the column face on the line to the pile, not at its centre.
+          const dx = px - cx, dy = py - cy
+          const len = Math.hypot(dx, dy) || 1
+          const tx = Math.min(colW / 2 / Math.abs(dx || 1e-9), colH / 2 / Math.abs(dy || 1e-9))
+          const fx = cx + dx * Math.min(tx, 1), fy = cy + dy * Math.min(tx, 1)
+          return <line key={`ck${i}`} x1={fx} y1={fy} x2={px - (dx / len) * pr} y2={py - (dy / len) * pr} />
+        })}
+        <rect x={cx - colW / 2 - punchOff} y={cy - colH / 2 - punchOff}
+          width={colW + 2 * punchOff} height={colH + 2 * punchOff} />
+      </g>
+      <text x={14} y={capY + cH + 56} fontSize={8} fill={CRACK}>
+        ┄ likely cracking: flexural, column face → pile · punching cone at d/2
+      </text>
 
       {/* Dimensions: Bx below, By right, pile spacing between the first pile pair */}
       <DimBelow xA={capX} xB={capX + cW} featY={capY + cH} dY={capY + cH + 16}

--- a/webapp/src/pages/PileCapDesign.tsx
+++ b/webapp/src/pages/PileCapDesign.tsx
@@ -215,7 +215,7 @@ export default function PileCapDesign() {
           <div data-pdf-drawing className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Cap plan</h2>
             {result ? (
-              <PileCapSchematic
+              <PileCapSchematic d={result.d}
                 capBx={result.capBx}
                 capBy={result.capBy}
                 coords={result.coords}
@@ -343,7 +343,7 @@ export default function PileCapDesign() {
             ['Effective depth d', `${result.d.toFixed(0)} mm`],
           ]}
           drawingTitle="Pile Cap Plan"
-          drawing={<PileCapSchematic capBx={result.capBx} capBy={result.capBy} coords={result.coords}
+          drawing={<PileCapSchematic d={result.d} capBx={result.capBx} capBy={result.capBy} coords={result.coords}
             pileDia={form.pileDia} colX={form.colX} colY={form.colY} reactions={result.reactions} />}
         />
       )}


### PR DESCRIPTION
> *pile cap design, remove the color of the piles and use broken lines for them and remove the color of the column (just draw its outline) and draw the possible path of cracking*

All three, and the first two turn out to have a reason beyond taste.

A pile in a cap plan is **below** the cap — you are looking at it through concrete — so a broken line is how it is drawn and a solid disc is simply wrong. The column is **above** the cut, so it is an outline. Both fills were also fighting the crack paths for attention, which is the third ask and the one that matters.

The pile fill additionally encoded the reaction as a **shade of blue**. That's gone: a shade can't be read back as a number, and the number is printed beside it anyway.

## The cracking

Two mechanisms, both starting at the column:

- **Flexural**, running from the column *face* out to each pile head. The cap spans as a deep member from column to piles, so the tension face cracks along those lines — which is also why the main mat runs pile-to-pile rather than uniformly, a fact the old drawing left entirely implicit.
- A **punching cone at d/2** from the column face — the same critical section the punching-shear page uses, so the two now agree on screen.

Drawn faint and dashed: these are expected crack *paths*, not a claim that the cap has failed.

`d` is a new **optional** prop. The cone is **omitted when it isn't supplied** rather than guessed from the cap plan; both call sites pass it, so it appears on screen and in the PDF.

## Found by rendering

The crack legend sat below the viewBox and was clipped away entirely.

## Verification

Rendered on the page, no console errors. `npx tsc -b`, `eslint`, `npm test` (**3109 tests**) and `npm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_