### PR TITLE
fix(pages): four layout and reading-order fixes

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -66,6 +66,21 @@ import ScheduleResources from './pages/ScheduleResources'
 import ScheduleReports from './pages/ScheduleReports'
 import ScheduleDaily from './pages/ScheduleDaily'
 
+
+/**
+ * Suspense fallback for a lazily-loaded page.
+ *
+ * It reserves roughly a screen of height. The bare `<p>` it replaces had none,
+ * so the footer rendered directly beneath the one-line message and then jumped
+ * down the moment the chunk arrived — the page appeared to load backwards.
+ */
+function PageLoading({ what }: { what: string }) {
+  return (
+    <div className="flex min-h-[70vh] items-center justify-center p-8">
+      <p className="text-sm text-slate-500">Loading {what}…</p>
+    </div>
+  )
+}
 export default function App() {
   const nav = useNavigate()
 
@@ -95,12 +110,12 @@ export default function App() {
         <Route path="/frame" element={<RequireAuth><FrameAnalysis /></RequireAuth>} />
         <Route path="/load-path" element={<LoadPath />} />
         <Route path="/model" element={
-          <Suspense fallback={<p className="p-8 text-center text-sm text-slate-500">Loading 3D model space…</p>}>
+          <Suspense fallback={<PageLoading what="3D model space" />}>
             <ModelSpace />
           </Suspense>
         } />
         <Route path="/truss" element={
-          <Suspense fallback={<p className="p-8 text-center text-sm text-slate-500">Loading truss space…</p>}>
+          <Suspense fallback={<PageLoading what="truss space" />}>
             <TrussSpace />
           </Suspense>
         } />

--- a/webapp/src/lib/beamSolution.ts
+++ b/webapp/src/lib/beamSolution.ts
@@ -95,6 +95,10 @@ export function buildBeamSolution(i: BeamDesignInput, r: BeamDesignResult): Solu
     title: 'Bar layout — spacing check & layers (§407.7)',
     lines: [
       txt(`Minimum clear spacing between parallel bars in a layer is max(d_b, 25 mm) = ${sn0(r.sMinClear)} mm (§407.7.1). The clear web width is b − 2(cover + dₛ) = ${sn0(bw)} mm, so at most ${r.maxPerLayer} bars fit per layer.`),
+      // A_b appeared here as a bare number for a bar the sheet had not yet
+      // named. Both come first now: which bar, and the area it gives.
+      txt(`The bar adopted above is ⌀${sn0(i.barDia)}, so one bar carries:`),
+      eq(String.raw`A_b = \tfrac{\pi}{4} d_b^2 = \tfrac{\pi}{4}(${sn0(i.barDia)})^2 = ${sn0(Ab)}\ \text{mm}^2`),
       eq(String.raw`n = \lceil A_s / A_b \rceil = \lceil ${sn0(r.As)} / ${sn0(Ab)} \rceil = ${r.bars}\ \text{bars} \Rightarrow \text{layers: } [${r.layers.join(', ')}]`),
       eq(String.raw`s_{clear} = \dfrac{${sn0(bw)} - ${r.layers[0]}(${sn0(i.barDia)})}{${Math.max(1, r.layers[0] - 1)}} = ${sn0(r.sClear)}\ \text{mm} \;\ge\; ${sn0(r.sMinClear)}\ \text{mm}\ \checkmark`),
       ...(multiLayer ? [

--- a/webapp/src/lib/rebarSolution.ts
+++ b/webapp/src/lib/rebarSolution.ts
@@ -166,3 +166,23 @@ export function buildRebarSelectionSolution(
 
   return steps
 }
+
+/**
+ * Splice the selection steps in AHEAD of the step that first uses a bar area.
+ *
+ * They used to be appended. That reads backwards: the layout step divides
+ * As by A_b — a number belonging to a bar the sheet has not yet named or
+ * justified — and only pages later does it explain which bar and why. A
+ * checker meets the consequence before the decision.
+ *
+ * Falls back to appending when a sheet has no layout step to sit ahead of.
+ */
+export function withRebarSelection(
+  base: readonly SolutionStep[], selection: readonly SolutionStep[],
+): SolutionStep[] {
+  if (selection.length === 0) return [...base]
+  const at = base.findIndex((s) => /bar layout|bar arrangement|reinforcement layout/i.test(s.title))
+  return at < 0
+    ? [...base, ...selection]
+    : [...base.slice(0, at), ...selection, ...base.slice(at)]
+}

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -10,7 +10,7 @@ import { WorkedSolution } from '../components/WorkedSolution'
 import { buildBeamSolution, beamProvidedCapacities } from '../lib/beamSolution'
 import { optimizeBeamRebar, optimizeBeamMember } from '../engine/beamRebarOptimize'
 import { RebarRanking } from '../components/RebarRanking'
-import { buildRebarSelectionSolution } from '../lib/rebarSolution'
+import { buildRebarSelectionSolution, withRebarSelection } from '../lib/rebarSolution'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { Math as KTex } from '../lib/math'
 import { f0, f1 } from '../lib/format'
@@ -149,10 +149,10 @@ export default function BeamDesign() {
   // the steel the flexure steps above derived, so it reads after them.
   const solution = useMemo(
     () => (r
-      ? [
-          ...buildBeamSolution({ ...fd, ...demand }, r),
-          ...(selection ? buildRebarSelectionSolution(selection, 'cage') : []),
-        ]
+      ? withRebarSelection(
+          buildBeamSolution({ ...fd, ...demand }, r),
+          selection ? buildRebarSelectionSolution(selection, 'cage') : [],
+        )
       : null),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [r, fd, demand.Mu, demand.Vu, selection],
@@ -225,6 +225,14 @@ export default function BeamDesign() {
           </div>
         } />
         <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
+        {reportData && (
+          <PrintReport {...reportData}
+            drawing={<BeamSchematic b={fd.b} h={fd.h} cover={fd.cover} barDia={fd.barDia} stirrupDia={fd.stirrupDia}
+              bars={r!.bars} d={r!.d} dPrime={r!.comprLayers.length > 0 ? r!.dPrime : undefined}
+              layers={r!.layers} comprLayers={r!.comprLayers} comprBars={r!.comprBars} comprBarDia={f.comprBarDia}
+              naDepth={r!.cNA} flexOK={r!.flexOK} hogging={hogging} />}
+          />
+        )}
       <div className="mx-auto max-w-[1500px] px-5 pb-8 sm:px-7">
 
       <div className="no-print mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
@@ -305,6 +313,10 @@ export default function BeamDesign() {
               </div>
             </fieldset>
           )}
+          {selection && (
+            <RebarRanking selection={selection}
+              title={multi ? 'Bar selection — whole member' : 'Bar selection'} />
+          )}
         </div>
 
         <div className="space-y-3.5 lg:sticky lg:top-14 lg:self-start">
@@ -323,10 +335,6 @@ export default function BeamDesign() {
               checks={checks}
               footnote={`ρ = ${r.rho.toFixed(4)} within ρmin ${r.rhoMin.toFixed(4)} … ρmax ${r.rhoMax.toFixed(4)} — §9.6.1.2 / §21.2.2`}
             />
-          )}
-          {selection && (
-            <RebarRanking selection={selection}
-              title={multi ? 'Bar selection — whole member' : 'Bar selection'} />
           )}
           {multi && (
             <ResultCard title="Section schedule">
@@ -452,14 +460,6 @@ export default function BeamDesign() {
             title={multi && active ? `Calculation report — ${active.label}` : 'Calculation report — worked solution'} />
         )}
       </div>
-      {reportData && (
-        <PrintReport {...reportData}
-          drawing={<BeamSchematic b={fd.b} h={fd.h} cover={fd.cover} barDia={fd.barDia} stirrupDia={fd.stirrupDia}
-            bars={r!.bars} d={r!.d} dPrime={r!.comprLayers.length > 0 ? r!.dPrime : undefined}
-            layers={r!.layers} comprLayers={r!.comprLayers} comprBars={r!.comprBars} comprBarDia={f.comprBarDia}
-            naDepth={r!.cNA} flexOK={r!.flexOK} hogging={hogging} />}
-        />
-      )}
       </div>
     </div>
   )

--- a/webapp/src/pages/ColumnDesign.tsx
+++ b/webapp/src/pages/ColumnDesign.tsx
@@ -16,7 +16,7 @@ import { WorkedSolution } from '../components/WorkedSolution'
 import { axialColumnSolution, eccentricColumnSolution, slendernessSolution } from '../lib/columnSolution'
 import { optimizeColumnRebar } from '../engine/columnRebarOptimize'
 import { RebarRanking } from '../components/RebarRanking'
-import { buildRebarSelectionSolution } from '../lib/rebarSolution'
+import { buildRebarSelectionSolution, withRebarSelection } from '../lib/rebarSolution'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { Math as KTex } from '../lib/math'
 import { f0, f1, f2 } from '../lib/format'
@@ -115,8 +115,9 @@ export default function ColumnDesign() {
       shape: tied ? 'tied' : 'spiral', b, h, D, cover, barDia: dbEff, tieDia, fc, fy, fyt, Pu,
       numBars: barMode === 'analyze' || eccentric ? numBars : cageChoice?.bars ?? undefined,
     }, axial))
-    if (cageChoice) steps.push(...buildRebarSelectionSolution(cageChoice.selection, 'cage'))
-    return steps
+    return withRebarSelection(
+      steps, cageChoice ? buildRebarSelectionSolution(cageChoice.selection, 'cage') : [],
+    )
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [slender, eccentric, inter, cap, axial, Pu, MuEff, cageChoice])
 
@@ -283,6 +284,7 @@ export default function ColumnDesign() {
               </>}
             </Card>
           )}
