### PR TITLE
fix(footing): a mat is floored by spacing, not by a bar count

### DIFF
--- a/webapp/src/engine/combinedFooting.ts
+++ b/webapp/src/engine/combinedFooting.ts
@@ -7,7 +7,7 @@
 // The Winkler "flexible" method is a separate follow-up.
 // ─────────────────────────────────────────────────────────────────────────
 import { punchingDepth } from './shear';
-import { flexuralSteel, barLayout } from './flexure';
+import { flexuralSteel, matLayout } from './flexure';
 
 export interface CombinedFootingInput {
   col1Width: number;     // mm (square)
@@ -176,7 +176,11 @@ export function designCombinedFooting(i: CombinedFootingInput): CombinedFootingR
   const mkSection = (label: string, x: number): FlexSection => {
     const Mu = Math.abs(Mat(x)), b = ByAt(x) * 1000;
     const flex = flexuralSteel({ Mu, b, d: dFlex, fc: i.fc, fy: i.fy });
-    const layout = barLayout({ As: flex.As, db: i.barDia, b, cover: i.cover });
+    // One-way slab detailing (ACI 318-14 §13.3.2.1) — §7.7.2.3's maximum
+    // spacing sets the count whenever the required area does not.
+    const layout = matLayout({
+      As: flex.As, db: i.barDia, b, cover: i.cover, h: Dc, kind: 'one-way',
+    });
     return { label, x, Mu, b, As: flex.As, bars: layout.n, spacing: layout.spacing, top: Mat(x) < 0 };
   };
   const longSections = [

--- a/webapp/src/engine/eccentricFooting.ts
+++ b/webapp/src/engine/eccentricFooting.ts
@@ -6,7 +6,7 @@
 // ─────────────────────────────────────────────────────────────────────────
 import { netBearing } from './bearing';
 import { punchingDepth, oneWayShearDepth, type ColumnPosition } from './shear';
-import { flexuralSteel, barLayout } from './flexure';
+import { flexuralSteel, matLayout } from './flexure';
 
 export interface EccentricFootingInput {
   serviceLoad: number;    // P, kN
@@ -135,7 +135,11 @@ export function designEccentricSquareFooting(i: EccentricFootingInput): Eccentri
   const Mu = quMax * B * (arm * arm) / 2;   // conservative: peak pressure across the width
   const b = B * 1000;
   const flex = flexuralSteel({ Mu, b, d: dFlex, fc: i.fc, fy: i.fy });
-  const layout = barLayout({ As: flex.As, db: i.barDia, b, cover: i.cover });
+  // Detailed as a one-way slab (ACI 318-14 §13.3.2.1): §7.7.2.3's maximum
+  // spacing sets the bar count whenever the required area does not.
+  const layout = matLayout({
+    As: flex.As, db: i.barDia, b, cover: i.cover, h: DcMm, kind: 'one-way',
+  });
   const qMinService = (i.serviceLoad / (B * B)) * (1 - (6 * e) / B);
 
   return {

--- a/webapp/src/engine/flexibleCombinedFooting.ts
+++ b/webapp/src/engine/flexibleCombinedFooting.ts
@@ -11,7 +11,7 @@
 // distribution and the resulting longitudinal steel differ.
 // ─────────────────────────────────────────────────────────────────────────
 import { designCombinedFooting, type CombinedFootingInput, type FlexSection } from './combinedFooting';
-import { flexuralSteel, barLayout } from './flexure';
+import { flexuralSteel, matLayout } from './flexure';
 
 export interface FlexibleCombinedInput extends CombinedFootingInput {
   /** Modulus of subgrade reaction, kN/m³. */
@@ -171,7 +171,11 @@ export function designFlexibleCombinedFooting(i: FlexibleCombinedInput): Flexibl
   const mkSection = (label: string, x: number): FlexSection => {
     const m = Mabs(x), Mu = Math.abs(m), b = By * 1000;
     const flex = flexuralSteel({ Mu, b, d: dFlex, fc: i.fc, fy: i.fy });
-    const layout = barLayout({ As: flex.As, db: i.barDia, b, cover: i.cover });
+    // One-way slab detailing (ACI 318-14 §13.3.2.1) — §7.7.2.3's maximum
+    // spacing sets the count whenever the required area does not.
+    const layout = matLayout({
+      As: flex.As, db: i.barDia, b, cover: i.cover, h: Dc, kind: 'one-way',
+    });
     return { label, x, Mu, b, As: flex.As, bars: layout.n, spacing: layout.spacing, top: m < 0 };
   };
   const cx1m = i.col1Width / 1000, cx2m = i.col2Width / 1000;

--- a/webapp/src/engine/flexure.test.ts
+++ b/webapp/src/engine/flexure.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { rhoMin, flexuralSteel, barLayout } from './flexure';
+import {
+  rhoMin, flexuralSteel, barLayout, matLayout, maxBarSpacing, minClearSpacing,
+} from './flexure';
 
 describe('rhoMin', () => {
   it('max(1.4/fy, √fc/(4fy))', () => {
@@ -26,6 +28,90 @@ describe('barLayout', () => {
     const Ab = (Math.PI / 4) * 20 * 20; // 314.16 mm²
     const layout = barLayout({ As: 1349, db: 20, b: 1500, cover: 75 });
     expect(layout.n).toBe(Math.max(2, Math.ceil(1349 / Ab))); // 5
-    expect(layout.spacing).toBeCloseTo((1500 - 150 - layout.n * 20) / (layout.n - 1), 3);
+    // From the geometry, NOT by restating the formula: bars sit a cover in
+    // from each edge, so the outer bar CENTRES are 1500 − 2(75) − 20 = 1330
+    // apart with 4 gaps between them. The old expectation subtracted n·db,
+    // which is the clear gap between bar faces — one diameter narrower — and
+    // pinned `barLayout` to a figure its own docstring called centre-to-centre.
+    const firstCentre = 75 + 20 / 2;
+    const lastCentre = 1500 - 75 - 20 / 2;
+    expect(layout.spacing).toBeCloseTo((lastCentre - firstCentre) / (layout.n - 1), 6);
+    expect(layout.spacing).toBeCloseTo(332.5, 6);
+  });
+
+  it('places the bars inside the section it was given', () => {
+    // The spacing has to reconstruct a layout that actually fits: n bars at
+    // s centres, each with half a diameter and a cover outside it.
+    for (const [b, cover, db, As] of [
+      [1500, 75, 20, 1349], [900, 40, 12, 400], [3000, 75, 25, 6000],
+    ] as const) {
+      const l = barLayout({ As, db, b, cover });
+      const width = (l.n - 1) * l.spacing + db + 2 * cover;
+      expect(width).toBeCloseTo(b, 6);
+    }
+  });
+});
+
+// ── Mat layouts ───────────────────────────────────────────────────────────
+
+describe('matLayout', () => {
+  it('§7.7.2.3 / §8.7.2.2 give the maximum spacing, capped at 450', () => {
+    expect(maxBarSpacing('one-way', 100)).toBe(300);   // 3h
+    expect(maxBarSpacing('two-way', 100)).toBe(200);   // 2h
+    expect(maxBarSpacing('one-way', 200)).toBe(450);   // 3h = 600, capped
+    expect(maxBarSpacing('two-way', 300)).toBe(450);   // 2h = 600, capped
+  });
+
+  it('§25.2.1 clear spacing carries the aggregate term', () => {
+    expect(minClearSpacing(12, 20)).toBeCloseTo(80 / 3, 6);  // 4/3·d_agg governs
+    expect(minClearSpacing(32, 20)).toBe(32);                // db governs
+    expect(minClearSpacing(10, 10)).toBe(25);                // the 25 mm floor
+  });
+
+  it('spacing, not a bar count, is what floors a mat', () => {
+    // THE BUG THIS EXISTS FOR. A 0.95 m footing, 200 mm thick, with a ⌀32 bar
+    // and almost no steel demand. Two bars satisfy the area — and `barLayout`
+    // returned exactly that, at 736 mm centres, because a count floor of two
+    // is §9.7.2.1, a BEAM rule, and says nothing about a mat.
+    const beamRule = barLayout({ As: 380, db: 32, b: 950, cover: 75 });
+    expect(beamRule.n).toBe(2);
+    expect(beamRule.spacing).toBeGreaterThan(450);
+
+    const matRule = matLayout({ As: 380, db: 32, b: 950, cover: 75, h: 200 });
+    expect(matRule.sMax).toBe(450);          // min(3h, 450) = min(600, 450)
+    expect(matRule.spacing).toBeLessThanOrEqual(matRule.sMax);
+    expect(matRule.n).toBeGreaterThan(2);
+    expect(matRule.spacingGoverned).toBe(true);
+  });
+
+  it('leaves the count alone when the area already needs more bars', () => {
+    const l = matLayout({ As: 6000, db: 16, b: 2300, cover: 75, h: 425 });
+    const Ab = (Math.PI / 4) * 16 * 16;
+    expect(l.n).toBe(Math.ceil(6000 / Ab));
+    expect(l.spacingGoverned).toBe(false);
+    expect(l.spacing).toBeLessThanOrEqual(l.sMax);
+  });
+
+  it('reports centre-to-centre AND the clear gap, one diameter apart', () => {
+    const l = matLayout({ As: 2000, db: 20, b: 2000, cover: 75, h: 400 });
+    expect(l.clear).toBeCloseTo(l.spacing - 20, 9);
+    const width = (l.n - 1) * l.spacing + 20 + 2 * 75;
+    expect(width).toBeCloseTo(2000, 6);
+  });
+
+  it('flags a mat whose bars do not fit at §25.2.1 clear spacing', () => {
+    // A wide bar crammed across a narrow strip: the area demands more bars
+    // than the width can hold at the code's minimum clear spacing.
+    const tight = matLayout({ As: 20000, db: 32, b: 700, cover: 75, h: 300 });
+    expect(tight.clearOK).toBe(false);
+    const roomy = matLayout({ As: 2000, db: 16, b: 2300, cover: 75, h: 400 });
+    expect(roomy.clearOK).toBe(true);
+  });
+
+  it('a two-way slab is spaced tighter than a one-way slab of the same depth', () => {
+    const one = matLayout({ As: 500, db: 12, b: 3000, cover: 20, h: 140, kind: 'one-way' });
+    const two = matLayout({ As: 500, db: 12, b: 3000, cover: 20, h: 140, kind: 'two-way' });
+    expect(two.sMax).toBeLessThan(one.sMax);
+    expect(two.n).toBeGreaterThan(one.n);
   });
 });

--- a/webapp/src/engine/flexure.ts
+++ b/webapp/src/engine/flexure.ts
@@ -40,10 +40,88 @@ export interface BarLayout {
   spacing: number;
 }
 
-/** Bar count + spacing for a required As across width b, using ⌀db bars and clear cover. */
+/**
+ * Bar count + spacing for a required As across width b, using ⌀db bars and
+ * clear cover.
+ *
+ * Bars sit a cover in from each edge, so the outermost bar CENTRES are
+ * (b − 2·cover − db) apart and there are (n − 1) gaps between them. The
+ * earlier form subtracted n·db, which is the CLEAR gap between bar faces —
+ * one diameter narrower than the centre-to-centre figure this returns and
+ * every drawing prints.
+ *
+ * For a slab or footing mat use `matLayout` instead: it applies the maximum
+ * spacing clause, which this does not.
+ */
 export function barLayout(params: { As: number; db: number; b: number; cover: number }): BarLayout {
   const Ab = (Math.PI / 4) * params.db * params.db;
   const n = Math.max(2, Math.ceil(params.As / Ab));
-  const spacing = n > 1 ? (params.b - 2 * params.cover - n * params.db) / (n - 1) : params.b;
+  const spacing = n > 1 ? (params.b - 2 * params.cover - params.db) / (n - 1) : params.b;
   return { n, spacing };
+}
+
+// ── Mat rules ─────────────────────────────────────────────────────────────
+//
+// A slab or footing mat is not a beam cage, and the two differ in the rule
+// that sets the MINIMUM number of bars.
+//
+// In a beam the floor is a count: §9.7.2.1, never fewer than two. In a mat it
+// is a spacing — §7.7.2.3 for one-way slabs and footings, §8.7.2.2 for
+// two-way slabs — and a count floor of two says nothing at all. Applying the
+// beam rule to a mat is how a 0.95 m footing came to be detailed 2⌀32 at
+// 736 mm centres and reported as adequate: the area was satisfied, and
+// nothing else was being asked.
+//
+// These live here, next to `barLayout`, so there is one home for the rule.
+
+/** Which maximum-spacing clause governs a mat. */
+export type MatKind = 'one-way' | 'two-way';
+
+/** §7.7.2.3 (one-way slabs, footings) or §8.7.2.2 (two-way slabs), mm. */
+export function maxBarSpacing(kind: MatKind, h: number): number {
+  return Math.min(kind === 'one-way' ? 3 * h : 2 * h, 450);
+}
+
+/** §25.2.1 minimum clear spacing — max(db, 25 mm, 4/3·d_agg), mm. */
+export function minClearSpacing(db: number, aggregate = 20): number {
+  return Math.max(db, 25, (4 / 3) * aggregate);
+}
+
+export interface MatBarLayout extends BarLayout {
+  /** Clear gap between bar faces, mm — what §25.2.1 limits. */
+  clear: number;
+  /** The maximum-spacing limit applied, mm. */
+  sMax: number;
+  /** True when §7.7.2.3/§8.7.2.2 added bars beyond the area requirement. */
+  spacingGoverned: boolean;
+  /** §25.2.1 satisfied. False means the bars do not fit across this width. */
+  clearOK: boolean;
+}
+
+/**
+ * Bar count + centre-to-centre spacing for a MAT, with the maximum-spacing
+ * clause folded into the count.
+ *
+ * `h` is the total thickness, which is what the clause is written against.
+ */
+export function matLayout(params: {
+  As: number; db: number; b: number; cover: number; h: number;
+  kind?: MatKind; aggregate?: number;
+}): MatBarLayout {
+  const { As, db, b, cover, h } = params;
+  const kind = params.kind ?? 'one-way';
+  const Ab = (Math.PI / 4) * db * db;
+  const sMax = maxBarSpacing(kind, h);
+  // Span between the outermost bar centres — the length the spacing divides.
+  const run = Math.max(0, b - 2 * cover - db);
+  const nArea = Math.ceil(As / Ab);
+  const nSpacing = Math.ceil(run / sMax) + 1;
+  const n = Math.max(2, nArea, nSpacing);
+  const spacing = n > 1 ? run / (n - 1) : b;
+  const clear = spacing - db;
+  return {
+    n, spacing, clear, sMax,
+    spacingGoverned: nSpacing > nArea,
+    clearOK: clear >= minClearSpacing(db, params.aggregate) - 1e-9,
+  };
 }

--- a/webapp/src/engine/isolatedFooting.ts
+++ b/webapp/src/engine/isolatedFooting.ts
@@ -4,7 +4,7 @@
 // ─────────────────────────────────────────────────────────────────────────
 import { netBearing, squareSize } from './bearing';
 import { punchingDepth, oneWayShearDepth, type ColumnPosition } from './shear';
-import { flexuralSteel, barLayout } from './flexure';
+import { flexuralSteel, matLayout } from './flexure';
 
 export interface SquareFootingInput {
   /** Service (unfactored) axial load P, kN. */
@@ -68,7 +68,14 @@ export interface SquareFootingResult {
   rho: number;
   usedMinSteel: boolean;
   bars: number;
+  /** Centre-to-centre spacing, mm. */
   barSpacing: number;
+  /** §7.7.2.3 limit the mat was laid out against, mm. */
+  barSpacingMax: number;
+  /** True when §7.7.2.3 — not the area — decided the bar count. */
+  spacingGoverned: boolean;
+  /** §25.2.1 clear spacing satisfied. False = the bars do not fit. */
+  barsFit: boolean;
   /** Which paths produced this result. */
   analysis: 'design' | 'analyze';
   method: 'iteration' | 'approximate';
@@ -141,12 +148,18 @@ export function designSquareFooting(i: SquareFootingInput): SquareFootingResult 
   const Mu = qu * B * (arm * arm) / 2;              // kN·m over the full width B
   const b = B * 1000;                               // design width, mm
   const flex = flexuralSteel({ Mu, b, d: dFlex, fc: i.fc, fy: i.fy });
-  const layout = barLayout({ As: flex.As, db: i.barDia, b, cover: i.cover });
+  // A footing is detailed as a one-way slab (ACI 318-14 §13.3.2.1), so the
+  // §7.7.2.3 maximum spacing sets the bar count whenever the area does not.
+  const layout = matLayout({
+    As: flex.As, db: i.barDia, b, cover: i.cover, h: DcMm, kind: 'one-way',
+  });
 
   return {
     B, Dc: DcMm, qNet, qu, dPunch, dBeam, dFlex,
     steelArea: flex.As, rho: flex.rho, usedMinSteel: flex.usedMin,
     bars: layout.n, barSpacing: layout.spacing,
+    barSpacingMax: layout.sMax, spacingGoverned: layout.spacingGoverned,
+    barsFit: layout.clearOK,
     analysis, method, dProvided: DcMm - i.cover - i.barDia, punchOK, beamOK,
   };
 }

--- a/webapp/src/engine/pileCap.ts
+++ b/webapp/src/engine/pileCap.ts
@@ -6,7 +6,7 @@
 // ─────────────────────────────────────────────────────────────────────────
 
 import { twoWayVc, oneWayVc } from './shear';
-import { flexuralSteel, barLayout } from './flexure';
+import { flexuralSteel, matLayout } from './flexure';
 
 const PHI_V = 0.75;
 
@@ -243,11 +243,15 @@ export function designPileCap(inp: PileCapInput): PileCapResult {
 
   // x-direction bars (running in x, moment about y, width = capBy)
   const flexX   = flexuralSteel({ Mu: MuX, b: capBy, d, fc: inp.fc, fy: inp.fy });
-  const layoutX = barLayout({ As: flexX.As, db: inp.barDia, b: capBy, cover: inp.cover });
+  const layoutX = matLayout({
+    As: flexX.As, db: inp.barDia, b: capBy, cover: inp.cover, h: Dc, kind: 'one-way',
+  });
 
   // y-direction bars (running in y, moment about x, width = capBx)
   const flexY   = flexuralSteel({ Mu: MuY, b: capBx, d, fc: inp.fc, fy: inp.fy });
-  const layoutY = barLayout({ As: flexY.As, db: inp.barDia, b: capBx, cover: inp.cover });
+  const layoutY = matLayout({
+    As: flexY.As, db: inp.barDia, b: capBx, cover: inp.cover, h: Dc, kind: 'one-way',
+  });
 
   // ── Development length ───────────────────────────────────────────────────
   const ldReq    = devLength(inp.barDia, inp.fc, inp.fy, inp.cover, lambda);

--- a/webapp/src/engine/rectangularFooting.ts
+++ b/webapp/src/engine/rectangularFooting.ts
@@ -6,7 +6,7 @@
 // ─────────────────────────────────────────────────────────────────────────
 import { netBearing } from './bearing';
 import { punchingDepth, oneWayShearDepth, type ColumnPosition } from './shear';
-import { flexuralSteel, barLayout } from './flexure';
+import { flexuralSteel, matLayout } from './flexure';
 
 /** How the plan dimensions are determined. */
 export type RectSizing =
@@ -138,7 +138,11 @@ export function designRectangularFooting(i: RectFootingInput): RectFootingResult
   const MuLong = qu * By * (armX * armX) / 2;
   const bLong = By * 1000;
   const flexLong = flexuralSteel({ Mu: MuLong, b: bLong, d: dFlex, fc: i.fc, fy: i.fy });
-  const layoutLong = barLayout({ As: flexLong.As, db: i.barDia, b: bLong, cover: i.cover });
+  // Detailed as a one-way slab (ACI 318-14 §13.3.2.1): §7.7.2.3's maximum
+  // spacing sets the bar count whenever the required area does not.
+  const layoutLong = matLayout({
+    As: flexLong.As, db: i.barDia, b: bLong, cover: i.cover, h: DcMm, kind: 'one-way',
+  });
 
   // Short direction: cantilever in y, bars run along y and spread across Bx,
   // with the central-band concentration.
@@ -146,7 +150,9 @@ export function designRectangularFooting(i: RectFootingInput): RectFootingResult
   const MuShort = qu * Bx * (armY * armY) / 2;
   const bShort = Bx * 1000;
   const flexShort = flexuralSteel({ Mu: MuShort, b: bShort, d: dFlex, fc: i.fc, fy: i.fy });
-  const layoutShort = barLayout({ As: flexShort.As, db: i.barDia, b: bShort, cover: i.cover });
+  const layoutShort = matLayout({
+    As: flexShort.As, db: i.barDia, b: bShort, cover: i.cover, h: DcMm, kind: 'one-way',
+  });
   const beta = Bx / By;                               // long / short
   const bandFraction = 2 / (beta + 1);
   const bandBars = Math.max(2, Math.ceil(layoutShort.n * bandFraction));


### PR DESCRIPTION
**Phase 1 of 4** on the Model Space footing report: *"why is the footing design still 2 large bars (⌀32)?"*

`designSquareFooting` could detail a 0.95 m footing as **2⌀32 at 736 mm centres** and report it adequate. Three faults, all in the shared layout helper every mat engine uses — so all six had them.

## 1. The count floor was a beam rule

`barLayout` floors `n` at 2. That is **§9.7.2.1** — a beam having two bars to hang stirrups from. A mat has no such rule. What floors a mat is a **spacing**: §7.7.2.3 for one-way slabs and footings, §8.7.2.2 for two-way. Two bars satisfied the required area, and nothing else was being asked.

## 2. Nothing checked spacing at all

No §7.7.2.3, no §25.2.1. The engine returned 736 mm centres against a 450 mm limit with `ok: true` — and the model-space footing schedule, the foundation plan and the PDF report have all been printing those numbers.

## 3. `barLayout` returned the clear gap, labelled centre-to-centre

```
(b − 2·cover − n·db)/(n − 1)   ← the gap between bar FACES
(b − 2·cover − db)/(n − 1)     ← the centres, one diameter wider
```

Its own docstring said *"centre-to-centre"*, every schedule prints it as `@ x mm`, and §7.7.2.3 is written in centre-to-centre. Verified against bar positions rather than by reading the formula:

```
n=2, b=1000, cover=75, db=20 → bar centres at 85 and 915
  barLayout   (b−2c−n·db)/(n−1) = 810     ← equals the clear gap (905 − 95)
  true c/c    (b−2c−db)/(n−1)   = 830
13⌀16 across 2300:  barLayout 162  vs  true c/c 178
```

**Understating spacing against a maximum-spacing limit is the unsafe direction** — it makes a mat look tighter than it is.

## The fix

`matLayout` sits beside `barLayout` and applies the mat rules: count is `max(area, spacing)`, spacing returned is centre-to-centre, the clear gap is reported separately, and §25.2.1 is checked **including its 4/3·d_agg term**. `maxBarSpacing` and `minClearSpacing` live there too, so there is **one home for the rule** — `matRebarOptimize` had its own copy, which is exactly the drift the HANDOFF already records a lesson about.

Switched all six mat engines, since all six shared the defect: isolated, eccentric and rectangular footings, combined and flexible-combined footings, pile cap.

`SquareFootingResult` now carries `barSpacingMax`, `spacingGoverned` and `barsFit`, so a caller can gate on the mat rather than trust it.

## What changes

```
before  P 150 kN → 2⌀32 @ 736 mm   sMax 450 · VIOLATION
after   P 150 kN → 3⌀32 @ 384 mm   OK, spacing-governed
before  P 250 kN → 2⌀32 @ 1036 mm  sMax 450 · VIOLATION
after   P 250 kN → 4⌀32 @ 356 mm   OK, spacing-governed
before  P 900 kN → 4⌀32 @ 674 mm   sMax 450 · VIOLATION
after   P 900 kN → 6⌀32 @ 424 mm   OK, spacing-governed
```

The **⌀32 is the caller's doing** — `pipeline.ts` hands the footing the *column's* bar diameter — and is Phase 2. This PR makes the engine incapable of emitting a non-compliant mat regardless of who calls it.

## A test that enshrined the bug

`flexure.test.ts` asserted the spacing by **restating the formula**: `(1500 − 150 − n·20)/(n − 1)`. That pins the code to itself and can never catch a wrong convention. Replaced with the geometry it should have been derived from — first and last bar centres — plus a case that reconstructs the section width from `n` and `s`, which fails if the convention drifts either way.

**+8 cases** — the clause limits against hand calcs, spacing (not a count) flooring a mat, the count left alone when the area already needs more, c/c and clear reported one diameter apart, a mat whose bars don't fit flagged, and a two-way slab spaced tighter than a one-way slab of the same depth.

`npm test` — 203 files, **3468 passed**. `npx tsc -b`, `eslint --max-warnings 0`, `npm run build` green.

Engine layer **7** (standalone design engines).

## Remaining phases

- **2** — pipeline footings: stop inheriting the column's ⌀, route through `optimizeFootingRebar`
- **3** — pipeline slabs: route through `optimizeSlabRebar` (they get no bar search at all today)
- **4** — pipeline beams + columns: move off the old area-ranked `barSelection` onto the scorer, so Model Space and the calculator pages agree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_