### PR TITLE
feat(rebar): score every layout instead of taking the first valid one

### DIFF
--- a/webapp/src/engine/beamRebarOptimize.test.ts
+++ b/webapp/src/engine/beamRebarOptimize.test.ts
@@ -155,3 +155,144 @@ describe('the search is bounded by what the caller asks for', () => {
       .toBeGreaterThanOrEqual(relaxed.selection.best!.layout.clearSpacing)
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────────
+// CONTINUITY. Bars run through a member and on through the joint, so one
+// diameter has to serve the whole run. These are the tests that stop the
+// optimiser handing the same beam three different bar sizes.
+// ─────────────────────────────────────────────────────────────────────────
+
+import { optimizeBeamMember, resolveBarContinuity, type BeamSectionDemand } from './beamRebarOptimize'
+
+const GEOM = {
+  b: 300, h: 550, cover: 40, barDia: 20, stirrupDia: 10, fc: 28, fy: 415,
+}
+
+/** A three-section run: support hogging, midspan sagging, support hogging —
+ *  with very different demands, which is exactly when a per-section optimiser
+ *  would drift. */
+const THREE: BeamSectionDemand[] = [
+  { id: 'A', label: 'Left support', Mu: 210, Vu: 190 },
+  { id: 'B', label: 'Midspan', Mu: 95, Vu: 40 },
+  { id: 'C', label: 'Right support', Mu: 240, Vu: 200 },
+]
+
+describe('one member, many sections', () => {
+  const m = optimizeBeamMember(GEOM, THREE)
+
+  it('adopts ONE diameter for the whole member', () => {
+    expect(m.db).not.toBeNull()
+    expect(m.sections).toHaveLength(3)
+    const dias = new Set(m.sections.map((s) => s.design.bars > 0 ? m.db : m.db))
+    expect(dias.size).toBe(1)
+  })
+
+  it('is NOT what three independent per-section runs would give', () => {
+    // The point of the member-level API. If the per-section optimiser happened
+    // to agree here the test would be vacuous, so assert the demands really do
+    // pull in different directions.
+    const each = THREE.map((s) =>
+      optimizeBeamRebar({ ...GEOM, Mu: s.Mu, Vu: s.Vu }).selection.best!.layout.db)
+    expect(new Set(each).size).toBeGreaterThan(1)     // they DO disagree…
+    expect(new Set([m.db]).size).toBe(1)              // …and the member does not
+  })
+
+  it('lets the bar COUNT differ per section — only the diameter is shared', () => {
+    // Cuts and splices absorb the count. Forcing one count would buy the
+    // midspan steel it does not need.
+    const counts = m.sections.map((s) => s.design.bars)
+    expect(new Set(counts).size).toBeGreaterThan(1)
+  })
+
+  it('every section is compliant at the adopted diameter', () => {
+    for (const c of m.selection.best!.compliance) {
+      expect(c.pass, `${c.id} — ${c.label}`).toBe(true)
+    }
+    for (const s of m.sections) expect(s.design.flexOK).toBe(true)
+  })
+
+  it('names the section that sized the member', () => {
+    expect(m.governing).toBe('C')      // the largest hogging moment
+  })
+
+  it('rejects a diameter that fails at ANY section, naming where', () => {
+    // A member whose support is far too heavily loaded for a small bar: the
+    // small sizes must be rejected for the whole member, not adopted because
+    // midspan was happy with them.
+    const hard = optimizeBeamMember(GEOM, [
+      { id: 'A', label: 'Support', Mu: 480, Vu: 300 },
+      { id: 'B', label: 'Midspan', Mu: 40, Vu: 30 },
+    ])
+    const rejected = hard.selection.rejected
+    expect(rejected.length).toBeGreaterThan(0)
+    const withPlace = rejected.filter((x) => (x.failedGate!.detail ?? '').includes('at '))
+    expect(withPlace.length).toBeGreaterThan(0)
+    expect(withPlace[0].failedGate!.detail).toContain('Support')
+  })
+
+  it('a single-section member matches the per-section optimiser', () => {
+    const one = optimizeBeamMember(GEOM, [{ id: 'X', Mu: 150, Vu: 120 }])
+    const solo = optimizeBeamRebar({ ...GEOM, Mu: 150, Vu: 120 })
+    expect(one.db).toBe(solo.selection.best!.layout.db)
+  })
+
+  it('handles a member with no sections without throwing', () => {
+    const none = optimizeBeamMember(GEOM, [])
+    expect(none.db).toBeNull()
+    expect(none.sections).toHaveLength(0)
+    expect(none.selection.margin).toMatch(/no critical sections/)
+  })
+
+  it('is deterministic', () => {
+    expect(optimizeBeamMember(GEOM, THREE).db).toBe(m.db)
+  })
+})
+
+describe('one run, many members — resolveBarContinuity', () => {
+  it('pulls a collinear run onto ONE diameter', () => {
+    // Beam A wants ⌀20, Beam B wants ⌀25, and they meet at a column.
+    const chosen = new Map([['A', 20], ['B', 25], ['C', 16]])
+    const out = resolveBarContinuity(chosen, [['A', 'B', 'C']])
+    expect([...new Set(out.values())]).toEqual([25])
+  })
+
+  it('adopts the LARGEST, because a smaller bar would fail the span that asked', () => {
+    const out = resolveBarContinuity(new Map([['A', 16], ['B', 32]]), [['A', 'B']])
+    expect(out.get('A')).toBe(32)
+    expect(out.get('B')).toBe(32)
+  })
+
+  it('keeps separate runs separate', () => {
+    const chosen = new Map([['A', 20], ['B', 25], ['X', 12], ['Y', 16]])
+    const out = resolveBarContinuity(chosen, [['A', 'B'], ['X', 'Y']])
+    expect(out.get('A')).toBe(25)
+    expect(out.get('X')).toBe(16)
+  })
+
+  it('leaves a member with no adopted diameter alone rather than inheriting one', () => {
+    // It is already a reported failure; silently giving it a size would hide
+    // that the section does not work.
+    const chosen = new Map([['A', 20]])
+    const out = resolveBarContinuity(chosen, [['A', 'B']])
+    expect(out.has('B')).toBe(false)
+    expect(out.get('A')).toBe(20)
+  })
+
+  it('does not touch a group that is already consistent', () => {
+    const chosen = new Map([['A', 20], ['B', 20]])
+    const out = resolveBarContinuity(chosen, [['A', 'B']])
+    expect(out).toEqual(chosen)
+  })
+
+  it('ignores a group with nothing to reconcile', () => {
+    const chosen = new Map([['A', 20]])
+    expect(resolveBarContinuity(chosen, [['A']])).toEqual(chosen)
+    expect(resolveBarContinuity(chosen, [[]])).toEqual(chosen)
+  })
+
+  it('is idempotent — resolving twice changes nothing', () => {
+    const chosen = new Map([['A', 20], ['B', 25]])
+    const once = resolveBarContinuity(chosen, [['A', 'B']])
+    expect(resolveBarContinuity(once, [['A', 'B']])).toEqual(once)
+  })
+})

--- a/webapp/src/engine/beamRebarOptimize.test.ts
+++ b/webapp/src/engine/beamRebarOptimize.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest'
+import { optimizeBeamRebar, BEAM_BAR_SIZES } from './beamRebarOptimize'
+import { designBeam, type BeamDesignInput } from './beamDesign'
+
+const BASE: BeamDesignInput = {
+  b: 300, h: 500, cover: 40, barDia: 20, stirrupDia: 10,
+  fc: 28, fy: 415, Mu: 150, Vu: 120,
+}
+
+describe('it searches the catalogue instead of using the input diameter', () => {
+  const r = optimizeBeamRebar(BASE)
+
+  it('designs the beam at every size it can lay out', () => {
+    expect(r.designs.size).toBeGreaterThanOrEqual(BEAM_BAR_SIZES.length - 1)
+    for (const db of r.designs.keys()) expect(BEAM_BAR_SIZES).toContain(db)
+  })
+
+  it('adopts a layout and reports the design that produced it', () => {
+    expect(r.selection.best).not.toBeNull()
+    expect(r.design).not.toBeNull()
+    expect(r.input!.barDia).toBe(r.selection.best!.layout.db)
+    // The reported design really is the one for the adopted diameter.
+    expect(r.design!.bars).toBe(r.selection.best!.layout.bars)
+  })
+
+  it('ignores the diameter the caller passed in', () => {
+    const a = optimizeBeamRebar({ ...BASE, barDia: 12 })
+    const b = optimizeBeamRebar({ ...BASE, barDia: 32 })
+    expect(a.selection.best!.layout.db).toBe(b.selection.best!.layout.db)
+  })
+
+  it('ranks every compliant size and rejects the rest with a clause', () => {
+    expect(r.selection.ranked.length).toBeGreaterThan(1)
+    for (const x of r.selection.rejected) {
+      expect(x.failedGate).not.toBeNull()
+      expect(x.failedGate!.clause).toMatch(/§|practice/)
+    }
+  })
+
+  it('is deterministic', () => {
+    const again = optimizeBeamRebar(BASE)
+    expect(again.selection.ranked.map((x) => `${x.layout.bars}⌀${x.layout.db}`))
+      .toEqual(r.selection.ranked.map((x) => `${x.layout.bars}⌀${x.layout.db}`))
+  })
+})
+
+describe('the adopted layout is genuinely compliant', () => {
+  const cases: [string, BeamDesignInput][] = [
+    ['light', { ...BASE, b: 250, h: 400, Mu: 60, Vu: 70 }],
+    ['ordinary', BASE],
+    ['heavy', { ...BASE, b: 300, h: 600, Mu: 320, Vu: 180 }],
+    ['very heavy', { ...BASE, b: 400, h: 700, Mu: 600, Vu: 300 }],
+  ]
+
+  it.each(cases)('%s: every compliance check passes on the winner', (_name, inp) => {
+    const r = optimizeBeamRebar(inp)
+    expect(r.selection.best).not.toBeNull()
+    for (const c of r.selection.best!.compliance) {
+      expect(c.pass, `${c.id} — ${c.label}`).toBe(true)
+    }
+  })
+
+  it.each(cases)('%s: the winning design carries the moment', (_name, inp) => {
+    const r = optimizeBeamRebar(inp)
+    const d = r.design!
+    expect(d.flexOK).toBe(true)
+    expect(d.bars).toBeGreaterThanOrEqual(2)
+    expect(d.layers.length).toBeLessThanOrEqual(3)
+  })
+
+  it.each(cases)('%s: the winner never exceeds the §24.3.2 spacing limit', (_name, inp) => {
+    const r = optimizeBeamRebar(inp)
+    const crack = r.selection.best!.compliance.find((c) => c.id === 'crack-spacing')!
+    expect(crack.pass).toBe(true)
+  })
+})
+
+describe('it does not pick the minimum-steel layout by default', () => {
+  it('adopts a layout that is NOT the lightest in the compliant set', () => {
+    // The whole point of the change: on an ordinary beam the least-steel
+    // option is a small bar at tight spacing, and it loses on
+    // constructability.
+    const r = optimizeBeamRebar(BASE)
+    const lightest = [...r.selection.ranked].sort((a, b) => a.layout.AsProv - b.layout.AsProv)[0]
+    expect(r.selection.best!.layout.AsProv).toBeGreaterThan(lightest.layout.AsProv)
+  })
+
+  it('does not pick the fewest-bars layout either', () => {
+    const r = optimizeBeamRebar(BASE)
+    const fewest = [...r.selection.ranked].sort((a, b) => a.layout.bars - b.layout.bars)[0]
+    expect(r.selection.best!.layout.bars).toBeGreaterThan(fewest.layout.bars)
+  })
+
+  it('a huge bar that technically works is beaten by a distributed cage', () => {
+    const r = optimizeBeamRebar(BASE)
+    const big = r.selection.ranked.find((x) => x.layout.db === 32)
+    if (big) expect(r.selection.best!.total).toBeGreaterThan(big.total)
+  })
+})
+
+describe('the §25.2.1 aggregate term is enforced', () => {
+  it('rejects a layout whose clear spacing clears max(db,25) but not 4/3 d_agg', () => {
+    // `designBeam` packs a layer on max(db, 25). §25.2.1 also asks for
+    // 4/3 the nominal aggregate, which on 20 mm stone is 26.7 mm — so a
+    // layout the engine laid out can still be non-compliant, and it must be
+    // rejected here rather than adopted.
+    const r = optimizeBeamRebar(BASE, { aggregate: 20 })
+    const rejected = r.selection.rejected.filter((x) => x.failedGate!.id === 'bars-fit')
+    expect(rejected.length).toBeGreaterThan(0)
+    for (const x of rejected) expect(x.failedGate!.clause).toContain('25.2.1')
+  })
+
+  it('a smaller aggregate lets more layouts through', () => {
+    const coarse = optimizeBeamRebar(BASE, { aggregate: 25 })
+    const fine = optimizeBeamRebar(BASE, { aggregate: 10 })
+    expect(fine.selection.ranked.length).toBeGreaterThanOrEqual(coarse.selection.ranked.length)
+  })
+})
+
+describe('when the section is simply too small', () => {
+  it('reports no winner rather than adopting a failing layout', () => {
+    // 200×300 asked to carry 400 kN·m — nothing in the catalogue works.
+    const r = optimizeBeamRebar({ ...BASE, b: 200, h: 300, Mu: 400, Vu: 250 })
+    expect(r.selection.best).toBeNull()
+    expect(r.design).toBeNull()
+    expect(r.selection.margin).toMatch(/no layout satisfies/)
+    expect(r.selection.rejected.length).toBeGreaterThan(0)
+  })
+})
+
+describe('it agrees with designBeam for the size it adopts', () => {
+  it('re-running designBeam at the adopted diameter reproduces the result', () => {
+    // The optimiser must not massage anything — it selects among designs the
+    // verified engine produced, and the adopted one has to be reproducible.
+    const r = optimizeBeamRebar(BASE)
+    const again = designBeam(r.input!)
+    expect(again.bars).toBe(r.design!.bars)
+    expect(again.d).toBeCloseTo(r.design!.d, 9)
+    expect(again.As).toBeCloseTo(r.design!.As, 9)
+    expect(again.layers).toEqual(r.design!.layers)
+  })
+})
+
+describe('the search is bounded by what the caller asks for', () => {
+  it('honours a restricted size list', () => {
+    const r = optimizeBeamRebar(BASE, { sizes: [16, 20] })
+    expect(r.designs.size).toBe(2)
+    expect([16, 20]).toContain(r.selection.best!.layout.db)
+  })
+
+  it('a stricter vibrator clearance shifts the choice toward wider spacing', () => {
+    const relaxed = optimizeBeamRebar(BASE, { sComfort: 25 })
+    const strict = optimizeBeamRebar(BASE, { sComfort: 70 })
+    expect(strict.selection.best!.layout.clearSpacing)
+      .toBeGreaterThanOrEqual(relaxed.selection.best!.layout.clearSpacing)
+  })
+})

--- a/webapp/src/engine/beamRebarOptimize.ts
+++ b/webapp/src/engine/beamRebarOptimize.ts
@@ -13,6 +13,26 @@
 // implementation of §22.2 that drifts from the first is worse than no search
 // at all.
 //
+// ── CONTINUITY ───────────────────────────────────────────────────────────
+//
+// A beam is not detailed section by section. Bars run THROUGH a member and
+// on through the joint into the next span, so one diameter has to serve the
+// whole run — a ⌀25 span meeting a ⌀20 span at the same column is a
+// detailing error, and `meshValidation` already refuses it.
+//
+// The per-section entry point below is therefore the wrong unit on its own.
+// `optimizeBeamMember` is the real one: it scores each DIAMETER across EVERY
+// critical section of the member at once, so a diameter is feasible only if
+// it complies everywhere. Bar COUNT stays free per section — cuts and
+// splices absorb that, and forcing a single count would buy steel the span
+// does not need.
+//
+// `resolveBarContinuity` then takes the run one level up: given the groups
+// `barContinuityGroups` finds (a continuous beam line, a column stack), every
+// member in a group adopts the group's LARGEST diameter. Largest, not
+// smallest: a smaller bar somewhere in the run would fail the section that
+// asked for the bigger one.
+//
 // ── WHAT COUNTS AS A CANDIDATE ───────────────────────────────────────────
 //
 // Every diameter in the catalogue, paired with the bar count `designBeam`
@@ -38,6 +58,7 @@ import {
   selectRebar, type Candidate, type ComplianceCheck, type RebarLayout,
   type RebarSelection, type ScoreContext,
 } from './rebarScore'
+
 
 /** Bar diameters searched by default — the PNS range a yard carries. */
 export const BEAM_BAR_SIZES = [12, 16, 20, 25, 28, 32] as const
@@ -144,6 +165,18 @@ function complianceOf(
   ]
 }
 
+/**
+ * Which of two designs sizes the member.
+ *
+ * Compared on As REQUIRED, not bar count: the count is rounded up to a whole
+ * bar, so 210 and 240 kN·m can land on the same number and the comparison
+ * would then be decided by whichever section came first in the list.
+ */
+function moreDemanding(a: BeamDesignResult, b: BeamDesignResult): boolean {
+  if (Math.abs(a.As - b.As) > 1e-6) return a.As > b.As
+  return a.bars > b.bars
+}
+
 /** Centre-to-centre spacing of the bars nearest the tension face, mm. */
 function barSpacingOf(i: BeamDesignInput, r: BeamDesignResult): number {
   const n = r.layers[0] ?? 0
@@ -153,11 +186,13 @@ function barSpacingOf(i: BeamDesignInput, r: BeamDesignResult): number {
 }
 
 /**
- * Design the beam at every candidate diameter and adopt the best-scoring
+ * Design ONE SECTION at every candidate diameter and adopt the best-scoring
  * compliant layout.
  *
- * `i.barDia` is ignored as a choice and used only as a fallback when nothing
- * in the catalogue complies — a failing design the user can read beats a null.
+ * For a member with more than one critical section use `optimizeBeamMember`
+ * instead — this one has no way to know that the bars carry on into the next
+ * section, and used per-section it will happily give the same beam three
+ * different diameters.
  */
 export function optimizeBeamRebar(
   i: BeamDesignInput, opts: BeamRebarOptions = {},
@@ -217,4 +252,159 @@ export function optimizeBeamRebar(
     input: winner !== null ? inputs.get(winner) ?? null : null,
     designs,
   }
+}
+
+
+// ── One member, many sections ─────────────────────────────────────────────
+
+/** A critical section's demand. Moments are magnitudes; hogging and sagging
+ *  are both designed for |Mu| against the same section. */
+export interface BeamSectionDemand {
+  id: string
+  label?: string
+  /** kN·m, magnitude. */
+  Mu: number
+  /** kN. */
+  Vu: number
+}
+
+export interface BeamMemberChoice {
+  /** Diameters scored across the WHOLE member, ranked. */
+  selection: RebarSelection
+  /** The adopted diameter, or null when no size works at every section. */
+  db: number | null
+  /** The design at each section, at the adopted diameter. Bar counts differ
+   *  between them — that is the point; only the diameter is shared. */
+  sections: { id: string; label?: string; design: BeamDesignResult }[]
+  /** The section that sized the member — the one with the most steel. */
+  governing: string | null
+}
+
+/**
+ * Choose ONE bar diameter for a whole member by scoring each candidate across
+ * every one of its critical sections.
+ *
+ * A diameter is feasible only if it complies at EVERY section: a size that
+ * works at midspan and fails over the support is not a size this beam can be
+ * built with. The compliance check that fails carries the section it failed
+ * at, so the report says where.
+ *
+ * The layout that gets SCORED is the governing section's — the one with the
+ * most steel. That is the section that sets congestion, spacing and layer
+ * count, so it is the honest representative of what the member will be like
+ * to build.
+ */
+export function optimizeBeamMember(
+  geom: Omit<BeamDesignInput, 'Mu' | 'Vu'>,
+  demands: readonly BeamSectionDemand[],
+  opts: BeamRebarOptions = {},
+): BeamMemberChoice {
+  if (demands.length === 0) {
+    return {
+      selection: { best: null, ranked: [], rejected: [], margin: 'no critical sections supplied' },
+      db: null, sections: [], governing: null,
+    }
+  }
+
+  const sizes = opts.sizes ?? BEAM_BAR_SIZES
+  const perSize = new Map<number, { id: string; label?: string; design: BeamDesignResult }[]>()
+  const candidates: Candidate[] = []
+
+  for (const db of sizes) {
+    // Mu/Vu are placeholders here; each section supplies its own below.
+    const trial: BeamDesignInput = {
+      ...geom, barDia: db, comprBarDia: geom.comprBarDia ?? db, Mu: 0, Vu: 0,
+    }
+    const designs: { id: string; label?: string; design: BeamDesignResult }[] = []
+    let failed = false
+    for (const s of demands) {
+      try {
+        designs.push({
+          id: s.id, label: s.label,
+          design: designBeam({ ...trial, Mu: Math.abs(s.Mu), Vu: Math.abs(s.Vu) }),
+        })
+      } catch { failed = true; break }
+    }
+    if (failed || designs.length !== demands.length) continue
+    perSize.set(db, designs)
+
+    const sMinClear = Math.max(db, 25, (4 / 3) * (opts.aggregate ?? 20))
+    const sMaxCrack = crackSpacingLimit(geom.fy, geom.cover)
+
+    // Compliance across the WHOLE member: a check passes only if it passes at
+    // every section, and it reports the first section where it did not.
+    const merged: ComplianceCheck[] = []
+    const template = complianceOf({ ...trial, Mu: 0, Vu: 0 }, designs[0].design, sMaxCrack, sMinClear)
+    for (let k = 0; k < template.length; k++) {
+      let worst: { c: ComplianceCheck; at: typeof designs[number] } | null = null
+      for (const d of designs) {
+        const c = complianceOf({ ...trial, Mu: Math.abs(demands.find((x) => x.id === d.id)!.Mu), Vu: 0 },
+          d.design, sMaxCrack, sMinClear)[k]
+        if (!c.pass) { worst = { c, at: d }; break }
+      }
+      merged.push(worst
+        ? { ...worst.c, detail: `${worst.c.detail ?? ''}${worst.c.detail ? ' · ' : ''}at ${worst.at.label ?? worst.at.id}`.trim() }
+        : template[k])
+    }
+
+    // Score the governing section — the one that sizes the member.
+    const Ab = (Math.PI / 4) * db * db
+    const gov = designs.reduce((a, b) => (moreDemanding(b.design, a.design) ? b : a), designs[0])
+    const g = gov.design
+    const layout: RebarLayout = {
+      db,
+      bars: g.bars,
+      layers: g.layers,
+      AsProv: g.bars * Ab,
+      AsReq: g.As,
+      clearSpacing: g.sClear,
+      spacing: barSpacingOf(trial, g),
+      d: g.d,
+      utilization: g.phiMnMax > 0 ? Math.abs(demands.find((x) => x.id === gov.id)!.Mu) / g.phiMnMax : Infinity,
+    }
+    candidates.push({ layout, compliance: merged })
+  }
+
+  const ctx: ScoreContext = {
+    sMax: crackSpacingLimit(geom.fy, geom.cover),
+    sMinCode: Math.max(25, (4 / 3) * (opts.aggregate ?? 20)),
+    sComfort: opts.sComfort ?? 40,
+    maxLayers: MAX_LAYERS,
+    barComfort: 8,
+    wantSymmetric: true,
+  }
+  const selection = selectRebar(candidates, ctx)
+  const db = selection.best?.layout.db ?? null
+  const sections = db !== null ? perSize.get(db) ?? [] : []
+  const governing = sections.length
+    ? sections.reduce((a, b) => (moreDemanding(b.design, a.design) ? b : a), sections[0]).id
+    : null
+
+  return { selection, db, sections, governing }
+}
+
+// ── One run, many members ─────────────────────────────────────────────────
+
+/**
+ * Force every member of a continuity group onto a single diameter.
+ *
+ * The group adopts its LARGEST required diameter. Largest, not smallest or
+ * most common: a smaller bar would fail the member that asked for the bigger
+ * one, and compliance is not something a continuity rule gets to trade away.
+ *
+ * Members with no adopted diameter (nothing complied) are left alone — they
+ * are already a reported failure and must not silently inherit a size.
+ */
+export function resolveBarContinuity(
+  chosen: ReadonlyMap<string, number>,
+  groups: readonly (readonly string[])[],
+): Map<string, number> {
+  const out = new Map(chosen)
+  for (const group of groups) {
+    const present = group.map((id) => chosen.get(id)).filter((v): v is number => v !== undefined)
+    if (present.length < 2) continue
+    const dmax = Math.max(...present)
+    for (const id of group) if (chosen.get(id) !== undefined) out.set(id, dmax)
+  }
+  return out
 }

--- a/webapp/src/engine/beamRebarOptimize.ts
+++ b/webapp/src/engine/beamRebarOptimize.ts
@@ -1,0 +1,220 @@
+// ─────────────────────────────────────────────────────────────────────────
+// BEAM FLEXURAL STEEL — search the bar catalogue, score, adopt the best.
+//
+// `designBeam` is a complete, code-checked design AT ONE BAR DIAMETER: it
+// iterates the layer arrangement, recomputes d by Varignon, and reports every
+// §407 / §22.2 outcome. What it never did was ask whether a DIFFERENT
+// diameter would give a better section — the diameter was an input, and
+// whatever the user typed is what got detailed.
+//
+// So this module does not re-derive any strength. It runs `designBeam` once
+// per candidate diameter, turns each result into a scored layout, and lets
+// `rebarScore` rank them. Reusing the verified engine is the point: a second
+// implementation of §22.2 that drifts from the first is worse than no search
+// at all.
+//
+// ── WHAT COUNTS AS A CANDIDATE ───────────────────────────────────────────
+//
+// Every diameter in the catalogue, paired with the bar count `designBeam`
+// settles on for it. The count is not searched independently: for a given
+// diameter the required area fixes it, and the layer/pairing rules in
+// `barLayers` fix the arrangement. Searching counts as well would only
+// generate layouts that provide MORE steel than needed at the same diameter —
+// strictly worse on economy and no better on anything else.
+//
+// ── COMPLIANCE ───────────────────────────────────────────────────────────
+//
+// Taken from the design result, not re-checked: flexural adequacy, the
+// tension-controlled ρ ceiling, minimum steel, bars-fit-the-web, the §25.2.1
+// clear-spacing floor, minimum bar count, the §24.3.2 crack-control spacing
+// limit, and the layer cap. Any failure makes the layout infeasible.
+//
+// Units: mm, mm², kN·m.
+// ─────────────────────────────────────────────────────────────────────────
+
+import { designBeam, type BeamDesignInput, type BeamDesignResult } from './beamDesign'
+import { crackSpacingLimit } from './barSelection'
+import {
+  selectRebar, type Candidate, type ComplianceCheck, type RebarLayout,
+  type RebarSelection, type ScoreContext,
+} from './rebarScore'
+
+/** Bar diameters searched by default — the PNS range a yard carries. */
+export const BEAM_BAR_SIZES = [12, 16, 20, 25, 28, 32] as const
+
+/** §9.7.2.1 — a beam never carries fewer than two bars in a layer. */
+const MIN_BARS = 2
+/** Layers past which the effective depth is being thrown away. */
+const MAX_LAYERS = 3
+
+export interface BeamRebarOptions {
+  /** Diameters to search. Defaults to `BEAM_BAR_SIZES`. */
+  sizes?: readonly number[]
+  /** Aggregate size, mm — §25.2.1 also asks for 4/3 d_agg clear. */
+  aggregate?: number
+  /** Clear spacing below which a poker vibrator will not fit. */
+  sComfort?: number
+}
+
+export interface BeamRebarChoice {
+  selection: RebarSelection
+  /** The full design that produced the winning layout, ready to report. */
+  design: BeamDesignResult | null
+  /** The input that produced it — the diameter actually adopted. */
+  input: BeamDesignInput | null
+  /** Every design tried, keyed by diameter, for the report's ranking table. */
+  designs: Map<number, BeamDesignResult>
+}
+
+/**
+ * Compliance for one designed beam, in the order a checker reads them.
+ *
+ * Order matters: the first failure is what gets reported, and "the section is
+ * too shallow" must not be reported as "the bars do not fit".
+ */
+function complianceOf(
+  i: BeamDesignInput, r: BeamDesignResult, sMaxCrack: number, sMinClear: number,
+): ComplianceCheck[] {
+  const util = r.phiMnMax > 0 ? i.Mu / r.phiMnMax : Infinity
+  return [
+    {
+      id: 'layout-converged',
+      clause: 'ACI 318-14 §22.2 · §9.3.1',
+      label: 'the bar layout converges — d does not collapse toward d′',
+      pass: r.flexOK,
+      detail: r.flexOK ? undefined : 'the section cannot accommodate the steel it needs',
+    },
+    {
+      id: 'compression-effective',
+      clause: 'ACI 318-14 §22.2.2',
+      label: "compression steel yields usefully (f′s > 0.85f′c)",
+      pass: r.mode !== 'DRRB' || r.comprEffective,
+    },
+    {
+      id: 'compression-above-na',
+      clause: 'ACI 318-14 §22.2.1',
+      label: 'the deepest compression layer stays above the neutral axis',
+      pass: r.comprNAOK,
+    },
+    {
+      id: 'tension-controlled',
+      clause: 'ACI 318-14 §21.2.2 · §9.3.3.1',
+      label: 'tension-controlled — ρ within the ρmax ceiling at εt = 0.005',
+      pass: r.mode === 'DRRB' || r.rho <= r.rhoMax + 1e-9,
+      detail: `ρ = ${r.rho.toFixed(4)} vs ρmax = ${r.rhoMax.toFixed(4)}`,
+    },
+    {
+      id: 'min-steel',
+      clause: 'ACI 318-14 §9.6.1.2',
+      label: 'minimum flexural steel',
+      pass: r.As >= r.rhoMin * (i.bMin ?? i.b) * r.d - 1e-6,
+    },
+    {
+      id: 'min-bars',
+      clause: 'ACI 318-14 §9.7.2.1',
+      label: 'at least two bars',
+      pass: r.bars >= MIN_BARS,
+    },
+    {
+      id: 'bars-fit',
+      clause: 'ACI 318-14 §25.2.1',
+      label: 'the bars fit the web at the required clear spacing',
+      pass: r.maxPerLayer >= MIN_BARS && r.sClear >= sMinClear - 1e-6,
+      detail: `clear ${r.sClear.toFixed(0)} mm vs ${sMinClear.toFixed(0)} mm required`,
+    },
+    {
+      id: 'layer-cap',
+      clause: 'Detailing practice',
+      label: `no more than ${MAX_LAYERS} layers`,
+      pass: r.layers.length <= MAX_LAYERS,
+    },
+    {
+      id: 'crack-spacing',
+      clause: 'ACI 318-14 §24.3.2',
+      label: 'bar spacing within the crack-control limit',
+      pass: barSpacingOf(i, r) <= sMaxCrack + 1e-6,
+      detail: `s = ${barSpacingOf(i, r).toFixed(0)} mm vs ${sMaxCrack.toFixed(0)} mm`,
+    },
+    {
+      id: 'flexural-capacity',
+      clause: 'ACI 318-14 §22.2',
+      label: 'φMn ≥ Mu',
+      pass: r.mode === 'DRRB' ? r.flexOK : util <= 1 + 1e-9,
+    },
+  ]
+}
+
+/** Centre-to-centre spacing of the bars nearest the tension face, mm. */
+function barSpacingOf(i: BeamDesignInput, r: BeamDesignResult): number {
+  const n = r.layers[0] ?? 0
+  if (n <= 1) return 0            // a single bar has no spacing to control
+  const bw = i.b - 2 * (i.cover + i.stirrupDia)
+  return (bw - i.barDia) / (n - 1)
+}
+
+/**
+ * Design the beam at every candidate diameter and adopt the best-scoring
+ * compliant layout.
+ *
+ * `i.barDia` is ignored as a choice and used only as a fallback when nothing
+ * in the catalogue complies — a failing design the user can read beats a null.
+ */
+export function optimizeBeamRebar(
+  i: BeamDesignInput, opts: BeamRebarOptions = {},
+): BeamRebarChoice {
+  const sizes = opts.sizes ?? BEAM_BAR_SIZES
+  const designs = new Map<number, BeamDesignResult>()
+  const candidates: Candidate[] = []
+  const inputs = new Map<number, BeamDesignInput>()
+
+  for (const db of sizes) {
+    // The compression bars follow the tension bars unless the caller pinned
+    // them; a beam detailed with two different main sizes is a schedule
+    // nobody thanks you for.
+    const trial: BeamDesignInput = { ...i, barDia: db, comprBarDia: i.comprBarDia ?? db }
+    let r: BeamDesignResult
+    try {
+      r = designBeam(trial)
+    } catch {
+      continue                    // a size the section cannot even lay out
+    }
+    designs.set(db, r)
+    inputs.set(db, trial)
+
+    // §25.2.1 clear spacing: the greater of db, 25 mm and 4/3 the aggregate.
+    const sMinClear = Math.max(db, 25, (4 / 3) * (opts.aggregate ?? 20))
+    const sMaxCrack = crackSpacingLimit(i.fy, i.cover)
+
+    const Ab = (Math.PI / 4) * db * db
+    const layout: RebarLayout = {
+      db,
+      bars: r.bars,
+      layers: r.layers,
+      AsProv: r.bars * Ab,
+      AsReq: r.As,
+      clearSpacing: r.sClear,
+      spacing: barSpacingOf(trial, r),
+      d: r.d,
+      utilization: r.phiMnMax > 0 ? i.Mu / r.phiMnMax : Infinity,
+    }
+    candidates.push({ layout, compliance: complianceOf(trial, r, sMaxCrack, sMinClear) })
+  }
+
+  const ctx: ScoreContext = {
+    sMax: crackSpacingLimit(i.fy, i.cover),
+    sMinCode: Math.max(25, (4 / 3) * (opts.aggregate ?? 20)),
+    sComfort: opts.sComfort ?? 40,
+    maxLayers: MAX_LAYERS,
+    barComfort: 8,
+    wantSymmetric: true,
+  }
+
+  const selection = selectRebar(candidates, ctx)
+  const winner = selection.best?.layout.db ?? null
+  return {
+    selection,
+    design: winner !== null ? designs.get(winner) ?? null : null,
+    input: winner !== null ? inputs.get(winner) ?? null : null,
+    designs,
+  }
+}

--- a/webapp/src/engine/rebarScore.test.ts
+++ b/webapp/src/engine/rebarScore.test.ts
@@ -1,0 +1,362 @@
+import { describe, it, expect } from 'vitest'
+import {
+  selectRebar, compareByTotal, comparePair, firstFailure,
+  PRIORITY_WEIGHTS, NEAR_TIE, COMMON_BARS,
+  type Candidate, type ComplianceCheck, type RebarLayout, type ScoreContext,
+} from './rebarScore'
+
+const CTX: ScoreContext = { sMax: 280, sMinCode: 25, sComfort: 40, maxLayers: 3, barComfort: 8 }
+
+const ok = (id: string): ComplianceCheck =>
+  ({ id, clause: 'ACI 318-14 §9.x', label: id, pass: true })
+const fail = (id: string, clause = 'ACI 318-14 §9.x'): ComplianceCheck =>
+  ({ id, clause, label: id, pass: false })
+
+/** A layout with sensible defaults; override only what a test is about. */
+const layout = (over: Partial<RebarLayout> = {}): RebarLayout => {
+  const db = over.db ?? 20
+  const bars = over.bars ?? 4
+  return {
+    db, bars,
+    layers: over.layers ?? [bars],
+    AsProv: over.AsProv ?? bars * (Math.PI / 4) * db * db,
+    AsReq: over.AsReq ?? bars * (Math.PI / 4) * db * db * 0.95,
+    clearSpacing: over.clearSpacing ?? 55,
+    spacing: over.spacing ?? 90,
+    d: over.d ?? 500,
+    utilization: over.utilization ?? 0.9,
+    ...over,
+  }
+}
+const cand = (l: Partial<RebarLayout>, checks: ComplianceCheck[] = [ok('strength')]): Candidate =>
+  ({ layout: layout(l), compliance: checks })
+
+describe('the weights encode the stated priority order', () => {
+  it('sums to 1', () => {
+    const sum = Object.values(PRIORITY_WEIGHTS).reduce((a, b) => a + b, 0)
+    expect(sum).toBeCloseTo(1, 12)
+  })
+
+  it('ranks serviceability > constructability > economy > simplicity', () => {
+    const { serviceability: s, constructability: c, economy: e, simplicity: p } = PRIORITY_WEIGHTS
+    expect(s).toBeGreaterThan(c)
+    expect(c).toBeGreaterThan(e)
+    expect(e).toBeGreaterThan(p)
+  })
+})
+
+describe('compliance is a GATE, never a score', () => {
+  it('excludes a non-compliant layout however well it scores otherwise', () => {
+    // The failing candidate is ideal on every other axis: one layer, common
+    // bar, even count, generous spacing, least steel. It must still lose.
+    const r = selectRebar([
+      cand({ db: 16, bars: 4, AsProv: 800, spacing: 60, clearSpacing: 70 }, [fail('strength')]),
+      cand({ db: 25, bars: 6, AsProv: 2945, spacing: 120, clearSpacing: 45 }),
+    ], CTX)
+    expect(r.best!.layout.db).toBe(25)
+    expect(r.ranked.map((x) => x.layout.db)).not.toContain(16)
+    expect(r.rejected).toHaveLength(1)
+  })
+
+  it('reports the FIRST failed clause, not the last', () => {
+    // Someone sent to widen the web when the section is simply too shallow
+    // has been sent to the wrong place.
+    const r = selectRebar([
+      cand({ db: 20 }, [fail('strength', '§22.2'), fail('clear spacing', '§25.2.1')]),
+    ], CTX)
+    expect(r.best).toBeNull()
+    expect(r.rejected[0].failedGate!.id).toBe('strength')
+    expect(r.rejected[0].failedGate!.clause).toBe('§22.2')
+    expect(r.rejected[0].reason).toContain('§22.2')
+  })
+
+  it('returns no winner when nothing complies, and says so', () => {
+    const r = selectRebar([
+      cand({ db: 16 }, [fail('a')]),
+      cand({ db: 20 }, [fail('b')]),
+    ], CTX)
+    expect(r.best).toBeNull()
+    expect(r.ranked).toHaveLength(0)
+    expect(r.margin).toMatch(/no layout satisfies/)
+    expect(r.margin).toContain('2 candidates')
+  })
+
+  it('firstFailure passes a fully compliant set', () => {
+    expect(firstFailure([ok('a'), ok('b')])).toBeNull()
+  })
+
+  it('handles an empty candidate set without throwing', () => {
+    const r = selectRebar([], CTX)
+    expect(r.best).toBeNull()
+    expect(r.margin).toMatch(/no candidates/)
+  })
+})
+
+describe('it does NOT simply minimise steel', () => {
+  it('prefers a better-distributed cage over the lightest one', () => {
+    // 3⌀25 (1473 mm²) is lighter than 6⌀16 (1206... ) — make the point
+    // explicitly: give the big-bar option LESS steel and worse spacing.
+    const r = selectRebar([
+      cand({ db: 25, bars: 3, AsProv: 1473, AsReq: 1400, spacing: 170, clearSpacing: 60, layers: [3] }),
+      cand({ db: 16, bars: 8, AsProv: 1608, AsReq: 1400, spacing: 70, clearSpacing: 45, layers: [8] }),
+    ], CTX)
+    expect(r.best!.layout.db).toBe(16)
+    expect(r.best!.layout.AsProv).toBeGreaterThan(1473)   // it bought MORE steel
+  })
+
+  it('does NOT simply minimise bar count either', () => {
+    const r = selectRebar([
+      cand({ db: 32, bars: 2, AsProv: 1608, AsReq: 1500, spacing: 200, clearSpacing: 80, layers: [2] }),
+      cand({ db: 20, bars: 5, AsProv: 1571, AsReq: 1500, spacing: 85, clearSpacing: 50, layers: [5] }),
+    ], CTX)
+    expect(r.best!.layout.bars).toBe(5)
+  })
+
+  it('still prefers less steel when everything else is equal', () => {
+    // Economy is the decider only where performance is equivalent.
+    const r = selectRebar([
+      cand({ db: 20, bars: 6, AsProv: 1885, AsReq: 1400, spacing: 90, clearSpacing: 50, layers: [6] }),
+      cand({ db: 20, bars: 5, AsProv: 1571, AsReq: 1400, spacing: 90, clearSpacing: 50, layers: [5] }),
+    ], CTX)
+    expect(r.best!.layout.bars).toBe(5)
+  })
+})
+
+describe('serviceability', () => {
+  it('rewards spacing well inside the §24.3.2 limit', () => {
+    const r = selectRebar([
+      cand({ db: 20, bars: 4, spacing: 270, clearSpacing: 60 }),
+      cand({ db: 20, bars: 4, spacing: 100, clearSpacing: 60 }),
+    ], CTX)
+    expect(r.best!.layout.spacing).toBe(100)
+    expect(r.ranked[0].scores.serviceability).toBeGreaterThan(r.ranked[1].scores.serviceability)
+  })
+
+  it('rewards steel AT the tension face over steel buried in a stack', () => {
+    const flat = cand({ db: 20, bars: 6, layers: [6], clearSpacing: 45 })
+    const stacked = cand({ db: 20, bars: 6, layers: [3, 3], clearSpacing: 45 })
+    const r = selectRebar([stacked, flat], CTX)
+    const s = (n: number) => r.ranked.find((x) => x.layout.layers.length === n)!
+    expect(s(1).scores.serviceability).toBeGreaterThan(s(2).scores.serviceability)
+  })
+
+  it('treats diameter RELATIVELY — a set of one size does not all score badly', () => {
+    const r = selectRebar([
+      cand({ db: 32, bars: 4, spacing: 90 }),
+      cand({ db: 32, bars: 5, spacing: 90 }),
+    ], CTX)
+    // Nothing differs on diameter, so it must not separate them.
+    expect(r.ranked[0].scores.serviceability)
+      .toBeCloseTo(r.ranked[1].scores.serviceability, 9)
+  })
+})
+
+describe('constructability', () => {
+  it('penalises every extra layer', () => {
+    const r = selectRebar([
+      cand({ db: 20, bars: 8, layers: [8] }),
+      cand({ db: 20, bars: 8, layers: [4, 4] }),
+      cand({ db: 20, bars: 8, layers: [3, 3, 2] }),
+    ], CTX)
+    const by = (n: number) => r.ranked.find((x) => x.layout.layers.length === n)!.scores.constructability
+    expect(by(1)).toBeGreaterThan(by(2))
+    expect(by(2)).toBeGreaterThan(by(3))
+  })
+
+  it('penalises clear spacing that is legal but too tight to vibrate', () => {
+    // 26 mm clears §25.2.1 and is still no place for a poker.
+    const r = selectRebar([
+      cand({ db: 20, bars: 6, clearSpacing: 26 }),
+      cand({ db: 20, bars: 6, clearSpacing: 55 }),
+    ], CTX)
+    expect(r.best!.layout.clearSpacing).toBe(55)
+  })
+
+  it('does not separate layouts that are all comfortably spaced', () => {
+    const r = selectRebar([
+      cand({ db: 20, bars: 4, clearSpacing: 60, layers: [4] }),
+      cand({ db: 20, bars: 4, clearSpacing: 90, layers: [4] }),
+    ], CTX)
+    const [a, b] = r.ranked
+    expect(a.scores.constructability).toBeCloseTo(b.scores.constructability, 9)
+  })
+
+  it('only counts bars against a layout once it is genuinely crowded', () => {
+    // 4 vs 6 bars is not a labour difference; 6 vs 20 is.
+    const small = selectRebar([
+      cand({ db: 20, bars: 4, layers: [4] }), cand({ db: 20, bars: 6, layers: [6] }),
+    ], CTX)
+    const [a, b] = small.ranked
+    expect(a.scores.constructability).toBeCloseTo(b.scores.constructability, 9)
+  })
+})
+
+describe('the near-tie rule', () => {
+  it('breaks a near-tie on serviceability + constructability, not economy', () => {
+    // Built so the economical one edges the total by less than NEAR_TIE while
+    // being clearly worse distributed and harder to build.
+    const cheap = cand({
+      db: 25, bars: 4, AsProv: 1963, AsReq: 1900,
+      spacing: 200, clearSpacing: 28, layers: [2, 2],
+    })
+    const better = cand({
+      db: 20, bars: 6, AsProv: 1885, AsReq: 1900,
+      spacing: 95, clearSpacing: 55, layers: [6],
+    })
+    const r = selectRebar([cheap, better], CTX)
+    expect(r.best!.layout.db).toBe(20)
+    const pair = (s: typeof r.ranked[0]) => s.scores.serviceability + s.scores.constructability
+    expect(pair(r.ranked[0])).toBeGreaterThan(pair(r.ranked[1]))
+  })
+
+  it('uses the total when the gap is CLEAR of the near-tie band', () => {
+    // b has the better pair score but is 0.40 behind — far outside the band,
+    // so it must not be promoted.
+    const r = selectRebar([
+      cand({ db: 20, bars: 4, layers: [4], spacing: 250, clearSpacing: 90, AsProv: 1257, AsReq: 1250 }),
+      cand({ db: 16, bars: 12, layers: [4, 4, 4], spacing: 40, clearSpacing: 26, AsProv: 2413, AsReq: 1250 }),
+    ], CTX)
+    expect(r.best!.layout.db).toBe(20)
+    expect(r.best!.total).toBeGreaterThan(r.ranked[1].total)
+  })
+
+  it('the ranking is a TOTAL ORDER — the comparator cannot be intransitive', () => {
+    // Ranking is by total (a real order) and the near-tie rule is applied as
+    // a leading-group promotion, not as a comparator. Written as a comparator
+    // it would be intransitive: A~B, B~C, but A and C differ by more than the
+    // band, and Array.sort would then give an implementation-defined order.
+    const mk = (total: number, serv: number) =>
+      ({ total, scores: { serviceability: serv, constructability: 0, economy: 0, simplicity: 0 },
+         layout: { db: 20, bars: 4, layers: [4] } }) as never
+    const a = mk(0.90, 0), b = mk(0.88, 0.5), c = mk(0.86, 1)
+    // compareByTotal is a strict order on the totals.
+    expect(compareByTotal(a, b)).toBeLessThan(0)
+    expect(compareByTotal(b, c)).toBeLessThan(0)
+    expect(compareByTotal(a, c)).toBeLessThan(0)
+    // comparePair is a strict order on the pair score.
+    expect(comparePair(c, b)).toBeLessThan(0)
+    expect(comparePair(b, a)).toBeLessThan(0)
+    expect(comparePair(c, a)).toBeLessThan(0)
+  })
+
+  it('promotes the best of the WHOLE leading group, not just the runner-up', () => {
+    // Three candidates inside the band; the third has the best pair score and
+    // must win even though it has the lowest total.
+    const r = selectRebar([
+      cand({ db: 25, bars: 4, layers: [2, 2], spacing: 200, clearSpacing: 28, AsProv: 1963, AsReq: 1950 }),
+      cand({ db: 25, bars: 5, layers: [3, 2], spacing: 190, clearSpacing: 30, AsProv: 2454, AsReq: 1950 }),
+      cand({ db: 20, bars: 7, layers: [7], spacing: 80, clearSpacing: 55, AsProv: 2199, AsReq: 1950 }),
+    ], CTX)
+    const pairs = r.ranked.map((s) => s.scores.serviceability + s.scores.constructability)
+    expect(pairs[0]).toBe(Math.max(...pairs.filter((_, k) => r.ranked[0].total - r.ranked[k].total <= NEAR_TIE)))
+  })
+
+  it('NEAR_TIE is small enough to be a tie and not a policy', () => {
+    expect(NEAR_TIE).toBeGreaterThan(0)
+    expect(NEAR_TIE).toBeLessThan(0.10)
+  })
+})
+
+describe('simplicity', () => {
+  it('prefers an even (symmetric) bar count when symmetry is wanted', () => {
+    const r = selectRebar([
+      cand({ db: 20, bars: 5, layers: [5], AsProv: 1571, AsReq: 1500 }),
+      cand({ db: 20, bars: 6, layers: [6], AsProv: 1885, AsReq: 1500 }),
+    ], { ...CTX, wantSymmetric: true })
+    const five = r.ranked.find((x) => x.layout.bars === 5)!
+    const six = r.ranked.find((x) => x.layout.bars === 6)!
+    expect(six.scores.simplicity).toBeGreaterThan(five.scores.simplicity)
+  })
+
+  it('does not ask a slab mat to be symmetric', () => {
+    const r = selectRebar([
+      cand({ db: 12, bars: 7, layers: [7] }),
+      cand({ db: 12, bars: 8, layers: [8] }),
+    ], { ...CTX, wantSymmetric: false })
+    const [a, b] = r.ranked
+    expect(a.scores.simplicity).toBeCloseTo(b.scores.simplicity, 9)
+  })
+
+  it('prefers a commonly stocked bar size', () => {
+    const r = selectRebar([
+      cand({ db: 36, bars: 4, layers: [4] }),
+      cand({ db: 20, bars: 4, layers: [4] }),
+    ], CTX)
+    const big = r.ranked.find((x) => x.layout.db === 36)!
+    const std = r.ranked.find((x) => x.layout.db === 20)!
+    expect(std.scores.simplicity).toBeGreaterThan(big.scores.simplicity)
+    expect(COMMON_BARS.has(20)).toBe(true)
+    expect(COMMON_BARS.has(36)).toBe(false)
+  })
+
+  it('prefers a regular stack over a ragged one', () => {
+    const r = selectRebar([
+      cand({ db: 20, bars: 6, layers: [3, 3] }),
+      cand({ db: 20, bars: 6, layers: [4, 2] }),
+    ], CTX)
+    const even = r.ranked.find((x) => x.layout.layers[0] === 3)!
+    const ragged = r.ranked.find((x) => x.layout.layers[0] === 4)!
+    expect(even.scores.simplicity).toBeGreaterThan(ragged.scores.simplicity)
+  })
+})
+
+describe('the result carries the ranking and the reason', () => {
+  const r = selectRebar([
+    cand({ db: 16, bars: 8, AsProv: 1608, AsReq: 1500, spacing: 70, clearSpacing: 45, layers: [8] }),
+    cand({ db: 20, bars: 5, AsProv: 1571, AsReq: 1500, spacing: 95, clearSpacing: 55, layers: [5] }),
+    cand({ db: 25, bars: 4, AsProv: 1963, AsReq: 1500, spacing: 150, clearSpacing: 65, layers: [4] }),
+    cand({ db: 32, bars: 2, AsProv: 1608, AsReq: 1500, spacing: 210, clearSpacing: 90, layers: [2] }, [fail('min bars', '§9.7.2.1')]),
+  ], CTX)
+
+  it('ranks every compliant candidate, best first', () => {
+    expect(r.ranked).toHaveLength(3)
+    for (let i = 1; i < r.ranked.length; i++) {
+      expect(r.ranked[i - 1].total).toBeGreaterThanOrEqual(r.ranked[i].total - NEAR_TIE)
+    }
+  })
+
+  it('gives the winner a reason naming the arrangement', () => {
+    expect(r.best!.reason).toContain(`⌀${r.best!.layout.db}`)
+    expect(r.best!.reason).toContain(String(r.best!.layout.bars))
+  })
+
+  it('explains the margin over the runner-up', () => {
+    expect(r.margin.length).toBeGreaterThan(20)
+    expect(r.margin).toContain(`⌀${r.best!.layout.db}`)
+  })
+
+  it('lists the rejected candidate with its clause', () => {
+    expect(r.rejected).toHaveLength(1)
+    expect(r.rejected[0].failedGate!.clause).toBe('§9.7.2.1')
+  })
+
+  it('is deterministic — same input, same ranking', () => {
+    const again = selectRebar([
+      cand({ db: 16, bars: 8, AsProv: 1608, AsReq: 1500, spacing: 70, clearSpacing: 45, layers: [8] }),
+      cand({ db: 20, bars: 5, AsProv: 1571, AsReq: 1500, spacing: 95, clearSpacing: 55, layers: [5] }),
+      cand({ db: 25, bars: 4, AsProv: 1963, AsReq: 1500, spacing: 150, clearSpacing: 65, layers: [4] }),
+      cand({ db: 32, bars: 2, AsProv: 1608, AsReq: 1500, spacing: 210, clearSpacing: 90, layers: [2] }, [fail('min bars', '§9.7.2.1')]),
+    ], CTX)
+    expect(again.ranked.map((x) => `${x.layout.bars}⌀${x.layout.db}`))
+      .toEqual(r.ranked.map((x) => `${x.layout.bars}⌀${x.layout.db}`))
+  })
+
+  it('every score is a proper 0..1 fraction', () => {
+    for (const s of [...r.ranked, ...r.rejected]) {
+      for (const v of Object.values(s.scores)) {
+        expect(v).toBeGreaterThanOrEqual(0)
+        expect(v).toBeLessThanOrEqual(1)
+      }
+      expect(s.total).toBeGreaterThanOrEqual(0)
+      expect(s.total).toBeLessThanOrEqual(1)
+    }
+  })
+
+  it('says so plainly when there was only one compliant option', () => {
+    const one = selectRebar([
+      cand({ db: 20 }),
+      cand({ db: 25 }, [fail('x')]),
+    ], CTX)
+    expect(one.margin).toMatch(/only compliant/)
+  })
+})

--- a/webapp/src/engine/rebarScore.ts
+++ b/webapp/src/engine/rebarScore.ts
@@ -1,0 +1,416 @@
+// ─────────────────────────────────────────────────────────────────────────
+// CHOOSING A REINFORCEMENT LAYOUT — enumerate every feasible arrangement,
+// score it, and adopt the best overall. Not the first that works, and not
+// the one with the least steel.
+//
+// ── WHY NOT "FIRST VALID" ────────────────────────────────────────────────
+//
+// The engines used to take a bar diameter as an INPUT and compute
+// n = ceil(As/Ab). Whatever the user typed was what got detailed, and the
+// one place that did search — `barSelection`, used by the model-space
+// pipeline — ranked purely on steel area with a smaller-bar tie-break.
+//
+// Both are wrong for the same reason: a layout is not just an area. 6⌀16 and
+// 3⌀25 carry almost the same steel, and on a drawing they are not remotely
+// the same thing. The first distributes crack width across twice as many
+// bars; the second is quicker to tie and easier to vibrate around. Which one
+// wins depends on the section, and picking whichever the loop reached first
+// is not an answer to that question.
+//
+// ── THE PRIORITY ORDER ───────────────────────────────────────────────────
+//
+//   1. COMPLIANCE      — a HARD GATE, never a score. NSCP 2015 / ACI 318-14
+//                        strength AND detailing. A layout that fails any
+//                        check is infeasible and is never ranked, however
+//                        attractive it looks on the other four.
+//   2. SERVICEABILITY  — crack control: bar distribution and spacing, with a
+//                        preference for smaller diameters — but not at the
+//                        cost of a cage nobody can build.
+//   3. CONSTRUCTABILITY— congestion, layers, room for a vibrator, labour.
+//   4. ECONOMY         — steel weight, over-provision waste, fabrication.
+//   5. SIMPLICITY      — symmetric, regular, standard sizes.
+//
+// The weights below encode that order and sum to 1. They are exported and
+// named so they can be argued with rather than reverse-engineered from
+// behaviour.
+//
+// ── THE NEAR-TIE RULE ────────────────────────────────────────────────────
+//
+// Two layouts within `NEAR_TIE` of each other on total score are treated as
+// equivalent, and the tie is broken on serviceability + constructability
+// alone. Without this, a 1% economy edge silently outranks a materially
+// better-distributed cage — which is the behaviour this module exists to
+// prevent.
+//
+// It is applied as a LEADING-GROUP promotion, not as a comparator. Written as
+// a comparator it is not transitive — A ties B, B ties C, but A and C differ
+// by more than the band — and `Array.sort` with a non-transitive comparator
+// gives an implementation-defined order, which is no way to produce a
+// schedule. So: rank by total (a genuine total order), take everything within
+// NEAR_TIE of the leader, and pick the winner out of that group on
+// serviceability + constructability.
+//
+// ── NORMALISATION ────────────────────────────────────────────────────────
+//
+// "Smaller bar", "less steel" and "fewer bars" are RELATIVE claims, so they
+// are normalised across the candidate set actually generated, not against
+// hard-coded reference values. A set where every option is a ⌀20 scores them
+// all equally on diameter rather than all badly.
+//
+// Units: db and spacings mm, areas mm².
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Priority weights. Sum to 1; the order is the requirement, the values are
+ *  a calibration and may be tuned without changing the ranking's meaning. */
+export const PRIORITY_WEIGHTS = {
+  serviceability: 0.40,
+  constructability: 0.30,
+  economy: 0.20,
+  simplicity: 0.10,
+} as const
+
+/** Total-score band inside which two layouts count as equivalent. */
+export const NEAR_TIE = 0.03
+
+/**
+ * Bar sizes a Philippine yard stocks and a bender handles without comment.
+ * Simplicity only — never a compliance matter, and never a reason to reject.
+ */
+export const COMMON_BARS = new Set([12, 16, 20, 25])
+/** Sizes that are ordinary but less universally stocked. */
+export const STOCKED_BARS = new Set([10, 28, 32])
+
+// ── The thing being scored ────────────────────────────────────────────────
+
+export interface RebarLayout {
+  /** Bar diameter, mm. */
+  db: number
+  /** Total bars in the group, after any detailing bump. */
+  bars: number
+  /** Bars per layer, extreme (tension-face) layer first. */
+  layers: number[]
+  /** Steel provided by this layout, mm². */
+  AsProv: number
+  /** Steel the strength check demanded AT THIS LAYOUT's effective depth. */
+  AsReq: number
+  /** Clear spacing in the fullest layer, mm. */
+  clearSpacing: number
+  /** Centre-to-centre spacing of the bars nearest the tension face, mm. */
+  spacing: number
+  /** Effective depth this arrangement achieves, mm — layers reduce it. */
+  d: number
+  /** Demand / capacity at this layout. ≤ 1 when the section is adequate. */
+  utilization: number
+}
+
+/** One code requirement, evaluated. Compliance is a gate, so every one of
+ *  these must pass for the layout to be ranked at all. */
+export interface ComplianceCheck {
+  id: string
+  /** The clause it comes from — what a checker looks up. */
+  clause: string
+  label: string
+  pass: boolean
+  detail?: string
+}
+
+/** Limits the member type supplies. Everything here is a property of the
+ *  section and the code, not of the layout being scored. */
+export interface ScoreContext {
+  /** §24.3.2 crack-control spacing limit, mm. */
+  sMax: number
+  /** Minimum clear spacing the code permits, mm — §25.2.1. */
+  sMinCode: number
+  /**
+   * Clear spacing below which placing and vibrating concrete gets awkward.
+   * Not a code limit — a site one. A 25 mm gap is legal and unpleasant.
+   */
+  sComfort?: number
+  /** Layers past which the cage reads as congested. */
+  maxLayers?: number
+  /** Bar count past which tying labour starts to dominate. */
+  barComfort?: number
+  /** Whether an even (symmetric) bar count is preferred. Beams and columns
+   *  yes; a slab mat has no centreline to be symmetric about. */
+  wantSymmetric?: boolean
+}
+
+export interface LayoutScores {
+  serviceability: number
+  constructability: number
+  economy: number
+  simplicity: number
+}
+
+export interface ScoredLayout {
+  layout: RebarLayout
+  feasible: boolean
+  compliance: ComplianceCheck[]
+  /** The first clause it failed, when infeasible. */
+  failedGate: ComplianceCheck | null
+  scores: LayoutScores
+  /** Weighted total, 0..1. Meaningless for an infeasible layout. */
+  total: number
+  /** One line naming what this layout is and what it is good at. */
+  reason: string
+}
+
+export interface RebarSelection {
+  /** The adopted layout, or null when nothing in the set complies. */
+  best: ScoredLayout | null
+  /** Feasible layouts, best first. */
+  ranked: ScoredLayout[]
+  /** Infeasible layouts, each with the gate it failed. */
+  rejected: ScoredLayout[]
+  /** How the winner beat the runner-up — or why there was no contest. */
+  margin: string
+}
+
+// ── Small helpers ─────────────────────────────────────────────────────────
+
+const clamp01 = (v: number): number => (Number.isFinite(v) ? Math.min(1, Math.max(0, v)) : 0)
+
+/**
+ * Map a value into 0..1 across the range present in the candidate set, with
+ * `best` = 1. Returns 1 for every candidate when they all share a value —
+ * a dimension on which nothing differs should not separate anything.
+ */
+function normalise(v: number, all: number[], smallerIsBetter: boolean): number {
+  const lo = Math.min(...all), hi = Math.max(...all)
+  if (!Number.isFinite(lo) || !Number.isFinite(hi) || hi - lo < 1e-9) return 1
+  const t = (v - lo) / (hi - lo)
+  return clamp01(smallerIsBetter ? 1 - t : t)
+}
+
+// ── The four scores ───────────────────────────────────────────────────────
+
+/**
+ * SERVICEABILITY — how well this layout controls cracking.
+ *
+ * Crack width at the tension face is governed by how far apart the bars are
+ * (§24.3.2 exists for exactly this) and by how much of the steel sits in the
+ * layer nearest that face. A smaller bar at the same area means more bars,
+ * closer together, and a finer crack pattern.
+ *
+ * The spacing term measures MARGIN against the §24.3.2 limit rather than
+ * pass/fail: compliance already gated on the limit, so what is left to
+ * reward is how far inside it the layout sits.
+ */
+function serviceability(l: RebarLayout, ctx: ScoreContext, allDb: number[]): number {
+  const crack = clamp01(1 - l.spacing / Math.max(ctx.sMax, 1e-9))
+  const diameter = normalise(l.db, allDb, true)
+  // Fraction of the bars in the extreme tension layer — the ones the crack
+  // actually forms around. A deep stack buries steel where it does least for
+  // crack control.
+  const atFace = l.bars > 0 ? clamp01((l.layers[0] ?? 0) / l.bars) : 0
+  return 0.45 * crack + 0.35 * diameter + 0.20 * atFace
+}
+
+/**
+ * CONSTRUCTABILITY — whether a crew can build this without improvising, and
+ * improvising is how a cage stops matching the drawing.
+ *
+ * Layers dominate: a second layer means spacers, a lost effective depth and a
+ * much slower tie. Clear spacing is measured against a COMFORT figure, not
+ * the code minimum — 25 mm is legal and still too tight to get a poker down.
+ */
+function constructability(l: RebarLayout, ctx: ScoreContext, allBars: number[]): number {
+  const maxL = ctx.maxLayers ?? 3
+  const nL = Math.max(1, l.layers.length)
+  // 1 for a single layer, falling away and reaching 0 at the layer cap.
+  const layerScore = clamp01(1 - (nL - 1) / Math.max(1, maxL - 1))
+
+  const comfort = ctx.sComfort ?? 40
+  const room = comfort > ctx.sMinCode
+    ? clamp01((l.clearSpacing - ctx.sMinCode) / (comfort - ctx.sMinCode))
+    : 1
+
+  // Bar count is a labour proxy. Below the comfort threshold everything is
+  // equally easy, so only the crowded end is separated.
+  const bc = ctx.barComfort ?? 8
+  const count = l.bars <= bc ? 1 : normalise(l.bars, allBars.filter((n) => n > bc), true)
+
+  return 0.45 * layerScore + 0.35 * room + 0.20 * count
+}
+
+/**
+ * ECONOMY — steel bought, steel wasted, and bars handled.
+ *
+ * Deliberately the third-ranked term and only 20% of the total. Where two
+ * layouts perform equivalently it decides between them; it is never allowed
+ * to buy a worse-distributed or harder-to-build cage.
+ */
+function economy(l: RebarLayout, allAs: number[], allBars: number[]): number {
+  const steel = normalise(l.AsProv, allAs, true)
+  // Over-provision: how much of the steel bought is actually working.
+  const waste = l.AsProv > 0 ? clamp01(l.AsReq / l.AsProv) : 0
+  const fabrication = normalise(l.bars, allBars, true)
+  return 0.50 * steel + 0.25 * waste + 0.25 * fabrication
+}
+
+/**
+ * SIMPLICITY — how easily this gets drawn, scheduled and read on site.
+ *
+ * An even bar count is symmetric about the web centreline; equal layers are a
+ * regular stack; a common bar size is one the yard has and the schedule
+ * already lists. None of it is structural, which is why it carries the
+ * smallest weight — but between two equal cages it is a real difference.
+ */
+function simplicity(l: RebarLayout, ctx: ScoreContext): number {
+  const wantSym = ctx.wantSymmetric ?? true
+  const even = !wantSym || l.bars % 2 === 0 ? 1 : 0.6
+
+  const regular = l.layers.length <= 1
+    ? 1
+    : new Set(l.layers).size === 1 ? 0.85 : 0.7
+
+  const standard = COMMON_BARS.has(l.db) ? 1 : STOCKED_BARS.has(l.db) ? 0.8 : 0.6
+
+  return 0.35 * even + 0.30 * regular + 0.35 * standard
+}
+
+// ── Compliance ────────────────────────────────────────────────────────────
+
+/** The first failing check, or null when every one passes. */
+export function firstFailure(checks: readonly ComplianceCheck[]): ComplianceCheck | null {
+  return checks.find((c) => !c.pass) ?? null
+}
+
+// ── Scoring and ranking ───────────────────────────────────────────────────
+
+export interface Candidate {
+  layout: RebarLayout
+  compliance: ComplianceCheck[]
+}
+
+function describe(l: RebarLayout, s: LayoutScores): string {
+  const arrangement = l.layers.length > 1
+    ? `${l.bars}⌀${l.db} in ${l.layers.length} layers (${l.layers.join('+')})`
+    : `${l.bars}⌀${l.db} in one layer`
+  const strengths: string[] = []
+  if (s.serviceability >= 0.7) strengths.push('well distributed for crack control')
+  if (s.constructability >= 0.8) strengths.push('easy to place')
+  if (s.economy >= 0.8) strengths.push('economical')
+  if (s.simplicity >= 0.9) strengths.push('symmetric and standard')
+  return strengths.length
+    ? `${arrangement} — ${strengths.join(', ')}.`
+    : `${arrangement}.`
+}
+
+/**
+ * Score every candidate and rank the compliant ones.
+ *
+ * Compliance is applied FIRST and as a gate: an infeasible layout is scored
+ * (so the report can show how close it was) but never ranked and never
+ * adopted. The comparator implements the near-tie rule.
+ */
+export function selectRebar(candidates: readonly Candidate[], ctx: ScoreContext): RebarSelection {
+  if (candidates.length === 0) {
+    return { best: null, ranked: [], rejected: [], margin: 'no candidates were generated' }
+  }
+
+  const compliant = candidates.filter((c) => firstFailure(c.compliance) === null)
+  // Normalise across the FEASIBLE set: an infeasible outlier must not stretch
+  // the scale and flatten the differences between the real options.
+  const pool = compliant.length > 0 ? compliant : candidates
+  const allDb = pool.map((c) => c.layout.db)
+  const allAs = pool.map((c) => c.layout.AsProv)
+  const allBars = pool.map((c) => c.layout.bars)
+
+  const scored: ScoredLayout[] = candidates.map((c) => {
+    const gate = firstFailure(c.compliance)
+    const scores: LayoutScores = {
+      serviceability: serviceability(c.layout, ctx, allDb),
+      constructability: constructability(c.layout, ctx, allBars),
+      economy: economy(c.layout, allAs, allBars),
+      simplicity: simplicity(c.layout, ctx),
+    }
+    const total =
+      PRIORITY_WEIGHTS.serviceability * scores.serviceability +
+      PRIORITY_WEIGHTS.constructability * scores.constructability +
+      PRIORITY_WEIGHTS.economy * scores.economy +
+      PRIORITY_WEIGHTS.simplicity * scores.simplicity
+    return {
+      layout: c.layout,
+      feasible: gate === null,
+      compliance: c.compliance,
+      failedGate: gate,
+      scores,
+      total,
+      reason: gate
+        ? `${c.layout.bars}⌀${c.layout.db} — rejected: ${gate.label} (${gate.clause}).`
+        : describe(c.layout, scores),
+    }
+  })
+
+  // Rank on the total — a real total order, so the sort is well defined.
+  const byTotal = scored.filter((s) => s.feasible).sort(compareByTotal)
+  const rejected = scored.filter((s) => !s.feasible)
+    .sort((a, b) => a.layout.db - b.layout.db || a.layout.bars - b.layout.bars)
+
+  // Then promote the best of the leading group. Everything within NEAR_TIE of
+  // the top total counts as equivalent on the weighted score, so the choice
+  // between them is made on serviceability + constructability alone.
+  const leader = byTotal[0]
+  const contenders = leader
+    ? byTotal.filter((s) => leader.total - s.total <= NEAR_TIE)
+    : []
+  const best = contenders.length > 0 ? [...contenders].sort(comparePair)[0] : null
+
+  const ranked = best
+    ? [best, ...byTotal.filter((s) => s !== best)]
+    : byTotal
+
+  const margin = !best
+    ? `no layout satisfies every check — ${rejected.length} candidate${rejected.length === 1 ? '' : 's'} rejected`
+    : ranked.length === 1
+      ? 'the only compliant layout in the set'
+      : marginText(best, ranked[1], contenders.length > 1)
+
+  return { best, ranked, rejected, margin }
+}
+
+/** Rank by weighted total, with deterministic tie-breaks all the way down so
+ *  the same input always yields the same schedule. */
+export function compareByTotal(a: ScoredLayout, b: ScoredLayout): number {
+  if (Math.abs(a.total - b.total) > 1e-12) return b.total - a.total
+  return breakTies(a, b)
+}
+
+/** Within the leading group: serviceability + constructability decides. */
+export function comparePair(a: ScoredLayout, b: ScoredLayout): number {
+  const pairA = a.scores.serviceability + a.scores.constructability
+  const pairB = b.scores.serviceability + b.scores.constructability
+  if (Math.abs(pairA - pairB) > 1e-9) return pairB - pairA
+  return breakTies(a, b)
+}
+
+/** Prefer the smaller bar (finer distribution), then fewer layers, then
+ *  fewer bars. Never leaves two candidates genuinely equal. */
+function breakTies(a: ScoredLayout, b: ScoredLayout): number {
+  if (a.layout.db !== b.layout.db) return a.layout.db - b.layout.db
+  if (a.layout.layers.length !== b.layout.layers.length) return a.layout.layers.length - b.layout.layers.length
+  return a.layout.bars - b.layout.bars
+}
+
+function marginText(best: ScoredLayout, next: ScoredLayout, nearTie: boolean): string {
+  const label = (s: ScoredLayout) => `${s.layout.bars}⌀${s.layout.db}`
+  if (!nearTie) {
+    const driver = biggestGain(best, next)
+    return `${label(best)} scores ${best.total.toFixed(3)} against ${label(next)} at ` +
+      `${next.total.toFixed(3)} — decided on ${driver}`
+  }
+  const pair = (s: ScoredLayout) => (s.scores.serviceability + s.scores.constructability).toFixed(2)
+  return `${label(best)} and ${label(next)} are within ${NEAR_TIE} on total score, so they count ` +
+    `as equivalent; ${label(best)} wins on serviceability + constructability ` +
+    `(${pair(best)} vs ${pair(next)})`
+}
+
+/** Which weighted term contributed most of the winner's lead. */
+function biggestGain(best: ScoredLayout, next: ScoredLayout): string {
+  const terms: [keyof LayoutScores, number][] = (
+    Object.keys(PRIORITY_WEIGHTS) as (keyof LayoutScores)[]
+  ).map((k) => [k, PRIORITY_WEIGHTS[k] * (best.scores[k] - next.scores[k])])
+  terms.sort((x, y) => y[1] - x[1])
+  return terms[0][1] > 0 ? terms[0][0] : 'the weighted total'
+}


### PR DESCRIPTION
**Phase 1 of 4** for the reinforcement-selection rework: the scoring core, plus the **beam** wired end to end to prove it. Column, slab and footing follow in their own PRs.

## What was there

`beamDesign`, `columnDesign`, `slabDDM` and `isolatedFooting` all take the bar diameter as an **input** and compute `n = ceil(As/Ab)`. Whatever the user typed is what got detailed — **there was no search at all.** The one place that did search, `barSelection` in the model-space pipeline, ranked purely on **steel area** with a smaller-bar tie-break.

Both are wrong the same way: a layout is not just an area. 6⌀16 and 3⌀25 carry nearly the same steel and are not remotely the same thing on a drawing. Which one wins depends on the section, and whichever the loop reached first is not an answer to that question.

## The priority order

| | | weight |
|---|---|---|
| 1 | **Compliance** — a *hard gate*, never a score. NSCP 2015 / ACI 318-14, strength **and** detailing. | gate |
| 2 | **Serviceability** — spacing margin against §24.3.2, smaller diameters, steel at the tension face | 0.40 |
| 3 | **Constructability** — layers, room for a vibrator, tying labour | 0.30 |
| 4 | **Economy** — steel, over-provision waste, fabrication | 0.20 |
| 5 | **Simplicity** — symmetric count, regular stack, stocked size | 0.10 |

Weights are exported and named so they can be argued with rather than reverse-engineered from behaviour; a test asserts they carry the stated order and sum to 1.

## The near-tie rule — and why it is not a comparator

> *"If two solutions are nearly equivalent, favour the one with better serviceability and constructability."*

Written as a comparator that rule is **not transitive** — A ties B, B ties C, but A and C differ by more than the band — and `Array.sort` with a non-transitive comparator gives an implementation-defined order, which is no way to produce a schedule.

My first version did exactly that, and probing real beams caught it: a candidate with a **higher** total ranked *below* one with a lower total, and the rest of the list was consistent with neither.

It is now a **leading-group promotion**: rank by total (a genuine total order), take everything within `NEAR_TIE` of the leader, and pick the winner from that group on serviceability + constructability. Transitive, deterministic, and it promotes the best of the *whole* group rather than just the runner-up.

## Relative, not absolute

"Smaller bar", "less steel", "fewer bars" are relative claims, so they are normalised across the candidate set actually generated — a set where every option is a ⌀32 scores them all *equally* on diameter rather than all badly. Normalisation runs over the **feasible** set, so an infeasible outlier cannot stretch the scale and flatten the real options.

## The beam

`optimizeBeamRebar` runs the existing, verified `designBeam` once per diameter and scores the results. It re-derives **no** strength — a second implementation of §22.2 that drifts from the first is worse than no search at all. Ten compliance checks come off the design result, ordered so the **first** failure is the one reported: *"the section is too shallow"* must not surface as *"the bars do not fit"*.

On the reference 300×500 at Mu = 150 kN·m:

```
ADOPTED: 4⌀20
4⌀20 and 5⌀16 are within 0.03 on total score, so they count as equivalent;
4⌀20 wins on serviceability + constructability (1.82 vs 1.66)

   4⌀20  As 1257  s  60  clear  40 | serv 0.82 con 1.00 eco 0.57 sim 1.00 = 0.841
   5⌀16  As 1005  s  46  clear  30 | serv 0.93 con 0.74 eco 0.74 sim 0.86 = 0.826
   3⌀25  As 1473  s  88  clear  63 | serv 0.66 con 1.00 eco 0.45 sim 0.86 = 0.741
   2⌀28  As 1232  s 172  clear 144 | serv 0.47 con 1.00 eco 0.76 sim 0.93 = 0.732
   2⌀32  As 1608  s 168  clear 136 | serv 0.38 con 1.00 eco 0.40 sim 0.93 = 0.628
 ✗ 9⌀12: the bars fit the web at the required clear spacing (§25.2.1)
```

5⌀16 has **less steel and tighter spacing** and still loses — 30 mm clear is no place for a poker vibrator. It is provably neither the min-steel nor the min-bar choice, and there are tests for both.

## Found while doing it

`designBeam` packs a layer on clear spacing = `max(db, 25)` and **omits the §25.2.1 4/3·d_agg term** — on 20 mm aggregate that is 26.7 mm, so the engine can lay out a layer that is not actually compliant. The optimiser re-checks with the aggregate term and rejects those layouts *with the clause*, which is the safe direction, but `designBeam` should carry the aggregate itself. Left as a follow-up rather than changed under a scoring PR.

## Verification

**+33 scoring cases** — gate-before-score, both *"not min steel"* and *"not min bars"*, each score dimension in isolation, near-tie promotion over the whole leading group, total-order guarantees, determinism, 0..1 bounds.

**+26 beam cases** — the winner is fully compliant across four section sizes from light to very heavy, is reproducible by re-running `designBeam` at the adopted diameter, and the optimiser reports *no winner* rather than adopting a failing layout when the section is simply too small.

`npm test` — 201 files, **3358 passed**. `npx tsc -b`, `eslint`, `npm run build` green.

## Remaining phases

- **Phase 2** — column: search diameter × count over symmetric layouts
- **Phase 3** — slab + footing: spacing-governed mats (`wantSymmetric: false`)
- **Phase 4** — surface the ranking, margin and reason on each page and in the worked solutions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_