+          {cageChoice && <RebarRanking selection={cageChoice.selection} title="Cage selection" />}
         </div>
 
         <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
@@ -291,7 +293,6 @@ export default function ColumnDesign() {
               stats={verdict.stats} checks={verdict.checks} footnote={verdict.footnote} />
           )}
 
-          {cageChoice && <RebarRanking selection={cageChoice.selection} title="Cage selection" />}
 
           {/* The same card the beam page uses — graph-paper ground, title and
               section meta in a header strip above the drawing. The two pages

--- a/webapp/src/pages/CombinedFootingDesign.tsx
+++ b/webapp/src/pages/CombinedFootingDesign.tsx
@@ -171,6 +171,30 @@ export default function CombinedFootingDesign() {
     <div>
       <PageHeader title="Combined Footing" badges={['ACI 318-14', 'NSCP 2015']} />
       <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
+      {result && solutionSteps && (
+        <PrintReport
+          docTitle={result.shape === 'Trapezoidal (CTF)' ? 'Combined Footing (Trapezoidal)' : 'Combined Footing (Rectangular)'}
+          docCode="F-02" badges={['ACI 318-14', 'NSCP 2015']}
+          ok={result.qNet > 0} governing="Rigid (conventional) method — resultant matched to factored column loads"
+          lh={lh}
+          stats={[
+            { label: 'Plan', value: result.shape === 'Trapezoidal (CTF)' ? `${f2(result.Bx)} × ${f2(result.By1)}→${f2(result.By2)}` : `${f2(result.Bx)} × ${f2(result.By)}`, unit: 'm' },
+            { label: 'Thickness Dc', value: f0(result.Dc), unit: 'mm' },
+            { label: 'q net', value: f2(result.qNet), unit: 'kPa' },
+          ]}
+          data={[
+            ['Column 1 DL / LL', `${f0(form.dl1)} / ${f0(form.ll1)} kN`], ['Column 2 DL / LL', `${f0(form.dl2)} / ${f0(form.ll2)} kN`],
+            ['Column spacing', `${f2(form.spacing)} m`], ["Concrete f'c", `${form.fc} MPa`],
+            ['Steel fy', `${form.fy} MPa`], ['Allowable qa', `${form.qAllow} kPa`],
+            ['Total depth H', `${f2(form.H)} m`], ['Bar ⌀', `${form.barDia} mm`],
+          ]}
+          steps={solutionSteps}
+          drawingTitle="Combined Footing Plan"
+          drawing={<CombinedFootingSchematic
+            shape={result.shape} Bx={result.Bx} By={result.By} By1={result.By1} By2={result.By2}
+            x1={result.x1} x2={result.x2} col1Width={form.col1Width} col2Width={form.col2Width} />}
+        />
+      )}
       <div className="mx-auto max-w-[1500px] px-5 pb-8 sm:px-7">
 
       <div className="no-print mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
@@ -350,30 +374,6 @@ export default function CombinedFootingDesign() {
           <WorkedSolution steps={solutionSteps} title="Combined footing — worked solution (rigid method)" />
         )}
       </div>
-      {result && solutionSteps && (
-        <PrintReport
-          docTitle={result.shape === 'Trapezoidal (CTF)' ? 'Combined Footing (Trapezoidal)' : 'Combined Footing (Rectangular)'}
-          docCode="F-02" badges={['ACI 318-14', 'NSCP 2015']}
-          ok={result.qNet > 0} governing="Rigid (conventional) method — resultant matched to factored column loads"
-          lh={lh}
-          stats={[
-            { label: 'Plan', value: result.shape === 'Trapezoidal (CTF)' ? `${f2(result.Bx)} × ${f2(result.By1)}→${f2(result.By2)}` : `${f2(result.Bx)} × ${f2(result.By)}`, unit: 'm' },
-            { label: 'Thickness Dc', value: f0(result.Dc), unit: 'mm' },
-            { label: 'q net', value: f2(result.qNet), unit: 'kPa' },
-          ]}
-          data={[
-            ['Column 1 DL / LL', `${f0(form.dl1)} / ${f0(form.ll1)} kN`], ['Column 2 DL / LL', `${f0(form.dl2)} / ${f0(form.ll2)} kN`],
-            ['Column spacing', `${f2(form.spacing)} m`], ["Concrete f'c", `${form.fc} MPa`],
-            ['Steel fy', `${form.fy} MPa`], ['Allowable qa', `${form.qAllow} kPa`],
-            ['Total depth H', `${f2(form.H)} m`], ['Bar ⌀', `${form.barDia} mm`],
-          ]}
-          steps={solutionSteps}
-          drawingTitle="Combined Footing Plan"
-          drawing={<CombinedFootingSchematic
-            shape={result.shape} Bx={result.Bx} By={result.By} By1={result.By1} By2={result.By2}
-            x1={result.x1} x2={result.x2} col1Width={form.col1Width} col2Width={form.col2Width} />}
-        />
-      )}
       </div>
     </div>
   )

--- a/webapp/src/pages/FoundationDesign.tsx
+++ b/webapp/src/pages/FoundationDesign.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, type ReactNode } from 'react'
 import { designSquareFooting } from '../engine/isolatedFooting'
 import { optimizeFootingRebar } from '../engine/matRebarOptimize'
 import { RebarRanking } from '../components/RebarRanking'
-import { buildRebarSelectionSolution } from '../lib/rebarSolution'
+import { buildRebarSelectionSolution, withRebarSelection } from '../lib/rebarSolution'
 import { nameMat } from '../lib/rebarLabel'
 // The page used to carry its own byte-identical copy of this input.
 import { Num as NumField } from '../components/qty'
@@ -276,10 +276,10 @@ export default function FoundationDesign() {
       punchOK: view.punchOK, beamOK: view.beamOK,
       long: view.long, short: view.short, ecc: view.ecc,
     }
-    return [
-      ...buildFoundationSolution(ctx),
-      ...(matChoice ? buildRebarSelectionSolution(matChoice.selection, 'mat') : []),
-    ]
+    return withRebarSelection(
+      buildFoundationSolution(ctx),
+      matChoice ? buildRebarSelectionSolution(matChoice.selection, 'mat') : [],
+    )
   }, [view, form, dbEff, matChoice, serviceLoad, ultimateLoad, individual, circular, colWidth, colWidthY])
 
   // Verdict data — presentation of engine outputs only: utilization is the
@@ -300,6 +300,33 @@ export default function FoundationDesign() {
           </button>
         } />
         <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
+        {view && solutionSteps && (
+          <PrintReport
+            docTitle="Isolated Footing" docCode="F-01" badges={['ACI 318-14', 'NSCP 2015']}
+            ok={allOK} governing={`Governing: ${governing} · ${globalThis.Math.max(punchRatio, beamRatio).toFixed(2)}`}
+            lh={lh}
+            stats={[
+              { label: 'Plan size', value: `${f2(view.Bx)} × ${f2(view.By)}`, unit: 'm' },
+              { label: 'Thickness Dc', value: f0(view.Dc), unit: 'mm' },
+              { label: view.type === 'square' ? 'Steel each way' : 'Steel — long', value: `${view.long.bars}-⌀${dbEff}`, unit: `@${f0(view.long.spacing)}` },
+            ]}
+            checks={[
+              { name: 'Two-way (punching) shear — d req/prov', ratio: punchRatio, ok: view.punchOK },
+              { name: 'One-way (beam) shear — d req/prov', ratio: beamRatio, ok: view.beamOK },
+            ]}
+            data={[
+              ['Service load P', `${f0(serviceLoad)} kN`], ['Ultimate load Pu', `${f0(ultimateLoad)} kN`],
+              ["Concrete f'c", `${form.fc} MPa`], ['Steel fy', `${form.fy} MPa`],
+              ['Column width c', `${f0(colWidth)} mm (${form.position})`], ['Bar diameter db', `⌀${dbEff} mm`],
+              ['Allowable bearing qa', `${form.qAllow} kPa`], ['Clear cover', `${form.cover} mm`],
+              ['Unit weight, soil γs', `${form.gammaSoil} kN/m³`], ['Unit weight, concrete γc', `${form.gammaConc} kN/m³`],
+              ['Total depth H', `${f2(form.H)} m`], ['Surcharge', `${form.surcharge} kPa`],
+            ]}
+            steps={solutionSteps}
+            drawingTitle="Isolated Footing"
+            drawing={<FootingSchematic Bx={view.Bx} By={view.By} Dc={view.Dc} columnWidth={colWidth} H={form.H} />}
+          />
+        )}
       <div className="mx-auto max-w-[1500px] px-5 pb-8 sm:px-7">
       <div className="no-print"><ExcelImport onResult={setBatch} /></div>
 
@@ -448,6 +475,9 @@ export default function FoundationDesign() {
             <NumField label={<>Total depth <Math tex="H" /></>} unit="m" value={form.H} onChange={set('H')} />
             <NumField label="Surcharge" unit="kPa" value={form.surcharge} onChange={set('surcharge')} />
           </Card>
+          {matChoice && (
+            <RebarRanking selection={matChoice.selection} title="Mat selection" name={nameMat} />
+          )}
         </div>
 
         {/* ── Verdict rail ── */}
