### PR TITLE
fix(steel): beam extrudes along the span, white viewport, no dead API wait

### DIFF
--- a/webapp/src/components/SteelViewer3D.tsx
+++ b/webapp/src/components/SteelViewer3D.tsx
@@ -58,11 +58,17 @@ function Arrow({ from, to, color = '#16a34a', r = 0.04, headR = 0.10, headH = 0.
 
 function CanvasWrap({ children, box }: { children: React.ReactNode; box: { min:[number,number,number]; max:[number,number,number] } }) {
   return (
-    <div className="no-print h-72 w-full overflow-hidden rounded-xl border border-slate-200 bg-slate-900">
+    <div className="no-print h-72 w-full overflow-hidden rounded-xl border border-slate-200 bg-white">
       <Canvas camera={{ fov: 45, near: 0.01, far: 500 }}>
-        <ambientLight intensity={0.5} />
-        <directionalLight position={[5, 10, 5]} intensity={1.2} castShadow />
-        <directionalLight position={[-5, -3, -5]} intensity={0.4} />
+        {/* The Canvas paints its own background, so the wrapper's colour never
+            showed through — the viewport has to be told, not the div. */}
+        <color attach="background" args={['#ffffff']} />
+        {/* Lighting rebalanced for a white ground: on the old dark background
+            an ambient of 0.5 read as "lit", and against white the same member
+            came out flat and washed. */}
+        <ambientLight intensity={0.75} />
+        <directionalLight position={[5, 10, 5]} intensity={1.05} castShadow />
+        <directionalLight position={[-5, -3, -5]} intensity={0.35} />
         <OrbitControls makeDefault enableDamping={false} />
         <FitView box={box} dir={[1.2, 0.9, 1.5]} margin={1.4} />
         {children}
@@ -123,13 +129,18 @@ export function BeamViewer3D({ shape, span, wDead, wLive }: {
 
   return (
     <CanvasWrap box={box}>
-      <group rotation={[-Math.PI / 2, 0, 0]}>
-        <ExtrudedSection shapes={shapes} length={span} color="#8b9fc1" />
-      </group>
+      {/* NO ROTATION. `ExtrudedSection` already extrudes along +Z, which is the
+          span direction the supports (z = 0 and z = span), the UDL and the
+          section label all use. The old −90° about X stood the member UP along
+          Y, so the beam ran vertically out of a scene whose supports and loads
+          ran horizontally — the member appeared as a thin line off to one side
+          while everything else pointed elsewhere. (The COLUMN view rotates by
+          +90° on purpose: a column should stand up.) */}
+      <ExtrudedSection shapes={shapes} length={span} color="#8b9fc1" />
       <DistLoad span={span} w={wDead + wLive} />
       <PinSupport3D pos={[0, -d, 0]} />
       <RollerSupport3D pos={[0, -d, span]} />
-      <SceneText position={[bf + 0.15, 0, span / 2]} rotation={[0, -Math.PI / 2, 0]} fontSize={0.18} color="#e2e8f0" anchorX="center">
+      <SceneText position={[bf + 0.15, 0, span / 2]} rotation={[0, -Math.PI / 2, 0]} fontSize={0.18} color="#0f1b2a" anchorX="center">
         {shape.name}
       </SceneText>
     </CanvasWrap>
@@ -164,7 +175,7 @@ export function ColumnViewer3D({ shape, L, Pu, Mux }: {
       {Mux > 0 && <Arrow from={[-0.6, L + 0.1, 0]} to={[0.1, L + 0.1, 0]} color="#f59e0b" headR={0.10} headH={0.22} />}
       {/* fixed base */}
       <mesh position={[0, -0.03, 0]}><boxGeometry args={[0.8, 0.06, 0.5]} /><meshStandardMaterial color="#0056b3" /></mesh>
-      <SceneText position={[bf + 0.35, L / 2, 0]} rotation={[0, 0, 0]} fontSize={0.18} color="#e2e8f0" anchorX="center">
+      <SceneText position={[bf + 0.35, L / 2, 0]} rotation={[0, 0, 0]} fontSize={0.18} color="#0f1b2a" anchorX="center">
         {shape.name}
       </SceneText>
     </CanvasWrap>
@@ -202,7 +213,7 @@ export function ConnectionViewer3D({ geom, db, t_plate, critical }: {
               <cylinderGeometry args={[dbm / 2, dbm / 2, 0.4, 12]} />
               <meshStandardMaterial color={isCrit ? '#f59e0b' : '#d4a017'} metalness={0.7} roughness={0.3} />
             </mesh>
-            <SceneText position={[dbm * 0.8, dbm * 0.8, 0.05]} fontSize={0.018} color={isCrit ? '#fbbf24' : '#e2e8f0'}>
+            <SceneText position={[dbm * 0.8, dbm * 0.8, 0.05]} fontSize={0.018} color={isCrit ? '#b45309' : '#0f1b2a'}>
               {b.id}
             </SceneText>
           </group>

--- a/webapp/src/lib/calcApi.ts
+++ b/webapp/src/lib/calcApi.ts
@@ -32,6 +32,14 @@ async function localFallback<T>(path: string, body: unknown): Promise<T> {
 }
 
 async function post<T>(path: string, body: unknown): Promise<T> {
+  // NO API CONFIGURED → DO NOT ASK. Without VITE_API_URL the fetch goes to a
+  // same-origin path that a static deploy does not serve, so every calculation
+  // waited on a round trip that was always going to 404 before falling back to
+  // the identical local engine. On the steel page that was the "computing…"
+  // badge sitting there on first load. The fallback is the same engine, so
+  // skipping the doomed request costs nothing but the wait.
+  if (!BASE) return localFallback<T>(path, body)
+
   let res: Response
   try {
     res = await fetch(`${BASE}${path}`, {

--- a/webapp/src/pages/SteelDesign.tsx
+++ b/webapp/src/pages/SteelDesign.tsx
@@ -150,7 +150,7 @@ function BeamTab() {
         </Card>
       </div>
 
-      <div className="space-y-4 lg:sticky lg:top-4 lg:self-start">
+      <div className="space-y-4 lg:sticky lg:top-4 lg:max-h-[calc(100vh-2rem)] lg:self-start lg:overflow-y-auto lg:pr-1">
         <Suspense fallback={<Spinner />}>
           <BeamViewer3D shape={shape} span={span} wDead={wD} wLive={wL} />
         </Suspense>
@@ -281,7 +281,7 @@ function ColumnTab() {
         </Card>
       </div>
 
-      <div className="space-y-4 lg:sticky lg:top-4 lg:self-start">
+      <div className="space-y-4 lg:sticky lg:top-4 lg:max-h-[calc(100vh-2rem)] lg:self-start lg:overflow-y-auto lg:pr-1">
         <Suspense fallback={<Spinner />}>
           <ColumnViewer3D shape={shape} L={L} Pu={Pu} Mux={Mux} />
         </Suspense>
@@ -523,7 +523,7 @@ function ConnectionTab() {
       </div>
 
       {/* ── results ── */}
-      <div className="space-y-4 lg:sticky lg:top-4 lg:self-start">
+      <div className="space-y-4 lg:sticky lg:top-4 lg:max-h-[calc(100vh-2rem)] lg:self-start lg:overflow-y-auto lg:pr-1">
         {res && connType === 'bolt' && (<>
           <ResultCard title="Bolt capacity / bolt">
             <Row label="φRn shear" value={`${f2(res.phiRnBolt.phiRn_shear)} kN`} />


### PR DESCRIPTION
Backlog item: *"steel design, fix the render of the member and the background of the viewport should be white and check why there's 'computing' at load start of the page and when i scroll the right cards overlap the solution when scrolling"*

Four reported faults on `/steel`, each with a different cause.

### 1. The member rendered along the wrong axis

`BeamViewer3D` wrapped `ExtrudedSection` in a `rotation={[-Math.PI/2, 0, 0]}` group — but `ExtrudedSection` **already extrudes along +Z**, the same axis the supports (`z = 0` and `z = span`), the UDL arrows and the section label all use. The extra rotation stood the beam on end.

A scene probe (via `__THREE_DEVTOOLS__`) read world bounds:

| | before | after |
|---|---|---|
| min | `[-0.18, -0.5, -0.18]` | `[-0.18, -0.5, -0.18]` |
| max | `[0.23, **6**, 6.18]` | `[0.23, **0.94**, 6.18]` |

Before, the member ran to `y = 6` while its supports ran to `z = 6` — the beam and its own supports were on perpendicular axes. After, `ExtrudeGeometry` has local bounds `[-0.08, -0.16, 0] → [0.08, 0.16, 6]` with rotation `[0,0,0]`: a 160×320 section spanning 6 m along Z.

The **column** view keeps its `+Math.PI/2` rotation on purpose — a column should stand up — so the fix is local to the beam, with a comment saying why the two differ.

### 2. The viewport was dark

`bg-slate-900` on the wrapper never showed, because the `<Canvas>` paints its own background over it. Both are now white (`bg-white` + `<color attach="background" args={['#ffffff']} />`), verified: `scene.background` reads `#ffffff`.

Lighting rebalanced for the new background (ambient 0.5→0.75, directionals 1.2→1.05 and 0.4→0.35), and the two label colours that were near-white — `#e2e8f0` and `#fbbf24` — became `#0f1b2a` and `#b45309`, since they were invisible on white.

### 3. "computing…" hung at page load

`calcApi.post` always tried the same-origin `/api` route first — which 404s on a static deploy — and only then fell back to the **identical** local engine. With no API base configured there is nothing to wait for, so it now short-circuits straight to the fallback.

Measured: **computing clears in 2211 ms with 0 `/api` requests**, and 0 page errors.

### 4. Right-hand cards overlapped the solution on scroll

The three sticky result columns (beam / column / connection tabs) were `sticky` with no height bound, so a column taller than the viewport slid over the content beside it. Each is now capped at `calc(100vh-2rem)` and scrolls internally — measured computed style `max-height: 968px; overflow-y: auto` at a 1000 px viewport.

### Verification

Verified in headless Chromium by **scene introspection**, not pixels: the canvas reads blank through `toDataURL` without `preserveDrawingBuffer`, which is the WebGL caveat CLAUDE.md calls out. The probe reads geometry bounds, transforms, `scene.background`, resource timings and computed styles directly.

`npm test` — 197 files, **3129 passed**. `npx tsc -b` and `npm run build` green.

### Layer

Not an engine change: UI only (`components/SteelViewer3D.tsx`, `pages/SteelDesign.tsx`) plus one transport short-circuit in `lib/calcApi.ts`. The local fallback path already existed and computes the same result — this only stops the page waiting on a request that cannot succeed.

---

Remaining backlog after this: #22 Truss Space optimizer, #30 dev & splice drawing + hint buttons, #34 retaining wall drawing + solutions, #35 geotechnical page split, #38 network diagram branching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_