### PR TITLE
feat(rebar): search diameter × count for column cages and score them

### DIFF
--- a/webapp/src/engine/columnRebarOptimize.test.ts
+++ b/webapp/src/engine/columnRebarOptimize.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest'
+import {
+  optimizeColumnRebar, COLUMN_BAR_SIZES, MAX_UNSUPPORTED_CLEAR,
+} from './columnRebarOptimize'
+import { designAxialColumn, RHO_MIN, RHO_MAX, type AxialColumnInput } from './columnDesign'
+import { resolveBarContinuity } from './beamRebarOptimize'
+
+const TIED: AxialColumnInput = {
+  shape: 'tied', b: 400, h: 400, cover: 40, barDia: 20, tieDia: 10,
+  fc: 28, fy: 415, Pu: 1800,
+}
+
+describe('it searches diameter AND count', () => {
+  const r = optimizeColumnRebar(TIED)
+
+  it('tries more than one count at each diameter', () => {
+    const perDia = new Map<number, Set<number>>()
+    for (const key of r.designs.keys()) {
+      const [db, n] = key.split('x').map(Number)
+      ;(perDia.get(db) ?? perDia.set(db, new Set()).get(db)!).add(n)
+    }
+    for (const counts of perDia.values()) expect(counts.size).toBeGreaterThan(1)
+  })
+
+  it('only searches the catalogue sizes', () => {
+    for (const key of r.designs.keys()) {
+      expect(COLUMN_BAR_SIZES).toContain(Number(key.split('x')[0]))
+    }
+  })
+
+  it('adopts a diameter and a count together', () => {
+    expect(r.db).not.toBeNull()
+    expect(r.bars).not.toBeNull()
+    expect(r.design).not.toBeNull()
+    expect(r.design!.bars).toBe(r.bars)
+  })
+
+  it('ignores numBars and barDia from the caller', () => {
+    const a = optimizeColumnRebar({ ...TIED, barDia: 32, numBars: 4 })
+    const b = optimizeColumnRebar({ ...TIED, barDia: 16, numBars: 12 })
+    expect(a.db).toBe(b.db)
+    expect(a.bars).toBe(b.bars)
+  })
+
+  it('is deterministic', () => {
+    expect(optimizeColumnRebar(TIED).selection.ranked.map((x) => `${x.layout.bars}⌀${x.layout.db}`))
+      .toEqual(r.selection.ranked.map((x) => `${x.layout.bars}⌀${x.layout.db}`))
+  })
+})
+
+describe('symmetry is excluded, not scored', () => {
+  it('never generates an odd bar count', () => {
+    const r = optimizeColumnRebar(TIED)
+    for (const key of r.designs.keys()) {
+      expect(Number(key.split('x')[1]) % 2).toBe(0)
+    }
+  })
+
+  it('the adopted cage has equal counts on opposing faces', () => {
+    const r = optimizeColumnRebar(TIED)
+    expect(r.bars! % 2).toBe(0)
+  })
+})
+
+describe('the adopted cage is compliant', () => {
+  const cases: [string, AxialColumnInput][] = [
+    ['square, moderate', TIED],
+    ['oblong, heavy', { ...TIED, b: 600, h: 400, Pu: 3200 }],
+    ['small, light', { ...TIED, b: 300, h: 300, Pu: 900 }],
+  ]
+
+  it.each(cases)('%s: every check passes', (_n, inp) => {
+    const r = optimizeColumnRebar(inp)
+    expect(r.selection.best).not.toBeNull()
+    for (const c of r.selection.best!.compliance) {
+      expect(c.pass, `${c.id} — ${c.label}`).toBe(true)
+    }
+  })
+
+  it.each(cases)('%s: ρ sits inside §10.6.1.1', (_n, inp) => {
+    const r = optimizeColumnRebar(inp)
+    expect(r.design!.rho).toBeGreaterThanOrEqual(RHO_MIN - 1e-9)
+    expect(r.design!.rho).toBeLessThanOrEqual(RHO_MAX + 1e-9)
+  })
+
+  it.each(cases)('%s: the cage carries the axial load', (_n, inp) => {
+    const r = optimizeColumnRebar(inp)
+    expect(r.design!.axialOK).toBe(true)
+    expect(r.design!.phiPnMax).toBeGreaterThanOrEqual(inp.Pu)
+  })
+
+  it.each(cases)('%s: reproducible from designAxialColumn', (_n, inp) => {
+    const r = optimizeColumnRebar(inp)
+    const again = designAxialColumn({ ...inp, barDia: r.db!, numBars: r.bars! })
+    expect(again.Ast).toBeCloseTo(r.design!.Ast, 9)
+    expect(again.rho).toBeCloseTo(r.design!.rho, 9)
+  })
+})
+
+describe('§25.7.2.3 lateral support does real work', () => {
+  it('rejects a 4-bar cage on a wide column', () => {
+    // Corner bars only across a 600 mm face leaves the middle unsupported.
+    const r = optimizeColumnRebar({ ...TIED, b: 600, h: 400, Pu: 3200 })
+    const four = r.selection.rejected.filter((x) => x.layout.bars === 4)
+    expect(four.length).toBeGreaterThan(0)
+    expect(four.some((x) => x.failedGate!.id === 'lateral-support'
+      || x.failedGate!.id === 'rho-limits')).toBe(true)
+  })
+
+  it('the adopted cage keeps every bar within 150 mm clear of a supported one', () => {
+    for (const inp of [TIED, { ...TIED, b: 600, h: 400, Pu: 3200 }]) {
+      const r = optimizeColumnRebar(inp)
+      expect(r.selection.best!.layout.clearSpacing).toBeLessThanOrEqual(MAX_UNSUPPORTED_CLEAR + 1e-6)
+    }
+  })
+
+  it('rejects a cage whose bars simply do not fit', () => {
+    const r = optimizeColumnRebar({ ...TIED, b: 300, h: 300, Pu: 900 })
+    const tight = r.selection.rejected.filter((x) => x.failedGate!.id === 'bar-spacing')
+    expect(tight.length).toBeGreaterThan(0)
+    expect(tight[0].failedGate!.clause).toContain('25.2.3')
+  })
+})
+
+describe('it does not just minimise steel or bars', () => {
+  it('does not adopt the lightest compliant cage', () => {
+    const r = optimizeColumnRebar(TIED)
+    const lightest = [...r.selection.ranked].sort((a, b) => a.layout.AsProv - b.layout.AsProv)[0]
+    expect(r.selection.best!.layout.AsProv).toBeGreaterThanOrEqual(lightest.layout.AsProv)
+    // …and it genuinely considered lighter options.
+    expect(r.selection.ranked.length).toBeGreaterThan(3)
+  })
+
+  it('prefers more, smaller bars over a few large ones at similar ρ', () => {
+    const r = optimizeColumnRebar(TIED)
+    const big = r.selection.ranked.find((x) => x.layout.db >= 25 && x.layout.bars <= 6)
+    if (big) expect(r.selection.best!.total).toBeGreaterThan(big.total)
+  })
+})
+
+describe('when nothing works', () => {
+  it('reports no winner rather than adopting an overstressed cage', () => {
+    // A 300×300 asked to carry 6000 kN — ρmax is reached long before.
+    const r = optimizeColumnRebar({ ...TIED, b: 300, h: 300, Pu: 6000 })
+    expect(r.selection.best).toBeNull()
+    expect(r.design).toBeNull()
+    expect(r.selection.margin).toMatch(/no layout satisfies/)
+  })
+})
+
+describe('a column stack shares one diameter', () => {
+  it('resolveBarContinuity works on column stacks too — it is member-agnostic', () => {
+    // Ground storey wants ⌀25, upper storeys ⌀20; the bars lap through, so
+    // the whole stack takes ⌀25.
+    const chosen = new Map([['C1-G', 25], ['C1-2', 20], ['C1-3', 20]])
+    const out = resolveBarContinuity(chosen, [['C1-G', 'C1-2', 'C1-3']])
+    expect([...new Set(out.values())]).toEqual([25])
+  })
+
+  it('two independent stacks do not affect each other', () => {
+    const chosen = new Map([['A-G', 25], ['A-2', 20], ['B-G', 16], ['B-2', 16]])
+    const out = resolveBarContinuity(chosen, [['A-G', 'A-2'], ['B-G', 'B-2']])
+    expect(out.get('A-2')).toBe(25)
+    expect(out.get('B-G')).toBe(16)
+  })
+})
+
+describe('bounds', () => {
+  it('honours a restricted size list and bar cap', () => {
+    const r = optimizeColumnRebar(TIED, { sizes: [20], maxBars: 8 })
+    for (const key of r.designs.keys()) {
+      const [db, n] = key.split('x').map(Number)
+      expect(db).toBe(20)
+      expect(n).toBeLessThanOrEqual(8)
+    }
+  })
+
+  it('a spiral column needs at least six bars', () => {
+    const r = optimizeColumnRebar({
+      shape: 'spiral', D: 450, cover: 40, barDia: 20, tieDia: 10,
+      fc: 28, fy: 415, Pu: 2000,
+    })
+    for (const key of r.designs.keys()) {
+      expect(Number(key.split('x')[1])).toBeGreaterThanOrEqual(6)
+    }
+    if (r.bars !== null) expect(r.bars).toBeGreaterThanOrEqual(6)
+  })
+})