@@ -472,10 +502,6 @@ export default function FoundationDesign() {
                 ? 'Flexure: As,min = 0.0018·b·h governs (ρmin) — §24.4.3.2'
                 : `Flexure: ρ = ${view.long.rho.toFixed(4)} — §24.4.3.2 satisfied`}
             />
-          )}
-
-          {matChoice && (
-            <RebarRanking selection={matChoice.selection} title="Mat selection" name={nameMat} />
           )}
 
           <DrawingCard pdfDrawing title="Drawing" meta="plan · section">
@@ -531,33 +557,6 @@ export default function FoundationDesign() {
       </div>
 
       <div className="no-print">{solutionSteps && <WorkedSolution steps={solutionSteps} title="Calculation report — worked solution" />}</div>
-      {view && solutionSteps && (
-        <PrintReport
-          docTitle="Isolated Footing" docCode="F-01" badges={['ACI 318-14', 'NSCP 2015']}
-          ok={allOK} governing={`Governing: ${governing} · ${globalThis.Math.max(punchRatio, beamRatio).toFixed(2)}`}
-          lh={lh}
-          stats={[
-            { label: 'Plan size', value: `${f2(view.Bx)} × ${f2(view.By)}`, unit: 'm' },
-            { label: 'Thickness Dc', value: f0(view.Dc), unit: 'mm' },
-            { label: view.type === 'square' ? 'Steel each way' : 'Steel — long', value: `${view.long.bars}-⌀${dbEff}`, unit: `@${f0(view.long.spacing)}` },
-          ]}
-          checks={[
-            { name: 'Two-way (punching) shear — d req/prov', ratio: punchRatio, ok: view.punchOK },
-            { name: 'One-way (beam) shear — d req/prov', ratio: beamRatio, ok: view.beamOK },
-          ]}
-          data={[
-            ['Service load P', `${f0(serviceLoad)} kN`], ['Ultimate load Pu', `${f0(ultimateLoad)} kN`],
-            ["Concrete f'c", `${form.fc} MPa`], ['Steel fy', `${form.fy} MPa`],
-            ['Column width c', `${f0(colWidth)} mm (${form.position})`], ['Bar diameter db', `⌀${dbEff} mm`],
-            ['Allowable bearing qa', `${form.qAllow} kPa`], ['Clear cover', `${form.cover} mm`],
-            ['Unit weight, soil γs', `${form.gammaSoil} kN/m³`], ['Unit weight, concrete γc', `${form.gammaConc} kN/m³`],
-            ['Total depth H', `${f2(form.H)} m`], ['Surcharge', `${form.surcharge} kPa`],
-          ]}
-          steps={solutionSteps}
-          drawingTitle="Isolated Footing"
-          drawing={<FootingSchematic Bx={view.Bx} By={view.By} Dc={view.Dc} columnWidth={colWidth} H={form.H} />}
-        />
-      )}
       </div>
     </div>
   )

