### PR TITLE
fix(slab): correct the bar cut-offs against ACI Fig. 8.7.4.1.3(a)

### DIFF
--- a/webapp/src/engine/slabBarDetail.test.ts
+++ b/webapp/src/engine/slabBarDetail.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
-  slabBarRuns, tempSteelArea, tempSpacingMax, DEFAULT_EXT, type BarRun,
+  slabBarRuns, tempSteelArea, tempSpacingMax, DEFAULT_EXT, DROP_PANEL_EXT, type BarRun,
 } from './slabBarDetail'
 
 // 6 m centres, 400 mm columns → ℓn = 5.6 m, faces at 0.2 and 5.8 m.
@@ -61,13 +61,29 @@ describe('slabBarRuns', () => {
     expect(cont.x2).toBeLessThanOrEqual(6)
   })
 
-  it('stops the discontinuous bottom bars short of the supports', () => {
-    const b = bottom(layout().runs)
-    const short = b.find((r) => r.label.includes('from face'))!
-    expect(short.x1).toBeCloseTo(0.2 + 0.20 * 5.6, 9)
-    expect(short.x2).toBeCloseTo(5.8 - 0.20 * 5.6, 9)
-    // …and that they still overlap mid-span rather than leaving a gap.
+  it('gives the COLUMN strip no short bottom run — its bottom mat is 100% continuous', () => {
+    // Fig. 8.7.4.1.3(a): the column-strip bottom row reads "100% …
+    // Continuous bars", with splices permitted only in the mid-span region.
+    // An earlier version cut these at 0.20ℓn from each face — a run the
+    // figure does not contain, and one that would have removed the very bars
+    // §8.7.4.2 keeps through the column core.
+    expect(DEFAULT_EXT.column.bottomShort).toBeNull()
+    const b = bottom(layout('column').runs)
+    expect(b).toHaveLength(1)
+    expect(b[0].label).toMatch(/^continuous/)
+  })
+
+  it('stops the MIDDLE strip remainder at 0.15ℓn from the support centreline', () => {
+    const b = bottom(layout('middle').runs)
+    const short = b.find((r) => r.label.includes('0.15'))!
+    // Measured from the CENTRELINE (x = 0 and x = L1), not the face.
+    expect(short.x1).toBeCloseTo(0.15 * 5.6, 9)
+    expect(short.x2).toBeCloseTo(6 - 0.15 * 5.6, 9)
+    // …and it still spans mid-span rather than leaving a gap.
     expect(short.x1).toBeLessThan(short.x2)
+    // It must reach CLOSER to the support than a face-datum reading would,
+    // which is the conservative direction if the datum were misread.
+    expect(short.x1).toBeLessThan(0.2 + 0.15 * 5.6)
   })
 
   it('gives the middle strip shorter top runs than the column strip', () => {
@@ -116,5 +132,52 @@ describe('tempSpacingMax — §24.4.3.3', () => {
     expect(tempSpacingMax(80)).toBe(400)    // 5h governs on a thin slab
     expect(tempSpacingMax(200)).toBe(450)   // the 450 cap governs
     expect(tempSpacingMax(90)).toBe(450)    // 5h = 450, the boundary
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// Every number pinned to ACI 318-14 Fig. 8.7.4.1.3(a), so a future edit that
+// drifts from the figure fails here rather than on a drawing.
+// ─────────────────────────────────────────────────────────────────────────
+describe('the extensions match Fig. 8.7.4.1.3(a)', () => {
+  it('column strip, without drop panels: top 0.30 / 0.20, bottom continuous', () => {
+    expect(DEFAULT_EXT.column.topLong).toBe(0.30)
+    expect(DEFAULT_EXT.column.topShort).toBe(0.20)
+    expect(DEFAULT_EXT.column.bottomShort).toBeNull()
+  })
+
+  it('middle strip: top 100% at 0.22, bottom remainder at 0.15', () => {
+    // The figure gives ONE top extension for the middle strip at 100%, so
+    // both runs carry the same fraction rather than a long/short split.
+    expect(DEFAULT_EXT.middle.topLong).toBe(0.22)
+    expect(DEFAULT_EXT.middle.topShort).toBe(0.22)
+    expect(DEFAULT_EXT.middle.bottomShort).toBe(0.15)
+  })
+
+  it('carries the 6 in. embedment as 150 mm in both strips', () => {
+    expect(DEFAULT_EXT.column.supportEmbed).toBe(150)
+    expect(DEFAULT_EXT.middle.supportEmbed).toBe(150)
+  })
+
+  it('with drop panels, ONLY the column-strip long top run moves — 0.30 → 0.33', () => {
+    expect(DROP_PANEL_EXT.column.topLong).toBe(0.33)
+    expect(DROP_PANEL_EXT.column.topShort).toBe(DEFAULT_EXT.column.topShort)
+    expect(DROP_PANEL_EXT.column.bottomShort).toBeNull()
+    expect(DROP_PANEL_EXT.middle).toEqual(DEFAULT_EXT.middle)
+  })
+
+  it('the drop panel lengthens the top steel — it does not shorten it', () => {
+    const noDrop = slabBarRuns(L1, C, H, COVER, DEFAULT_EXT.column)
+    const drop = slabBarRuns(L1, C, H, COVER, DROP_PANEL_EXT.column)
+    const longest = (r: BarRun[]) => Math.max(...top(r).map((x) => x.x2 - x.x1))
+    expect(longest(drop.runs)).toBeGreaterThan(longest(noDrop.runs))
+  })
+
+  it('labels say which datum each cut-off is measured from', () => {
+    // A cut-off length on a drawing is useless without its datum, and the
+    // two mats use different ones: top from the face, bottom from the ℄.
+    const mid = layout('middle').runs
+    expect(bottom(mid).find((r) => r.label.includes('0.15'))!.label).toContain('℄')
+    expect(top(mid)[0].label).toMatch(/ℓn/)
   })
 })

--- a/webapp/src/engine/slabBarDetail.ts
+++ b/webapp/src/engine/slabBarDetail.ts
@@ -6,20 +6,34 @@
 // mid-span, and the shrinkage/temperature mat running the other way (seen
 // end-on, so it draws as a row of dots).
 //
-// ⚠ THE EXTENSION FRACTIONS ARE NOT VERIFIED AGAINST THE PRINTED FIGURE.
+// EXTENSIONS: ACI 318-14 Fig. 8.7.4.1.3(a) / NSCP 2015 Fig. 408.7.4.1.3(a) —
+// "minimum extensions for deformed reinforcement in two-way slabs without
+// beams". Checked against the printed figure; what it gives is:
 //
-// They are meant to be ACI 318-14 Fig. 8.7.4.1.3(a) / NSCP 2015
-// Fig. 408.7.4.1.3(a) — "minimum extensions for deformed reinforcement in
-// two-way slabs without beams" — for the case WITHOUT drop panels. I could not
-// open the figure from the environment this was written in, so `DEFAULT_EXT`
-// is written from memory and MUST be checked against a copy of the code before
-// anyone details from it.
+//                           | WITHOUT drop panels | WITH drop panels
+//   ------------------------+---------------------+------------------
+//   COLUMN  top, 50%        |      0.30 ln        |     0.33 ln
+//   STRIP   top, remainder  |      0.20 ln        |     0.20 ln
+//           bottom, 100%    |   CONTINUOUS, 150 mm into the support
+//   ------------------------+---------------------+------------------
+//   MIDDLE  top, 100%       |      0.22 ln        |     0.22 ln
+//   STRIP   bottom, 50%     |   CONTINUOUS, 150 mm into the support
+//           bottom, rem.    |   max 0.15 ln from the support centreline
 //
-// That is why the fractions are an INPUT with a default rather than a constant
-// buried in a drawing: the numbers are printed on the drawing itself, next to
-// the clause, so an engineer sees exactly what was assumed and can change it.
-// A wrong cut-off length that nobody can see is the failure mode worth
-// designing against here.
+// THE COLUMN STRIP HAS NO SHORT BOTTOM RUN. The figure gives its bottom mat
+// as 100% continuous, with splices permitted only in the mid-span region and
+// at least two bars carried through the column core per §8.7.4.2 (structural
+// integrity). An earlier version of this file cut the column-strip bottom
+// bars at 0.20 ln from each face — a run that does not exist in the figure,
+// and one that would have removed the very bars §8.7.4.2 exists to keep.
+// `bottomShort: null` is how "all of them are continuous" is expressed.
+//
+// The 6 in. embedment in the figure is carried as 150 mm.
+//
+// The fractions stay an INPUT with a default rather than a constant buried in
+// a drawing: they are printed on the drawing next to the clause, so an
+// engineer sees exactly what was assumed. A wrong cut-off length that nobody
+// can see is the failure mode worth designing against here.
 //
 // Units: metres for spans, millimetres for the slab and its cover.
 // ─────────────────────────────────────────────────────────────────────────
@@ -30,22 +44,42 @@ export interface SlabBarExtensions {
   topLong: number
   /** Top mat, the remainder. */
   topShort: number
-  /** Bottom mat, the bars that stop short — the remainder that is not continuous. */
-  bottomShort: number
+  /**
+   * Bottom mat, the remainder that is not carried through the support —
+   * a fraction of ln measured from the support CENTRELINE.
+   *
+   * `null` where the figure gives the bottom mat as 100% continuous, which is
+   * the case for the column strip. Not zero: zero would draw a bar that stops
+   * exactly at the centreline, which is a different (and wrong) statement.
+   *
+   * Measured from the CENTRELINE, not the face. The figure dimensions this
+   * one from the support centre line, and it is the tighter of the two
+   * readings — it carries the bar closer to the support, so a
+   * misinterpretation errs toward more steel rather than less.
+   */
+  bottomShort: number | null
   /** Minimum embedment of a continuous bottom bar into the support, mm. */
   supportEmbed: number
 }
 
 /**
- * Defaults for a flat plate — no beams, no drop panels.
- *
- * See the warning at the top of this file: unverified. The column strip and
- * middle strip differ in the figure, which is why `slabBarRuns` takes the set
- * to use rather than choosing one.
+ * Flat plate — no beams, NO drop panels. The column strip and middle strip
+ * differ in the figure, which is why `slabBarRuns` takes the set to use
+ * rather than choosing one.
  */
 export const DEFAULT_EXT: Record<'column' | 'middle', SlabBarExtensions> = {
-  column: { topLong: 0.30, topShort: 0.20, bottomShort: 0.20, supportEmbed: 150 },
+  column: { topLong: 0.30, topShort: 0.20, bottomShort: null, supportEmbed: 150 },
   middle: { topLong: 0.22, topShort: 0.22, bottomShort: 0.15, supportEmbed: 150 },
+}
+
+/**
+ * Flat slab WITH drop panels. Only one number moves: the column strip's
+ * longer top run goes from 0.30 ln to 0.33 ln, because the drop panel pushes
+ * the point of inflection further into the span.
+ */
+export const DROP_PANEL_EXT: Record<'column' | 'middle', SlabBarExtensions> = {
+  column: { ...DEFAULT_EXT.column, topLong: 0.33 },
+  middle: { ...DEFAULT_EXT.middle },
 }
 
 /** One drawn bar run, in metres along the span from the left support centre. */
@@ -103,20 +137,24 @@ export function slabBarRuns(
   }
 
   // ── Bottom mat ────────────────────────────────────────────────────────
-  // At least half continuous through the support; the remainder stops short of
-  // it. The continuous bars are what stop a mid-span crack from becoming a
-  // hinge, so they are drawn running the whole way with the embedment noted.
+  // Continuous through the support — 100% of the column strip, 50% of the
+  // middle strip. These are the bars that stop a mid-span crack becoming a
+  // hinge (§8.7.4.2), so they run the whole way with the embedment noted.
   const embed = ext.supportEmbed / 1000
   runs.push({
     mat: 'bottom', x1: face - Math.min(embed, face), x2: right + Math.min(embed, face),
     label: `continuous · ${ext.supportEmbed} mm into support`,
     continuesLeft: false, continuesRight: false,
   })
-  runs.push({
-    mat: 'bottom', x1: face + ext.bottomShort * ln, x2: right - ext.bottomShort * ln,
-    label: `0.${(ext.bottomShort * 100).toFixed(0)}ℓn from face`,
-    continuesLeft: false, continuesRight: false,
-  })
+  // The remainder, where the figure has one. Measured from the support
+  // CENTRELINE — see `bottomShort`. The column strip has no such run.
+  if (ext.bottomShort !== null) {
+    runs.push({
+      mat: 'bottom', x1: ext.bottomShort * ln, x2: l1 - ext.bottomShort * ln,
+      label: `max 0.${(ext.bottomShort * 100).toFixed(0)}ℓn from support ℄`,
+      continuesLeft: false, continuesRight: false,
+    })
+  }
 
   return {
     ln, support, total: l1, runs,

--- a/webapp/src/pages/SlabDesign.tsx
+++ b/webapp/src/pages/SlabDesign.tsx
@@ -301,10 +301,11 @@ export default function SlabDesign() {
                   Sections are taken along <KTex tex="l_1" /> in the x-direction. Top steel is the
                   negative-moment mat over the supports; bottom steel is the positive-moment mat
                   through mid-span. The shrinkage and temperature bars run perpendicular, so a
-                  section cuts them end-on.{' '}
-                  <strong className="font-semibold text-amber-800">
-                    Check the cut-off fractions against ACI 318-14 Fig. 8.7.4.1.3(a) before detailing.
-                  </strong>
+                  section cuts them end-on. Cut-offs follow ACI 318-14
+                  Fig. 8.7.4.1.3(a) for a flat plate without drop panels: top steel from the
+                  FACE of support, the bottom remainder from the support CENTRELINE. The column
+                  strip's bottom mat is 100% continuous — at least two bars pass through the
+                  column core per §8.7.4.2.
                 </p>
               </ResultCard>
 


### PR DESCRIPTION
The extension fractions in `slabBarDetail` were written from memory — the figure could not be opened from the environment they were written in, and the file carried a ⚠ saying so. The figure is now to hand and they have been checked.

## One of the four was wrong

**The column strip has no short bottom run.** The figure gives its bottom mat as **100% continuous** — *"Continuous bars"*, with splices permitted only in the mid-span region and *"at least two bars or wires shall conform to 8.7.4.2"* (structural integrity, through the column core).

The code cut those bars at 0.20 ℓn from each face: a run the figure does not contain, and one that removes exactly the bars §8.7.4.2 exists to keep.

`bottomShort` is now `number | null`, and the column strip is `null` — not zero, which would draw a bar stopping at the centreline and is a different (wrong) statement.

## The other three check out

| | value | |
|---|---|---|
| column strip, top 50% | 0.30 ℓn | ✓ |
| column strip, top remainder | 0.20 ℓn | ✓ |
| middle strip, top 100% | 0.22 ℓn | ✓ (one fraction, not a long/short split) |
| middle strip, bottom remainder | 0.15 ℓn | ✓ |
| both, embedment | 6 in. → 150 mm | ✓ |

## A datum that was not being stated

The figure dimensions the **top** extensions from the **face of support**, and the middle-strip **bottom remainder** from the **support centreline**. The code measured both from the face.

The centreline reading is also the *tighter* of the two — it carries the bar closer to the support — so this errs toward more steel rather than less if I am misreading the scan. Both drawn labels now name their datum: `0.30ℓn` (from the face) and `max 0.15ℓn from support ℄`.

## Added

`DROP_PANEL_EXT`, since the figure gives the with-drop-panels case and only one number moves: the column strip's long top run, **0.30 → 0.33 ℓn** (the drop panel pushes the point of inflection further into the span).

## Verified in the browser

Rendered both strips and read the labels back:

```
column strip: 0.30ℓn · 0.20ℓn · continuous 150 mm into support     ← one bottom run
middle strip: 0.22ℓn · 0.22ℓn · continuous · max 0.15ℓn from support ℄
```

0 label overlaps, 0 labels outside the frame, 0 page errors.

## Tests

The case that asserted the old column-strip cut-off is **replaced** by one asserting there is no such run, plus a block pinning every fraction to the figure so a future edit that drifts fails here rather than on a drawing. The ⚠ is gone from the module header and from the page note.

`npm test` — 199 files, **3306 passed**. `npx tsc -b`, `eslint` and `npm run build` green.

---

This was one of the two items flagged in `HANDOFF.md` as needing a human. The other — running the Supabase migrations and setting `GUEST_TRIAL_SALT` — still does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_