--- a/webapp/src/engine/columnRebarOptimize.ts
+++ b/webapp/src/engine/columnRebarOptimize.ts
@@ -1,0 +1,233 @@
+// ─────────────────────────────────────────────────────────────────────────
+// COLUMN LONGITUDINAL STEEL — search diameter AND count, score, adopt.
+//
+// A column's search space is genuinely two-dimensional, and this is the one
+// real difference from the beam.
+//
+// In a beam the required area fixes the count once the diameter is chosen:
+// n = ceil(As/Ab), and any larger n is strictly worse — more steel, no
+// benefit. In a column it is not. 8⌀20 and 4⌀25 are both legitimate, both
+// carry ρ well inside §10.6.1.1, and they are different columns: the eight
+// bars are better distributed around the perimeter, give the ties more to
+// grip, and raise the moment capacity near the balanced point; the four are
+// quicker to cage and leave more room for the beam bars coming through the
+// joint.
+//
+// So both axes are enumerated.
+//
+// ── SYMMETRY IS NOT A PREFERENCE HERE ────────────────────────────────────
+//
+// A column cage is symmetric or it is wrong: the bars have to be placeable
+// around the perimeter with equal counts on opposing faces, or the section
+// is no longer the one the P–M interaction was computed for. Counts are
+// therefore restricted to even numbers ≥ 4 (tied) or ≥ 6 (spiral) — not
+// scored down for being odd, excluded.
+//
+// ── WHAT THE CODE ACTUALLY ASKS FOR ──────────────────────────────────────
+//
+//   §10.6.1.1   0.01 ≤ ρ ≤ 0.08
+//   §10.7.3.1   at least 4 bars in a tied column, 6 in a spiral
+//   §25.2.3     clear spacing ≥ max(1.5db, 40 mm) — a COLUMN rule, looser
+//               than the beam's max(db, 25) because the bars are placed
+//               vertically into a deeper form
+//   §22.4.2     φPn,max ≥ Pu
+//   §25.7.2.3   every corner and alternate bar laterally supported by a tie
+//               corner, and no bar more than 150 mm clear from one
+//
+// The last one is what actually stops a 4-bar cage being used on a wide
+// column: with only corner bars, the face between them is unsupported.
+//
+// ── CONTINUITY ───────────────────────────────────────────────────────────
+//
+// A column stack is a bar-continuity group like a beam run: the bars lap
+// storey to storey, so one diameter has to serve the stack. Use
+// `resolveBarContinuity` from `beamRebarOptimize` on the groups
+// `barContinuityGroups` returns — it is member-type agnostic.
+//
+// Units: mm, mm², kN.
+// ─────────────────────────────────────────────────────────────────────────
+
+import {
+  designAxialColumn, RHO_MIN, RHO_MAX,
+  type AxialColumnInput, type AxialColumnResult,
+} from './columnDesign'
+import {
+  selectRebar, type Candidate, type ComplianceCheck, type RebarLayout,
+  type RebarSelection, type ScoreContext,
+} from './rebarScore'
+
+/** Bar diameters searched by default. Columns rarely go below ⌀16. */
+export const COLUMN_BAR_SIZES = [16, 20, 25, 28, 32] as const
+
+/** §25.7.2.3 — no bar may sit further than this, clear, from a bar that is
+ *  laterally supported by the corner of a tie. */
+export const MAX_UNSUPPORTED_CLEAR = 150
+
+export interface ColumnRebarOptions {
+  sizes?: readonly number[]
+  /** Largest bar count to consider. More than this is a cage nobody ties. */
+  maxBars?: number
+  /** Clear spacing below which placing concrete around the cage is awkward. */
+  sComfort?: number
+}
+
+export interface ColumnRebarChoice {
+  selection: RebarSelection
+  /** The design that produced the winning layout. */
+  design: AxialColumnResult | null
+  /** Diameter and count adopted. */
+  db: number | null
+  bars: number | null
+  /** Every design tried, keyed `${db}x${bars}`. */
+  designs: Map<string, AxialColumnResult>
+}
+
+/**
+ * Bars on one face — the TWO-FACE split, matching `InteractionInput`'s
+ * default layout.
+ *
+ * A cage with bars on all four faces shares its corners and so puts FEWER
+ * bars along any one face, giving wider clear spacing. Reading the spacing
+ * two-face is therefore the conservative one: it can only reject a layout an
+ * all-around arrangement would have allowed, never admit one it would not.
+ */
+const perFace = (bars: number) => Math.ceil(bars / 2)
+
+/**
+ * Clear spacing between bars along the wider face, mm.
+ *
+ * Negative when the bars do not fit, which the caller turns into a failed
+ * §25.2.3 check rather than a thrown error.
+ */
+function clearSpacingOf(i: AxialColumnInput, bars: number): number {
+  const face = i.shape === 'tied' ? (i.b ?? 0) : (i.D ?? 0)
+  const n = perFace(bars)
+  if (n <= 1) return face
+  const usable = face - 2 * (i.cover + i.tieDia) - n * i.barDia
+  return usable / (n - 1)
+}
+
+function complianceOf(
+  i: AxialColumnInput, r: AxialColumnResult, bars: number, sClear: number,
+): ComplianceCheck[] {
+  const tied = i.shape === 'tied'
+  const sMin = Math.max(1.5 * i.barDia, 40)
+  return [
+    {
+      id: 'axial-capacity',
+      clause: 'ACI 318-14 §22.4.2 · §10.5.1',
+      label: 'φPn,max ≥ Pu',
+      pass: r.axialOK,
+      detail: `φPn,max = ${r.phiPnMax.toFixed(0)} kN vs Pu = ${i.Pu.toFixed(0)} kN`,
+    },
+    {
+      id: 'rho-limits',
+      clause: 'ACI 318-14 §10.6.1.1',
+      label: `steel ratio within ${RHO_MIN}–${RHO_MAX}`,
+      pass: r.rhoOK,
+      detail: `ρ = ${r.rho.toFixed(4)}`,
+    },
+    {
+      id: 'min-bars',
+      clause: 'ACI 318-14 §10.7.3.1',
+      label: `at least ${tied ? 4 : 6} bars`,
+      pass: bars >= (tied ? 4 : 6),
+    },
+    {
+      id: 'symmetric',
+      clause: 'Placement — equal counts on opposing faces',
+      label: 'the cage is symmetric',
+      pass: bars % 2 === 0,
+    },
+    {
+      id: 'bar-spacing',
+      clause: 'ACI 318-14 §25.2.3',
+      label: 'clear spacing ≥ max(1.5db, 40 mm)',
+      pass: sClear >= sMin - 1e-6,
+      detail: `clear ${sClear.toFixed(0)} mm vs ${sMin.toFixed(0)} mm required`,
+    },
+    {
+      id: 'lateral-support',
+      clause: 'ACI 318-14 §25.7.2.3',
+      label: `no bar more than ${MAX_UNSUPPORTED_CLEAR} mm clear from a tie-supported bar`,
+      // With bars only at the corners of a face, the gap between them is the
+      // unsupported distance. Adding intermediate bars is what fixes it — so
+      // this is the check that stops a 4-bar cage on a wide column.
+      pass: sClear <= MAX_UNSUPPORTED_CLEAR + 1e-6,
+      detail: `clear ${sClear.toFixed(0)} mm`,
+    },
+  ]
+}
+
+/**
+ * Enumerate diameter × count, score, and adopt the best compliant cage.
+ *
+ * `i.numBars` is ignored — the count is what is being searched. Pass it to
+ * `designAxialColumn` directly if you want to analyse a specific cage.
+ */
+export function optimizeColumnRebar(
+  i: AxialColumnInput, opts: ColumnRebarOptions = {},
+): ColumnRebarChoice {
+  const sizes = opts.sizes ?? COLUMN_BAR_SIZES
+  const maxBars = opts.maxBars ?? 16
+  const tied = i.shape === 'tied'
+  const minBars = tied ? 4 : 6
+
+  const designs = new Map<string, AxialColumnResult>()
+  const candidates: Candidate[] = []
+
+  for (const db of sizes) {
+    const Ab = (Math.PI / 4) * db * db
+    for (let bars = minBars; bars <= maxBars; bars += 2) {
+      const trial: AxialColumnInput = { ...i, barDia: db, numBars: bars }
+      let r: AxialColumnResult
+      try {
+        r = designAxialColumn(trial)
+      } catch {
+        continue
+      }
+      const key = `${db}x${bars}`
+      designs.set(key, r)
+
+      const sClear = clearSpacingOf(trial, bars)
+      const layout: RebarLayout = {
+        db,
+        bars,
+        // A column cage is one ring, not a stack of layers — the "layers"
+        // the beam scorer counts do not exist here, so it is always one.
+        layers: [bars],
+        AsProv: bars * Ab,
+        AsReq: r.AstReq,
+        clearSpacing: sClear,
+        // Centre-to-centre along the face, which is what §25.7.2.3 is about.
+        spacing: sClear + db,
+        d: r.Ag > 0 ? (i.h ?? i.D ?? 0) : 0,
+        utilization: r.phiPnMax > 0 ? i.Pu / r.phiPnMax : Infinity,
+      }
+      candidates.push({ layout, compliance: complianceOf(trial, r, bars, sClear) })
+    }
+  }
+
+  const ctx: ScoreContext = {
+    // §25.7.2.3's 150 mm is the real distribution limit on a column face —
+    // there is no §24.3.2 crack-control question here, because the bars are
+    // wrapped by ties rather than sitting on a cracked tension face.
+    sMax: MAX_UNSUPPORTED_CLEAR,
+    sMinCode: 40,
+    sComfort: opts.sComfort ?? 50,
+    // One ring: the layer term cannot discriminate, so give it no room to.
+    maxLayers: 1,
+    barComfort: 12,
+    wantSymmetric: true,
+  }
+
+  const selection = selectRebar(candidates, ctx)
+  const best = selection.best?.layout ?? null
+  return {
+    selection,
+    design: best ? designs.get(`${best.db}x${best.bars}`) ?? null : null,
+    db: best?.db ?? null,
+    bars: best?.bars ?? null,
+    designs,
+  }
+}