--- a/webapp/src/pages/PileCapDesign.tsx
+++ b/webapp/src/pages/PileCapDesign.tsx
@@ -163,6 +163,38 @@ export default function PileCapDesign() {
     <div>
       <PageHeader title="Pile Cap" badges={['ACI 318-14', 'NSCP 2015']} />
       <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
+      {result && (
+        <PrintReport
+          docTitle="Pile Cap" docCode="PC-01" badges={['ACI 318-14', 'NSCP 2015']}
+          ok={!!allOK}
+          governing={`Governing ratio ${globalThis.Math.max(
+            result.VuPunchCol / result.phiVcPunchCol, result.VuPunchPile / result.phiVcPunchPile,
+            result.VuBeamX / result.phiVcBeamX, result.VuBeamY / result.phiVcBeamY).toFixed(2)} across punching / beam shear`}
+          lh={lh}
+          stats={[
+            { label: 'Cap plan', value: `${f2(result.capBx)} × ${f2(result.capBy)}`, unit: 'm' },
+            { label: 'Thickness Dc', value: f0(result.Dc), unit: 'mm' },
+            { label: 'Piles', value: `${form.nPiles}-⌀${form.pileDia}`, unit: 'mm' },
+          ]}
+          checks={[
+            { name: 'Column punching Vu/φVc', ratio: result.VuPunchCol / result.phiVcPunchCol, ok: result.punchColOK },
+            { name: 'Pile punching Vu/φVc', ratio: result.VuPunchPile / result.phiVcPunchPile, ok: result.punchPileOK },
+            { name: 'One-way shear X Vu/φVc', ratio: result.VuBeamX / result.phiVcBeamX, ok: result.beamXOK },
+            { name: 'One-way shear Y Vu/φVc', ratio: result.VuBeamY / result.phiVcBeamY, ok: result.beamYOK },
+            { name: 'Development ld,req/avail', ratio: result.ldRequired / globalThis.Math.max(result.ldAvailable, 1e-9), ok: result.ldOK },
+          ]}
+          data={[
+            ['Service / ultimate load', `${form.serviceLoad} / ${form.ultimateLoad} kN`],
+            ['Moments MuX / MuY', `${result.MuX.toFixed(1)} / ${result.MuY.toFixed(1)} kN·m`],
+            ['Pile capacity', `${form.pileCapacity} kN`], ['Pile spacing / edge', `${form.spacing} / ${form.edgeDist} mm`],
+            ['Column', `${form.colX} × ${form.colY} mm`], ["Concrete f'c / fy", `${form.fc} / ${form.fy} MPa`],
+            ['Effective depth d', `${result.d.toFixed(0)} mm`],
+          ]}
+          drawingTitle="Pile Cap Plan"
+          drawing={<PileCapSchematic d={result.d} capBx={result.capBx} capBy={result.capBy} coords={result.coords}
+            pileDia={form.pileDia} colX={form.colX} colY={form.colY} reactions={result.reactions} />}
+        />
+      )}
       <div className="mx-auto max-w-[1500px] px-5 pb-8 sm:px-7">
 
       <div className="no-print mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
@@ -315,38 +347,6 @@ export default function PileCapDesign() {
           )}
         </div>
       </div>
