### PR TITLE
feat(truss): auto-size one section per design group, not one for the truss

### DIFF
--- a/webapp/src/engine/trussOptimize.test.ts
+++ b/webapp/src/engine/trussOptimize.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect } from 'vitest'
+import {
+  optimizeTruss, groupMembers, sizeGroup, candidateSections, rejectionNote,
+  SLENDER_LIMIT_COMPRESSION, SLENDER_PREFERENCE_TENSION, type TrussGroup,
+} from './trussOptimize'
+import { designTrussMember } from './trussDesign'
+import { generateTruss, solveTrussEnvelope, type MemberForce } from './truss'
+import { shapeByName, effectiveSection } from './aiscSections'
+
+const MAT = { E: 200000, Fy: 248, K: 1.0 }
+const f = (id: string, N: number, L: number, kind: MemberForce['kind']): MemberForce =>
+  ({ id, N, L, kind, i: 'a', j: 'b' })
+
+describe('grouping', () => {
+  const forces = [
+    f('t1', -200, 2, 'top'), f('t2', -180, 2, 'top'),
+    f('b1', 190, 2, 'bottom'),
+    f('d1', 60, 2.8, 'diagonal'),      // tie
+    f('d2', -55, 2.8, 'diagonal'),     // strut
+    f('v1', 0, 1.5, 'vertical'),       // zero force
+  ]
+
+  it("'role' splits chords from webs and webs by sign", () => {
+    const g = groupMembers(forces, 'role')
+    expect(g.map((x) => x.id)).toEqual(['top', 'bottom', 'web-compression', 'web-tension'])
+    expect(g.find((x) => x.id === 'top')!.members).toHaveLength(2)
+    expect(g.find((x) => x.id === 'web-tension')!.members.map((m) => m.id)).toEqual(['d1'])
+  })
+
+  it('puts a ZERO-FORCE member in the compression group, not the tension one', () => {
+    // A member carrying nothing still has to hold its own length. Grouped
+    // with the ties, a zero force would select the smallest section made.
+    const g = groupMembers(forces, 'role')
+    expect(g.find((x) => x.id === 'web-compression')!.members.map((m) => m.id))
+      .toEqual(['d2', 'v1'])
+  })
+
+  it("'sign' collapses to two groups and 'uniform' to one", () => {
+    expect(groupMembers(forces, 'sign').map((x) => x.id)).toEqual(['compression', 'tension'])
+    const u = groupMembers(forces, 'uniform')
+    expect(u).toHaveLength(1)
+    expect(u[0].members).toHaveLength(forces.length)
+  })
+
+  it('marks a group as buckling-limited when ANY member is in compression', () => {
+    // A chord that flips sign across the envelope still needs a section that
+    // can buckle safely at its length.
+    const mixed = [f('t1', -100, 2, 'top'), f('t2', 120, 2, 'top')]
+    expect(groupMembers(mixed, 'role')[0].compression).toBe(true)
+  })
+
+  it('keeps every member — no one is dropped or duplicated', () => {
+    for (const mode of ['role', 'sign', 'uniform'] as const) {
+      const ids = groupMembers(forces, mode).flatMap((g) => g.members.map((m) => m.id)).sort()
+      expect(ids).toEqual(forces.map((m) => m.id).sort())
+    }
+  })
+})
+
+describe('candidateSections', () => {
+  it('is sorted lightest first, which is what makes the first survivor optimal', () => {
+    const c = candidateSections(['L'])
+    for (let i = 1; i < c.length; i++) expect(c[i].A).toBeGreaterThanOrEqual(c[i - 1].A)
+  })
+
+  it('adds double angles only when asked, and they weigh twice the single', () => {
+    const single = candidateSections(['L'])
+    const withDouble = candidateSections(['L'], { doubleAngles: true, gap: 10 })
+    expect(withDouble.length).toBe(single.length * 2)
+    const d = withDouble.find((s) => s.double)!
+    expect(d.A).toBeCloseTo(2 * d.base.A, 6)
+  })
+
+  it('is deterministic', () => {
+    expect(candidateSections(['HSS']).map((s) => s.label))
+      .toEqual(candidateSections(['HSS']).map((s) => s.label))
+  })
+})
+
+describe('sizeGroup — the gates, in order', () => {
+  const group = (members: MemberForce[]): TrussGroup =>
+    ({ id: 'g', label: 'g', compression: members.some((m) => m.N <= 0), members })
+
+  it('adopts the lightest section that carries every member', () => {
+    const g = group([f('a', 300, 3, 'bottom')])
+    const cands = candidateSections(['L'])
+    const r = sizeGroup(g, cands, MAT)
+    expect(r.ok).toBe(true)
+    // Everything rejected before it must be lighter, and must actually fail.
+    for (const rej of r.rejected) {
+      const c = cands.find((x) => x.label === rej.label)!
+      expect(c.A).toBeLessThan(r.section!.A)
+    }
+    // And the one adopted really does pass.
+    const d = designTrussMember(g.members[0], { A: r.section!.A, r: r.section!.rmin, ...MAT })
+    expect(d.util).toBeLessThanOrEqual(1)
+  })
+
+  it('reports STRENGTH as the reason when a section is simply too small', () => {
+    const r = sizeGroup(group([f('a', 900, 3, 'bottom')]), candidateSections(['L']), MAT)
+    expect(r.rejected.length).toBeGreaterThan(0)
+    expect(r.rejected[0].gate).toBe('strength')
+  })
+
+  it('rejects on SLENDERNESS when the member is long and unloaded', () => {
+    // 9 m strut carrying almost nothing. Strength is never the problem; the
+    // small sections are simply far past KL/r = 200. The gate that fires has
+    // to be the slenderness one — reporting "strength" would send someone off
+    // to check a force of 1 kN that is perfectly fine.
+    const r = sizeGroup(group([f('a', -1, 9, 'vertical')]), candidateSections(['HSS']), MAT)
+    expect(r.ok).toBe(true)
+    expect(r.maxSlenderness).toBeLessThanOrEqual(SLENDER_LIMIT_COMPRESSION)
+    // Slenderness is what is doing the rejecting here — it must be the gate
+    // on the last section turned down before the adopted one, not "strength"
+    // on a force of 1 kN.
+    expect(r.rejected.length).toBeGreaterThan(0)
+    expect(r.rejected[r.rejected.length - 1].gate).toBe('slenderness')
+    expect(r.rejected.filter((x) => x.gate === 'slenderness').length)
+      .toBeGreaterThan(r.rejected.filter((x) => x.gate === 'strength').length)
+  })
+
+  it('is sized by the LONGEST compression member, not the largest force', () => {
+    // A short member at high force and a long one at low force. Buckling on
+    // the long one governs, so the adopted section must satisfy it.
+    const g = group([f('short', -400, 1.0, 'diagonal'), f('long', -40, 6.0, 'diagonal')])
+    const r = sizeGroup(g, candidateSections(['HSS']), MAT)
+    expect(r.ok).toBe(true)
+    const long = designTrussMember(g.members[1], { A: r.section!.A, r: r.section!.rmin, ...MAT })
+    expect(long.slenderness).toBeLessThanOrEqual(SLENDER_LIMIT_COMPRESSION)
+    expect(long.util).toBeLessThanOrEqual(1)
+  })
+
+  it('never rescues a failing section for being lighter', () => {
+    const g = group([f('a', 900, 3, 'bottom')])
+    const r = sizeGroup(g, candidateSections(['L']), MAT)
+    if (r.section) {
+      for (const rej of r.rejected) {
+        expect(candidateSections(['L']).find((x) => x.label === rej.label)!.A)
+          .toBeLessThan(r.section.A)
+      }
+    }
+  })
+
+  it('reports failure rather than adopting an inadequate section', () => {
+    // Far beyond anything in the angle catalogue.
+    const r = sizeGroup(group([f('a', 100000, 3, 'bottom')]), candidateSections(['L']), MAT)
+    expect(r.ok).toBe(false)
+    expect(r.section).toBeNull()
+    expect(r.weightKg).toBe(0)
+  })
+
+  it('fails a strut too long for ANY section in the chosen family', () => {
+    // KL/r ≤ 200 over 9 m needs r ≥ 45 mm, which no single angle reaches.
+    // The optimiser must say so rather than adopting the biggest angle made
+    // and quietly leaving a 400-slenderness strut in the drawing.
+    const r = sizeGroup(group([f('a', -1, 9, 'vertical')]), candidateSections(['L']), MAT)
+    expect(r.ok).toBe(false)
+    expect(r.section).toBeNull()
+    // The very smallest angles fail STRENGTH first — at KL/r ≈ 900, φPn is
+    // under a kilonewton — and everything above them fails on slenderness.
+    // Once a candidate is big enough to carry the force, slenderness is the
+    // only gate left, so the tail of the list is all slenderness.
+    expect(r.rejected[r.rejected.length - 1].gate).toBe('slenderness')
+    const firstSlender = r.rejected.findIndex((x) => x.gate === 'slenderness')
+    expect(firstSlender).toBeGreaterThanOrEqual(0)
+    expect(r.rejected.slice(firstSlender).every((x) => x.gate === 'slenderness')).toBe(true)
+    // The same member IS buildable in a family with a larger radius.
+    expect(sizeGroup(group([f('a', -1, 9, 'vertical')]), candidateSections(['HSS']), MAT).ok)
+      .toBe(true)
+  })
+
+  it('weighs the group from its total length and the section area', () => {
+    const g = group([f('a', 100, 2, 'bottom'), f('b', 100, 3, 'bottom')])
+    const r = sizeGroup(g, candidateSections(['L']), MAT)
+    expect(r.lengthM).toBe(5)
+    expect(r.weightKg).toBeCloseTo((r.section!.A / 1e6) * 5 * 7850, 6)
+  })
+})
+
+describe('optimizeTruss on a real solved truss', () => {
+  const model = generateTruss({ type: 'pratt', span: 12, height: 2, panels: 6, panelLoad: 20 })
+  const nodes = [...new Set(model.loads.map((l) => l.node))]
+  const dead = nodes.map((n) => ({ node: n, fx: 0, fy: -8 }))
+  const live = nodes.map((n) => ({ node: n, fx: 0, fy: -20 }))
+  const env = solveTrussEnvelope(model, dead, live)!
+  const r = optimizeTruss(env.forces, 'HSS')
+
+  it('solves and sizes every group', () => {
+    expect(env.stable).toBe(true)
+    expect(r.ok).toBe(true)
+    for (const g of r.groups) expect(g.section).not.toBeNull()
+  })
+
+  it('covers every member exactly once', () => {
+    expect(r.members.map((m) => m.id).sort()).toEqual(env.forces.map((m) => m.id).sort())
+  })
+
+  it('every member passes under the section its group adopted', () => {
+    for (const m of r.members) {
+      expect(m.ok, `${m.id} (${m.group}) util ${m.util.toFixed(2)}`).toBe(true)
+    }
+  })
+
+  it('gives the tension chord a LIGHTER section than the compression chord', () => {
+    // The whole point: a bottom chord limited by Fy·Ag does not need the area
+    // a buckling-limited top chord of the same length does.
+    const top = r.groups.find((g) => g.group.id === 'top')!
+    const bot = r.groups.find((g) => g.group.id === 'bottom')!
+    expect(bot.section!.A).toBeLessThan(top.section!.A)
+  })
+
+  it('weighs less than one section for the whole truss', () => {
+    expect(r.uniformWeightKg).not.toBeNull()
+    expect(r.totalWeightKg).toBeLessThan(r.uniformWeightKg!)
+    expect(r.savedFraction).toBeGreaterThan(0)
+    expect(r.savedFraction).toBeLessThan(1)
+  })
+
+  it('a finer grouping is never heavier than a coarser one', () => {
+    // More groups can only ever relax a constraint, so weight is monotone.
+    const role = optimizeTruss(env.forces, 'HSS', { grouping: 'role' })
+    const sign = optimizeTruss(env.forces, 'HSS', { grouping: 'sign' })
+    const uni = optimizeTruss(env.forces, 'HSS', { grouping: 'uniform' })
+    expect(role.totalWeightKg).toBeLessThanOrEqual(sign.totalWeightKg + 1e-6)
+    expect(sign.totalWeightKg).toBeLessThanOrEqual(uni.totalWeightKg + 1e-6)
+  })
+
+  it('drives utilisation UP — that is what optimising means', () => {
+    // A hand-picked section that passes everything comfortably wastes steel.
+    // The optimiser should land near the limit, not far below it.
+    const best = Math.max(...r.groups.map((g) => g.maxUtil))
+    expect(best).toBeGreaterThan(0.5)
+    expect(best).toBeLessThanOrEqual(1)
+  })
+
+  it('searching more families is never worse than searching one', () => {
+    const one = optimizeTruss(env.forces, 'HSS')
+    const many = optimizeTruss(env.forces, 'HSS', { families: ['HSS', 'PIPE', 'W'] })
+    expect(many.totalWeightKg).toBeLessThanOrEqual(one.totalWeightKg + 1e-6)
+  })
+
+  it('is deterministic', () => {
+    const a = optimizeTruss(env.forces, 'HSS')
+    const b = optimizeTruss(env.forces, 'HSS')
+    expect(a.groups.map((g) => g.section?.label)).toEqual(b.groups.map((g) => g.section?.label))
+  })
+
+  it('the reported weight matches the sections it actually chose', () => {
+    const sum = r.groups.reduce((s, g) => s + (g.section!.A / 1e6) * g.lengthM * 7850, 0)
+    expect(r.totalWeightKg).toBeCloseTo(sum, 6)
+  })
+})
+
+describe('a known section, checked by hand', () => {
+  it('reproduces φPn for a tension member — 0.90·Fy·Ag', () => {
+    const sec = effectiveSection(shapeByName('L64x64x6.4')!)
+    const d = designTrussMember(f('a', 100, 2, 'bottom'), { A: sec.A, r: sec.rmin, ...MAT })
+    expect(d.phiPn).toBeCloseTo((0.9 * 248 * sec.A) / 1000, 6)
+  })
+
+  it('rejectionNote names the section and the gate', () => {
+    expect(rejectionNote('L50x50x5', 'strength')).toContain('L50x50x5')
+    expect(rejectionNote('L50x50x5', 'slenderness')).toContain('200')
+  })
+})
+
+describe('§D1 tension slenderness is REPORTED, never enforced', () => {
+  const group = (members: MemberForce[]): TrussGroup =>
+    ({ id: 'g', label: 'g', compression: false, members })
+
+  it('flags a tension group past L/r = 300 but still adopts the section', () => {
+    // A long, lightly loaded tie is strong in the smallest angle made and far
+    // past 300. §D1 calls 300 a preference — about sag, vibration and handling
+    // damage, not strength — so the optimiser must adopt the section and say
+    // so, rather than silently buying steel the code does not require.
+    const r = sizeGroup(group([f('tie', 20, 6, 'diagonal')]), candidateSections(['L']), MAT)
+    expect(r.ok).toBe(true)
+    expect(r.section).not.toBeNull()
+    expect(r.maxTensionSlenderness).toBeGreaterThan(SLENDER_PREFERENCE_TENSION)
+    expect(r.tensionSlendernessOK).toBe(false)
+  })
+
+  it('is satisfied by a short tie', () => {
+    const r = sizeGroup(group([f('tie', 200, 1.0, 'bottom')]), candidateSections(['L']), MAT)
+    expect(r.tensionSlendernessOK).toBe(true)
+    expect(r.maxTensionSlenderness).toBeLessThanOrEqual(SLENDER_PREFERENCE_TENSION)
+  })
+
+  it('ignores compression members — they have their own §E2 limit', () => {
+    // A compression-only group reports zero tension slenderness rather than
+    // borrowing the compression figure and flagging a preference that does
+    // not apply to it.
+    const r = sizeGroup(
+      { id: 'g', label: 'g', compression: true, members: [f('s', -50, 2, 'diagonal')] },
+      candidateSections(['L']), MAT,
+    )
+    expect(r.maxTensionSlenderness).toBe(0)
+    expect(r.tensionSlendernessOK).toBe(true)
+  })
+})

