### PR TITLE
feat(dev-length): detail drawing, per-parameter code hints, standard hook

### DIFF
--- a/webapp/src/components/CodeHint.tsx
+++ b/webapp/src/components/CodeHint.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useId, useRef, useState } from 'react'
+import type { CodeHintSpec } from '../lib/devLengthHints'
+
+// ─────────────────────────────────────────────────────────────────────────
+// A "?" button beside an input that opens the clause behind it.
+//
+// The page asks for a factor and shows the number it produced. The step in
+// between — WHICH ROW of which table you are choosing, and why the table is
+// shaped that way — was never on screen, so the page could only be used by
+// someone who already knew the answer.
+//
+// Deliberately not a tooltip: the content is a table and a paragraph, it has
+// to be readable long enough to compare rows, and it has to work on touch.
+// So it is a click-to-open popover that closes on Escape, on outside click,
+// and on a second click of its own button.
+// ─────────────────────────────────────────────────────────────────────────
+
+export function CodeHint({ spec }: { spec: CodeHintSpec }) {
+  const [open, setOpen] = useState(false)
+  const wrap = useRef<HTMLSpanElement>(null)
+  const id = useId()
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false) }
+    const onDown = (e: MouseEvent) => {
+      if (wrap.current && !wrap.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('keydown', onKey)
+    document.addEventListener('mousedown', onDown)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.removeEventListener('mousedown', onDown)
+    }
+  }, [open])
+
+  return (
+    <span ref={wrap} className="no-print relative inline-block align-middle">
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-controls={open ? id : undefined}
+        aria-label={`Code guidance — ${spec.title}`}
+        title={spec.clause}
+        onClick={() => setOpen((v) => !v)}
+        className={`ml-1 inline-flex h-[15px] w-[15px] items-center justify-center rounded-full border text-[10px] font-bold leading-none transition-colors ${
+          open
+            ? 'border-[#0f4c92] bg-[#0f4c92] text-white'
+            : 'border-[#c9c4b6] bg-white text-[#a39d8d] hover:border-[#0f4c92] hover:text-[#0f4c92]'
+        }`}
+      >?</button>
+
+      {open && (
+        <span id={id} role="dialog" aria-label={spec.title}
+          // Anchored to the button but allowed to spill left near the right
+          // edge of a card; the width is capped so a long clause statement
+          // wraps instead of stretching the column.
+          className="absolute left-0 top-[20px] z-50 block w-[min(21rem,78vw)] rounded-lg border border-[#d6d3c9] bg-white p-3 text-left shadow-[0_8px_24px_rgba(15,27,42,.16)]">
+          <span className="mb-1 flex items-baseline gap-2">
+            <span className="text-[12px] font-bold text-[#0f1b2a]">{spec.title}</span>
+            <button type="button" onClick={() => setOpen(false)}
+              aria-label="Close" className="ml-auto text-[13px] leading-none text-[#a39d8d] hover:text-[#5c6675]">×</button>
+          </span>
+          <span className="mb-2 block font-mono text-[10px] font-semibold text-[#0f4c92]">{spec.clause}</span>
+          <span className="block text-[11.5px] leading-relaxed text-[#5c6675]">{spec.statement}</span>
+
+          {spec.table && (
+            <span className="mt-2 block overflow-x-auto">
+              <table className="w-full border-collapse text-[11px]">
+                <thead>
+                  <tr>
+                    {spec.table.head.map((h) => (
+                      <th key={h} className="border-b border-[#d6d3c9] px-1.5 py-1 text-left font-semibold text-[#0f1b2a]">{h}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {spec.table.rows.map((row, i) => (
+                    <tr key={i}>
+                      {row.map((cell, j) => (
+                        <td key={j} className={`border-b border-[#f3f1ea] px-1.5 py-1 align-top ${
+                          j === row.length - 1 ? 'font-mono font-semibold text-[#0f1b2a]' : 'text-[#5c6675]'}`}>{cell}</td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </span>
+          )}
+
+          {spec.why && (
+            <span className="mt-2 block border-t border-[#f3f1ea] pt-2 text-[10.5px] leading-relaxed text-[#a39d8d]">
+              {spec.why}
+            </span>
+          )}
+        </span>
+      )}
+    </span>
+  )
+}

--- a/webapp/src/components/DevLengthDetail.tsx
+++ b/webapp/src/components/DevLengthDetail.tsx
@@ -1,0 +1,249 @@
+// ─────────────────────────────────────────────────────────────────────────
+// What ld, ldh, ls and cb actually are, drawn.
+//
+// The page returns four lengths in millimetres and never says what any of
+// them is measured BETWEEN. Four things the numbers cannot carry:
+//
+//   • ld is measured FROM THE CRITICAL SECTION — the section where the bar
+//     is stressed to fy — not from the face of the support and not from the
+//     end of the bar. Getting the datum wrong is the usual way a bar ends up
+//     short on site while the calculation says it is fine.
+//   • A HOOK is measured to the OUTSIDE END of the bend, and the 12db tail
+//     is NOT part of ldh. Detailers routinely include it and lose the tail.
+//   • A LAP is a length of OVERLAP between two bars, not the length of
+//     either bar, and Class B is 1.3× Class A because more of the steel is
+//     spliced at one section.
+//   • cb is measured to the bar CENTRE, not to its surface — the difference
+//     is db/2, which is enough to move (cb+Ktr)/db a long way.
+//
+// Geometry only. `engine/devLength` decides every number; this labels them.
+// ─────────────────────────────────────────────────────────────────────────
+
+const INK = '#37526e'
+const CONC = '#eef3f8'
+const BAR = '#0f4c92'
+const CRIT = '#c2402a'
+const DIM = '#1f77b4'
+const FAINT = '#a39d8d'
+const TIE = '#0e7490'
+
+export interface DevLengthDetailProps {
+  /** Bar diameter, mm — everything is drawn relative to it. */
+  db: number
+  /** Lengths from the engine, mm. */
+  ld: number
+  ldh: number
+  ls_B: number
+  hookTail: number
+  hookBendDia: number
+  /** Splice class currently being described. */
+  spliceClass?: 'A' | 'B'
+}
+
+/** Panel geometry — every panel is drawn in the same box and then placed. */
+const PW = 300, PH = 152, GAP = 26
+
+export function DevLengthDetail(p: DevLengthDetailProps) {
+  const { db, ld, ldh, ls_B, hookTail, hookBendDia } = p
+  const W = PW * 2 + GAP, H = PH * 2 + GAP + 16
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="mx-auto block h-auto w-full"
+      style={{ fontFamily: 'Arial, sans-serif' }}>
+      <defs>
+        <marker id="dl-tick" markerWidth="6" markerHeight="6" refX="3" refY="3" orient="auto">
+          <path d="M1 5 L5 1" stroke={DIM} strokeWidth="1.2" fill="none" />
+        </marker>
+      </defs>
+
+      <g transform="translate(0,0)"><StraightPanel ld={ld} db={db} /></g>
+      <g transform={`translate(${PW + GAP},0)`}>
+        <HookPanel ldh={ldh} db={db} tail={hookTail} bend={hookBendDia} />
+      </g>
+      <g transform={`translate(0,${PH + GAP})`}>
+        <SplicePanel ls={ls_B} db={db} cls={p.spliceClass ?? 'B'} />
+      </g>
+      <g transform={`translate(${PW + GAP},${PH + GAP})`}><ConfinePanel db={db} /></g>
+    </svg>
+  )
+}
+
+function Title({ n, text, sub }: { n: string; text: string; sub: string }) {
+  return (
+    <g>
+      <text x={0} y={9} fontSize={8.5} fontWeight={700} fill={INK}>{n}  {text}</text>
+      <text x={0} y={19} fontSize={7} fill={FAINT}>{sub}</text>
+    </g>
+  )
+}
+
+/** ─ A ─ straight development in tension, and where it is measured from. */
+function StraightPanel({ ld, db }: { ld: number; db: number }) {
+  const x0 = 30, xEnd = PW - 14, yb = 88          // the bar
+  const xCrit = x0 + 26                            // the critical section
+  return (
+    <g>
+      <Title n="A" text="DEVELOPMENT IN TENSION — ℓd"
+        sub="measured from the critical section to the end of the bar" />
+
+      {/* concrete, with the member continuing off to the left */}
+      <rect x={x0 - 26} y={58} width={xEnd - x0 + 34} height={54} fill={CONC} stroke={INK} strokeWidth={1.1} />
+
+      {/* the critical section: where the bar is stressed to fy */}
+      {/* Labels sit to the RIGHT of the line: anchored `end` on its left they
+          ran off the panel, and this panel is the leftmost one, so off the
+          panel means off the drawing. */}
+      <line x1={xCrit} y1={50} x2={xCrit} y2={120} stroke={CRIT} strokeWidth={1.6} strokeDasharray="5 3" />
+      <text x={xCrit + 4} y={40} fontSize={7} fill={CRIT}>critical section</text>
+      <text x={xCrit + 4} y={49} fontSize={6.5} fill={FAINT}>bar stressed to fy here</text>
+
+      {/* the bar, running through the critical section and beyond */}
+      <line x1={x0 - 24} y1={yb} x2={xEnd} y2={yb} stroke={BAR} strokeWidth={3} strokeLinecap="round" />
+
+      {/* ld, dimensioned between the two things it is actually measured between */}
+      <Dim x1={xCrit} x2={xEnd} y={128} label={`ℓd = ${Math.round(ld)} mm`} />
+      <text x={(xCrit + xEnd) / 2} y={144} fontSize={6.5} fill={FAINT} textAnchor="middle">
+        = {(ld / db).toFixed(0)} db · NOT measured from the support face
+      </text>
+
+      {/* the bond stress that has to add up to the bar force */}
+      {Array.from({ length: 9 }, (_, k) => {
+        const x = xCrit + 8 + k * ((xEnd - xCrit - 12) / 8)
+        return (
+          <g key={k} stroke={FAINT} strokeWidth={0.8}>
+            <line x1={x} y1={yb - 9} x2={x} y2={yb - 4} />
+            <line x1={x} y1={yb + 4} x2={x} y2={yb + 9} />
+          </g>
+        )
+      })}
+      <text x={xEnd} y={yb - 13} fontSize={6.5} fill={FAINT} textAnchor="end">bond over the full length</text>
+    </g>
+  )
+}
+
+/** ─ B ─ standard hook: measured to the OUTSIDE of the bend, tail excluded. */
+function HookPanel({ ldh, db, tail, bend }: { ldh: number; db: number; tail: number; bend: number }) {
+  // xOut has to leave room for BOTH the tail and its dimension inside the
+  // panel, and the tail has to finish inside the concrete — a hook tail
+  // drawn poking out of the member is the opposite of the detail's point.
+  const xCrit = 44, xOut = PW - 78, yb = 74
+  const r = 11                                     // drawn bend radius
+  const tailLen = 24
+  return (
+    <g>
+      <Title n="B" text="STANDARD HOOK — ℓdh"
+        sub="measured to the OUTSIDE of the bend; the 12db tail is extra" />
+
+      <rect x={20} y={48} width={PW - 40} height={68} fill={CONC} stroke={INK} strokeWidth={1.1} />
+      <line x1={xCrit} y1={40} x2={xCrit} y2={122} stroke={CRIT} strokeWidth={1.6} strokeDasharray="5 3" />
+      <text x={xCrit + 4} y={38} fontSize={7} fill={CRIT}>critical section</text>
+
+      {/* straight run, 90° bend, then the tail going DOWN */}
+      <path
+        d={`M${xCrit - 26} ${yb} L${xOut - r} ${yb} A ${r} ${r} 0 0 1 ${xOut} ${yb + r} L${xOut} ${yb + r + tailLen}`}
+        fill="none" stroke={BAR} strokeWidth={3} strokeLinecap="round" />
+
+      {/* ldh stops at the OUTSIDE face of the bend — the point of the panel */}
+      <Dim x1={xCrit} x2={xOut} y={128} label={`ℓdh = ${Math.round(ldh)} mm`} />
+
+      {/* the tail, dimensioned separately so it cannot be read as part of ldh */}
+      <g>
+        <line x1={xOut + 12} y1={yb + r} x2={xOut + 12} y2={yb + r + tailLen} stroke={DIM} strokeWidth={0.9} />
+        {[yb + r, yb + r + tailLen].map((y) => (
+          <line key={y} x1={xOut + 9} y1={y + 3} x2={xOut + 15} y2={y - 3} stroke={DIM} strokeWidth={1.1} />
+        ))}
+        <text x={xOut + 17} y={yb + r + tailLen / 2 + 3} fontSize={7} fill={DIM}>
+          12db = {Math.round(tail)}
+        </text>
+      </g>
+      <text x={20} y={PH - 4} fontSize={6.5} fill={FAINT}>
+        min inside bend ⌀ {Math.round(bend)} mm ({db <= 25 ? '6db' : '8db'}, §25.3.1) · ℓdh ≥ max(8db, 150)
+      </text>
+    </g>
+  )
+}
+
+/** ─ C ─ a lap splice: the OVERLAP, not the bar length. */
+function SplicePanel({ ls, db, cls }: { ls: number; db: number; cls: 'A' | 'B' }) {
+  const yA = 74, yB = 84
+  const xLapL = 74, xLapR = PW - 74
+  return (
+    <g>
+      <Title n="C" text={`TENSION LAP SPLICE — ℓst (Class ${cls})`}
+        sub="the length the two bars OVERLAP, in contact, side by side" />
+
+      <rect x={14} y={54} width={PW - 28} height={52} fill={CONC} stroke={INK} strokeWidth={1.1} />
+
+      {/* two bars, overlapping over ls — drawn on slightly different levels
+          because a contact lap sits the bars against each other, not in line */}
+      <line x1={20} y1={yA} x2={xLapR} y2={yA} stroke={BAR} strokeWidth={3} strokeLinecap="round" />
+      <line x1={xLapL} y1={yB} x2={PW - 20} y2={yB} stroke={BAR} strokeWidth={3} strokeLinecap="round" />
+
+      <Dim x1={xLapL} x2={xLapR} y={120} label={`ℓst = ${Math.round(ls)} mm`} />
+      <text x={PW / 2} y={136} fontSize={6.5} fill={FAINT} textAnchor="middle">
+        = {(ls / db).toFixed(0)} db · Class B = 1.3 × ℓd; Class A only if ≤50% spliced and As,prov ≥ 2As,req
+      </text>
+      <text x={PW / 2} y={146} fontSize={6.5} fill={CRIT} textAnchor="middle">
+        Stagger the splices — this is the overlap, not the bar length.
+      </text>
+    </g>
+  )
+}
+
+/** ─ D ─ the section, and what cb is measured to. */
+function ConfinePanel({ db }: { db: number }) {
+  const cx = PW / 2, cy = 84
+  const bw = 116, bh = 62
+  const l = cx - bw / 2, t = cy - bh / 2
+  const barY = cy + bh / 2 - 16
+  const bars = [-1, 0, 1].map((k) => cx + k * 30)
+  return (
+    <g>
+      <Title n="D" text="SECTION — what cb and Ktr measure"
+        sub="cb is to the bar CENTRE, not to its surface" />
+
+      {/* the beam section */}
+      <rect x={l} y={t} width={bw} height={bh} fill={CONC} stroke={INK} strokeWidth={1.2} />
+      {/* the tie that supplies Ktr */}
+      <rect x={l + 7} y={t + 7} width={bw - 14} height={bh - 14} fill="none" stroke={TIE} strokeWidth={1.6} rx={4} />
+      {/* the bars being developed */}
+      {bars.map((x) => <circle key={x} cx={x} cy={barY} r={4} fill={BAR} />)}
+
+      {/* cb, side branch: to the CENTRE of the corner bar */}
+      <g>
+        <line x1={l} y1={barY} x2={bars[0]} y2={barY} stroke={DIM} strokeWidth={0.9} />
+        {[l, bars[0]].map((x) => <line key={x} x1={x - 3} y1={barY + 4} x2={x + 3} y2={barY - 4} stroke={DIM} strokeWidth={1.1} />)}
+        <text x={(l + bars[0]) / 2} y={barY - 7} fontSize={7} fill={DIM} textAnchor="middle"
+          paintOrder="stroke" stroke="#fff" strokeWidth={2.4}>cb</text>
+      </g>
+      {/* the other cb branch: half the bar spacing */}
+      <g>
+        <line x1={bars[0]} y1={barY + 15} x2={bars[1]} y2={barY + 15} stroke={DIM} strokeWidth={0.9} strokeDasharray="3 2" />
+        <text x={(bars[0] + bars[1]) / 2} y={barY + 26} fontSize={6.5} fill={DIM} textAnchor="middle">s → cb ≤ s/2</text>
+      </g>
+      <text x={l + bw + 6} y={t + 14} fontSize={7} fill={TIE}>tie → Ktr</text>
+      <text x={l + bw + 6} y={t + 24} fontSize={6.5} fill={FAINT}>40Atr/(s·n)</text>
+
+      <text x={l - 16} y={PH - 4} fontSize={6.5} fill={FAINT}>
+        cb = min(cover to CENTRE, s/2) · db = {db} mm · (cb + Ktr)/db ≤ 2.5
+      </text>
+    </g>
+  )
+}
+
+/** A horizontal dimension with slash ticks and the label above the line. */
+function Dim({ x1, x2, y, label }: { x1: number; x2: number; y: number; label: string }) {
+  return (
+    <g>
+      <line x1={x1} y1={y} x2={x2} y2={y} stroke={DIM} strokeWidth={0.9} />
+      {[x1, x2].map((x) => (
+        <g key={x}>
+          <line x1={x - 3} y1={y + 4} x2={x + 3} y2={y - 4} stroke={DIM} strokeWidth={1.2} />
+          <line x1={x} y1={y - 7} x2={x} y2={y + 4} stroke={DIM} strokeWidth={0.6} />
+        </g>
+      ))}
+      <text x={(x1 + x2) / 2} y={y - 5} fontSize={8} fontWeight={700} fill={DIM} textAnchor="middle"
+        paintOrder="stroke" stroke="#fff" strokeWidth={2.6}>{label}</text>
+    </g>
+  )
+}

--- a/webapp/src/components/qty.tsx
+++ b/webapp/src/components/qty.tsx
@@ -21,7 +21,9 @@ export function Num({ label, unit, value, onChange, step = 'any', hint }: {
 }
 
 export function Pick<T extends string>({ label, value, onChange, options }: {
-  label: string; value: T; onChange: (v: T) => void; options: [T, string][]
+  // ReactNode, not string, so a label can carry a `<CodeHint>` beside it —
+  // the same widening `Num` already had.
+  label: ReactNode; value: T; onChange: (v: T) => void; options: [T, string][]
 }) {
   return (
     <label className="flex flex-col text-sm">

--- a/webapp/src/engine/devLength.test.ts
+++ b/webapp/src/engine/devLength.test.ts
@@ -153,3 +153,99 @@ describe('calcDevLength — compression splices §25.5.5', () => {
     expect(r.lsc).toBeGreaterThanOrEqual(300)
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────────
+// §25.4.1.4 — the √f'c cap, and the standard hook of §25.4.3.
+// ─────────────────────────────────────────────────────────────────────────
+describe("§25.4.1.4 — √f'c is capped at 8.3 MPa", () => {
+  const at = (fc: number) => calcDevLength({
+    db: 20, fc, fy: 415, topBar: false, epoxy: 'none', lambda: 1, cbKtr_db: 1.5,
+  })
+
+  it('leaves ordinary strengths alone', () => {
+    expect(at(28).sqrtFc).toBeCloseTo(Math.sqrt(28), 9)
+    expect(at(28).sqrtFcCapped).toBe(false)
+  })
+
+  it('caps at 8.3 and says so', () => {
+    // √69 = 8.307 — just over the cap; √100 = 10 is well over.
+    expect(at(100).sqrtFc).toBe(8.3)
+    expect(at(100).sqrtFcCapped).toBe(true)
+  })
+
+  it('stops ld shrinking with strength once the cap bites', () => {
+    // Without the cap, ld ∝ 1/√f'c would keep falling. It must not.
+    expect(at(100).ld).toBeCloseTo(at(200).ld, 9)
+    expect(at(100).ld).toBeGreaterThan(0)
+  })
+
+  it('applies the cap to EVERY §25.4 length, not just ld', () => {
+    expect(at(100).ldc).toBeCloseTo(at(200).ldc, 9)
+    expect(at(100).ldh).toBeCloseTo(at(200).ldh, 9)
+  })
+
+  it('the cap is conservative — capped ld is LONGER than uncapped would be', () => {
+    const capped = at(100).ld
+    const uncapped = (415 * at(100).psi_te * at(100).psi_s * 20) / (1.1 * 1 * Math.sqrt(100) * 1.5)
+    expect(capped).toBeGreaterThan(uncapped)
+  })
+})
+
+describe('standard hook in tension — §25.4.3', () => {
+  const base = {
+    db: 20, fc: 28, fy: 415, topBar: false, epoxy: 'none' as const,
+    lambda: 1, cbKtr_db: 1.5,
+  }
+  const r = calcDevLength(base)
+
+  it('matches the hand calculation for the reference bar', () => {
+    // ldh = 0.24(1.0)(1.0)(1.0)(415)/(1.0·√28) · 20
+    //     = 99.6/5.2915 · 20 = 376.5 mm
+    expect(r.ldh_raw).toBeCloseTo((0.24 * 415 * 20) / Math.sqrt(28), 3)
+    expect(r.ldh_raw).toBeCloseTo(376.5, 0)
+    expect(r.ldh).toBeCloseTo(r.ldh_raw, 6)
+  })
+
+  it('is much shorter than the straight ld — the whole reason hooks exist', () => {
+    expect(r.ldh).toBeLessThan(r.ld)
+  })
+
+  it('applies the max(8db, 150) floor', () => {
+    // A small bar in strong concrete drives the formula below 8db.
+    const small = calcDevLength({ ...base, db: 10, fy: 275, fc: 55 })
+    expect(small.ldh).toBe(Math.max(8 * 10, 150))
+    expect(small.ldh).toBeGreaterThan(small.ldh_raw)
+  })
+
+  it('ψc = 0.7 for adequate cover, ψr = 0.8 for confining ties', () => {
+    expect(calcDevLength({ ...base, hookCover: true }).psi_c).toBe(0.7)
+    expect(calcDevLength({ ...base, hookTies: true }).psi_r).toBe(0.8)
+    const both = calcDevLength({ ...base, hookCover: true, hookTies: true })
+    expect(both.ldh_raw).toBeCloseTo(r.ldh_raw * 0.7 * 0.8, 6)
+  })
+
+  it('withholds ψc and ψr from bars larger than ⌀36 — §25.4.3.2', () => {
+    const big = calcDevLength({ ...base, db: 40, hookCover: true, hookTies: true })
+    expect(big.psi_c).toBe(1.0)
+    expect(big.psi_r).toBe(1.0)
+  })
+
+  it('uses ψe = 1.2 for a coated hook, never the straight-bar 1.5', () => {
+    const heavy = calcDevLength({ ...base, epoxy: 'coated-heavy' })
+    expect(heavy.psi_e).toBe(1.5)                       // straight bar
+    expect(heavy.ldh_raw).toBeCloseTo(r.ldh_raw * 1.2, 6)  // hook
+  })
+
+  it('ignores the casting-position penalty — ψt does not apply to hooks', () => {
+    const top = calcDevLength({ ...base, topBar: true })
+    expect(top.psi_t).toBe(1.3)                 // still reported for ld
+    expect(top.ldh).toBeCloseTo(r.ldh, 9)       // but the hook is unchanged
+    expect(top.ld).toBeGreaterThan(r.ld)        // while ld does grow
+  })
+
+  it('gives the §25.3.1 hook geometry', () => {
+    expect(r.hookTail).toBe(12 * 20)
+    expect(r.hookBendDia).toBe(6 * 20)                        // ⌀25 and smaller
+    expect(calcDevLength({ ...base, db: 32 }).hookBendDia).toBe(8 * 32)  // ⌀28+
+  })
+})

--- a/webapp/src/engine/devLength.ts
+++ b/webapp/src/engine/devLength.ts
@@ -2,9 +2,26 @@
 // Development and splice lengths — ACI 318-14 §25.4 + §25.5.
 // SI units: lengths mm, stress MPa.
 // Tension development: §25.4.2.3  (SI coefficient 1/1.1 ≈ 0.909).
+// Standard hook in tension: §25.4.3.1, with the §25.3.1 hook geometry.
 // Compression development: §25.4.9.2.
 // Splice — tension Class A/B: §25.5.2; compression: §25.5.5.1–2.
 // ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * §25.4.1.4 — the value of √f'c used to calculate a development length shall
+ * not exceed 8.3 MPa, i.e. f'c is effectively capped at about 69 MPa.
+ *
+ * The clause exists because the splitting bond tests behind §25.4 were run on
+ * ordinary-strength concrete; above that range the measured bond strength
+ * stops tracking √f'c. Without the cap, a high-strength mix buys a shorter
+ * development length than it has been shown to deliver — which is why this is
+ * a cap and not a convenience.
+ */
+export const SQRT_FC_MAX = 8.3
+
+/** √f'c as §25.4.1.4 allows it to be used. */
+export const devSqrtFc = (fc: number): number =>
+  Math.min(Math.sqrt(Math.max(fc, 1)), SQRT_FC_MAX)
 
 /** Epoxy-coating case for ψe factor (§25.4.2.4b). */
 export type EpoxyCase =
@@ -26,6 +43,17 @@ export interface DevLengthInput {
   epoxy: EpoxyCase     // coating → ψe
   lambda: number       // lightweight factor §19.2.4.1: 1.0 normal, 0.75 lightweight
   cbKtr_db: number     // (cb + Ktr)/db confinement term; internally capped at 2.5
+
+  /**
+   * §25.4.3.2 ψc — side cover to the hook ≥ 65 mm AND, for a 90° hook, cover
+   * on the tail extension ≥ 50 mm. Worth 0.7 for ⌀36 and smaller.
+   */
+  hookCover?: boolean
+  /**
+   * §25.4.3.2 ψr — the hook is enclosed within ties or stirrups perpendicular
+   * to the bar at s ≤ 3db. Worth 0.8 for ⌀36 and smaller.
+   */
+  hookTies?: boolean
 }
 
 export interface DevLengthResult {
@@ -51,11 +79,26 @@ export interface DevLengthResult {
 
   // Compression splice §25.5.5
   lsc: number          // compression splice length, mm (≥ 300)
+
+  /** √f'c as §25.4.1.4 permits it to be used, and whether the cap bit. */
+  sqrtFc: number
+  sqrtFcCapped: boolean
+
+  // Standard hook in tension §25.4.3
+  psi_c: number        // §25.4.3.2 cover factor  (0.7 or 1.0)
+  psi_r: number        // §25.4.3.2 confining factor (0.8 or 1.0)
+  ldh_raw: number      // formula result, before the 8db / 150 mm floor
+  ldh: number          // adopted, mm
+  /** §25.3.1 hook geometry, for detailing and for the drawing. */
+  hookTail: number     // 90° hook tail extension, 12db
+  hookBendDia: number  // minimum inside bend diameter, 6db or 8db
 }
 
 export function calcDevLength(i: DevLengthInput): DevLengthResult {
   const { db, fc, fy, lambda } = i
-  const sqrtFc = Math.sqrt(Math.max(fc, 1))
+  // §25.4.1.4 — the cap applies to every length in §25.4, not just to ld.
+  const sqrtFc = devSqrtFc(fc)
+  const sqrtFcCapped = Math.sqrt(Math.max(fc, 1)) > SQRT_FC_MAX + 1e-12
 
   // §25.4.2.4 modification factors
   const psi_t = i.topBar ? 1.3 : 1.0
@@ -87,5 +130,32 @@ export function calcDevLength(i: DevLengthInput): DevLengthResult {
   const lsc_fc  = fc < 21 ? (4 / 3) : 1.0
   const lsc     = Math.max(lsc_raw * lsc_fc, 300)
 
-  return { psi_t, psi_e, psi_s, psi_te, confine, ld_raw, ld, ldc, ls_A, ls_B, lsc }
+  // ── Standard hook in tension §25.4.3.1 ─────────────────────────────────
+  //
+  //     ldh = ( 0.24 · ψe · ψc · ψr · fy ) / ( λ √f'c ) · db
+  //
+  // measured from the CRITICAL SECTION to the OUTSIDE END of the hook, not to
+  // the bend. ψt does NOT appear: the casting-position penalty is a straight-
+  // bar bond effect, and a hook anchors mostly by bearing inside the bend.
+  //
+  // The ψc / ψr reductions apply only to ⌀36 and smaller (§25.4.3.2).
+  const hookEligible = db <= 36
+  const psi_c = hookEligible && i.hookCover ? 0.7 : 1.0
+  const psi_r = hookEligible && i.hookTies ? 0.8 : 1.0
+  // §25.4.3.2: ψe for a hook is 1.2 for epoxy-coated bars and 1.0 otherwise —
+  // it does not carry the 1.5 heavy-coating case that straight bars do.
+  const psi_e_hook = i.epoxy === 'none' ? 1.0 : 1.2
+  const ldh_raw = (0.24 * psi_e_hook * psi_c * psi_r * fy * db) / (lambda * sqrtFc)
+  const ldh = Math.max(ldh_raw, 8 * db, 150)
+
+  // §25.3.1 hook geometry — a 90° hook carries a 12db tail, and the minimum
+  // inside bend diameter steps up at ⌀28.
+  const hookTail = 12 * db
+  const hookBendDia = (db <= 25 ? 6 : 8) * db
+
+  return {
+    psi_t, psi_e, psi_s, psi_te, confine, ld_raw, ld, ldc, ls_A, ls_B, lsc,
+    sqrtFc, sqrtFcCapped,
+    psi_c, psi_r, ldh_raw, ldh, hookTail, hookBendDia,
+  }
 }

--- a/webapp/src/lib/devLengthHints.test.ts
+++ b/webapp/src/lib/devLengthHints.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest'
+import { DEV_HINTS, type CodeHintSpec } from './devLengthHints'
+import { calcDevLength, devSqrtFc, SQRT_FC_MAX, type DevLengthInput } from '../engine/devLength'
+
+// ─────────────────────────────────────────────────────────────────────────
+// A hint that disagrees with the engine is worse than no hint: it teaches
+// the wrong rule with the authority of a clause number. So every factor a
+// hint table quotes is checked against what the engine actually computes
+// for that same condition.
+// ─────────────────────────────────────────────────────────────────────────
+
+const BASE: DevLengthInput = {
+  db: 20, fc: 28, fy: 415, topBar: false, epoxy: 'none', lambda: 1, cbKtr_db: 1.5,
+}
+const specs = Object.entries(DEV_HINTS) as [string, CodeHintSpec][]
+
+describe('every hint is well formed', () => {
+  it.each(specs)('%s carries a clause, a statement and a reason', (_k, h) => {
+    expect(h.title.length).toBeGreaterThan(4)
+    expect(h.clause).toMatch(/ACI 318-14/)
+    expect(h.clause).toMatch(/§\d|Table/)
+    // A statement short enough to be a label is not a statement.
+    expect(h.statement.length).toBeGreaterThan(60)
+    expect(h.why!.length).toBeGreaterThan(60)
+  })
+
+  it.each(specs)('%s has a rectangular table with a header', (_k, h) => {
+    if (!h.table) return
+    expect(h.table.head.length).toBeGreaterThanOrEqual(2)
+    for (const row of h.table.rows) expect(row.length).toBe(h.table.head.length)
+    expect(h.table.rows.length).toBeGreaterThan(1)
+  })
+})
+
+describe('the ψs table matches the engine', () => {
+  it.each([[10, 0.8], [16, 0.8], [20, 0.8], [25, 1.0], [32, 1.0], [36, 1.0]])(
+    '⌀%i → ψs = %f', (db, psi) => {
+      expect(calcDevLength({ ...BASE, db }).psi_s).toBe(psi)
+    })
+
+  it('quotes the same two values the engine can produce', () => {
+    const quoted = DEV_HINTS.db.table.rows.map((r) => parseFloat(r[1]))
+    expect(new Set(quoted)).toEqual(new Set([0.8, 1.0]))
+  })
+})
+
+describe("the √f'c table matches §25.4.1.4 as implemented", () => {
+  it.each(DEV_HINTS.fc.table.rows)("f'c = %s MPa", (fcStr, used) => {
+    const fc = parseFloat(fcStr)
+    const expected = devSqrtFc(fc)
+    // The cell may read "8.31 → 8.3 (cap)" or "8.3 (capped)"; take its first
+    // number and, when the cap applies, require the cell to say so.
+    const shown = parseFloat(used)
+    if (Math.sqrt(fc) > SQRT_FC_MAX) {
+      expect(used).toMatch(/cap/i)
+      expect(expected).toBe(SQRT_FC_MAX)
+    } else {
+      expect(shown).toBeCloseTo(expected, 2)
+    }
+  })
+
+  it('names the cap value the engine uses', () => {
+    expect(DEV_HINTS.fc.statement).toContain(String(SQRT_FC_MAX))
+  })
+})
+
+describe('the ψe table matches the engine', () => {
+  it.each([
+    ['none' as const, 1.0], ['coated-light' as const, 1.2], ['coated-heavy' as const, 1.5],
+  ])('%s → ψe = %f', (epoxy, psi) => {
+    expect(calcDevLength({ ...BASE, epoxy }).psi_e).toBe(psi)
+  })
+
+  it('quotes every value the engine can produce', () => {
+    const quoted = DEV_HINTS.psiE.table.rows.map((r) => parseFloat(r[1]))
+    expect(new Set(quoted)).toEqual(new Set([1.0, 1.2, 1.5]))
+  })
+
+  it('states the 1.7 product cap the engine applies', () => {
+    expect(DEV_HINTS.psiE.statement).toContain('1.7')
+    const worst = calcDevLength({ ...BASE, topBar: true, epoxy: 'coated-heavy' })
+    expect(worst.psi_t * worst.psi_e).toBeCloseTo(1.95, 6)
+    expect(worst.psi_te).toBe(1.7)
+  })
+})
+
+describe('the ψt table matches the engine', () => {
+  it('1.3 for a top bar, 1.0 otherwise', () => {
+    expect(calcDevLength({ ...BASE, topBar: true }).psi_t).toBe(1.3)
+    expect(calcDevLength({ ...BASE, topBar: false }).psi_t).toBe(1.0)
+    expect(DEV_HINTS.psiT.table.rows.map((r) => parseFloat(r[1]))).toEqual([1.3, 1.0])
+  })
+
+  it('names the 300 mm trigger, not a vaguer "near the top"', () => {
+    expect(DEV_HINTS.psiT.statement).toContain('300 mm')
+    expect(DEV_HINTS.psiT.table.rows[0][0]).toContain('300 mm')
+  })
+})
+
+describe('the λ table', () => {
+  it('offers exactly the values Table 19.2.4.1(a) lists', () => {
+    expect(DEV_HINTS.lambda.table.rows.map((r) => parseFloat(r[1]))).toEqual([1.0, 0.85, 0.75])
+  })
+
+  it('lengthens ld, matching the "divides" wording', () => {
+    const light = calcDevLength({ ...BASE, lambda: 0.75 })
+    expect(light.ld).toBeCloseTo(calcDevLength(BASE).ld / 0.75, 6)
+    expect(DEV_HINTS.lambda.statement).toMatch(/DIVIDES/)
+  })
+})
+
+describe('the confinement hint', () => {
+  it('states the 2.5 cap the engine enforces', () => {
+    expect(DEV_HINTS.confine.statement).toContain('2.5')
+    expect(calcDevLength({ ...BASE, cbKtr_db: 4 }).confine).toBe(2.5)
+  })
+
+  it('defines cb to the bar CENTRE — the distinction the drawing makes', () => {
+    expect(DEV_HINTS.confine.statement).toMatch(/centre of the bar/i)
+  })
+
+  it('gives Ktr in the form the clause uses', () => {
+    expect(DEV_HINTS.confine.statement).toContain('40')
+  })
+})
+
+describe('the hook hint matches §25.4.3 as implemented', () => {
+  it('quotes ψc and ψr the engine applies', () => {
+    const both = calcDevLength({ ...BASE, hookCover: true, hookTies: true })
+    expect(both.psi_c).toBe(0.7)
+    expect(both.psi_r).toBe(0.8)
+    const cells = DEV_HINTS.hook.table.rows.map((r) => r[1]).join(' ')
+    expect(cells).toContain('0.7')
+    expect(cells).toContain('0.8')
+  })
+
+  it('states the floor and the geometry the engine returns', () => {
+    const r = calcDevLength(BASE)
+    expect(r.ldh).toBeGreaterThanOrEqual(Math.max(8 * BASE.db, 150))
+    const cells = DEV_HINTS.hook.table.rows.map((r2) => r2.join(' ')).join(' | ')
+    expect(cells).toContain('8db')
+    expect(cells).toContain('150')
+    expect(cells).toContain('12db')          // r.hookTail = 12db
+    expect(cells).toMatch(/6db.*8db/)        // r.hookBendDia steps 6db → 8db
+    expect(r.hookTail).toBe(12 * BASE.db)
+    expect(r.hookBendDia).toBe(6 * BASE.db)
+  })
+
+  it('says ψt does not apply — and the engine agrees', () => {
+    expect(DEV_HINTS.hook.statement).toMatch(/ψt does\s+NOT apply/)
+    expect(calcDevLength({ ...BASE, topBar: true }).ldh)
+      .toBeCloseTo(calcDevLength(BASE).ldh, 9)
+  })
+})

--- a/webapp/src/lib/devLengthHints.ts
+++ b/webapp/src/lib/devLengthHints.ts
@@ -1,0 +1,197 @@
+// ─────────────────────────────────────────────────────────────────────────
+// The code behind each input on the development-length page.
+//
+// Every factor on that page is a lookup from a table in ACI 318-14 §25.4,
+// and the page previously showed only the resulting number. Someone filling
+// it in had to already know which row of which table they were choosing —
+// which is precisely the knowledge the page exists to supply.
+//
+// Held as DATA rather than JSX so it can be asserted against: the tests below
+// check that every row of every table matches what the engine computes for
+// the same condition, so a hint cannot drift away from the calculation it
+// describes.
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface HintTable {
+  /** Column headers. The last column is the factor value. */
+  head: string[]
+  rows: string[][]
+}
+
+export interface CodeHintSpec {
+  /** Short title for the popover. */
+  title: string
+  /** Clause reference, shown in the popover header. */
+  clause: string
+  /** The clause's own statement, paraphrased tightly. */
+  statement: string
+  /** The table the clause defines, when it defines one. */
+  table?: HintTable
+  /** Why the rule exists — the part a table cannot carry. */
+  why?: string
+}
+
+export const DEV_HINTS = {
+  db: {
+    title: 'Bar diameter and ψs',
+    clause: 'ACI 318-14 Table 25.4.2.4',
+    statement:
+      'The bar-size factor ψs is 0.8 for ⌀20 and smaller, and 1.0 for ⌀25 and larger. ' +
+      'It is applied to the tension development length only.',
+    table: {
+      head: ['Bar size', 'ψs'],
+      rows: [['⌀20 and smaller', '0.8'], ['⌀25 and larger', '1.0']],
+    },
+    why:
+      'A smaller bar has more surface area per unit of steel area, so it develops its ' +
+      'yield force in proportionally less length. The step at ⌀25 is the code’s ' +
+      'simplification of a continuous trend.',
+  },
+
+  fc: {
+    title: "Concrete strength f'c",
+    clause: 'ACI 318-14 §25.4.1.4',
+    statement:
+      "The value of √f'c used to calculate development length shall not exceed 8.3 MPa — " +
+      "so f'c is effectively capped at about 69 MPa for every length in §25.4.",
+    table: {
+      head: ["f'c, MPa", "√f'c used"],
+      rows: [
+        ['21', '4.58'], ['28', '5.29'], ['35', '5.92'],
+        ['48', '6.93'], ['69', '8.31 → 8.3 (cap)'], ['80', '8.3 (capped)'],
+      ],
+    },
+    why:
+      'The splitting-bond tests behind §25.4 were run on ordinary-strength concrete. ' +
+      "Above that range the measured bond strength stops tracking √f'c, so a stronger " +
+      'mix cannot be allowed to buy a shorter length than it has been shown to deliver.',
+  },
+
+  fy: {
+    title: 'Bar yield strength fy',
+    clause: 'ACI 318-14 §25.4.2.3',
+    statement:
+      'Development length is DIRECTLY proportional to fy: the bar has to transfer its ' +
+      'full yield force into the concrete, and a higher grade means a larger force over ' +
+      'the same bar surface.',
+    table: {
+      head: ['Grade', 'fy, MPa', 'ld relative to Grade 415'],
+      rows: [['275', '275', '0.66'], ['415 (PNS)', '415', '1.00'], ['420', '420', '1.01'], ['550', '550', '1.33']],
+    },
+    why:
+      'Substituting a higher grade to reduce the bar count does not shorten the ' +
+      'anchorage — it lengthens it, which is how a detail that fitted at Grade 415 ' +
+      'stops fitting at Grade 550.',
+  },
+
+  lambda: {
+    title: 'Lightweight concrete λ',
+    clause: 'ACI 318-14 Table 19.2.4.1(a) · §25.4.2.4',
+    statement:
+      'λ accounts for the reduced tensile strength of lightweight concrete. It DIVIDES ' +
+      'the development length, so λ = 0.75 makes every length 33% longer.',
+    table: {
+      head: ['Concrete', 'λ'],
+      rows: [
+        ['Normalweight', '1.00'],
+        ['Sand-lightweight', '0.85'],
+        ['All-lightweight', '0.75'],
+      ],
+    },
+    why:
+      'Bond failure in §25.4 is a SPLITTING failure — the concrete cracks along the bar ' +
+      'rather than the steel slipping. Splitting is governed by tensile strength, which ' +
+      'is what lightweight aggregate reduces.',
+  },
+
+  psiT: {
+    title: 'Casting position ψt',
+    clause: 'ACI 318-14 Table 25.4.2.4',
+    statement:
+      'ψt = 1.3 where more than 300 mm of fresh concrete is placed BELOW the horizontal ' +
+      'bar as it is cast; 1.0 otherwise.',
+    table: {
+      head: ['Casting position', 'ψt'],
+      rows: [
+        ['More than 300 mm of fresh concrete below the bar', '1.3'],
+        ['Other', '1.0'],
+      ],
+    },
+    why:
+      'Bleed water and entrapped air rise and collect under a bar near the top of a deep ' +
+      'pour, leaving a weaker bond surface. The trigger is the depth of concrete BELOW ' +
+      'the bar during casting — not whether the bar ends up near the top in service.',
+  },
+
+  psiE: {
+    title: 'Epoxy coating ψe',
+    clause: 'ACI 318-14 Table 25.4.2.4',
+    statement:
+      'ψe penalises the reduced friction of a coated bar. §25.4.2.4 also caps the ' +
+      'PRODUCT ψt·ψe at 1.7, so the two penalties cannot both apply in full.',
+    table: {
+      head: ['Condition', 'ψe'],
+      rows: [
+        ['Epoxy-coated, cover < 3db OR clear spacing < 6db', '1.5'],
+        ['All other epoxy-coated or zinc-and-epoxy bars', '1.2'],
+        ['Uncoated or zinc-coated (galvanized)', '1.0'],
+      ],
+    },
+    why:
+      'The 1.7 cap exists because the two effects are not independent: a top bar and a ' +
+      'coated bar both degrade the same bond interface, and testing did not support ' +
+      'multiplying the penalties without limit.',
+  },
+
+  confine: {
+    title: 'Confinement term (cb + Ktr)/db',
+    clause: 'ACI 318-14 §25.4.2.3',
+    statement:
+      'cb is the SMALLER of (a) the distance from the centre of the bar to the nearest ' +
+      'concrete surface, and (b) one-half the centre-to-centre spacing of the bars being ' +
+      'developed. Ktr = 40·Atr/(s·n). The term (cb + Ktr)/db shall not be taken greater ' +
+      'than 2.5.',
+    table: {
+      head: ['Term', 'Meaning'],
+      rows: [
+        ['cb', 'min(cover to bar CENTRE, half the c/c bar spacing), mm'],
+        ['Atr', 'total area of transverse steel crossing the splitting plane, mm²'],
+        ['s', 'spacing of that transverse steel, mm'],
+        ['n', 'number of bars being developed at the splitting plane'],
+        ['Ktr = 0', 'always permitted as a design simplification'],
+        ['cap', '(cb + Ktr)/db ≤ 2.5'],
+      ],
+    },
+    why:
+      'This one term carries the whole splitting mechanism: more cover, wider bar spacing ' +
+      'and more ties all delay the split, and all three shorten ld. The 2.5 cap is there ' +
+      'because beyond it the failure mode changes from splitting to pullout, which the ' +
+      'formula does not describe.',
+  },
+
+  hook: {
+    title: 'Standard hook factors ψc and ψr',
+    clause: 'ACI 318-14 §25.4.3.2 · §25.3.1',
+    statement:
+      'ldh is measured from the critical section to the OUTSIDE END of the hook. ψt does ' +
+      'NOT apply to hooks. ψc and ψr apply to ⌀36 and smaller only, and ψe for a hook is ' +
+      '1.2 for epoxy-coated bars (never 1.5).',
+    table: {
+      head: ['Condition', 'Factor'],
+      rows: [
+        ['Side cover ≥ 65 mm and, for a 90° hook, tail cover ≥ 50 mm', 'ψc = 0.7'],
+        ['Hook enclosed by ties/stirrups ⊥ to the bar at s ≤ 3db', 'ψr = 0.8'],
+        ['Neither condition met', '1.0'],
+        ['Floor on ldh', 'the greater of 8db and 150 mm'],
+        ['90° hook tail (§25.3.1)', '12db'],
+        ['Inside bend diameter (§25.3.1)', '6db for ⌀10–⌀25, 8db for ⌀28–⌀36'],
+      ],
+    },
+    why:
+      'A hook anchors mostly by BEARING inside the bend, not by friction along the bar, ' +
+      'which is why the casting-position penalty drops out and why confinement across ' +
+      'the bend is worth so much — it stops the concrete in front of the hook splitting off.',
+  },
+} as const satisfies Record<string, CodeHintSpec>
+
+export type DevHintKey = keyof typeof DEV_HINTS

--- a/webapp/src/lib/devLengthSolution.ts
+++ b/webapp/src/lib/devLengthSolution.ts
@@ -8,15 +8,20 @@ import { type SolutionStep, type SolutionLine, sn0, sn1, sn2, sn3 } from './solu
 const txt = (text: string): SolutionLine => ({ text })
 const eq = (tex: string): SolutionLine => ({ tex })
 
+// Keyed on the engine's own EpoxyCase values. The first version used
+// 'coated'/'coatedClose', which match nothing the engine emits, so every
+// coated bar printed the raw enum string instead of a reason.
 const EPOXY_WHY: Record<string, string> = {
-  none: 'uncoated bar',
-  coated: 'epoxy-coated, cover ≥ 3db and clear spacing ≥ 6db',
-  coatedClose: 'epoxy-coated with close cover or spacing',
+  'none': 'uncoated or zinc-coated bar',
+  'coated-light': 'epoxy-coated, cover ≥ 3db and clear spacing ≥ 6db',
+  'coated-heavy': 'epoxy-coated with cover < 3db or clear spacing < 6db',
 }
 
 export function buildDevLengthSolution(i: DevLengthInput, r: DevLengthResult): SolutionStep[] {
   const { db, fc, fy, lambda } = i
-  const sq = Math.sqrt(Math.max(fc, 1))
+  // √f'c AS THE ENGINE USED IT — §25.4.1.4 caps it at 8.3. Recomputing it here
+  // let the sheet print a different number from the one the answer came from.
+  const sq = r.sqrtFc
   const ldc1 = (0.24 * fy * db) / (lambda * sq)
   const ldc2 = 0.043 * fy * db
   const lscRaw = fy <= 420 ? 0.0725 * fy * db : (0.13 * fy - 24) * db
@@ -29,10 +34,17 @@ export function buildDevLengthSolution(i: DevLengthInput, r: DevLengthResult): S
         txt('Each factor raises or lowers the basic length for a condition that changes bond quality. ψt penalises bars with more than 300 mm of fresh concrete cast below them, because bleed water collects under the bar. The product ψt·ψe is capped at 1.7.'),
         eq(String.raw`\psi_t = ${sn1(r.psi_t)}\quad(\text{${i.topBar ? 'top bar — more than 300 mm cast below' : 'not a top bar'}})`),
         eq(String.raw`\psi_e = ${sn1(r.psi_e)}\quad(\text{${EPOXY_WHY[i.epoxy] ?? i.epoxy}})`),
-        eq(String.raw`\psi_s = ${sn1(r.psi_s)}\quad(\text{d_b = ${sn0(db)} mm, ${db <= 20 ? '\\le 20 mm' : '> 20 mm'}})`),
+        // d_b and \le have to live in MATH mode. Wrapped in \text{} they are
+        // a KaTeX parse error, and this line rendered as raw source on every
+        // visit to the page.
+        eq(String.raw`\psi_s = ${sn1(r.psi_s)}\quad\left(d_b = ${sn0(db)}\ \text{mm} ${db <= 20 ? '\\le' : '>'} 20\ \text{mm}\right)`),
         eq(String.raw`\psi_t\psi_e = ${sn1(r.psi_t)} \times ${sn1(r.psi_e)} = ${sn2(r.psi_t * r.psi_e)} \Rightarrow \psi_{te} = \min(\ldots, 1.7) = ${sn2(r.psi_te)}`),
         eq(String.raw`\lambda = ${sn2(lambda)}\quad(\text{${lambda < 1 ? 'lightweight concrete' : 'normal-weight concrete'}})`),
+        eq(String.raw`\sqrt{f'_c} = \min(\sqrt{${sn0(fc)}},\ 8.3) = ${sn3(sq)}\ \text{MPa}`),
       ],
+      note: r.sqrtFcCapped
+        ? "§25.4.1.4 caps √f'c at 8.3 MPa, and that cap governs here — concrete stronger than about 69 MPa buys no further reduction in any §25.4 length."
+        : undefined,
     },
     {
       title: 'Confinement term',
@@ -53,6 +65,21 @@ export function buildDevLengthSolution(i: DevLengthInput, r: DevLengthResult): S
         eq(String.raw`\ell_d = \max(${sn1(r.ld_raw)},\ 300) = \mathbf{${sn0(r.ld)}}\ \text{mm}`),
       ],
       note: r.ld_raw < 300 ? 'The 300 mm floor governs.' : undefined,
+    },
+    {
+      title: 'Standard hook in tension',
+      clause: 'ACI 318-14 §25.4.3.1 · §25.4.3.2 · §25.3.1',
+      lines: [
+        txt('Where a straight bar cannot fit, a standard hook anchors it in a much shorter length. ℓdh is measured from the critical section to the OUTSIDE END of the hook, and the 12db tail is NOT part of it. ψt does not appear: the casting-position penalty is a straight-bar bond effect, while a hook anchors mostly by bearing inside the bend.'),
+        eq(String.raw`\ell_{dh} = \frac{0.24\,\psi_e\psi_c\psi_r f_y}{\lambda\sqrt{f'_c}}\,d_b`),
+        eq(String.raw`\psi_e = ${sn1(i.epoxy === 'none' ? 1.0 : 1.2)}\ (\text{hook: 1.2 if coated, never 1.5}),\quad \psi_c = ${sn1(r.psi_c)},\quad \psi_r = ${sn1(r.psi_r)}`),
+        eq(String.raw`\ell_{dh} = \frac{0.24 \times ${sn1(i.epoxy === 'none' ? 1.0 : 1.2)} \times ${sn1(r.psi_c)} \times ${sn1(r.psi_r)} \times ${sn0(fy)}}{${sn2(lambda)} \times ${sn3(sq)}} \times ${sn0(db)} = ${sn1(r.ldh_raw)}\ \text{mm}`),
+        eq(String.raw`\ell_{dh} = \max(${sn1(r.ldh_raw)},\ 8d_b = ${sn0(8 * db)},\ 150) = \mathbf{${sn0(r.ldh)}}\ \text{mm}`),
+        eq(String.raw`\text{tail} = 12d_b = ${sn0(r.hookTail)}\ \text{mm},\qquad \text{inside bend } \varnothing = ${sn0(r.hookBendDia)}\ \text{mm}`),
+      ],
+      note: db > 36
+        ? 'ψc and ψr apply to ⌀36 and smaller only, so both are 1.0 for this bar.'
+        : `ℓdh is ${(r.ldh / r.ld * 100).toFixed(0)}% of the straight ℓd — which is why hooks exist.`,
     },
     {
       title: 'Development length in compression',

--- a/webapp/src/pages/DevLength.tsx
+++ b/webapp/src/pages/DevLength.tsx
@@ -6,6 +6,9 @@ import { ReportControls } from '../components/ReportControls'
 import { buildDevLengthSolution } from '../lib/devLengthSolution'
 import { f0, f1, f2 } from '../lib/format'
 import { WorkedSolution } from '../components/WorkedSolution'
+import { CodeHint } from '../components/CodeHint'
+import { DevLengthDetail } from '../components/DevLengthDetail'
+import { DEV_HINTS } from '../lib/devLengthHints'
 
 const BAR_SIZES: [string, string][] = [
   ['10', '10 mm (ø10)'],
@@ -20,7 +23,9 @@ const BAR_SIZES: [string, string][] = [
 
 interface FormState extends Omit<DevLengthInput, 'db' | 'lambda'> {
   db: string
-  lambda: '1' | '0.75'
+  lambda: '1' | '0.85' | '0.75'
+  hookCover: boolean
+  hookTies: boolean
 }
 
 const DEFAULTS: FormState = {
@@ -30,6 +35,8 @@ const DEFAULTS: FormState = {
   epoxy: 'none',
   lambda: '1',
   cbKtr_db: 1.5,
+  hookCover: false,
+  hookTies: false,
 }
 
 const EPOXY_OPTS: [EpoxyCase, string][] = [
@@ -53,6 +60,7 @@ export default function DevLength() {
       epoxy: f.epoxy,
       lambda: parseFloat(f.lambda),
       cbKtr_db: f.cbKtr_db,
+      hookCover: f.hookCover, hookTies: f.hookTies,
     })
   }, [f])
 
@@ -62,6 +70,7 @@ export default function DevLength() {
   const solution = r ? buildDevLengthSolution({
     db: parseFloat(f.db), fc: f.fc, fy: f.fy, topBar: f.topBar,
     epoxy: f.epoxy, lambda: parseFloat(f.lambda), cbKtr_db: f.cbKtr_db,
+    hookCover: f.hookCover, hookTies: f.hookTies,
   }, r) : null
 
   const report = r ? {
@@ -71,6 +80,7 @@ export default function DevLength() {
     stats: [
       { label: 'ld (tension)', value: f0(r.ld), unit: 'mm' },
       { label: 'Class B splice', value: f0(r.ls_B), unit: 'mm' },
+      { label: 'ldh (hook)', value: f0(r.ldh), unit: 'mm' },
       { label: 'ldc (compression)', value: f0(r.ldc), unit: 'mm' },
     ],
     data: [
@@ -84,6 +94,9 @@ export default function DevLength() {
       ['λ (lightweight)', f.lambda],
       ['Confinement (cb+Ktr)/db', r.confine.toFixed(2)],
       ['ld before 300 mm floor', `${f0(r.ld_raw)} mm`],
+      ["√f'c used (§25.4.1.4 cap 8.3)", r.sqrtFc.toFixed(2)],
+      ['Hook ψc / ψr', `${r.psi_c.toFixed(2)} / ${r.psi_r.toFixed(2)}`],
+      ['Hook ℓdh', `${f0(r.ldh)} mm`],
       ['Class A splice', `${f0(r.ls_A)} mm`],
       ['Compression splice', `${f0(r.lsc)} mm`],
     ] as [string, string][],
@@ -106,27 +119,48 @@ export default function DevLength() {
         {/* ── INPUTS ── */}
         <div className="flex flex-col gap-6">
           <Card title="Bar &amp; Concrete">
-            <Pick label="Bar diameter db" value={f.db} onChange={set('db')} options={BAR_SIZES} />
-            <Num  label="f'c" unit="MPa" value={f.fc} onChange={set('fc')} />
-            <Num  label="fy"  unit="MPa" value={f.fy} onChange={set('fy')} />
-            <Pick label="Lightweight concrete λ" value={f.lambda} onChange={set('lambda')}
-              options={[['1', '1.0 — Normal weight'], ['0.75', '0.75 — Lightweight']]} />
+            <Pick label={<>Bar diameter db<CodeHint spec={DEV_HINTS.db} /></>}
+              value={f.db} onChange={set('db')} options={BAR_SIZES} />
+            <Num  label={<>f'c<CodeHint spec={DEV_HINTS.fc} /></>}
+              unit="MPa" value={f.fc} onChange={set('fc')} />
+            <Num  label={<>fy<CodeHint spec={DEV_HINTS.fy} /></>}
+              unit="MPa" value={f.fy} onChange={set('fy')} />
+            <Pick label={<>Lightweight concrete λ<CodeHint spec={DEV_HINTS.lambda} /></>}
+              value={f.lambda} onChange={set('lambda')}
+              options={[
+                ['1', '1.0 — Normalweight'],
+                ['0.85', '0.85 — Sand-lightweight'],
+                ['0.75', '0.75 — All-lightweight'],
+              ]} />
           </Card>
 
           <Card title="Modification Factors §25.4.2.4">
-            <Pick label="Bar position" value={f.topBar ? 'top' : 'other'}
+            <Pick label={<>Bar position<CodeHint spec={DEV_HINTS.psiT} /></>}
+              value={f.topBar ? 'top' : 'other'}
               onChange={(v) => set('topBar')(v === 'top')}
               options={[['other', 'Other bars (ψt = 1.0)'], ['top', 'Top bar >300 mm (ψt = 1.3)']]} />
-            <Pick label="Epoxy coating" value={f.epoxy} onChange={set('epoxy')}
-              options={EPOXY_OPTS} />
+            <Pick label={<>Epoxy coating<CodeHint spec={DEV_HINTS.psiE} /></>}
+              value={f.epoxy} onChange={set('epoxy')} options={EPOXY_OPTS} />
           </Card>
 
           <Card title="Confinement §25.4.2.3">
-            <Num label="(cb + Ktr) / db" value={f.cbKtr_db} onChange={set('cbKtr_db')}
-              step="0.1" />
+            <Num label={<>(cb + Ktr) / db<CodeHint spec={DEV_HINTS.confine} /></>}
+              value={f.cbKtr_db} onChange={set('cbKtr_db')} step="0.1" />
             <div className="col-span-full text-xs text-slate-500 -mt-2">
               cb = smaller of cover-to-bar-CL or half cc spacing · Ktr = 40Atr/(s·n) · cap 2.5.
               Use 1.5 when in doubt (conservative), 2.5 with adequate cover and ties.
+            </div>
+          </Card>
+
+          <Card title={<>Standard Hook §25.4.3<CodeHint spec={DEV_HINTS.hook} /></>}>
+            <Pick label="Side / tail cover ψc" value={f.hookCover ? 'yes' : 'no'}
+              onChange={(v) => set('hookCover')(v === 'yes')}
+              options={[['no', 'Not satisfied (ψc = 1.0)'], ['yes', 'Cover ≥ 65/50 mm (ψc = 0.7)']]} />
+            <Pick label="Confining ties ψr" value={f.hookTies ? 'yes' : 'no'}
+              onChange={(v) => set('hookTies')(v === 'yes')}
+              options={[['no', 'Not satisfied (ψr = 1.0)'], ['yes', 'Ties at s ≤ 3db (ψr = 0.8)']]} />
+            <div className="col-span-full -mt-2 text-xs text-slate-500">
+              ψc and ψr apply to ⌀36 and smaller only. ψt does NOT apply to hooks.
             </div>
           </Card>
         </div>
@@ -142,12 +176,25 @@ export default function DevLength() {
                 alert={r.psi_t * r.psi_e > 1.7} />
               <Row label="(cb+Ktr)/db used"      value={f2(r.confine)}
                 sub={r.confine < f.cbKtr_db ? 'capped at 2.5' : ''} />
+              <Row label="√f'c used" value={f2(r.sqrtFc)}
+                sub={r.sqrtFcCapped ? '§25.4.1.4 cap 8.3 applied' : ''}
+                alert={r.sqrtFcCapped} />
             </ResultCard>
 
             <ResultCard title="Development Length — Tension §25.4.2.3">
               <Row label="ℓd (formula)" value={`${f0(r.ld_raw)} mm`} />
               <Row label="ℓd (adopted ≥ 300 mm)" value={`${f0(r.ld)} mm`}
                 sub={`${f1(r.ld / parseFloat(f.db))} db`} />
+            </ResultCard>
+
+            <ResultCard title="Standard Hook — Tension §25.4.3">
+              <Row label="ψc — cover" value={f2(r.psi_c)} />
+              <Row label="ψr — confining ties" value={f2(r.psi_r)} />
+              <Row label="ℓdh (formula)" value={`${f0(r.ldh_raw)} mm`} />
+              <Row label="ℓdh (adopted)" value={`${f0(r.ldh)} mm`}
+                sub={`${f1(r.ldh / parseFloat(f.db))} db · floor max(8db, 150)`} />
+              <Row label="Tail 12db (not part of ℓdh)" value={`${f0(r.hookTail)} mm`} />
+              <Row label="Min inside bend ⌀" value={`${f0(r.hookBendDia)} mm`} />
             </ResultCard>
 
             <ResultCard title="Development Length — Compression §25.4.9.2">
@@ -173,6 +220,20 @@ export default function DevLength() {
           </p>
         )}
       </div>
+      {/* What the four lengths are measured BETWEEN — the part the numbers
+          on their own cannot carry. */}
+      {r && (
+        <div className="mt-6 rounded-lg border border-[#e3e1da] bg-white p-4 print-avoid-break">
+          <h2 className="mb-3 text-[13.5px] font-bold text-[#0f1b2a]">
+            Detail — where each length is measured from
+          </h2>
+          <DevLengthDetail
+            db={parseFloat(f.db)} ld={r.ld} ldh={r.ldh} ls_B={r.ls_B}
+            hookTail={r.hookTail} hookBendDia={r.hookBendDia}
+          />
+        </div>
+      )}
+
       {/* The step-by-step already existed and only ever reached the PDF. */}
       {solution && solution.length > 0 && (
         <div className="mt-5">


### PR DESCRIPTION
Backlog item: *"Dev and splice, add drawing and solution and hint buttons on each card of parameters that would pop up a guide with the table or statement from the code of how to use them."*

**Engine layer 7** — standalone design engine. (The *solution* half of this item shipped earlier in #514; this is the drawing, the hints, and what they turned up.)

## Two defects found on the way

**§25.4.1.4 was not implemented.** The clause caps the `√f'c` used in *any* §25.4 development length at **8.3 MPa**. Without it, concrete stronger than about 69 MPa bought a shorter development length than the splitting-bond tests behind §25.4 support — `ld` kept falling as `1/√f'c` with no floor. Now capped, applied to `ld`, `ldc` and `ldh` alike, and surfaced on the page when it bites.

**One equation never rendered.** The ψs line built `\text{d_b = 20 mm}` — an underscore in text mode is a KaTeX parse error, so that line printed as **raw LaTeX source on every visit to the page**. Two more in the same file:

- `EPOXY_WHY` was keyed on `'coated'` / `'coatedClose'`, which the engine never emits (`'coated-light'` / `'coated-heavy'`), so every coated bar printed the raw enum string instead of a reason.
- The solution recomputed `√f'c` itself. After the cap above, it would have printed a different number from the one the answer came from; it now reads the engine's value.

## Standard hook §25.4.3

The drawing has to show a hook, and an undimensioned hook is not a detail. Added `ldh` with:

- ψc = 0.7 for adequate cover, ψr = 0.8 for confining ties, **both withheld above ⌀36** per §25.4.3.2
- ψe = 1.2 for a coated hook — never the straight-bar 1.5
- the `max(8db, 150)` floor
- §25.3.1 geometry: 12db tail, 6db/8db minimum inside bend

ψt deliberately does **not** apply: a hook anchors by bearing inside the bend, not by bond along the bar. The test asserts this by running the engine with `topBar` on and confirming `ldh` does not move while `ld` does.

## The drawing

Four panels, each answering *"measured between what?"* —

| | |
|---|---|
| **A** | `ld` from the **critical section**, not the support face |
| **B** | `ldh` to the **outside of the bend**, with the 12db tail dimensioned separately so it cannot be read as part of it |
| **C** | a lap as the **overlap of two bars**, not the length of either |
| **D** | the section: `cb` to the bar **centre**, and the tie that supplies `Ktr` |

## Hint buttons

A **?** beside every input opens the clause behind it: the statement, the table it defines, and why the rule is shaped that way. Eight of them, one per factor. Click to open; closes on Escape, outside click, or its own button — a tooltip cannot hold a table you need to compare rows in, and cannot be read on touch.

The hint content is **data**, and **45 tests assert each table against the engine** for the same condition: every ψs, ψe, ψt and λ value a table quotes is the value `calcDevLength` actually returns, and the quoted caps are the caps the code enforces. A hint that disagrees with the engine is worse than no hint — it teaches the wrong rule with the authority of a clause number.

Also: **λ now offers 0.85 sand-lightweight**, the middle row of Table 19.2.4.1(a) that the page was missing. `Pick`'s `label` widened to `ReactNode` to match `Num`.

## Verified in a headless browser

Overlap audit across two bar sizes: **0 label overlaps, 0 labels outside the frame, 0 non-finite coordinates, 0 KaTeX errors, 0 page errors.** It caught a label running off the left edge of the leftmost panel, and a hook tail drawn poking out through the bottom of the concrete. All **8 popovers** were opened programmatically: each renders its table, fits the viewport, and closes on Escape.

## Verification

- **+13 engine cases** for the cap and the hook, against hand calculations (`ldh = 0.24·415/√28 · 20 = 376.5 mm`).
- **+45 hint-consistency cases.**
- `npm test` — 198 files, **3187 passed**. `npx tsc -b`, `eslint` and `npm run build` green.

---

Remaining backlog after this: #22 Truss Space optimizer, #35 geotechnical page split, #38 network diagram branching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_