### PR TITLE
fix(model): the footing mat picks its own bar, not the column's

### DIFF
--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -962,3 +962,65 @@ describe('engine integrations — prestressed member check', () => {
     expect(plain.prestressed).toEqual([])
   })
 })
+
+// ── Footing mats ──────────────────────────────────────────────────────────
+
+describe('footing mats are the footing\'s, not the column\'s', () => {
+  const designAt = (barDia: number) => {
+    const sec: RectSection = { ...section, barDia }
+    const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section: sec, slabThickness: 200 })
+    m.loads = m.plates.flatMap((p): ModelLoad[] => [
+      { kind: 'area', plate: p.id, q: 4.8, cat: 'D' },
+      { kind: 'area', plate: p.id, q: 2.4, cat: 'L' },
+    ])
+    return designStructure(m, soil)!
+  }
+
+  it('does not inherit the column cage diameter', () => {
+    // THE BUG. `pipeline` handed the footing `section.barDia`, so a ⌀32 column
+    // cage detailed the footing mat in ⌀32 — and with only the area to satisfy
+    // that came out as two bars at 700+ mm centres.
+    const mats = [20, 25, 32].map((db) => designAt(db).footings.map((f) => f.barDia))
+    for (const m of mats) expect(m).toEqual(mats[0])
+    // and the mat is not simply the column bar
+    expect(designAt(32).footings.every((f) => f.barDia < 32)).toBe(true)
+  })
+
+  it('every scheduled mat satisfies §7.7.2.3', () => {
+    for (const db of [20, 32]) {
+      for (const f of designAt(db).footings) {
+        expect(f.design.barSpacing, `${f.node} @⌀${db}`)
+          .toBeLessThanOrEqual(f.design.barSpacingMax + 1e-9)
+        expect(f.design.barsFit).toBe(true)
+        expect(f.design.bars).toBeGreaterThanOrEqual(2)
+      }
+    }
+  })
+
+  it('the row quotes the mat its own selection adopted', () => {
+    // Two sources of truth is how a schedule ends up citing a reason that
+    // describes a different mat: `designSquareFooting` lays out the bare
+    // §7.7.2.3 minimum, the optimiser picks off the spacing module.
+    for (const f of designAt(25).footings) {
+      const best = f.selection.best
+      expect(best, f.node).not.toBeNull()
+      expect(f.design.bars).toBe(best!.layout.bars)
+      expect(f.design.barSpacing).toBeCloseTo(best!.layout.spacing, 9)
+      expect(f.barDia).toBe(best!.layout.db)
+    }
+  })
+
+  it('provides at least the steel the flexure check demanded', () => {
+    for (const f of designAt(25).footings) {
+      const Ab = (Math.PI / 4) * f.barDia * f.barDia
+      expect(f.design.bars * Ab).toBeGreaterThanOrEqual(f.design.steelArea - 1e-6)
+    }
+  })
+
+  it('reports a ranking, so the choice can be argued with', () => {
+    const f = designAt(20).footings[0]
+    expect(f.selection.ranked.length).toBeGreaterThan(1)
+    expect(f.selection.margin.length).toBeGreaterThan(10)
+    expect(f.selection.best!.reason).toMatch(/⌀\d+ @ \d+/)
+  })
+})

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -35,6 +35,8 @@ import { designSteelJoints, designBeamBeamJoints, type SteelJoint, type BeamBeam
 import {
   chooseBar, crackControlOK, constructabilityOK, type BarCandidate,
 } from './barSelection'
+import { optimizeFootingRebar } from './matRebarOptimize'
+import type { RebarSelection } from './rebarScore'
 
 export interface SoilOptions {
   qAllow: number; gammaSoil: number; gammaConc: number; H: number
@@ -130,6 +132,18 @@ export interface ColumnScheduleRow {
 export interface FootingScheduleRow {
   node: string; P: number; Pu: number
   design: SquareFootingResult
+  /**
+   * The mat's OWN bar diameter, mm.
+   *
+   * It used to be the column's: the footing was handed `section.barDia`, so a
+   * ⌀32 column cage detailed the footing mat in ⌀32 too. Downstream then had
+   * to guess it back — `planDetails` reverse-engineered it from As/count and
+   * the report and take-off each reached for the column section — three
+   * independent guesses at a number nothing was carrying.
+   */
+  barDia: number
+  /** Ranked alternatives and the reason this mat was adopted. */
+  selection: RebarSelection
   ok: boolean
   gov?: string
 }
@@ -939,13 +953,35 @@ function designFromRuns(
     if (Pu < 1e-6) continue
     const P = Math.max(serviceAt(ru.node), Pu / 1.4)
     const fs = footSec(ru.node)
-    const d = designSquareFooting({
+    // The mat picks its own diameter and spacing. `fs` is the COLUMN section
+    // and only supplies the concrete grade, the steel grade and the column
+    // width the footing cantilevers from — its bar size is not the footing's
+    // business, and passing it was what produced 2⌀32 mats.
+    const fin = {
       serviceLoad: P, ultimateLoad: Pu, columnWidth: Math.min(fs.b, fs.h),
       fc: fs.fc, fy: fs.fy, qAllow: soil.qAllow,
       gammaSoil: soil.gammaSoil, gammaConc: soil.gammaConc, H: soil.H,
       barDia: fs.barDia, cover: 75,
+    }
+    const choice = optimizeFootingRebar(fin)
+    // No compliant mat is a real answer, but the row still needs a section to
+    // report — design it at the seed diameter and let `ok` carry the failure.
+    const base = choice.design ?? designSquareFooting(fin)
+    const barDia = choice.db ?? fs.barDia
+    // Quote the mat the optimiser ADOPTED, not the one `designSquareFooting`
+    // fell back to. The two differ: the engine lays out the bare §7.7.2.3
+    // minimum (2⌀10 @ 390 on a 0.55 m pad), the optimiser picks off the
+    // spacing module and scores it (3⌀10 @ 150). Leaving both in the row
+    // would put two different mats on the same footing — the schedule saying
+    // one thing and the selection it cites saying another.
+    const d: SquareFootingResult = choice.bars !== null && choice.spacing !== null
+      ? { ...base, bars: choice.bars, barSpacing: choice.spacing }
+      : base
+    footings.push({
+      node: ru.node, P, Pu, design: d, barDia, selection: choice.selection,
+      ok: d.qNet > 0 && d.punchOK && d.beamOK && d.barsFit && choice.db !== null,
+      gov,
     })
-    footings.push({ node: ru.node, P, Pu, design: d, ok: d.qNet > 0 && d.punchOK && d.beamOK, gov })
   }
 
   // ── Base plates (steel columns landing on a base support) ──

--- a/webapp/src/engine/planRenderer.ts
+++ b/webapp/src/engine/planRenderer.ts
@@ -35,7 +35,12 @@ export interface SlabScheduleRow { mark: string; thk: string; type: string }
 /** Minimal per-footing shape the foundation plan needs — mapped from the
  *  pipeline's `design.footings` by the caller, so this module stays decoupled
  *  from the design pipeline. Geometry in m; thickness/spacing in mm. */
-export interface PlanFooting { node: string; B: number; Dc: number; bars: number; barSpacing: number; barDia?: number }
+/** A designed footing, as the foundation plan needs it. `barDia` is the mat's
+ *  own bar — it used to be optional because the pipeline did not carry one and
+ *  callers inverted it out of As/count. */
+export interface PlanFooting {
+  node: string; B: number; Dc: number; bars: number; barSpacing: number; barDia: number
+}
 
 /** Anything the serializer can paint: typed primitives + their world bounds.
  *  Both plan drawings and standalone details satisfy this. */
@@ -159,7 +164,7 @@ export function buildPlan(model: StructuralModel, opts: PlanOptions = {}): PlanD
     if (!mk) {
       mk = `WF-${footMarkBySize.size + 1}`; footMarkBySize.set(key, mk)
       const sp = Math.round(f.barSpacing)
-      const reinf = f.barDia ? `${f.bars}-⌀${f.barDia}@${sp} mm E.W.` : `${f.bars}@${sp} mm E.W.`
+      const reinf = `${f.bars}-⌀${f.barDia}@${sp} mm E.W.`
       footingSchedule.push({ mark: mk, size: `${Bmm}×${Bmm}`, thk: `${Math.round(f.Dc)}`, reinf })
     }
     return mk

--- a/webapp/src/engine/takeoff.ts
+++ b/webapp/src/engine/takeoff.ts
@@ -226,10 +226,9 @@ export function estimateTakeoff(
 
   // ── Isolated footings ──
   for (const f of design.footings) {
-    const cs = (() => { const col = colAtNode(f.node); return col ? secOf(col.id) : fallback })()
     const B = f.design.B, Dc = f.design.Dc / 1000
     const tag = `Footing ${f.node}`
-    const steelKg = add(tag, 'Bottom (each way)', cs.barDia, 2 * f.design.bars, Math.max(0.1, B - 0.15))
+    const steelKg = add(tag, 'Bottom (each way)', f.barDia, 2 * f.design.bars, Math.max(0.1, B - 0.15))
     byElement.push({
       kind: 'Footing', id: f.node, concreteM3: B * B * Dc, formworkM2: 4 * B * Dc, steelKg,
       intersections: f.design.bars * f.design.bars,

--- a/webapp/src/lib/modelReport.ts
+++ b/webapp/src/lib/modelReport.ts
@@ -385,9 +385,8 @@ export function buildModelReport(
     head: ['Node', 'P (kN)', 'Pu (kN)', 'B (m)', 'Dc (mm)', 'Reinforcement', 'Status'],
     right: [1, 2, 3, 4],
     rows: design.footings.map((f) => {
-      const cs = colSectionAt(f.node)
       return [f.node, f0(f.P), f0(f.Pu), f2(f.design.B), f0(f.design.Dc),
-        `${f.design.bars}⌀${cs?.barDia ?? fallbackSec.barDia}@${Math.round(f.design.barSpacing)} e.w.`, f.ok ? 'PASS' : 'FAIL']
+        `${f.design.bars}⌀${f.barDia}@${Math.round(f.design.barSpacing)} e.w.`, f.ok ? 'PASS' : 'FAIL']
     }),
   })
   if (design.combined.length) tables.push({

--- a/webapp/src/lib/planDetails.test.ts
+++ b/webapp/src/lib/planDetails.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { generateGridModel } from '../engine/modelBuilder'
 import { designStructure } from '../engine/pipeline'
-import { footingsForPlan, footingDetailBundles, recoverBarDia } from './planDetails'
+import { footingsForPlan, footingDetailBundles } from './planDetails'
 import type { RectSection, ModelLoad } from '../engine/model'
 
 const section: RectSection = { id: 'S1', name: '400×400', b: 400, h: 400, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
@@ -19,13 +19,21 @@ function designed() {
 describe('planDetails — design → plan/detail inputs', () => {
   const { model, design } = designed()
 
-  it('recoverBarDia snaps a steel area + count back to a standard bar', () => {
-    const As = 4 * (Math.PI / 4) * 20 * 20   // 4 × ⌀20
-    expect(recoverBarDia(As, 4)).toBe(20)
-    expect(recoverBarDia(0, 0)).toBe(16)      // safe fallback
+  it('takes the bar Ø from the schedule row rather than recovering it', () => {
+    // There used to be a `recoverBarDia` here that inverted As/count back to a
+    // standard size, because the row did not carry the diameter. It does now,
+    // and the plan quotes it directly — an inversion cannot be wrong about a
+    // number it is no longer computing.
+    const fs = footingsForPlan(design)
+    for (const [i, f] of fs.entries()) {
+      expect(f.barDia).toBe(design.footings[i].barDia)
+      // and the area it reports is consistent with that bar and that count
+      const Ab = (Math.PI / 4) * f.barDia * f.barDia
+      expect(f.bars * Ab).toBeGreaterThanOrEqual(design.footings[i].design.steelArea - 1e-6)
+    }
   })
 
-  it('maps every designed footing to a PlanFooting with a recovered bar Ø', () => {
+  it('maps every designed footing to a PlanFooting with its own bar Ø', () => {
     const fs = footingsForPlan(design)
     expect(fs).toHaveLength(design.footings.length)
     for (const f of fs) {

--- a/webapp/src/lib/planDetails.ts
+++ b/webapp/src/lib/planDetails.ts
@@ -11,22 +11,13 @@ import type { ColumnSchematicProps } from '../components/ColumnSchematic'
 
 export interface SoilInput { qAllow?: number; gammaSoil?: number; gammaConc?: number; H?: number }
 
-const STD_BARS = [10, 12, 16, 20, 25, 28, 32, 36]   // mm ladder
-
-/** Recover the main-bar diameter from a designed steel area + bar count
- *  (the footing result carries As and count, not the diameter). */
-export function recoverBarDia(As: number, bars: number): number {
-  if (!bars || As <= 0) return 16
-  const d = Math.sqrt((4 * (As / bars)) / Math.PI)
-  return STD_BARS.reduce((p, c) => (Math.abs(c - d) < Math.abs(p - d) ? c : p), STD_BARS[0])
-}
 
 /** Designed footings → the plan renderer's minimal PlanFooting shape. */
 export function footingsForPlan(design: StructureDesign): PlanFooting[] {
   return design.footings.map((r) => ({
     node: r.node, B: r.design.B, Dc: r.design.Dc,
     bars: r.design.bars, barSpacing: r.design.barSpacing,
-    barDia: recoverBarDia(r.design.steelArea, r.design.bars),
+    barDia: r.barDia,
   }))
 }
 
@@ -63,7 +54,7 @@ export function footingDetailBundles(model: StructuralModel, design: StructureDe
       mark,
       detail: {
         mark, B: r.design.B, H: r.design.Dc / 1000, cover: 75,
-        barDia: recoverBarDia(r.design.steelArea, r.design.bars),
+        barDia: r.barDia,
         bars: r.design.bars, barSpacing: r.design.barSpacing,
         colB, colH, colBars, colBarDia, tieDia, colCover: sec?.cover ?? 40,
         foundingElev: soil.H != null ? -Math.abs(soil.H) : undefined,


### PR DESCRIPTION
**Phase 2 of 4** on the Model Space footing report, on top of #533.

## The bug

`pipeline.ts` handed `designSquareFooting` **`section.barDia` — the column's cage bar**:

```ts
const fs = footSec(ru.node)          // ← the COLUMN section at this node
const d = designSquareFooting({ …, barDia: fs.barDia, cover: 75 })
```

Define your columns with ⌀32 and every footing mat in the model was detailed in ⌀32. With only the required area to satisfy (#533 has the rest of that story), that came out as **two bars**.

There is no engineering relationship between a column cage bar and a footing mat bar. `fs` legitimately supplies the concrete grade, the steel grade and the column width the footing cantilevers from. Its bar size was never the footing's business.

## The fix

Footings now go through `optimizeFootingRebar` — the same search the Foundation Design page has used since #530: diameter × spacing module, gated on §22.2 / §21.2.2 / §7.6.1.1 / §7.7.2.3 / §25.2.1, scored on the stated priority order.

On the reference grid, **the mat is now identical whatever the column cage is** — which is the whole point:

```
column cage ⌀20:  n0.0.0  Pu  62 kN  B 0.55  →  3⌀10 @ 150 mm  PASS
                  n1.0.0  Pu 136 kN  B 0.80  →  4⌀10 @ 175 mm  PASS
column cage ⌀25:  n0.0.0  Pu  62 kN  B 0.55  →  3⌀10 @ 150 mm  PASS
column cage ⌀32:  n0.0.0  Pu  62 kN  B 0.55  →  3⌀10 @ 150 mm  PASS

reason: ⌀10 @ 150 — 3 bars across the strip — well distributed for crack
        control, easy to place, economical, a standard bar size.
```

## Three independent guesses, deleted

Nothing was carrying the footing's diameter, so three consumers each invented one:

| | was | now |
|---|---|---|
| `planDetails` | **inverted it out of As ÷ count** (`recoverBarDia`) and snapped to the nearest standard size | reads the row |
| `modelReport` | `cs?.barDia ?? fallbackSec.barDia` — the column section again | reads the row |
| `takeoff` | weighed footing steel at the **column bar size** | reads the row |

`FootingScheduleRow` now carries `barDia` and the full `selection`. `recoverBarDia` is deleted — an inversion cannot be wrong about a number it is no longer computing. `PlanFooting.barDia` becomes required; it was optional only because no caller had one to give.

The compiler found all three the moment the reads were replaced: each left a now-unused `cs`, `STD_BARS` or import behind, which is decent evidence they existed *only* to paper over the missing field.

## One more, found while wiring it

The row quoted `designSquareFooting`'s own layout while citing the **optimiser's** selection as the reason — and the two differ. The engine lays out the bare §7.7.2.3 minimum; the optimiser picks off the spacing module and scores it:

```
engine     2⌀10 @ 390    ← minimum that complies
optimiser  3⌀10 @ 150    ← what the reason describes
```

Two mats on one footing, with the schedule and the reason it cites disagreeing. The row now adopts the mat that was actually selected, and there is a test pinning them together.

## Verification

**+5 pipeline cases** — the mat does not track the column cage across three diameters *and* is never simply the column bar; every scheduled mat satisfies §7.7.2.3 and fits per §25.2.1; the row quotes the mat its own selection adopted; the steel provided covers the flexure demand; a ranking with a margin is reported. The `planDetails` test for the deleted inversion becomes one asserting the plan takes the diameter from the row and that it is consistent with the area.

`npm test` — 203 files, **3473 passed**. `npx tsc -b`, `eslint --max-warnings 0`, `npm run build` green.

Engine layer **6** (design pipeline).

## Remaining

- **3** — pipeline slabs: route through `optimizeSlabRebar` (they get no bar search at all today)
- **4** — pipeline beams + columns: move off the old area-ranked `barSelection` onto the scorer, so Model Space and the calculator pages agree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_