### PR TITLE
feat(settlement): draw the soil profile and the stress decay

### DIFF
--- a/webapp/src/components/SoilProfile.tsx
+++ b/webapp/src/components/SoilProfile.tsx
@@ -1,0 +1,147 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Soil profile under a footing, with the stress bulb that drives settlement.
+//
+// The page reports a settlement per layer and never shows the profile those
+// layers form. Three things only a drawing makes obvious:
+//
+//   • WHERE the water table sits relative to each layer. Below it the layer
+//     is buoyant, so σ′ climbs more slowly — which is why `effectiveStress`
+//     subtracts pore pressure and why the same soil settles differently at
+//     different depths.
+//   • THAT Δσ DECAYS. The stress increase is largest just under the footing
+//     and small a couple of widths down, so a thick soft layer deep in the
+//     profile may contribute less than a thin one near the surface. A table
+//     of per-layer settlements makes the governing layer look arbitrary; the
+//     decay curve makes it obvious.
+//   • WHICH layer governs — highlighted, so the number the page already
+//     computes has a place on the picture.
+//
+// Geometry only. `engine/settlement` decides everything.
+// ─────────────────────────────────────────────────────────────────────────
+
+const INK = '#37526e'
+const WATER = '#0e7490'
+const STRESS = '#c2402a'
+const GOV = '#b97d10'
+const DIM = '#1f77b4'
+const FAINT = '#a39d8d'
+
+/** Distinct, muted fills for successive strata. Cycled, so any number of
+ *  layers draws without a palette lookup failing. */
+const STRATA = ['#e7e2d4', '#dfe6ec', '#e6e0e8', '#dde8de', '#eae3d8']
+
+export interface ProfileLayer {
+  name: string
+  /** Depth to the top of the layer and its thickness, m. */
+  zTop: number
+  H: number
+  /** Stress increase at mid-height, kPa — from the engine. */
+  dSigma: number
+  /** Effective overburden at mid-height, kPa — from the engine. */
+  sigma0: number
+  /** Settlement contributed, mm. */
+  settlement: number
+}
+
+export interface SoilProfileProps {
+  layers: ProfileLayer[]
+  /** Founding depth and footing width, m. */
+  Df: number
+  B: number
+  /** Water table depth below ground, m. Infinity = none within the profile. */
+  waterTable: number
+  /** Bearing pressure, kPa. */
+  q: number
+  /** Index of the layer contributing the most settlement, or -1. */
+  governing: number
+}
+
+export function SoilProfile({ layers, Df, B, waterTable, q, governing }: SoilProfileProps) {
+  const total = layers.reduce((a, l) => Math.max(a, l.zTop + l.H), 0) || 1
+  const ML = 118, MR = 96, MT = 46, MB = 44
+  const COL_W = 150, DEPTH = 250
+  const s = DEPTH / total
+  const W = ML + COL_W + MR, HT = MT + DEPTH + MB
+  const zy = (z: number) => MT + z * s
+
+  // Δσ decay plot, to the right of the strata, on its own scale.
+  const dMax = Math.max(q, ...layers.map((l) => l.dSigma), 1)
+  const px = (v: number) => ML + COL_W + 12 + (v / dMax) * (MR - 30)
+
+  const fw = Math.min(COL_W * 0.8, B * s)   // footing, to the profile's scale
+
+  return (
+    <svg viewBox={`0 0 ${W} ${HT}`} className="mx-auto block h-auto w-full"
+      style={{ fontFamily: 'Arial, sans-serif' }}>
+      {/* strata */}
+      {layers.map((l, i) => {
+        const y = zy(l.zTop), hgt = l.H * s
+        const gov = i === governing
+        return (
+          <g key={i}>
+            <rect x={ML} y={y} width={COL_W} height={hgt}
+              fill={STRATA[i % STRATA.length]} stroke={INK} strokeWidth={0.9} />
+            {gov && <rect x={ML} y={y} width={COL_W} height={hgt} fill={GOV} opacity={0.22}
+              stroke={GOV} strokeWidth={2} />}
+            <text x={ML - 8} y={y + hgt / 2 - 3} fontSize={8} fill={INK} textAnchor="end">{l.name}</text>
+            <text x={ML - 8} y={y + hgt / 2 + 8} fontSize={7} fill={FAINT} textAnchor="end">
+              {l.H.toFixed(1)} m · {l.settlement.toFixed(1)} mm{gov ? ' ← governs' : ''}
+            </text>
+          </g>
+        )
+      })}
+
+      {/* ground line and the footing sitting at Df */}
+      <line x1={ML - 30} y1={MT} x2={ML + COL_W + 6} y2={MT} stroke={INK} strokeWidth={1.6} />
+      <rect x={ML + (COL_W - fw) / 2} y={zy(Df) - 10} width={fw} height={10}
+        fill={INK} opacity={0.8} />
+      <text x={ML + COL_W / 2} y={zy(Df) - 14} fontSize={7.5} fill={INK} textAnchor="middle">
+        q = {q.toFixed(0)} kPa
+      </text>
+      {/* Df sits INSIDE the profile column: outside it, on the left, it printed
+          straight through the layer names. */}
+      <g>
+        <line x1={ML + 8} y1={MT} x2={ML + 8} y2={zy(Df)} stroke={DIM} strokeWidth={0.8} />
+        {[MT, zy(Df)].map((y) => <line key={y} x1={ML + 5} y1={y} x2={ML + 11} y2={y} stroke={DIM} strokeWidth={0.9} />)}
+        <text x={ML + 13} y={(MT + zy(Df)) / 2 + 3} fontSize={7.5} fill={DIM}>Df = {Df.toFixed(1)} m</text>
+      </g>
+
+      {/* water table — the reason σ′ and σ diverge below it */}
+      {Number.isFinite(waterTable) && waterTable <= total && (
+        <g>
+          <line x1={ML - 12} y1={zy(waterTable)} x2={ML + COL_W + 6} y2={zy(waterTable)}
+            stroke={WATER} strokeWidth={1.3} />
+          {[0, 1, 2].map((k) => (
+            <path key={k} d={`M${ML + 8 + k * 7} ${zy(waterTable) + 4} l3 -4 l3 4`}
+              fill="none" stroke={WATER} strokeWidth={1} />
+          ))}
+          <text x={ML + COL_W + 8} y={zy(waterTable) - 3} fontSize={7.5} fill={WATER}>
+            ▽ WT {waterTable.toFixed(1)} m
+          </text>
+        </g>
+      )}
+
+      {/* Δσ decay — the point of the whole drawing */}
+      <g>
+        <line x1={px(0)} y1={MT} x2={px(0)} y2={MT + DEPTH} stroke={FAINT} strokeWidth={0.8} />
+        <polyline
+          points={layers.map((l) => `${px(l.dSigma)},${zy(l.zTop + l.H / 2)}`).join(' ')}
+          fill="none" stroke={STRESS} strokeWidth={1.6} />
+        {layers.map((l, i) => (
+          <g key={i}>
+            <circle cx={px(l.dSigma)} cy={zy(l.zTop + l.H / 2)} r={2.2} fill={STRESS} />
+            <text x={px(l.dSigma) + 5} y={zy(l.zTop + l.H / 2) + 3} fontSize={7} fill={STRESS}>
+              {l.dSigma.toFixed(0)}
+            </text>
+          </g>
+        ))}
+        <text x={px(0)} y={MT - 8} fontSize={7.5} fill={STRESS}>Δσ at mid-height, kPa</text>
+      </g>
+
+      <text x={ML} y={MT - 26} fontSize={9} fontWeight={700} fill={INK}>SOIL PROFILE &amp; STRESS DECAY</text>
+      <text x={W / 2} y={HT - 6} fontSize={7.5} fill={FAINT} textAnchor="middle">
+Δσ is zero above founding level, peaks just under the footing, then decays — a thick deep layer can settle less than a thin shallow one.
+      </text>
+    </svg>
+  )
+}