-      {result && (
-        <PrintReport
-          docTitle="Pile Cap" docCode="PC-01" badges={['ACI 318-14', 'NSCP 2015']}
-          ok={!!allOK}
-          governing={`Governing ratio ${globalThis.Math.max(
-            result.VuPunchCol / result.phiVcPunchCol, result.VuPunchPile / result.phiVcPunchPile,
-            result.VuBeamX / result.phiVcBeamX, result.VuBeamY / result.phiVcBeamY).toFixed(2)} across punching / beam shear`}
-          lh={lh}
-          stats={[
-            { label: 'Cap plan', value: `${f2(result.capBx)} × ${f2(result.capBy)}`, unit: 'm' },
-            { label: 'Thickness Dc', value: f0(result.Dc), unit: 'mm' },
-            { label: 'Piles', value: `${form.nPiles}-⌀${form.pileDia}`, unit: 'mm' },
-          ]}
-          checks={[
-            { name: 'Column punching Vu/φVc', ratio: result.VuPunchCol / result.phiVcPunchCol, ok: result.punchColOK },
-            { name: 'Pile punching Vu/φVc', ratio: result.VuPunchPile / result.phiVcPunchPile, ok: result.punchPileOK },
-            { name: 'One-way shear X Vu/φVc', ratio: result.VuBeamX / result.phiVcBeamX, ok: result.beamXOK },
-            { name: 'One-way shear Y Vu/φVc', ratio: result.VuBeamY / result.phiVcBeamY, ok: result.beamYOK },
-            { name: 'Development ld,req/avail', ratio: result.ldRequired / globalThis.Math.max(result.ldAvailable, 1e-9), ok: result.ldOK },
-          ]}
-          data={[
-            ['Service / ultimate load', `${form.serviceLoad} / ${form.ultimateLoad} kN`],
-            ['Moments MuX / MuY', `${result.MuX.toFixed(1)} / ${result.MuY.toFixed(1)} kN·m`],
-            ['Pile capacity', `${form.pileCapacity} kN`], ['Pile spacing / edge', `${form.spacing} / ${form.edgeDist} mm`],
-            ['Column', `${form.colX} × ${form.colY} mm`], ["Concrete f'c / fy", `${form.fc} / ${form.fy} MPa`],
-            ['Effective depth d', `${result.d.toFixed(0)} mm`],
-          ]}
-          drawingTitle="Pile Cap Plan"
-          drawing={<PileCapSchematic d={result.d} capBx={result.capBx} capBy={result.capBy} coords={result.coords}
-            pileDia={form.pileDia} colX={form.colX} colY={form.colY} reactions={result.reactions} />}
-        />
-      )}
       </div>
     </div>
   )

--- a/webapp/src/pages/PrestressedBeam.tsx
+++ b/webapp/src/pages/PrestressedBeam.tsx
@@ -76,6 +76,30 @@ export default function PrestressedBeam() {
     <div className="min-h-screen">
       <PageHeader title="Prestressed Beam" badges={[...badges, `class ${klass}`]} />
       <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(p) => setLh((s) => ({ ...s, ...p }))} /></div>
+      {r && (
+        <PrintReport docTitle="Prestressed Beam" docCode="PS-01" badges={badges} ok={r.ok}
+          governing={`losses ${r.lossPct.toFixed(1)}% · utilization ${(r.Mu / Math.max(r.phiMn, 1e-9)).toFixed(2)}`}
+          lh={lh}
+          stats={[
+            { label: 'φMn', value: f1(r.phiMn), unit: 'kN·m' },
+            { label: 'fse', value: f1(r.fse), unit: 'MPa' },
+            { label: 'Pe', value: f1(r.Pe), unit: 'kN' },
+          ]}
+          checks={[
+            { name: 'Transfer stresses §24.5.3', ratio: r.transfer.bot / r.limTransferC, ok: r.transferOK },
+            { name: 'Service stresses §24.5.4', ratio: Number.isFinite(r.limServiceT) ? Math.max(0, -r.service.bot) / r.limServiceT : 0, ok: r.serviceOK },
+            { name: 'Strength Mu/φMn', ratio: r.Mu / Math.max(r.phiMn, 1e-9), ok: r.strengthOK },
+            { name: 'φMn ≥ 1.2Mcr', ratio: (1.2 * r.Mcr) / Math.max(r.phiMn, 1e-9), ok: r.crackingOK },
+          ]}
+          data={[
+            ['Section', `${b} × ${h} mm`], ['Span', `${span} m`], ["f'c / f'ci", `${fc} / ${fci} MPa`],
+            ['Tendons', `Aps ${Aps} mm² · fpu ${fpu} · e ${e} mm`], ['Loads', `SDL ${wSDL} · LL ${wLL} kN/m`],
+            ['Losses', `${r.lossPct.toFixed(1)} % → fse ${f1(r.fse)} MPa`],
+          ]}
+          steps={steps}
+          drawing={<PSElevation h={h} e={e} span={span} />}
+          drawingTitle="Prestressed beam" />
+      )}
       <div className="mx-auto max-w-[1500px] px-5 py-5 sm:px-7">
         <p className="no-print text-[13px] text-[#5c6675]">
           <Link to="/" className="font-semibold text-[#0f4c92]">← Home</Link> · Pretensioned bonded beam: PCI losses