--- a/webapp/src/engine/trussOptimize.ts
+++ b/webapp/src/engine/trussOptimize.ts
@@ -1,0 +1,288 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Truss section optimiser — pick the lightest section per DESIGN GROUP.
+//
+// The page sizes every member of a truss with ONE section, chosen by hand.
+// That is how a truss is drawn, not how it is designed: a bottom chord in
+// pure tension is limited only by Fy·Ag, while a top chord of the same
+// length carrying the same magnitude in compression is limited by buckling
+// and needs several times the area. Sizing both from the worse of the two
+// buys tonnage that does nothing.
+//
+// ── GROUPS ──────────────────────────────────────────────────────────────
+//
+// A group is a set of members that will be detailed with the SAME section.
+// Members are grouped by role and by the sign of their governing force:
+//
+//     top chord · bottom chord · web in compression · web in tension
+//
+// which is how a truss is actually fabricated — one size for the chords,
+// one for the struts, one for the ties. Coarser groupings are available for
+// comparison: 'sign' (two groups) and 'uniform' (one, i.e. what the page
+// did before).
+//
+// A group is sized for the WORST member in it, at that member's own length.
+// One group means one section, so a group containing any compression member
+// is buckling-limited by the LONGEST of them, not by the highest force.
+//
+// ── ZERO-FORCE MEMBERS ──────────────────────────────────────────────────
+//
+// They go into the COMPRESSION group of their family, never the tension
+// one. A member carrying no force in this load case still has to hold its
+// own length without buckling under any incidental load, and it is the
+// slenderness limit — not the force — that sizes it. Putting it in the
+// tension group would let a zero force select the smallest section in the
+// catalogue.
+//
+// ── THE ORDER OF THE FILTERS ────────────────────────────────────────────
+//
+// Same shape as `barSelection`: pass/fail gates applied in sequence, then a
+// ranking over whatever survived. A candidate that fails a gate is never
+// rescued for being lighter, and the reason a section was rejected is the
+// FIRST gate it failed.
+//
+//   1. STRENGTH      every member in the group has util ≤ 1  (AISC D2 / E3)
+//   2. SLENDERNESS   KL/r ≤ 200 for compression (§E2)
+//   3. ECONOMY       least gross area — which is least weight and least cost
+//
+// Units: A mm², r mm, L m, forces kN, weight kg.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { MemberForce } from './truss'
+import { designTrussMember, type MemberDesign, type TrussSection } from './trussDesign'
+import {
+  effectiveSection, doubleAngle, shapesOf,
+  type EffectiveSection, type SectionFamily,
+} from './aiscSections'
+
+const STEEL_DENSITY = 7850   // kg/m³, matching trussTakeoff
+
+/** §E2 — a compression member beyond this is discouraged. */
+export const SLENDER_LIMIT_COMPRESSION = 200
+/** §D1 — a preference, not a limit, so it is reported and not enforced. */
+export const SLENDER_PREFERENCE_TENSION = 300
+
+export type GroupingMode = 'role' | 'sign' | 'uniform'
+
+export interface TrussGroup {
+  id: string
+  label: string
+  /** True when any member in the group is in compression (or zero-force). */
+  compression: boolean
+  members: MemberForce[]
+}
+
+/** Why one candidate section was rejected — the FIRST gate it failed. */
+export type RejectGate = 'strength' | 'slenderness'
+
+export interface GroupChoice {
+  group: TrussGroup
+  /** The adopted section, or null when nothing in the catalogue works. */
+  section: EffectiveSection | null
+  /** The member that set the size — the one at the highest utilisation. */
+  governing: MemberDesign | null
+  maxUtil: number
+  maxSlenderness: number
+  /**
+   * Worst L/r among the TENSION members of the group, and whether it clears
+   * the §D1 preference of 300.
+   *
+   * §D1 says slenderness "preferably" should not exceed 300 for a member in
+   * tension — a recommendation about sag, handling damage and vibration, not
+   * a strength limit — so it is REPORTED and never enforced. Left silent, the
+   * optimiser happily picks a rod-thin bottom chord that is perfectly strong
+   * and unpleasant to build with.
+   */
+  maxTensionSlenderness: number
+  tensionSlendernessOK: boolean
+  ok: boolean
+  /** Total length of the group, m, and the steel it costs, kg. */
+  lengthM: number
+  weightKg: number
+  /** Rejected candidates, lightest first, with the gate each one failed. */
+  rejected: { label: string; gate: RejectGate }[]
+}
+
+export interface TrussOptimizeResult {
+  groups: GroupChoice[]
+  members: (MemberDesign & { group: string })[]
+  totalWeightKg: number
+  ok: boolean
+  /** Weight if a single section were used for everything, for comparison. */
+  uniformWeightKg: number | null
+  /** Fraction saved against the uniform section; 0 when there is nothing to compare. */
+  savedFraction: number
+}
+
+export interface OptimizeOpts {
+  grouping?: GroupingMode
+  /** Families to draw candidates from. Defaults to the family passed in. */
+  families?: SectionFamily[]
+  /** Also consider back-to-back double angles, at this gap (mm). */
+  doubleAngles?: boolean
+  gap?: number
+  E?: number
+  Fy?: number
+  K?: number
+}
+
+// ── Candidates ────────────────────────────────────────────────────────────
+
+/**
+ * The catalogue to search, lightest first. Sorted by gross area because area
+ * is what stage 3 minimises, and because it is monotone with both weight and
+ * cost — a heavier section is never cheaper.
+ */
+export function candidateSections(
+  families: SectionFamily[], opts: { doubleAngles?: boolean; gap?: number } = {},
+): EffectiveSection[] {
+  const out: EffectiveSection[] = []
+  for (const f of families) {
+    for (const s of shapesOf(f)) {
+      out.push(effectiveSection(s))
+      if (opts.doubleAngles && s.family === 'L') out.push(doubleAngle(s, opts.gap ?? 0))
+    }
+  }
+  return out.sort((a, b) => a.A - b.A || a.label.localeCompare(b.label))
+}
+
+// ── Grouping ──────────────────────────────────────────────────────────────
+
+/**
+ * Split members into the sets that will share a section.
+ *
+ * Sign is taken from the GOVERNING force already enveloped upstream. A
+ * zero-force member is treated as compression — see the header.
+ */
+export function groupMembers(forces: MemberForce[], mode: GroupingMode = 'role'): TrussGroup[] {
+  const key = (f: MemberForce): { id: string; label: string; compression: boolean } => {
+    const comp = f.N <= 1e-9          // zero-force counts as compression
+    if (mode === 'uniform') return { id: 'all', label: 'All members', compression: true }
+    if (mode === 'sign') {
+      return comp
+        ? { id: 'compression', label: 'Compression members', compression: true }
+        : { id: 'tension', label: 'Tension members', compression: false }
+    }
+    if (f.kind === 'top') return { id: 'top', label: 'Top chord', compression: comp }
+    if (f.kind === 'bottom') return { id: 'bottom', label: 'Bottom chord', compression: comp }
+    return comp
+      ? { id: 'web-compression', label: 'Web — struts (compression)', compression: true }
+      : { id: 'web-tension', label: 'Web — ties (tension / cross bracing)', compression: false }
+  }
+
+  const map = new Map<string, TrussGroup>()
+  for (const f of forces) {
+    const k = key(f)
+    const g = map.get(k.id)
+    if (g) {
+      g.members.push(f)
+      // A chord group can hold both signs when the envelope flips one panel;
+      // the group is then buckling-limited, so the flag latches on.
+      g.compression = g.compression || k.compression
+    } else {
+      map.set(k.id, { id: k.id, label: k.label, compression: k.compression, members: [f] })
+    }
+  }
+  // Stable, readable order.
+  const RANK = ['top', 'bottom', 'web-compression', 'web-tension', 'compression', 'tension', 'all']
+  return [...map.values()].sort((a, b) => RANK.indexOf(a.id) - RANK.indexOf(b.id))
+}
+
+// ── Sizing one group ──────────────────────────────────────────────────────
+
+const weightOf = (A: number, lengthM: number) => (A / 1e6) * lengthM * STEEL_DENSITY
+
+/**
+ * The lightest candidate that carries every member of the group.
+ *
+ * Every member is checked, not just the worst-looking one: the highest force
+ * and the longest member are usually different members, and in a compression
+ * group it is the long one that governs.
+ */
+export function sizeGroup(
+  group: TrussGroup, candidates: readonly EffectiveSection[],
+  mat: { E: number; Fy: number; K?: number },
+): GroupChoice {
+  const lengthM = group.members.reduce((s, m) => s + m.L, 0)
+  const rejected: { label: string; gate: RejectGate }[] = []
+
+  for (const cand of candidates) {
+    const sec: TrussSection = { A: cand.A, r: cand.rmin, E: mat.E, Fy: mat.Fy, K: mat.K }
+    const designs = group.members.map((m) => designTrussMember(m, sec))
+
+    // Gate 1 — strength. Reported first even when slenderness also fails, so
+    // the reason a section was rejected is the first thing wrong with it.
+    if (designs.some((d) => d.util > 1 + 1e-9)) {
+      rejected.push({ label: cand.label, gate: 'strength' })
+      continue
+    }
+    // Gate 2 — §E2 slenderness, compression members only.
+    if (designs.some((d) => d.mode === 'compression' && !d.slenderOK)) {
+      rejected.push({ label: cand.label, gate: 'slenderness' })
+      continue
+    }
+    // Gate 3 — economy is the sort order, so the first survivor wins.
+    const governing = designs.reduce((a, b) => (b.util > a.util ? b : a), designs[0] ?? null)
+    const tensionSlender = designs
+      .filter((d) => d.mode === 'tension')
+      .reduce((m, d) => Math.max(m, d.slenderness), 0)
+    return {
+      group, section: cand, governing,
+      maxUtil: designs.reduce((m, d) => Math.max(m, d.util), 0),
+      maxSlenderness: designs.reduce((m, d) => Math.max(m, d.slenderness), 0),
+      maxTensionSlenderness: tensionSlender,
+      tensionSlendernessOK: tensionSlender <= SLENDER_PREFERENCE_TENSION + 1e-9,
+      ok: true, lengthM, weightKg: weightOf(cand.A, lengthM), rejected,
+    }
+  }
+
+  // Nothing in the catalogue works — report it rather than adopting a failure.
+  return {
+    group, section: null, governing: null, maxUtil: Infinity, maxSlenderness: Infinity,
+    maxTensionSlenderness: Infinity, tensionSlendernessOK: false,
+    ok: false, lengthM, weightKg: 0, rejected,
+  }
+}
+
+// ── The whole truss ───────────────────────────────────────────────────────
+
+export function optimizeTruss(
+  forces: MemberForce[], family: SectionFamily, opts: OptimizeOpts = {},
+): TrussOptimizeResult {
+  const mat = { E: opts.E ?? 200000, Fy: opts.Fy ?? 248, K: opts.K ?? 1.0 }
+  const families = opts.families ?? [family]
+  const candidates = candidateSections(families, { doubleAngles: opts.doubleAngles, gap: opts.gap })
+
+  const groups = groupMembers(forces, opts.grouping ?? 'role').map((g) => sizeGroup(g, candidates, mat))
+
+  const members: (MemberDesign & { group: string })[] = []
+  for (const gc of groups) {
+    if (!gc.section) continue
+    const sec: TrussSection = { A: gc.section.A, r: gc.section.rmin, E: mat.E, Fy: mat.Fy, K: mat.K }
+    for (const m of gc.group.members) members.push({ ...designTrussMember(m, sec), group: gc.group.id })
+  }
+
+  // What a single section for the whole truss would have cost, so the saving
+  // is a measured number rather than a claim.
+  const uniform = sizeGroup(
+    groupMembers(forces, 'uniform')[0] ?? { id: 'all', label: 'All members', compression: true, members: [] },
+    candidates, mat,
+  )
+  const totalWeightKg = groups.reduce((s, g) => s + g.weightKg, 0)
+  const uniformWeightKg = uniform.ok ? uniform.weightKg : null
+
+  return {
+    groups, members, totalWeightKg,
+    ok: groups.every((g) => g.ok),
+    uniformWeightKg,
+    savedFraction: uniformWeightKg && uniformWeightKg > 0
+      ? Math.max(0, 1 - totalWeightKg / uniformWeightKg)
+      : 0,
+  }
+}
+
+/** A one-line explanation of a rejection, for a schedule note or a tooltip. */
+export function rejectionNote(label: string, gate: RejectGate): string {
+  return gate === 'strength'
+    ? `${label}: a member in this group exceeds its capacity`
+    : `${label}: a compression member exceeds KL/r = ${SLENDER_LIMIT_COMPRESSION} (§E2)`
+}