--- a/webapp/src/pages/Settlement.tsx
+++ b/webapp/src/pages/Settlement.tsx
@@ -8,6 +8,7 @@ import {
 } from '../engine/settlement'
 import { buildSettlementSolution } from '../lib/settlementSolution'
 import { WorkedSolution } from '../components/WorkedSolution'
+import { SoilProfile } from '../components/SoilProfile'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -183,6 +184,17 @@ export default function Settlement() {
           <Field label="Poisson ν" value={nu} onChange={setNu} step="0.05" />
           <Field label="Time horizon" unit="yr" value={years} onChange={setYears} step="1" />
         </div>
+      </section>
+
+      <section data-pdf-drawing className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm
+        [background-image:linear-gradient(#f0eee7_1px,transparent_1px),linear-gradient(90deg,#f0eee7_1px,transparent_1px)] [background-size:22px_22px]">
+        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Soil profile</h2>
+        <SoilProfile
+          layers={cons.layers.map((l, i) => ({
+            name: l.name || `Layer ${i + 1}`, zTop: l.zTop, H: l.H,
+            dSigma: l.dSigma, sigma0: l.sigma0, settlement: l.settlement,
+          }))}
+          Df={Df} B={B} waterTable={wt} q={q} governing={govLayer} />
       </section>
 
       <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">


### PR DESCRIPTION
> *settlement, add drawing of the soil profile*

The page listed a settlement per layer and never showed the profile those layers form.

## Three things only the drawing makes visible

- **Where the water table sits** relative to each layer. Below it the soil is buoyant and σ′ climbs more slowly — which is why `effectiveStress` subtracts pore pressure, and why the same soil settles differently at different depths.
- **That Δσ decays.** Plotted beside the strata at each layer's mid-height. Without it the governing layer looks arbitrary: on the default profile a **6 m soft clay contributes 77 mm** while a **5 m stiff clay below it contributes 1.6 mm** — and the reason is the decay curve, not the thickness.
- **Which layer governs** — outlined and tinted, so the number the page already computes has a place on the picture.

Every value comes from the engine result; the component derives only positions and a colour.

## Two things rendering caught

- The `Df` dimension printed straight through the layer names. Moved inside the profile column.
- My first footer read *"Δσ falls with depth"* — but Δσ is **zero above founding level**, peaks just under the footing, and only then decays. The drawing showed 0 → 21 → 5 and the caption contradicted it. Now it says what the curve actually does.

## Verification

Rendered on the page, no console errors. `npx tsc -b`, `eslint`, `npm test` (**3109 tests**) and `npm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_