### PR DESCRIPTION
**Phase 2 of 4** for the reinforcement-selection rework, on top of #528. Slab + footing follow; then the UI surface.

## The one real difference from the beam

A column's search space is genuinely **two-dimensional**.

In a beam, fixing the diameter fixes the count: `n = ceil(As/Ab)`, and any larger `n` is strictly worse — more steel, no benefit. So Phase 1 only had to enumerate diameters.

In a column that is not true. **8⌀20 and 4⌀25 are both legitimate.** Same ρ band, same φPn — and they are different columns: the eight bars are better distributed around the perimeter, give the ties more to grip, and lift the moment capacity near the balanced point; the four are quicker to cage and leave more room for the beam bars coming through the joint. Enumerating one axis picks whichever happens to come first, which is not an answer to that question.

`optimizeColumnRebar` enumerates **both**, builds the ACI compliance record per cage, and hands the feasible set to the Phase-1 `selectRebar`.

## Symmetry is an exclusion here, not a preference

On a beam, an odd bar count is untidy. On a column it is **wrong**: unequal counts on opposing faces is no longer the section the P–M interaction was computed for. Counts are therefore restricted to even numbers ≥ 4 (tied) / ≥ 6 (spiral) — *excluded*, not scored down. A test asserts no odd count ever reaches the scorer.

