### PR TITLE
feat(rebar): show the reinforcement selection on the pages

### DIFF
--- a/webapp/src/components/RebarRanking.tsx
+++ b/webapp/src/components/RebarRanking.tsx
@@ -1,0 +1,154 @@
+import { useState } from 'react'
+import {
+  PRIORITY_WEIGHTS, blockingGates,
+  type RebarLayout, type RebarSelection, type ScoredLayout,
+} from '../engine/rebarScore'
+import { nameCage } from '../lib/rebarLabel'
+
+// ─────────────────────────────────────────────────────────────────────────
+// The reinforcement selection, shown rather than asserted.
+//
+// The optimiser's answer is only worth trusting if the working is visible:
+// what was adopted, what it beat, by how much, and — when nothing complies —
+// which clause did the rejecting. This renders that for a beam cage, a column
+// cage or a slab mat alike; the only thing that differs is how a layout is
+// named, which the caller supplies.
+// ─────────────────────────────────────────────────────────────────────────
+
+const pct = (v: number) => `${(v * 100).toFixed(0)}`
+
+/** Column headers carry their weight, so the ranking can be argued with. */
+const DIMS = [
+  ['Serv', 'serviceability'],
+  ['Const', 'constructability'],
+  ['Econ', 'economy'],
+  ['Simp', 'simplicity'],
+] as const
+
+function ScoreRow({ s, adopted, name }: {
+  s: ScoredLayout; adopted: boolean; name: (l: RebarLayout) => string
+}) {
+  return (
+    <tr className={adopted ? 'bg-[#eaf1f9]' : ''}>
+      <td className="py-1 pr-2 font-mono text-[11.5px] font-semibold text-[#0f1b2a]">
+        {adopted && <span className="mr-1 text-[#0f4c92]">▸</span>}
+        {name(s.layout)}
+      </td>
+      {DIMS.map(([, k]) => (
+        <td key={k} className="py-1 pr-2 text-right font-mono text-[11px] text-[#5c6675]">
+          {pct(s.scores[k])}
+        </td>
+      ))}
+      <td className="py-1 text-right font-mono text-[11.5px] font-semibold text-[#0f1b2a]">
+        {s.total.toFixed(3)}
+      </td>
+    </tr>
+  )
+}
+
+export function RebarRanking({
+  selection, title = 'Bar selection', name = nameCage, limit = 6,
+}: {
+  selection: RebarSelection
+  title?: string
+  /** How to name a layout — a cage counts bars, a mat quotes a spacing. */
+  name?: (l: RebarLayout) => string
+  /** Ranked rows to show before the "show all" toggle. */
+  limit?: number
+}) {
+  const [all, setAll] = useState(false)
+  const [showRejected, setShowRejected] = useState(false)
+  const { best, ranked, rejected, margin } = selection
+  const gates = blockingGates(selection)
+  const shown = all ? ranked : ranked.slice(0, limit)
+
+  return (
+    <div className="rail-card print-avoid-break rounded-lg border border-[#e3e1da] bg-white p-4">
+      <h2 className="mb-2 text-[13.5px] font-bold text-[#0f1b2a]">{title}</h2>
+
+      {best ? (
+        <>
+          <div className="mb-2 rounded border border-[#cddcf0] bg-[#eaf1f9] px-3 py-2">
+            <div className="font-mono text-[15px] font-bold text-[#0f4c92]">{name(best.layout)}</div>
+            <div className="mt-0.5 text-[11.5px] text-[#3d4a5c]">{best.reason}</div>
+          </div>
+          <p className="mb-2 text-[11px] text-[#5c6675]">{margin}</p>
+        </>
+      ) : (
+        <div className="mb-2 rounded border border-[#efd4cc] bg-[#fbeeea] px-3 py-2">
+          <div className="text-[12.5px] font-bold text-[#8f2f1e]">No compliant layout</div>
+          {/* The gates ARE the diagnosis — more than one usually fires, and
+              the combination is what says "the section, not the bars". */}
+          <ul className="mt-1 space-y-0.5">
+            {gates.map((g) => (
+              <li key={g.check.id} className="text-[11.5px] text-[#8f2f1e]">
+                <span className="font-mono">{g.n}×</span> {g.check.label}
+                <span className="text-[#c2402a]"> · {g.check.clause}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {ranked.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[320px] text-[12px]">
+            <thead>
+              <tr className="border-b border-[#eeece5] text-left text-[10.5px] text-[#a39d8d]">
+                <th className="pb-1 pr-2 font-semibold">Layout</th>
+                {DIMS.map(([label, k]) => (
+                  <th key={k} className="pb-1 pr-2 text-right font-semibold">
+                    {label}
+                    <span className="ml-0.5 font-mono font-normal">·{PRIORITY_WEIGHTS[k].toFixed(2)}</span>
+                  </th>
+                ))}
+                <th className="pb-1 text-right font-semibold">Score</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[#f3f1ea]">
+              {shown.map((s) => (
+                <ScoreRow key={`${s.layout.db}-${s.layout.bars}-${s.layout.spacing}`}
+                  s={s} adopted={s === best} name={name} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {ranked.length > 0 && (
+        <p className="mt-1.5 text-[10px] text-[#a39d8d]">
+          Each column is scored 0–100 <em>relative to the candidates generated here</em>, then
+          weighted by the figure beside its heading. Compliance is a gate, never a score.
+        </p>
+      )}
+
+      <div className="no-print mt-2 flex flex-wrap gap-3 text-[11px]">
+        {ranked.length > limit && (
+          <button type="button" onClick={() => setAll((v) => !v)}
+            className="!bg-transparent !p-0 !text-[11px] font-semibold text-[#0f4c92] underline">
+            {all ? 'Show fewer' : `Show all ${ranked.length} compliant`}
+          </button>
+        )}
+        {rejected.length > 0 && (
+          <button type="button" onClick={() => setShowRejected((v) => !v)}
+            className="!bg-transparent !p-0 !text-[11px] font-semibold text-[#5c6675] underline">
+            {showRejected ? 'Hide' : `${rejected.length} rejected`}
+          </button>
+        )}
+      </div>
+
+      {showRejected && (
+        <ul className="mt-2 space-y-1 border-t border-[#f3f1ea] pt-2">
+          {rejected.map((r) => (
+            <li key={`${r.layout.db}-${r.layout.bars}-${r.layout.spacing}`}
+              className="flex flex-wrap items-baseline gap-x-2 text-[11px]">
+              <span className="font-mono font-semibold text-[#5c6675]">{name(r.layout)}</span>
+              <span className="text-[#8f2f1e]">{r.failedGate?.label}</span>
+              <span className="text-[#a39d8d]">{r.failedGate?.clause}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/webapp/src/components/qty.tsx
+++ b/webapp/src/components/qty.tsx
@@ -3,16 +3,21 @@ import type { ConcreteClass } from '../engine/quantities'
 import { ReportControls } from './ReportControls'
 
 /** Numeric input. */
-export function Num({ label, unit, value, onChange, step = 'any', hint }: {
-  label: ReactNode; unit?: string; value: number; onChange: (v: number) => void; step?: string; hint?: string
+export function Num({ label, unit, value, onChange, step = 'any', hint, disabled }: {
+  label: ReactNode; unit?: string; value: number; onChange: (v: number) => void
+  step?: string; hint?: string
+  /** Read-only: something upstream owns this value (e.g. an optimiser). */
+  disabled?: boolean
 }) {
   return (
-    <label className="flex flex-col text-sm">
+    <label className={`flex flex-col text-sm ${disabled ? 'opacity-70' : ''}`}>
       <span className="mb-1 text-[11.5px] font-semibold text-[#5c6675]">{label}</span>
-      <span className="flex overflow-hidden rounded-md border border-[#d6d3c9] bg-[#fcfbf8] focus-within:border-[#0f4c92] focus-within:shadow-[0_0_0_3px_rgba(15,76,146,.14)]">
+      <span className={`flex overflow-hidden rounded-md border border-[#d6d3c9] ${
+        disabled ? 'bg-[#f2f0ea]' : 'bg-[#fcfbf8]'
+      } focus-within:border-[#0f4c92] focus-within:shadow-[0_0_0_3px_rgba(15,76,146,.14)]`}>
         <input type="number" inputMode="decimal" step={step} value={Number.isFinite(value) ? value : ''}
-          onChange={(e) => onChange(parseFloat(e.target.value))}
-          className="min-w-0 flex-1 !rounded-none !border-0 !bg-transparent text-[13px] !shadow-none" />
+          disabled={disabled} onChange={(e) => onChange(parseFloat(e.target.value))}
+          className="min-w-0 flex-1 !rounded-none !border-0 !bg-transparent text-[13px] !shadow-none disabled:cursor-not-allowed" />
         {unit && <span className="flex items-center border-l border-[#eeece5] bg-[#f7f6f1] px-2.5 font-mono text-[10.5px] text-[#a39d8d]">{unit}</span>}
       </span>
       {hint ? <span className="mt-0.5 text-[10px] text-[#a39d8d]">{hint}</span> : null}

--- a/webapp/src/engine/matRebarOptimize.test.ts
+++ b/webapp/src/engine/matRebarOptimize.test.ts
@@ -7,7 +7,7 @@ import {
 } from './matRebarOptimize'
 import { designSquareFooting, type SquareFootingInput } from './isolatedFooting'
 import { designSlabDDM, type SlabInput } from './slabDDM'
-import { firstFailure } from './rebarScore'
+import { firstFailure, MAX_TIE_STEEL } from './rebarScore'
 
 // ── Fixtures ──────────────────────────────────────────────────────────────
 
@@ -191,14 +191,36 @@ describe('what it is not', () => {
     expect(c.spacing).toBeGreaterThan(tightest)
   })
 
-  it('does not simply take the smallest bar, despite serviceability leading', () => {
-    // Serviceability rewards small diameters, so the smallest FEASIBLE bar is
-    // the choice the priority order is most likely to over-reach for. It does
-    // not: on this strip ⌀10 complies at several spacings and still loses.
-    const c = optimizeMatRebar([strip()], section())
-    const feasible = new Set(c.selection.ranked.map((s) => s.layout.db))
-    expect(feasible.has(10)).toBe(true)
-    expect(c.db).toBeGreaterThan(10)
+  it('does not simply take the smallest bar — the footing skips ⌀10 and ⌀12', () => {
+    const c = optimizeFootingRebar(footing())
+    expect(c.designs.has(10)).toBe(true)     // it was searched
+    expect(c.db).toBeGreaterThan(12)         // and lost anyway
+  })
+
+  it('never buys its way to a tighter mat through the near-tie rule', () => {
+    // The failure this guards against, measured: on a lightly loaded strip
+    // the spacing modules run 75–300 mm, so the areas at one diameter span
+    // 1.3× to 4.4× the requirement while the totals compress into one 0.03
+    // band. Promoting on serviceability alone reached the tight end every
+    // time — 2.6× the steel for a 0.014 difference in score.
+    const light = strip({ b: 3000, d: 114, AsReq: 1032 })
+    const c = optimizeMatRebar([light], section({ h: 140 }))
+    const best = c.selection.best!
+    const leader = c.selection.ranked.reduce((a, s) => (s.total > a.total ? s : a))
+    expect(best.layout.AsProv)
+      .toBeLessThanOrEqual(leader.layout.AsProv * (1 + MAX_TIE_STEEL) + 1e-9)
+    // and the concrete outcome: nothing near 2.6× survives
+    expect(best.layout.AsProv / best.layout.AsReq).toBeLessThan(2)
+  })
+
+  it('detailing a whole panel gives the light strips a looser mat than the heavy ones', () => {
+    const c = optimizeSlabRebar(panel())
+    const byLoad = [...c.strips].sort((a, b) => a.AsReq / a.b - b.AsReq / b.b)
+    const lightest = byLoad[0], heaviest = byLoad[byLoad.length - 1]
+    expect(heaviest.AsReq / heaviest.b).toBeGreaterThan(lightest.AsReq / lightest.b)
+    // One diameter, different spacings — which is what "⌀12 @ 100 T, @ 175 B"
+    // on a drawing means, and what quoting one mat everywhere would lose.
+    expect(lightest.spacing).toBeGreaterThan(heaviest.spacing)
   })
 })
 
@@ -313,5 +335,28 @@ describe('two-way slab panels', () => {
     expect(heavy.db).not.toBeNull()
     const per = (c: typeof light) => c.selection.best!.layout.AsProv / c.selection.best!.layout.spacing
     expect(per(heavy)).toBeGreaterThan(per(light))
+  })
+})
+
+// ── The prose matches the drawing ─────────────────────────────────────────
+
+describe('how a mat is named', () => {
+  it('quotes a spacing, not a bar count, in the reason and the margin', () => {
+    const c = optimizeMatRebar([strip()], section())
+    const spaced = /⌀\d+ @ \d+/
+    expect(c.selection.best!.reason).toMatch(spaced)
+    expect(c.selection.margin).toMatch(spaced)
+    // "30⌀12" is what a beam schedule says; a slab drawing does not.
+    expect(c.selection.best!.reason).not.toMatch(/^\d+⌀/)
+  })
+
+  it('never calls a mat symmetric — there is no centreline to be symmetric about', () => {
+    const c = optimizeMatRebar([strip()], section())
+    for (const s of c.selection.ranked) expect(s.reason).not.toMatch(/symmetric/)
+  })
+
+  it('a rejected mat names itself the same way', () => {
+    const c = optimizeMatRebar([strip()], section())
+    for (const r of c.selection.rejected) expect(r.reason).toMatch(/⌀\d+ @ \d+/)
   })
 })

--- a/webapp/src/engine/matRebarOptimize.ts
+++ b/webapp/src/engine/matRebarOptimize.ts
@@ -243,6 +243,7 @@ export function matContext(strip: MatStrip, sec: MatSection): ScoreContext {
     // well: this is the bar count a perfectly ordinary 150 mm mat produces.
     barComfort: barsAt(strip.b, sec.cover, 150),
     wantSymmetric: false,
+    naming: 'spacing',
   }
 }
 

--- a/webapp/src/engine/rebarScore.test.ts
+++ b/webapp/src/engine/rebarScore.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   selectRebar, compareByTotal, comparePair, firstFailure,
   blockingGates, dominantBlocker,
-  PRIORITY_WEIGHTS, NEAR_TIE, COMMON_BARS,
+  PRIORITY_WEIGHTS, NEAR_TIE, MAX_TIE_STEEL, COMMON_BARS,
   type Candidate, type ComplianceCheck, type RebarLayout, type ScoreContext,
 } from './rebarScore'
 
@@ -401,5 +401,45 @@ describe('blocking gates', () => {
     ], CTX)
     expect(blockingGates(none)).toHaveLength(1)
     expect(dominantBlocker(none)?.id).toBe('too-shallow')
+  })
+})
+
+// ── The near-tie rule breaks ties; it does not buy steel ──────────────────
+
+describe('the near-tie steel guard', () => {
+  it('promotes a near-tie contender that costs no more steel', () => {
+    const r = selectRebar([
+      // Lower total, better serviceability, essentially the same area.
+      cand({ db: 16, bars: 8, AsProv: 1608, AsReq: 1500, spacing: 60, clearSpacing: 44, layers: [8] }),
+      cand({ db: 20, bars: 5, AsProv: 1571, AsReq: 1500, spacing: 110, clearSpacing: 70, layers: [5] }),
+    ], CTX)
+    expect(r.best!.layout.AsProv).toBeLessThanOrEqual(1608)
+  })
+
+  it('refuses to promote one that buys its way there', () => {
+    const lean = cand({ db: 20, bars: 5, AsProv: 1571, AsReq: 1500, spacing: 110, clearSpacing: 70, layers: [5] })
+    // Far better distributed, and 2.5× the steel. Whatever the totals say,
+    // these two are not "nearly equivalent".
+    const fat = cand({ db: 12, bars: 35, AsProv: 3958, AsReq: 1500, spacing: 30, clearSpacing: 18, layers: [35] })
+    const r = selectRebar([lean, fat], CTX)
+    if (r.best) {
+      const leader = r.ranked.reduce((a, s) => (s.total > a.total ? s : a))
+      expect(r.best.layout.AsProv)
+        .toBeLessThanOrEqual(leader.layout.AsProv * (1 + MAX_TIE_STEEL) + 1e-9)
+    }
+  })
+
+  it('the leader always survives its own guard, so a winner always exists', () => {
+    for (const As of [800, 1500, 4000]) {
+      const r = selectRebar([
+        cand({ db: 16, bars: 8, AsProv: As, AsReq: As * 0.9, spacing: 60, clearSpacing: 44, layers: [8] }),
+      ], CTX)
+      expect(r.best).not.toBeNull()
+    }
+  })
+
+  it('the guard is a fraction, and a loose one — it is not a second economy score', () => {
+    expect(MAX_TIE_STEEL).toBeGreaterThan(0)
+    expect(MAX_TIE_STEEL).toBeLessThan(0.5)
   })
 })

--- a/webapp/src/engine/rebarScore.ts
+++ b/webapp/src/engine/rebarScore.ts
@@ -73,6 +73,25 @@ export const PRIORITY_WEIGHTS = {
 export const NEAR_TIE = 0.03
 
 /**
+ * How much extra steel a near-tie promotion may buy, as a fraction.
+ *
+ * The tie-break exists to choose between layouts the weighted total cannot
+ * separate. It must not be a way to BUY the better-distributed one: two mats
+ * differing by 2.6× in steel are not "nearly equivalent" in any sense an
+ * engineer would accept, however close their totals land.
+ *
+ * That case is real and is what this guard was written for. On a slab strip
+ * the spacing modules span 75–300 mm, so the candidates at one diameter run
+ * from 1.3× to 4.4× the required area; the totals compress into a band of
+ * 0.03 while the steel varies fourfold, and promoting on serviceability alone
+ * reached the tight end every time. On a beam or a column the candidates are
+ * much closer in area and this rarely binds.
+ *
+ * The leader always satisfies it, so the contender set is never empty.
+ */
+export const MAX_TIE_STEEL = 0.15
+
+/**
  * Bar sizes a Philippine yard stocks and a bender handles without comment.
  * Simplicity only — never a compliance matter, and never a reason to reject.
  */
@@ -133,6 +152,14 @@ export interface ScoreContext {
   /** Whether an even (symmetric) bar count is preferred. Beams and columns
    *  yes; a slab mat has no centreline to be symmetric about. */
   wantSymmetric?: boolean
+  /**
+   * How a layout is named in the prose this module writes.
+   *
+   * A cage is counted — "4⌀20". A mat is spaced — "⌀12 @ 100". Calling a mat
+   * "30⌀12" is not wrong so much as not what the drawing says, and a reason
+   * that does not match the headline reads as two different answers.
+   */
+  naming?: 'count' | 'spacing'
 }
 
 export interface LayoutScores {
@@ -312,15 +339,26 @@ export interface Candidate {
   compliance: ComplianceCheck[]
 }
 
-function describe(l: RebarLayout, s: LayoutScores): string {
-  const arrangement = l.layers.length > 1
-    ? `${l.bars}⌀${l.db} in ${l.layers.length} layers (${l.layers.join('+')})`
-    : `${l.bars}⌀${l.db} in one layer`
+/** What this layout is called — see `ScoreContext.naming`. */
+function nameOf(l: RebarLayout, ctx: ScoreContext): string {
+  return ctx.naming === 'spacing' ? `⌀${l.db} @ ${l.spacing.toFixed(0)}` : `${l.bars}⌀${l.db}`
+}
+
+function describe(l: RebarLayout, s: LayoutScores, ctx: ScoreContext): string {
+  const name = nameOf(l, ctx)
+  const arrangement = ctx.naming === 'spacing'
+    ? `${name} — ${l.bars} bars across the strip`
+    : l.layers.length > 1
+      ? `${name} in ${l.layers.length} layers (${l.layers.join('+')})`
+      : `${name} in one layer`
   const strengths: string[] = []
   if (s.serviceability >= 0.7) strengths.push('well distributed for crack control')
   if (s.constructability >= 0.8) strengths.push('easy to place')
   if (s.economy >= 0.8) strengths.push('economical')
-  if (s.simplicity >= 0.9) strengths.push('symmetric and standard')
+  // Symmetry is only a virtue where there is something to be symmetric about.
+  if (s.simplicity >= 0.9) {
+    strengths.push(ctx.wantSymmetric === false ? 'a standard bar size' : 'symmetric and standard')
+  }
   return strengths.length
     ? `${arrangement} — ${strengths.join(', ')}.`
     : `${arrangement}.`
@@ -367,8 +405,8 @@ export function selectRebar(candidates: readonly Candidate[], ctx: ScoreContext)
       scores,
       total,
       reason: gate
-        ? `${c.layout.bars}⌀${c.layout.db} — rejected: ${gate.label} (${gate.clause}).`
-        : describe(c.layout, scores),
+        ? `${nameOf(c.layout, ctx)} — rejected: ${gate.label} (${gate.clause}).`
+        : describe(c.layout, scores, ctx),
     }
   })
 
@@ -382,7 +420,10 @@ export function selectRebar(candidates: readonly Candidate[], ctx: ScoreContext)
   // between them is made on serviceability + constructability alone.
   const leader = byTotal[0]
   const contenders = leader
-    ? byTotal.filter((s) => leader.total - s.total <= NEAR_TIE)
+    ? byTotal.filter((s) =>
+        leader.total - s.total <= NEAR_TIE
+        // ...and does not buy its way there, see MAX_TIE_STEEL.
+        && s.layout.AsProv <= leader.layout.AsProv * (1 + MAX_TIE_STEEL) + 1e-9)
     : []
   const best = contenders.length > 0 ? [...contenders].sort(comparePair)[0] : null
 
@@ -401,7 +442,7 @@ export function selectRebar(candidates: readonly Candidate[], ctx: ScoreContext)
       (gates.length ? `: ${gates.join(', ')}` : '')
     : ranked.length === 1
       ? 'the only compliant layout in the set'
-      : marginText(best, ranked[1], contenders.length > 1)
+      : marginText(best, ranked[1], contenders.length > 1, ctx)
 
   return { best, ranked, rejected, margin }
 }
@@ -429,8 +470,10 @@ function breakTies(a: ScoredLayout, b: ScoredLayout): number {
   return a.layout.bars - b.layout.bars
 }
 
-function marginText(best: ScoredLayout, next: ScoredLayout, nearTie: boolean): string {
-  const label = (s: ScoredLayout) => `${s.layout.bars}⌀${s.layout.db}`
+function marginText(
+  best: ScoredLayout, next: ScoredLayout, nearTie: boolean, ctx: ScoreContext,
+): string {
+  const label = (s: ScoredLayout) => nameOf(s.layout, ctx)
   if (!nearTie) {
     const driver = biggestGain(best, next)
     return `${label(best)} scores ${best.total.toFixed(3)} against ${label(next)} at ` +

--- a/webapp/src/lib/rebarLabel.ts
+++ b/webapp/src/lib/rebarLabel.ts
@@ -1,0 +1,11 @@
+import type { RebarLayout } from '../engine/rebarScore'
+
+// How a layout is written on a drawing. A cage is counted; a mat is spaced —
+// "4⌀20" and "⌀16 @ 125" are the same kind of fact stated the way each trade
+// reads it. Kept out of the component so fast refresh stays happy.
+
+/** "4⌀20" — beams and columns count bars. */
+export const nameCage = (l: RebarLayout): string => `${l.bars}⌀${l.db}`
+
+/** "⌀16 @ 125" — mats are specified by spacing. */
+export const nameMat = (l: RebarLayout): string => `⌀${l.db} @ ${l.spacing.toFixed(0)}`

--- a/webapp/src/lib/rebarSolution.ts
+++ b/webapp/src/lib/rebarSolution.ts
@@ -1,0 +1,168 @@
+// ─────────────────────────────────────────────────────────────────────────
+// WHY THIS BAR — the reinforcement selection, written out.
+//
+// The rest of a worked solution derives the steel a section NEEDS. This is
+// the step that says which of the layouts satisfying that requirement was
+// adopted, and it belongs on the sheet for the same reason every other step
+// does: a checker has to be able to disagree with it.
+//
+// A results table saying "4⌀20" is not checkable. "4⌀20 out of 6 layouts
+// generated, 1 rejected on §25.2.1, adopted at 0.898 against 0.778 for the
+// runner-up, decided on serviceability" is.
+//
+// Applies equally to a beam cage, a column cage and a slab mat — the layouts
+// name themselves per `ScoreContext.naming`, which the optimiser sets.
+// ─────────────────────────────────────────────────────────────────────────
+
+import {
+  PRIORITY_WEIGHTS, blockingGates,
+  type RebarLayout, type RebarSelection, type ScoredLayout,
+} from '../engine/rebarScore'
+import { nameCage, nameMat } from './rebarLabel'
+import { sn0, sn2, sn3, type SolutionStep } from './solution'
+
+export type LayoutKind = 'cage' | 'mat'
+
+const nameOf = (kind: LayoutKind) => (kind === 'mat' ? nameMat : nameCage)
+
+/** KaTeX-safe: `⌀20 @ 125` carries characters that break in math mode. */
+const tt = (s: string) => `\\mathrm{${s.replace(/⌀/g, 'D').replace(/@/g, '\\ @\\ ')}}`
+
+function scoreLine(s: ScoredLayout, name: (l: RebarLayout) => string): string {
+  const w = PRIORITY_WEIGHTS
+  return `S(${tt(name(s.layout))}) = ` +
+    `${sn2(w.serviceability)}(${sn2(s.scores.serviceability)}) + ` +
+    `${sn2(w.constructability)}(${sn2(s.scores.constructability)}) + ` +
+    `${sn2(w.economy)}(${sn2(s.scores.economy)}) + ` +
+    `${sn2(w.simplicity)}(${sn2(s.scores.simplicity)}) = ${sn3(s.total)}`
+}
+
+/**
+ * The selection, as worked-solution steps.
+ *
+ * Returns an empty list when there is nothing to justify (no candidates at
+ * all), so a caller can concatenate unconditionally.
+ */
+export function buildRebarSelectionSolution(
+  sel: RebarSelection, kind: LayoutKind = 'cage',
+): SolutionStep[] {
+  const name = nameOf(kind)
+  const total = sel.ranked.length + sel.rejected.length
+  if (total === 0) return []
+
+  const thing = kind === 'mat' ? 'mat' : 'cage'
+  const steps: SolutionStep[] = []
+
+  // ── 1. What was searched ────────────────────────────────────────────────
+  steps.push({
+    title: 'Layouts considered',
+    clause: 'ACI 318-14 §25.2 · §9.7.2',
+    lines: [
+      {
+        text: kind === 'mat'
+          ? 'Every bar diameter is paired with every spacing off the standard module, ' +
+            'because a mat is specified by spacing and the bar count follows from it. ' +
+            'The required steel comes from the flexure check above; nothing is re-derived here.'
+          : 'Every bar diameter is laid out against the steel the flexure check above ' +
+            'requires, so the choice is made between complete arrangements rather than ' +
+            'between areas. No strength is re-derived here.',
+      },
+      { tex: `n_{\\mathrm{generated}} = ${sn0(sel.ranked.length)} + ${sn0(sel.rejected.length)} = ${sn0(total)}` },
+    ],
+  })
+
+  // ── 2. The gate ─────────────────────────────────────────────────────────
+  const gates = blockingGates(sel)
+  if (sel.best) {
+    const checks = sel.best.compliance
+    steps.push({
+      title: 'Code compliance — a gate, not a score',
+      clause: sel.best.compliance[0]?.clause ?? 'ACI 318-14 §25.2',
+      pass: true,
+      lines: [
+        {
+          text: `A layout failing any one check is infeasible and is never ranked, however ` +
+            `well it scores on everything else. The adopted ${thing} passes all ` +
+            `${checks.length} of them; ${sel.rejected.length} of the ${total} layouts ` +
+            `generated did not and were discarded.`,
+        },
+        ...checks.map((c) => ({
+          text: `Satisfied — ${c.label} per ${c.clause}${c.detail ? `, ${c.detail}` : ''}.`,
+        })),
+      ],
+    })
+  } else {
+    steps.push({
+      title: 'Code compliance — no layout satisfies every check',
+      clause: gates[0]?.check.clause ?? 'ACI 318-14 §25.2',
+      pass: false,
+      lines: [
+        {
+          text: `None of the ${total} layouts generated is compliant, so there is nothing ` +
+            `to rank. More than one gate usually fires and the combination is the ` +
+            `diagnosis: what has to change is almost always the section, not the bar.`,
+        },
+        ...gates.map((g) => ({ text: `${sn0(g.n)} rejected on ${g.check.label} — ${g.check.clause}` })),
+      ],
+    })
+    return steps
+  }
+
+  // ── 3. The weighted score ───────────────────────────────────────────────
+  const w = PRIORITY_WEIGHTS
+  steps.push({
+    title: 'Weighted score of the compliant layouts',
+    clause: 'ACI 318-14 §24.3.2 · §25.2 (serviceability & detailing basis)',
+    lines: [
+      {
+        text: 'Each dimension is scored 0 to 1 relative to the layouts generated here, ' +
+          'then weighted in the stated priority order: serviceability first, then ' +
+          'constructability, then economy, then simplicity.',
+      },
+      {
+        tex: `S = ${sn2(w.serviceability)}\\,S_{serv} + ${sn2(w.constructability)}\\,S_{con} + ` +
+          `${sn2(w.economy)}\\,S_{eco} + ${sn2(w.simplicity)}\\,S_{simp}`,
+      },
+      ...sel.ranked.slice(0, 4).map((s) => ({ tex: scoreLine(s, name) })),
+    ],
+  })
+
+  // ── 4. What was adopted, and why ────────────────────────────────────────
+  steps.push({
+    title: `Adopted — ${name(sel.best.layout)}`,
+    clause: 'ACI 318-14 §25.2 · good detailing practice',
+    pass: true,
+    lines: [
+      { text: `${sel.best.reason} ${sel.margin.charAt(0).toUpperCase()}${sel.margin.slice(1)}.` },
+      {
+        text: 'Where two layouts score within 0.03 of each other they are treated as ' +
+          'equivalent and the better distributed one is preferred — but only if it does ' +
+          'not buy that distribution with materially more steel.',
+      },
+      {
+        tex: `A_{s,prov} = ${sn0(sel.best.layout.AsProv)}\\ \\text{mm}^2 \\ge ` +
+          `A_{s,req} = ${sn0(sel.best.layout.AsReq)}\\ \\text{mm}^2`,
+      },
+      {
+        // Provided-over-required is the number a checker reaches for first:
+        // it says in one figure whether this layout is tight or generous.
+        tex: `\\dfrac{A_{s,prov}}{A_{s,req}} = \\dfrac{${sn0(sel.best.layout.AsProv)}}` +
+          `{${sn0(sel.best.layout.AsReq)}} = ` +
+          `${sn2(sel.best.layout.AsProv / Math.max(sel.best.layout.AsReq, 1e-9))}`,
+      },
+      {
+        tex: `s = ${sn0(sel.best.layout.spacing)}\\ \\text{mm} \\Rightarrow ` +
+          `s_{clear} = s - d_b = ${sn0(sel.best.layout.spacing)} - ${sn0(sel.best.layout.db)} = ` +
+          `${sn0(sel.best.layout.clearSpacing)}\\ \\text{mm}`,
+      },
+      {
+        tex: `d_{achieved} = ${sn0(sel.best.layout.d)}\\ \\text{mm}` +
+          `\\quad (${sn0(sel.best.layout.layers.length)}\\ \\text{layer}` +
+          `${sel.best.layout.layers.length === 1 ? '' : 's'}` +
+          `${sel.best.layout.layers.length > 1 ? `: ${sel.best.layout.layers.join('+')}` : ''})`,
+      },
+    ],
+  })
+
+  return steps
+}

--- a/webapp/src/lib/workedSolutions.test.ts
+++ b/webapp/src/lib/workedSolutions.test.ts
@@ -36,6 +36,9 @@ import { generalBearingCapacity } from '../engine/bearingGeneral'
 import {
   buildEarthPressureSolution, buildBearingSolution, buildInfiniteSlopeSolution,
 } from './geotechPageSolutions'
+import { buildRebarSelectionSolution } from './rebarSolution'
+import { optimizeBeamRebar } from '../engine/beamRebarOptimize'
+import { optimizeFootingRebar } from '../engine/matRebarOptimize'
 
 // ─────────────────────────────────────────────────────────────────────────
 // What a worked solution has to be, applied to every builder at once.
@@ -185,6 +188,16 @@ const BUILDERS: [string, () => SolutionStep[]][] = [
     const si = { c: 5, phiDeg: 30, gamma: 18, z: 3, betaDeg: 20, seepage: true, gammaSat: 20 }
     return buildInfiniteSlopeSolution(si, infiniteSlopeFS({ ...si, phiDeg: si.phiDeg }))
   }],
+  ['rebar selection (cage)', () => buildRebarSelectionSolution(
+    optimizeBeamRebar({
+      b: 300, h: 500, cover: 40, stirrupDia: 10, fc: 28, fy: 415, Mu: 180, Vu: 150,
+      barDia: 20,   // ignored — the optimiser searches every diameter
+    }).selection, 'cage')],
+  ['rebar selection (mat)', () => buildRebarSelectionSolution(
+    optimizeFootingRebar({
+      serviceLoad: 1200, ultimateLoad: 1700, columnWidth: 400, fc: 21, fy: 415,
+      qAllow: 200, gammaSoil: 18, gammaConc: 24, H: 1.5, barDia: 20, cover: 75,
+    }).selection, 'mat')],
 ]
 
 const eqs = (steps: SolutionStep[]) =>

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -10,6 +10,7 @@ import { WorkedSolution } from '../components/WorkedSolution'
 import { buildBeamSolution, beamProvidedCapacities } from '../lib/beamSolution'
 import { optimizeBeamRebar, optimizeBeamMember } from '../engine/beamRebarOptimize'
 import { RebarRanking } from '../components/RebarRanking'
+import { buildRebarSelectionSolution } from '../lib/rebarSolution'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { Math as KTex } from '../lib/math'
 import { f0, f1 } from '../lib/format'
@@ -144,10 +145,17 @@ export default function BeamDesign() {
   const demand = multi
     ? { Mu: Math.abs(active?.Mu ?? 0), Vu: Math.abs(active?.Vu ?? 0) }
     : { Mu: Math.abs(f.Mu), Vu: f.Vu }
+  // The selection is appended, not prepended: it justifies the bar chosen for
+  // the steel the flexure steps above derived, so it reads after them.
   const solution = useMemo(
-    () => (r ? buildBeamSolution({ ...fd, ...demand }, r) : null),
+    () => (r
+      ? [
+          ...buildBeamSolution({ ...fd, ...demand }, r),
+          ...(selection ? buildRebarSelectionSolution(selection, 'cage') : []),
+        ]
+      : null),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [r, fd, demand.Mu, demand.Vu],
+    [r, fd, demand.Mu, demand.Vu, selection],
   )
 
   const deflection = useMemo(() => {

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -8,6 +8,8 @@ import type { CriticalSection } from '../engine/beamSections'
 import { BeamSchematic } from '../components/BeamSchematic'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { buildBeamSolution, beamProvidedCapacities } from '../lib/beamSolution'
+import { optimizeBeamRebar, optimizeBeamMember } from '../engine/beamRebarOptimize'
+import { RebarRanking } from '../components/RebarRanking'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { Math as KTex } from '../lib/math'
 import { f0, f1 } from '../lib/format'
@@ -74,6 +76,10 @@ export default function BeamDesign() {
   const [svcWD, setSvcWD] = useState<number>(NaN)
   const [svcWL, setSvcWL] = useState<number>(NaN)
   const [multi, setMulti] = useState<boolean>(handoff.multi)
+  // The optimiser chooses the diameter; everything else on the page is still
+  // the user's. Off puts the ⌀ field back in charge, which is what checking an
+  // existing drawing needs.
+  const [autoBar, setAutoBar] = useState(true)
   const [sections, setSections] = useState<SecRow[]>(handoff.multi ? handoff.sections : DEF_SECTIONS)
   const [selId, setSelId] = useState<number | null>(handoff.multi ? handoff.sections[0].id : null)
   const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) => setF((s) => ({ ...s, [k]: v }))
@@ -86,14 +92,45 @@ export default function BeamDesign() {
       && f.h - f.cover - f.stirrupDia - f.barDia / 2 > 0
   }, [f])
 
+  // ── Bar selection ────────────────────────────────────────────────────
+  // In multi-section mode the whole member gets ONE diameter, scored across
+  // every critical section — three sections of one beam detailed with three
+  // different bars is not a beam anybody builds.
+  const memberChoice = useMemo(() => {
+    if (!autoBar || !sectionGeomOK || !multi) return null
+    const valid = sections.filter((s) => Number.isFinite(s.Mu) && Number.isFinite(s.Vu))
+    if (valid.length === 0) return null
+    return optimizeBeamMember(f, valid.map((s) => ({
+      id: String(s.id), label: s.label, Mu: Math.abs(s.Mu), Vu: Math.abs(s.Vu),
+    })))
+  }, [autoBar, sectionGeomOK, multi, f, sections])
+
+  const singleChoice = useMemo(() => {
+    if (!autoBar || !sectionGeomOK || multi) return null
+    if (!Number.isFinite(f.Mu) || !Number.isFinite(f.Vu)) return null
+    return optimizeBeamRebar({ ...f, Mu: Math.abs(f.Mu) })
+  }, [autoBar, sectionGeomOK, multi, f])
+
+  const adoptedDb = multi
+    ? memberChoice?.db ?? null
+    : singleChoice?.selection.best?.layout.db ?? null
+
+  /** The form as designed with — identical to `f` unless the optimiser chose. */
+  const fd: FormState = useMemo(
+    () => (adoptedDb === null ? f : { ...f, barDia: adoptedDb, comprBarDia: adoptedDb }),
+    [f, adoptedDb],
+  )
+
+  const selection = multi ? memberChoice?.selection ?? null : singleChoice?.selection ?? null
+
   // Per-section designs (multi) — hogging sections design with |Mu|.
   const designs = useMemo(() => {
     if (!sectionGeomOK || !multi) return []
     return sections.map((s) => {
       if (!Number.isFinite(s.Mu) || !Number.isFinite(s.Vu)) return null
-      return designBeam({ ...f, Mu: Math.abs(s.Mu), Vu: Math.abs(s.Vu) })
+      return designBeam({ ...fd, Mu: Math.abs(s.Mu), Vu: Math.abs(s.Vu) })
     })
-  }, [f, sections, multi, sectionGeomOK])
+  }, [fd, sections, multi, sectionGeomOK])
 
   // The active demand: selected section (multi) or the single Mu/Vu fields.
   const selIdx = multi ? Math.max(0, sections.findIndex((s) => s.id === selId)) : -1
@@ -103,14 +140,14 @@ export default function BeamDesign() {
   const singleValid = sectionGeomOK && Number.isFinite(f.Mu) && Number.isFinite(f.Vu)
   const r = multi
     ? designs[selIdx] ?? null
-    : singleValid ? designBeam({ ...f, Mu: Math.abs(f.Mu) }) : null
+    : singleValid ? designBeam({ ...fd, Mu: Math.abs(fd.Mu) }) : null
   const demand = multi
     ? { Mu: Math.abs(active?.Mu ?? 0), Vu: Math.abs(active?.Vu ?? 0) }
     : { Mu: Math.abs(f.Mu), Vu: f.Vu }
   const solution = useMemo(
-    () => (r ? buildBeamSolution({ ...f, ...demand }, r) : null),
+    () => (r ? buildBeamSolution({ ...fd, ...demand }, r) : null),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [r, f, demand.Mu, demand.Vu],
+    [r, fd, demand.Mu, demand.Vu],
   )
 
   const deflection = useMemo(() => {
@@ -132,7 +169,7 @@ export default function BeamDesign() {
   // required-over-provided clear spacing, shear Vu/φVc while no stirrups are
   // demanded — all existing outputs, no new calculation.
   const allOK = !!r && sectionOK(r) && (!deflection || (deflection.liveOK && deflection.totalOK))
-  const cap = r ? beamProvidedCapacities(f, r) : null
+  const cap = r ? beamProvidedCapacities(fd, r) : null
   const checks = r && cap ? [
     { name: 'Flexure Mu/φMn', ratio: demand.Mu / cap.phiMn },
     { name: 'Shear Vu/φVn', ratio: demand.Vu / cap.phiVn },
@@ -150,7 +187,7 @@ export default function BeamDesign() {
     governing: `Governing: flexure · utilization ${cap ? (demand.Mu / cap.phiMn).toFixed(2) : '—'}${r.mode === 'DRRB' ? ' · DRRB' : ''}`,
     lh,
     stats: [
-      { label: hogging ? 'Tension (top)' : 'Tension steel', value: `${r.bars}-⌀${f.barDia}` },
+      { label: hogging ? 'Tension (top)' : 'Tension steel', value: `${r.bars}-⌀${fd.barDia}` },
       { label: 'Stirrups', value: r.sAdopt > 0 ? `⌀${f.stirrupDia} @${f0(r.sAdopt)}` : REGION[r.region] },
       { label: 'Eff. depth d', value: f0(r.d), unit: 'mm' },
     ],
@@ -158,7 +195,7 @@ export default function BeamDesign() {
     data: [
       ['Section b × h', `${f.b} × ${f.h} mm`], ['Clear cover', `${f.cover} mm`],
       ["Concrete f'c", `${f.fc} MPa`], ['Steel fy / fyt', `${f.fy} / ${f.fyt} MPa`],
-      ['Bar ⌀ / stirrup ⌀', `${f.barDia} / ${f.stirrupDia} mm (${f.legs}-leg)`],
+      ['Bar ⌀ / stirrup ⌀', `${fd.barDia} / ${fd.stirrupDia} mm (${fd.legs}-leg)`],
       ['Moment Mu', `${f1(demand.Mu)} kN·m${hogging ? ' (hogging)' : ''}`],
       ['Shear Vu', `${f1(demand.Vu)} kN`], ['ρ / ρmin / ρmax', `${r.rho.toFixed(4)} / ${r.rhoMin.toFixed(4)} / ${r.rhoMax.toFixed(4)}`],
     ] as [string, string][],
@@ -183,12 +220,23 @@ export default function BeamDesign() {
 
       <div className="no-print mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
         <div className="space-y-3.5">
-          <Card title="Section">
+          <Card title="Section"
+            hint={
+              <label className="no-print flex cursor-pointer items-center gap-1.5 text-[11px] font-semibold text-[#5c6675]">
+                <input type="checkbox" checked={autoBar} onChange={(e) => setAutoBar(e.target.checked)}
+                  className="h-3.5 w-3.5 accent-[#0f4c92]" />
+                Auto-select bar ⌀
+              </label>
+            }>
             <Num label="Width b" unit="mm" value={f.b} onChange={set('b')} />
             <Num label="Total depth h" unit="mm" value={f.h} onChange={set('h')} />
             <Num label="Clear cover" unit="mm" value={f.cover} onChange={set('cover')} />
-            <Num label={<>Bar <KTex tex="d_b" /></>} unit="mm" value={f.barDia} onChange={set('barDia')} />
-            <Num label={<>Compr. bar <KTex tex="d_b'" /></>} unit="mm" value={f.comprBarDia} onChange={set('comprBarDia')} />
+            <Num label={<>Bar <KTex tex="d_b" /></>} unit="mm" value={fd.barDia} onChange={set('barDia')}
+              disabled={autoBar}
+              hint={autoBar ? (adoptedDb ? 'chosen by the optimiser' : 'no compliant ⌀ — see the ranking') : undefined} />
+            <Num label={<>Compr. bar <KTex tex="d_b'" /></>} unit="mm" value={fd.comprBarDia} onChange={set('comprBarDia')}
+              disabled={autoBar}
+              hint={autoBar ? 'follows the tension bar' : undefined} />
             <Num label={<>Stirrup <KTex tex="d_s" /></>} unit="mm" value={f.stirrupDia} onChange={set('stirrupDia')} />
             <Num label="Stirrup legs" value={f.legs} onChange={set('legs')} />
           </Card>
@@ -259,13 +307,17 @@ export default function BeamDesign() {
                 : 'CHECK FAILED — revise the section'}
               governing={`Governing: flexure · utilization ${cap ? (demand.Mu / cap.phiMn).toFixed(2) : '—'}${r.mode === 'DRRB' ? ' · DRRB (compression steel engaged)' : ''}`}
               stats={[
-                { label: hogging ? 'Tension (top)' : 'Tension steel', value: `${r.bars}-⌀${f.barDia}`, unit: hogging ? 'top' : 'bottom' },
+                { label: hogging ? 'Tension (top)' : 'Tension steel', value: `${r.bars}-⌀${fd.barDia}`, unit: hogging ? 'top' : 'bottom' },
                 { label: 'Stirrups', value: r.sAdopt > 0 ? `⌀${f.stirrupDia}` : '—', unit: r.sAdopt > 0 ? `${f.legs}-leg @${f0(r.sAdopt)}` : REGION[r.region] },
                 { label: 'Eff. depth d', value: f0(r.d), unit: 'mm' },
               ]}
               checks={checks}
               footnote={`ρ = ${r.rho.toFixed(4)} within ρmin ${r.rhoMin.toFixed(4)} … ρmax ${r.rhoMax.toFixed(4)} — §9.6.1.2 / §21.2.2`}
             />
+          )}
+          {selection && (
+            <RebarRanking selection={selection}
+              title={multi ? 'Bar selection — whole member' : 'Bar selection'} />
           )}
           {multi && (
             <ResultCard title="Section schedule">
@@ -290,8 +342,8 @@ export default function BeamDesign() {
                             bad ? 'bg-red-50 text-red-700' : ''} ${s.id === active?.id ? 'outline outline-1 outline-[#0056b3]' : ''}`}>
                           <td className="py-1 pr-2">{s.label}{s.Mu < 0 ? ' (hog)' : ''}</td>
                           <td className="py-1 pr-2">{d ? d.mode : '—'}</td>
-                          <td className="py-1 pr-2">{d ? `${d.bars}⌀${f.barDia}${d.layers.length > 1 ? ` (${d.layers.join('+')})` : ''}` : '—'}</td>
-                          <td className="py-1 pr-2">{d && d.comprBars > 0 ? `${d.comprBars}⌀${f.comprBarDia}` : '—'}</td>
+                          <td className="py-1 pr-2">{d ? `${d.bars}⌀${fd.barDia}${d.layers.length > 1 ? ` (${d.layers.join('+')})` : ''}` : '—'}</td>
+                          <td className="py-1 pr-2">{d && d.comprBars > 0 ? `${d.comprBars}⌀${fd.comprBarDia}` : '—'}</td>
                           <td className="py-1">{d ? (d.sAdopt > 0 ? `@${f0(d.sAdopt)}` : d.region === 'none' ? 'none' : '⚠') : '—'}</td>
                         </tr>
                       )
@@ -305,10 +357,10 @@ export default function BeamDesign() {
 
           <DrawingCard pdfDrawing title={`Section${multi && active ? ` — ${active.label}` : ''}`} meta={`${f0(f.b)} × ${f0(f.h)} · to scale`}>
             {r ? (
-              <BeamSchematic b={f.b} h={f.h} cover={f.cover} barDia={f.barDia} stirrupDia={f.stirrupDia}
+              <BeamSchematic b={fd.b} h={fd.h} cover={fd.cover} barDia={fd.barDia} stirrupDia={fd.stirrupDia}
                 bars={r.bars} d={r.d} dPrime={r.comprLayers.length > 0 ? r.dPrime : undefined}
                 layers={r.layers} comprLayers={r.comprLayers}
-                comprBars={r.comprBars} comprBarDia={f.comprBarDia}
+                comprBars={r.comprBars} comprBarDia={fd.comprBarDia}
                 naDepth={r.cNA} flexOK={r.flexOK} hogging={hogging} />
             ) : (
               <p className="py-8 text-center text-sm text-[#a39d8d]">Enter a valid section (d must be positive).</p>
@@ -394,7 +446,7 @@ export default function BeamDesign() {
       </div>
       {reportData && (
         <PrintReport {...reportData}
-          drawing={<BeamSchematic b={f.b} h={f.h} cover={f.cover} barDia={f.barDia} stirrupDia={f.stirrupDia}
+          drawing={<BeamSchematic b={fd.b} h={fd.h} cover={fd.cover} barDia={fd.barDia} stirrupDia={fd.stirrupDia}
             bars={r!.bars} d={r!.d} dPrime={r!.comprLayers.length > 0 ? r!.dPrime : undefined}
             layers={r!.layers} comprLayers={r!.comprLayers} comprBars={r!.comprBars} comprBarDia={f.comprBarDia}
             naDepth={r!.cNA} flexOK={r!.flexOK} hogging={hogging} />}

--- a/webapp/src/pages/ColumnDesign.tsx
+++ b/webapp/src/pages/ColumnDesign.tsx
@@ -14,6 +14,8 @@ import { initialLetterhead } from '../lib/letterhead'
 import { InteractionDiagram } from '../components/InteractionDiagram'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { axialColumnSolution, eccentricColumnSolution, slendernessSolution } from '../lib/columnSolution'
+import { optimizeColumnRebar } from '../engine/columnRebarOptimize'
+import { RebarRanking } from '../components/RebarRanking'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { Math as KTex } from '../lib/math'
 import { f0, f1, f2 } from '../lib/format'
@@ -38,6 +40,10 @@ export default function ColumnDesign() {
   const [Mu, setMu] = useState(200)
   const [barMode, setBarMode] = useState<BarMode>('design')
   const [numBars, setNumBars] = useState(8)
+  // Auto-selection applies to the AXIAL design only. Analyze mode and the
+  // eccentric pilot both exist to check a cage the user already has, so
+  // choosing one for them would defeat the point.
+  const [autoBar, setAutoBar] = useState(true)
   const [layout, setLayout] = useState<BarLayout>('all-around')   // P–M bar distribution
   // Seismic / lateral system
   const [system, setSystem] = useState<LateralSystem>('gravity')
@@ -53,16 +59,33 @@ export default function ColumnDesign() {
   const tied = shape === 'tied' || eccentric    // eccentric pilot is tied-rect only
   const Pu = loadInput === 'individual' ? factoredLoad({ dead, live }) : PuDirect
 
+  // ── Cage selection ───────────────────────────────────────────────────
+  // Both axes are searched: diameter AND count. Unlike a beam, a column's
+  // count is not fixed once the diameter is — 8⌀20 and 4⌀25 are both real.
+  const cageChoice = useMemo(() => {
+    if (!autoBar || eccentric || barMode !== 'design') return null
+    if (!(fc > 0 && fy > 0 && Pu > 0)) return null
+    try {
+      return optimizeColumnRebar({
+        shape: tied ? 'tied' : 'spiral', b, h, D, cover, barDia, tieDia, fc, fy, fyt, Pu,
+        system, columnLength: colLen, hx: hx > 0 ? hx : undefined,
+      })
+    } catch { return null }
+  }, [autoBar, eccentric, barMode, tied, b, h, D, cover, barDia, tieDia, fc, fy, fyt, Pu, system, colLen, hx])
+
+  /** The diameter actually detailed — the optimiser's, or the user's field. */
+  const dbEff = cageChoice?.db ?? barDia
+
   const axial = useMemo(() => {
     if (!(fc > 0 && fy > 0 && Pu > 0)) return null
     try {
       return designAxialColumn({
-        shape: tied ? 'tied' : 'spiral', b, h, D, cover, barDia, tieDia, fc, fy, fyt, Pu,
-        numBars: barMode === 'analyze' || eccentric ? numBars : undefined,
+        shape: tied ? 'tied' : 'spiral', b, h, D, cover, barDia: dbEff, tieDia, fc, fy, fyt, Pu,
+        numBars: barMode === 'analyze' || eccentric ? numBars : cageChoice?.bars ?? undefined,
         system, columnLength: colLen, hx: hx > 0 ? hx : undefined,
       })
     } catch { return null }
-  }, [tied, b, h, D, cover, barDia, tieDia, fc, fy, fyt, Pu, barMode, numBars, eccentric, system, colLen, hx])
+  }, [tied, b, h, D, cover, dbEff, tieDia, fc, fy, fyt, Pu, barMode, numBars, eccentric, system, colLen, hx, cageChoice])
 
   const slender = useMemo(() => {
     if (!eccentric || !slenderOn) return null
@@ -88,8 +111,8 @@ export default function ColumnDesign() {
     if (slender) steps.push(...slendernessSolution({ Pu, M1, M2, k: kEff, Lu, h, EI: EIin > 0 ? EIin : undefined, fc, b }, slender))
     if (eccentric && inter && cap) steps.push(...eccentricColumnSolution({ b, h, cover, barDia, tieDia, fc, fy, numBars, layout }, inter, Pu, MuEff, cap))
     if (axial) steps.push(...axialColumnSolution({
-      shape: tied ? 'tied' : 'spiral', b, h, D, cover, barDia, tieDia, fc, fy, fyt, Pu,
-      numBars: barMode === 'analyze' || eccentric ? numBars : undefined,
+      shape: tied ? 'tied' : 'spiral', b, h, D, cover, barDia: dbEff, tieDia, fc, fy, fyt, Pu,
+      numBars: barMode === 'analyze' || eccentric ? numBars : cageChoice?.bars ?? undefined,
     }, axial))
     return steps
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -128,7 +151,7 @@ export default function ColumnDesign() {
           : `Governing: P–M interaction · utilization ${util !== null ? util.toFixed(2) : '—'}`)
         : `Governing: axial · φPn,max = ${f1(axial.phiPnMax)} kN`,
       stats: [
-        { label: 'Longitudinal', value: `${axial.bars}-⌀${barDia}`, unit: `ρ ${(axial.rho * 100).toFixed(2)}%` },
+        { label: 'Longitudinal', value: `${axial.bars}-⌀${dbEff}`, unit: `ρ ${(axial.rho * 100).toFixed(2)}%` },
         { label: tied ? 'Ties' : 'Spiral',
           value: `⌀${tied ? Math.max(tieDia, axial.tieDiaMin) : tieDia}`,
           unit: `@${f0(spacing)} mm` },
@@ -137,7 +160,7 @@ export default function ColumnDesign() {
       checks,
       footnote: `ρ = ${(axial.rho * 100).toFixed(2)}% within ${(RHO_MIN * 100).toFixed(0)} … ${(RHO_MAX * 100).toFixed(0)}% — §410.6.1.1${eccentric && slender ? ` · δ = ${slender.delta.toFixed(3)}` : ''}`,
     }
-  }, [axial, eccentric, util, unstable, tied, slender, Pu, barDia, tieDia])
+  }, [axial, eccentric, util, unstable, tied, slender, Pu, dbEff, tieDia])
 
   // ~12 representative rows for the P-M table, balanced point always included.
   const tableRows = useMemo(() => {
@@ -167,7 +190,14 @@ export default function ColumnDesign() {
 
       <div className="no-print mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
         <div className="space-y-5">
-          <Card title="Column">
+          <Card title="Column"
+            hint={!eccentric && barMode === 'design' ? (
+              <label className="no-print flex cursor-pointer items-center gap-1.5 text-[11px] font-semibold text-[#5c6675]">
+                <input type="checkbox" checked={autoBar} onChange={(e) => setAutoBar(e.target.checked)}
+                  className="h-3.5 w-3.5 accent-[#0f4c92]" />
+                Auto-select cage
+              </label>
+            ) : undefined}>
             <Pick label="Loading" value={mode} onChange={(v) => setMode(v as Mode)}
               options={[['axial', 'Concentric (axial)'], ['eccentric', 'Eccentric (P + M)']]} />
             <Pick label="Shape" value={eccentric ? 'tied' : shape} onChange={(v) => setShape(v as ColumnShape)}
@@ -179,7 +209,9 @@ export default function ColumnDesign() {
               <Num label="Diameter D" unit="mm" value={D} onChange={setD} />
             )}
             <Num label="Clear cover" unit="mm" value={cover} onChange={setCover} />
-            <Num label={<>Bar <KTex tex="d_b" /></>} unit="mm" value={barDia} onChange={setBarDia} />
+            <Num label={<>Bar <KTex tex="d_b" /></>} unit="mm" value={dbEff} onChange={setBarDia}
+              disabled={!!cageChoice}
+              hint={cageChoice ? (cageChoice.db ? 'chosen by the optimiser' : 'no compliant cage — see the ranking') : undefined} />
             <Num label={tied ? <>Tie <KTex tex="d_t" /></> : <>Spiral <KTex tex="d_s" /></>} unit="mm" value={tieDia} onChange={setTieDia} />
             <Pick label="Bars" value={eccentric ? 'analyze' : barMode} onChange={(v) => setBarMode(v as BarMode)}
               options={eccentric ? [['analyze', 'Given count']] : [['design', 'Design automatically'], ['analyze', 'Given count']]} />
@@ -256,13 +288,15 @@ export default function ColumnDesign() {
               stats={verdict.stats} checks={verdict.checks} footnote={verdict.footnote} />
           )}
 
+          {cageChoice && <RebarRanking selection={cageChoice.selection} title="Cage selection" />}
+
           {/* The same card the beam page uses — graph-paper ground, title and
               section meta in a header strip above the drawing. The two pages
               draw the same kind of thing and should look like it. */}
           <DrawingCard pdfDrawing title="Section"
-            meta={`${tied ? `${f0(b)} × ${f0(h)}` : `⌀${f0(D)}`} · ${axial?.bars ?? numBars} ⌀${barDia} · to scale`}>
+            meta={`${tied ? `${f0(b)} × ${f0(h)}` : `⌀${f0(D)}`} · ${axial?.bars ?? numBars} ⌀${dbEff} · to scale`}>
             <ColumnSchematic shape={tied ? 'tied' : 'spiral'} b={b} h={h} D={D} cover={cover}
-              barDia={barDia} tieDia={tieDia} bars={axial?.bars ?? numBars}
+              barDia={dbEff} tieDia={tieDia} bars={axial?.bars ?? numBars}
               tieSpacing={axial ? (tied ? axial.tieSpacingFinal : axial.spiralPitch) : undefined} />
           </DrawingCard>
 
@@ -279,7 +313,7 @@ export default function ColumnDesign() {
                 <Row alert={util > 1} label="Utilisation" value={`${(util * 100).toFixed(0)} %`}
                   sub={`φPn=${f1(cap.phi * cap.Pn)} kN @ e=${f0((MuEff / Pu) * 1000)} mm`} />
               )}
-              <Row label="Bars" value={`${axial.bars} ⌀${barDia} mm`}
+              <Row label="Bars" value={`${axial.bars} ⌀${dbEff} mm`}
                 sub={`ρ=${(axial.rho * 100).toFixed(2)}% ${axial.rhoOK ? '✓' : '✗ (1–8%)'}`} />
               <Row alert={!axial.axialOK && !eccentric} label={<KTex tex="\phi P_{n,max}" />}
                 value={`${f1(axial.phiPnMax)} kN`}
@@ -388,7 +422,7 @@ export default function ColumnDesign() {
             : `Axial φPn,max = ${f1(axial.phiPnMax)} kN`}
           lh={lh}
           stats={[
-            { label: 'Bars', value: `${axial.bars}-⌀${barDia}` },
+            { label: 'Bars', value: `${axial.bars}-⌀${dbEff}` },
             { label: tied ? 'Ties' : 'Spiral pitch', value: tied ? `⌀${Math.max(tieDia, axial.tieDiaMin)} @${f0(axial.tieSpacingFinal)}` : `@${f0(axial.spiralPitch)}`, unit: 'mm' },
             { label: 'φPn,max', value: f1(axial.phiPnMax), unit: 'kN' },
             ...(eccentric && slender ? [{

--- a/webapp/src/pages/ColumnDesign.tsx
+++ b/webapp/src/pages/ColumnDesign.tsx
@@ -16,6 +16,7 @@ import { WorkedSolution } from '../components/WorkedSolution'
 import { axialColumnSolution, eccentricColumnSolution, slendernessSolution } from '../lib/columnSolution'
 import { optimizeColumnRebar } from '../engine/columnRebarOptimize'
 import { RebarRanking } from '../components/RebarRanking'
+import { buildRebarSelectionSolution } from '../lib/rebarSolution'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { Math as KTex } from '../lib/math'
 import { f0, f1, f2 } from '../lib/format'
@@ -114,9 +115,10 @@ export default function ColumnDesign() {
       shape: tied ? 'tied' : 'spiral', b, h, D, cover, barDia: dbEff, tieDia, fc, fy, fyt, Pu,
       numBars: barMode === 'analyze' || eccentric ? numBars : cageChoice?.bars ?? undefined,
     }, axial))
+    if (cageChoice) steps.push(...buildRebarSelectionSolution(cageChoice.selection, 'cage'))
     return steps
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [slender, eccentric, inter, cap, axial, Pu, MuEff])
+  }, [slender, eccentric, inter, cap, axial, Pu, MuEff, cageChoice])
 
   const util = cap && cap.phi * cap.Pn > 1e-9 ? Pu / (cap.phi * cap.Pn) : null
 

--- a/webapp/src/pages/FoundationDesign.tsx
+++ b/webapp/src/pages/FoundationDesign.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, type ReactNode } from 'react'
 import { designSquareFooting } from '../engine/isolatedFooting'
 import { optimizeFootingRebar } from '../engine/matRebarOptimize'
 import { RebarRanking } from '../components/RebarRanking'
+import { buildRebarSelectionSolution } from '../lib/rebarSolution'
 import { nameMat } from '../lib/rebarLabel'
 // The page used to carry its own byte-identical copy of this input.
 import { Num as NumField } from '../components/qty'
@@ -275,8 +276,11 @@ export default function FoundationDesign() {
       punchOK: view.punchOK, beamOK: view.beamOK,
       long: view.long, short: view.short, ecc: view.ecc,
     }
-    return buildFoundationSolution(ctx)
-  }, [view, form, dbEff, serviceLoad, ultimateLoad, individual, circular, colWidth, colWidthY])
+    return [
+      ...buildFoundationSolution(ctx),
+      ...(matChoice ? buildRebarSelectionSolution(matChoice.selection, 'mat') : []),
+    ]
+  }, [view, form, dbEff, matChoice, serviceLoad, ultimateLoad, individual, circular, colWidth, colWidthY])
 
   // Verdict data — presentation of engine outputs only: utilization is the
   // required-over-provided effective depth per shear mode (capacity grows with

--- a/webapp/src/pages/FoundationDesign.tsx
+++ b/webapp/src/pages/FoundationDesign.tsx
@@ -1,5 +1,10 @@
 import { useMemo, useState, type ReactNode } from 'react'
 import { designSquareFooting } from '../engine/isolatedFooting'
+import { optimizeFootingRebar } from '../engine/matRebarOptimize'
+import { RebarRanking } from '../components/RebarRanking'
+import { nameMat } from '../lib/rebarLabel'
+// The page used to carry its own byte-identical copy of this input.
+import { Num as NumField } from '../components/qty'
 import { designRectangularFooting } from '../engine/rectangularFooting'
 import { designEccentricSquareFooting } from '../engine/eccentricFooting'
 import { netBearing } from '../engine/bearing'
@@ -104,24 +109,6 @@ interface View {
 }
 
 
-function NumField({ label, unit, value, onChange, step = 'any' }: {
-  label: ReactNode; unit?: string; value: number; onChange: (v: number) => void; step?: string
-}) {
-  return (
-    <label className="flex flex-col text-sm">
-      <span className="mb-1 text-[11.5px] font-semibold text-[#5c6675]">{label}</span>
-      <span className="flex overflow-hidden rounded-md border border-[#d6d3c9] bg-[#fcfbf8] focus-within:border-[#0f4c92] focus-within:shadow-[0_0_0_3px_rgba(15,76,146,.14)]">
-        <input
-          type="number" inputMode="decimal" step={step} value={Number.isFinite(value) ? value : ''}
-          onChange={(e) => onChange(parseFloat(e.target.value))}
-          className="min-w-0 flex-1 !rounded-none !border-0 !bg-transparent text-[13px] !shadow-none"
-        />
-        {unit && <span className="flex items-center border-l border-[#eeece5] bg-[#f7f6f1] px-2.5 font-mono text-[10.5px] text-[#a39d8d]">{unit}</span>}
-      </span>
-    </label>
-  )
-}
-
 function Select<T extends string>({ label, value, onChange, options }: {
   label: string; value: T; onChange: (v: T) => void; options: [T, string][]
 }) {
@@ -192,12 +179,34 @@ export default function FoundationDesign() {
   const serviceLoad = individual ? form.deadLoad + form.liveLoad : form.serviceLoad
   const ultimateLoad = individual ? factoredLoad({ dead: form.deadLoad, live: form.liveLoad }) : form.ultimateLoad
 
-  const view: View | null = useMemo(() => {
+  // ── Mat selection ────────────────────────────────────────────────────
+  // Only the concentric SQUARE path for now — that is the footing the mat
+  // optimiser covers. The rectangular and eccentric paths keep the ⌀ field.
+  const [autoBar, setAutoBar] = useState(true)
+  const squareConcentric = !rect && !ecc
+  const matChoice = useMemo(() => {
+    if (!autoBar || !valid || !squareConcentric) return null
+    try {
+      return optimizeFootingRebar({
+        serviceLoad, ultimateLoad, columnWidth: colWidth, columnWidthY: colWidthY,
+        fc: form.fc, fy: form.fy, qAllow: form.qAllow, gammaSoil: form.gammaSoil,
+        gammaConc: form.gammaConc, H: form.H, barDia: form.barDia, cover: form.cover,
+        surcharge: form.surcharge, position: form.position,
+        analysis: form.analysisMethod, solutionMethod: form.solutionMethod,
+        givenB: form.givenB, givenDc: form.givenDc,
+      })
+    } catch { return null }
+  }, [autoBar, valid, squareConcentric, serviceLoad, ultimateLoad, colWidth, colWidthY, form])
+
+  /** The diameter actually detailed. */
+  const dbEff = matChoice?.db ?? form.barDia
+
+  const viewRaw: View | null = useMemo(() => {
     if (!valid) return null
     const common = {
       serviceLoad, ultimateLoad, columnWidth: colWidth, columnWidthY: colWidthY,
       fc: form.fc, fy: form.fy, qAllow: form.qAllow, gammaSoil: form.gammaSoil, gammaConc: form.gammaConc,
-      H: form.H, barDia: form.barDia, cover: form.cover, surcharge: form.surcharge, position: form.position,
+      H: form.H, barDia: dbEff, cover: form.cover, surcharge: form.surcharge, position: form.position,
     }
     const methods = {
       analysis: form.analysisMethod, solutionMethod: form.solutionMethod,
@@ -241,7 +250,14 @@ export default function FoundationDesign() {
       punchOK: r.punchOK, beamOK: r.beamOK,
       long: r.long, short: r.short, ecc: null,
     }
-  }, [form, valid, rect, ecc, serviceLoad, ultimateLoad, colWidth, colWidthY])
+  }, [form, dbEff, valid, rect, ecc, serviceLoad, ultimateLoad, colWidth, colWidthY])
+
+  // The mat is drawn on a spacing module, so the adopted spacing — not the
+  // count that falls out of As/Ab — is what goes on the schedule.
+  const view: View | null = useMemo(() => {
+    if (!viewRaw || !matChoice?.bars || !matChoice.spacing) return viewRaw
+    return { ...viewRaw, long: { ...viewRaw.long, bars: matChoice.bars, spacing: matChoice.spacing } }
+  }, [viewRaw, matChoice])
 
   const solutionSteps = useMemo(() => {
     if (!view) return null
@@ -253,14 +269,14 @@ export default function FoundationDesign() {
       columnWidth: colWidth, columnWidthY: colWidthY, fc: form.fc, fy: form.fy,
       column: circular ? { shape: 'circular' as const, dia: form.columnWidth } : null,
       qAllow: form.qAllow, gammaSoil: form.gammaSoil, gammaConc: form.gammaConc, H: form.H,
-      barDia: form.barDia, cover: form.cover, surcharge: form.surcharge, position: form.position,
+      barDia: dbEff, cover: form.cover, surcharge: form.surcharge, position: form.position,
       Bx: view.Bx, By: view.By, Dc: view.Dc, qNet: view.qNet, qu: view.qu,
       dPunch: view.dPunch, dBeamLong: view.dBeamLong, dBeamShort: view.dBeamShort, dProvided: view.dProvided,
       punchOK: view.punchOK, beamOK: view.beamOK,
       long: view.long, short: view.short, ecc: view.ecc,
     }
     return buildFoundationSolution(ctx)
-  }, [view, form, serviceLoad, ultimateLoad, individual, circular, colWidth, colWidthY])
+  }, [view, form, dbEff, serviceLoad, ultimateLoad, individual, circular, colWidth, colWidthY])
 
   // Verdict data — presentation of engine outputs only: utilization is the
   // required-over-provided effective depth per shear mode (capacity grows with
@@ -405,9 +421,18 @@ export default function FoundationDesign() {
           </Card>
 
           <Card title="Materials">
+            {squareConcentric && (
+              <label className="col-span-full flex cursor-pointer items-center gap-1.5 text-[11px] font-semibold text-[#5c6675]">
+                <input type="checkbox" checked={autoBar} onChange={(e) => setAutoBar(e.target.checked)}
+                  className="h-3.5 w-3.5 accent-[#0f4c92]" />
+                Auto-select bar ⌀ and spacing
+              </label>
+            )}
             <NumField label={<Math tex="f'_c" />} unit="MPa" value={form.fc} onChange={set('fc')} />
             <NumField label={<Math tex="f_y" />} unit="MPa" value={form.fy} onChange={set('fy')} />
-            <NumField label={<>Bar <Math tex="d_b" /></>} unit="mm" value={form.barDia} onChange={set('barDia')} />
+            <NumField label={<>Bar <Math tex="d_b" /></>} unit="mm" value={dbEff} onChange={set('barDia')}
+              disabled={!!matChoice}
+              hint={matChoice ? (matChoice.db ? 'chosen by the optimiser' : 'no compliant mat — see the ranking') : undefined} />
             <NumField label="Clear cover" unit="mm" value={form.cover} onChange={set('cover')} />
           </Card>
 
@@ -432,7 +457,7 @@ export default function FoundationDesign() {
               stats={[
                 { label: 'Plan size', value: view.type === 'square' ? `${f2(view.Bx)} × ${f2(view.By)}` : `${f2(view.Bx)} × ${f2(view.By)}`, unit: 'm' },
                 { label: 'Thickness Dc', value: f0(view.Dc), unit: 'mm' },
-                { label: view.type === 'square' ? 'Steel each way' : 'Steel — long', value: `${view.long.bars}-⌀${form.barDia}`, unit: `@${f0(view.long.spacing)}` },
+                { label: view.type === 'square' ? 'Steel each way' : 'Steel — long', value: `${view.long.bars}-⌀${dbEff}`, unit: `@${f0(view.long.spacing)}` },
               ]}
               checks={[
                 { name: 'Punching shear (d req / prov)', ratio: punchRatio },
@@ -442,6 +467,10 @@ export default function FoundationDesign() {
                 ? 'Flexure: As,min = 0.0018·b·h governs (ρmin) — §24.4.3.2'
                 : `Flexure: ρ = ${view.long.rho.toFixed(4)} — §24.4.3.2 satisfied`}
             />
+          )}
+
+          {matChoice && (
+            <RebarRanking selection={matChoice.selection} title="Mat selection" name={nameMat} />
           )}
 
           <DrawingCard pdfDrawing title="Drawing" meta="plan · section">
@@ -478,11 +507,11 @@ export default function FoundationDesign() {
                 value={`${f0(view.dPunch)} mm`}
                 check={view.type === 'square' ? `beam ${f0(view.dBeamLong)} mm` : `beam x/y ${f0(view.dBeamLong)}/${f0(view.dBeamShort)} mm`} />
               {view.type === 'square'
-                ? steelRow('Steel (each way)', view.long, form.barDia)
+                ? steelRow('Steel (each way)', view.long, dbEff)
                 : (
                   <>
-                    {steelRow('Steel — long (x)', view.long, form.barDia)}
-                    {view.short && steelRow('Steel — short (y)', view.short, form.barDia)}
+                    {steelRow('Steel — long (x)', view.long, dbEff)}
+                    {view.short && steelRow('Steel — short (y)', view.short, dbEff)}
                     {view.short && (
                       <Row label="Central band (short)"
                         value={`${view.short.bandBars} of ${view.short.bars} bars`}
@@ -506,7 +535,7 @@ export default function FoundationDesign() {
           stats={[
             { label: 'Plan size', value: `${f2(view.Bx)} × ${f2(view.By)}`, unit: 'm' },
             { label: 'Thickness Dc', value: f0(view.Dc), unit: 'mm' },
-            { label: view.type === 'square' ? 'Steel each way' : 'Steel — long', value: `${view.long.bars}-⌀${form.barDia}`, unit: `@${f0(view.long.spacing)}` },
+            { label: view.type === 'square' ? 'Steel each way' : 'Steel — long', value: `${view.long.bars}-⌀${dbEff}`, unit: `@${f0(view.long.spacing)}` },
           ]}
           checks={[
             { name: 'Two-way (punching) shear — d req/prov', ratio: punchRatio, ok: view.punchOK },
@@ -515,7 +544,7 @@ export default function FoundationDesign() {
           data={[
             ['Service load P', `${f0(serviceLoad)} kN`], ['Ultimate load Pu', `${f0(ultimateLoad)} kN`],
             ["Concrete f'c", `${form.fc} MPa`], ['Steel fy', `${form.fy} MPa`],
-            ['Column width c', `${f0(colWidth)} mm (${form.position})`], ['Bar diameter db', `⌀${form.barDia} mm`],
+            ['Column width c', `${f0(colWidth)} mm (${form.position})`], ['Bar diameter db', `⌀${dbEff} mm`],
             ['Allowable bearing qa', `${form.qAllow} kPa`], ['Clear cover', `${form.cover} mm`],
             ['Unit weight, soil γs', `${form.gammaSoil} kN/m³`], ['Unit weight, concrete γc', `${form.gammaConc} kN/m³`],
             ['Total depth H', `${f2(form.H)} m`], ['Surcharge', `${form.surcharge} kPa`],

--- a/webapp/src/pages/SlabDesign.tsx
+++ b/webapp/src/pages/SlabDesign.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { designSlabDDM, type SlabInput, type SlabDirResult, type SlabSectionSteel } from '../engine/slabDDM'
 import { optimizeSlabRebar } from '../engine/matRebarOptimize'
 import { RebarRanking } from '../components/RebarRanking'
+import { buildRebarSelectionSolution } from '../lib/rebarSolution'
 import { nameMat } from '../lib/rebarLabel'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { ReportControls } from '../components/ReportControls'
@@ -140,7 +141,12 @@ export default function SlabDesign() {
 
   const defl = r?.deflection
 
-  const solution = r ? buildSlabSolution(inputEff, r) : null
+  const solution = r
+    ? [
+        ...buildSlabSolution(inputEff, r),
+        ...(slabChoice ? buildRebarSelectionSolution(slabChoice.selection, 'mat') : []),
+      ]
+    : null
 
   const report = r ? {
     docCode: 'S-SL',

--- a/webapp/src/pages/SlabDesign.tsx
+++ b/webapp/src/pages/SlabDesign.tsx
@@ -1,6 +1,9 @@
 import { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { designSlabDDM, type SlabInput, type SlabDirResult, type SlabSectionSteel } from '../engine/slabDDM'
+import { optimizeSlabRebar } from '../engine/matRebarOptimize'
+import { RebarRanking } from '../components/RebarRanking'
+import { nameMat } from '../lib/rebarLabel'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { ReportControls } from '../components/ReportControls'
 import { buildSlabSolution } from '../lib/slabSolution'
@@ -33,14 +36,25 @@ const DEFAULTS: FormState = {
   withBeams: 'yes',
 }
 
-function steelText(s: SlabSectionSteel, db: number) {
-  return `${s.bars}⌀${db} @${f0(s.spacing)} mm`
+/** The mat adopted for one strip: bars laid on a spacing MODULE, not the
+ *  arithmetic spacing that falls out of As/Ab. */
+export interface StripMat { bars: number; spacing: number }
+
+function steelText(s: SlabSectionSteel, db: number, mat?: StripMat) {
+  const m = mat ?? s
+  return `${m.bars}⌀${db} @${f0(m.spacing)} mm`
 }
 function steelSub(s: SlabSectionSteel) {
   return `As=${f0(s.As)} mm²${s.usedMin ? ' (T/S min)' : ''}`
 }
 
-function DirCard({ title, dir, barDia }: { title: string; dir: SlabDirResult; barDia: number }) {
+function DirCard({ title, dir, barDia, mats }: {
+  title: string; dir: SlabDirResult; barDia: number
+  /** Keyed by `slabStrips`' label, so the schedule quotes the adopted mat. */
+  mats?: Map<string, StripMat>
+}) {
+  const mat = (loc: string, which: 'column' | 'middle') =>
+    mats?.get(`${dir.dir}-dir ${loc} ${which} strip`)
   return (
     <ResultCard title={title}>
       <Row label="Span l₁" value={`${f2(dir.l1)} m`} sub={`l₂=${f2(dir.l2)} m`} />
@@ -64,13 +78,13 @@ function DirCard({ title, dir, barDia }: { title: string; dir: SlabDirResult; ba
                 <td className="py-1 pr-2 font-medium text-slate-700">{loc.name}</td>
                 <td className="py-1 pr-2 text-slate-600">{f1(loc.M)}</td>
                 <td className="py-1 pr-2">
-                  <div className="font-semibold text-slate-800">{steelText(loc.column, barDia)}</div>
+                  <div className="font-semibold text-slate-800">{steelText(loc.column, barDia, mat(loc.name, 'column'))}</div>
                   <div className="text-slate-500">{steelSub(loc.column)}</div>
                 </td>
                 <td className="py-1">
                   {loc.middle.b > 0 ? (
                     <>
-                      <div className="font-semibold text-slate-800">{steelText(loc.middle, barDia)}</div>
+                      <div className="font-semibold text-slate-800">{steelText(loc.middle, barDia, mat(loc.name, 'middle'))}</div>
                       <div className="text-slate-500">{steelSub(loc.middle)}</div>
                     </>
                   ) : <span className="text-slate-500">—</span>}
@@ -86,6 +100,7 @@ function DirCard({ title, dir, barDia }: { title: string; dir: SlabDirResult; ba
 
 export default function SlabDesign() {
   const [f, setF] = useState<FormState>(DEFAULTS)
+  const [autoBar, setAutoBar] = useState(true)
   const set = <K extends keyof FormState>(k: K) => (v: FormState[K]) => setF((s) => ({ ...s, [k]: v }))
 
   const input = useMemo((): SlabInput => ({
@@ -103,14 +118,29 @@ export default function SlabDesign() {
     return nums.every((k) => Number.isFinite(f[k] as number)) && f.lx > 0 && f.ly > 0 && f.fc > 0 && f.fy > 0 && f.D >= 0 && f.L >= 0
   }, [f])
 
-  const r = useMemo(() => (valid ? designSlabDDM(input) : null), [valid, input])
+  // ── Mat selection ────────────────────────────────────────────────────
+  // ONE diameter for the panel, spacing chosen per strip — which is how a
+  // slab is drawn, and why the strips carry their own spacing below.
+  const slabChoice = useMemo(
+    () => (autoBar && valid ? optimizeSlabRebar(input) : null),
+    [autoBar, valid, input],
+  )
+  const dbEff = slabChoice?.db ?? f.barDia
+  const inputEff = useMemo(() => ({ ...input, barDia: dbEff }), [input, dbEff])
+  const mats = useMemo(() => {
+    const m = new Map<string, StripMat>()
+    for (const st of slabChoice?.strips ?? []) m.set(st.label, { bars: st.bars, spacing: st.spacing })
+    return m
+  }, [slabChoice])
+
+  const r = useMemo(() => (valid ? designSlabDDM(inputEff) : null), [valid, inputEff])
   // §424.4.3 shrinkage and temperature steel — a slab detail the DDM result
   // does not carry, because it is not a flexural demand.
   const temp = useMemo(() => tempSteelArea(r?.h ?? 0, f.fy), [r, f.fy])
 
   const defl = r?.deflection
 
-  const solution = r ? buildSlabSolution(input, r) : null
+  const solution = r ? buildSlabSolution(inputEff, r) : null
 
   const report = r ? {
     docCode: 'S-SL',
@@ -139,7 +169,7 @@ export default function SlabDesign() {
       ['Live load L', `${f1(f.L)} kPa`],
       ["Concrete f'c", `${f.fc} MPa`],
       ['Steel fy', `${f.fy} MPa`],
-      ['Cover / bar ⌀', `${f.cover} / ${f.barDia} mm`],
+      ['Cover / bar ⌀', `${f.cover} / ${dbEff} mm`],
       ['Minimum thickness', `${Math.round(r.hmin)} mm`],
       ['Panel action', r.twoWay ? 'two-way' : 'one-way'],
       ['Exterior x / y', `${f.extX} / ${f.extY}`],
@@ -180,10 +210,19 @@ export default function SlabDesign() {
             <Num label={<KTex tex="f_y" />} unit="MPa" value={f.fy} onChange={set('fy')} />
           </Card>
 
-          <Card title="Detailing">
+          <Card title="Detailing"
+            hint={
+              <label className="no-print flex cursor-pointer items-center gap-1.5 text-[11px] font-semibold text-[#5c6675]">
+                <input type="checkbox" checked={autoBar} onChange={(e) => setAutoBar(e.target.checked)}
+                  className="h-3.5 w-3.5 accent-[#0f4c92]" />
+                Auto-select bar ⌀ and spacing
+              </label>
+            }>
             <Num label="Thickness h (blank = auto)" unit="mm" value={f.h} onChange={set('h')} />
             <Num label="Clear cover" unit="mm" value={f.cover} onChange={set('cover')} />
-            <Num label={<>Bar <KTex tex="d_b" /></>} unit="mm" value={f.barDia} onChange={set('barDia')} />
+            <Num label={<>Bar <KTex tex="d_b" /></>} unit="mm" value={dbEff} onChange={set('barDia')}
+              disabled={autoBar}
+              hint={autoBar ? (slabChoice?.db ? 'chosen by the optimiser' : 'no compliant mat — see the ranking') : undefined} />
           </Card>
 
           <Card title="Span type">
@@ -198,6 +237,9 @@ export default function SlabDesign() {
 
         {/* ── RESULTS ── */}
         <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
+          {slabChoice && (
+            <RebarRanking selection={slabChoice.selection} title="Mat selection — whole panel" name={nameMat} />
+          )}
           {r ? (
             <>
               {/* Summary */}
@@ -227,10 +269,10 @@ export default function SlabDesign() {
               )}
 
               {/* X direction */}
-              <DirCard title={`Direction x (l₁ = ${f2(r.x.l1)} m)`} dir={r.x} barDia={f.barDia} />
+              <DirCard title={`Direction x (l₁ = ${f2(r.x.l1)} m)`} dir={r.x} barDia={dbEff} mats={mats} />
 
               {/* Y direction */}
-              <DirCard title={`Direction y (l₁ = ${f2(r.y.l1)} m)`} dir={r.y} barDia={f.barDia} />
+              <DirCard title={`Direction y (l₁ = ${f2(r.y.l1)} m)`} dir={r.y} barDia={dbEff} mats={mats} />
 
               {/* ── Bar arrangement ─────────────────────────────────── */}
               <ResultCard title="Bar arrangement — section through the span">
@@ -243,8 +285,8 @@ export default function SlabDesign() {
                     return (
                       <SlabBarSection key={strip} strip={strip}
                         l1={r.x.l1} support={f.colWidth / 1000} h={r.h} cover={f.cover}
-                        topBars={`⌀${f.barDia} @ ${f0(negSec.spacing)} mm`}
-                        bottomBars={`⌀${f.barDia} @ ${f0(sec.spacing)} mm`}
+                        topBars={`⌀${dbEff} @ ${f0(negSec.spacing)} mm`}
+                        bottomBars={`⌀${dbEff} @ ${f0(sec.spacing)} mm`}
                         tempBars={`As ${f0(temp.As)} mm²/m · max s ${f0(tempSpacingMax(r.h))} mm`} />
                     )
                   })}


### PR DESCRIPTION
**Phase 4 of 4**, on top of #528 (core + beam), #529 (column), #530 (mats). The engine now chooses a layout; this is where you can see *why* — on the page, on the calc sheet, and in the PDF.

## The card

`RebarRanking` renders the same thing for a beam cage, a column cage and a slab mat — only the naming differs, which the caller supplies. Column headings carry their own weights so the ranking can be argued with rather than reverse-engineered from behaviour.

```
Bar selection
┌────────────────────────────────────────────────────────────┐
│ 4⌀20                                                       │
│ 4⌀20 in one layer — well distributed for crack control,    │
│ easy to place, economical, symmetric and standard.         │
└────────────────────────────────────────────────────────────┘
4⌀20 scores 0.898 against 2⌀28 at 0.778 — decided on serviceability

Layout      Serv ·0.40   Const ·0.30   Econ ·0.20   Simp ·0.10    Score
▸ 4⌀20              82           100           85          100    0.898
  2⌀28              47           100           99           93    0.778
  3⌀25              66           100           58           86    0.769
  7⌀16              87            51           48           77    0.675
  2⌀32              38           100           44           93    0.634

Each column is scored 0–100 relative to the candidates generated here, then
weighted by the figure beside its heading. Compliance is a gate, never a score.

Show all 5 compliant    1 rejected
```

When nothing complies it shows the **blocking gates with their clauses** instead — the diagnosis from #530, where more than one gate firing is the point.

## …and on the calc sheet

A results table saying `4⌀20` is not checkable. `buildRebarSelectionSolution` puts the selection on the sheet as four steps, for the same reason every other step is there — so a checker can disagree with it:

| step | contents |
|---|---|
| **Layouts considered** | what was searched, and that no strength is re-derived here |
| **Code compliance — a gate, not a score** | every check the adopted layout passes, with its clause *and its numbers*; PASS chip |
| **Weighted score of the compliant layouts** | the weights, then the substituted score for the top four |
| **Adopted — 4⌀20** | the reason, the margin, As,prov/As,req, the spacing chain, the effective depth reached |

```
S = 0.40 S_serv + 0.30 S_con + 0.20 S_eco + 0.10 S_simp
S(4D20) = 0.40(0.82) + 0.30(1.00) + 0.20(0.85) + 0.10(1.00) = 0.898
S(2D28) = 0.40(0.47) + 0.30(1.00) + 0.20(0.99) + 0.10(0.93) = 0.778
A_s,prov = 1257 mm² ≥ A_s,req = 1189 mm²
```

Appended rather than prepended: it justifies the bar chosen for the steel the flexure steps derived, so it reads after them. Both report paths share the array, so **the PDF carries it too**. When nothing complies it stops after the gate step and lists the blockers with counts — there is nothing to rank.

## Wired into four pages

Each gets an **auto-select toggle, ON by default**. Off puts the ⌀ field back in charge, which is what checking an existing drawing needs; on, the field goes **read-only** rather than silently having no effect — which is what it did in my first pass.

| page | what is chosen | scope |
|---|---|---|
| **Beam** | one ⌀ for the whole member in multi-section mode, scored across every critical section | full |
| **Column** | ⌀ × count | axial design only — *analyze* mode and the eccentric pilot exist to check a cage you already have |
| **Slab** | one ⌀ for the panel, spacing **per strip** | full |
| **Footing** | ⌀ and spacing | concentric square only, which is what the mat optimiser covers; rectangular and eccentric keep the field |

The slab schedule is the visible payoff — before, one mat everywhere; now:

```
LOCATION      M (kN·m)   COL STRIP              MID STRIP
Support −M       140.6   24⌀12 @125 mm          17⌀12 @175 mm
                         As=2657 mm²            As=1154 mm²
+M                75.7   17⌀12 @175 mm          17⌀12 @175 mm
```

And the footing Results row now quotes the **module spacing** (`16 ⌀16 @ 150`) rather than the count that falls out of As/Ab.

## Two engine defects, both found by rendering it

### 1. The near-tie rule was buying steel

The slab strips all came out at the *same* mat — and at **2.63× the required steel**. Rendering the schedule is what made that obvious; every unit test was green.

On a slab strip the spacing modules span 75–300 mm, so at one diameter the areas run **1.3× to 4.4×** the requirement while the totals compress into a single 0.03 band. Promoting on serviceability alone then reached the tight end every time:

```
lightest strip, As,req = 1032 mm²
   @175  n 17  AsProv 1923 (1.86×) | serv 0.72 con 1.00 eco 0.75 = 0.838  ← leader
   @200  n 15  AsProv 1696 (1.64×) | serv 0.68 con 1.00 eco 0.82 = 0.836
   @150  n 20  AsProv 2262 (2.19×) | serv 0.76 con 1.00 eco 0.65 = 0.834
   @250  n 12  AsProv 1357 (1.31×) | serv 0.60 con 1.00 eco 0.94 = 0.827
   @125  n 24  AsProv 2714 (2.63×) | serv 0.80 con 1.00 eco 0.52 = 0.824  ← was adopted
```

**Two layouts differing by 2.6× in steel are not "nearly equivalent"** in any sense an engineer would accept, however close their totals land. The band was failing to capture a real difference and the tie-break was then discarding it entirely — over-provision carries only 0.25 × 0.20 = **5%** of the total, which is exactly the width of the band.

`MAX_TIE_STEEL = 0.15`: a near-tie contender may be promoted only if it does not buy more than 15% extra steel over the leader. The leader always satisfies it, so a winner always exists.

Result: the light strips drop to **1.86×** and the panel gets a real per-strip schedule.

**This also settles the concern I flagged honestly in #529.** With the guard, the 400×400 column adopts **8⌀16 rather than 10⌀16 (−25% steel)** and the 450⌀ spiral **8⌀16 rather than 12⌀16 (−50%)** — and in both cases that candidate was the leader by total all along. The beam and footing answers are unchanged (4⌀20; ⌀16 @ 150).

### 2. A mat was calling itself symmetric

The card headline said `⌀12 @ 100` and the reason underneath said *"30⌀12 in one layer — … symmetric and standard"*. A mat is **spaced, not counted**, and has no centreline to be symmetric about — `wantSymmetric: false` was correctly stopping it being *scored* on symmetry but the prose still claimed it.

`ScoreContext.naming` now carries the vocabulary, so the reason, the margin and the rejection lines all read *"⌀12 @ 100 — 17 bars across the strip — well distributed for crack control, easy to place, a standard bar size."*

## The contract guard earned its keep again

Adding the builder to `workedSolutions.test.ts` caught three things: a compliance line too terse to explain itself, units written `\mathrm` where the sheets use `\text`, and — correctly — that I had written `A_s,prov = X ≥ A_s,req = Y = 1.05×`, chaining an equals sign after a greater-or-equal. The ratio is now its own equation.

## Also

`FoundationDesign` carried a **byte-identical copy** of `qty`'s `Num`. It now uses the shared one, so the new read-only state lives in one place rather than two that drift.

## Verification

Headless Chromium against the dev server, all four pages:

```
beam-design       adopted: 4⌀20        katex-errors 0  raw-latex 0
                  auto off → card hidden ✓, disabled fields 0
column-design     adopted: 8⌀28        katex-errors 0  raw-latex 0
                  auto off → card hidden ✓, disabled fields 0
slab-design       adopted: ⌀12 @ 100   katex-errors 0  raw-latex 0
                  auto off → card hidden ✓, disabled fields 0
foundation        adopted: ⌀16 @ 150   katex-errors 0  raw-latex 0
                  auto off → card hidden ✓, disabled fields 0
PAGE ERRORS: []
```

Cards and solution steps screenshotted and read on all four; the footing card's `⌀16 @ 150` matches its Results row, and the slab card's panel choice matches the per-strip schedule.

**+25 cases** — the near-tie steel guard (promotes when it costs nothing, refuses when it buys, leader always survives so a winner always exists), mat naming (spacing not count, never "symmetric", rejections named the same way), per-strip spacing (light strips get a looser mat than heavy ones), and both selection builders under the full worked-solution contract.

`npm test` — 203 files, **3460 passed**. `npx tsc -b`, `eslint --max-warnings 0`, `npm run build` green.

## Left open, deliberately

Both are pre-existing engine issues surfaced by this series, and neither belongs under a selection PR:

- `designBeam` packs layers on `max(db, 25)` and **omits §25.2.1's 4/3·d_agg term**. The optimiser re-checks with it and rejects, which is the safe direction.
- `designSlabDDM` at its §408.3.1.2 minimum thickness can land **past the tension-controlled limit**, because that formula assumes edge beams with αfm ≥ 2 while the module deliberately does not credit αf for slab steel. Reported as a blocked section with both gates named.

Also noted: KaTeX cannot render ⌀ in math mode, so the score equations read `S(4D20)`. `D20` is standard bar notation; the substitution is documented at the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)