### PR TITLE
feat(retaining-wall): section drawing, worked solution, toe/heel design

### DIFF
--- a/webapp/src/components/RetainingWallSection.tsx
+++ b/webapp/src/components/RetainingWallSection.tsx
@@ -1,0 +1,379 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Cantilever retaining wall — the working section.
+//
+// The page reports two factors of safety, a bearing pressure and three bar
+// areas. Four things only the drawing can settle:
+//
+//   • WHICH FACE THE BARS GO ON. The stem is pushed away from the fill, so
+//     its tension face is the EARTH face. The toe bends up and steels its
+//     BOTTOM; the heel bends down and steels its TOP. Three members, three
+//     different faces — the single most common detailing error on this
+//     element, and a number on its own cannot express it.
+//   • WHERE THE THRUST ACTS. Earth pressure is TRIANGULAR (resultant at H/3)
+//     while a surcharge is RECTANGULAR (resultant at H/2). The page adds
+//     their moments; the drawing shows why they cannot be added before that.
+//   • WHAT THE BASE IS SITTING ON. The bearing pressure is a trapezoid that
+//     collapses to a triangle once the resultant leaves the middle third —
+//     which is exactly the moment the heel starts to lift.
+//   • THAT THE PRESSURE IS WHAT LOADS THE TOE. The same trapezoid is the
+//     load on the toe cantilever, drawn once and used twice.
+//
+// LAYOUT NOTE. Bars carry numbered MARKS and are listed in a schedule below
+// the section, rather than each having a leader out to its own block of
+// text. The first version used long leaders and they collided with the
+// dimension lines and ran past the frame — which is also why real detail
+// sheets mark and schedule instead of annotating in place.
+//
+// Geometry only. `engine/retainingWall` decides everything; every number
+// here is passed in and labelled, never recomputed.
+// ─────────────────────────────────────────────────────────────────────────
+
+const INK = '#37526e'
+const CONC = '#eef3f8'
+const SOIL = '#e7e2d4'
+const EARTH = '#c2402a'      // active pressure — what pushes the wall over
+const BEAR = '#0e7490'       // bearing pressure — what holds it up
+const BAR = '#0f4c92'        // reinforcement
+const DIM = '#1f77b4'
+const FAINT = '#a39d8d'
+const GRID = '#d8d3c6'
+
+export interface RetainingWallSectionProps {
+  /** Geometry, mm — as entered on the page. */
+  Hs: number; tb: number; ts: number; bt: number; bh: number
+  /** Service earth-pressure resultants, kN/m, and the surcharge, kPa. */
+  Pa: number; Pq: number; q_sur: number
+  /** Retained height and base width, m. */
+  H: number; B: number
+  /** Service bearing pressures at toe and heel, kPa. */
+  q_max: number; q_min: number
+  /** Resultant position from the toe and its eccentricity, m. */
+  xbar: number; e: number
+  /** Bar callouts, already formatted (e.g. "⌀16 @ 250"). */
+  bars: { stem: string; toe: string; heel: string; temp: string }
+}
+
+export function RetainingWallSection(p: RetainingWallSectionProps) {
+  const { Hs, tb, ts, bt, bh, H, B, q_max, q_min, xbar, e, bars } = p
+
+  // ── frame ───────────────────────────────────────────────────────────────
+  // Left carries the two vertical dimensions and the (uncounted) passive
+  // wedge; right carries the pressure diagram and its two resultants; below
+  // the section sit the dimension chain, the bearing diagram and the bar
+  // schedule, each in its own band so nothing can overlap anything else.
+  // The surcharge arrows and their label live ABOVE the ground line, so the
+  // top margin has to grow to make room for them — otherwise they print
+  // through the drawing's own subtitle.
+  const ML = 132, MR = 244, MT = p.q_sur > 0 ? 78 : 54
+  const DRAW_H = 300
+  const wallH = (Hs + tb) / 1000
+  const s = DRAW_H / Math.max(wallH, 1e-9)          // m → px, both axes
+  const bw = B * s
+
+  const x0 = ML                                     // the toe (x = 0)
+  const yTop = MT, yBase = MT + (Hs / 1000) * s, yBot = MT + DRAW_H
+  const xStemL = x0 + (bt / 1000) * s
+  const xStemR = xStemL + (ts / 1000) * s
+  const xHeel = x0 + bw
+
+  // bands below the section
+  const yDim1 = yBot + 30, yDim2 = yBot + 56
+  const yq = yBot + 96, qh = 48
+  const ySch = yq + qh + 64
+  const W = ML + bw + MR, HT = ySch + 86
+
+  // pressure diagram, to the right of the backfill
+  const xp = xHeel + 40, wedge = 58
+  const rect = p.q_sur > 0 ? 20 : 0
+  const xLbl = xp + wedge + rect + 30
+
+  const lift = q_min < 0
+
+  return (
+    <svg viewBox={`0 0 ${W} ${HT}`} className="mx-auto block h-auto w-full"
+      style={{ fontFamily: 'Arial, sans-serif' }}>
+      <defs>
+        <pattern id="rw-soil" width="8" height="8" patternUnits="userSpaceOnUse">
+          <path d="M0 8 L8 0" stroke={GRID} strokeWidth={0.8} />
+        </pattern>
+        <marker id="rw-arrow" markerWidth="7" markerHeight="7" refX="6" refY="2.5"
+          orient="auto"><path d="M0 0 L6 2.5 L0 5 z" fill={EARTH} /></marker>
+      </defs>
+
+      <text x={x0 - 60} y={22} fontSize={10} fontWeight={700} fill={INK}>
+        SECTION — cantilever retaining wall
+      </text>
+      <text x={x0 - 60} y={34} fontSize={7} fill={FAINT}>
+        Drawn to scale from the entered geometry. Marks ①–⑤ are scheduled below.
+      </text>
+
+      {/* ── retained soil, behind the stem and over the heel ─────────────── */}
+      <rect x={xStemR} y={yTop} width={xp - xStemR} height={yBase - yTop} fill={SOIL} />
+      <rect x={xStemR} y={yTop} width={xp - xStemR} height={yBase - yTop} fill="url(#rw-soil)" />
+      <line x1={xStemR} y1={yTop} x2={xp} y2={yTop} stroke={INK} strokeWidth={1.4} />
+      {p.q_sur > 0 && (
+        <g>
+          {Array.from({ length: 6 }, (_, k) => {
+            const x = xStemR + 12 + k * ((xp - 16 - xStemR) / 5)
+            return <line key={k} x1={x} y1={yTop - 15} x2={x} y2={yTop - 2}
+              stroke={EARTH} strokeWidth={1.1} markerEnd="url(#rw-arrow)" />
+          })}
+          <text x={(xStemR + xp) / 2} y={yTop - 20} fontSize={7.5} fill={EARTH}
+            textAnchor="middle">q = {p.q_sur.toFixed(1)} kPa</text>
+        </g>
+      )}
+
+      {/* soil in front of the toe — faint, because its passive resistance is
+          deliberately NOT counted in the sliding check */}
+      <rect x={x0 - 62} y={yBase - 24} width={62} height={yBot - yBase + 24}
+        fill={SOIL} opacity={0.45} />
+      <line x1={x0 - 62} y1={yBase - 24} x2={x0} y2={yBase - 24} stroke={FAINT} strokeWidth={1} />
+      <text x={x0 - 60} y={yBase - 14} fontSize={6.5} fill={FAINT}>passive — not counted</text>
+
+      {/* ── the wall ────────────────────────────────────────────────────── */}
+      <rect x={xStemL} y={yTop} width={xStemR - xStemL} height={yBase - yTop}
+        fill={CONC} stroke={INK} strokeWidth={1.6} />
+      <rect x={x0} y={yBase} width={bw} height={yBot - yBase}
+        fill={CONC} stroke={INK} strokeWidth={1.6} />
+
+      {/* ── active pressure on the back face ─────────────────────────────── */}
+      <g>
+        {/* triangular earth pressure: 0 at the surface, Ka·γ·H at the base */}
+        <polygon points={`${xp},${yTop} ${xp + wedge},${yBot} ${xp},${yBot}`}
+          fill={EARTH} opacity={0.15} stroke={EARTH} strokeWidth={0.9} />
+        {/* rectangular surcharge pressure, constant with depth */}
+        {rect > 0 && (
+          <rect x={xp + wedge} y={yTop} width={rect} height={yBot - yTop}
+            fill={EARTH} opacity={0.28} stroke={EARTH} strokeWidth={0.9} />
+        )}
+        {/* the two resultants, at their two DIFFERENT heights */}
+        <Thrust y={yBot - (yBot - yTop) / 3} xFrom={xLbl - 6} xTo={xp + 3}
+          label={`Pa = ${p.Pa.toFixed(1)} kN/m`} sub={`at H/3 = ${(H / 3).toFixed(2)} m`}
+          xLbl={xLbl} solid />
+        {p.Pq > 0 && (
+          <Thrust y={yBot - (yBot - yTop) / 2} xFrom={xLbl - 6} xTo={xp + wedge + 3}
+            label={`Pq = ${p.Pq.toFixed(1)} kN/m`} sub={`at H/2 = ${(H / 2).toFixed(2)} m`}
+            xLbl={xLbl} />
+        )}
+        <text x={xp} y={yBot + 12} fontSize={7} fill={EARTH}>Ka·γs·H</text>
+      </g>
+
+      {/* ── reinforcement ───────────────────────────────────────────────── */}
+      {(() => {
+        const c = 7
+        const xEarth = xStemR - c, xFront = xStemL + c
+        const yTopBase = yBase + c, yBotBase = yBot - c
+        return (
+          <g>
+            {/* ① STEM main steel — EARTH face, carried down into the base and
+                bent TOWARD THE TOE. Hooking it that way runs the bar under
+                the stem, where the base is at full depth for the whole
+                development length. */}
+            <path d={`M${xEarth} ${yTop + 10} L${xEarth} ${yBotBase} L${Math.max(x0 + c, xEarth - 40)} ${yBotBase}`}
+              fill="none" stroke={BAR} strokeWidth={2.2} strokeLinecap="round" strokeLinejoin="round" />
+            {/* minimum vertical steel on the front face — §11.6.1 ρl */}
+            <line x1={xFront} y1={yTop + 10} x2={xFront} y2={yBase + 14}
+              stroke={BAR} strokeWidth={1.3} strokeDasharray="5 3" strokeLinecap="round" />
+            {/* ② stem horizontal steel, cut end-on */}
+            {[0.16, 0.38, 0.6, 0.82].map((f) => (
+              <circle key={f} cx={xEarth - 9} cy={yTop + (yBase - yTop) * f} r={1.7} fill={BAR} />
+            ))}
+
+            {/* ③ TOE steel — BOTTOM face, because the toe bends UP */}
+            <path d={`M${xStemR - 4} ${yBotBase} L${x0 + c} ${yBotBase} L${x0 + c} ${yBotBase - 24}`}
+              fill="none" stroke={BAR} strokeWidth={2.2} strokeLinecap="round" strokeLinejoin="round" />
+            {/* ④ HEEL steel — TOP face, because the heel bends DOWN */}
+            <path d={`M${xStemL + 4} ${yTopBase} L${xHeel - c} ${yTopBase} L${xHeel - c} ${yTopBase + 24}`}
+              fill="none" stroke={BAR} strokeWidth={2.2} strokeLinecap="round" strokeLinejoin="round" />
+            {/* ⑤ distribution steel in the base, cut end-on */}
+            {[0.28, 0.5, 0.72].map((f) => (
+              <g key={f}>
+                <circle cx={x0 + bw * f} cy={yTopBase + 9} r={1.5} fill={BAR} opacity={0.75} />
+                <circle cx={x0 + bw * f} cy={yBotBase - 9} r={1.5} fill={BAR} opacity={0.75} />
+              </g>
+            ))}
+
+            {/* marks, set just clear of the steel they name */}
+            <Mark n="1" x={xEarth + 13} y={yTop + 46} />
+            <Mark n="2" x={xEarth - 22} y={yTop + (yBase - yTop) * 0.38} />
+            <Mark n="3" x={x0 + 22} y={yBotBase - 15} />
+            <Mark n="4" x={xHeel - 24} y={yTopBase + 15} />
+            <Mark n="5" x={x0 + bw * 0.5} y={(yTopBase + yBotBase) / 2} />
+          </g>
+        )
+      })()}
+
+      {/* ── dimensions ──────────────────────────────────────────────────── */}
+      <g stroke={DIM} fill={DIM}>
+        <VDim x={x0 - 82} y1={yTop} y2={yBase} label={`Hs = ${(Hs / 1000).toFixed(2)} m`} />
+        <VDim x={x0 - 108} y1={yTop} y2={yBot} label={`H = ${H.toFixed(2)} m`} />
+        {/* A long heel squeezes bt and ts to a few pixels each, and their
+            labels then print over one another. Any segment too narrow to
+            hold its own text gets lifted onto its own tier with a leader. */}
+        {(() => {
+          const segs: [number, number, string][] = [
+            [x0, xStemL, `bt ${bt}`], [xStemL, xStemR, `ts ${ts}`], [xStemR, xHeel, `bh ${bh}`],
+          ]
+          let tier = 0
+          return segs.map(([a, z, label]) => {
+            const narrow = z - a < label.length * 4.6
+            const lift = narrow ? 15 + tier++ * 11 : 0
+            return <HDim key={label} y={yDim1} x1={a} x2={z} label={label} lift={lift} />
+          })
+        })()}
+        <HDim y={yDim2} x1={x0} x2={xHeel} label={`B = ${B.toFixed(2)} m`} />
+        <text x={xHeel + 6} y={(yBase + yBot) / 2 + 3} fontSize={7.5} stroke="none">tb = {tb}</text>
+      </g>
+
+      {/* ── bearing pressure under the base ──────────────────────────────── */}
+      {(() => {
+        // The resultant has to land ON the base for a pressure block to
+        // exist at all. Once x̄ ≤ 0 the wall has already rotated off its toe,
+        // and dividing by 3x̄ reports an absurd pressure (a 158 GPa "q,max"
+        // is what the first version printed) instead of saying so.
+        if (!(xbar > 0.01)) {
+          return (
+            <g>
+              <line x1={x0} y1={yq} x2={xHeel} y2={yq} stroke={INK} strokeWidth={1} />
+              <text x={x0} y={yq + 18} fontSize={9} fontWeight={700} fill={EARTH}>
+                No bearing block — the resultant falls outside the base.
+              </text>
+              <text x={x0} y={yq + 30} fontSize={7.5} fill={FAINT}>
+                x̄ = {xbar.toFixed(2)} m ≤ 0: the wall overturns before any pressure
+                distribution is meaningful. Lengthen the heel.
+              </text>
+            </g>
+          )
+        }
+        const qm = Math.max(q_max, Math.abs(q_min), 1)
+        const hAt = (q: number) => (Math.max(q, 0) / qm) * qh
+        // Once the resultant leaves the middle third the block shortens to
+        // 3x̄ and rises; a trapezoid with a negative corner would be a picture
+        // of something soil cannot do.
+        const contact = lift ? Math.min(3 * xbar, B) : B
+        const xEnd = x0 + contact * s
+        // ΣV/B = (q_max + q_min)/2 by the trapezoid formula, so this is the
+        // triangular block carrying the SAME vertical load over 3x̄.
+        const qToe = lift ? ((q_max + q_min) * B) / (3 * xbar) : q_max
+        const xr = x0 + xbar * s
+        return (
+          <g>
+            <line x1={x0} y1={yq} x2={xHeel} y2={yq} stroke={INK} strokeWidth={1} />
+            <polygon
+              points={lift
+                ? `${x0},${yq} ${xEnd},${yq} ${x0},${yq + hAt(qToe)}`
+                : `${x0},${yq} ${xHeel},${yq} ${xHeel},${yq + hAt(q_min)} ${x0},${yq + hAt(q_max)}`}
+              fill={BEAR} opacity={0.2} stroke={BEAR} strokeWidth={1.3} />
+            <text x={x0 - 6} y={yq + hAt(lift ? qToe : q_max) + 4} fontSize={8} fill={BEAR}
+              textAnchor="end">q,max {(lift ? qToe : q_max).toFixed(1)} kPa</text>
+            <text x={xHeel + 6} y={yq + Math.max(hAt(q_min), 4) + 4} fontSize={8} fill={BEAR}>
+              q,min {Math.max(q_min, 0).toFixed(1)} kPa
+            </text>
+            {/* the resultant, and the middle third it has to stay inside */}
+            <line x1={xr} y1={yq - 20} x2={xr} y2={yq + 4} stroke={INK} strokeWidth={1.5} />
+            <text x={xr} y={yq - 24} fontSize={7.5} fill={INK} textAnchor="middle">
+              ΣV @ x̄ = {xbar.toFixed(2)} m
+            </text>
+            <g stroke={FAINT} strokeDasharray="3 3">
+              <line x1={x0 + (B / 3) * s} y1={yq - 12} x2={x0 + (B / 3) * s} y2={yq} />
+              <line x1={x0 + (2 * B / 3) * s} y1={yq - 12} x2={x0 + (2 * B / 3) * s} y2={yq} />
+            </g>
+            <text x={x0} y={yq + qh + 22} fontSize={7.5} fill={lift ? EARTH : FAINT}>
+              e = {e.toFixed(3)} m {Math.abs(e) <= B / 6 ? '≤' : '>'} B/6 = {(B / 6).toFixed(3)} m
+              {lift
+                ? ' — heel lifts, so the block is triangular over 3x̄'
+                : ' — the full base stays in compression'}
+            </text>
+            <text x={x0} y={yq + qh + 33} fontSize={7} fill={FAINT}>
+              This same pressure is the load on the toe cantilever.
+            </text>
+          </g>
+        )
+      })()}
+
+      {/* ── bar schedule ────────────────────────────────────────────────── */}
+      {(() => {
+        const rows: [string, string, string][] = [
+          ['1', `STEM vertical ${bars.stem}`, 'EARTH face — the tension face'],
+          ['2', 'STEM horizontal', '§11.6.1 ρt = 0.0020, both faces'],
+          ['3', `TOE ${bars.toe}`, 'BOTTOM of base — the toe bends up'],
+          ['4', `HEEL ${bars.heel}`, 'TOP of base — the heel bends down'],
+          ['5', `Base distribution ${bars.temp}`, '§24.4.3.2 shrinkage & temperature'],
+        ]
+        const colW = (W - x0 - 20) / 2
+        return (
+          <g>
+            <text x={x0 - 60} y={ySch - 10} fontSize={9} fontWeight={700} fill={INK}>
+              BAR SCHEDULE
+            </text>
+            <line x1={x0 - 60} y1={ySch - 5} x2={W - 20} y2={ySch - 5} stroke={INK} strokeWidth={0.8} />
+            {rows.map(([n, label, note], k) => {
+              const col = k % 2, row = Math.floor(k / 2)
+              const bx = x0 - 60 + col * colW, by = ySch + 12 + row * 22
+              return (
+                <g key={n}>
+                  <Mark n={n} x={bx + 6} y={by - 3} />
+                  <text x={bx + 18} y={by} fontSize={8} fontWeight={700} fill={BAR}>{label}</text>
+                  <text x={bx + 18} y={by + 9} fontSize={7} fill={FAINT}>{note}</text>
+                </g>
+              )
+            })}
+          </g>
+        )
+      })()}
+    </svg>
+  )
+}
+
+/** A numbered bar mark — a circled digit, keyed to the schedule. */
+function Mark({ n, x, y }: { n: string; x: number; y: number }) {
+  return (
+    <g>
+      <circle cx={x} cy={y} r={6} fill="#fff" stroke={BAR} strokeWidth={1.1} />
+      <text x={x} y={y + 2.8} fontSize={7.5} fontWeight={700} fill={BAR} textAnchor="middle">{n}</text>
+    </g>
+  )
+}
+
+/** One thrust resultant: an arrow pushing the wall, with its height of action. */
+function Thrust({ y, xFrom, xTo, label, sub, xLbl, solid }: {
+  y: number; xFrom: number; xTo: number; label: string; sub: string
+  xLbl: number; solid?: boolean
+}) {
+  return (
+    <g>
+      <line x1={xFrom} y1={y} x2={xTo} y2={y} stroke={EARTH}
+        strokeWidth={solid ? 1.8 : 1.4} strokeDasharray={solid ? undefined : '4 2'}
+        markerEnd="url(#rw-arrow)" />
+      <text x={xLbl} y={y - 4} fontSize={8} fill={EARTH}>{label}</text>
+      <text x={xLbl} y={y + 7} fontSize={7} fill={FAINT}>{sub}</text>
+    </g>
+  )
+}
+
+function VDim({ x, y1, y2, label }: { x: number; y1: number; y2: number; label: string }) {
+  return (
+    <g>
+      <line x1={x} y1={y1} x2={x} y2={y2} strokeWidth={0.9} />
+      {[y1, y2].map((y) => <line key={y} x1={x - 4} y1={y + 4} x2={x + 4} y2={y - 4} strokeWidth={1.2} />)}
+      <text x={x - 6} y={(y1 + y2) / 2} fontSize={8} textAnchor="middle" stroke="none"
+        transform={`rotate(-90 ${x - 6} ${(y1 + y2) / 2})`}>{label}</text>
+    </g>
+  )
+}
+
+/** `lift` raises the label clear of the dimension line and draws a leader to
+ *  it, for segments too narrow to carry their own text in place. */
+function HDim({ y, x1, x2, label, lift = 0 }: {
+  y: number; x1: number; x2: number; label: string; lift?: number
+}) {
+  const mid = (x1 + x2) / 2
+  return (
+    <g>
+      <line x1={x1} y1={y} x2={x2} y2={y} strokeWidth={0.9} />
+      {[x1, x2].map((x) => <line key={x} x1={x - 3} y1={y + 4} x2={x + 3} y2={y - 4} strokeWidth={1.2} />)}
+      {lift > 0 && <line x1={mid} y1={y - 2} x2={mid} y2={y - lift + 2} strokeWidth={0.6} />}
+      <text x={mid} y={y - 4 - lift} fontSize={7.5} textAnchor="middle" stroke="none">{label}</text>
+    </g>
+  )
+}