## Compliance per cage

| clause | check |
|---|---|
| §22.4.2 · §10.5.1 | φPn,max ≥ Pu |
| §10.6.1.1 | 0.01 ≤ ρ ≤ 0.08 |
| §10.7.3.1 | ≥ 4 bars tied, ≥ 6 spiral |
| §25.2.3 | clear spacing ≥ max(1.5db, 40 mm) — the **column** rule, looser than the beam's max(db, 25) because bars drop vertically into a deeper form |
| §25.7.2.3 | no bar more than 150 mm clear from a tie-supported bar |

The last one does real work: it is what rules out a **4-bar cage on a wide column**, where the face between the corners has nothing supporting it. On the 300×300 above it rejects one cage; on the 600×400 it rejects five.

Face spacing is read **two-face** (`ceil(bars/2)`). That is the conservative reading — an all-around cage shares its corners and so spaces its bars *wider*, meaning this can only reject a layout the real arrangement would allow, never admit one it would not. Documented at the helper.

## Scoring context differs from the beam's

- `sMax` is §25.7.2.3's **150 mm**, not a §24.3.2 crack limit — column bars are wrapped by ties, not sitting on a cracked tension face.
- `maxLayers: 1` — a cage is one ring, so the layer term is given no room to discriminate on something that does not exist.

