### PR TITLE
fix(model): beams and columns use the scorer, not the old ladder

### DIFF
--- a/webapp/src/engine/columnRebarOptimize.ts
+++ b/webapp/src/engine/columnRebarOptimize.ts
@@ -69,6 +69,29 @@ export interface ColumnRebarOptions {
   maxBars?: number
   /** Clear spacing below which placing concrete around the cage is awkward. */
   sComfort?: number
+  /**
+   * Extra gates for THIS cage, appended to the code checks.
+   *
+   * `designAxialColumn` is a pure axial design, and a real column usually
+   * carries a moment too. Rather than a second search that re-derives the P–M
+   * interaction here, the caller supplies the check it already knows how to
+   * make — the model-space pipeline gates on utilisation at the eccentricity
+   * Mu/Pu, using the same `capacityAtEccentricity` its schedule reports.
+   */
+  extraChecks?: (i: AxialColumnInput, r: AxialColumnResult) => ComplianceCheck[]
+  /**
+   * Which bar counts to consider for a diameter. Defaults to the full even
+   * sweep, which is the two-axis search this module exists for.
+   *
+   * A caller that cannot STORE a count must narrow it. The model-space
+   * pipeline is one: `RectSection` carries `barDia` and no bar count, so the
+   * count is re-derived downstream by `designAxialColumn`. Searching a count
+   * there would adopt a cage the schedule then silently recomputes into a
+   * different one — and a P–M check that passed during the search would fail
+   * on the section that actually shipped. It pins the count to the one the
+   * final design will use, and gets the scoring without the mismatch.
+   */
+  counts?: (i: AxialColumnInput, db: number) => readonly number[]
 }
 
 export interface ColumnRebarChoice {
@@ -178,7 +201,9 @@ export function optimizeColumnRebar(
 
   for (const db of sizes) {
     const Ab = (Math.PI / 4) * db * db
-    for (let bars = minBars; bars <= maxBars; bars += 2) {
+    const sweep: number[] = []
+    for (let n = minBars; n <= maxBars; n += 2) sweep.push(n)
+    for (const bars of opts.counts?.(i, db) ?? sweep) {
       const trial: AxialColumnInput = { ...i, barDia: db, numBars: bars }
       let r: AxialColumnResult
       try {
@@ -204,7 +229,13 @@ export function optimizeColumnRebar(
         d: r.Ag > 0 ? (i.h ?? i.D ?? 0) : 0,
         utilization: r.phiPnMax > 0 ? i.Pu / r.phiPnMax : Infinity,
       }
-      candidates.push({ layout, compliance: complianceOf(trial, r, bars, sClear) })
+      candidates.push({
+        layout,
+        compliance: [
+          ...complianceOf(trial, r, bars, sClear),
+          ...(opts.extraChecks?.(trial, r) ?? []),
+        ],
+      })
     }
   }
 

--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -1090,3 +1090,57 @@ describe('slab mats are searched, not assumed', () => {
     }
   })
 })
+
+// ── Beam and column bars go through the scorer ────────────────────────────
+
+describe('model space and the calculator pages agree on bars', () => {
+  const gridAt = (barDia: number) => {
+    const sec: RectSection = { ...section, barDia }
+    const m = generateGridModel({ baysX: [6, 6], baysZ: [5], storeyH: [3.5, 3], section: sec, slabThickness: 200 })
+    m.loads = m.plates.flatMap((p): ModelLoad[] => [
+      { kind: 'area', plate: p.id, q: 4.8, cat: 'D' },
+      { kind: 'area', plate: p.id, q: 2.4, cat: 'L' },
+    ])
+    return m
+  }
+
+  it('a beam member keeps ONE diameter across all its critical sections', () => {
+    const m = selectBarDiameters(gridAt(28), soil)
+    const d = designStructure(m, soil)!
+    const secOf = new Map(m.sections.map((s) => [s.id, s]))
+    const memSec = new Map(m.members.map((x) => [x.id, x.section]))
+    for (const row of d.beams) {
+      const sec = secOf.get(memSec.get(row.id) ?? '')
+      expect(sec, row.id).toBeDefined()
+      // every section of the member is detailed from that one section record
+      expect(row.sections.length).toBeGreaterThan(0)
+    }
+    // and the whole grid settles on sensible beam bars rather than the ⌀28 seed
+    const beamDias = new Set(m.sections.filter((s) => s.id.startsWith('b')).map((s) => s.barDia))
+    expect([...beamDias].every((d0) => d0 < 28)).toBe(true)
+  })
+
+  it('selection does not make a previously passing design fail', () => {
+    // The count axis is the trap: `RectSection` stores a diameter and no bar
+    // count, so a search that adopts a count has it silently recomputed
+    // downstream — and a P–M check that passed during the search fails on the
+    // section that shipped. Pinning the count is what keeps these equal.
+    const m0 = gridAt(28)
+    const before = designStructure(m0, soil)!
+    const after = designStructure(selectBarDiameters(m0, soil), soil)!
+    expect(after.columns.filter((c) => c.ok).length)
+      .toBeGreaterThanOrEqual(before.columns.filter((c) => c.ok).length)
+    expect(after.beams.filter((b) => b.ok).length)
+      .toBeGreaterThanOrEqual(before.beams.filter((b) => b.ok).length)
+  })
+
+  it('keeps one diameter through a continuous line and a column stack', () => {
+    const m = selectBarDiameters(gridAt(28), soil)
+    const secOf = new Map(m.sections.map((s) => [s.id, s]))
+    const memSec = new Map(m.members.map((x) => [x.id, x.section]))
+    for (const group of barContinuityGroups(m)) {
+      const dias = new Set(group.map((mid) => secOf.get(memSec.get(mid) ?? '')?.barDia))
+      expect(dias.size, group.join(',')).toBe(1)
+    }
+  })
+})

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -32,10 +32,9 @@ import { woodRefOf, checkWoodBeam, checkWoodColumn, getWoodRef, woodAdjusted } f
 import { designWoodSlab, type WoodSlabResult } from './woodSlab'
 import { designBasePlate, adoptPlateThickness, type BasePlateResult } from './baseplate'
 import { designSteelJoints, designBeamBeamJoints, type SteelJoint, type BeamBeamJoint } from './steelConnections'
-import {
-  chooseBar, crackControlOK, constructabilityOK, type BarCandidate,
-} from './barSelection'
 import { optimizeFootingRebar, optimizeSlabRebar, applySlabMats } from './matRebarOptimize'
+import { optimizeBeamMember } from './beamRebarOptimize'
+import { optimizeColumnRebar } from './columnRebarOptimize'
 import type { RebarSelection } from './rebarScore'
 
 export interface SoilOptions {
@@ -587,6 +586,35 @@ function designBeamRow(
 
 /** Column capacity for a given section and a known factored P/M demand (no frame
  *  solve — bar diameter does not change demands, so this is reused for bar trials). */
+/**
+ * φPn for a GIVEN cage at the eccentricity Mu/Pu, kN.
+ *
+ * Split out of `designColumnFromPM` so the bar search can gate on the same
+ * P–M capacity the schedule reports instead of carrying a second reading of
+ * the interaction diagram. `designAxialColumn` is pure axial; this is where
+ * the moment enters.
+ */
+function pmCapacity(
+  sec: RectSection, barDia: number, numBars: number, Pu: number, Mu: number,
+  phiPnMax: number, layout: BarLayout = 'two-face',
+): number {
+  const e = Pu > 1e-9 ? Mu / Pu : 0
+  if (e <= 1e-4) return phiPnMax
+  const g = { b: sec.b, h: sec.h, cover: sec.cover, barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, numBars, layout }
+  const cap = capacityAtEccentricity(g, e)
+  const inter = interaction(g)
+  return Math.min(cap.phi * cap.Pn, 0.65 * inter.PnMax)
+}
+
+/** Utilisation Pu/φPn for a given cage under P and M. */
+export function pmUtilisation(
+  sec: RectSection, barDia: number, numBars: number, Pu: number, Mu: number,
+  phiPnMax = Infinity,
+): number {
+  const phiPn = pmCapacity(sec, barDia, numBars, Pu, Mu, phiPnMax)
+  return phiPn > 1e-9 ? Pu / phiPn : Infinity
+}
+
 function designColumnFromPM(
   sec: RectSection, Pu: number, Mu: number,
   system: 'gravity' | 'imf' | 'smf' = 'gravity', columnLength?: number,
@@ -597,16 +625,8 @@ function designColumnFromPM(
     barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, Pu,
     system, columnLength,
   })
-  let phiPn = ax.phiPnMax
   const e = Pu > 1e-9 ? Mu / Pu : 0
-  if (e > 1e-4) {
-    const cap = capacityAtEccentricity(
-      { b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, numBars: ax.bars, layout },
-      e,
-    )
-    const inter = interaction({ b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, numBars: ax.bars, layout })
-    phiPn = Math.min(cap.phi * cap.Pn, 0.65 * inter.PnMax)
-  }
+  const phiPn = pmCapacity(sec, sec.barDia, ax.bars, Pu, Mu, ax.phiPnMax, layout)
   const util = phiPn > 1e-9 ? Pu / phiPn : Infinity
   return {
     e, bars: ax.bars, Ast: ax.Ast, phiPn, util,
@@ -1459,17 +1479,6 @@ export async function optimizeStructureAsync(
 export const BAR_LADDER_BEAM = [16, 20, 25, 28, 32]
 export const BAR_LADDER_COLUMN = [20, 25, 28, 32]
 
-/** §425.2.1 — do `bars` of Ø `db` fit one face of the column at the minimum
- *  clear spacing max(1.5db, 40 mm)? Bars split evenly over the two faces ⟂ to h
- *  (the interaction model's layout), spread across width b. */
-function columnBarsFit(sec: RectSection, db: number, bars: number): boolean {
-  const perFace = Math.ceil(bars / 2)
-  if (perFace <= 1) return true
-  const clearWidth = sec.b - 2 * (sec.cover + sec.tieDia) - perFace * db
-  const sClear = clearWidth / (perFace - 1)
-  return sClear >= Math.max(1.5 * db, 40) - 1e-6
-}
-
 /**
  * Pick the most economical bar diameter for every beam/girder and column from a
  * candidate ladder: the smallest-steel size that still passes, falling back to
@@ -1489,57 +1498,62 @@ export function selectBarDiameters(
   // candidate sizes, SMALLEST first — we adopt the first one that passes.
   const ladder = (cands: number[], current: number) => [...new Set([current, ...cands])].sort((a, b) => a - b)
 
-  // beams/girders: smallest bar Ø whose every section passes capacity AND the
-  // §407.7.1 clear-spacing / layer-fit check (both folded into beamOK).
+  // Beams/girders: ONE diameter for the whole member, scored across every one
+  // of its critical sections.
+  //
+  // This is the same `optimizeBeamMember` the Beam Design page uses. Model
+  // space ran its own four-gate ladder ranked on STEEL AREA, so the two halves
+  // of the app could answer the same question differently for the same beam —
+  // and the ladder's "smallest that passes" is exactly the min-steel rule the
+  // scorer exists to replace.
   for (const row of design.beams) {
     const sec = secById.get(memSecId.get(row.id) ?? ''); if (!sec) continue
-    // Each candidate is scored on all four gates across EVERY critical section
-    // of the member — one section failing serviceability rejects the size for
-    // the whole member — and then ranked on steel. See `barSelection` for why
-    // the stages are ordered and why a tie goes to the smaller bar.
-    const cands: BarCandidate[] = ladder(BAR_LADDER_BEAM, sec.barDia).map((db) => {
-      const designs = row.sections.map((s) => designBeam({
-        b: sec.b, h: sec.h, cover: sec.cover, barDia: db, comprBarDia: 16,
-        stirrupDia: sec.tieDia, fc: sec.fc, fy: sec.fy, Mu: Math.abs(s.Mu), Vu: s.Vu,
-      }))
-      return {
-        db,
-        strength: designs.every((d) => d.region !== 'inadequate' && d.comprEffective && d.comprNAOK),
-        // Crack control uses the CENTRE-TO-CENTRE spacing the clause is written
-        // in terms of; `sClear` is the clear gap, so the bar itself is added.
-        serviceability: designs.every((d) =>
-          crackControlOK(d.sClear + db, sec.fy, sec.cover)),
-        detailing: designs.every((d) => d.flexOK),
-        constructability: designs.every((d) => constructabilityOK(d.bars, d.layers.length)),
-        steelArea: Math.max(...designs.map((d) => d.bars * (Math.PI / 4) * db * db)),
-      }
-    })
-    const pick = chooseBar(cands)
-    if (pick.db !== null && pick.db !== sec.barDia) chosen.set(sec.id, pick.db)
+    const choice = optimizeBeamMember(
+      {
+        b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia, comprBarDia: 16,
+        stirrupDia: sec.tieDia, fc: sec.fc, fy: sec.fy,
+      },
+      row.sections.map((sx, i) => ({
+        id: `${row.id}:${i}`, label: sx.label, Mu: Math.abs(sx.Mu), Vu: sx.Vu,
+      })),
+      { sizes: ladder(BAR_LADDER_BEAM, sec.barDia) },
+    )
+    if (choice.db !== null && choice.db !== sec.barDia) chosen.set(sec.id, choice.db)
   }
 
-  // columns: smallest bar Ø that passes P–M + ρ AND fits the §425.2.1 minimum
-  // clear bar spacing across the section face (≥ max(1.5db, 40 mm)).
+  // Columns: diameter AND count, the same two-axis search the Column Design
+  // page runs. `designAxialColumn` inside the optimiser sizes the cage; the
+  // moment is added here as an extra gate, because a model-space column
+  // carries Mu and the optimiser deliberately does not know about
+  // eccentricity. Same P–M capacity the schedule already reports — no second
+  // interaction implementation.
   for (const row of design.columns) {
     const sec = secById.get(memSecId.get(row.id) ?? ''); if (!sec) continue
-    const cands: BarCandidate[] = ladder(BAR_LADDER_COLUMN, sec.barDia).map((db) => {
-      const r = designColumnFromPM({ ...sec, barDia: db }, row.Pu, row.Mu)
-      return {
-        db,
-        strength: r.ok,
-        // A column's bars are distributed around the perimeter by construction,
-        // so the crack-control spacing rule is not the governing serviceability
-        // question it is for a beam's tension face. Nothing to check here yet —
-        // said explicitly rather than left as an unexplained `true`.
-        serviceability: true,
-        detailing: columnBarsFit(sec, db, r.bars),
-        // One layer per face, so the layer limit cannot bite; the bar count can.
-        constructability: constructabilityOK(r.bars, 1),
-        steelArea: r.bars * (Math.PI / 4) * db * db,
-      }
-    })
-    const pick = chooseBar(cands)
-    if (pick.db !== null && pick.db !== sec.barDia) chosen.set(sec.id, pick.db)
+    const choice = optimizeColumnRebar(
+      {
+        shape: 'tied', b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia,
+        tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, fyt: sec.fy, Pu: row.Pu,
+      },
+      {
+        sizes: ladder(BAR_LADDER_COLUMN, sec.barDia),
+        // `RectSection` stores a diameter and no bar count, so the count is
+        // re-derived downstream. Pin the search to the count the final design
+        // will use — searching it here adopts a cage the schedule then
+        // recomputes into a different one.
+        counts: (i, db) => [designAxialColumn({ ...i, barDia: db }).bars],
+        extraChecks: (i, r) => {
+          const util = pmUtilisation(sec, i.barDia, r.bars, row.Pu, row.Mu)
+          return [{
+            id: 'pm-capacity',
+            clause: 'ACI 318-14 §22.4 · §10.5',
+            label: 'φPn at e = Mu/Pu ≥ Pu',
+            pass: util <= 1 + 1e-6,
+            detail: `utilisation ${Number.isFinite(util) ? util.toFixed(2) : '∞'}`,
+          }]
+        },
+      },
+    )
+    if (choice.db !== null && choice.db !== sec.barDia) chosen.set(sec.id, choice.db)
   }
 
   // ── Bar-diameter continuity guard: one Ø through each continuous beam line


### PR DESCRIPTION
**Phase 4 of 4** — the last piece of *"why is the footing design still 2 large bars?"*. On top of #533, #534 and #535.

## Model space had its own bar chooser

A four-gate ladder that tried each size smallest-first and ranked the survivors on **steel area**. That is the min-steel rule the whole rebar series exists to replace, and it meant **the two halves of the app could answer the same question differently for the same beam**.

- **Beams** now go through `optimizeBeamMember` — one diameter scored across every critical section of the member, the same call the Beam Design page makes.
- **Columns** now go through `optimizeColumnRebar`, which brings gates the old `columnBarsFit` never had: **§10.6.1.1** ρ, **§10.7.3.1** minimum bars, cage symmetry and **§25.7.2.3** lateral support — alongside the §25.2.3 clear spacing it did check.

`barSelection`'s `chooseBar` / `crackControlOK` / `constructabilityOK` and the local `columnBarsFit` are now unreachable from the pipeline and deleted. `crackSpacingLimit` stays — `beamRebarOptimize` uses it.

## Two things the column needed

### 1. The moment

`designAxialColumn` is pure axial and a model-space column carries `Mu`. Rather than a second reading of the interaction diagram, `optimizeColumnRebar` gained an `extraChecks` hook and the pipeline supplies a P–M utilisation gate built on **the same `capacityAtEccentricity` its schedule already reports**. `pmCapacity` / `pmUtilisation` are split out of `designColumnFromPM` so both paths share one implementation.

### 2. The count axis — a regression I caught by probing a real model

This one is worth reading. `RectSection` stores a **diameter and no bar count**, so a search that adopts a count has it silently recomputed downstream by `designAxialColumn`. The cage the optimiser scored was **not the cage that shipped**, and a P–M check that passed during the search failed on the section that actually got built:

```
main   →  cols ⌀20 and ⌀28   beams ⌀16   beamsOK 14/14   colsOK 12/12
mine   →  cols ⌀20           beams ⌀16   beamsOK 14/14   colsOK 10/12   ← regression
fixed  →  cols ⌀20 and ⌀28   beams ⌀16   beamsOK 14/14   colsOK 12/12
```

**The full test suite was green through all three of those.** It took building the page's own default model and reading the pass counts to see it.

`ColumnRebarOptions.counts` now lets a caller pin the search to the count the final design will use. Model space pins it; the Column Design page still gets the full two-axis sweep, because a page can hold a cage the model cannot.

Searching the count in model space needs the bar count **in the model** — an L1 schema change with a `meshValidation` rule attached. Left as a stated follow-up rather than smuggled in here.

## Verification

**+3 pipeline cases** — a member keeps one diameter across its sections and the grid settles below the ⌀28 seed; **selection never turns a passing design into a failing one** (the regression guard); continuity holds through every beam line and column stack.

`npm test` — 203 files, **3481 passed**. `npx tsc -b`, `eslint --max-warnings 0`, `npm run build` green.

Engine layer **6** (design pipeline).

## The series, end to end

| | |
|---|---|
| #533 | a mat is floored by spacing, not a bar count — 2⌀32 @ 736 mm was reported adequate |
| #534 | the footing mat picks its own bar, not the column's — and three consumers stop guessing it |
| #535 | slabs get a searched mat; a fabricated one is never shown |
| #536 | one header, one letterhead, one place (page consistency) |
| **this** | beams and columns off the area-ranked ladder |

Model space and the calculator pages now run the same selection machinery for all four member types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_