@@ -133,30 +157,6 @@ export default function PrestressedBeam() {
           </div>
         )}
       </div>
-      {r && (
-        <PrintReport docTitle="Prestressed Beam" docCode="PS-01" badges={badges} ok={r.ok}
-          governing={`losses ${r.lossPct.toFixed(1)}% · utilization ${(r.Mu / Math.max(r.phiMn, 1e-9)).toFixed(2)}`}
-          lh={lh}
-          stats={[
-            { label: 'φMn', value: f1(r.phiMn), unit: 'kN·m' },
-            { label: 'fse', value: f1(r.fse), unit: 'MPa' },
-            { label: 'Pe', value: f1(r.Pe), unit: 'kN' },
-          ]}
-          checks={[
-            { name: 'Transfer stresses §24.5.3', ratio: r.transfer.bot / r.limTransferC, ok: r.transferOK },
-            { name: 'Service stresses §24.5.4', ratio: Number.isFinite(r.limServiceT) ? Math.max(0, -r.service.bot) / r.limServiceT : 0, ok: r.serviceOK },
-            { name: 'Strength Mu/φMn', ratio: r.Mu / Math.max(r.phiMn, 1e-9), ok: r.strengthOK },
-            { name: 'φMn ≥ 1.2Mcr', ratio: (1.2 * r.Mcr) / Math.max(r.phiMn, 1e-9), ok: r.crackingOK },
-          ]}
-          data={[
-            ['Section', `${b} × ${h} mm`], ['Span', `${span} m`], ["f'c / f'ci", `${fc} / ${fci} MPa`],
-            ['Tendons', `Aps ${Aps} mm² · fpu ${fpu} · e ${e} mm`], ['Loads', `SDL ${wSDL} · LL ${wLL} kN/m`],
-            ['Losses', `${r.lossPct.toFixed(1)} % → fse ${f1(r.fse)} MPa`],
-          ]}
-          steps={steps}
-          drawing={<PSElevation h={h} e={e} span={span} />}
-          drawingTitle="Prestressed beam" />
-      )}
     </div>
   )
 }

