### PR TITLE
fix(model): slabs get a searched mat, and a fabricated one is never shown

### DIFF
--- a/webapp/src/engine/matRebarOptimize.ts
+++ b/webapp/src/engine/matRebarOptimize.ts
@@ -47,7 +47,9 @@
 // ─────────────────────────────────────────────────────────────────────────
 
 import { designSquareFooting, type SquareFootingInput, type SquareFootingResult } from './isolatedFooting'
-import { designSlabDDM, type SlabInput, type SlabDesignResult } from './slabDDM'
+import {
+  designSlabDDM, type SlabInput, type SlabDesignResult, type SlabDirResult,
+} from './slabDDM'
 import {
   dominantBlocker, selectRebar, type Candidate, type ComplianceCheck,
   type RebarLayout, type RebarSelection, type ScoreContext,
@@ -424,6 +426,32 @@ export function slabStrips(r: SlabDesignResult): MatStrip[] {
     }
   }
   return out
+}
+
+/**
+ * Fold the adopted per-strip mats back into a DDM result.
+ *
+ * `optimizeSlabRebar` chooses one diameter for the panel and a spacing per
+ * strip; `designSlabDDM` lays out whatever it was handed. Leaving both in play
+ * puts two different mats on one panel — the schedule saying one thing and the
+ * selection it cites saying another. The strip labels are built here, so the
+ * mapping back belongs here too.
+ */
+export function applySlabMats(
+  r: SlabDesignResult, strips: readonly SlabRebarChoice['strips'][number][],
+): SlabDesignResult {
+  const by = new Map(strips.map((s) => [s.label, s]))
+  const dir = (dr: SlabDirResult): SlabDirResult => ({
+    ...dr,
+    locations: dr.locations.map((loc) => {
+      const cut = (which: 'column' | 'middle') => {
+        const m = by.get(`${dr.dir}-dir ${loc.name} ${which} strip`)
+        return m ? { ...loc[which], bars: m.bars, spacing: m.spacing } : loc[which]
+      }
+      return { ...loc, column: cut('column'), middle: cut('middle') }
+    }),
+  })
+  return { ...r, x: dir(r.x), y: dir(r.y) }
 }
 
 /**

--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -1024,3 +1024,69 @@ describe('footing mats are the footing\'s, not the column\'s', () => {
     expect(f.selection.best!.reason).toMatch(/⌀\d+ @ \d+/)
   })
 })
+
+// ── Slab mats ─────────────────────────────────────────────────────────────
+
+describe('slab mats are searched, not assumed', () => {
+  const panelAt = (thickness: number, D: number, L: number) => {
+    const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section, slabThickness: thickness })
+    m.loads = m.plates.flatMap((p): ModelLoad[] => [
+      { kind: 'area', plate: p.id, q: D, cat: 'D' },
+      { kind: 'area', plate: p.id, q: L, cat: 'L' },
+    ])
+    return designStructure(m, soil)!.slabs
+  }
+
+  it('the diameter responds to the load instead of being a hard-coded 12', () => {
+    // It was literally `barDia: 12` in the pipeline, again in the take-off as
+    // SLAB_BAR, and again in the on-screen schedule as the string "⌀12".
+    const light = panelAt(200, 4.8, 2.4)
+    const heavy = panelAt(250, 6.0, 5.0)
+    expect(light[0].barDia).toBeLessThan(heavy[0].barDia)
+    expect(light.every((s) => s.barDia > 0)).toBe(true)
+  })
+
+  it('one diameter serves a panel, but the spacing varies by strip', () => {
+    // Mixing bar sizes within a panel is how the wrong bar reaches the wrong
+    // strip; varying the SPACING is how a slab is actually drawn.
+    for (const sl of panelAt(150, 3.0, 2.0)) {
+      const spacings = [sl.design.x, sl.design.y].flatMap((dr) =>
+        dr.locations.flatMap((l) => [l.column.spacing, ...(l.middle.b > 1 ? [l.middle.spacing] : [])]))
+      expect(new Set(spacings.map((x) => Math.round(x))).size).toBeGreaterThan(1)
+    }
+  })
+
+  it('every strip satisfies §8.7.2.2', () => {
+    for (const sl of panelAt(200, 4.8, 2.4)) {
+      const sMax = Math.min(2 * sl.design.h, 450)
+      for (const dr of [sl.design.x, sl.design.y]) {
+        for (const loc of dr.locations) {
+          expect(loc.column.spacing, `${sl.plate} ${dr.dir} ${loc.name} CS`).toBeLessThanOrEqual(sMax + 1e-6)
+          if (loc.middle.b > 1) {
+            expect(loc.middle.spacing, `${sl.plate} ${dr.dir} ${loc.name} MS`).toBeLessThanOrEqual(sMax + 1e-6)
+          }
+        }
+      }
+    }
+  })
+
+  it('the schedule quotes the diameter its own selection adopted', () => {
+    for (const sl of panelAt(200, 4.8, 2.4)) {
+      expect(sl.selection.best).not.toBeNull()
+      expect(sl.barDia).toBe(sl.selection.best!.layout.db)
+      expect(sl.selection.best!.reason).toMatch(/⌀\d+ @ \d+/)
+    }
+  })
+
+  it('every strip still carries at least the steel its flexure check demanded', () => {
+    for (const sl of panelAt(250, 6.0, 5.0)) {
+      const Ab = (Math.PI / 4) * sl.barDia * sl.barDia
+      for (const dr of [sl.design.x, sl.design.y]) {
+        for (const loc of dr.locations) {
+          expect(loc.column.bars * Ab).toBeGreaterThanOrEqual(loc.column.As - 1e-6)
+          if (loc.middle.b > 1) expect(loc.middle.bars * Ab).toBeGreaterThanOrEqual(loc.middle.As - 1e-6)
+        }
+      }
+    }
+  })
+})

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -35,7 +35,7 @@ import { designSteelJoints, designBeamBeamJoints, type SteelJoint, type BeamBeam
 import {
   chooseBar, crackControlOK, constructabilityOK, type BarCandidate,
 } from './barSelection'
-import { optimizeFootingRebar } from './matRebarOptimize'
+import { optimizeFootingRebar, optimizeSlabRebar, applySlabMats } from './matRebarOptimize'
 import type { RebarSelection } from './rebarScore'
 
 export interface SoilOptions {
@@ -158,6 +158,17 @@ export interface SlabScheduleRow {
   plate: string
   lx: number; ly: number
   design: SlabDesignResult
+  /**
+   * The panel's bar diameter, mm.
+   *
+   * It used to be a hard-coded 12 here and again in the take-off and again in
+   * the on-screen schedule — three copies of an assumption nobody had chosen.
+   * One diameter serves the whole panel; the SPACING varies per strip, which
+   * is how a slab is drawn.
+   */
+  barDia: number
+  /** Ranked alternatives and the reason this mat was adopted. */
+  selection: RebarSelection
   ok: boolean
 }
 /** A plate carrying a timber deck-on-joist floor, designed by the woodSlab
@@ -1075,19 +1086,33 @@ function designFromRuns(
     const cs = footSec(p.corners[0])
     const extX = cc.some((q) => Math.abs(q.x - xMin) < 1e-4) || cc.some((q) => Math.abs(q.x - xMax) < 1e-4)
     const extZ = cc.some((q) => Math.abs(q.z - zMin) < 1e-4) || cc.some((q) => Math.abs(q.z - zMax) < 1e-4)
-    const design = designSlabDDM({
+    const sin = {
       lx, ly: lz, colWidth: Math.min(cs.b, cs.h), D: areaD, L: areaL,
       fc: cs.fc, fy: cs.fy, h: p.thickness, cover: 20, barDia: 12,
       exterior: { x: extX, y: extZ }, withBeams: true,
-    })
+    }
+    // One diameter for the panel, spacing per strip. The 12 above is only a
+    // seed for the degenerate path — the search replaces it.
+    const mat = optimizeSlabRebar(sin)
+    const barDia = mat.db ?? 12
+    // Quote the mats that were actually selected, not the layout designSlabDDM
+    // fell back to; the two differ and a schedule citing a reason that
+    // describes a different mat is worse than no reason at all.
+    const design = mat.design && mat.db !== null
+      ? applySlabMats(mat.design, mat.strips)
+      : designSlabDDM(sin)
     // Pass = §408.3.1.2 minimum thickness AND §424.2 immediate-live + long-term
     // deflection. DDM inapplicability (one-way panel, L > 2D) stays a schedule
     // note — the strips are still detailed conservatively — so it does not
     // dead-end the optimizer; serviceability violations DO fail the design.
     slabs.push({
-      plate: p.id, lx, ly: lz, design,
+      plate: p.id, lx, ly: lz, design, barDia, selection: mat.selection,
       ok: design.h >= design.hmin - 1e-9
-        && design.deflection.liveOK && design.deflection.totalOK,
+        && design.deflection.liveOK && design.deflection.totalOK
+        // No compliant mat is a design failure, not a detailing note: on a
+        // panel at its §408.3.1.2 minimum thickness it means the steel it
+        // needs is past the tension-controlled limit at φ = 0.90.
+        && mat.db !== null,
     })
   }
   // timber-deck panels add their joist + decking volume to the timber total

--- a/webapp/src/engine/takeoff.ts
+++ b/webapp/src/engine/takeoff.ts
@@ -28,7 +28,6 @@ const STEEL_DENSITY = 7850            // kg/m³
 const BAR_LENGTH = 6                  // m, commercial length
 const TIE_WIRE_ROLL = 2385            // m per roll (#16 G.I.)
 const GI_WIRE_KG_PER_M = 0.0189       // #16 G.I. tie wire, ~1.6 mmØ
-const SLAB_BAR = 12                   // slab mat bar Ø, mm (matches designSlabDDM)
 
 const barAreaM2 = (dia: number) => (Math.PI / 4) * (dia / 1000) ** 2
 const kgPerM = (dia: number) => barAreaM2(dia) * STEEL_DENSITY
@@ -269,9 +268,9 @@ export function estimateTakeoff(
         if (bars <= 0) continue
         if (loc.name === '+M') {
           bottomBarsOf.push(bars)
-          steelKg += add(tag, `Bottom +M (${label})`, SLAB_BAR, bars, span)        // full-span bottom mat
+          steelKg += add(tag, `Bottom +M (${label})`, sl.barDia, bars, span)       // full-span bottom mat
         } else {
-          steelKg += add(tag, `Top ${loc.name} (${label})`, SLAB_BAR, bars, 0.3 * dir.ln) // cutoff over support
+          steelKg += add(tag, `Top ${loc.name} (${label})`, sl.barDia, bars, 0.3 * dir.ln) // cutoff over support
         }
       }
     }

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -4701,6 +4701,11 @@ export default function ModelSpace() {
                       open && (
                         <tr key={`${key}:sol`}>
                           <td colSpan={6} className="bg-slate-50/60 px-3 pb-3">
+                            {!sl.selection.best && (
+                              <div className="mb-3 rounded border border-[#efd4cc] bg-[#fbeeea] px-3 py-2 text-[11.5px] text-[#8f2f1e]">
+                                <b>No compliant mat.</b> {sl.selection.margin}
+                              </div>
+                            )}
                             <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
                               {[dd.x, dd.y].map((dr) => (
                                 <div key={dr.dir}>
@@ -4721,8 +4726,16 @@ export default function ModelSpace() {
                                         <tr key={li} className="border-t border-slate-100">
                                           <td className="py-0.5 pr-2">{loc.name} <span className="text-slate-500">({loc.coeff.toFixed(2)})</span></td>
                                           <td className="py-0.5 pr-2 text-right">{f1(loc.M)}</td>
-                                          <td className="py-0.5 pr-2">⌀12 @ {Math.round(loc.column.spacing)}{loc.column.usedMin ? ' (min)' : ''}</td>
-                                          <td className="py-0.5">{loc.middle.b > 1 ? `⌀12 @ ${Math.round(loc.middle.spacing)}${loc.middle.usedMin ? ' (min)' : ''}` : '—'}</td>
+                                          {/* When nothing complies there is no mat to quote. Printing the
+                                              fallback layout would present a §8.7.2.2 violation as a design. */}
+                                          <td className="py-0.5 pr-2">{sl.selection.best
+                                            ? `⌀${sl.barDia} @ ${Math.round(loc.column.spacing)}${loc.column.usedMin ? ' (min)' : ''}`
+                                            : <span className="text-[#c2402a]">no compliant mat</span>}</td>
+                                          <td className="py-0.5">{loc.middle.b > 1
+                                            ? (sl.selection.best
+                                              ? `⌀${sl.barDia} @ ${Math.round(loc.middle.spacing)}${loc.middle.usedMin ? ' (min)' : ''}`
+                                              : <span className="text-[#c2402a]">no compliant mat</span>)
+                                            : '—'}</td>
                                         </tr>
                                       ))}
                                     </tbody>
