### PR TITLE
feat(design): five-stage bar-diameter selection

### DIFF
--- a/webapp/src/engine/barSelection.test.ts
+++ b/webapp/src/engine/barSelection.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest'
+import {
+  chooseBar, firstFailure, crackSpacingLimit, crackControlOK,
+  constructabilityOK, rejectionNote, BUILDABLE, STAGES, type BarCandidate,
+} from './barSelection'
+
+const cand = (db: number, over: Partial<BarCandidate> = {}): BarCandidate => ({
+  db, strength: true, serviceability: true, detailing: true, constructability: true,
+  steelArea: 1000, ...over,
+})
+
+describe('the stages are applied IN ORDER', () => {
+  it('reports the FIRST stage a candidate fails, not the last', () => {
+    // A bar that fails strength AND detailing is a strength failure. Reporting
+    // the last check to run would send someone off to widen the web when the
+    // section is simply too small.
+    expect(firstFailure(cand(25, { strength: false, detailing: false }))).toBe('strength')
+    expect(firstFailure(cand(25, { serviceability: false, constructability: false })))
+      .toBe('serviceability')
+  })
+
+  it('passes a candidate that clears all four', () => {
+    expect(firstFailure(cand(20))).toBeNull()
+  })
+
+  it('covers every stage in the declared order', () => {
+    const seen = STAGES.map((st) => firstFailure(cand(20, { [st]: false } as Partial<BarCandidate>)))
+    expect(seen).toEqual([...STAGES])
+  })
+})
+
+describe('chooseBar', () => {
+  it('takes the least steel', () => {
+    const r = chooseBar([cand(20, { steelArea: 1200 }), cand(25, { steelArea: 900 })])
+    expect(r.db).toBe(25)
+  })
+
+  it('breaks a tie toward the SMALLER bar', () => {
+    // Equal tonnage is not equal on site: more, smaller bars control crack
+    // width better, bend tighter and are easier to place.
+    const r = chooseBar([cand(32, { steelArea: 1000 }), cand(20, { steelArea: 1000 })])
+    expect(r.db).toBe(20)
+  })
+
+  it('never rescues a failed candidate for being cheaper', () => {
+    // The cheapest option here fails strength. Economy ranks survivors; it
+    // does not vote on whether something survives.
+    const r = chooseBar([
+      cand(16, { strength: false, steelArea: 400 }),
+      cand(25, { steelArea: 1400 }),
+    ])
+    expect(r.db).toBe(25)
+    expect(r.rejected).toEqual([{ db: 16, stage: 'strength' }])
+  })
+
+  it('returns null when everything fails, and says why for each', () => {
+    const r = chooseBar([
+      cand(16, { strength: false }),
+      cand(20, { serviceability: false }),
+      cand(25, { detailing: false }),
+      cand(32, { constructability: false }),
+    ])
+    expect(r.db).toBeNull()
+    expect(r.rejected.map((x) => x.stage))
+      .toEqual(['strength', 'serviceability', 'detailing', 'constructability'])
+  })
+
+  it('handles an empty candidate list', () => {
+    expect(chooseBar([])).toEqual({ db: null, rejected: [], ranked: [] })
+  })
+
+  it('ranks every survivor, not just the winner', () => {
+    const r = chooseBar([
+      cand(20, { steelArea: 1200 }), cand(25, { steelArea: 900 }), cand(32, { steelArea: 1500 }),
+    ])
+    expect(r.ranked).toEqual([25, 20, 32])
+  })
+
+  it('is deterministic — the ranking is total', () => {
+    const set = [cand(16, { steelArea: 1000 }), cand(20, { steelArea: 1000 }), cand(25, { steelArea: 1000 })]
+    expect(chooseBar(set).ranked).toEqual(chooseBar([...set].reverse()).ranked)
+  })
+
+  it('does not let float noise reverse the size preference', () => {
+    // 1000 and 1000.0000001 are the same tonnage; the smaller bar should win.
+    const r = chooseBar([cand(32, { steelArea: 1000 }), cand(20, { steelArea: 1000.0000001 })])
+    expect(r.db).toBe(20)
+  })
+})
+
+describe('crack control — §24.3.2', () => {
+  it('matches the clause for Grade 420 at 40 mm cover', () => {
+    // fs = ⅔·420 = 280 → k = 1.0 → min(380 − 100, 300) = 280 mm.
+    expect(crackSpacingLimit(420, 40)).toBeCloseTo(280, 6)
+  })
+
+  it('tightens as cover grows — the 2.5cc term', () => {
+    expect(crackSpacingLimit(420, 75)).toBeLessThan(crackSpacingLimit(420, 40))
+  })
+
+  it('tightens as fy grows — higher service stress, wider cracks', () => {
+    expect(crackSpacingLimit(550, 40)).toBeLessThan(crackSpacingLimit(420, 40))
+  })
+
+  it('is capped by the 300·(280/fs) branch at low cover', () => {
+    // At zero cover the first branch would give 380·k; the cap governs.
+    expect(crackSpacingLimit(420, 0)).toBeCloseTo(300, 6)
+  })
+
+  it('passes and fails on the right side of the limit', () => {
+    expect(crackControlOK(280, 420, 40)).toBe(true)
+    expect(crackControlOK(281, 420, 40)).toBe(false)
+  })
+})
+
+describe('constructability', () => {
+  it('refuses a single bar and an absurd count', () => {
+    expect(constructabilityOK(1, 1)).toBe(false)
+    expect(constructabilityOK(BUILDABLE.maxBars + 1, 1)).toBe(false)
+  })
+
+  it('refuses a cage stacked too deep', () => {
+    expect(constructabilityOK(8, BUILDABLE.maxLayers + 1)).toBe(false)
+  })
+
+  it('accepts an ordinary cage', () => {
+    expect(constructabilityOK(6, 2)).toBe(true)
+    expect(constructabilityOK(BUILDABLE.minBars, 1)).toBe(true)
+    expect(constructabilityOK(BUILDABLE.maxBars, BUILDABLE.maxLayers)).toBe(true)
+  })
+})
+
+describe('rejectionNote', () => {
+  it('names the diameter and says something actionable for every stage', () => {
+    for (const st of STAGES) {
+      const note = rejectionNote(25, st)
+      expect(note).toContain('25')
+      expect(note.length).toBeGreaterThan(20)
+    }
+  })
+})