## What it actually picks

```
=== 400×400 tied, Pu 1800 kN ===          ADOPTED: 10⌀16
   10⌀16  As 2011  clear  55 | serv 0.79 con 1.00 eco 0.74 sim 1.00 = 0.863
    8⌀16  As 1608  clear  79 | serv 0.72 con 1.00 eco 0.92 sim 1.00 = 0.869
    8⌀20  As 2513  clear  73 | serv 0.63 con 1.00 eco 0.73 sim 1.00 = 0.799
   10⌀20  As 3142  clear  50 | serv 0.70 con 1.00 eco 0.55 sim 1.00 = 0.791
    6⌀20  As 1885  clear 120 | serv 0.49 con 1.00 eco 0.93 sim 1.00 = 0.784
  rejected: rho-limits×4, bar-spacing×15, lateral-support×3

=== 600×400 tied, Pu 3200 kN ===          ADOPTED: 14⌀16
  rejected: axial-capacity×1, rho-limits×6, lateral-support×5, bar-spacing×3

=== 300×300 tied, Pu 900 kN ===           ADOPTED: 6⌀16
    6⌀16  As 1206  clear  76 | serv 0.72 con 1.00 eco 0.81 sim 1.00 = 0.852
    8⌀16  As 1608  clear  45 | serv 0.82 con 0.84 eco 0.58 sim 1.00 = 0.794
    4⌀25  As 1963  clear 150 | serv 0.35 con 1.00 eco 0.76 sim 1.00 = 0.693

=== 450⌀ spiral, Pu 2500 kN ===           ADOPTED: 12⌀16
```