--- a/webapp/src/engine/retainingWall.test.ts
+++ b/webapp/src/engine/retainingWall.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { designRetainingWall } from './retainingWall'
+import { designRetainingWall, barSpacing, LF } from './retainingWall'
 
 // Reference: 3 m stem, 500 mm base, 300 mm stem, 500 toe, 1500 heel
 // Soil γ=18 kN/m³, φ=30°, q_sur=0, μ=0.5, qa=200 kPa
@@ -168,9 +168,23 @@ describe('designRetainingWall — stem design', () => {
     expect(r.Pa_stem).toBeCloseTo(0.5 * Ka * 18 * hs ** 2, 6)
   })
 
-  it('Mu_stem = Pa_stem·Hs/3 + Pq_stem·Hs/2', () => {
-    const expected = r.Pa_stem * (hs / 3) + r.Pq_stem * (hs / 2)
-    expect(r.Mu_stem).toBeCloseTo(expected, 6)
+  it('Mu_stem is the FACTORED moment — 1.6·(Pa·Hs/3 + Pq·Hs/2)', () => {
+    // Pa_stem and Pq_stem are service thrusts; Mu is a strength-design action,
+    // so §5.3.1(e) applies 1.6 to both the earth pressure and the surcharge.
+    // This module previously returned the service moment here and compared it
+    // straight against φMn, under-designing the stem by the full 1.6.
+    const service = r.Pa_stem * (hs / 3) + r.Pq_stem * (hs / 2)
+    expect(r.Mu_stem).toBeCloseTo(1.6 * service, 6)
+  })
+
+  it('Vu_stem is the FACTORED shear — 1.6·(Pa + Pq)', () => {
+    expect(r.Vu_stem).toBeCloseTo(1.6 * (r.Pa_stem + r.Pq_stem), 6)
+  })
+
+  it('surcharge and earth pressure carry their own factors', () => {
+    const r2 = designRetainingWall({ ...BASE, q_sur: 12 })
+    expect(r2.Mu_stem).toBeCloseTo(
+      LF.H * r2.Pa_stem * (hs / 3) + LF.L * r2.Pq_stem * (hs / 2), 6)
   })
 
   it('Vc_stem = φ·(√f\'c/6)·b·d / 1000  (kN/m, b=1000 mm)', () => {
@@ -189,5 +203,209 @@ describe('designRetainingWall — stem design', () => {
   it('higher surcharge → larger Mu_stem', () => {
     const r2 = designRetainingWall({ ...BASE, q_sur: 20 })
     expect(r2.Mu_stem).toBeGreaterThan(r.Mu_stem)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// Base-slab design. Hand calculation for BASE, worked through below so the
+// expected numbers are traceable rather than recorded from the code.
+//
+//   Service:  Pa = ½(⅓)(18)(3.5²) = 36.75 kN/m,  MO = 36.75(3.5/3) = 42.875
+//             W_stem 21.24 @ 0.65 · W_base 27.14 @ 1.15 · W_soil 81.0 @ 1.55
+//             ΣV = 129.38,  MR = 170.567
+//   Factored: ΣVu = 1.2(129.38) = 155.256,  MRu = 1.2(170.567) = 204.680
+//             MOu = 1.6(42.875) = 68.600
+//             x̄u = (204.680 − 68.600)/155.256 = 0.87651 m
+//             eu = 1.15 − 0.87651 = 0.27349 < B/6 = 0.38333  → trapezoid
+//             qu,toe  = (155.256/2.3)(1 + 6(0.27349)/2.3) = 115.66 kPa
+//             qu,heel = (155.256/2.3)(1 − 6(0.27349)/2.3) =  19.34 kPa
+// ─────────────────────────────────────────────────────────────────────────
+describe('designRetainingWall — factored base pressure', () => {
+  const r = designRetainingWall(BASE)
+
+  it('ΣVu applies 1.2 to the dead weights', () => {
+    expect(r.sumVu).toBeCloseTo(1.2 * r.sumV, 6)
+  })
+
+  it('MOu applies 1.6 to the lateral thrust', () => {
+    expect(r.MOu).toBeCloseTo(1.6 * r.MO, 6)
+  })
+
+  it('qu at the toe and heel match the hand calculation', () => {
+    expect(r.xbar_u).toBeCloseTo(0.87651, 4)
+    expect(r.qu_toe).toBeCloseTo(115.66, 1)
+    expect(r.qu_heel).toBeCloseTo(19.34, 1)
+    expect(r.uplift_u).toBe(false)
+  })
+
+  it('factored pressure is in equilibrium with ΣVu', () => {
+    // ∫q dx over the base must return the vertical load it carries.
+    expect((r.qu_toe + r.qu_heel) / 2 * r.B).toBeCloseTo(r.sumVu, 5)
+  })
+
+  it('switches to a TRIANGULAR block when eu > B/6', () => {
+    // A short heel throws the factored resultant outside the middle third.
+    // Soil cannot pull down, so the trapezoid formula's negative corner is
+    // wrong; the block must shorten to 3x̄ and rise instead.
+    const r2 = designRetainingWall({ ...BASE, bh: 600 })
+    expect(r2.uplift_u).toBe(true)
+    expect(r2.qu_heel).toBe(0)
+    expect(r2.qu_toe).toBeCloseTo((2 * r2.sumVu) / (3 * r2.xbar_u), 6)
+    // Still in equilibrium: ½·q·(3x̄) = ΣVu.
+    expect(0.5 * r2.qu_toe * 3 * r2.xbar_u).toBeCloseTo(r2.sumVu, 5)
+  })
+})
+
+describe('designRetainingWall — toe and heel', () => {
+  const r = designRetainingWall(BASE)
+
+  it('d is measured from the base thickness and its own cover', () => {
+    expect(r.toe.d).toBeCloseTo(500 - 75 - 8, 9)
+    expect(r.heel.d).toBeCloseTo(r.toe.d, 9)
+  })
+
+  it('toe Mu matches the hand calculation', () => {
+    // w(u) = qu(0.5 − u) = 94.72 + 41.878u kPa, u from the stem face.
+    // Mu = ∫₀^0.5 w·u du = 94.72(0.125) + 41.878(0.125/3) = 13.59 kN·m/m
+    expect(r.toe.Mu).toBeCloseTo(13.59, 1)
+  })
+
+  it('heel Mu matches the hand calculation', () => {
+    // Down: 1.2(23.6)(0.5) + 1.2(18)(3.0) = 78.96 kPa
+    // Up:   qu(0.8 + u) = 82.158 − 41.878u
+    // net = −3.198 + 41.878u → Mu = 1.125(41.878 − 3.198) = 43.52 kN·m/m
+    expect(r.heel.Mu).toBeCloseTo(43.52, 1)
+  })
+
+  it('the heel governs the base slab — it carries the backfill', () => {
+    expect(r.heel.Mu).toBeGreaterThan(r.toe.Mu)
+  })
+
+  it('takes toe shear at d from the face but heel shear AT the face', () => {
+    // §22.5.1.1 relief needs the reaction to compress the region. The toe is
+    // pushed up by bearing (it does); the heel is pushed down by the
+    // backfill, away from the support (it does not).
+    expect(r.toe.xv).toBeCloseTo(r.toe.d / 1000, 9)
+    expect(r.heel.xv).toBe(0)
+  })
+
+  it('heel Vu is the whole net load on the heel', () => {
+    // ∫₀^1.5 (−3.198 + 41.878u) du = −4.797 + 47.113 = 42.32 kN/m
+    expect(r.heel.Vu).toBeCloseTo(42.32, 1)
+  })
+
+  it('both cantilevers pass shear on a 500 mm base', () => {
+    // φVc = 0.75(√28/6)(1000)(417)/1000 = 275.8 kN/m
+    expect(r.toe.phiVc).toBeCloseTo(275.8, 0)
+    expect(r.toe.shearOK).toBe(true)
+    expect(r.heel.shearOK).toBe(true)
+  })
+
+  it('fails shear when the base is far too thin for the heel load', () => {
+    const r2 = designRetainingWall({ ...BASE, tb: 150, Hs: 6000, bh: 3000 })
+    expect(r2.heel.shearOK).toBe(false)
+  })
+
+  it('uses the ONE-WAY SLAB minimum, ρ·Ag — not the beam formula', () => {
+    // §7.6.1.1 → §24.4.3.2. fy = 415 MPa is BELOW Grade 420, so the table's
+    // 0.0020 row applies: 0.0020(1000)(500) = 1000 mm²/m. The beam formula of
+    // §9.6.1.2 would give 1.4/415·1000·417 = 1407 mm²/m — 41% more steel from
+    // a clause that does not apply to a slab.
+    expect(r.heel.As_min).toBeCloseTo(0.0020 * 1000 * 500, 6)
+    expect(r.toe.As_min).toBeCloseTo(0.0020 * 1000 * 500, 6)
+  })
+
+  it('drops to ρ = 0.0018 once fy reaches Grade 420', () => {
+    const r2 = designRetainingWall({ ...BASE, fy: 420 })
+    expect(r2.heel.As_min).toBeCloseTo(0.0018 * 1000 * 500, 6)
+  })
+
+  it('minimum steel governs both cantilevers here', () => {
+    expect(r.heel.As).toBeLessThan(r.heel.As_min)
+    expect(r.heel.As_design).toBeCloseTo(r.heel.As_min, 6)
+  })
+
+  it('provides at least the steel it designed for', () => {
+    for (const c of [r.toe, r.heel]) {
+      expect(c.As_prov).toBeGreaterThanOrEqual(c.As_design - 1e-6)
+      expect(c.spacing).toBeLessThanOrEqual(c.spacingMax)
+    }
+  })
+
+  it('a deeper wall drives more heel moment', () => {
+    const r2 = designRetainingWall({ ...BASE, Hs: 4500 })
+    expect(r2.heel.Mu).toBeGreaterThan(r.heel.Mu)
+  })
+})
+
+describe('designRetainingWall — detailing steel', () => {
+  const r = designRetainingWall(BASE)
+
+  it('stem spacing provides As_design and respects min(3h, 450)', () => {
+    expect(r.s_stem_max).toBe(Math.min(3 * 300, 450))
+    expect(r.As_stem_prov).toBeGreaterThanOrEqual(r.As_design - 1e-6)
+    expect(r.s_stem).toBeLessThanOrEqual(r.s_stem_max)
+  })
+
+  it('stem horizontal steel is §11.6.1 ρt = 0.0020 on the gross section', () => {
+    expect(r.As_horiz).toBeCloseTo(0.0020 * 1000 * 300, 9)
+  })
+
+  it('stem front-face vertical steel is §11.6.1 ρl = 0.0012', () => {
+    expect(r.As_stem_front).toBeCloseTo(0.0012 * 1000 * 300, 9)
+  })
+
+  it('base temperature steel is §24.4.3.2 ρ = 0.0018 at Grade 420', () => {
+    const r2 = designRetainingWall({ ...BASE, fy: 420 })
+    expect(r2.As_temp_base).toBeCloseTo(0.0018 * 1000 * 500, 9)
+  })
+
+  it('uses ρ = 0.0020 below Grade 420 — including fy = 415', () => {
+    // The table's rows are Grade 275/350 → 0.0020 and Grade 420 or greater →
+    // 0.0018. PNS Grade 415 sits under the threshold, so it takes 0.0020.
+    expect(r.As_temp_base).toBeCloseTo(0.0020 * 1000 * 500, 9)
+    expect(designRetainingWall({ ...BASE, fy: 280 }).As_temp_base)
+      .toBeCloseTo(0.0020 * 1000 * 500, 9)
+  })
+})
+
+describe('barSpacing', () => {
+  it('rounds DOWN to a 25 mm module, so As provided never falls short', () => {
+    // ⌀16 (201.06 mm²) for 900 mm²/m: 223.4 mm exact → 200 mm adopted.
+    const { spacing, As_prov } = barSpacing(900, 16, 450)
+    expect(spacing).toBe(200)
+    expect(As_prov).toBeGreaterThan(900)
+  })
+
+  it('never exceeds the code maximum, however light the demand', () => {
+    expect(barSpacing(1, 16, 450).spacing).toBe(450)
+    expect(barSpacing(1, 16, 300).spacing).toBe(300)
+  })
+
+  it('never drops below 75 mm — concrete has to get between the bars', () => {
+    expect(barSpacing(1e6, 12, 450).spacing).toBe(75)
+  })
+
+  it('a bigger bar buys a wider spacing for the same area', () => {
+    expect(barSpacing(900, 20, 450).spacing)
+      .toBeGreaterThan(barSpacing(900, 12, 450).spacing)
+  })
+})
+
+describe('the two load levels stay separate', () => {
+  const r = designRetainingWall(BASE)
+
+  it('stability uses SERVICE loads — factoring would double-count the FS', () => {
+    expect(r.FS_OT).toBeCloseTo(r.MR / r.MO, 9)
+    expect(r.sumV).toBeCloseTo(r.W_stem + r.W_base + r.W_soil + r.W_sur, 9)
+  })
+
+  it('the service bearing pressure is what qa is compared against', () => {
+    expect(r.q_max).toBeLessThan(r.qu_toe)   // service < factored
+    expect(r.bearingOK).toBe(r.q_max <= BASE.qa + 1e-9)
+  })
+
+  it('LF exposes the clause factors so they can be cited, not guessed', () => {
+    expect(LF).toEqual({ H: 1.6, D: 1.2, L: 1.6 })
   })
 })

--- a/webapp/src/engine/retainingWall.ts
+++ b/webapp/src/engine/retainingWall.ts
@@ -1,8 +1,8 @@
 // ─────────────────────────────────────────────────────────────────────────
-// Cantilever retaining wall — stability + stem RC design.
+// Cantilever retaining wall — stability + RC design of stem, toe and heel.
 // Earth pressure: Rankine active theory.
 // Stability: NSCP 2015 §307 (FS_OT ≥ 2.0, FS_SL ≥ 1.5).
-// Stem design: ACI 318-14 §22.5 (shear) + §22.2 (flexure), φ=0.75/0.90.
+// RC design: ACI 318-14 §22.5 (shear) + §22.2 (flexure), φ=0.75/0.90.
 // SI units throughout: geometry mm, forces kN/m, moments kN·m/m, σ kPa.
 // ─────────────────────────────────────────────────────────────────────────
 //
@@ -19,7 +19,36 @@
 //
 // Retained height for earth pressure: H = Hs + tb (includes base thickness).
 // Moments taken about the toe (front edge of base).
+//
+// ── TWO LOAD LEVELS, AND WHY THEY MUST NOT BE MIXED ──────────────────────
+//
+// STABILITY (overturning, sliding, bearing) is a SERVICE-load check. The
+// factor of safety IS the safety margin, so factoring the loads as well
+// would double-count it, and the bearing pressure compared against an
+// allowable qa has to be a service pressure by definition.
+//
+// MEMBER DESIGN (stem, toe, heel) is a STRENGTH check, so it needs FACTORED
+// loads: ACI 318-14 §5.3.1(e) / NSCP 2015 §405.3.1
+//
+//     U = 1.2D + 1.6L + 1.6H
+//
+// with H the lateral earth pressure and the surcharge treated as live.
+//
+// This module previously compared an UNFACTORED stem moment and shear
+// against φMn and φVc, which under-designed the stem by the full 1.6. The
+// factors below are applied to the design actions only; every stability
+// quantity above stays at service level.
 // ─────────────────────────────────────────────────────────────────────────
+
+/** Load factors, ACI 318-14 §5.3.1 / NSCP 2015 §405.3.1. */
+export const LF = {
+  /** Lateral earth pressure H — §5.3.1(e). */
+  H: 1.6,
+  /** Dead load D, where it acts unfavourably. */
+  D: 1.2,
+  /** Surcharge, carried as live load L. */
+  L: 1.6,
+} as const
 
 export interface RetainingWallInput {
   // Geometry (mm)
@@ -42,6 +71,37 @@ export interface RetainingWallInput {
   cover: number    // clear cover to main bar (retained side of stem), mm
   barDia: number   // main stem bar diameter, mm
   gamma_c?: number // unit weight of concrete, kN/m³ (default 23.6)
+
+  /** Clear cover in the base slab, mm — cast against ground, so §20.6.1.3.1
+   *  asks for 75 mm rather than the 50 mm used on a formed face. */
+  coverBase?: number
+  /** Base-slab main bar diameter, mm (default: same as the stem bar). */
+  barDiaBase?: number
+}
+
+/** One cantilever of the base slab (toe or heel), designed as a 1 m strip. */
+export interface SlabCantilever {
+  /** Projection length, m. */
+  L: number
+  /** Effective depth, mm. */
+  d: number
+  /** Factored moment at the critical section (the stem face), kN·m/m. */
+  Mu: number
+  /** Factored shear at the critical section, kN/m. */
+  Vu: number
+  /** Distance from the stem face to the shear critical section, m. */
+  xv: number
+  /** φVc = 0.75·(λ√f'c/6)·b·d, kN/m. */
+  phiVc: number
+  shearOK: boolean
+  /** Flexural steel, mm²/m. */
+  As: number
+  As_min: number
+  As_design: number
+  /** Chosen spacing of the main bar, mm, and the area it provides. */
+  spacing: number
+  As_prov: number
+  spacingMax: number
 }
 
 export interface RetainingWallResult {
@@ -89,6 +149,54 @@ export interface RetainingWallResult {
   As_stem: number   // from flexure (may be < As_min)
   As_min: number    // §9.6.1.2 max(0.25√f'c/fy, 1.4/fy)·b·d
   As_design: number // governing
+
+  /** Stem vertical bar spacing and the area it provides, mm / mm²/m. */
+  s_stem: number
+  As_stem_prov: number
+  s_stem_max: number
+
+  /** Horizontal (temperature) steel in the stem — §11.6.1 ρt = 0.0020. */
+  As_horiz: number
+  s_horiz: number
+  /** Vertical steel on the FRONT face of the stem — §11.6.1 ρl = 0.0012. */
+  As_stem_front: number
+
+  // ── Factored statics, used for member design only ──────────────────────
+  sumVu: number    // factored ΣV, kN/m
+  MRu: number      // factored restoring moment about the toe, kN·m/m
+  MOu: number      // factored overturning moment about the toe, kN·m/m
+  xbar_u: number   // factored resultant position from the toe, m
+  qu_toe: number   // factored bearing pressure at the toe, kPa
+  qu_heel: number  // factored bearing pressure at the heel, kPa
+  /** True when e_u > B/6, so the factored pressure block is triangular and
+   *  bears on only 3·x̄u of the base rather than the whole width. */
+  uplift_u: boolean
+
+  /** Base-slab design. */
+  toe: SlabCantilever
+  heel: SlabCantilever
+  /** Shrinkage and temperature steel in the base slab — §24.4.3.2. */
+  As_temp_base: number
+  s_temp_base: number
+}
+
+// ── Bar spacing ───────────────────────────────────────────────────────────
+
+/**
+ * Spacing of a single layer of ⌀db bars that provides at least As per metre,
+ * rounded DOWN to a 25 mm module because that is how a bar schedule is
+ * written and how a crew sets out.
+ *
+ * The cap is the smaller of the code maximum passed in and 450 mm, and the
+ * floor is 75 mm — below that the bars are too close to place concrete
+ * between, which no clause states but every pour demonstrates.
+ */
+export function barSpacing(As: number, db: number, sMax: number):
+  { spacing: number; As_prov: number } {
+  const Ab = (Math.PI / 4) * db * db
+  const sCalc = As > 1e-9 ? (Ab * 1000) / As : sMax
+  const spacing = Math.max(75, Math.min(Math.floor(sCalc / 25) * 25, sMax))
+  return { spacing, As_prov: (Ab * 1000) / spacing }
 }
 
 export function designRetainingWall(i: RetainingWallInput): RetainingWallResult {
@@ -143,29 +251,144 @@ export function designRetainingWall(i: RetainingWallInput): RetainingWallResult 
   const q_max = q_avg * (1 + 6 * e / B)
   const q_min = q_avg * (1 - 6 * e / B)
 
-  // Stem design at base of stem
   const sqrtFc = Math.sqrt(Math.max(i.fc, 1))
   const b = 1000   // mm — per unit length
+
+  // Flexural steel for a 1 m strip: Rn → ρ → As, ACI 318-14 §22.2 with φ=0.90.
+  // Returns null-safe zero when the section cannot develop the moment (the
+  // discriminant goes negative), which the caller sees as As = 0 alongside a
+  // failing shear or a visibly impossible spacing rather than a NaN.
+  const flexuralAs = (Mu: number, d: number): number => {
+    if (!(d > 0) || Mu <= 0) return 0
+    const Rn = (Mu * 1e6 / 0.9) / (b * d * d)
+    const m = i.fy / (0.85 * i.fc)
+    const disc = 1 - 2 * m * Rn / i.fy
+    if (disc < 0) return Infinity          // section too shallow — no valid ρ
+    return ((1 / m) * (1 - Math.sqrt(disc))) * b * d
+  }
+
+  // §9.6.1.2 minimum flexural steel.
+  const rho_min = Math.max(0.25 * sqrtFc / i.fy, 1.4 / i.fy)
+
+  // §22.5.5.1 one-way shear: φVc = φ·(λ√f'c/6)·b·d, kN/m with λ = 1.
+  const phiVcOf = (d: number) => 0.75 * (sqrtFc / 6) * b * d / 1000
+
+  // ── STEM — factored, §5.3.1(e) ──────────────────────────────────────────
   const d_stem = i.ts - i.cover - i.barDia / 2
 
+  // Service thrusts on the stem, over the STEM height only: the base slab is
+  // below the stem's fixed end and its share of the wedge does not bend it.
   const Pa_stem = 0.5 * Ka * i.gamma_s * hs * hs   // kN/m
   const Pq_stem = Ka * i.q_sur * hs                 // kN/m
-  const Vu_stem = Pa_stem + Pq_stem
-  const Mu_stem = Pa_stem * (hs / 3) + Pq_stem * (hs / 2)  // kN·m/m
 
-  // Shear §22.5.5 (simplified): φVc = φ·(λ√f'c/6)·b·d (kN/m, λ=1)
-  const Vc_stem = 0.75 * (sqrtFc / 6) * b * d_stem / 1000
+  // Factored: earth pressure and surcharge are both multiplied by 1.6.
+  const Vu_stem = LF.H * Pa_stem + LF.L * Pq_stem
+  const Mu_stem = LF.H * Pa_stem * (hs / 3) + LF.L * Pq_stem * (hs / 2)
 
-  // Flexure §22.2 (b = 1000 mm/m)
-  const Rn  = (Mu_stem * 1e6 / 0.9) / (b * d_stem * d_stem)
-  const m   = i.fy / (0.85 * i.fc)
-  const rho = (1 / m) * (1 - Math.sqrt(Math.max(0, 1 - 2 * m * Rn / i.fy)))
-  const As_stem = rho * b * d_stem
+  const Vc_stem = phiVcOf(d_stem)
 
-  // Minimum §9.6.1.2
-  const rho_min  = Math.max(0.25 * sqrtFc / i.fy, 1.4 / i.fy)
-  const As_min   = rho_min * b * d_stem
+  const As_stem = flexuralAs(Mu_stem, d_stem)
+  const As_min = rho_min * b * d_stem
   const As_design = Math.max(As_stem, As_min)
+
+  // §11.7.2.1 — spacing of the stem's vertical steel: min(3h, 450).
+  const s_stem_max = Math.min(3 * i.ts, 450)
+  const stemBars = barSpacing(As_design, i.barDia, s_stem_max)
+
+  // §11.6.1 minimum wall reinforcement, as ratios of the GROSS section:
+  // ρt = 0.0020 horizontal, ρl = 0.0012 vertical. The vertical minimum is the
+  // front (compression) face — the earth face is governed by flexure above.
+  const As_horiz = 0.0020 * b * i.ts
+  const As_stem_front = 0.0012 * b * i.ts
+  const s_horiz = barSpacing(As_horiz, i.barDia, Math.min(3 * i.ts, 450)).spacing
+
+  // ── FACTORED BASE PRESSURE, for toe and heel design ─────────────────────
+  // Same statics as the service check, re-run with §5.3.1(e) factors. Dead
+  // weights ×1.2, surcharge ×1.6, lateral thrust ×1.6.
+  const W_stem_u = LF.D * W_stem, W_base_u = LF.D * W_base
+  const W_soil_u = LF.D * W_soil, W_sur_u = LF.L * W_sur
+  const sumVu = W_stem_u + W_base_u + W_soil_u + W_sur_u
+  const MRu = W_stem_u * arm_stem + W_base_u * arm_base +
+              W_soil_u * arm_soil + W_sur_u * arm_sur
+  const MOu = LF.H * Pa * (H / 3) + LF.L * Pq * (H / 2)
+  const xbar_u = (MRu - MOu) / sumVu
+  const e_u = B / 2 - xbar_u
+
+  // Soil cannot pull the base down, so once e > B/6 the pressure block is a
+  // TRIANGLE bearing on 3·x̄ of the width, not a trapezoid with a negative
+  // corner. Designing the toe off a negative q_min would understate it.
+  const uplift_u = Math.abs(e_u) > B / 6 + 1e-12
+  const contact = 3 * xbar_u              // bearing length, from the toe
+  const qu_toe = uplift_u
+    ? (contact > 1e-9 ? (2 * sumVu) / contact : 0)
+    : (sumVu / B) * (1 + 6 * e_u / B)
+  const qu_heel = uplift_u ? 0 : (sumVu / B) * (1 - 6 * e_u / B)
+
+  /** Factored bearing pressure at distance x from the toe, kPa. */
+  const qu = (x: number): number => {
+    if (x < 0 || x > B) return 0
+    if (!uplift_u) return qu_toe + (qu_heel - qu_toe) * (x / B)
+    return x >= contact ? 0 : qu_toe * (1 - x / contact)
+  }
+
+  // Simpson's rule — exact for the quadratic integrand of ∫w(x)·x dx and for
+  // the linear ∫w(x) dx, so the toe/heel actions carry no quadrature error.
+  const simpson = (f: (x: number) => number, a: number, z: number, n = 200): number => {
+    if (!(z > a)) return 0
+    const h2 = (z - a) / n
+    let s = f(a) + f(z)
+    for (let k = 1; k < n; k++) s += f(a + k * h2) * (k % 2 ? 4 : 2)
+    return (s * h2) / 3
+  }
+
+  const d_base = i.tb - (i.coverBase ?? 75) - (i.barDiaBase ?? i.barDia) / 2
+  const s_base_max = Math.min(3 * i.tb, 450)
+  const dbBase = i.barDiaBase ?? i.barDia
+
+  // The base slab is a ONE-WAY SLAB, so its minimum flexural steel is
+  // §7.6.1.1 → §24.4.3.2: ρ·Ag on the GROSS section, not the beam formula of
+  // §9.6.1.2 on b·d. On a 500 mm base the two differ by better than 50%, and
+  // the beam value is not the applicable clause.
+  const rho_slab_min = i.fy >= 420 ? 0.0018 : 0.0020
+
+  const cantilever = (
+    L: number, w: (u: number) => number, xv: number,
+  ): SlabCantilever => {
+    // u measured from the stem face outward. Mu about the face; Vu is the
+    // net load beyond the shear critical section.
+    const Mu = Math.max(0, simpson((u) => w(u) * u, 0, L))
+    const Vu = Math.max(0, simpson(w, 0, Math.max(0, L - xv)))
+    const As = flexuralAs(Mu, d_base)
+    const As_min_c = rho_slab_min * b * i.tb
+    const As_design_c = Math.max(As, As_min_c)
+    const bars = barSpacing(As_design_c, dbBase, s_base_max)
+    const phiVc = phiVcOf(d_base)
+    return {
+      L, d: d_base, Mu, Vu, xv, phiVc, shearOK: Vu <= phiVc + 1e-9,
+      As, As_min: As_min_c, As_design: As_design_c,
+      spacing: bars.spacing, As_prov: bars.As_prov, spacingMax: s_base_max,
+    }
+  }
+
+  // TOE — net UPWARD. The self-weight of the toe slab and any soil over it
+  // relieve the pressure; both are neglected, which is conservative and
+  // sidesteps applying a load factor to a favourable action.
+  // Shear critical section at d from the face, §22.5.1.1: the bearing
+  // reaction puts the region into compression, so the relief applies.
+  const toe = cantilever(b_t, (u) => qu(b_t - u), d_base / 1000)
+
+  // HEEL — net DOWNWARD: the backfill, the surcharge and the slab's own
+  // weight, less the upward pressure. Here the load acts AWAY from the
+  // support, so §22.5.1.1 does not apply and the critical section stays at
+  // the face of the stem.
+  const w_heel_down = LF.D * gamma_c * t_b + LF.D * i.gamma_s * hs + LF.L * i.q_sur
+  const heel = cantilever(b_h, (u) => w_heel_down - qu(b_t + t_s + u), 0)
+
+  // §24.4.3.2 shrinkage and temperature steel in the base slab, on the gross
+  // section; §24.4.3.3 caps the spacing at min(5h, 450).
+  const rho_temp = i.fy >= 420 ? 0.0018 : 0.0020
+  const As_temp_base = rho_temp * b * i.tb
+  const s_temp_base = barSpacing(As_temp_base, dbBase, Math.min(5 * i.tb, 450)).spacing
 
   return {
     B, H, Ka,
@@ -181,5 +404,9 @@ export function designRetainingWall(i: RetainingWallInput): RetainingWallResult 
     d_stem, Pa_stem, Pq_stem, Vu_stem, Mu_stem, Vc_stem,
     shearOK: Vu_stem <= Vc_stem + 1e-9,
     As_stem, As_min, As_design,
+    s_stem: stemBars.spacing, As_stem_prov: stemBars.As_prov, s_stem_max,
+    As_horiz, s_horiz, As_stem_front,
+    sumVu, MRu, MOu, xbar_u, qu_toe, qu_heel, uplift_u,
+    toe, heel, As_temp_base, s_temp_base,
   }
 }

--- a/webapp/src/lib/retainingWallSolution.ts
+++ b/webapp/src/lib/retainingWallSolution.ts
@@ -1,0 +1,220 @@
+// Worked solution for a cantilever retaining wall.
+// Mirrors engine/retainingWall.ts: symbolic equation, substituted numbers,
+// result with unit, clause reference. Values come from the engine result, so
+// the sheet and the verdict cannot disagree.
+//
+// The sheet is deliberately explicit about WHICH LOAD LEVEL each step is at.
+// Stability runs on service loads (the factor of safety is the margin);
+// member design runs on factored loads (§5.3.1(e) U = 1.2D + 1.6L + 1.6H).
+// Mixing the two is the single most common error in a wall calculation, so
+// each step says which it is using.
+import type { RetainingWallInput, RetainingWallResult, SlabCantilever } from '../engine/retainingWall'
+import { LF } from '../engine/retainingWall'
+import { type SolutionStep, type SolutionLine, sn0, sn1, sn2, sn3, sn4 } from './solution'
+
+const txt = (text: string): SolutionLine => ({ text })
+const eq = (tex: string): SolutionLine => ({ tex })
+
+export function buildRetainingWallSolution(
+  i: RetainingWallInput, r: RetainingWallResult,
+): SolutionStep[] {
+  const gc = i.gamma_c ?? 23.6
+  const hs = i.Hs / 1000, tb = i.tb / 1000, ts = i.ts / 1000
+  const bt = i.bt / 1000, bh = i.bh / 1000
+  const sqfc = Math.sqrt(Math.max(i.fc, 1))
+  const qavg = r.sumV / r.B
+  const qavgU = r.sumVu / r.B
+
+  const steps: SolutionStep[] = [
+    {
+      title: 'Geometry and Rankine active coefficient',
+      clause: 'Rankine (1857) · NSCP 2015 §307',
+      lines: [
+        txt('The retained height for earth pressure is measured from the TOP OF THE WALL to the BOTTOM of the base slab: the wedge pushes on the whole back face of the structure, base included, not just on the stem.'),
+        eq(String.raw`B = b_t + t_s + b_h = ${sn2(bt)} + ${sn2(ts)} + ${sn2(bh)} = ${sn3(r.B)}\ \text{m}`),
+        eq(String.raw`H = H_s + t_b = ${sn2(hs)} + ${sn2(tb)} = ${sn3(r.H)}\ \text{m}`),
+        eq(String.raw`K_a = \tan^2\!\left(45^\circ - \tfrac{\phi}{2}\right) = \tan^2\!\left(45^\circ - \tfrac{${sn1(i.phi_deg)}^\circ}{2}\right) = ${sn4(r.Ka)}`),
+      ],
+      note: 'Rankine assumes a vertical, frictionless back face and a level backfill. A sloping backfill or wall friction needs Coulomb theory instead.',
+    },
+    {
+      title: 'Lateral thrust and overturning moment — SERVICE loads',
+      clause: 'Rankine · moments about the toe',
+      lines: [
+        txt('The soil pressure grows linearly with depth, so its resultant is a triangle acting at H/3 above the base. A uniform surcharge adds a RECTANGULAR pressure block, whose resultant sits at mid-height — the two act at different heights and cannot be added before taking moments.'),
+        eq(String.raw`P_a = \tfrac{1}{2}K_a\gamma_s H^2 = \tfrac{1}{2}(${sn4(r.Ka)})(${sn1(i.gamma_s)})(${sn3(r.H)})^2 = ${sn2(r.Pa)}\ \text{kN/m}`),
+        eq(String.raw`P_q = K_a\,q\,H = (${sn4(r.Ka)})(${sn1(i.q_sur)})(${sn3(r.H)}) = ${sn2(r.Pq)}\ \text{kN/m}`),
+        eq(String.raw`F_h = P_a + P_q = ${sn2(r.Fh)}\ \text{kN/m}`),
+        eq(String.raw`M_O = P_a\frac{H}{3} + P_q\frac{H}{2} = ${sn2(r.Pa)}\left(\frac{${sn3(r.H)}}{3}\right) + ${sn2(r.Pq)}\left(\frac{${sn3(r.H)}}{2}\right) = ${sn2(r.MO)}\ \text{kN·m/m}`),
+      ],
+    },
+    {
+      title: 'Vertical loads and restoring moment — SERVICE loads',
+      clause: 'NSCP 2015 §307 · statics, arms from the toe',
+      lines: [
+        txt('The soil sitting ON THE HEEL is what makes a cantilever wall work: it is usually the largest single restoring force, and it acts at the longest lever arm. The wall is stabilised mostly by the backfill it retains.'),
+        eq(String.raw`W_{stem} = \gamma_c t_s H_s = ${sn1(gc)}(${sn2(ts)})(${sn2(hs)}) = ${sn2(r.W_stem)}\ \text{kN/m} \quad @\ \bar{x} = ${sn3(r.arm_stem)}\ \text{m}`),
+        eq(String.raw`W_{base} = \gamma_c B t_b = ${sn1(gc)}(${sn3(r.B)})(${sn2(tb)}) = ${sn2(r.W_base)}\ \text{kN/m} \quad @\ \bar{x} = ${sn3(r.arm_base)}\ \text{m}`),
+        eq(String.raw`W_{soil} = \gamma_s b_h H_s = ${sn1(i.gamma_s)}(${sn2(bh)})(${sn2(hs)}) = ${sn2(r.W_soil)}\ \text{kN/m} \quad @\ \bar{x} = ${sn3(r.arm_soil)}\ \text{m}`),
+        ...(r.W_sur > 1e-9 ? [eq(String.raw`W_{sur} = q\,b_h = ${sn1(i.q_sur)}(${sn2(bh)}) = ${sn2(r.W_sur)}\ \text{kN/m} \quad @\ \bar{x} = ${sn3(r.arm_sur)}\ \text{m}`)] : []),
+        eq(String.raw`\Sigma V = ${sn2(r.sumV)}\ \text{kN/m}, \qquad M_R = \Sigma W\bar{x} = ${sn2(r.MR)}\ \text{kN·m/m}`),
+      ],
+    },
+    {
+      title: 'Factor of safety against overturning',
+      clause: 'NSCP 2015 §307 — FS ≥ 2.0',
+      pass: r.stableOT,
+      lines: [
+        txt('Taken about the toe, the front bottom edge of the base — the point the wall would rotate about if it tipped forward.'),
+        eq(String.raw`FS_{OT} = \frac{M_R}{M_O} = \frac{${sn2(r.MR)}}{${sn2(r.MO)}} = ${sn2(r.FS_OT)} \;${r.stableOT ? '\\ge' : '<'}\; 2.0`),
+      ],
+      note: r.stableOT ? undefined : 'Lengthen the heel — it adds both weight and lever arm, and is far more effective than thickening the stem.',
+    },
+    {
+      title: 'Factor of safety against sliding',
+      clause: 'NSCP 2015 §307 — FS ≥ 1.5',
+      pass: r.stableSL,
+      lines: [
+        txt('Friction on the underside of the base resists the horizontal thrust. Passive resistance in front of the toe is NEGLECTED: that soil can be excavated for services, scoured, or simply never compacted, and counting on it is how walls move.'),
+        eq(String.raw`F_{res} = \mu\,\Sigma V = ${sn2(i.mu)}(${sn2(r.sumV)}) = ${sn2(i.mu * r.sumV)}\ \text{kN/m}`),
+        eq(String.raw`FS_{SL} = \frac{\mu\,\Sigma V}{F_h} = \frac{${sn2(i.mu * r.sumV)}}{${sn2(r.Fh)}} = ${sn2(r.FS_SL)} \;${r.stableSL ? '\\ge' : '<'}\; 1.5`),
+      ],
+      note: r.stableSL ? undefined : 'Add a shear key under the base, or widen the base to pick up more vertical load — increasing μ is not a design decision.',
+    },
+    {
+      title: 'Bearing pressure under the base — SERVICE loads',
+      clause: 'NSCP 2015 §405 · middle-third rule',
+      pass: r.bearingOK && r.tensionOK,
+      lines: [
+        txt('The resultant of ΣV and Fh crosses the base at x̄ from the toe. Its offset from the base centre is the eccentricity, and while that stays inside the middle third (e ≤ B/6) the whole base stays in compression.'),
+        eq(String.raw`\bar{x} = \frac{M_R - M_O}{\Sigma V} = \frac{${sn2(r.MR)} - ${sn2(r.MO)}}{${sn2(r.sumV)}} = ${sn3(r.xbar)}\ \text{m}`),
+        eq(String.raw`e = \frac{B}{2} - \bar{x} = ${sn3(r.B / 2)} - ${sn3(r.xbar)} = ${sn3(r.e)}\ \text{m} \;${Math.abs(r.e) <= r.B / 6 ? '\\le' : '>'}\; \frac{B}{6} = ${sn3(r.B / 6)}\ \text{m}`),
+        eq(String.raw`q_{max,min} = \frac{\Sigma V}{B}\left(1 \pm \frac{6e}{B}\right) = ${sn2(qavg)}\left(1 \pm \frac{6(${sn3(r.e)})}{${sn3(r.B)}}\right)`),
+        eq(String.raw`q_{max} = ${sn2(r.q_max)}\ \text{kPa} \;${r.bearingOK ? '\\le' : '>'}\; q_a = ${sn1(i.qa)}\ \text{kPa}, \qquad q_{min} = ${sn2(r.q_min)}\ \text{kPa}`),
+      ],
+      note: r.tensionOK
+        ? 'q_min ≥ 0 — the base bears over its full width.'
+        : 'q_min < 0 means the heel wants to LIFT. Soil cannot pull, so the real pressure block shortens and q_max rises above the value above. Lengthen the heel.',
+    },
+    {
+      title: 'Switch to FACTORED loads for member design',
+      clause: 'ACI 318-14 §5.3.1(e) · NSCP 2015 §405.3.1',
+      lines: [
+        txt('Everything above is a service-load stability check, where the factor of safety carries the margin. The stem, toe and heel are STRENGTH checks against φMn and φVc, so from here on the loads are factored: U = 1.2D + 1.6L + 1.6H, with H the lateral earth pressure and the surcharge carried as live load.'),
+        eq(String.raw`\Sigma V_u = ${sn1(LF.D)}\,(W_{stem}+W_{base}+W_{soil}) + ${sn1(LF.L)}\,W_{sur} = ${sn2(r.sumVu)}\ \text{kN/m}`),
+        eq(String.raw`M_{Ou} = ${sn1(LF.H)}\,P_a\frac{H}{3} + ${sn1(LF.L)}\,P_q\frac{H}{2} = ${sn2(r.MOu)}\ \text{kN·m/m}, \qquad M_{Ru} = ${sn2(r.MRu)}\ \text{kN·m/m}`),
+        eq(String.raw`\bar{x}_u = \frac{M_{Ru} - M_{Ou}}{\Sigma V_u} = ${sn3(r.xbar_u)}\ \text{m}, \qquad e_u = ${sn3(r.B / 2 - r.xbar_u)}\ \text{m}`),
+        r.uplift_u
+          ? eq(String.raw`e_u > \frac{B}{6} \Rightarrow \text{triangular block over } 3\bar{x}_u = ${sn3(3 * r.xbar_u)}\ \text{m}: \quad q_{u,toe} = \frac{2\Sigma V_u}{3\bar{x}_u} = ${sn2(r.qu_toe)}\ \text{kPa},\ q_{u,heel} = 0`)
+          : eq(String.raw`q_{u} = \frac{\Sigma V_u}{B}\left(1 \pm \frac{6e_u}{B}\right) = ${sn2(qavgU)}\left(1 \pm \frac{6(${sn3(r.B / 2 - r.xbar_u)})}{${sn3(r.B)}}\right) \Rightarrow q_{u,toe} = ${sn2(r.qu_toe)},\ q_{u,heel} = ${sn2(r.qu_heel)}\ \text{kPa}`),
+      ],
+      note: r.uplift_u
+        ? 'The factored resultant falls outside the middle third, so the pressure block is a triangle bearing on only part of the base. Using the trapezoid formula here would report a negative pressure at the heel and understate the toe.'
+        : undefined,
+    },
+    {
+      title: 'Stem — shear at the base',
+      clause: 'ACI 318-14 §22.5.5.1',
+      pass: r.shearOK,
+      lines: [
+        txt('The stem is a vertical cantilever fixed at the top of the base slab, so only the pressure over the STEM height Hs bends it — the wedge acting on the base slab below is carried straight into the footing.'),
+        eq(String.raw`d = t_s - c_c - \tfrac{d_b}{2} = ${sn0(i.ts)} - ${sn0(i.cover)} - \tfrac{${sn0(i.barDia)}}{2} = ${sn1(r.d_stem)}\ \text{mm}`),
+        eq(String.raw`V_u = ${sn1(LF.H)}P_{a,stem} + ${sn1(LF.L)}P_{q,stem} = ${sn1(LF.H)}(${sn2(r.Pa_stem)}) + ${sn1(LF.L)}(${sn2(r.Pq_stem)}) = ${sn2(r.Vu_stem)}\ \text{kN/m}`),
+        eq(String.raw`\phi V_c = \phi\,\frac{\lambda\sqrt{f'_c}}{6}\,b\,d = 0.75\frac{${sn3(sqfc)}}{6}(1000)(${sn1(r.d_stem)})\times10^{-3} = ${sn2(r.Vc_stem)}\ \text{kN/m}`),
+        eq(String.raw`V_u = ${sn2(r.Vu_stem)} \;${r.shearOK ? '\\le' : '>'}\; \phi V_c = ${sn2(r.Vc_stem)}\ \text{kN/m}`),
+      ],
+      note: r.shearOK ? undefined : 'Thicken the stem at the base. Stirrups in a wall stem are impractical, so shear is a thickness decision.',
+    },
+    {
+      title: 'Stem — flexure and vertical steel',
+      clause: "ACI 318-14 §22.2 · §9.6.1.2 · §11.7.2.1",
+      lines: [
+        txt('The bars go on the EARTH FACE of the stem — that is the tension face, because the soil pushes the wall away from the fill. Putting them on the exposed face is a total loss of capacity, and is the classic detailing error on this member.'),
+        eq(String.raw`M_u = ${sn1(LF.H)}P_{a,stem}\frac{H_s}{3} + ${sn1(LF.L)}P_{q,stem}\frac{H_s}{2} = ${sn2(r.Mu_stem)}\ \text{kN·m/m}`),
+        eq(String.raw`R_n = \frac{M_u}{\phi b d^2} = \frac{${sn2(r.Mu_stem)}\times10^6}{0.9(1000)(${sn1(r.d_stem)})^2} = ${sn4((r.Mu_stem * 1e6 / 0.9) / (1000 * r.d_stem * r.d_stem))}\ \text{MPa}`),
+        eq(String.raw`\rho = \frac{0.85f'_c}{f_y}\left(1 - \sqrt{1 - \frac{2R_n}{0.85f'_c}}\right) \Rightarrow A_s = ${sn1(r.As_stem)}\ \text{mm}^2\text{/m}`),
+        eq(String.raw`A_{s,min} = \max\!\left(\frac{0.25\sqrt{f'_c}}{f_y}, \frac{1.4}{f_y}\right)b\,d = ${sn1(r.As_min)}\ \text{mm}^2\text{/m}`),
+        eq(String.raw`A_{s,design} = \max(${sn1(r.As_stem)},\ ${sn1(r.As_min)}) = \mathbf{${sn1(r.As_design)}}\ \text{mm}^2\text{/m}`),
+        eq(String.raw`s = \frac{A_b \times 1000}{A_{s,design}} \Rightarrow \text{adopt } \varnothing${sn0(i.barDia)}\ @\ \mathbf{${sn0(r.s_stem)}}\ \text{mm} \;\;(A_{s,prov} = ${sn1(r.As_stem_prov)}\ \text{mm}^2\text{/m},\ s_{max} = ${sn0(r.s_stem_max)}\ \text{mm})`),
+      ],
+      note: r.As_min > r.As_stem
+        ? 'Minimum steel governs — the stem is thicker than flexure alone demands, which is normal for a wall sized by shear and stiffness.'
+        : undefined,
+    },
+    cantileverStep(
+      'Toe — upward bearing pressure',
+      'ACI 318-14 §22.5.1.1 (shear at d) · §7.6.1.1',
+      r.toe,
+      [
+        txt('The toe is a cantilever bending UPWARD under the bearing pressure, so its steel goes in the BOTTOM of the base slab. The self-weight of the toe and any soil over it relieve the pressure and are neglected here — conservative, and it avoids applying a load factor to a favourable action.'),
+        txt('Because the bearing reaction puts the toe into compression at the support, §22.5.1.1 allows the shear critical section to be taken at d from the face of the stem.'),
+      ],
+      i,
+    ),
+    cantileverStep(
+      'Heel — downward backfill, less the pressure below',
+      'ACI 318-14 §7.6.1.1 · shear at the face',
+      r.heel,
+      [
+        txt('The heel carries the full weight of the backfill above it plus its own weight, less whatever the soil pushes back up. It bends DOWNWARD, so its steel goes in the TOP of the base slab — the opposite face from the toe, which is why a base slab needs two mats.'),
+        txt('Here the load acts away from the support, so the §22.5.1.1 relief does not apply and the shear critical section stays at the face of the stem.'),
+        eq(String.raw`w_{down} = ${sn1(LF.D)}\gamma_c t_b + ${sn1(LF.D)}\gamma_s H_s + ${sn1(LF.L)}q = ${sn1(LF.D)}(${sn1(gc)})(${sn2(tb)}) + ${sn1(LF.D)}(${sn1(i.gamma_s)})(${sn2(hs)}) + ${sn1(LF.L)}(${sn1(i.q_sur)}) = ${sn2(LF.D * gc * tb + LF.D * i.gamma_s * hs + LF.L * i.q_sur)}\ \text{kPa}`),
+      ],
+      i,
+    ),
+    {
+      title: 'Detailing steel',
+      clause: 'ACI 318-14 §11.6.1 · §24.4.3.2 · §24.4.3.3',
+      lines: [
+        txt('Beyond the flexural steel, a wall needs distributed reinforcement in both directions to control shrinkage and temperature cracking, and to spread any local load. None of it comes from a strength calculation — these are minimum ratios on the GROSS section.'),
+        eq(String.raw`\text{Stem, horizontal: } A_{st} = 0.0020\,b\,t_s = 0.0020(1000)(${sn0(i.ts)}) = ${sn1(r.As_horiz)}\ \text{mm}^2\text{/m} \Rightarrow \varnothing${sn0(i.barDia)}\ @\ ${sn0(r.s_horiz)}\ \text{mm}`),
+        eq(String.raw`\text{Stem, vertical front face: } A_{sl} = 0.0012\,b\,t_s = ${sn1(r.As_stem_front)}\ \text{mm}^2\text{/m}`),
+        eq(String.raw`\text{Base slab: } A_{s,temp} = \rho\,b\,t_b = ${sn4(i.fy >= 420 ? 0.0018 : 0.0020)}(1000)(${sn0(i.tb)}) = ${sn1(r.As_temp_base)}\ \text{mm}^2\text{/m} \Rightarrow \varnothing${sn0(i.barDiaBase ?? i.barDia)}\ @\ ${sn0(r.s_temp_base)}\ \text{mm}`),
+      ],
+      note: `§24.4.3.2 gives ρ = 0.0018 for Grade 420 and above and 0.0020 below it; fy = ${sn0(i.fy)} MPa takes ${i.fy >= 420 ? '0.0018' : '0.0020'}.`,
+    },
+  ]
+
+  return steps
+}
+
+/** One base-slab cantilever, as a step. Toe and heel differ only in their
+ *  narrative and their critical section, so the arithmetic is shared. */
+function cantileverStep(
+  title: string, clause: string, c: SlabCantilever, intro: SolutionLine[],
+  i: RetainingWallInput,
+): SolutionStep {
+  const dbBase = i.barDiaBase ?? i.barDia
+  const govMin = c.As_min >= c.As - 1e-9
+  return {
+    title,
+    clause,
+    pass: c.shearOK,
+    lines: [
+      ...intro,
+      eq(String.raw`d = t_b - c_c - \tfrac{d_b}{2} = ${sn0(i.tb)} - ${sn0(i.coverBase ?? 75)} - \tfrac{${sn0(dbBase)}}{2} = ${sn1(c.d)}\ \text{mm}`),
+      eq(String.raw`M_u = \int_0^{L} w(u)\,u\,du = ${sn2(c.Mu)}\ \text{kN·m/m} \qquad (L = ${sn2(c.L)}\ \text{m})`),
+      eq(String.raw`V_u = \int_0^{L - ${sn3(c.xv)}} w(u)\,du = ${sn2(c.Vu)}\ \text{kN/m} \;${c.shearOK ? '\\le' : '>'}\; \phi V_c = ${sn2(c.phiVc)}\ \text{kN/m}`),
+      eq(String.raw`A_s = ${Number.isFinite(c.As) ? sn1(c.As) : '\\text{section too shallow}'}\ \text{mm}^2\text{/m}, \qquad A_{s,min} = \rho\,b\,t_b = ${sn1(c.As_min)}\ \text{mm}^2\text{/m}`),
+      eq(String.raw`A_{s,design} = ${sn1(c.As_design)}\ \text{mm}^2\text{/m} \Rightarrow \text{adopt } \varnothing${sn0(dbBase)}\ @\ \mathbf{${sn0(c.spacing)}}\ \text{mm} \;\;(A_{s,prov} = ${sn1(c.As_prov)},\ s_{max} = ${sn0(c.spacingMax)}\ \text{mm})`),
+    ],
+    note: !c.shearOK
+      ? 'Shear fails — thicken the base slab. A base slab is not normally stirruped, so this is a depth decision.'
+      : govMin
+        ? `Minimum steel governs (§7.6.1.1 → §24.4.3.2, ρ·Ag on the gross ${sn0(i.tb)} mm section, not the beam formula on b·d).`
+        : undefined,
+  }
+}
+
+/** Bars actually required, as a one-line schedule note for the drawing. */
+export function retainingWallBarNote(i: RetainingWallInput, r: RetainingWallResult): {
+  stem: string; toe: string; heel: string; temp: string
+} {
+  const db = i.barDia, dbB = i.barDiaBase ?? i.barDia
+  return {
+    stem: `⌀${db} @ ${Math.round(r.s_stem)}`,
+    toe: `⌀${dbB} @ ${Math.round(r.toe.spacing)}`,
+    heel: `⌀${dbB} @ ${Math.round(r.heel.spacing)}`,
+    temp: `⌀${dbB} @ ${Math.round(r.s_temp_base)}`,
+  }
+}

--- a/webapp/src/lib/workedSolutions.test.ts
+++ b/webapp/src/lib/workedSolutions.test.ts
@@ -28,6 +28,8 @@ import { searchCriticalCircle, type Pt, type SlopeSoil } from '../engine/slopeSt
 import { buildSlopeSolution } from './slopeSolution'
 import { bromsClay, pyAnalysis } from '../engine/lateralPile'
 import { buildLateralPileSolution } from './lateralPileSolution'
+import { designRetainingWall } from '../engine/retainingWall'
+import { buildRetainingWallSolution } from './retainingWallSolution'
 
 // ─────────────────────────────────────────────────────────────────────────
 // What a worked solution has to be, applied to every builder at once.
@@ -121,6 +123,12 @@ const pileIn = {
   cu: 40, e50: 0.01, phiDeg: 33, k: 25000, gamma: 9,
 }
 
+const rwIn = {
+  Hs: 3000, tb: 500, ts: 300, bt: 500, bh: 1500,
+  gamma_s: 18, phi_deg: 30, q_sur: 10, mu: 0.5, qa: 200,
+  fc: 28, fy: 415, cover: 75, barDia: 16,
+}
+
 const BUILDERS: [string, () => SolutionStep[]][] = [
   ['punching shear', () => buildPunchingSolution(punchIn, designPunchingShear(punchIn))],
   ['torsion', () => buildTorsionSolution(torsIn, designTorsion(torsIn))],
@@ -148,6 +156,7 @@ const BUILDERS: [string, () => SolutionStep[]][] = [
     })
     return buildLateralPileSolution(pileIn, broms, py)
   }],
+  ['retaining wall', () => buildRetainingWallSolution(rwIn, designRetainingWall(rwIn))],
 ]
 
 const eqs = (steps: SolutionStep[]) =>
@@ -174,7 +183,7 @@ describe.each(BUILDERS)('%s worked solution', (_name, build) => {
       // Named methods are citations too — each is a published paper an
       // engineer can pull, which is exactly what this test is protecting.
       'Broms', 'Terzaghi', 'Boussinesq', 'Bishop', 'Fellenius', 'Janbu',
-      'Schmertmann', 'Steinbrenner', 'Matlock', 'Skempton',
+      'Schmertmann', 'Steinbrenner', 'Matlock', 'Skempton', 'Rankine', 'Coulomb',
       'working stress', 'thin-cylinder', 'Good practice',
     ].join('|'), 'i')
     for (const s of steps) {

--- a/webapp/src/pages/RetainingWall.tsx
+++ b/webapp/src/pages/RetainingWall.tsx
@@ -2,6 +2,9 @@ import { useMemo, useState } from 'react'
 import { designRetainingWall, type RetainingWallInput } from '../engine/retainingWall'
 import { Num, Card, ResultCard, Row } from '../components/qty'
 import { PageHeader, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
+import { RetainingWallSection } from '../components/RetainingWallSection'
+import { WorkedSolution } from '../components/WorkedSolution'
+import { buildRetainingWallSolution, retainingWallBarNote } from '../lib/retainingWallSolution'
 import { initialLetterhead } from '../lib/letterhead'
 import { f1, f2, f3 } from '../lib/format'
 
@@ -49,15 +52,19 @@ export default function RetainingWall() {
       <PageHeader title="Cantilever Retaining Wall" badges={['NSCP 2015', 'ACI 318-14']} />
       <div className="mx-auto max-w-[1500px] px-5 pb-8 sm:px-7">
 
-      {/* Schematic legend */}
-      <pre className="no-print mt-3 rounded-lg border border-slate-200 bg-slate-50 p-3 text-[0.65rem] leading-tight text-slate-500">
-{`         |← ts →|
-         +-------+  ← top (Hs)
-         | stem  |
-─────────+───────+──────────  ← top of base
-|← bt →|← ts →|←── bh ──→|
-|           base  (tb)      |`}
-      </pre>
+      {/* The section drawing carries what the numbers cannot: which FACE each
+          mat of bars goes on, and where the two thrust resultants act. */}
+      {r && (
+        <div className="mt-5 rounded-xl border border-slate-200 bg-white p-4 print-avoid-break">
+          <RetainingWallSection
+            Hs={f.Hs} tb={f.tb} ts={f.ts} bt={f.bt} bh={f.bh}
+            Pa={r.Pa} Pq={r.Pq} q_sur={f.q_sur}
+            H={r.H} B={r.B}
+            q_max={r.q_max} q_min={r.q_min} xbar={r.xbar} e={r.e}
+            bars={retainingWallBarNote(f, r)}
+          />
+        </div>
+      )}
 
       <div className="no-print mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
         {/* ── INPUTS ── */}
@@ -138,12 +145,52 @@ export default function RetainingWall() {
 
             <ResultCard title="Stem Design (at base)">
               <Row label="Effective depth d"  value={`${f1(r.d_stem)} mm`} />
-              <Row label="Vu (shear demand)"  value={`${f1(r.Vu_stem)} kN/m`} />
+              <Row label="Vu (factored)"      value={`${f1(r.Vu_stem)} kN/m`} sub="1.6H per §5.3.1(e)" />
               <Row label="φVc"                value={`${f1(r.Vc_stem)} kN/m`} alert={!r.shearOK} />
-              <Row label="Mu (moment demand)" value={`${f1(r.Mu_stem)} kN·m/m`} />
+              <Row label="Mu (factored)"      value={`${f1(r.Mu_stem)} kN·m/m`} />
               <Row label="As required"        value={`${f1(r.As_stem)} mm²/m`} />
               <Row label="As minimum"         value={`${f1(r.As_min)} mm²/m`} />
               <Row label="As design"          value={`${f1(r.As_design)} mm²/m`} />
+              <Row label="Vertical bars (earth face)"
+                value={`⌀${f.barDia} @ ${f1(r.s_stem)} mm`}
+                sub={`provides ${f1(r.As_stem_prov)} mm²/m · s,max ${f1(r.s_stem_max)} mm`} />
+              <Row label="Horizontal bars"
+                value={`⌀${f.barDia} @ ${f1(r.s_horiz)} mm`}
+                sub={`§11.6.1 ρt = 0.0020 → ${f1(r.As_horiz)} mm²/m`} />
+            </ResultCard>
+
+            <ResultCard title="Base Slab — factored pressure">
+              <Row label="ΣVu"        value={`${f1(r.sumVu)} kN/m`} sub="1.2D + 1.6L" />
+              <Row label="x̄u from toe" value={`${f2(r.xbar_u)} m`} />
+              <Row label="qu at toe"  value={`${f1(r.qu_toe)} kPa`} />
+              <Row label="qu at heel" value={`${f1(r.qu_heel)} kPa`}
+                sub={r.uplift_u ? 'triangular block — resultant outside the middle third' : undefined}
+                alert={r.uplift_u} />
+            </ResultCard>
+
+            <ResultCard title="Toe (bottom steel)">
+              <Row label="Projection"     value={`${f2(r.toe.L)} m`} />
+              <Row label="Mu at stem face" value={`${f1(r.toe.Mu)} kN·m/m`} />
+              <Row label="Vu at d from face" value={`${f1(r.toe.Vu)} kN/m`} />
+              <Row label="φVc"            value={`${f1(r.toe.phiVc)} kN/m`} alert={!r.toe.shearOK} />
+              <Row label="As design"      value={`${f1(r.toe.As_design)} mm²/m`}
+                sub={r.toe.As_min >= r.toe.As ? '§7.6.1.1 minimum governs' : 'flexure governs'} />
+              <Row label="Bars"           value={`⌀${f.barDiaBase ?? f.barDia} @ ${f1(r.toe.spacing)} mm`}
+                sub={`provides ${f1(r.toe.As_prov)} mm²/m`} />
+            </ResultCard>
+
+            <ResultCard title="Heel (top steel)">
+              <Row label="Projection"      value={`${f2(r.heel.L)} m`} />
+              <Row label="Mu at stem face" value={`${f1(r.heel.Mu)} kN·m/m`} />
+              <Row label="Vu at face"      value={`${f1(r.heel.Vu)} kN/m`} />
+              <Row label="φVc"             value={`${f1(r.heel.phiVc)} kN/m`} alert={!r.heel.shearOK} />
+              <Row label="As design"       value={`${f1(r.heel.As_design)} mm²/m`}
+                sub={r.heel.As_min >= r.heel.As ? '§7.6.1.1 minimum governs' : 'flexure governs'} />
+              <Row label="Bars"            value={`⌀${f.barDiaBase ?? f.barDia} @ ${f1(r.heel.spacing)} mm`}
+                sub={`provides ${f1(r.heel.As_prov)} mm²/m`} />
+              <Row label="Temperature steel"
+                value={`⌀${f.barDiaBase ?? f.barDia} @ ${f1(r.s_temp_base)} mm`}
+                sub={`§24.4.3.2 → ${f1(r.As_temp_base)} mm²/m`} />
             </ResultCard>
           </div>
         ) : (
@@ -152,22 +199,29 @@ export default function RetainingWall() {
           </p>
         )}
       </div>
+      {r && <WorkedSolution steps={buildRetainingWallSolution(f, r)} />}
+
       <div className="no-print mt-5"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
       {r && (
         <PrintReport
           docTitle="Cantilever Retaining Wall" docCode="RW-01" badges={['NSCP 2015', 'ACI 318-14']}
-          ok={r.stableSL && r.stableOT && r.bearingOK && r.tensionOK && r.shearOK}
+          ok={r.stableSL && r.stableOT && r.bearingOK && r.tensionOK && r.shearOK && r.toe.shearOK && r.heel.shearOK}
           governing={`FS sliding ${f2(r.FS_SL)} · FS overturning ${f2(r.FS_OT)} · q,max ${f1(r.q_max)} kPa`}
           lh={lh}
           stats={[
-            { label: 'Base width B', value: f2(r.B / 1000), unit: 'm' },
-            { label: 'Total height H', value: f2(r.H / 1000), unit: 'm' },
+            // B and H are ALREADY in metres — dividing by 1000 again printed
+            // a 2.3 m base as "0.00 m" on every report this page produced.
+            { label: 'Base width B', value: f2(r.B), unit: 'm' },
+            { label: 'Total height H', value: f2(r.H), unit: 'm' },
             { label: 'q,max', value: f1(r.q_max), unit: 'kPa' },
           ]}
           checks={[
             { name: 'Sliding (FS req 1.5 / FS)', ratio: 1.5 / r.FS_SL, ok: r.stableSL },
             { name: 'Overturning (FS req 2.0 / FS)', ratio: 2.0 / r.FS_OT, ok: r.stableOT },
             { name: 'Bearing q,max / qa', ratio: r.q_max / f.qa, ok: r.bearingOK },
+            { name: 'Stem shear Vu / φVc', ratio: r.Vu_stem / r.Vc_stem, ok: r.shearOK },
+            { name: 'Toe shear Vu / φVc', ratio: r.toe.Vu / r.toe.phiVc, ok: r.toe.shearOK },
+            { name: 'Heel shear Vu / φVc', ratio: r.heel.Vu / r.heel.phiVc, ok: r.heel.shearOK },
           ]}
           data={[
             ['Stem height Hs', `${f.Hs} mm`], ['Base thickness tb', `${f.tb} mm`],


### PR DESCRIPTION
Backlog item: *"retaining wall, there's no finished drawing so add one and detailed properly and add solutions also."*

**Engine layer 7** — standalone design engine.

## A load-factor defect, found while writing the solution

`Mu_stem` and `Vu_stem` were **service** actions compared straight against φMn and φVc. ACI 318-14 §5.3.1(e) / NSCP §405.3.1 give `U = 1.2D + 1.6L + 1.6H`, so the stem was under-designed by the full 1.6:

| default wall | before | after |
|---|---|---|
| `Mu_stem` | 27.00 kN·m/m | **43.20** kN·m/m |

I could not write a worked solution showing an unfactored moment against a strength capacity, so this is fixed here rather than flagged. One existing test asserted the old behaviour; it is rewritten with a comment saying what it was protecting.

**Stability stays at service level**, which is correct and is now stated explicitly in the module header and on every solution step: the factor of safety *is* the margin, and a bearing pressure compared against an allowable `qa` has to be a service pressure by definition. Mixing the two levels is the classic error in a wall calculation, so each step says which one it is using.

## Toe and heel are now designed

The page checked the stem and stopped — leaving the base slab, which the drawing has to show steel in, undesigned.

- **Factored base pressure** from the same statics re-run with §5.3.1(e) factors, including **triangular redistribution** once `e > B/6`. Soil cannot pull down, so the trapezoid formula's negative corner is not a thing that happens; the block shortens to `3x̄` and rises.
- **Toe** — net upward pressure; shear at `d` from the face (§22.5.1.1 applies, the bearing reaction compresses the region). Self-weight relief neglected: conservative, and it avoids applying a load factor to a favourable action.
- **Heel** — backfill + surcharge + self-weight, less the upward pressure; shear **at the face**, because the load acts away from the support so §22.5.1.1 does not apply. Moments by Simpson's rule, exact for these integrands.
- **One-way slab minimum steel**, §7.6.1.1 → §24.4.3.2 `ρ·Ag` on the gross section — *not* the §9.6.1.2 beam formula on `b·d`, which is 41% heavier on a 500 mm base and is not the applicable clause.
- Bar spacing rounded **down** to a 25 mm module, capped by §11.7.2.1 / §24.4.3.3, floored at 75 mm.
- §11.6.1 wall minimums (ρt = 0.0020 horizontal, ρl = 0.0012 vertical) and §24.4.3.2 base temperature steel.

## The drawing

`RetainingWallSection` draws the wall to scale with the backfill, the triangular earth pressure and rectangular surcharge shown as **separate resultants at H/3 and H/2**, the bearing trapezoid, the middle third, and all five bar mats.

Bars carry **numbered marks keyed to a schedule** below the section. The first version used long leaders out to blocks of text and they collided with the dimension lines and ran past the frame — which is exactly why real detail sheets mark and schedule instead of annotating in place.

The point of the drawing is the three different tension faces: **stem on the EARTH face, toe steel in the BOTTOM of the base, heel steel in the TOP.**

## Verified in a headless browser, not assumed

An overlap audit measures every `<text>` box against every other and against the frame, across four geometries: default, with surcharge, a lifting heel, and a 7 m stem with a 5 m heel. It caught **four real defects that the green test suite did not**:

1. The surcharge label printed straight through the drawing's subtitle.
2. `bt` / `ts` labels collided once a long heel squeezed those segments to a few pixels — narrow segments now lift onto their own tier with a leader.
3. The stem dowel was drawn **outside the concrete** on a thin stem.
4. A divide-by-`3x̄` printed **`q,max 158320000000.0 kPa`** when the resultant left the base. It now says the wall overturns, which is the useful answer.

Final state, all four geometries: **0 label overlaps, 0 labels outside the frame, 0 KaTeX errors, 0 non-finite coordinates, 0 page errors.**

## Also fixed

The PDF report divided `B` and `H` by 1000 when both are **already in metres**, so every report this page has ever produced printed `0.00 m` for the base width and total height. The report also now carries the three shear checks.

## Verification

- **+33 engine cases**, expectations worked by hand in the test file (`x̄u = 0.87651 m`, `qu,toe = 115.66 kPa`, `Mu,heel = 43.52 kN·m/m`, …) rather than recorded from the code, plus equilibrium checks on both pressure-block shapes.
- Registered with the shared worked-solution contract test, which gained **Rankine** and **Coulomb** as recognised citations — named published methods, exactly like Terzaghi and Broms already on that list.
- `npm test` — 197 files, **3168 passed**. `npx tsc -b`, `eslint` and `npm run build` all green.

---

Remaining backlog after this: #22 Truss Space optimizer, #30 dev & splice drawing + hint buttons, #35 geotechnical page split, #38 network diagram branching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_