--- a/webapp/src/engine/barSelection.ts
+++ b/webapp/src/engine/barSelection.ts
@@ -1,0 +1,147 @@
+// ─────────────────────────────────────────────────────────────────────────
+// CHOOSING A BAR DIAMETER — the five stages, in order, as an explicit gate
+// chain rather than a single boolean.
+//
+//   1. STRENGTH          does the section carry the demand?
+//   2. SERVICEABILITY    crack control — §24.3.2 bar-spacing limit.
+//   3. DETAILING         clear spacing, layers, minimum bar count.
+//   4. CONSTRUCTABILITY  can a person actually tie this cage?
+//   5. ECONOMY           least steel; on a tie, the SMALLER bar.
+//
+// The order is not cosmetic. Stages 1–4 are PASS/FAIL FILTERS applied in
+// sequence; stage 5 only ever ranks what survived. A candidate that fails an
+// earlier stage can never be rescued by being cheaper, and — the part that
+// matters when reading a result — the reason a size was rejected is the FIRST
+// stage it failed, not a mixture.
+//
+// WHY SMALLER WINS THE TIE. Two sizes with the same steel area are not equal
+// on site: more, smaller bars distribute crack width better (the same physics
+// behind §24.3.2), bend to a tighter radius, weigh less per stick to place,
+// and are more likely to be in the yard. Larger bars win only when they cut
+// the AREA, which stage 5 measures directly.
+//
+// The old selector was one loop that adopted "the smallest size that passes
+// capacity and fits". That silently conflated four different questions and
+// could not say why anything was rejected.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** The five stages, in the order they are applied. */
+export const STAGES = ['strength', 'serviceability', 'detailing', 'constructability'] as const
+export type Stage = typeof STAGES[number]
+
+/** What one candidate diameter was found to do. */
+export interface BarCandidate {
+  /** Bar diameter, mm. */
+  db: number
+  /** Stage 1 — the section carries the demand at this size. */
+  strength: boolean
+  /** Stage 2 — crack control and any deflection-driven limit. */
+  serviceability: boolean
+  /** Stage 3 — clear spacing, layer fit, minimum count. */
+  detailing: boolean
+  /** Stage 4 — buildable: not a congested cage, not an absurd bar count. */
+  constructability: boolean
+  /**
+   * Stage 5 — steel area PROVIDED, mm². Lower is cheaper. Area, not bar
+   * count: a bar count says nothing about tonnage, and tonnage is what is
+   * bought.
+   */
+  steelArea: number
+}
+
+export interface BarChoice {
+  /** The adopted diameter, or null when every candidate failed. */
+  db: number | null
+  /** Why each rejected candidate lost — the FIRST stage it failed. */
+  rejected: { db: number; stage: Stage }[]
+  /** Candidates that passed all four filters, in the order stage 5 ranked them. */
+  ranked: number[]
+}
+
+/** The first stage a candidate fails, or null when it passes all four. */
+export function firstFailure(c: BarCandidate): Stage | null {
+  if (!c.strength) return 'strength'
+  if (!c.serviceability) return 'serviceability'
+  if (!c.detailing) return 'detailing'
+  if (!c.constructability) return 'constructability'
+  return null
+}
+
+/**
+ * Apply the five stages and return the choice.
+ *
+ * Deterministic for a given input: the ranking is total, because ties on steel
+ * area are broken by diameter and two candidates cannot share a diameter.
+ */
+export function chooseBar(candidates: readonly BarCandidate[]): BarChoice {
+  const rejected: { db: number; stage: Stage }[] = []
+  const passed: BarCandidate[] = []
+
+  for (const c of candidates) {
+    const fail = firstFailure(c)
+    if (fail) rejected.push({ db: c.db, stage: fail })
+    else passed.push(c)
+  }
+
+  // Stage 5. Least steel first; on a tie, the smaller bar — see the header.
+  // The epsilon keeps two areas that differ only by floating-point noise from
+  // reversing the size preference.
+  const ranked = [...passed].sort((a, b) =>
+    Math.abs(a.steelArea - b.steelArea) > 1e-6 ? a.steelArea - b.steelArea : a.db - b.db)
+
+  return { db: ranked[0]?.db ?? null, rejected, ranked: ranked.map((c) => c.db) }
+}
+
+// ── Stage 2 and 4, as reusable checks ─────────────────────────────────────
+
+/**
+ * §24.3.2 / NSCP §424.3.2 — maximum centre-to-centre spacing of the bars
+ * nearest the tension face, for crack control:
+ *
+ *     s ≤ min( 380·(280/fs) − 2.5cc , 300·(280/fs) )
+ *
+ * with fs taken as ⅔fy per §24.3.2.1 when the stress is not computed, and cc
+ * the clear cover to the tension bars. This is the SERVICEABILITY gate: a
+ * section can be strong enough and still crack visibly because its bars are
+ * too far apart, which is exactly the failure a strength-only chooser misses.
+ */
+export function crackSpacingLimit(fy: number, clearCover: number): number {
+  const fs = (2 / 3) * Math.max(fy, 1)
+  const k = 280 / fs
+  return Math.min(380 * k - 2.5 * clearCover, 300 * k)
+}
+
+/** Whether the provided bar spacing satisfies the crack-control limit. */
+export const crackControlOK = (spacing: number, fy: number, clearCover: number): boolean =>
+  spacing <= crackSpacingLimit(fy, clearCover) + 1e-6
+
+/**
+ * Constructability limits.
+ *
+ * These are not code clauses — they are the difference between a cage a crew
+ * can tie and one they will improvise around, and improvising is how a design
+ * stops matching the drawing. Stated as named numbers so they can be argued
+ * with rather than discovered.
+ */
+export const BUILDABLE = {
+  /** Below two bars there is nothing to tie a stirrup to at the corners. */
+  minBars: 2,
+  /** More than this in one member is a congested cage and a slow pour. */
+  maxBars: 24,
+  /** More than this many layers and the effective depth is being thrown away. */
+  maxLayers: 3,
+} as const
+
+export function constructabilityOK(bars: number, layers: number): boolean {
+  return bars >= BUILDABLE.minBars && bars <= BUILDABLE.maxBars && layers <= BUILDABLE.maxLayers
+}
+
+/** A one-line explanation of a rejection, for a schedule note or a tooltip. */
+export function rejectionNote(db: number, stage: Stage): string {
+  switch (stage) {
+    case 'strength': return `⌀${db}: section does not carry the demand`
+    case 'serviceability': return `⌀${db}: bar spacing exceeds the §24.3.2 crack-control limit`
+    case 'detailing': return `⌀${db}: bars do not fit at the required clear spacing`
+    case 'constructability': return `⌀${db}: cage is not practically buildable (bar count or layers)`
+  }
+}

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -32,6 +32,9 @@ import { woodRefOf, checkWoodBeam, checkWoodColumn, getWoodRef, woodAdjusted } f
 import { designWoodSlab, type WoodSlabResult } from './woodSlab'
 import { designBasePlate, adoptPlateThickness, type BasePlateResult } from './baseplate'
 import { designSteelJoints, designBeamBeamJoints, type SteelJoint, type BeamBeamJoint } from './steelConnections'