--- a/webapp/src/pages/RetainingWall.tsx
+++ b/webapp/src/pages/RetainingWall.tsx
@@ -51,6 +51,37 @@ export default function RetainingWall() {
     <div>
       <PageHeader title="Cantilever Retaining Wall" badges={['NSCP 2015', 'ACI 318-14']} />
       <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
+      {r && (
+        <PrintReport
+          docTitle="Cantilever Retaining Wall" docCode="RW-01" badges={['NSCP 2015', 'ACI 318-14']}
+          ok={r.stableSL && r.stableOT && r.bearingOK && r.tensionOK && r.shearOK && r.toe.shearOK && r.heel.shearOK}
+          governing={`FS sliding ${f2(r.FS_SL)} · FS overturning ${f2(r.FS_OT)} · q,max ${f1(r.q_max)} kPa`}
+          lh={lh}
+          stats={[
+            // B and H are ALREADY in metres — dividing by 1000 again printed
+            // a 2.3 m base as "0.00 m" on every report this page produced.
+            { label: 'Base width B', value: f2(r.B), unit: 'm' },
+            { label: 'Total height H', value: f2(r.H), unit: 'm' },
+            { label: 'q,max', value: f1(r.q_max), unit: 'kPa' },
+          ]}
+          checks={[
+            { name: 'Sliding (FS req 1.5 / FS)', ratio: 1.5 / r.FS_SL, ok: r.stableSL },
+            { name: 'Overturning (FS req 2.0 / FS)', ratio: 2.0 / r.FS_OT, ok: r.stableOT },
+            { name: 'Bearing q,max / qa', ratio: r.q_max / f.qa, ok: r.bearingOK },
+            { name: 'Stem shear Vu / φVc', ratio: r.Vu_stem / r.Vc_stem, ok: r.shearOK },
+            { name: 'Toe shear Vu / φVc', ratio: r.toe.Vu / r.toe.phiVc, ok: r.toe.shearOK },
+            { name: 'Heel shear Vu / φVc', ratio: r.heel.Vu / r.heel.phiVc, ok: r.heel.shearOK },
+          ]}
+          data={[
+            ['Stem height Hs', `${f.Hs} mm`], ['Base thickness tb', `${f.tb} mm`],
+            ['Stem thickness ts', `${f.ts} mm`], ['Toe / heel', `${f.bt} / ${f.bh} mm`],
+            ['Soil γs / φ', `${f.gamma_s} kN/m³ / ${f.phi_deg}°`], ['Surcharge', `${f.q_sur} kPa`],
+            ['Friction μ', `${f.mu}`], ['Allowable qa', `${f.qa} kPa`],
+            ["Concrete f'c / fy", `${f.fc} / ${f.fy} MPa`], ['Ka (Rankine)', `${f3(r.Ka)}`],
+            ['Active thrust Pa + Pq', `${f1(r.Pa)} + ${f1(r.Pq)} kN/m`], ['Stem Mu', `${f1(r.Mu_stem)} kN·m/m`],
+          ]}
+        />
+      )}
       <div className="mx-auto max-w-[1500px] px-5 pb-8 sm:px-7">
 
       {/* The section drawing carries what the numbers cannot: which FACE each
@@ -202,37 +233,6 @@ export default function RetainingWall() {
       </div>
       {r && <WorkedSolution steps={buildRetainingWallSolution(f, r)} />}
 
-      {r && (
-        <PrintReport
-          docTitle="Cantilever Retaining Wall" docCode="RW-01" badges={['NSCP 2015', 'ACI 318-14']}
-          ok={r.stableSL && r.stableOT && r.bearingOK && r.tensionOK && r.shearOK && r.toe.shearOK && r.heel.shearOK}
-          governing={`FS sliding ${f2(r.FS_SL)} · FS overturning ${f2(r.FS_OT)} · q,max ${f1(r.q_max)} kPa`}
-          lh={lh}
-          stats={[
-            // B and H are ALREADY in metres — dividing by 1000 again printed
-            // a 2.3 m base as "0.00 m" on every report this page produced.
-            { label: 'Base width B', value: f2(r.B), unit: 'm' },
-            { label: 'Total height H', value: f2(r.H), unit: 'm' },
-            { label: 'q,max', value: f1(r.q_max), unit: 'kPa' },
-          ]}
-          checks={[
-            { name: 'Sliding (FS req 1.5 / FS)', ratio: 1.5 / r.FS_SL, ok: r.stableSL },
-            { name: 'Overturning (FS req 2.0 / FS)', ratio: 2.0 / r.FS_OT, ok: r.stableOT },
-            { name: 'Bearing q,max / qa', ratio: r.q_max / f.qa, ok: r.bearingOK },
-            { name: 'Stem shear Vu / φVc', ratio: r.Vu_stem / r.Vc_stem, ok: r.shearOK },
-            { name: 'Toe shear Vu / φVc', ratio: r.toe.Vu / r.toe.phiVc, ok: r.toe.shearOK },
-            { name: 'Heel shear Vu / φVc', ratio: r.heel.Vu / r.heel.phiVc, ok: r.heel.shearOK },
-          ]}
-          data={[
-            ['Stem height Hs', `${f.Hs} mm`], ['Base thickness tb', `${f.tb} mm`],
-            ['Stem thickness ts', `${f.ts} mm`], ['Toe / heel', `${f.bt} / ${f.bh} mm`],
-            ['Soil γs / φ', `${f.gamma_s} kN/m³ / ${f.phi_deg}°`], ['Surcharge', `${f.q_sur} kPa`],
-            ['Friction μ', `${f.mu}`], ['Allowable qa', `${f.qa} kPa`],
-            ["Concrete f'c / fy", `${f.fc} / ${f.fy} MPa`], ['Ka (Rankine)', `${f3(r.Ka)}`],
-            ['Active thrust Pa + Pq', `${f1(r.Pa)} + ${f1(r.Pq)} kN/m`], ['Stem Mu', `${f1(r.Mu_stem)} kN·m/m`],
-          ]}
-        />
-      )}
       </div>
     </div>
   )

--- a/webapp/src/pages/SlabDesign.tsx
+++ b/webapp/src/pages/SlabDesign.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react'
 import { designSlabDDM, type SlabInput, type SlabDirResult, type SlabSectionSteel } from '../engine/slabDDM'
 import { optimizeSlabRebar } from '../engine/matRebarOptimize'
 import { RebarRanking } from '../components/RebarRanking'
-import { buildRebarSelectionSolution } from '../lib/rebarSolution'
+import { buildRebarSelectionSolution, withRebarSelection } from '../lib/rebarSolution'
 import { nameMat } from '../lib/rebarLabel'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { ReportControls } from '../components/ReportControls'
@@ -142,10 +142,10 @@ export default function SlabDesign() {
   const defl = r?.deflection
 
   const solution = r
-    ? [
-        ...buildSlabSolution(inputEff, r),
-        ...(slabChoice ? buildRebarSelectionSolution(slabChoice.selection, 'mat') : []),
-      ]
+    ? withRebarSelection(
+        buildSlabSolution(inputEff, r),
+        slabChoice ? buildRebarSelectionSolution(slabChoice.selection, 'mat') : [],
+      )
     : null
 
   const report = r ? {
@@ -239,13 +239,13 @@ export default function SlabDesign() {
             <Pick label="Beams on all edges?" value={f.withBeams} onChange={set('withBeams')}
               options={[['yes', 'Yes (grid beams)'], ['no', 'No (flat plate)']]} />
           </Card>
+          {slabChoice && (
+            <RebarRanking selection={slabChoice.selection} title="Mat selection — whole panel" name={nameMat} />
+          )}
         </div>
 
         {/* ── RESULTS ── */}
         <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
-          {slabChoice && (
-            <RebarRanking selection={slabChoice.selection} title="Mat selection — whole panel" name={nameMat} />
-          )}
           {r ? (
             <>
               {/* Summary */}

--- a/webapp/src/pages/TBeamDesign.tsx
+++ b/webapp/src/pages/TBeamDesign.tsx
@@ -34,6 +34,27 @@ export default function TBeamDesign() {
     <div className="min-h-screen">
       <PageHeader title="T-Beam Design" badges={[...badges, kind]} />
       <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(p) => setLh((s) => ({ ...s, ...p }))} /></div>
+      {r && (
+        <PrintReport docTitle="T-Beam" docCode="TB-01" badges={badges} ok={r.ok}
+          governing={`${r.tBehavior ? 'true T behaviour' : 'rectangular behaviour'} · utilization ${(Math.abs(Mu) / Math.max(r.phiMn, 1e-9)).toFixed(2)}`}
+          lh={lh}
+          stats={[
+            { label: 'Steel', value: `${r.bars}-⌀${barDia}` },
+            { label: 'φMn', value: f1(r.phiMn), unit: 'kN·m' },
+            { label: 'bf', value: f0(r.bf), unit: 'mm' },
+          ]}
+          checks={[
+            { name: 'Flexure Mu/φMn', ratio: Math.abs(Mu) / Math.max(r.phiMn, 1e-9), ok: r.phiMn >= Math.abs(Mu) },
+            { name: 'Tension-controlled', ratio: r.As / Math.max(r.AsMax, 1e-9), ok: r.As <= r.AsMax },
+          ]}
+          data={[
+            ['Type', kind], ['Web bw × h', `${bw} × ${h} mm`], ['Flange bf × hf', `${f0(r.bf)} × ${hf} mm`],
+            ["f'c / fy", `${fc} / ${fy} MPa`], ['Mu', `${Mu} kN·m`], ['d / dt', `${f1(r.d)} / ${f1(r.dt)} mm`],
+          ]}
+          steps={steps}
+          drawing={<TSection bf={r.bf} bw={bw} h={h} hf={hf} a={r.a} bars={r.bars} barDia={barDia} layers={r.layers} cover={cover} stirrupDia={stirrupDia} />}
+          drawingTitle="T-beam section" />
+      )}
       <div className="mx-auto max-w-[1500px] px-5 py-5 sm:px-7">
         <p className="no-print text-[13px] text-[#5c6675]">
           <Link to="/" className="font-semibold text-[#0f4c92]">← Home</Link> · Flanged-beam flexure: §6.3.2 effective width,
@@ -90,27 +111,6 @@ export default function TBeamDesign() {
           </div>
         )}
       </div>
-      {r && (
-        <PrintReport docTitle="T-Beam" docCode="TB-01" badges={badges} ok={r.ok}
-          governing={`${r.tBehavior ? 'true T behaviour' : 'rectangular behaviour'} · utilization ${(Math.abs(Mu) / Math.max(r.phiMn, 1e-9)).toFixed(2)}`}
-          lh={lh}
-          stats={[
-            { label: 'Steel', value: `${r.bars}-⌀${barDia}` },
-            { label: 'φMn', value: f1(r.phiMn), unit: 'kN·m' },
-            { label: 'bf', value: f0(r.bf), unit: 'mm' },
-          ]}
-          checks={[
-            { name: 'Flexure Mu/φMn', ratio: Math.abs(Mu) / Math.max(r.phiMn, 1e-9), ok: r.phiMn >= Math.abs(Mu) },
-            { name: 'Tension-controlled', ratio: r.As / Math.max(r.AsMax, 1e-9), ok: r.As <= r.AsMax },
-          ]}
-          data={[
-            ['Type', kind], ['Web bw × h', `${bw} × ${h} mm`], ['Flange bf × hf', `${f0(r.bf)} × ${hf} mm`],
-            ["f'c / fy", `${fc} / ${fy} MPa`], ['Mu', `${Mu} kN·m`], ['d / dt', `${f1(r.d)} / ${f1(r.dt)} mm`],
-          ]}
-          steps={steps}
-          drawing={<TSection bf={r.bf} bw={bw} h={h} hf={hf} a={r.a} bars={r.bars} barDia={barDia} layers={r.layers} cover={cover} stirrupDia={stirrupDia} />}
-          drawingTitle="T-beam section" />
-      )}
     </div>
   )
 }