@@ -5455,7 +5468,7 @@ export default function ModelSpace() {
                       <td className="py-1 pr-2 text-right">{f1(f.P)} / {f1(f.Pu)}</td>
                       <td className="py-1 pr-2">B = {f2(f.design.B)} m</td>
                       <td className="py-1 pr-2">{Math.round(f.design.Dc)} mm</td>
-                      <td className="py-1 pr-2">{f.design.bars}⌀{cs?.barDia} @ {Math.round(f.design.barSpacing)} e.w.</td>
+                      <td className="py-1 pr-2">{f.design.bars}⌀{f.barDia} @ {Math.round(f.design.barSpacing)} e.w.</td>
                       <td className="py-1 text-slate-500">{f.gov}</td>
                     </tr>,
                     open && model && (


### PR DESCRIPTION
**Phase 3 of 4** on the Model Space footing/slab report, on top of #533 and #534.

## Slabs had no bar search at all

`barDia: 12` was hard-coded in the pipeline, again in the take-off as `SLAB_BAR`, and again in the on-screen schedule as the literal string `"⌀12"` — three copies of an assumption nobody had chosen.

Slabs now go through `optimizeSlabRebar`: **one diameter for the panel, spacing per strip**, which is how a slab is drawn. `applySlabMats` folds the adopted mats back onto the DDM result and lives in `matRebarOptimize`, because that is where the strip labels are built — the mapping and the labelling have to stay in one place.

```
h 200, D 4.8 / L 2.4  →  ⌀10, spacings 100 and 125
h 150, D 3.0 / L 2.0  →  ⌀10, spacings 100, 150, 175, 200
h 250, D 6.0 / L 5.0  →  ⌀12, spacings 125 and 150
```

## Two more, found by driving Model Space in a browser

The unit tests were green for both of these. Loading the page and clicking through a design run was what caught them.

### 1. A fourth consumer was still reading the column's bar

#534 fixed the report, the take-off and the plans. The **on-screen footing schedule has its own JSX** and was untouched:

```
schedule showed:   6⌀20 @ 175 e.w.      12⌀28 @ 125 e.w.
engine detailed:   6⌀10 @ 175           12⌀10 @ 125
```

Same counts, same spacings, different bar — which is exactly how this class of bug hides. Fixed, and confirmed in the browser after.

### 2. When no mat complies, the schedule still printed one

On the page's **own default model** — 6 × 5 panels, 150 mm, 4.8 + 2.4 kPa — the panel is genuinely too thin: 25 candidates fail §22.2 and 15 fail §21.2.2. The optimiser said so correctly. The pipeline then fell back to `designSlabDDM`, and the schedule printed that layout as though it were a design:

```
x Ext −M:  CS ⌀12 @ 276    MS ⌀12 @ 311   ← §8.7.2.2 limit is 2h = 300
x Int −M:  CS ⌀12 @  67    MS ⌀12 @ 311   ← VIOLATION
```

A non-answer presented as an answer, and a non-compliant one. The strips now read **"no compliant mat"** and the panel carries the blocking gates with their clause numbers, the same diagnosis the calculator pages got in #531.

## Verification

**+5 pipeline cases** — the diameter responds to load instead of being a constant; one diameter serves a panel while the spacing varies by strip; every strip satisfies §8.7.2.2; the schedule quotes the diameter its own selection adopted; every strip still carries at least the steel its flexure check demanded.

Browser-verified on `/model` through *Regenerate grid model → Design all → Design*: the footing schedule now reads `6⌀10 @ 175` where it read `6⌀20`, and 0 console errors.

`npm test` — 203 files, **3478 passed**. `npx tsc -b`, `eslint --max-warnings 0` green.

Engine layer **6** (design pipeline).

## Remaining

- **4** — pipeline beams + columns: move off the old area-ranked `barSelection` onto the scorer, so Model Space and the calculator pages agree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_