+import {
+  chooseBar, crackControlOK, constructabilityOK, type BarCandidate,
+} from './barSelection'
 
 export interface SoilOptions {
   qAllow: number; gammaSoil: number; gammaConc: number; H: number
@@ -1429,23 +1432,53 @@ export function selectBarDiameters(
   // §407.7.1 clear-spacing / layer-fit check (both folded into beamOK).
   for (const row of design.beams) {
     const sec = secById.get(memSecId.get(row.id) ?? ''); if (!sec) continue
-    for (const db of ladder(BAR_LADDER_BEAM, sec.barDia)) {
-      const allOK = row.sections.every((s) => beamOK(designBeam({
+    // Each candidate is scored on all four gates across EVERY critical section
+    // of the member — one section failing serviceability rejects the size for
+    // the whole member — and then ranked on steel. See `barSelection` for why
+    // the stages are ordered and why a tie goes to the smaller bar.
+    const cands: BarCandidate[] = ladder(BAR_LADDER_BEAM, sec.barDia).map((db) => {
+      const designs = row.sections.map((s) => designBeam({
         b: sec.b, h: sec.h, cover: sec.cover, barDia: db, comprBarDia: 16,
         stirrupDia: sec.tieDia, fc: sec.fc, fy: sec.fy, Mu: Math.abs(s.Mu), Vu: s.Vu,
-      })))
-      if (allOK) { if (db !== sec.barDia) chosen.set(sec.id, db); break }
-    }
+      }))
+      return {
+        db,
+        strength: designs.every((d) => d.region !== 'inadequate' && d.comprEffective && d.comprNAOK),
+        // Crack control uses the CENTRE-TO-CENTRE spacing the clause is written
+        // in terms of; `sClear` is the clear gap, so the bar itself is added.
+        serviceability: designs.every((d) =>
+          crackControlOK(d.sClear + db, sec.fy, sec.cover)),
+        detailing: designs.every((d) => d.flexOK),
+        constructability: designs.every((d) => constructabilityOK(d.bars, d.layers.length)),
+        steelArea: Math.max(...designs.map((d) => d.bars * (Math.PI / 4) * db * db)),
+      }
+    })
+    const pick = chooseBar(cands)
+    if (pick.db !== null && pick.db !== sec.barDia) chosen.set(sec.id, pick.db)
   }
 
   // columns: smallest bar Ø that passes P–M + ρ AND fits the §425.2.1 minimum
   // clear bar spacing across the section face (≥ max(1.5db, 40 mm)).
   for (const row of design.columns) {
     const sec = secById.get(memSecId.get(row.id) ?? ''); if (!sec) continue
-    for (const db of ladder(BAR_LADDER_COLUMN, sec.barDia)) {
+    const cands: BarCandidate[] = ladder(BAR_LADDER_COLUMN, sec.barDia).map((db) => {
       const r = designColumnFromPM({ ...sec, barDia: db }, row.Pu, row.Mu)
-      if (r.ok && columnBarsFit(sec, db, r.bars)) { if (db !== sec.barDia) chosen.set(sec.id, db); break }
-    }
+      return {
+        db,
+        strength: r.ok,
+        // A column's bars are distributed around the perimeter by construction,
+        // so the crack-control spacing rule is not the governing serviceability
+        // question it is for a beam's tension face. Nothing to check here yet —
+        // said explicitly rather than left as an unexplained `true`.
+        serviceability: true,
+        detailing: columnBarsFit(sec, db, r.bars),
+        // One layer per face, so the layer limit cannot bite; the bar count can.
+        constructability: constructabilityOK(r.bars, 1),
+        steelArea: r.bars * (Math.PI / 4) * db * db,
+      }
+    })
+    const pick = chooseBar(cands)
+    if (pick.db !== null && pick.db !== sec.barDia) chosen.set(sec.id, pick.db)
   }
 
   // ── Bar-diameter continuity guard: one Ø through each continuous beam line


### PR DESCRIPTION
> *beam columns and footings engines, change the algorithm of bar diameter chooser into this 1. Pass strength → 2. Pass serviceability → 3. Satisfy detailing → 4. Check constructability → 5. Minimize cost/steel/labor where smaller bars is better than using larger bars*

## What it replaces

One loop that adopted *"the smallest size that passes capacity and fits"*. That conflated four different questions into a single boolean, had **no serviceability check at all**, **no constructability check at all**, and could not say why a size was rejected.

## The chain

`engine/barSelection.ts` makes it explicit. Stages 1–4 are pass/fail **filters applied in order**; stage 5 only ranks what survived. Two consequences the old code got wrong or couldn't express:

- **A cheap candidate can never be rescued by being cheap.** Economy ranks survivors; it does not vote on survival. There's a test for exactly this, because it's the tempting shortcut.
- **The reason a size lost is the first stage it failed.** A bar failing strength *and* detailing is a **strength** failure — reporting the last check to run would send someone off to widen the web when the section is simply too small.

## New gates

**Serviceability** — §24.3.2 crack control, `s ≤ min(380·(280/fs) − 2.5cc, 300·(280/fs))` with `fs = ⅔fy` per §24.3.2.1. This is the gate a strength-only chooser cannot have: a section can carry its moment and still crack visibly because the bars are too far apart. Applied on the **centre-to-centre** spacing the clause is written in, not the clear gap.

**Constructability** — bar count 2…24, at most 3 layers. Not code clauses: the difference between a cage a crew can tie and one they improvise around, and improvising is how a design stops matching the drawing. Named constants, so they can be argued with rather than discovered.

## Stage 5

Ranks on **steel area, not bar count** — a count says nothing about tonnage and tonnage is what's bought. Ties go to the **smaller** bar: equal tonnage isn't equal on site, since more, smaller bars control crack width better (the same physics as §24.3.2), bend tighter and place faster. A float epsilon stops rounding noise reversing that preference.

Columns declare `serviceability: true` **explicitly, with the reason** — their bars are distributed around the perimeter by construction, so the tension-face spacing rule isn't the governing question it is for a beam. Better a stated non-check than an unexplained `true`.

## Verification

20 tests on the chain itself (ordering, the no-rescue rule, the tie-break, the §24.3.2 branches at Grade 420/40 mm cover = 280 mm, determinism). Whole suite **3,129 green**, including the existing `selectBarDiameters` coverage in `barSelectionAndGamma.test.ts`. `npx tsc -b`, `eslint`, `npm run build` clean.

## Scope note

Footings were named in the request but their engines don't run a diameter ladder — they size the mat directly. Nothing to convert there; say the word if you want one added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_