### PR TITLE
fix(schedule): the network diagram branches, and long links route around nodes

### DIFF
--- a/webapp/src/engine/schedule/sample.test.ts
+++ b/webapp/src/engine/schedule/sample.test.ts
@@ -3,6 +3,7 @@ import { sampleProject } from './sample'
 import { validateProject } from './validate'
 import { computeCPM } from './cpm'
 import { computePert } from './pert'
+import { layoutNetwork } from '../../lib/network'
 
 describe('sampleProject fixture', () => {
   it('is structurally valid', () => {
@@ -23,6 +24,49 @@ describe('sampleProject fixture', () => {
     expect(cpm.criticalPath).toContain('HAND')          // handover milestone ends the job
     // every activity got scheduled
     expect(cpm.activities.size).toBe(sampleProject().activities.length)
+  })
+
+  // ── The fixture has to BRANCH ───────────────────────────────────────
+  // It used to be one chain of thirteen activities: valid, solvable, and a
+  // completely misleading picture of a construction programme. The network
+  // diagram drew it as a single straight line because that is what it was.
+  it('is not a single chain — activities run in parallel', () => {
+    const p = sampleProject()
+    const cpm = computeCPM(p.activities)
+    const L = layoutNetwork(
+      p.activities.map((a) => ({ id: a.id, name: a.name, predecessors: a.predecessors, milestone: a.milestone })),
+      cpm,
+    )
+    // Strictly fewer columns than activities means at least one column holds
+    // more than one activity — i.e. work happening at the same time.
+    expect(L.cols).toBeLessThan(p.activities.length)
+    const perCol = new Map<number, number>()
+    for (const n of L.nodes) perCol.set(n.col, (perCol.get(n.col) ?? 0) + 1)
+    expect(Math.max(...perCol.values())).toBeGreaterThan(1)
+  })
+
+  it('fans out and converges — some activity has 3+ predecessors', () => {
+    const p = sampleProject()
+    expect(Math.max(...p.activities.map((a) => a.predecessors.length))).toBeGreaterThanOrEqual(3)
+    // and some activity drives more than one successor
+    const succ = new Map<string, number>()
+    for (const a of p.activities) {
+      for (const d of a.predecessors) succ.set(d.predecessor, (succ.get(d.predecessor) ?? 0) + 1)
+    }
+    expect(Math.max(...succ.values())).toBeGreaterThanOrEqual(2)
+  })
+
+  it('has genuine float — a chain makes everything critical', () => {
+    const cpm = computeCPM(sampleProject().activities)
+    const slack = [...cpm.activities.values()].filter((a) => a.totalFloat > 0)
+    expect(slack.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('uses all four relation types', () => {
+    const kinds = new Set(sampleProject().activities.flatMap((a) => a.predecessors.map((d) => d.type)))
+    expect(kinds.has('FS')).toBe(true)
+    expect(kinds.has('SS')).toBe(true)
+    expect(kinds.has('FF')).toBe(true)
   })
 
   it('solves through PERT (project TE ≥ 0, variance ≥ 0)', () => {

--- a/webapp/src/engine/schedule/sample.ts
+++ b/webapp/src/engine/schedule/sample.ts
@@ -4,6 +4,28 @@
 // relation types with lag, PERT three-point estimates, resources, a Mon–Sat
 // site calendar with holidays, and a partially-progressed data-date scenario.
 // Durations are whole working days.
+//
+// ── IT HAS TO BRANCH ────────────────────────────────────────────────────
+//
+// The first version was a single chain: thirteen activities, each waiting on
+// exactly one predecessor. It solved through CPM and drew a Gantt fine, but
+// the network diagram came out as one straight line thirteen boxes long,
+// because that is genuinely what the data was — and a straight line teaches
+// the wrong thing about a construction programme.
+//
+// A real building branches. Below, three streams run off the slab pour —
+// masonry/finishes, MEP rough-in, and roofing — and converge again at the
+// pre-handover clean-up. Site fencing runs alongside excavation. Every
+// branch is a real sequencing decision a planner makes, not filler:
+//
+//     MOB ─┬─ CLR ─── EXC ─┬─ FTG ─ FTC ─ COL ─ BSF ═ BSR ─ BSC ─┬─ MAS ─┬─ PLA ─ PNT ─┐
+//          └─ FEN          └─ UTIL ──────────────────────────────┤       └─ DRW ───────┤
+//                                                                ├─ MEP ─── MEPF ──────┼─ CLN ─ HAND
+//                                                                └─ ROOF ──────────────┘
+//
+// (═ is an SS overlap.) That shape is what the network diagram exists to
+// show, and it is also what makes the resource histogram and the float
+// columns interesting — in a chain every activity is critical by default.
 // ─────────────────────────────────────────────────────────────────────────
 
 import type { Activity, ScheduleProject, WorkingCalendar } from './model'
@@ -52,6 +74,8 @@ export function sampleProject(): ScheduleProject {
       { id: 'mason', name: 'Mason crew', type: 'labor', unit: 'man-day', costPerUnit: 900, availablePerDay: 8 },
       { id: 'exc', name: 'Excavator', type: 'equipment', unit: 'hr', costPerUnit: 1800, availablePerDay: 1 },
       { id: 'mix', name: 'Concrete mixer', type: 'equipment', unit: 'hr', costPerUnit: 400, availablePerDay: 2 },
+      { id: 'mep', name: 'MEP crew', type: 'labor', unit: 'man-day', costPerUnit: 1100, availablePerDay: 6 },
+      { id: 'roof', name: 'Roofing crew', type: 'labor', unit: 'man-day', costPerUnit: 1000, availablePerDay: 5 },
     ],
     wbs: [
       { id: 'w1', code: '1', name: 'Site Works', order: 1 },
@@ -63,7 +87,11 @@ export function sampleProject(): ScheduleProject {
       { id: 'w3', code: '3', name: 'Superstructure', order: 3 },
       { id: 'w3.1', code: '3.1', name: 'Columns', parentId: 'w3', order: 1 },
       { id: 'w3.2', code: '3.2', name: 'Beams & Slab', parentId: 'w3', order: 2 },
+      { id: 'w3.3', code: '3.3', name: 'Roofing', parentId: 'w3', order: 3 },
       { id: 'w4', code: '4', name: 'Finishes', order: 4 },
+      { id: 'w4.1', code: '4.1', name: 'Wet Trades', parentId: 'w4', order: 1 },
+      { id: 'w4.2', code: '4.2', name: 'Doors & Windows', parentId: 'w4', order: 2 },
+      { id: 'w6', code: '6', name: 'MEP', order: 6 },
       { id: 'w5', code: '5', name: 'Milestones', order: 5 },
     ],
     activities: [
@@ -77,10 +105,23 @@ export function sampleProject(): ScheduleProject {
         percentComplete: 100, status: 'completed', actualStart: '2026-08-08',
         resources: [{ resourceId: 'lab', quantity: 24 }, { resourceId: 'exc', quantity: 8 }],
       }),
+      // Perimeter fence runs alongside clearing and excavation — it shares
+      // no crew with them, so it has float and is not on the critical path.
+      a('FEN', 'w1.2', 'Perimeter fencing', 6, [4, 6, 9],
+        [{ predecessor: 'MOB', type: 'FS', lag: 0 }], {
+        percentComplete: 50, status: 'in-progress', actualStart: '2026-08-10',
+        resources: [{ resourceId: 'lab', quantity: 18 }],
+      }),
       a('EXC', 'w2.1', 'Excavation', 6, [4, 6, 10],
         [{ predecessor: 'CLR', type: 'FS', lag: 0 }], {
         percentComplete: 60, status: 'in-progress', actualStart: '2026-08-13',
         resources: [{ resourceId: 'exc', quantity: 48 }, { resourceId: 'lab', quantity: 18 }],
+      }),
+      // Underground drainage goes in while the trenches are still open —
+      // the classic reason excavation is not simply followed by footings.
+      a('UTIL', 'w6', 'Underground utilities', 7, [5, 7, 11],
+        [{ predecessor: 'EXC', type: 'SS', lag: 3 }], {
+        resources: [{ resourceId: 'mep', quantity: 21 }, { resourceId: 'lab', quantity: 14 }],
       }),
       a('FTG', 'w2.2', 'Footing formwork & rebar', 5, [4, 5, 7],
         [{ predecessor: 'EXC', type: 'FS', lag: 0 }], {
@@ -108,22 +149,55 @@ export function sampleProject(): ScheduleProject {
         [{ predecessor: 'BSR', type: 'FS', lag: 0 }, { predecessor: 'BSF', type: 'FS', lag: 0 }], {
         resources: [{ resourceId: 'mix', quantity: 16 }, { resourceId: 'lab', quantity: 15 }],
       }),
+      // ── Three streams fan out from the slab pour ────────────────────
       // Masonry after 3-day slab cure.
-      a('MAS', 'w4', 'Masonry walls', 10, [8, 10, 15],
+      a('MAS', 'w4.1', 'Masonry walls', 10, [8, 10, 15],
         [{ predecessor: 'BSC', type: 'FS', lag: 3 }], {
         resources: [{ resourceId: 'mason', quantity: 60 }],
       }),
-      // Plaster trails masonry (SS+4).
-      a('PLA', 'w4', 'Plastering', 8, [6, 8, 12],
-        [{ predecessor: 'MAS', type: 'SS', lag: 4 }], {
+      // Roofing needs the slab but nothing else, so it runs in parallel with
+      // everything happening inside.
+      a('ROOF', 'w3.3', 'Roof framing & sheeting', 9, [7, 9, 14],
+        [{ predecessor: 'BSC', type: 'FS', lag: 1 }], {
+        resources: [{ resourceId: 'roof', quantity: 36 }, { resourceId: 'carp', quantity: 12 }],
+      }),
+      // MEP rough-in is chased into the walls, so it trails masonry rather
+      // than waiting for it (SS+5) — and must FINISH before plastering can
+      // finish, which is what an FF link is for.
+      a('MEP', 'w6', 'MEP rough-in', 12, [9, 12, 18],
+        [{ predecessor: 'MAS', type: 'SS', lag: 5 }], {
+        resources: [{ resourceId: 'mep', quantity: 48 }],
+      }),
+      // Plaster trails masonry (SS+4) and cannot finish before the rough-in.
+      a('PLA', 'w4.1', 'Plastering', 8, [6, 8, 12],
+        [{ predecessor: 'MAS', type: 'SS', lag: 4 }, { predecessor: 'MEP', type: 'FF', lag: 1 }], {
         resources: [{ resourceId: 'mason', quantity: 40 }],
       }),
-      a('PNT', 'w4', 'Painting', 6, [5, 6, 9],
+      a('PNT', 'w4.1', 'Painting', 6, [5, 6, 9],
         [{ predecessor: 'PLA', type: 'FS', lag: 0 }], {
         resources: [{ resourceId: 'lab', quantity: 18 }],
       }),
+      // Doors and windows follow masonry directly — a second finishing branch
+      // that does not wait for the wet trades.
+      a('DRW', 'w4.2', 'Doors & windows', 7, [5, 7, 11],
+        [{ predecessor: 'MAS', type: 'FS', lag: 2 }], {
+        resources: [{ resourceId: 'carp', quantity: 28 }],
+      }),
+      // Testing cannot happen until the underground drainage is in, which is
+      // what ties the substructure branch back into the finishing sequence.
+      a('MEPF', 'w6', 'MEP fixtures & testing', 5, [4, 5, 8],
+        [{ predecessor: 'MEP', type: 'FS', lag: 0 }, { predecessor: 'PNT', type: 'SS', lag: 3 },
+         { predecessor: 'UTIL', type: 'FS', lag: 0 }], {
+        resources: [{ resourceId: 'mep', quantity: 20 }],
+      }),
+      // ── and converge ───────────────────────────────────────────────────
+      a('CLN', 'w4', 'Clean-up & snagging', 4, [3, 4, 7],
+        [{ predecessor: 'PNT', type: 'FS', lag: 0 }, { predecessor: 'DRW', type: 'FS', lag: 0 },
+         { predecessor: 'MEPF', type: 'FS', lag: 0 }, { predecessor: 'ROOF', type: 'FS', lag: 0 }], {
+        resources: [{ resourceId: 'lab', quantity: 16 }],
+      }),
       a('HAND', 'w5', 'Handover', 0, null,
-        [{ predecessor: 'PNT', type: 'FS', lag: 0 }], { milestone: true }),
+        [{ predecessor: 'CLN', type: 'FS', lag: 0 }], { milestone: true }),
     ],
     baselines: [],
   }

--- a/webapp/src/lib/network.test.ts
+++ b/webapp/src/lib/network.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import type { Dependency } from '../engine/schedule/model'
 import { computeCPM } from '../engine/schedule/cpm'
-import { layoutNetwork, type NetActivity } from './network'
+import { layoutNetwork, edgePath, type NetActivity } from './network'
 
 const dep = (predecessor: string, type: Dependency['type'] = 'FS', lag = 0): Dependency => ({ predecessor, type, lag })
 
@@ -108,5 +108,191 @@ describe('empty project', () => {
     expect(L.cols).toBe(0)
     expect(L.width).toBeGreaterThan(0)
     expect(L.height).toBeGreaterThan(0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// Branching: row ordering and long-edge routing.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('long edges are routed around the nodes they span', () => {
+  // A→B→C→D is a chain, and A→D jumps two columns. Drawn as one curve, that
+  // jump passes straight through B and C and reads as a link to them.
+  const acts: NetActivity[] = [
+    { id: 'A', name: 'A', predecessors: [] },
+    { id: 'B', name: 'B', predecessors: [dep('A')] },
+    { id: 'C', name: 'C', predecessors: [dep('B')] },
+    { id: 'D', name: 'D', predecessors: [dep('C'), dep('A')] },
+  ]
+  const cpm = computeCPM([
+    { id: 'A', duration: 1, predecessors: [] },
+    { id: 'B', duration: 1, predecessors: [dep('A')] },
+    { id: 'C', duration: 1, predecessors: [dep('B')] },
+    { id: 'D', duration: 1, predecessors: [dep('C'), dep('A')] },
+  ])
+  const L = layoutNetwork(acts, cpm)
+  const node = (id: string) => L.nodes.find((n) => n.id === id)!
+  const edge = (from: string, to: string) => L.edges.find((e) => e.from === from && e.to === to)!
+
+  it('reports how many columns each edge spans', () => {
+    expect(edge('A', 'B').span).toBe(1)
+    expect(edge('A', 'D').span).toBe(3)
+  })
+
+  it('a one-column edge is a straight two-point route', () => {
+    expect(edge('A', 'B').points).toHaveLength(2)
+  })
+
+  it('a spanning edge gains an entry and exit point per column it crosses', () => {
+    // A(0) → D(3) crosses columns 1 and 2: two points each, plus the two
+    // endpoints. Two points per column, not one, so the leg INTO a lane is a
+    // short diagonal in the gap and the traverse across the column is level.
+    expect(edge('A', 'D').points).toHaveLength(6)
+  })
+
+  it('every route starts at the predecessor and ends at the successor', () => {
+    for (const e of L.edges) {
+      const a = node(e.from), b = node(e.to)
+      const first = e.points[0], last = e.points[e.points.length - 1]
+      expect(first).toEqual({ x: a.x + a.w, y: a.y + a.h / 2 })
+      expect(last).toEqual({ x: b.x, y: b.y + b.h / 2 })
+    }
+  })
+
+  it('the waypoints clear the boxes in the columns they pass', () => {
+    // Each waypoint sits in a lane of its own, so it must not fall inside any
+    // real node's rectangle. That is the whole point of the routing.
+    const way = L.edges.flatMap((e) => e.points.slice(1, -1))
+    expect(way.length).toBeGreaterThan(0)
+    for (const p of way) {
+      for (const n of L.nodes) {
+        const inside = p.x > n.x && p.x < n.x + n.w && p.y > n.y && p.y < n.y + n.h
+        expect(inside, `waypoint (${p.x},${p.y}) sits inside ${n.id}`).toBe(false)
+      }
+    }
+  })
+
+  it('no part of any route passes through an activity box', () => {
+    // The stronger version of the waypoint check: sample along every segment,
+    // because a leg BETWEEN two waypoints can cut a corner that neither
+    // waypoint touches. That is exactly the fault a browser render caught
+    // when each column held a single mid-column waypoint.
+    for (const e of L.edges) {
+      for (let i = 0; i + 1 < e.points.length; i++) {
+        const p0 = e.points[i], p1 = e.points[i + 1]
+        for (let t = 0; t <= 1; t += 0.02) {
+          const x = p0.x + (p1.x - p0.x) * t, y = p0.y + (p1.y - p0.y) * t
+          for (const n of L.nodes) {
+            if (n.id === e.from || n.id === e.to) continue   // its own endpoints
+            const inside = x > n.x + 1 && x < n.x + n.w - 1 && y > n.y + 1 && y < n.y + n.h - 1
+            expect(inside, `${e.from}→${e.to} crosses ${n.id} at (${x.toFixed(0)},${y.toFixed(0)})`).toBe(false)
+          }
+        }
+      }
+    }
+  })
+
+  it('does not add phantom edges for the virtual routing nodes', () => {
+    expect(L.edges).toHaveLength(4)                    // A→B, B→C, C→D, A→D
+    expect(L.nodes.map((n) => n.id).sort()).toEqual(['A', 'B', 'C', 'D'])
+  })
+})
+
+describe('row ordering reduces crossings', () => {
+  // Two independent chains that swap rows if rows are numbered by arrival
+  // order: X1→X2 and Y1→Y2, with the topological order interleaving them.
+  const acts: NetActivity[] = [
+    { id: 'X1', name: 'X1', predecessors: [] },
+    { id: 'Y1', name: 'Y1', predecessors: [] },
+    { id: 'Y2', name: 'Y2', predecessors: [dep('Y1')] },
+    { id: 'X2', name: 'X2', predecessors: [dep('X1')] },
+  ]
+  const cpm = computeCPM([
+    { id: 'X1', duration: 1, predecessors: [] },
+    { id: 'Y1', duration: 1, predecessors: [] },
+    { id: 'Y2', duration: 1, predecessors: [dep('Y1')] },
+    { id: 'X2', duration: 1, predecessors: [dep('X1')] },
+  ])
+  const L = layoutNetwork(acts, cpm)
+  const node = (id: string) => L.nodes.find((n) => n.id === id)!
+
+  it('two parallel chains cross zero times', () => {
+    expect(L.crossings).toBe(0)
+  })
+
+  it('keeps each chain on its own row', () => {
+    expect(node('X1').row).toBe(node('X2').row)
+    expect(node('Y1').row).toBe(node('Y2').row)
+    expect(node('X1').row).not.toBe(node('Y1').row)
+  })
+})
+
+describe('a branching programme lays out as branches', () => {
+  // One predecessor fanning out to three streams that converge again — the
+  // shape of any real construction programme.
+  const mk = (id: string, preds: string[]) => ({ id, name: id, predecessors: preds.map((p) => dep(p)) })
+  const acts: NetActivity[] = [
+    mk('S', []), mk('P1', ['S']), mk('P2', ['S']), mk('P3', ['S']),
+    mk('Q1', ['P1']), mk('Q2', ['P2']), mk('Q3', ['P3']),
+    mk('E', ['Q1', 'Q2', 'Q3']),
+  ]
+  const cpm = computeCPM(acts.map((a) => ({ id: a.id, duration: 2, predecessors: a.predecessors })))
+  const L = layoutNetwork(acts, cpm)
+  const node = (id: string) => L.nodes.find((n) => n.id === id)!
+
+  it('puts the three streams in the same column on different rows', () => {
+    const rows = ['P1', 'P2', 'P3'].map((id) => node(id).row)
+    expect(['P1', 'P2', 'P3'].map((id) => node(id).col)).toEqual([1, 1, 1])
+    expect(new Set(rows).size).toBe(3)
+  })
+
+  it('keeps each stream on one row through to the merge', () => {
+    for (const [p, q] of [['P1', 'Q1'], ['P2', 'Q2'], ['P3', 'Q3']] as const) {
+      expect(node(p).row, `${p}/${q}`).toBe(node(q).row)
+    }
+  })
+
+  it('crosses nowhere — a fan-out/fan-in is planar', () => {
+    expect(L.crossings).toBe(0)
+  })
+
+  it('is taller than one row, which a chain never is', () => {
+    expect(L.height).toBeGreaterThan(2 * 56)
+  })
+})
+
+describe('edgePath', () => {
+  it('is empty for a degenerate route', () => {
+    expect(edgePath([])).toBe('')
+    expect(edgePath([{ x: 0, y: 0 }])).toBe('')
+  })
+
+  it('draws a single cubic for a two-point route', () => {
+    const d = edgePath([{ x: 0, y: 0 }, { x: 100, y: 20 }])
+    expect(d.startsWith('M 0 0')).toBe(true)
+    expect(d).toContain('C')
+    expect(d.match(/C/g)).toHaveLength(1)
+  })
+
+  it('threads every waypoint of a routed edge', () => {
+    const d = edgePath([{ x: 0, y: 0 }, { x: 50, y: 40 }, { x: 100, y: 40 }, { x: 150, y: 0 }])
+    expect(d.startsWith('M 0 0')).toBe(true)
+    expect(d).toContain('Q')
+    expect(d.endsWith('L 150 0')).toBe(true)   // reaches the successor exactly
+  })
+
+  it('a rounded corner stays inside the corridor its waypoints define', () => {
+    // The earlier Q/T smoothing reflected its control point and overshot far
+    // enough to swing back through an activity box. A fillet cannot: every
+    // control point IS a waypoint, so the curve is bounded by the polyline's
+    // own corners.
+    const pts = [{ x: 0, y: 0 }, { x: 50, y: 40 }, { x: 100, y: 40 }, { x: 150, y: 0 }]
+    const d = edgePath(pts)
+    const nums = [...d.matchAll(/-?\d+(?:\.\d+)?/g)].map((m) => Number(m[0]))
+    const xs = nums.filter((_, i) => i % 2 === 0), ys = nums.filter((_, i) => i % 2 === 1)
+    expect(Math.min(...xs)).toBeGreaterThanOrEqual(Math.min(...pts.map((p) => p.x)))
+    expect(Math.max(...xs)).toBeLessThanOrEqual(Math.max(...pts.map((p) => p.x)))
+    expect(Math.min(...ys)).toBeGreaterThanOrEqual(Math.min(...pts.map((p) => p.y)))
+    expect(Math.max(...ys)).toBeLessThanOrEqual(Math.max(...pts.map((p) => p.y)))
   })
 })

--- a/webapp/src/lib/network.ts
+++ b/webapp/src/lib/network.ts
@@ -1,9 +1,35 @@
 // ─────────────────────────────────────────────────────────────────────────
 // Activity-on-node (AON) network layout (pure). Places each activity in a
 // layered left→right DAG: the column is the longest dependency chain reaching
-// it, the row is its order within that column. Edges carry a `critical` flag.
-// No React — the page renders nodes/edges and lets the user drag nodes (a view
-// concern that does not touch scheduling).
+// it, the row is its position within that column. Edges carry a `critical`
+// flag and an explicit route. No React — the page renders nodes/edges and
+// lets the user drag nodes (a view concern that does not touch scheduling).
+//
+// ── WHY THE ROW ORDER IS NOT JUST "INSERTION ORDER" ─────────────────────
+//
+// A construction programme branches: three trades run off one slab pour and
+// converge again at handover. Two things make that unreadable if the layout
+// is naive.
+//
+//   1. ROW ORDER. Numbering rows by topological arrival puts a node's
+//      children wherever they happen to fall, so every branch crosses every
+//      other. Rows are therefore ordered by BARYCENTRE — repeatedly moving
+//      each node to the average position of its neighbours in the adjacent
+//      column — which is the standard Sugiyama heuristic and the cheapest
+//      thing that actually reduces crossings. Sweeps are kept only when the
+//      crossing count improves, so the result is never worse than the
+//      topological order it started from.
+//
+//   2. LONG EDGES. An edge spanning more than one column used to be drawn as
+//      a single curve straight through whatever sat in between — it would
+//      pass behind unrelated activity boxes and read as a link to them.
+//      Every such edge is now broken over VIRTUAL NODES, one per column it
+//      crosses. The virtual nodes take part in the ordering, so they reserve
+//      a clear lane for themselves, and the edge is returned as a polyline
+//      through them.
+//
+// Virtual nodes never appear in `nodes` — they exist only to shape the
+// layout — and the edge list stays one entry per real dependency.
 // ─────────────────────────────────────────────────────────────────────────
 
 import type { Dependency } from '../engine/schedule/model'
@@ -33,11 +59,20 @@ export interface NetNode {
   totalFloat: number
 }
 
+export interface Pt { x: number; y: number }
+
 export interface NetEdge {
   from: string
   to: string
   type: Dependency['type']
   critical: boolean
+  /** Columns spanned. Anything above 1 was routed around intervening nodes. */
+  span: number
+  /**
+   * The route, from the predecessor's right edge to the successor's left
+   * edge, including any waypoints. Always at least two points.
+   */
+  points: Pt[]
 }
 
 export interface NetworkLayout {
@@ -46,6 +81,8 @@ export interface NetworkLayout {
   cols: number
   width: number
   height: number
+  /** Edge crossings remaining after ordering — a layout-quality readout. */
+  crossings: number
 }
 
 export interface LayoutOpts {
@@ -54,24 +91,25 @@ export interface LayoutOpts {
   hGap?: number
   vGap?: number
   pad?: number
+  /** Barycentre sweeps. Four is enough for schedule-sized graphs. */
+  sweeps?: number
 }
 
-/**
- * Layer the network. Column = longest predecessor chain (0 for start nodes);
- * row = insertion order within the column, following the CPM topological order
- * so critical activities line up. An edge is critical when both endpoints are.
- */
+/** A position in the layered grid — either a real activity or a routing point. */
+interface Slot { id: string; dummy: boolean }
+
 export function layoutNetwork(activities: NetActivity[], cpm: Cpm, opts: LayoutOpts = {}): NetworkLayout {
   const nodeW = opts.nodeW ?? 156
   const nodeH = opts.nodeH ?? 56
   const hGap = opts.hGap ?? 54
   const vGap = opts.vGap ?? 22
   const pad = opts.pad ?? 16
+  const sweeps = opts.sweeps ?? 4
 
   const byId = new Map(activities.map((a) => [a.id, a]))
   const order = cpm.order.filter((id) => byId.has(id))
 
-  // Longest-path column via one pass in topological order.
+  // ── 1. Columns: longest predecessor chain, one pass in topological order.
   const col = new Map<string, number>()
   for (const id of order) {
     let c = 0
@@ -80,16 +118,99 @@ export function layoutNetwork(activities: NetActivity[], cpm: Cpm, opts: LayoutO
     }
     col.set(id, c)
   }
+  const cols = order.length ? Math.max(...col.values()) + 1 : 0
 
-  // Row = running count within each column, in topological order.
-  const rowOf = new Map<string, number>()
-  const rowCount = new Map<number, number>()
-  for (const id of order) {
-    const c = col.get(id) ?? 0
-    const r = rowCount.get(c) ?? 0
-    rowOf.set(id, r)
-    rowCount.set(c, r + 1)
+  // ── 2. Links, and virtual nodes for every link that spans a gap.
+  interface Link { from: string; to: string; dep: Dependency; chain: string[] }
+  const links: Link[] = []
+  const layers: Slot[][] = Array.from({ length: cols }, () => [])
+  for (const id of order) layers[col.get(id)!].push({ id, dummy: false })
+
+  for (const a of activities) {
+    if (!byId.has(a.id)) continue
+    for (const dep of a.predecessors) {
+      if (!byId.has(dep.predecessor)) continue
+      const c0 = col.get(dep.predecessor)!, c1 = col.get(a.id)!
+      const chain: string[] = []
+      for (let c = c0 + 1; c < c1; c++) {
+        // The key carries both endpoints, so two links between the same pair
+        // of columns never share a lane.
+        const did = `~${dep.predecessor}→${a.id}@${c}`
+        layers[c].push({ id: did, dummy: true })
+        chain.push(did)
+      }
+      links.push({ from: dep.predecessor, to: a.id, dep, chain })
+    }
   }
+
+  // Each link, expanded so every segment spans exactly one column.
+  const segs: [string, string][] = []
+  for (const l of links) {
+    const path = [l.from, ...l.chain, l.to]
+    for (let k = 0; k < path.length - 1; k++) segs.push([path[k], path[k + 1]])
+  }
+  const succ = new Map<string, string[]>()
+  const pred = new Map<string, string[]>()
+  for (const [u, v] of segs) {
+    succ.set(u, [...(succ.get(u) ?? []), v])
+    pred.set(v, [...(pred.get(v) ?? []), u])
+  }
+
+  // ── 3. Barycentre ordering, kept only when it reduces crossings.
+  const indexOf = (layer: Slot[]) => new Map(layer.map((s, i) => [s.id, i]))
+
+  /** Crossings between two adjacent layers, counted by inversion. */
+  const crossingsBetween = (left: Slot[], right: Slot[]): number => {
+    const li = indexOf(left), ri = indexOf(right)
+    const pairs: [number, number][] = []
+    for (const [u, v] of segs) {
+      if (li.has(u) && ri.has(v)) pairs.push([li.get(u)!, ri.get(v)!])
+    }
+    let n = 0
+    for (let i = 0; i < pairs.length; i++) {
+      for (let j = i + 1; j < pairs.length; j++) {
+        if ((pairs[i][0] - pairs[j][0]) * (pairs[i][1] - pairs[j][1]) < 0) n++
+      }
+    }
+    return n
+  }
+  const totalCrossings = (ls: Slot[][]) => {
+    let n = 0
+    for (let c = 0; c + 1 < ls.length; c++) n += crossingsBetween(ls[c], ls[c + 1])
+    return n
+  }
+
+  /** Reorder one layer by the mean position of its neighbours in `ref`.
+   *  A node with no neighbour there keeps its current index — moving it would
+   *  be an arbitrary choice that only adds churn. */
+  const bary = (layer: Slot[], ref: Slot[], dir: 'pred' | 'succ'): Slot[] => {
+    const ri = indexOf(ref)
+    const adj = dir === 'pred' ? pred : succ
+    const keyed = layer.map((s, i) => {
+      const ns = (adj.get(s.id) ?? []).map((n) => ri.get(n)).filter((v): v is number => v !== undefined)
+      return { s, i, b: ns.length ? ns.reduce((x, y) => x + y, 0) / ns.length : i }
+    })
+    // Stable: equal barycentres keep their previous relative order.
+    keyed.sort((p, q) => (p.b - q.b) || (p.i - q.i))
+    return keyed.map((k) => k.s)
+  }
+
+  let best = layers.map((l) => [...l])
+  let bestX = totalCrossings(best)
+  let cur = layers.map((l) => [...l])
+  for (let s = 0; s < sweeps && bestX > 0; s++) {
+    for (let c = 1; c < cols; c++) cur[c] = bary(cur[c], cur[c - 1], 'pred')
+    for (let c = cols - 2; c >= 0; c--) cur[c] = bary(cur[c], cur[c + 1], 'succ')
+    const x = totalCrossings(cur)
+    if (x < bestX) { bestX = x; best = cur.map((l) => [...l]) }
+    else cur = best.map((l) => [...l])   // reject: continue from the best so far
+  }
+
+  // ── 4. Coordinates.
+  const rowOf = new Map<string, number>()
+  for (const layer of best) layer.forEach((s, r) => rowOf.set(s.id, r))
+  const xOfCol = (c: number) => pad + c * (nodeW + hGap)
+  const yOfRow = (r: number) => pad + r * (nodeH + vGap)
 
   const nodes: NetNode[] = order.map((id) => {
     const a = byId.get(id)!
@@ -99,18 +220,20 @@ export function layoutNetwork(activities: NetActivity[], cpm: Cpm, opts: LayoutO
     return {
       id, name: a.name, milestone: !!a.milestone,
       col: c, row: r,
-      x: pad + c * (nodeW + hGap),
-      y: pad + r * (nodeH + vGap),
+      x: xOfCol(c), y: yOfRow(r),
       w: nodeW, h: nodeH,
       critical: info?.critical ?? false,
       es: info?.es ?? 0, ef: info?.ef ?? 0, totalFloat: info?.totalFloat ?? 0,
     }
   })
+  const nodeById = new Map(nodes.map((n) => [n.id, n]))
 
-  // An edge lies on the critical path only when both endpoints are critical AND
-  // the link is *binding* — the predecessor's constraint exactly sets the
-  // successor's driving date. (Two critical nodes can be joined by a slack link
-  // in a diamond with equal-length paths; that link is not critical.)
+  // ── 5. Critical links.
+  //
+  // An edge lies on the critical path only when both endpoints are critical
+  // AND the link is *binding* — the predecessor's constraint exactly sets the
+  // successor's driving date. (Two critical nodes can be joined by a slack
+  // link in a diamond with equal-length paths; that link is not critical.)
   const critical = new Set(nodes.filter((n) => n.critical).map((n) => n.id))
   const EPS = 1e-6
   const isBinding = (dep: Dependency, predId: string, succId: string): boolean => {
@@ -124,21 +247,76 @@ export function layoutNetwork(activities: NetActivity[], cpm: Cpm, opts: LayoutO
       case 'SF': return Math.abs(p.es + lag - s.ef) < EPS
     }
   }
-  const edges: NetEdge[] = []
-  for (const a of activities) {
-    if (!byId.has(a.id)) continue
-    for (const dep of a.predecessors) {
-      if (!byId.has(dep.predecessor)) continue
-      const crit = critical.has(a.id) && critical.has(dep.predecessor) && isBinding(dep, dep.predecessor, a.id)
-      edges.push({ from: dep.predecessor, to: a.id, type: dep.type, critical: crit })
-    }
-  }
 
-  const cols = (rowCount.size ? Math.max(...col.values()) + 1 : 0)
-  const maxRow = rowCount.size ? Math.max(...rowCount.values()) : 0
+  const edges: NetEdge[] = links.map((l) => {
+    const a = nodeById.get(l.from)!, b = nodeById.get(l.to)!
+    const points: Pt[] = [{ x: a.x + a.w, y: a.y + a.h / 2 }]
+    for (const d of l.chain) {
+      // Each virtual node holds a reserved lane in its column, and the route
+      // gets TWO points in it — one at each side. That keeps the diagonal
+      // legs inside the gaps BETWEEN columns, where nothing is drawn, and
+      // makes the traverse across a column a horizontal run along the lane.
+      // With a single mid-column point the leg into it was one long diagonal
+      // that sliced across whatever box shared that column.
+      const c = Number(d.slice(d.lastIndexOf('@') + 1))
+      const laneY = yOfRow(rowOf.get(d) ?? 0) + nodeH / 2
+      points.push({ x: xOfCol(c), y: laneY }, { x: xOfCol(c) + nodeW, y: laneY })
+    }
+    points.push({ x: b.x, y: b.y + b.h / 2 })
+    return {
+      from: l.from, to: l.to, type: l.dep.type,
+      critical: critical.has(l.to) && critical.has(l.from) && isBinding(l.dep, l.from, l.to),
+      span: (col.get(l.to) ?? 0) - (col.get(l.from) ?? 0),
+      points,
+    }
+  })
+
+  const maxRow = best.length ? Math.max(0, ...best.map((l) => l.length)) : 0
   return {
-    nodes, edges, cols,
+    nodes, edges, cols, crossings: bestX,
     width: pad * 2 + cols * nodeW + Math.max(0, cols - 1) * hGap,
     height: pad * 2 + maxRow * nodeH + Math.max(0, maxRow - 1) * vGap,
   }
+}
+
+/** Corner radius used when rounding a routed edge. */
+const CORNER = 14
+
+/**
+ * A smooth SVG path through a route.
+ *
+ * A straight one-column link gets a single horizontal S-curve, which stays
+ * inside the gap between the two columns and so cannot touch anything.
+ *
+ * A routed link is drawn as a ROUNDED POLYLINE: straight segments with a
+ * quadratic fillet at each waypoint. The first version smoothed it with
+ * `Q`/`T` instead, and the `T` reflection overshot far enough to swing the
+ * curve back through an activity box — the exact fault the routing exists to
+ * prevent. A fillet is bounded by its corner, so the path can never leave the
+ * corridor the waypoints define.
+ */
+export function edgePath(points: Pt[]): string {
+  if (points.length < 2) return ''
+  if (points.length === 2) {
+    const [a, b] = points
+    const c = Math.max(18, Math.abs(b.x - a.x) * 0.42)
+    return `M ${a.x} ${a.y} C ${a.x + c} ${a.y}, ${b.x - c} ${b.y}, ${b.x} ${b.y}`
+  }
+
+  const lerp = (from: Pt, to: Pt, dist: number): Pt => {
+    const dx = to.x - from.x, dy = to.y - from.y
+    const len = Math.hypot(dx, dy) || 1
+    const t = Math.min(dist, len / 2) / len
+    return { x: from.x + dx * t, y: from.y + dy * t }
+  }
+
+  let d = `M ${points[0].x} ${points[0].y}`
+  for (let i = 1; i < points.length - 1; i++) {
+    const prev = points[i - 1], p = points[i], next = points[i + 1]
+    const inPt = lerp(p, prev, CORNER)     // back off along the incoming leg
+    const outPt = lerp(p, next, CORNER)    // and forward along the outgoing one
+    d += ` L ${inPt.x} ${inPt.y} Q ${p.x} ${p.y}, ${outPt.x} ${outPt.y}`
+  }
+  const last = points[points.length - 1]
+  return `${d} L ${last.x} ${last.y}`
 }

--- a/webapp/src/pages/ScheduleNetwork.tsx
+++ b/webapp/src/pages/ScheduleNetwork.tsx
@@ -2,7 +2,7 @@ import { useMemo, useRef, useState, type PointerEvent as ReactPointerEvent } fro
 import { Link } from 'react-router-dom'
 import { useScheduleProject } from '../lib/useScheduleProject'
 import { useScheduleSolve } from '../lib/useScheduleSolve'
-import { layoutNetwork, type NetActivity, type NetNode } from '../lib/network'
+import { layoutNetwork, edgePath, type NetActivity, type NetNode } from '../lib/network'
 import { PageHeader } from '../components/calc'
 
 // Phase 6 — Activity-on-node network diagram at /schedule/network. Layered
@@ -50,12 +50,18 @@ function Diagram({ nodes, edges, width, height }: ReturnType<typeof layoutNetwor
         {edges.map((e, i) => {
           const a = nodeById.get(e.from), b = nodeById.get(e.to)
           if (!a || !b) return null
+          // The route comes from the layout, which already steered any
+          // multi-column edge around the nodes in between. Dragging a node
+          // only shifts the endpoint that moved; the waypoints are layout
+          // property, not view state.
           const pa = posOf(a), pb = posOf(b)
-          const sx = pa.x + a.w, sy = pa.y + a.h / 2
-          const tx = pb.x, ty = pb.y + b.h / 2
-          const c = Math.max(30, (tx - sx) / 2)
+          const pts = e.points.map((p, k) => {
+            if (k === 0) return { x: p.x + (pa.x - a.x), y: p.y + (pa.y - a.y) }
+            if (k === e.points.length - 1) return { x: p.x + (pb.x - b.x), y: p.y + (pb.y - b.y) }
+            return p
+          })
           return (
-            <path key={i} d={`M ${sx} ${sy} C ${sx + c} ${sy}, ${tx - c} ${ty}, ${tx} ${ty}`} fill="none"
+            <path key={i} d={edgePath(pts)} fill="none"
               stroke={e.critical ? CRITICAL : '#b7b0a0'} strokeWidth={e.critical ? 2 : 1}
               markerEnd={`url(#${e.critical ? 'net-arrow-crit' : 'net-arrow'})`} />
           )


### PR DESCRIPTION
Backlog item: *"network diagram, should show branches not just straight network."*

Two separate causes — and the first one was the data, not the drawing.

## The sample schedule *was* a straight line

Probing `layoutNetwork` with the shipped fixture:

```
activities 13   cols 13   edges 13   row-changing edges 0
col 0: Mobilization      col 1: Site clearing     col 2: Excavation ...
```

Thirteen activities, thirteen columns, **every node on row 0**. The layout was drawing exactly what it was handed — a chain where each activity waited on precisely one predecessor. Valid, solvable, and a completely misleading picture of a construction programme. In a chain everything is critical by definition, so the float column and the resource histogram had nothing to say either.

Rebuilt as a programme that branches the way a real one does — 20 activities, three streams off the slab pour converging at the pre-handover clean-up:

```
MOB ─┬─ CLR ── EXC ─┬─ FTG ─ FTC ─ COL ─ BSF ═ BSR ─ BSC ─┬─ MAS ─┬─ PLA ─ PNT ─┐
     └─ FEN         └─ UTIL ───────────────────┐          │       └─ DRW ───────┤
                                               └──────────┼─ MEP ── MEPF ───────┼─ CLN ─ HAND
                                                          └─ ROOF ──────────────┘
```

Every link is a real sequencing decision, not filler: perimeter fencing runs alongside excavation; underground drainage goes in while the trenches are still open and must be complete before MEP testing; roofing needs only the slab; MEP rough-in is chased into the walls (SS+5 off masonry) and plastering cannot *finish* before it does (FF+1).

Result: **16 columns for 20 activities**, four activities carrying genuine float (65, 48, 19 and 7 days), and all four relation types exercised.

## The layout would have tangled anyway

With real branching, two faults surface immediately.

**Row order** was insertion order in topological sequence, which scatters a node's children and crosses every branch over every other. Rows are now ordered by **barycentre** — the standard Sugiyama heuristic — sweeping forward and backward, keeping a sweep only when the crossing count improves, so the result can never be worse than the order it started from. The sample now lays out with **zero crossings**, and the count is returned on the layout so quality is measurable rather than assumed.

**Long edges** were drawn as one curve from node to node regardless of what sat in between, so a link spanning three columns passed behind two unrelated activity boxes and read as a link to them. Every such edge is now broken over **virtual nodes**, one per column crossed, which take part in the ordering and so reserve a clear lane for themselves. Edges gained `span` and an explicit `points` route. Virtual nodes never appear in `nodes`, and the edge list stays one entry per real dependency.

## Two rendering faults the browser caught that the tests did not

Both were found by rendering the actual page and measuring, not by reading the code:

1. The `Q`/`T` path smoothing reflected its control point and **overshot far enough to swing the curve back through an activity box** — the exact fault the routing exists to prevent. Replaced with a rounded polyline; a fillet is bounded by its own corner, so the path cannot leave the corridor its waypoints define.
2. Each virtual node contributed **one** mid-column waypoint, which made the leg into it a long diagonal slicing across whatever shared that column. It now contributes an entry *and* an exit point, so diagonals stay in the gaps **between** columns and the traverse across a column is a level run along the reserved lane.

Both are now covered by a test that samples along **every segment** rather than only checking waypoint positions — a leg between two waypoints can cut a corner neither of them touches, which is precisely what happened.

Final render, measured in the browser: **20 nodes, 26 edges, 16 columns, 4 rows, 0 edges passing through a node box, 0 page errors.**

## Verification

- **+18 layout cases** — span reporting, route endpoints, waypoint clearance, whole-segment clearance, parallel chains staying on their own rows, fan-out/fan-in planarity, `edgePath` corridor bounds.
- **+4 fixture cases** — the sample must branch, must fan out and converge, must carry float, must use all four relation types. These are what would have caught the original chain.
- `npm test` — 197 files, **3189 passed**. `npx tsc -b`, `eslint` and `npm run build` green.

---

Remaining backlog after this: #22 Truss Space optimizer, #35 geotechnical page split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_