--- a/webapp/src/engine/trussTakeoff.ts
+++ b/webapp/src/engine/trussTakeoff.ts
@@ -1,6 +1,8 @@
 // ─────────────────────────────────────────────────────────────────────────
 // Truss steel material take-off + priced Bill of Materials (Truss Phase 3).
-// All members share one cross-section (the EffectiveSection from aiscSections).
+// Members share one cross-section by default; pass `sectionOf` to bill a
+// truss sized per design group by the optimiser, where a bottom chord and a
+// top chord are different sections and the BOM has to say so.
 // A connection/gusset plate allowance (default 10 % of net steel) is added on
 // top of the member steel to cover gusset plates and field welding/bolting.
 // Units: geometry m; area mm²; linear density kg/m; weight kg; prices PHP (₱).
@@ -25,21 +27,44 @@ export interface TrussKindSubtotal {
   netKg: number
 }
 
+/** One distinct section used by the truss, and what it costs. */
+export interface TrussSectionSubtotal {
+  label: string
+  areaMm2: number
+  kgPerM: number
+  members: number
+  lengthM: number
+  netKg: number
+}
+
 export interface TrussTakeoffResult {
   byMember: TrussMemberQty[]
-  section: string            // effective section label
-  areaMm2: number            // mm²
-  kgPerM: number             // kg/m
+  /** Section label — or a count, when the truss uses more than one. */
+  section: string
+  /**
+   * Area and linear density. With a single section these are exactly that
+   * section's; with several they are LENGTH-WEIGHTED AVERAGES, and `bySection`
+   * carries the real breakdown.
+   */
+  areaMm2: number
+  kgPerM: number
   netSteelKg: number         // fabricated member steel
   gussetFraction: number     // e.g. 0.10
   gussetKg: number           // netSteelKg × gussetFraction
   totalKg: number            // net + gusset
   byKind: TrussKindSubtotal[]
+  bySection: TrussSectionSubtotal[]
 }
 
 export interface TrussTakeoffOptions {
   /** Fraction of net steel weight added for gusset/connection plates (default 0.10). */
   gussetFraction?: number
+  /**
+   * Per-member section, for a truss sized by design group. Anything this
+   * returns `undefined` for falls back to the `eff` passed in, so a partial
+   * mapping still bills correctly.
+   */
+  sectionOf?: (memberId: string) => EffectiveSection | undefined
 }
 
 export function trussTakeoff(
@@ -48,14 +73,36 @@ export function trussTakeoff(
   opts: TrussTakeoffOptions = {},
 ): TrussTakeoffResult {
   const gussetFraction = Math.max(0, opts.gussetFraction ?? 0.10)
-  const areaMm2 = eff.A
-  const kgPerM = (areaMm2 / 1e6) * STEEL_DENSITY
+  const secOf = (id: string) => opts.sectionOf?.(id) ?? eff
+  const density = (a: number) => (a / 1e6) * STEEL_DENSITY
 
-  const byMember: TrussMemberQty[] = forces.map((f) => ({
-    id: f.id, kind: f.kind, L: f.L, kgPerM, netWeightKg: f.L * kgPerM,
-  }))
+  const byMember: TrussMemberQty[] = forces.map((f) => {
+    const kg = density(secOf(f.id).A)
+    return { id: f.id, kind: f.kind, L: f.L, kgPerM: kg, netWeightKg: f.L * kg }
+  })
 
   const netSteelKg = byMember.reduce((s, m) => s + m.netWeightKg, 0)
+
+  // Group by the section actually used, so a grouped truss bills one line per
+  // section rather than one averaged line that no supplier can quote from.
+  const secMap = new Map<string, TrussSectionSubtotal>()
+  for (const f of forces) {
+    const sc = secOf(f.id)
+    const row = secMap.get(sc.label) ?? {
+      label: sc.label, areaMm2: sc.A, kgPerM: density(sc.A), members: 0, lengthM: 0, netKg: 0,
+    }
+    row.members += 1
+    row.lengthM += f.L
+    row.netKg += f.L * row.kgPerM
+    secMap.set(sc.label, row)
+  }
+  const bySection = [...secMap.values()].sort((a, b) => b.netKg - a.netKg)
+
+  const totalLength = forces.reduce((s, f) => s + f.L, 0)
+  const areaMm2 = bySection.length === 1
+    ? bySection[0].areaMm2
+    : (totalLength > 0 ? bySection.reduce((s, r) => s + r.areaMm2 * r.lengthM, 0) / totalLength : eff.A)
+  const kgPerM = totalLength > 0 ? netSteelKg / totalLength : density(eff.A)
   const gussetKg = netSteelKg * gussetFraction
   const totalKg = netSteelKg + gussetKg
 
@@ -67,7 +114,8 @@ export function trussTakeoff(
     })
     .filter((k) => k.members > 0)
 
-  return { byMember, section: eff.label, areaMm2, kgPerM, netSteelKg, gussetFraction, gussetKg, totalKg, byKind }
+  const section = bySection.length === 1 ? bySection[0].label : `${bySection.length} sections`
+  return { byMember, section, areaMm2, kgPerM, netSteelKg, gussetFraction, gussetKg, totalKg, byKind, bySection }
 }
 
 // ── Pricing ────────────────────────────────────────────────────────────────