### PR DESCRIPTION
Four issues from a walkthrough of the deployed app, all measured in a headless browser rather than eyeballed.

## 1. The footer rode up while `/model` loaded

The Suspense fallback was a bare `<p className="p-8">` with **no height**, so the footer rendered directly beneath a one-line message and then got shoved down the moment the chunk landed — the page appeared to load backwards.

`PageLoading` reserves ~70vh. Measured during load, 900 px viewport:

```
before  footer at y = 913   (on screen, above the fold)
after   footer at y = 1111  (below the fold, where it belongs)
```

Applied to both lazy routes — 3D Model Space and Truss Space.

## 2. The worked solution read backwards

The bar-layout step divides `As` by **`A_b`** — a number belonging to a bar the sheet had not yet named, let alone justified — and the selection that picks that bar was appended **four steps later**. A checker met the consequence before the decision.

```
before   … 4 Tension steel · 5 Bar layout · 6-9 shear · 10-13 selection
after    … 4 Tension steel · 5-8 selection · 9 Bar layout · 10-13 shear
```

`withRebarSelection` splices the selection in ahead of the layout step rather than appending it, on all four pages. And the layout step now **names the adopted bar and works `A_b` out from it before using it**:

```
The bar adopted above is ⌀20, so one bar carries:
    A_b = π/4 · d_b² = π/4 (20)² = 314 mm²
    n = ⌈A_s / A_b⌉ = ⌈1189 / 314⌉ = 4 bars ⇒ layers: [4]
```

## 3. The Calculation report card was at the bottom

Moved to sit with the letterhead at the top on all eight calc-template pages — `letterheadY = 182`, `calcReportCardY = 362`.

The **whole guarded block** moved, not just the element: `PrintReport` deliberately owns the export props in one place, and hoisting them out to a second component is exactly the drift its own comment warns about. My first attempt moved only the element and left an empty `{reportData && ( )}` behind — caught by the compiler.

## 4. 835 px of dead space under the inputs

The two-column grid had a short input column beside a very tall verdict rail. Moving the **bar-selection card to the left column** balances them and shortens the page:

| page | left | right |
|---|---|---|
| beam-design | 778 → **1143** | 1613 → **1230** |
| column-design | → **1089** | → **900** |
| slab-design | → **1715** | → **1715** |
| foundation | → **1302** | → **1089** |

It reads better there too: inputs, then which bar those inputs led to, with the verdict and drawing opposite.

## Verification

```
solution steps:  4 Tension steel (SRRB)
                 5 Layouts considered
                 6 Code compliance — a gate, not a score
                 7 Weighted score of the compliant layouts
                 8 Adopted — 4⌀20
                 9 Bar layout — spacing check & layers (§407.7)
A_b defined before use:  true
letterheadY=182  calcReportCardY=362
footer Y during load:  1111
```

`npm test` — 203 files, **3478 passed**. `npx tsc -b`, `eslint --max-warnings 0`, `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_