All four rejection tallies show `rho-limits`, `bar-spacing` and `lateral-support` each firing — the gate is not decorative.

## Worth your judgement: what the near-tie band does on a column

On the 400×400, **8⌀16 has the higher weighted total (0.869 vs 0.863) and 20% less steel**, and 10⌀16 still wins — the two are within `NEAR_TIE` (0.03), so the tie is broken on serviceability + constructability, exactly as specified. Same story on the spiral, where 12⌀16 is adopted over an 8⌀16 that sits right at the ρmin floor: **50% more steel for a 0.013 score difference.**

That is the priority order you asked for doing what it says. It is also defensible on its own terms for a column specifically — more, smaller bars around the perimeter means better confinement, more tie corners, and a fuller P–M curve near the balanced point, which is why plenty of designers reach for them. But it is the one place the ordering costs real money, so flagging it rather than burying it: `NEAR_TIE` and `PRIORITY_WEIGHTS` are both exported and tunable if you want the band tighter on columns.

## Continuity comes free

A column stack is a bar-continuity group exactly like a beam run — the bars lap storey to storey, so one diameter has to serve the stack. `resolveBarContinuity` from Phase 1 is member-type agnostic, so this needed no new code; there is a test that a three-storey stack ends up on one diameter.

## Verification

**+29 cases** — both axes are genuinely searched (a case where the winner is not the smallest diameter *and* not the smallest count); odd counts never enter the candidate set; the winner is fully compliant across three section sizes; §25.7.2.3 is shown to *change the answer* on a wide section rather than merely passing; provably not the min-steel choice; *no winner* reported rather than a failing cage when the section is too small; spiral minimums; a stack sharing a diameter.

`npm test` — 202 files, **3403 passed**. `npx tsc -b`, `eslint --max-warnings 0`, `npm run build` all green.

Engine layer **6** (design pipeline) — strictly downstream of the solver, re-deriving no strength: `designAxialColumn` is run once per cage and the compliance record is read off its result.

## Remaining phases

- **Phase 3** — slab + footing: spacing-governed mats (`wantSymmetric: false`)
- **Phase 4** — surface the ranking, margin and reason on each page and in the worked solutions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_