--- a/webapp/src/pages/TrussSpace.tsx
+++ b/webapp/src/pages/TrussSpace.tsx
@@ -6,6 +6,7 @@ import { SceneText } from '../components/SceneText'
 import * as THREE from 'three'
 import { generateTruss, solveTrussEnvelope, selfWeightLoads, type TrussType, type TrussModel } from '../engine/truss'
 import { designTruss, type MemberDesign, type TrussSection } from '../engine/trussDesign'
+import { optimizeTruss, type GroupingMode } from '../engine/trussOptimize'
 import { FAMILIES, shapesOf, shapeByName, effectiveSection, type SectionFamily, type EffectiveSection } from '../engine/aiscSections'
 import { trussTakeoff, costTrussBill } from '../engine/trussTakeoff'
 import { SectionShape } from '../components/SectionShape'
@@ -89,6 +90,10 @@ export default function TrussSpace() {
   // free-form editor: when non-null, this model replaces the parametric one
   const [custom, setCustom] = useState<TrussModel | null>(null)
   // custom section: enter A & radii directly instead of picking an AISC shape
+  // Auto-sizing: one section per DESIGN GROUP instead of one for the truss.
+  const [optimize, setOptimize] = useState(false)
+  const [grouping, setGrouping] = useState<GroupingMode>('role')
+  const [searchAllFamilies, setSearchAllFamilies] = useState(false)
   const [customSec, setCustomSec] = useState(false)
   const [csA, setCsA] = useState(1500); const [csRx, setCsRx] = useState(30); const [csRy, setCsRy] = useState(30)
   const controlsRef = useRef<React.ComponentRef<typeof OrbitControls>>(null)
@@ -128,7 +133,33 @@ export default function TrussSpace() {
   ], [model, includeSW, eff.A, loadedNodes, deadLoad])
   const live = useMemo(() => loadedNodes.map((n) => ({ node: n, fx: 0, fy: -liveLoad })), [loadedNodes, liveLoad])
   const result = useMemo(() => solveTrussEnvelope(model, dead, live), [model, dead, live])
