### PR TITLE
style(pages): one header, one letterhead, one place

### DIFF
--- a/webapp/src/components/ReportControls.tsx
+++ b/webapp/src/components/ReportControls.tsx
@@ -1,6 +1,7 @@
 import { useState, type JSX } from 'react'
 import type { CalcPdfInput } from '../lib/calcPdf'
 import { ExportPdfButton } from './ExportPdfButton'
+import { LetterheadCard } from './calc'
 import { loadProfile, letterheadDefaults } from '../lib/auth/profile'
 import { BRAND_MARK, BRAND_TAIL, docLabel } from '../lib/brand'
 
@@ -53,14 +54,6 @@ export function ReportControls({ title, badges = ['NSCP 2015', 'ACI 318-14'], re
     window.setTimeout(() => { document.title = prev }, 500)
   }
 
-  const field = (label: string, value: string, set: (v: string) => void, ph: string, mono = false) => (
-    <label className="flex min-w-36 flex-1 flex-col text-sm">
-      <span className="mb-1 text-[11.5px] font-semibold text-[#5c6675]">{label}</span>
-      <input value={value} onChange={(e) => set(e.target.value)} placeholder={ph}
-        className={`text-[13px] ${mono ? 'font-mono' : ''}`} />
-    </label>
-  )
-
   const lhCells: [string, string, boolean][] = [
     ['Project', project || '—', false], ['Sheet', sheet || '—', true],
     ['Prepared by', preparedBy || '—', false], ['Date', today, true],
@@ -68,27 +61,28 @@ export function ReportControls({ title, badges = ['NSCP 2015', 'ACI 318-14'], re
 
   return (
     <>
-      {/* Screen: letterhead card + export */}
-      <div className="no-print mt-4 rounded-lg border border-[#e3e1da] bg-white p-3">
-        <div className="mb-2 flex items-center justify-between px-1">
-          <h2 className="text-[13.5px] font-bold text-[#0f1b2a]">Report letterhead</h2>
-          <span className="font-mono text-[10px] text-[#a39d8d]">prints on the calc sheet</span>
-        </div>
-        <div className="flex flex-wrap items-end gap-3">
-          {field('Project / job', project, setProject, 'Lot 12 Residence')}
-          {field('Sheet', sheet, setSheet, 'S-01 · Rev A', true)}
-          {field('Prepared by', preparedBy, setPreparedBy, 'Engineer, CE')}
-          {report ? (
+      {/* Screen: the SAME letterhead card the calc-template pages use. It used
+          to be a second implementation here — outlined inputs in a flex row
+          rather than the borderless grid — so the two halves of the app looked
+          like two apps. One card, one style. */}
+      <div className="no-print mt-4">
+        <LetterheadCard
+          lh={{ project, sheet, preparedBy }}
+          onChange={(p) => {
+            if (p.project !== undefined) setProject(p.project)
+            if (p.sheet !== undefined) setSheet(p.sheet)
+            if (p.preparedBy !== undefined) setPreparedBy(p.preparedBy)
+          }}
+          action={report ? (
             <ExportPdfButton {...report} docTitle={title} badges={badges}
               lh={{ project, sheet, preparedBy }}
-              className="ml-auto inline-flex items-center gap-2 rounded-md bg-[#0f4c92] px-4 py-2 text-sm font-semibold text-white hover:bg-[#0d3f78] disabled:opacity-50" />
+              className="inline-flex flex-none items-center gap-2 rounded-md bg-[#0f4c92] px-3.5 py-1.5 text-[12.5px] font-semibold text-white hover:bg-[#0d3f78] disabled:opacity-50" />
           ) : (
             <button type="button" onClick={print}
-              className="ml-auto inline-flex items-center gap-2 rounded-md bg-[#0f4c92] px-4 py-2 text-sm font-semibold text-white hover:bg-[#0d3f78]">
+              className="inline-flex flex-none items-center gap-2 rounded-md bg-[#0f4c92] px-3.5 py-1.5 text-[12.5px] font-semibold text-white hover:bg-[#0d3f78]">
               ⎙ Export report
             </button>
-          )}
-        </div>
+          )} />
       </div>
 
       {/* Print: calc-sheet letterhead header */}

--- a/webapp/src/components/calc.tsx
+++ b/webapp/src/components/calc.tsx
@@ -122,7 +122,12 @@ export function DrawingCard({ title, meta, children, pdfDrawing }: {
 // ── Report letterhead (screen card) ─────────────────────────────────────────
 export interface LetterheadState { project: string; sheet: string; preparedBy: string }
 
-export function LetterheadCard({ lh, onChange }: { lh: LetterheadState; onChange: (p: Partial<LetterheadState>) => void }) {
+export function LetterheadCard({ lh, onChange, action }: {
+  lh: LetterheadState
+  onChange: (p: Partial<LetterheadState>) => void
+  /** Optional export control, rendered beside the heading. */
+  action?: ReactNode
+}) {
   const today = new Date().toISOString().slice(0, 10)
   const cell = (label: string, value: string, key: keyof LetterheadState, ph: string, mono = false) => (
     <div>
@@ -133,9 +138,9 @@ export function LetterheadCard({ lh, onChange }: { lh: LetterheadState; onChange
   )
   return (
     <section className="rail-card no-print rounded-lg border border-[#e3e1da] bg-white p-4">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-3">
         <h2 className="text-[13.5px] font-bold text-[#0f1b2a]">Report letterhead</h2>
-        <span className="font-mono text-[10px] text-[#a39d8d]">prints on the calc sheet</span>
+        {action ?? <span className="font-mono text-[10px] text-[#a39d8d]">prints on the calc sheet</span>}
       </div>
       <div className="mt-2.5 grid grid-cols-2 gap-x-3.5 gap-y-2">
         {cell('Project', lh.project, 'project', 'Lot 12 Residence')}

--- a/webapp/src/pages/BeamAnalysis.tsx
+++ b/webapp/src/pages/BeamAnalysis.tsx
@@ -12,6 +12,7 @@ import { ReportControls } from '../components/ReportControls'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { f1, f2 } from '../lib/format'
 import 'katex/dist/katex.min.css'
+import { PageHeader } from '../components/calc'
 
 const CATS: [LoadCategory, string][] = [
   ['D', 'D — dead'], ['L', 'L — live'], ['Lr', 'Lr — roof live'],
@@ -105,9 +106,9 @@ export default function BeamAnalysis() {
   const vlines = supports.map((s) => ({ x: s.x, label: s.type === 'spring' ? 'k' : s.type[0].toUpperCase() }))
 
   return (
-    <div className="mx-auto max-w-[1500px] p-6">
-      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
-      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Beam Analysis</h1>
+    <div>
+      <PageHeader title="Beam Analysis" badges={['NSCP 2015', 'ACI 318-14']} />
+      <div className="mx-auto max-w-[1500px] px-6 pb-6 pt-5">
       <p className="no-print mt-1 text-slate-600">
         Euler–Bernoulli FEM (Hermite elements, Gauss-5) with modular supports — pin / roller / fixed / spring at any
         position — and categorised loads run through all 7 NSCP 2015 load combinations. Includes a three-moment
@@ -285,6 +286,7 @@ export default function BeamAnalysis() {
           </p>
         </div>
       )}
+      </div>
     </div>
   )
 }

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -224,6 +224,7 @@ export default function BeamDesign() {
             ))}
           </div>
         } />
+        <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
       <div className="mx-auto max-w-[1500px] px-5 pb-8 sm:px-7">
 
       <div className="no-print mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
@@ -442,7 +443,6 @@ export default function BeamDesign() {
                 sub={`L/240 = ${deflection.limitL240.toFixed(1)} mm${deflection.totalOK ? ' ✓' : ' ✗'}`} />
             </ResultCard>
           )}
-          <LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} />
         </div>
       </div>
 

--- a/webapp/src/pages/BearingCapacity.tsx
+++ b/webapp/src/pages/BearingCapacity.tsx
@@ -1,5 +1,4 @@
 import { useState, useMemo } from 'react'
-import { Link } from 'react-router-dom'
 import {
   generalBearingCapacity, compareMethods, BEARING_METHOD_LABEL, type BearingMethod,
 } from '../engine/bearingGeneral'
@@ -9,6 +8,7 @@ import { WorkedSolution } from '../components/WorkedSolution'
 import { buildBearingSolution } from '../lib/geotechPageSolutions'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { f1, f2, f3 } from '../lib/format'
+import { PageHeader } from '../components/calc'
 
 // Split out of the old combined "Geotechnical toolkit" page. Bearing capacity
 // is reached from foundation design, earth pressure from retaining walls —
@@ -53,9 +53,9 @@ export default function BearingCapacity() {
   const r = solved.r
 
   return (
-    <main className="mx-auto max-w-[1400px] px-5 py-8 sm:px-7">
-      <Link to="/geotech" className="no-print text-sm text-[#0056b3] hover:underline">← Geotechnical</Link>
-      <h1 className="mt-1 text-2xl font-extrabold tracking-tight text-[#0056b3]">Bearing Capacity</h1>
+        <div>
+      <PageHeader title="Bearing Capacity" badges={['Meyerhof', 'Hansen', 'Vesić']} />
+      <main className="mx-auto max-w-[1400px] px-5 py-6 sm:px-7">
       <p className="no-print mt-1 max-w-3xl text-sm text-slate-600">
         Shallow-foundation bearing capacity by the general equation, with shape, depth and
         inclination factors and Meyerhof&rsquo;s effective area for eccentric load. Nq and Nc are
@@ -155,5 +155,6 @@ export default function BearingCapacity() {
 
       {steps.length > 0 && <WorkedSolution steps={steps} />}
     </main>
+    </div>
   )
 }

--- a/webapp/src/pages/BoltedConnection.tsx
+++ b/webapp/src/pages/BoltedConnection.tsx
@@ -4,6 +4,7 @@ import { ConnectionDrawing } from '../components/ConnectionDrawing'
 import { outOfPlaneBoltGroup, pryingAction } from '../engine/steelDesign'
 import type { BoltPos, BoltGrade } from '../engine/steelDesign'
 import { ReportControls } from '../components/ReportControls'
+import { PageHeader } from '../components/calc'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -46,9 +47,9 @@ export default function BoltedConnection() {
   const delBolt = (i: number) => setBolts((bs) => bs.filter((_, j) => j !== i).map((b, k) => ({ ...b, id: `B${k + 1}` })))
 
   return (
-    <main className="mx-auto max-w-[1400px] px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Structural · Steel</p>
-      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Eccentric bolted connection</h1>
+        <div>
+      <PageHeader title="Eccentric bolted connection" badges={['AISC 360-16']} />
+      <main className="mx-auto max-w-[1400px] px-5 py-6">
       <ReportControls title="Bolted Connection Report" badges={['AISC 360-16']} />
       <p className="mt-2 max-w-3xl text-sm text-slate-600">
         Elastic (vector) method for an eccentrically-loaded bolt group. Each bolt carries the direct
@@ -220,5 +221,6 @@ export default function BoltedConnection() {
         )}
       </section>
     </main>
+    </div>
   )
 }

--- a/webapp/src/pages/ColumnDesign.tsx
+++ b/webapp/src/pages/ColumnDesign.tsx
@@ -188,6 +188,7 @@ export default function ColumnDesign() {
   return (
     <div>
       <PageHeader title="RC Column" badges={['ACI 318-14', 'NSCP 2015']} />
+      <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
       <div className="mx-auto max-w-[1500px] px-5 pb-8 sm:px-7">
 
       <div className="no-print mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
@@ -413,7 +414,6 @@ export default function ColumnDesign() {
         </div>
       )}
 
-      <div className="no-print mt-5"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
       <div className="no-print">{solution.length > 0 && <WorkedSolution steps={solution} title="Calculation report — worked solution" />}</div>
       {axial && solution.length > 0 && (
         <PrintReport

--- a/webapp/src/pages/CombinedFootingDesign.tsx
+++ b/webapp/src/pages/CombinedFootingDesign.tsx
@@ -170,6 +170,7 @@ export default function CombinedFootingDesign() {
   return (
     <div>
       <PageHeader title="Combined Footing" badges={['ACI 318-14', 'NSCP 2015']} />
+      <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
       <div className="mx-auto max-w-[1500px] px-5 pb-8 sm:px-7">
 
       <div className="no-print mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
@@ -344,7 +345,6 @@ export default function CombinedFootingDesign() {
         )}
       </div>
 
-      <div className="no-print mt-5"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
       <div className="no-print">
         {solutionSteps && (
           <WorkedSolution steps={solutionSteps} title="Combined footing — worked solution (rigid method)" />

--- a/webapp/src/pages/DevLength.tsx
+++ b/webapp/src/pages/DevLength.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
 import { calcDevLength, type DevLengthInput, type EpoxyCase } from '../engine/devLength'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { ReportControls } from '../components/ReportControls'
@@ -9,6 +8,7 @@ import { WorkedSolution } from '../components/WorkedSolution'
 import { CodeHint } from '../components/CodeHint'
 import { DevLengthDetail } from '../components/DevLengthDetail'
 import { DEV_HINTS } from '../lib/devLengthHints'
+import { PageHeader } from '../components/calc'
 
 const BAR_SIZES: [string, string][] = [
   ['10', '10 mm (ø10)'],
@@ -104,11 +104,9 @@ export default function DevLength() {
   } : undefined
 
   return (
-    <div className="mx-auto max-w-[1500px] p-6">
-      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
-      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">
-        Development &amp; Splice Lengths
-      </h1>
+        <div>
+      <PageHeader title="Development & Splice Lengths" badges={['ACI 318-14 §25.4', 'NSCP 2015']} />
+      <div className="mx-auto max-w-[1500px] p-6">
       <p className="no-print mt-1 text-slate-600">
         ACI 318-14 §25.4 development + §25.5 splices. SI units (mm, MPa).
         Tension §25.4.2.3 · Compression §25.4.9.2 · Splices §25.5.2/5.
@@ -240,6 +238,7 @@ export default function DevLength() {
           <WorkedSolution steps={solution} title="Calculation report — worked solution" />
         </div>
       )}
+    </div>
     </div>
   )
 }

--- a/webapp/src/pages/EarthPressure.tsx
+++ b/webapp/src/pages/EarthPressure.tsx
@@ -1,5 +1,4 @@
 import { useState, useMemo } from 'react'
-import { Link } from 'react-router-dom'
 import { activeThrust, passiveThrust } from '../engine/geotech'
 import { coulombActiveThrust, coulombPassiveThrust, mononobeOkabe } from '../engine/coulomb'
 import { ReportControls } from '../components/ReportControls'
@@ -8,6 +7,7 @@ import { WorkedSolution } from '../components/WorkedSolution'
 import { buildEarthPressureSolution } from '../lib/geotechPageSolutions'
 import { Num, Card, ResultCard, Row } from '../components/qty'
 import { f1, f2, f3 } from '../lib/format'
+import { PageHeader } from '../components/calc'
 
 // Split out of the old combined "Geotechnical toolkit" page, which stacked
 // earth pressure, bearing capacity and slope stability on one screen. They
@@ -63,9 +63,9 @@ export default function EarthPressure() {
   const notes = [...(coulomb.active?.notes ?? []), ...(coulomb.passive?.notes ?? []), ...(seismic.r?.notes ?? [])]
 
   return (
-    <main className="mx-auto max-w-[1400px] px-5 py-8 sm:px-7">
-      <Link to="/geotech" className="no-print text-sm text-[#0056b3] hover:underline">← Geotechnical</Link>
-      <h1 className="mt-1 text-2xl font-extrabold tracking-tight text-[#0056b3]">Lateral Earth Pressure</h1>
+        <div>
+      <PageHeader title="Lateral Earth Pressure" badges={['Rankine', 'Coulomb', 'NSCP 2015']} />
+      <main className="mx-auto max-w-[1400px] px-5 py-6 sm:px-7">
       <p className="no-print mt-1 max-w-3xl text-sm text-slate-600">
         Rankine and Coulomb active and passive thrust, with the Mononobe–Okabe seismic case.
         Rankine needs a smooth vertical wall and level fill; Coulomb carries wall friction, an
@@ -151,5 +151,6 @@ export default function EarthPressure() {
 
       <WorkedSolution steps={steps} />
     </main>
+    </div>
   )
 }

--- a/webapp/src/pages/FoundationDesign.tsx
+++ b/webapp/src/pages/FoundationDesign.tsx
@@ -299,6 +299,7 @@ export default function FoundationDesign() {
             ⎙ Export report
           </button>
         } />
+        <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
       <div className="mx-auto max-w-[1500px] px-5 pb-8 sm:px-7">
       <div className="no-print"><ExcelImport onResult={setBatch} /></div>
 
@@ -526,7 +527,6 @@ export default function FoundationDesign() {
             </div>
           )}
 
-          <LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} />
         </div>
       </div>
 

--- a/webapp/src/pages/FrameAnalysis.tsx
+++ b/webapp/src/pages/FrameAnalysis.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
 import {
   analyzeFrame2D, type FNode, type FMember, type FSupport, type FSupportType, type FLoad,
 } from '../engine/frame2d'
@@ -10,6 +9,7 @@ import { ReportControls } from '../components/ReportControls'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { f1, f2 } from '../lib/format'
 import 'katex/dist/katex.min.css'
+import { PageHeader } from '../components/calc'
 
 const CATS: [LoadCategory, string][] = [
   ['D', 'D — dead'], ['L', 'L — live'], ['Lr', 'Lr — roof live'],
@@ -88,9 +88,9 @@ export default function FrameAnalysis() {
   const updMember = upd(setMembers)
 
   return (
-    <div className="mx-auto max-w-[1500px] p-6">
-      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
-      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Frame Analysis (2D)</h1>
+    <div>
+      <PageHeader title="Frame Analysis (2D)" badges={['NSCP 2015', 'ACI 318-14']} />
+      <div className="mx-auto max-w-[1500px] px-6 pb-6 pt-5">
       <p className="no-print mt-1 text-slate-600">
         2D frame FEM — 6-DOF members (axial + Hermite bending) built on the shared core, with pinned / roller /
         fixed nodes, nodal & member gravity loads, and all 7 NSCP 2015 load combinations. Phase 2 of the 3D
@@ -268,6 +268,7 @@ export default function FrameAnalysis() {
           </div>
         </div>
       )}
+      </div>
     </div>
   )
 }

--- a/webapp/src/pages/LateralPile.tsx
+++ b/webapp/src/pages/LateralPile.tsx
@@ -6,6 +6,7 @@ import {
 } from '../engine/lateralPile'
 import { buildLateralPileSolution } from '../lib/lateralPileSolution'
 import { WorkedSolution } from '../components/WorkedSolution'
+import { PageHeader } from '../components/calc'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -163,9 +164,9 @@ export default function LateralPile() {
   }
 
   return (
-    <main className="mx-auto max-w-3xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
-      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Laterally loaded pile</h1>
+        <div>
+      <PageHeader title="Laterally loaded pile" badges={['Broms', 'Matlock', 'API RP 2A']} />
+      <main className="mx-auto max-w-3xl px-5 py-6">
       <ReportControls title="Laterally Loaded Pile" badges={['Broms', 'Matlock', 'API RP 2A']} report={report} />
       <p className="mt-2 text-sm text-slate-600">
         Two questions, two methods. <strong>Broms</strong> gives the ultimate lateral capacity in closed form and
@@ -259,5 +260,6 @@ export default function LateralPile() {
         <WorkedSolution steps={solution} title="Calculation report — worked solution" />
       </div>
     </main>
+    </div>
   )
 }

--- a/webapp/src/pages/LoadCombinations.tsx
+++ b/webapp/src/pages/LoadCombinations.tsx
@@ -1,9 +1,9 @@
 import { useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
 import { calcLoadCombinations, type LoadDemands } from '../engine/loadCombinations'
 import { Num, Card } from '../components/qty'
 import { ReportControls } from '../components/ReportControls'
 import { f2 } from '../lib/format'
+import { PageHeader } from '../components/calc'
 
 const DEFAULTS: LoadDemands = { D: 0, L: 0, Lr: 0, W: 0, E: 0 }
 
@@ -22,11 +22,9 @@ export default function LoadCombinations() {
   )
 
   return (
-    <div className="mx-auto max-w-[1200px] p-6">
-      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
-      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">
-        Load Combinations
-      </h1>
+        <div>
+      <PageHeader title="Load Combinations" badges={['NSCP 2015', 'ACI 318-14']} />
+      <div className="mx-auto max-w-[1200px] p-6">
       <p className="no-print mt-1 text-slate-600">
         NSCP 2015 §203.3 Strength Design (LRFD) — 13 factored combinations.
         Enter unfactored characteristic loads; the table shows every factored result
@@ -109,6 +107,7 @@ export default function LoadCombinations() {
           </p>
         )}
       </div>
+    </div>
     </div>
   )
 }

--- a/webapp/src/pages/LoadPath.tsx
+++ b/webapp/src/pages/LoadPath.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import { distributePanel, wallLineLoad, type AreaLoad } from '../engine/tributary'
 import type { LoadCategory } from '../engine/beamAnalysis'
 import { PanelSketch } from '../components/PanelSketch'
@@ -9,6 +9,7 @@ import { tributarySolution } from '../lib/tributarySolution'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { f1, f2 } from '../lib/format'
 import 'katex/dist/katex.min.css'
+import { PageHeader } from '../components/calc'
 
 export const BEAM_LOADS_HANDOFF_KEY = 'beam-analysis-loads-handoff'
 
@@ -48,9 +49,9 @@ export default function LoadPath() {
   }
 
   return (
-    <div className="mx-auto max-w-[1500px] p-6">
-      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
-      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Slab Load Path (Tributary)</h1>
+        <div>
+      <PageHeader title="Slab Load Path (Tributary)" badges={['NSCP 2015', 'ACI 318-14']} />
+      <div className="mx-auto max-w-[1500px] p-6">
       <p className="no-print mt-1 text-slate-600">
         Distribute a slab panel's area loads to its edge beams — one-way (UDL on the long edges) or two-way
         (45° tributary triangles & trapezoids) — with categories preserved for the NSCP combinations. Send any
@@ -140,6 +141,7 @@ export default function LoadPath() {
       </div>
 
       {solution && <WorkedSolution steps={solution} title="Load path — step by step" />}
+    </div>
     </div>
   )
 }

--- a/webapp/src/pages/Micropile.tsx
+++ b/webapp/src/pages/Micropile.tsx
@@ -3,6 +3,7 @@ import { designMicropile } from '../engine/micropile'
 import { ReportControls } from '../components/ReportControls'
 import { buildMicropileSolution } from '../lib/geotechSolutions'
 import { WorkedSolution } from '../components/WorkedSolution'
+import { PageHeader } from '../components/calc'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -81,9 +82,9 @@ export default function Micropile() {
   }
 
   return (
-    <main className="mx-auto max-w-3xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
-      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Micropile — axial capacity</h1>
+        <div>
+      <PageHeader title="Micropile — axial capacity" badges={['FHWA-NHI-05-039']} />
+      <main className="mx-auto max-w-3xl px-5 py-6">
       <ReportControls title="Micropile" badges={['FHWA-NHI-05-039']} report={report} />
       <p className="mt-2 text-sm text-slate-600">
         FHWA-NHI-05-039 allowable-stress check: structural capacity of the bar/casing/grout vs the
@@ -143,5 +144,6 @@ export default function Micropile() {
         <WorkedSolution steps={solution} title="Calculation report — worked solution" />
       </div>
     </main>
+    </div>
   )
 }

--- a/webapp/src/pages/PileCapDesign.tsx
+++ b/webapp/src/pages/PileCapDesign.tsx
@@ -162,6 +162,7 @@ export default function PileCapDesign() {
   return (
     <div>
       <PageHeader title="Pile Cap" badges={['ACI 318-14', 'NSCP 2015']} />
+      <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
       <div className="mx-auto max-w-[1500px] px-5 pb-8 sm:px-7">
 
       <div className="no-print mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
@@ -314,7 +315,6 @@ export default function PileCapDesign() {
           )}
         </div>
       </div>
-      <div className="no-print mt-5"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
       {result && (
         <PrintReport
           docTitle="Pile Cap" docCode="PC-01" badges={['ACI 318-14', 'NSCP 2015']}

--- a/webapp/src/pages/PlumbingDesign.tsx
+++ b/webapp/src/pages/PlumbingDesign.tsx
@@ -5,6 +5,7 @@ import { designDrainage, drainageSolution } from '../engine/drainage'
 import { designSepticTank, septicSolution } from '../engine/septicTank'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { ReportControls } from '../components/ReportControls'
+import { PageHeader } from '../components/calc'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -88,9 +89,9 @@ export default function PlumbingDesign() {
   )
 
   return (
-    <main className="mx-auto max-w-3xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Plumbing &amp; Sanitary</p>
-      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Plumbing System Design</h1>
+        <div>
+      <PageHeader title="Plumbing System Design" badges={['RNPCP 2000']} />
+      <main className="mx-auto max-w-3xl px-5 py-6">
       <ReportControls title="Plumbing Design Report" badges={['RNPCP 2000']} />
       <p className="mt-2 text-sm text-slate-600">
         Water supply, sanitary drainage (DWV) and on-site sewage treatment to the Revised National Plumbing Code
@@ -243,5 +244,6 @@ export default function PlumbingDesign() {
         </>
       )}
     </main>
+    </div>
   )
 }

--- a/webapp/src/pages/PrestressedBeam.tsx
+++ b/webapp/src/pages/PrestressedBeam.tsx
@@ -75,6 +75,7 @@ export default function PrestressedBeam() {
   return (
     <div className="min-h-screen">
       <PageHeader title="Prestressed Beam" badges={[...badges, `class ${klass}`]} />
+      <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(p) => setLh((s) => ({ ...s, ...p }))} /></div>
       <div className="mx-auto max-w-[1500px] px-5 py-5 sm:px-7">
         <p className="no-print text-[13px] text-[#5c6675]">
           <Link to="/" className="font-semibold text-[#0f4c92]">← Home</Link> · Pretensioned bonded beam: PCI losses
@@ -124,7 +125,6 @@ export default function PrestressedBeam() {
                 <PSElevation h={h} e={e} span={span} />
               </DrawingCard>
             )}
-            <LetterheadCard lh={lh} onChange={(p) => setLh((s) => ({ ...s, ...p }))} />
           </div>
         </div>
         {r && (

--- a/webapp/src/pages/PunchingShear.tsx
+++ b/webapp/src/pages/PunchingShear.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
 import { designPunchingShear, type PunchingInput, type ColPosition } from '../engine/punchingShear'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { ReportControls } from '../components/ReportControls'
@@ -7,6 +6,7 @@ import { buildPunchingSolution } from '../lib/punchingSolution'
 import { f0, f1, f2, f3 } from '../lib/format'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { PunchingPlan } from '../components/PunchingPlan'
+import { PageHeader } from '../components/calc'
 
 interface FormState {
   c1: number; c2: number         // column dimensions, mm
@@ -88,11 +88,9 @@ export default function PunchingShear() {
   } : undefined
 
   return (
-    <div className="mx-auto max-w-[1500px] p-6">
-      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
-      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">
-        Punching Shear
-      </h1>
+        <div>
+      <PageHeader title="Punching Shear" badges={['ACI 318-14 §22.6', 'NSCP 2015']} />
+      <div className="mx-auto max-w-[1500px] p-6">
       <p className="no-print mt-1 text-slate-600">
         Two-way slab–column punching shear — ACI 318-14 §22.6.
         Critical perimeter at d/2 from column face. φ = 0.75.
@@ -181,6 +179,7 @@ export default function PunchingShear() {
           <WorkedSolution steps={solution} title="Calculation report — worked solution" />
         </div>
       )}
+    </div>
     </div>
   )
 }

--- a/webapp/src/pages/RetainingWall.tsx
+++ b/webapp/src/pages/RetainingWall.tsx
@@ -50,6 +50,7 @@ export default function RetainingWall() {
   return (
     <div>
       <PageHeader title="Cantilever Retaining Wall" badges={['NSCP 2015', 'ACI 318-14']} />
+      <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
       <div className="mx-auto max-w-[1500px] px-5 pb-8 sm:px-7">
 
       {/* The section drawing carries what the numbers cannot: which FACE each
@@ -201,7 +202,6 @@ export default function RetainingWall() {
       </div>
       {r && <WorkedSolution steps={buildRetainingWallSolution(f, r)} />}
 
-      <div className="no-print mt-5"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
       {r && (
         <PrintReport
           docTitle="Cantilever Retaining Wall" docCode="RW-01" badges={['NSCP 2015', 'ACI 318-14']}

--- a/webapp/src/pages/RockAnchor.tsx
+++ b/webapp/src/pages/RockAnchor.tsx
@@ -3,6 +3,7 @@ import { designRockAnchor } from '../engine/rockAnchor'
 import { ReportControls } from '../components/ReportControls'
 import { buildRockAnchorSolution } from '../lib/geotechSolutions'
 import { WorkedSolution } from '../components/WorkedSolution'
+import { PageHeader } from '../components/calc'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -73,9 +74,9 @@ export default function RockAnchor() {
   }
 
   return (
-    <main className="mx-auto max-w-3xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
-      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Rock / ground anchor</h1>
+        <div>
+      <PageHeader title="Rock / ground anchor" badges={['PTI DC35.1']} />
+      <main className="mx-auto max-w-3xl px-5 py-6">
       <ReportControls title="Rock Anchor" badges={['PTI DC35.1']} report={report} />
       <p className="mt-2 text-sm text-slate-600">
         PTI DC35.1 / FHWA-IF-99-015 check: prestressing-tendon design load (0.60·GUTS) and grout-ground
@@ -113,5 +114,6 @@ export default function RockAnchor() {
         <WorkedSolution steps={solution} title="Calculation report — worked solution" />
       </div>
     </main>
+    </div>
   )
 }

--- a/webapp/src/pages/SeismicWizard.tsx
+++ b/webapp/src/pages/SeismicWizard.tsx
@@ -4,6 +4,7 @@ import {
   nscpSeismicParams, baseShearCoeff, STRUCTURAL_SYSTEMS,
   type SoilProfile, type SeismicSource, type SeismicZone, type Occupancy,
 } from '../engine/nscpSeismic'
+import { PageHeader } from '../components/calc'
 
 const f3 = (n: number) => (Number.isFinite(n) ? n.toFixed(3) : '—')
 
@@ -56,9 +57,9 @@ export default function SeismicWizard() {
   const cur = steps[Math.min(step, steps.length - 1)]
 
   return (
-    <main className="mx-auto max-w-3xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Structural</p>
-      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">NSCP 208 Seismic Wizard</h1>
+        <div>
+      <PageHeader title="NSCP 208 Seismic Wizard" badges={['NSCP 2015 §208']} />
+      <main className="mx-auto max-w-3xl px-5 py-6">
       <ReportControls title="Seismic Parameters Report" badges={['NSCP 2015 §208']} />
       <p className="mt-2 text-sm text-slate-600">
         Walk through the NSCP 2015 §208 static lateral-force tables — zone, soil, near-source, occupancy and
@@ -182,5 +183,6 @@ export default function SeismicWizard() {
         </p>
       </section>
     </main>
+    </div>
   )
 }

--- a/webapp/src/pages/Settlement.tsx
+++ b/webapp/src/pages/Settlement.tsx
@@ -9,6 +9,7 @@ import {
 import { buildSettlementSolution } from '../lib/settlementSolution'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { SoilProfile } from '../components/SoilProfile'
+import { PageHeader } from '../components/calc'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -162,9 +163,9 @@ export default function Settlement() {
   }
 
   return (
-    <main className="mx-auto max-w-3xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
-      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Foundation settlement</h1>
+        <div>
+      <PageHeader title="Foundation settlement" badges={['Boussinesq', 'Terzaghi', 'Schmertmann']} />
+      <main className="mx-auto max-w-3xl px-5 py-6">
       <ReportControls title="Foundation Settlement" badges={['Boussinesq', 'Terzaghi', 'Schmertmann']} report={report} />
       <p className="mt-2 text-sm text-slate-600">
         Immediate (elastic and Schmertmann) plus primary consolidation settlement of a rectangular footing on a
@@ -299,5 +300,6 @@ export default function Settlement() {
         <WorkedSolution steps={solution} title="Calculation report — worked solution" />
       </div>
     </main>
+    </div>
   )
 }

--- a/webapp/src/pages/ShotcreteFacing.tsx
+++ b/webapp/src/pages/ShotcreteFacing.tsx
@@ -3,6 +3,7 @@ import { designFacing } from '../engine/shotcreteFacing'
 import { ReportControls } from '../components/ReportControls'
 import { buildFacingSolution } from '../lib/geotechSolutions'
 import { WorkedSolution } from '../components/WorkedSolution'
+import { PageHeader } from '../components/calc'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -80,9 +81,9 @@ export default function ShotcreteFacing() {
   }
 
   return (
-    <main className="mx-auto max-w-3xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
-      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Soil-nail shotcrete facing</h1>
+        <div>
+      <PageHeader title="Soil-nail shotcrete facing" badges={['FHWA GEC-7']} />
+      <main className="mx-auto max-w-3xl px-5 py-6">
       <ReportControls title="Shotcrete Facing" badges={['FHWA GEC-7']} report={report} />
       <p className="mt-2 text-sm text-slate-600">
         FHWA GEC-7 facing check. The thin shotcrete panel spans <b>between</b> the nail heads, so earth
@@ -129,5 +130,6 @@ export default function ShotcreteFacing() {
         <WorkedSolution steps={solution} title="Calculation report — worked solution" />
       </div>
     </main>
+    </div>
   )
 }

--- a/webapp/src/pages/SlabDesign.tsx
+++ b/webapp/src/pages/SlabDesign.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
 import { designSlabDDM, type SlabInput, type SlabDirResult, type SlabSectionSteel } from '../engine/slabDDM'
 import { optimizeSlabRebar } from '../engine/matRebarOptimize'
 import { RebarRanking } from '../components/RebarRanking'
@@ -14,6 +13,7 @@ import { tempSteelArea, tempSpacingMax } from '../engine/slabBarDetail'
 import { f0, f1, f2 } from '../lib/format'
 import 'katex/dist/katex.min.css'
 import { WorkedSolution } from '../components/WorkedSolution'
+import { PageHeader } from '../components/calc'
 
 interface FormState {
   lx: number; ly: number
@@ -187,9 +187,9 @@ export default function SlabDesign() {
   } : undefined
 
   return (
-    <div className="mx-auto max-w-[1500px] p-6">
-      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
-      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Two-Way Slab Design</h1>
+        <div>
+      <PageHeader title="Two-Way Slab Design" badges={['ACI 318-14 §8.10', 'NSCP 2015 §408.10']} />
+      <div className="mx-auto max-w-[1500px] p-6">
       <p className="no-print mt-1 text-slate-600">
         Direct Design Method — NSCP 2015 §408.10 / ACI 318-14 §8.10. Square or rectangular interior and end panels;
         column-strip / middle-strip flexure; temp/shrinkage minimum; §408.7.2.2 spacing; mid-panel deflection by
@@ -338,6 +338,7 @@ export default function SlabDesign() {
           <WorkedSolution steps={solution} title="Calculation report — worked solution" />
         </div>
       )}
+    </div>
     </div>
   )
 }

--- a/webapp/src/pages/SlopeStability.tsx
+++ b/webapp/src/pages/SlopeStability.tsx
@@ -9,6 +9,7 @@ import { infiniteSlopeFS } from '../engine/geotech'
 import { buildInfiniteSlopeSolution } from '../lib/geotechPageSolutions'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { SoilLayerPicker } from '../components/SoilLayerPicker'
+import { PageHeader } from '../components/calc'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -166,9 +167,9 @@ export default function SlopeStability() {
   } : undefined
 
   return (
-    <main className="mx-auto max-w-3xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
-      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Slope stability — method of slices</h1>
+        <div>
+      <PageHeader title="Slope stability — method of slices" badges={['Bishop', 'Fellenius', 'Janbu']} />
+      <main className="mx-auto max-w-3xl px-5 py-6">
       <ReportControls title="Slope Stability" badges={['Bishop', 'Fellenius', 'Janbu']} report={report} />
       <p className="mt-2 text-sm text-slate-600">
         Circular-failure factor of safety by the method of slices — Fellenius/OMS, Bishop&rsquo;s simplified and
@@ -306,5 +307,6 @@ export default function SlopeStability() {
         <WorkedSolution steps={infSteps} title="Infinite slope — worked solution" />
       </section>
     </main>
+    </div>
   )
 }

--- a/webapp/src/pages/SoilNail.tsx
+++ b/webapp/src/pages/SoilNail.tsx
@@ -3,6 +3,7 @@ import { designSoilNail } from '../engine/soilNail'
 import { ReportControls } from '../components/ReportControls'
 import { buildSoilNailSolution } from '../lib/geotechSolutions'
 import { WorkedSolution } from '../components/WorkedSolution'
+import { PageHeader } from '../components/calc'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -83,9 +84,9 @@ export default function SoilNail() {
   }
 
   return (
-    <main className="mx-auto max-w-3xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Geotechnical</p>
-      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Soil-nail wall — per-nail check</h1>
+        <div>
+      <PageHeader title="Soil-nail wall — per-nail check" badges={['FHWA GEC-7']} />
+      <main className="mx-auto max-w-3xl px-5 py-6">
       <ReportControls title="Soil-Nail Wall" badges={['FHWA GEC-7']} report={report} />
       <p className="mt-2 text-sm text-slate-600">
         Preliminary FHWA GEC-7 checks for a single nail: tributary active demand vs bar-tensile and
@@ -133,5 +134,6 @@ export default function SoilNail() {
         <WorkedSolution steps={solution} title="Calculation report — worked solution" />
       </div>
     </main>
+    </div>
   )
 }

--- a/webapp/src/pages/StairDesign.tsx
+++ b/webapp/src/pages/StairDesign.tsx
@@ -4,6 +4,7 @@ import { ReportControls } from '../components/ReportControls'
 import { buildStairSolution } from '../lib/stairSolution'
 import { StairElevation } from '../components/StairElevation'
 import { WorkedSolution } from '../components/WorkedSolution'
+import { PageHeader } from '../components/calc'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -78,9 +79,9 @@ export default function StairDesign() {
   }
 
   return (
-    <main className="mx-auto max-w-3xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Structural</p>
-      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">RC stair flight — waist slab</h1>
+        <div>
+      <PageHeader title="RC stair flight — waist slab" badges={['NSCP 2015', 'ACI 318-14']} />
+      <main className="mx-auto max-w-3xl px-5 py-6">
       <ReportControls title="Stair Design" badges={['NSCP 2015', 'ACI 318-14']} report={report} />
       <p className="mt-2 text-sm text-slate-600">
         One-way waist-slab stair to NSCP 2015 / ACI 318-14. Self-weight of the inclined waist plus
@@ -145,5 +146,6 @@ export default function StairDesign() {
         <WorkedSolution steps={solution} title="Calculation report — worked solution" />
       </div>
     </main>
+    </div>
   )
 }

--- a/webapp/src/pages/SteelDesign.tsx
+++ b/webapp/src/pages/SteelDesign.tsx
@@ -1,5 +1,4 @@
 import { lazy, Suspense, useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
 import { shapesOf, shapeByName } from '../engine/aiscSections'
 import type { AiscShape } from '../engine/aiscSections'
 // type-only imports — no engine code bundled into the browser from here
@@ -14,6 +13,7 @@ import { ConnectionDrawing } from '../components/ConnectionDrawing'
 import type { SolutionStep } from '../lib/solution'
 import { f1, f2, f3 } from '../lib/format'
 import { sn1, sn2, sn3 } from '../lib/solution'
+import { PageHeader } from '../components/calc'
 
 const BeamViewer3D       = lazy(() => import('../components/SteelViewer3D').then(m => ({ default: m.BeamViewer3D })))
 const ColumnViewer3D     = lazy(() => import('../components/SteelViewer3D').then(m => ({ default: m.ColumnViewer3D })))
@@ -656,9 +656,9 @@ export default function SteelDesign() {
     </button>
   )
   return (
-    <div className="mx-auto max-w-[1500px] p-6">
-      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
-      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">Steel Design</h1>
+    <div>
+      <PageHeader title="Steel Design" badges={['NSCP 2015', 'ACI 318-14']} />
+      <div className="mx-auto max-w-[1500px] px-6 pb-6 pt-5">
       <p className="no-print mt-1 text-slate-600">
         AISC 360-16 LRFD — beams (§F/G + deflections), columns (§E3 + §H1-1), connections
         (bolt group with in-plane eccentricity, bearing/shear stresses, block shear §J4.3;
@@ -674,6 +674,7 @@ export default function SteelDesign() {
         {tab === 'beam'       && <BeamTab />}
         {tab === 'column'     && <ColumnTab />}
         {tab === 'connection' && <ConnectionTab />}
+      </div>
       </div>
     </div>
   )

--- a/webapp/src/pages/TBeamDesign.tsx
+++ b/webapp/src/pages/TBeamDesign.tsx
@@ -33,6 +33,7 @@ export default function TBeamDesign() {
   return (
     <div className="min-h-screen">
       <PageHeader title="T-Beam Design" badges={[...badges, kind]} />
+      <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(p) => setLh((s) => ({ ...s, ...p }))} /></div>
       <div className="mx-auto max-w-[1500px] px-5 py-5 sm:px-7">
         <p className="no-print text-[13px] text-[#5c6675]">
           <Link to="/" className="font-semibold text-[#0f4c92]">← Home</Link> · Flanged-beam flexure: §6.3.2 effective width,
@@ -81,7 +82,6 @@ export default function TBeamDesign() {
                 <TSection bf={r.bf} bw={bw} h={h} hf={hf} a={r.a} bars={r.bars} barDia={barDia} layers={r.layers} cover={cover} stirrupDia={stirrupDia} />
               </DrawingCard>
             )}
-            <LetterheadCard lh={lh} onChange={(p) => setLh((s) => ({ ...s, ...p }))} />
           </div>
         </div>
         {r && (

--- a/webapp/src/pages/TorsionDesign.tsx
+++ b/webapp/src/pages/TorsionDesign.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
 import { designTorsion, type TorsionInput } from '../engine/torsionDesign'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { ReportControls } from '../components/ReportControls'
@@ -7,6 +6,7 @@ import { buildTorsionSolution } from '../lib/torsionSolution'
 import { TorsionSection } from '../components/TorsionSection'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { f1, f2, f3 } from '../lib/format'
+import { PageHeader } from '../components/calc'
 
 interface FormState extends Omit<TorsionInput, 'legs' | 'lambda'> {
   legs: 2 | 4
@@ -79,11 +79,9 @@ export default function TorsionDesign() {
   } : undefined
 
   return (
-    <div className="mx-auto max-w-[1500px] p-6">
-      <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
-      <h1 className="mt-1 text-3xl font-extrabold tracking-tight text-[#0056b3]">
-        Torsion Design
-      </h1>
+        <div>
+      <PageHeader title="Torsion Design" badges={['ACI 318-14 §22.7', 'NSCP 2015']} />
+      <div className="mx-auto max-w-[1500px] p-6">
       <p className="no-print mt-1 text-slate-600">
         Rectangular RC section — ACI 318-14 §22.7 combined shear + torsion. SI units (mm, kN, MPa).
       </p>
@@ -202,6 +200,7 @@ export default function TorsionDesign() {
           <WorkedSolution steps={solution} title="Calculation report — worked solution" />
         </div>
       )}
+    </div>
     </div>
   )
 }

--- a/webapp/src/pages/WaterTank.tsx
+++ b/webapp/src/pages/WaterTank.tsx
@@ -4,6 +4,7 @@ import { ReportControls } from '../components/ReportControls'
 import { buildWaterTankSolution } from '../lib/waterTankSolution'
 import { TankSection } from '../components/TankSection'
 import { WorkedSolution } from '../components/WorkedSolution'
+import { PageHeader } from '../components/calc'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -78,9 +79,9 @@ export default function WaterTank() {
   }
 
   return (
-    <main className="mx-auto max-w-3xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Structural</p>
-      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Circular RC water tank — wall</h1>
+        <div>
+      <PageHeader title="Circular RC water tank — wall" badges={['IS 3370', 'ACI 350']} />
+      <main className="mx-auto max-w-3xl px-5 py-6">
       <ReportControls title="Circular Water Tank" badges={['IS 3370', 'ACI 350']} report={report} />
       <p className="mt-2 text-sm text-slate-600">
         Permissible-stress (working-stress) wall design for a circular liquid-retaining tank, following the
@@ -134,5 +135,6 @@ export default function WaterTank() {
         <WorkedSolution steps={solution} title="Calculation report — worked solution" />
       </div>
     </main>
+    </div>
   )
 }

--- a/webapp/src/pages/WeldedConnection.tsx
+++ b/webapp/src/pages/WeldedConnection.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { solveWeldedConnection, type WeldSegment } from '../engine/weldedConnection'
 import { ReportControls } from '../components/ReportControls'
+import { PageHeader } from '../components/calc'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -59,9 +60,9 @@ export default function WeldedConnection() {
   const delSeg = (i: number) => setSegs((ss) => ss.filter((_, j) => j !== i).map((s, k) => ({ ...s, id: `W${k + 1}` })))
 
   return (
-    <main className="mx-auto max-w-[1400px] px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Structural · Steel</p>
-      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Eccentric weld group</h1>
+        <div>
+      <PageHeader title="Eccentric weld group" badges={['AISC 360-16']} />
+      <main className="mx-auto max-w-[1400px] px-5 py-6">
       <ReportControls title="Welded Connection Report" badges={['AISC 360-16']} />
       <p className="mt-2 max-w-3xl text-sm text-slate-600">
         Elastic (weld-as-a-line) method for an eccentrically-loaded fillet weld group. Each unit length
@@ -139,5 +140,6 @@ export default function WeldedConnection() {
         </section>
       </div>
     </main>
+    </div>
   )
 }

--- a/webapp/src/pages/WoodSlab.tsx
+++ b/webapp/src/pages/WoodSlab.tsx
@@ -4,6 +4,7 @@ import { speciesList, gradesOf, resolveWoodSpecies } from '../engine/woodDesign'
 import type { LoadDuration } from '../engine/woodDesign'
 import { costTimberRows } from '../engine/takeoff'
 import { ReportControls } from '../components/ReportControls'
+import { PageHeader } from '../components/calc'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -92,9 +93,9 @@ export default function WoodSlab() {
   }) : null
 
   return (
-    <main className="mx-auto max-w-3xl px-5 py-10">
-      <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Structural · Timber</p>
-      <h1 className="mt-1 text-2xl font-bold text-[#0056b3]">Wood slab — deck on joists</h1>
+        <div>
+      <PageHeader title="Wood slab — deck on joists" badges={['NDS 2018 §3', 'NSCP 2015 §6']} />
+      <main className="mx-auto max-w-3xl px-5 py-6">
       <ReportControls title="Wood Slab Design Report" badges={['NDS 2018 §3', 'NSCP 2015 §6']} />
       <p className="mt-2 text-sm text-slate-600">
         ASD design of a wood floor slab: decking (planks or bamboo slats) spanning between repetitive
@@ -265,5 +266,6 @@ export default function WoodSlab() {
         </section>
       )}
     </main>
+    </div>
   )
 }


### PR DESCRIPTION
The app had **two page templates**. Eight calculator pages used the calc template — a `PageHeader` bar with title and code badges, and a `LetterheadCard` with borderless fields. The other **twenty-five** used a bespoke header (back-link, `h1`, description) and a *second* letterhead implementation inside `ReportControls` with outlined inputs in a flex row.

Two halves of one app that looked like two apps.

## 1. One letterhead

`ReportControls` now renders the **same `LetterheadCard`** the calc template uses, with the export control passed in through a new `action` slot. The duplicate field markup is deleted, so the borderless style is not something twenty-five pages have to keep agreeing about.

| | before | after |
|---|---|---|
| fields | outlined inputs, flex row, `Project / job · Sheet · Prepared by` | borderless, 2-col grid, `PROJECT · SHEET · PREPARED BY · DATE` |
| export | full-size button in the row | compact button in the card header |

## 2. One header

All twenty-five bespoke headers become `PageHeader`, carrying the title and the badges **the page already passed to `ReportControls`** — so nothing new had to be invented. Two shapes were in play:

- **kicker + h1** — `Structural · Timber` / `Wood slab — deck on joists` (13 pages)
- **back-link + h1 + description** — `← Home` / `Two-Way Slab Design` / paragraph (12 pages)

Both are now the same bar as Beam and Column.

## 3. Letterhead at the top, everywhere

It already *was* at the top on the twenty-five — it was the calc-template pages that had drifted:

```
BeamDesign        line 445 of 470   (bottom of the right rail)
RetainingWall     line 204          (mid-page)
FoundationDesign  line 529          (bottom)
T-Beam            line  84          (near the top)
```

All eight now sit directly under the header, at y ≈ 178.

## The back-links came out with the headers

The app shell already renders a breadcrumb — `Workbench / Concrete / Slab Design` — so a `← Home` link under it was the same navigation twice. **Descriptions stay**: those are content, not chrome, and they differ per page.

## Verification

Headless browser across **all 33 pages**. Every one: `PageHeader` bar present, letterhead between y = 168 and y = 288, all three letterhead fields borderless, no console error.

```
slab-design      h1="Two-Way Slab Design"  bar=1  letterheadY=256  borderless=3  err=0
beam-design      h1="Rectangular RC Beam"  bar=1  letterheadY=182  borderless=3  err=0
stair            h1="RC stair flight…"     bar=1  letterheadY=204  borderless=3  err=0
combined         h1="Combined Footing"     bar=1  letterheadY=178  borderless=3  err=0
…25 more, all identical in shape
```

`npm test` — 203 files, **3473 passed**. `npx tsc -b`, `eslint --max-warnings 0`, `npm run build` green.

Three pages (`BeamAnalysis`, `FrameAnalysis`, `SteelDesign`) are rooted in a `<div>` rather than a `<main>` and have helper components with their own closing tags — the bulk transform closed the wrong one, so those three were reverted and converted individually.

**Out of scope, noted rather than fixed:** `/beam-analysis` logs a React *"unique key"* warning that predates this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_