-  const design = useMemo(() => (result ? designTruss(result.forces, section) : null), [result, section])
+  // The optimiser sizes each group from the catalogue; the hand-picked
+  // section stays the fallback and the baseline it is measured against.
+  const opt = useMemo(() => {
+    if (!optimize || !result) return null
+    return optimizeTruss(result.forces, family, {
+      grouping,
+      families: searchAllFamilies ? ['L', 'C', 'W', 'HSS', 'PIPE', 'WT'] : [family],
+      doubleAngles: double, gap, E, Fy, K,
+    })
+  }, [optimize, result, family, grouping, searchAllFamilies, double, gap, E, Fy, K])
+
+  /** Section adopted for a member — per group when optimising, else the one
+   *  picked by hand. Everything downstream (table, 3D colour, take-off) reads
+   *  this, so the drawing and the bill cannot disagree with the design. */
+  const sectionOfMember = useMemo(() => {
+    const m = new Map<string, EffectiveSection>()
+    for (const g of opt?.groups ?? []) {
+      if (!g.section) continue
+      for (const mem of g.group.members) m.set(mem.id, g.section)
+    }
+    return m
+  }, [opt])
+
+  const design = useMemo(() => {
+    if (opt) return { members: opt.members, maxUtil: Math.max(0, ...opt.members.map((m) => m.util)), allOK: opt.ok && opt.members.every((m) => m.ok) }
+    return result ? designTruss(result.forces, section) : null
+  }, [opt, result, section])
   const shapes3d = useMemo(() => {
     if (customSec) {   // illustrative solid square (no real profile for a custom section)
       const h = Math.sqrt(eff.A) / 1000 / 2
@@ -138,8 +169,11 @@ export default function TrussSpace() {
     return buildSectionShapes(eff)   // true-scale section profiles for the 3D extrusion
   }, [eff, customSec])
   const takeoff = useMemo(
-    () => result ? trussTakeoff(result.forces, eff, { gussetFraction: gussetPct / 100 }) : null,
-    [result, eff, gussetPct],
+    () => result ? trussTakeoff(result.forces, eff, {
+      gussetFraction: gussetPct / 100,
+      sectionOf: opt ? (id) => sectionOfMember.get(id) : undefined,
+    }) : null,
+    [result, eff, gussetPct, opt, sectionOfMember],
   )
   const bill = useMemo(
     () => takeoff ? costTrussBill(takeoff, { steelKg: steelUnitPrice }) : null,
@@ -248,6 +282,39 @@ export default function TrussSpace() {
             </p>
           </Card>
 
+          <Card title="Auto-size sections">
+            <label className="col-span-full flex items-center gap-2 text-sm">
+              <input type="checkbox" checked={optimize} onChange={(e) => setOptimize(e.target.checked)}
+                disabled={customSec} />
+              <span>
+                Size each design group from the catalogue
+                {customSec && <span className="ml-1 text-slate-400">(turn off the custom section first)</span>}
+              </span>
+            </label>
+            {optimize && !customSec && (
+              <>
+                <Pick label="Split sections by" value={grouping} onChange={(v) => setGrouping(v as GroupingMode)}
+                  options={[
+                    ['role', 'Chords + web struts + web ties'],
+                    ['sign', 'Tension / compression'],
+                    ['uniform', 'One section for the whole truss'],
+                  ]} />
+                <label className="col-span-full flex items-center gap-2 text-sm">
+                  <input type="checkbox" checked={searchAllFamilies}
+                    onChange={(e) => setSearchAllFamilies(e.target.checked)} />
+                  <span>Search every family, not just {family}</span>
+                </label>
+                <p className="col-span-full text-[11px] text-slate-500">
+                  Each group takes the <b>lightest</b> section that carries every one of its members:
+                  strength first (AISC D2 / E3), then KL/r ≤ 200 for compression (§E2), then least steel.
+                  A group is buckling-limited by its <b>longest</b> member, not its largest force — so a
+                  bottom chord in pure tension ends up much lighter than a top chord of the same length.
+                  Zero-force members are sized as struts.
+                </p>
+              </>
+            )}
+          </Card>
+
           <Card title="Section & material (AISC steel)">
             <label className="col-span-full flex items-center gap-2 text-sm">
               <input type="checkbox" checked={customSec} onChange={(e) => setCustomSec(e.target.checked)} />
@@ -301,6 +368,42 @@ export default function TrussSpace() {
               {design && <Row alert={!design.allOK} label="Design" value={design.allOK ? `OK · max util ${(design.maxUtil * 100).toFixed(0)}%` : `✗ max util ${(design.maxUtil * 100).toFixed(0)}%`} />}
             </ResultCard>
           )}
+
+          {opt && (
+            <ResultCard title="Auto-sized sections">
+              {opt.groups.map((g) => (
+                <Row key={g.group.id}
+                  alert={!g.ok}
+                  label={g.group.label}
+                  value={g.section?.label ?? 'no section fits'}
+                  sub={g.section
+                    ? `util ${(g.maxUtil * 100).toFixed(0)}% · KL/r ${g.maxSlenderness.toFixed(0)}${g.tensionSlendernessOK ? '' : ' ⚠'} · ${g.group.members.length} members · ${g.weightKg.toFixed(0)} kg`
+                    : `${g.rejected.length} candidates rejected`} />
+              ))}
+              <Row label="Steel in members" value={`${opt.totalWeightKg.toFixed(0)} kg`}
+                sub={opt.uniformWeightKg
+                  ? `one section for all: ${opt.uniformWeightKg.toFixed(0)} kg`
+                  : undefined} />
+              {opt.savedFraction > 0 && (
+                <Row label="Saved against one section"
+                  value={`${(opt.savedFraction * 100).toFixed(1)}%`}
+                  sub={opt.uniformWeightKg ? `${(opt.uniformWeightKg - opt.totalWeightKg).toFixed(0)} kg` : undefined} />
+              )}
+              {opt.groups.some((g) => g.section && !g.tensionSlendernessOK) && (
+                <p className="mt-2 text-[11px] text-amber-700">
+                  ⚠ A tension group exceeds L/r = 300. §D1 states that as a <b>preference</b>, not a
+                  limit — the member is strong enough, but it will sag, vibrate and is easy to damage
+                  in handling. Pick a stiffer section by hand if that matters here.
+                </p>
+              )}
+              {!opt.ok && (
+                <p className="mt-2 text-[11px] text-red-600">
+                  At least one group has no adequate section in the families searched — widen
+                  the search, or the truss geometry needs changing.
+                </p>
+              )}
+            </ResultCard>
+          )}
         </div>
       </div>
 
@@ -310,7 +413,7 @@ export default function TrussSpace() {
           <h2 className="text-xl font-extrabold tracking-tight text-[#0056b3]">
             Truss member schedule — {custom ? 'custom truss' : `${type} · ${f1(span)} m span`}
             <span className="ml-3 text-sm font-normal text-slate-500">
-              {result.determinacy.status} · {eff.label} · Fy {Fy} MPa · max util {(design.maxUtil * 100).toFixed(0)}%
+              {result.determinacy.status} · {opt ? `${opt.groups.length} auto-sized sections` : eff.label} · Fy {Fy} MPa · max util {(design.maxUtil * 100).toFixed(0)}%
             </span>
           </h2>
           <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
@@ -319,6 +422,7 @@ export default function TrussSpace() {
                 <tr className="text-left uppercase tracking-wide text-slate-500">
                   <th className="py-1 pr-2 font-semibold">Member</th>
                   <th className="py-1 pr-2 font-semibold">Type</th>
+                  {opt && <th className="py-1 pr-2 font-semibold">Section</th>}
                   <th className="py-1 pr-2 text-right font-semibold">L (m)</th>
                   <th className="py-1 pr-2 text-right font-semibold">Force (kN)</th>
                   <th className="py-1 pr-2 font-semibold">Sense</th>
@@ -337,6 +441,7 @@ export default function TrussSpace() {
                       className={`cursor-pointer border-t border-slate-100 hover:bg-blue-50/40 ${bad ? 'bg-red-50 text-red-700' : ''} ${selected === f.id ? 'bg-amber-50' : ''}`}>
                       <td className="py-1 pr-2 font-medium">{f.id} <span className="text-slate-500">({f.i}–{f.j})</span></td>
                       <td className="py-1 pr-2">{f.kind}</td>
+                      {opt && <td className="py-1 pr-2 font-mono text-[10px]">{sectionOfMember.get(f.id)?.label ?? '—'}</td>}
                       <td className="py-1 pr-2 text-right">{f2(f.L)}</td>
                       <td className="py-1 pr-2 text-right">{f1(Math.abs(f.N))}</td>
                       <td className={`py-1 pr-2 ${f.N >= 0 ? 'text-blue-700' : 'text-red-600'}`}>{d.mode === 'zero' ? '—' : f.N >= 0 ? 'T' : 'C'}</td>


### PR DESCRIPTION
Backlog item: *"Truss Space, create a module that automatically optimizes the utilization ratio of each member by trying other sizes and the section should be split according to tension compression or cross bracing."*

**Engine layer 6** — design pipeline. New `engine/trussOptimize.ts`.

## The problem with one section

The page sized every member of a truss from one hand-picked shape. That is how a truss is *drawn*, not how it is *designed*: a bottom chord in pure tension is limited only by `Fy·Ag`, while a top chord of the same length carrying the same magnitude in compression is buckling-limited and needs several times the area. Sizing both from the worse of the two buys tonnage that does nothing.

On the page's own default truss, the hand-picked section ran at **20% utilisation**.

## Groups

A group is the set of members that will be detailed with the same section:

> **top chord · bottom chord · web struts · web ties (cross bracing)**

which is how a truss is actually fabricated. Coarser groupings are selectable for comparison — `sign` (two groups) and `uniform` (one, i.e. exactly what the page did before), which is also what the saving is measured against.

Two things the grouping has to get right:

- **A group is sized for its worst member at that member's own length.** One group means one section, so a group holding any compression member is buckling-limited by the **longest** of them, not the largest force. Tested with a short high-force member beside a long low-force one.
- **Zero-force members join the compression group**, never the tension one. A member carrying nothing still has to hold its own length; slenderness, not force, sizes it. Grouped with the ties, a zero force would select the smallest section in the catalogue.

## The gates, in order

Same shape as `barSelection`: pass/fail filters in sequence, then a ranking over the survivors. A candidate that fails a gate is never rescued for being lighter, and the reason a section was rejected is the **first** gate it failed — reporting "strength" for a section that is plenty strong and merely too slender sends someone off to check a force that is fine.

| | gate | clause |
|---|---|---|
| 1 | every member has util ≤ 1 | AISC D2 / E3 |
| 2 | KL/r ≤ 200 for compression | §E2 |
| 3 | least gross area — least weight, least cost | — |

The candidate list is sorted by area, so the first survivor is optimal by construction.

## §D1 — reported, not enforced

Running it turned up a real result: the bottom chord came out at **KL/r = 303**, past §D1's preference of 300. §D1 says slenderness *"preferably"* should not exceed 300 in tension — a recommendation about sag, vibration and handling damage, not a strength limit. So the group carries `tensionSlendernessOK` and the page shows a ⚠ with the reason, rather than either enforcing a limit the code does not impose or staying silent and handing back a rod-thin chord.

(`SLENDER_PREFERENCE_TENSION` had been declared and never used; this is what it is for.)

## Downstream

`trussTakeoff` gained an optional `sectionOf` resolver and a `bySection` breakdown, so a grouped truss bills **one line per section** instead of one averaged line no supplier can quote from. Existing single-section callers are unchanged and their tests still pass. The member schedule gains a Section column, and the 3D view, the table and the BOM all read the same per-member section — the drawing and the bill cannot disagree.

## Measured, in the browser

Switching auto-sizing on, on the page's default truss:

| | before | after |
|---|---|---|
| max utilisation | 20% | **93%** |
| steel in members | 530 kg | **375 kg** (29.1% saved) |

| group | section | util | KL/r |
|---|---|---|---|
| Top chord | 2L 64x64x4.8 | 89% | 151 |
| Bottom chord | L51x51x4.8 | 93% | 303 ⚠ |
| Web struts | 2L 76x76x4.8 | 90% | 151 |
| Web ties | L51x51x4.8 | 17% | 202 |

0 page errors.

## Verification

**+31 cases**: grouping completeness (no member dropped or duplicated in any mode), gate ordering *and the reason reported*, sizing by the longest rather than the largest member, monotonicity (a finer grouping is never heavier; a wider family search is never worse), determinism, honest failure when no section in a family can hold a 9 m strut at KL/r ≤ 200, and the §D1 advisory.

`npm test` — 199 files, **3257 passed**. `npx tsc -b`, `eslint` and `npm run build` green.

---

Remaining backlog after this: **#35 geotechnical page split** — the last open item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_