### PR TITLE
fix(engine): T-beam solves As at the depth its own cage produces

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1581,3 +1581,64 @@ Yes, it is maintained, at both scales:
   three shapes search. A rectangular footing takes one diameter and a spacing
   per direction.
 - KaTeX cannot render ⌀ in math mode, so the score equations read `S(4D20)`.
+
+# T-beam: `a` from equilibrium, and the depth the cage destroys (PR #540, August 2026)
+
+Asked how `a` is derived in a T-beam and whether it satisfies C = T, the answer
+turned out to be **yes, exactly, in both branches** — and verifying it found a
+design defect sitting next to it.
+
+## How `a` is derived (`tBeamCapacity`)
+
+`a` is never assumed. It is solved from horizontal equilibrium; the branches
+differ only in which concrete area supplies C.
+
+| case | compression zone | solved a |
+|---|---|---|
+| `a ≤ hf` | rectangle of width **bf** | `a = T / (0.85 f′c bf)` |
+| `a > hf` | overhangs **full** at hf + web block | `a = (T − 0.85 f′c (bf−bw) hf) / (0.85 f′c bw)` |
+
+Hogging is passed `bf = bw`, so the overhang term is zero and the second form
+degenerates into the first — one equation, not a special case. Verified across
+20 combinations at **0.0000 %** residual, with `a = β1·c` exact.
+
+## The defect it exposed
+
+`designTBeam` solved `As` at `d = dt` and only **then** dropped `d` to the
+bar-group centroid, never redesigning. `designBeam` has iterated both faces all
+along; the T-beam engine never did. The cage came back sized for a lever arm the
+cage itself had destroyed:
+
+```
+bf 600  hf 80  Mu 700   As 2905 → 2945 provided, φMn 690.7  ✗
+bf 1200 hf 100 Mu 1900  As 8153 → 8836 provided, φMn 1732.6 ✗   (d fell 89 mm)
+```
+
+More steel than the As printed beside it, and still short. Now the layout and
+`As` are solved together. The map `d ↦ d_next` is monotone (deeper d → less
+steel → fewer bars → shallower stack → deeper d_next) and starts at `d = dt`, the
+largest d the section has, so it only falls and the integer bar count makes it
+settle — typically in 2 passes.
+
+## Three more found while verifying, all in the browser
+
+| where | what was wrong |
+|---|---|
+| `designTBeam` | Oscillated forever when the web ran out of singly-reinforced capacity: `As` collapsed to `Asf` (a *lighter* cage the worse the overload) and the stack sprang back. That is a failed design, not a convergence problem — it now reports `Asw` at the tension-controlled ceiling and stops. |
+| `designTBeam` | **Hogging reported as "true T"**. `tBeamCapacity` gets `bf = bw` there, so its own `a > hf` flag compares a web block depth against a flange thickness that plays no part. A 700×75 flange under Mu = −150 came out "true T" on that accident, and the worked solution then printed the overhang formula for a section whose flange is in tension. |
+| `TBeamDesign` | Summary read `6-⌀25 (2112 mm²)` — the bar count beside the area **required**, which reads as the area those bars supply. Same on the tension-controlled bar, which compared the demand against a cap that governs what gets built (0.24 shown where 0.34 was true). |
+
+`designTBeam` also gained §25.2.1's **4/3·d_agg** term, which `designBeam` got in
+#539 — the T-beam engine was still packing layers on `max(db, 25)`.
+
+## β1, consolidated
+
+Three copies of `max(0.65, sloped-row)` remained after #530 — `loads.ts`
+(feeding `beamDesign`, `columnDesign`, `scwb`, `columnSolution`), `tbeam.ts` and
+`prestressedBeam.ts`. All now re-export `flexure.beta1`, the table form.
+
+## Worked solution
+
+`/tbeam-design` now shows the equilibrium derivation itself: T, the C expression
+for the branch taken, `a` solved from it, and a `C = T` closing check — plus a
+step for the stacked-cage `d` when the bars need more than one layer.

--- a/webapp/src/engine/loads.ts
+++ b/webapp/src/engine/loads.ts
@@ -21,10 +21,13 @@ export function factoredLoad({ dead, live }: ServiceLoad): number {
 }
 
 /**
- * β₁ equivalent-stress-block depth factor (NSCP 2015 §422.2.2.4.3).
+ * β₁ equivalent-stress-block depth factor (NSCP 2015 §422.2.2.4.3 /
+ * ACI 318-14 Table 22.2.2.4.3) — re-exported from `flexure`, which owns it.
+ *
+ * The form written here was `max(0.65, 0.85 − 0.05(f′c − 28)/7)`. That is the
+ * sloped row clamped, and the SI table is not continuous: the slope is valid
+ * only for 28 < f′c < 55 and evaluates to 0.657 at 55 MPa, where the table
+ * gives a flat 0.65. Three copies of the clamped form were in the engine.
  * @param fc concrete compressive strength f′c, MPa
  */
-export function beta1(fc: number): number {
-  if (fc <= 28) return 0.85;
-  return Math.max(0.65, 0.85 - (0.05 * (fc - 28)) / 7);
-}
+export { beta1 } from './flexure';

--- a/webapp/src/engine/prestressedBeam.ts
+++ b/webapp/src/engine/prestressedBeam.ts
@@ -8,6 +8,10 @@
 // and the §9.6.2.1 φMn ≥ 1.2Mcr guard → Vci/Vcw web/flexure shear (§22.5.8.3)
 // → midspan camber/deflection. Rectangular or direct (A, I, yt, yb) sections.
 
+// β1 per ACI Table 22.2.2.4.3 — the table's flat 0.65 above 55 MPa, not the
+// sloped row clamped (which reads 0.657 there). Owned by `flexure`.
+import { beta1 } from './flexure'
+
 export interface PrestressedInput {
   // section: rectangular b×h OR direct properties
   b?: number; h: number
@@ -54,8 +58,6 @@ export interface PrestressedResult {
   ok: boolean
   notes: string[]
 }
-
-const beta1 = (fc: number) => (fc <= 28 ? 0.85 : Math.max(0.65, 0.85 - (0.05 * (fc - 28)) / 7))
 
 export function designPrestressed(i: PrestressedInput): PrestressedResult {
   const notes: string[] = []

--- a/webapp/src/engine/tbeam.test.ts
+++ b/webapp/src/engine/tbeam.test.ts
@@ -42,12 +42,16 @@ describe('designTBeam — rectangular behaviour (a ≤ hf)', () => {
     expect(r.phiMn).toBeGreaterThanOrEqual(400)
     expect(r.ok).toBe(true)
   })
-  it('hand calc: Rn with b = bf = 1800 → As ≈ Mu/(0.9·fy·(d−a/2))', () => {
-    // a = As·fy/(0.85·f'c·bf); iterate ≈ jd ~ 0.98d. With d = 537.5:
-    // Rn = 400e6/(0.9·1800·537.5²) = 0.855 MPa → ρ = 0.85·21/415·(1−√(1−2·0.855/17.85))
-    const Rn = 400e6 / (0.9 * 1800 * 537.5 ** 2)
+  it('hand calc: Rn with b = bf = 1800, at the CONVERGED d', () => {
+    // 5 bars are needed and only 4 fit per layer, so the cage is [4, 2] and the
+    // Varignon centroid sits (2·50)/6 = 16.667 mm above the extreme layer:
+    // d = 537.5 − 16.667 = 520.833, NOT dt. Solving at dt and then dropping d
+    // is the bug this case now pins — it left the section short of its own Mu.
+    const dConv = 537.5 - (2 * (25 + 25)) / 6
+    expect(r.d).toBeCloseTo(dConv, 9)
+    const Rn = 400e6 / (0.9 * 1800 * dConv ** 2)
     const rho = ((0.85 * 21) / 415) * (1 - Math.sqrt(1 - (2 * Rn) / (0.85 * 21)))
-    expect(r.As).toBeCloseTo(Math.max(rho * 1800 * 537.5, r.AsMin), 6)
+    expect(r.As).toBeCloseTo(Math.max(rho * 1800 * dConv, r.AsMin), 6)
   })
   it('εt ≥ 0.005 → φ = 0.90 (shallow block, tension-controlled)', () => {
     expect(r.et).toBeGreaterThan(0.005)
@@ -76,12 +80,64 @@ describe('designTBeam — true T behaviour (a > hf)', () => {
   })
 })
 
+describe('how `a` is derived — C = T in both branches', () => {
+  // `a` is never assumed; it is solved FROM horizontal equilibrium, and the two
+  // branches differ only in which area the compression acts on:
+  //
+  //   a ≤ hf  the block is entirely inside the flange, so the section behaves as
+  //           a rectangle of width bf:      C = 0.85 f'c bf a       → a = T/(0.85 f'c bf)
+  //   a > hf  the flange alone cannot carry T. The overhangs are FULL at depth
+  //           hf and only the web carries the remainder:
+  //           C = 0.85 f'c (bf−bw) hf + 0.85 f'c bw a
+  //                                        → a = (T − C_over)/(0.85 f'c bw)
+  //
+  // Hogging passes bf = bw, which makes C_over = 0 and degenerates the second
+  // form back into the first — one equation, not a special case.
+  const compression = (bf: number, bw: number, hf: number, fc: number, a: number) =>
+    a <= hf ? 0.85 * fc * bf * a : 0.85 * fc * ((bf - bw) * hf + bw * a)
+
+  it('equilibrium holds exactly, flange block and web block alike', () => {
+    const sec = { bw: 300, hf: 100, fc: 21, fy: 415 }
+    for (const bf of [300, 600, 1200, 1800]) {          // 300 = the hogging case
+      for (const As of [1500, 3000, 4500, 8000, 12000]) {
+        const cap = tBeamCapacity(sec, bf, 600, 620, As)
+        const T = As * sec.fy
+        expect(compression(bf, sec.bw, sec.hf, sec.fc, cap.a)).toBeCloseTo(T, 6)
+        expect(cap.tBehavior).toBe(cap.a > sec.hf)
+        expect(cap.c * beta1(sec.fc)).toBeCloseTo(cap.a, 9)   // a = β1·c
+      }
+    }
+  })
+
+  it('β1 is the ACI Table 22.2.2.4.3 step, not the sloped row clamped', () => {
+    // The sloped row evaluated at 55 MPa gives 0.657; the table says a flat 0.65
+    // from 55 MPa up. This module used to carry its own `max(0.65, slope)` copy.
+    expect(beta1(28)).toBeCloseTo(0.85, 9)
+    expect(beta1(35)).toBeCloseTo(0.80, 9)
+    expect(beta1(55)).toBe(0.65)
+    expect(beta1(80)).toBe(0.65)
+  })
+})
+
 describe('minimum steel and hogging (flange in tension)', () => {
   it('As,min = max(0.25√f\'c, 1.4)/fy·bw·d governs tiny moments', () => {
     const r = designTBeam({ ...base, Mu: 20 })
     expect(r.minGoverns).toBe(true)
     expect(r.As).toBeCloseTo((Math.max(0.25 * Math.sqrt(21), 1.4) / 415) * 300 * r.d, 3)
   })
+  it('hogging is never reported as T behaviour, however deep the web block gets', () => {
+    // The flange is in TENSION here, so there is no flange couple to speak of.
+    // `tBeamCapacity` is handed bf = bw, which zeroes the overhang term and
+    // degenerates it to the rectangle — but its own `a > hf` flag then compares
+    // a web block depth against a flange thickness that plays no part. A 700 mm
+    // flange, 75 mm thick, under Mu = −150 came out "true T" on that accident.
+    const r = designTBeam({ ...base, bfGiven: 700, hf: 75, h: 650, Mu: -150 })
+    expect(r.a).toBeGreaterThan(75)               // the block IS deeper than hf
+    expect(r.tBehavior).toBe(false)               // and that means nothing here
+    // a still comes from the plain rectangle b = bw, as the hogging case demands
+    expect(r.a).toBeCloseTo((r.bars * (Math.PI / 4) * 25 ** 2 * 415) / (0.85 * 21 * 300), 6)
+  })
+
   it('negative moment designs the web rectangle (b = bw) and doubles bw,min when determinate', () => {
     const r = designTBeam({ ...base, Mu: -150 })
     expect(r.tBehavior).toBe(false)
@@ -125,6 +181,48 @@ describe('bar layering — no layer carries a single bar', () => {
       for (let Mu = 100; Mu <= 700; Mu += 50) {
         const r = designTBeam({ ...base, bw, Mu })
         expect(r.layers.every((n) => n >= 2)).toBe(true)
+      }
+    }
+  })
+
+  it('the design covers its own demand once the cage stacks', () => {
+    // The engine solved As at d = dt and only THEN dropped d to the bar-group
+    // centroid, never redesigning. The cage it handed back was sized for a lever
+    // arm the cage itself had destroyed, so multi-layer T-beams came back with
+    // MORE steel than the As printed beside them and still φMn < Mu:
+    //
+    //   bf 600  hf 80  Mu 700   As 2905 → 2945 provided, φMn 690.7  ✗
+    //   bf 1200 hf 100 Mu 1900  As 8153 → 8836 provided, φMn 1732.6 ✗
+    //
+    // These four are the true-T cases from that probe. All are tension-
+    // controlled (φ = 0.90), so nothing but d explained the shortfall.
+    const cases = [
+      { bfGiven: 600, hf: 80, Mu: 700, h: 750 },
+      { bfGiven: 600, hf: 80, Mu: 900, h: 750 },
+      { bfGiven: 1200, hf: 100, Mu: 1900, h: 750 },
+      { bfGiven: 700, hf: 90, Mu: 1100, h: 750 },
+    ]
+    for (const c of cases) {
+      const r = designTBeam({ ...base, ...c })
+      expect(r.tBehavior).toBe(true)
+      expect(r.layers.length).toBeGreaterThan(1)      // the cage does stack
+      expect(r.d).toBeLessThan(r.dt)                  // and d does drop
+      if (r.ok) expect(r.phiMn).toBeGreaterThanOrEqual(c.Mu - 1e-6)
+    }
+  })
+
+  it('a reported-ok design is self-consistent: recomputing at its own d reproduces φMn ≥ Mu', () => {
+    // Convergence, stated as a property rather than a fixture: if the engine
+    // says ok, then As solved at the RETURNED d must still fit the returned bars.
+    const Ab = (Math.PI / 4) * base.barDia ** 2
+    for (const bfGiven of [500, 700, 900, 1200, 1800]) {
+      for (let Mu = 200; Mu <= 1200; Mu += 100) {
+        const r = designTBeam({ ...base, bfGiven, Mu, h: 700 })
+        if (!r.ok) continue
+        expect(r.bars * Ab).toBeGreaterThanOrEqual(r.As - 1e-6)
+        const cap = tBeamCapacity({ ...base, hf: base.hf }, r.bf, r.d, r.dt, r.bars * Ab)
+        expect(cap.phiMn).toBeCloseTo(r.phiMn, 6)
+        expect(r.phiMn).toBeGreaterThanOrEqual(Mu - 1e-6)
       }
     }
   })

--- a/webapp/src/engine/tbeam.ts
+++ b/webapp/src/engine/tbeam.ts
@@ -10,6 +10,7 @@
 // flange is in tension on statically determinate spans).
 
 import { splitLayers, centroidRise } from './barLayers'
+import { beta1 } from './flexure'
 
 export type TBeamKind = 'interior' | 'edge' | 'isolated'
 
@@ -21,6 +22,8 @@ export interface TBeamInput {
   sw?: number                         // clear web-to-web spacing, m
   cover: number; stirrupDia: number; barDia: number
   fc: number; fy: number
+  /** Nominal maximum aggregate size, mm — §25.2.1's 4/3·d_agg term. Default 20. */
+  aggregate?: number
   Mu: number                          // kN·m (+ = flange in compression)
   /** Analyze a given steel area instead of designing. */
   AsGiven?: number
@@ -39,13 +42,21 @@ export interface TBeamResult {
   AsMin: number; minGoverns: boolean
   AsMax: number                       // tension-controlled cap (εt = 0.005)
   bars: number; layers: number[]; sClear: number; sClearMin: number
+  /** Passes taken by the layout ↔ effective-depth loop (see `designTBeam`). */
+  layerIters: number
   phiMn: number                       // capacity at the FINAL As, kN·m
   ok: boolean
   notes: string[]
 }
 
 const ES = 200000
-export const beta1 = (fc: number) => (fc <= 28 ? 0.85 : Math.max(0.65, 0.85 - (0.05 * (fc - 28)) / 7))
+const LAYER_CLEAR = 25       // §425.2.2 clear distance between bar layers, mm
+
+// β1 comes from `flexure` — the ACI Table 22.2.2.4.3 form, which is a FLAT 0.65
+// for f′c ≥ 55 MPa, not the sloped row clamped at 0.65. This module kept its own
+// `max(0.65, slope)` copy, which returns 0.657 at 55 MPa: the wrong table row,
+// and a `c = a/β1` about 1% short with it.
+export { beta1 }
 
 /** Effective flange width, mm — ACI Table 6.3.2.1 / §6.3.2.2. */
 export function effectiveFlange(i: TBeamInput): { bf: number; govern: string; isolatedOK: boolean } {
@@ -95,10 +106,10 @@ export function designTBeam(i: TBeamInput): TBeamResult {
   const { bf, govern, isolatedOK } = effectiveFlange(i)
   const Ab = (Math.PI / 4) * i.barDia ** 2
   const dt = i.h - i.cover - i.stirrupDia - i.barDia / 2
-  let d = dt                                  // refined after layering
   const b1 = beta1(i.fc)
 
-  // tension-controlled steel cap (c = 3/8·dt): block may enter the web
+  // tension-controlled steel cap (c = 3/8·dt): block may enter the web. Anchored
+  // on dt, the EXTREME layer, so it does not move as the group centroid does.
   const cTC = (3 / 8) * dt
   const aTC = b1 * cTC
   const CcTC = aTC <= i.hf
@@ -109,63 +120,128 @@ export function designTBeam(i: TBeamInput): TBeamResult {
   // §9.6.1.2: As,min = max(0.25√f'c, 1.4)/fy · bw·d; flange-in-tension
   // determinate spans use bw → min(2bw, bf) (§9.6.1.2(b) via Mu < 0 case).
   const bwMin = i.Mu < 0 && i.determinate ? Math.min(2 * i.bw, bf) : i.bw
-  const AsMin = (Math.max(0.25 * Math.sqrt(i.fc), 1.4) / i.fy) * bwMin * d
+
+  // §407.7.1 / ACI 318-14 §25.2.1 — clear spacing ≥ max(db, 25 mm, 4/3·d_agg);
+  // bars per layer that fit: n·db + (n−1)·s_min ≤ bw − 2(cover + ds).
+  const dAgg = i.aggregate ?? 20
+  const sClearMin = Math.max(i.barDia, 25, (4 / 3) * dAgg)
+  const web = i.bw - 2 * (i.cover + i.stirrupDia)
+  const perLayer = Math.max(2, Math.floor((web + sClearMin) / (i.barDia + sClearMin)))
+  const pitch = i.barDia + LAYER_CLEAR       // layer-to-layer centroid distance
+
+  const MuAbs = Math.abs(i.Mu)
+  const analyze = !!(i.AsGiven && i.AsGiven > 0)
+
+  // ── Iterate layout → Varignon d → redesign, until the arrangement stops
+  //    changing — the SAME loop `designBeam` runs on the rectangular section.
+  //
+  // Stacking bars raises the group centroid, which lowers d, which raises the
+  // steel the moment demands, which can add another bar. Solving once at d = dt
+  // and then dropping d after layout — which is what this engine did — hands
+  // back a cage sized for a lever arm the cage itself destroyed. It showed up as
+  // designs reporting `phiMn < Mu` while providing MORE steel than the As they
+  // had just computed: e.g. bf 1200 / hf 100 / Mu 1900 came back 8836 mm² over a
+  // required 8153 and still only φMn = 1733 kN·m, because d had quietly fallen
+  // 89 mm to the centroid of five layers.
+  //
+  // The map d ↦ d_next is monotone: a deeper d needs less steel, hence fewer
+  // bars and a shallower stack, hence a deeper d_next. Starting from d = dt (the
+  // largest d the section can offer) the sequence therefore only ever falls, and
+  // the bar count is an integer, so it settles. The one thing that breaks that
+  // monotonicity is the section running out of singly-reinforced capacity: As
+  // collapses to the cap and the stack springs back up, which oscillates
+  // forever. That case is not a convergence problem — it is a failed design, so
+  // it is reported as one and the loop stops.
+  let d = dt
+  let As = 0, Asf = 0, Asw = 0, AsMin = 0
+  let bars = 0
+  let layers: number[] = [0]
+  let layerIters = 0
+  let converged = false
+  let inadequate: string | null = null
+
+  for (let iter = 0; iter < 12; iter++) {
+    layerIters = iter + 1
+    Asf = 0
+    inadequate = null
+    AsMin = (Math.max(0.25 * Math.sqrt(i.fc), 1.4) / i.fy) * bwMin * d
+
+    if (analyze) {
+      As = i.AsGiven as number
+      Asw = As
+    } else if (i.Mu < 0) {
+      // flange in tension → rectangular web design, b = bw
+      const Rn = (MuAbs * 1e6) / (0.9 * i.bw * d * d)
+      const disc = 1 - (2 * Rn) / (0.85 * i.fc)
+      if (disc <= 0) inadequate = 'web section inadequate for the hogging moment — enlarge bw/h'
+      const rho = disc > 0 ? ((0.85 * i.fc) / i.fy) * (1 - Math.sqrt(disc)) : AsMax / (i.bw * d)
+      As = Math.max(rho * i.bw * d, AsMin)
+      Asw = As
+    } else if (MuAbs * 1e6 <= 0.9 * 0.85 * i.fc * bf * i.hf * (d - i.hf / 2)) {
+      // a ≤ hf → rectangular with b = bf
+      const Rn = (MuAbs * 1e6) / (0.9 * bf * d * d)
+      const rho = ((0.85 * i.fc) / i.fy) * (1 - Math.sqrt(Math.max(0, 1 - (2 * Rn) / (0.85 * i.fc))))
+      As = Math.max(rho * bf * d, AsMin)
+      Asw = As
+    } else {
+      // true T: flange-overhang couple + web rectangle for the remainder
+      Asf = (0.85 * i.fc * (bf - i.bw) * i.hf) / i.fy
+      const Muf = (0.90 * Asf * i.fy * (d - i.hf / 2)) / 1e6
+      const Muw = MuAbs - Muf
+      const Rn = (Muw * 1e6) / (0.9 * i.bw * d * d)
+      const disc = 1 - (2 * Rn) / (0.85 * i.fc)
+      if (disc <= 0) {
+        // The web cannot carry the remainder singly reinforced. Report the most
+        // steel the section may legally hold rather than the meaningless small
+        // number the collapsed radicand gives — Asf alone, which read as a
+        // *lighter* cage the worse the overload got.
+        inadequate = 'web remainder exceeds singly-reinforced capacity — enlarge the section'
+        Asw = Math.max(0, AsMax - Asf)
+      } else {
+        Asw = ((0.85 * i.fc) / i.fy) * (1 - Math.sqrt(disc)) * i.bw * d
+      }
+      As = Math.max(Asf + Asw, AsMin)
+    }
+
+    // `splitLayers` — the SAME rule the rectangular-beam engine uses — pairs a
+    // lone bar in the upper layer. This engine used to stack them greedily, so a
+    // T-beam could be detailed with one bar sitting alone with nothing to tie to
+    // on either side. The pairing bumps the count, so `bars` (not the strength
+    // demand) is what As-provided must be computed from.
+    const split = splitLayers(Math.max(2, Math.ceil(As / Ab)), perLayer)
+    const newLayers = split.layers
+    const dNew = dt - centroidRise(newLayers, pitch)
+    const same = newLayers.length === layers.length && newLayers.every((k, j) => k === layers[j])
+    bars = split.bars
+    layers = newLayers
+
+    // Divergence guard: each added layer lowers d, which demands more steel,
+    // which adds layers. If the stack keeps growing, the web cannot take it.
+    if (newLayers.length > 6 || dNew <= i.cover + i.stirrupDia + i.barDia) {
+      inadequate = 'bar group is too deep for the web — the section is inadequate; enlarge bw/h'
+      d = dNew
+      converged = true          // reported through the note, not as non-convergence
+      break
+    }
+    if (inadequate) { d = dNew; converged = true; break }
+
+    if (same && Math.abs(dNew - d) < 1e-9) { converged = true; break }
+    d = dNew
+  }
+
+  if (inadequate) notes.push(inadequate)
+  if (!converged) notes.push('bar layout did not settle in 12 passes — check the reported capacity')
+  const minGoverns = !analyze && As <= AsMin + 1e-9
+  const sClear = layers[0] > 1 ? (web - layers[0] * i.barDia) / (layers[0] - 1) : web
+  if (layers.length > 1) {
+    notes.push(`${layers.length} bar layers — d reduced to the group centroid (${dt.toFixed(1)} → ${d.toFixed(1)} mm)`)
+  }
 
   // φ·capacity with the block exactly filling the flange — the T/rect switch
   const MnfPhi = (0.90 * 0.85 * i.fc * bf * i.hf * (d - i.hf / 2)) / 1e6
 
-  let As: number, Asf = 0, Asw: number
-  const MuAbs = Math.abs(i.Mu)
-  if (i.AsGiven && i.AsGiven > 0) {
-    As = i.AsGiven
-    Asw = As
-  } else if (i.Mu < 0) {
-    // flange in tension → rectangular web design, b = bw
-    const Rn = (MuAbs * 1e6) / (0.9 * i.bw * d * d)
-    const disc = 1 - (2 * Rn) / (0.85 * i.fc)
-    if (disc <= 0) notes.push('web section inadequate for the hogging moment — enlarge bw/h')
-    const rho = disc > 0 ? ((0.85 * i.fc) / i.fy) * (1 - Math.sqrt(disc)) : AsMax / (i.bw * d)
-    As = Math.max(rho * i.bw * d, AsMin)
-    Asw = As
-  } else if (MuAbs * 1e6 <= 0.9 * 0.85 * i.fc * bf * i.hf * (d - i.hf / 2)) {
-    // a ≤ hf → rectangular with b = bf
-    const Rn = (MuAbs * 1e6) / (0.9 * bf * d * d)
-    const rho = ((0.85 * i.fc) / i.fy) * (1 - Math.sqrt(Math.max(0, 1 - (2 * Rn) / (0.85 * i.fc))))
-    As = Math.max(rho * bf * d, AsMin)
-    Asw = As
-  } else {
-    // true T: flange-overhang couple + web rectangle for the remainder
-    Asf = (0.85 * i.fc * (bf - i.bw) * i.hf) / i.fy
-    const Muf = (0.90 * Asf * i.fy * (d - i.hf / 2)) / 1e6
-    const Muw = MuAbs - Muf
-    const Rn = (Muw * 1e6) / (0.9 * i.bw * d * d)
-    const disc = 1 - (2 * Rn) / (0.85 * i.fc)
-    if (disc <= 0) notes.push('web remainder exceeds singly-reinforced capacity — enlarge the section')
-    const rho = disc > 0 ? ((0.85 * i.fc) / i.fy) * (1 - Math.sqrt(disc)) : 0
-    Asw = rho * i.bw * d
-    As = Math.max(Asf + Asw, AsMin)
-  }
-  const minGoverns = !(i.AsGiven && i.AsGiven > 0) && As <= AsMin + 1e-9
-
-  // bar layout in the web: fit per layer with §25.2.1 clear spacing
-  const sClearMin = Math.max(25, i.barDia)
-  const web = i.bw - 2 * (i.cover + i.stirrupDia)
-  const perLayer = Math.max(2, Math.floor((web + sClearMin) / (i.barDia + sClearMin)))
-  // `splitLayers` — the SAME rule the rectangular-beam engine uses — pairs a
-  // lone bar in the upper layer. This engine used to stack them greedily, so a
-  // T-beam could be detailed with one bar sitting alone with nothing to tie to
-  // on either side. The pairing bumps the count, so `bars` (not the strength
-  // demand) is what As-provided must be computed from.
-  const { bars, layers } = splitLayers(Math.max(2, Math.ceil(As / Ab)), perLayer)
-  const sClear = layers[0] > 1 ? (web - layers[0] * i.barDia) / (layers[0] - 1) : web
-  if (layers.length > 1) {
-    // shift d to the group centroid (25 mm clear between layers, §425.2.2)
-    d = dt - centroidRise(layers, i.barDia + 25)
-    notes.push(`${layers.length} bar layers — d reduced to the group centroid`)
-  }
-
   const AsProv = bars * Ab
-  const capAs = i.AsGiven && i.AsGiven > 0 ? i.AsGiven : AsProv
+  const capAs = analyze ? (i.AsGiven as number) : AsProv
   const cap = tBeamCapacity(i, i.Mu < 0 ? i.bw : bf, d, dt, capAs)
   const tcOK = capAs <= AsMax + 1e-9
   if (!tcOK) notes.push('As exceeds the tension-controlled cap (εt < 0.005) — enlarge the section')
@@ -175,10 +251,15 @@ export function designTBeam(i: TBeamInput): TBeamResult {
 
   return {
     bf, bfGovern: govern, d, dt, isolatedOK,
-    MnfPhi, tBehavior: cap.tBehavior,
+    // Hogging puts the flange in TENSION — the compression zone is the web
+    // rectangle and there is no T action to report. `tBeamCapacity` is handed
+    // bf = bw there, so its own `a > hf` test is comparing the web block depth
+    // against a flange thickness that plays no part; a deep enough hogging
+    // block was flagged "true T" on that accident alone.
+    MnfPhi, tBehavior: i.Mu < 0 ? false : cap.tBehavior,
     a: cap.a, c: cap.c, et: cap.et, phi: cap.phi,
     Asf, Asw, As, AsMin, minGoverns, AsMax,
-    bars, layers, sClear, sClearMin,
+    bars, layers, sClear, sClearMin, layerIters,
     phiMn: cap.phiMn, ok, notes,
   }
 }

--- a/webapp/src/lib/tbeamSolution.ts
+++ b/webapp/src/lib/tbeamSolution.ts
@@ -8,6 +8,15 @@ const eq = (tex: string): SolutionLine => ({ tex })
 
 export function buildTBeamSolution(i: TBeamInput, r: TBeamResult): SolutionStep[] {
   const hog = i.Mu < 0
+  // Steel the capacity was actually computed on — the detailed cage, or the
+  // area handed in for an analyze run.
+  const AsProv = i.AsGiven && i.AsGiven > 0 ? i.AsGiven : r.bars * (Math.PI / 4) * i.barDia ** 2
+  // C recomputed from the reported a, to show the equilibrium closing.
+  const bComp = hog ? i.bw : r.bf
+  const Ccheck = r.tBehavior
+    ? 0.85 * i.fc * ((bComp - i.bw) * i.hf + i.bw * r.a)
+    : 0.85 * i.fc * bComp * r.a
+  const webCapped = r.notes.some((n) => n.includes('singly-reinforced'))
   const steps: SolutionStep[] = [
     {
       title: 'Effective flange width',
@@ -34,18 +43,55 @@ export function buildTBeamSolution(i: TBeamInput, r: TBeamResult): SolutionStep[
     clause: 'flange couple + web',
     lines: [
       eq(String.raw`A_{sf} = \dfrac{0.85 f'_c (b_f - b_w) h_f}{f_y} = ${sn0(r.Asf)}\ \text{mm}^2`),
-      eq(String.raw`A_{sw} = ${sn0(r.Asw)}\ \text{mm}^2\ (\text{web rectangle for } M_u - M_{uf})`),
+      eq(String.raw`A_{sw} = ${sn0(r.Asw)}\ \text{mm}^2\ ${webCapped
+        ? String.raw`(\text{capped at } A_{s,max} - A_{sf}\text{ — see the note})`
+        : String.raw`(\text{web rectangle for } M_u - M_{uf})`}`),
+      ...(webCapped ? [txt('The web cannot carry Mu − Muf singly reinforced at any legal steel ratio, so Asw is shown at the tension-controlled ceiling rather than at a value the section cannot reach. Enlarge bw or h, or add compression steel.')] : []),
     ],
   })
   steps.push(
     {
       title: 'Steel area and minimum',
       clause: 'ACI 318-14 §9.6.1.2',
-      pass: r.As <= r.AsMax + 1e-9,
+      // The cap applies to the steel that gets BUILT, not to the demand — a
+      // section can need less than AsMax and still be over-reinforced once the
+      // bar count is rounded up and the lone-bar pairing adds one.
+      pass: AsProv <= r.AsMax + 1e-9,
       lines: [
         eq(String.raw`A_{s,min} = \dfrac{\max(0.25\sqrt{f'_c},\ 1.4)}{f_y}\, b_w d = ${sn0(r.AsMin)}\ \text{mm}^2${r.minGoverns ? String.raw`\ \Rightarrow\ \text{governs}` : ''}`),
-        eq(String.raw`A_s = ${sn0(r.As)}\ \text{mm}^2 \;\le\; A_{s,max}(\varepsilon_t = 0.005) = ${sn0(r.AsMax)}\ \text{mm}^2\ ${r.As <= r.AsMax ? '\\checkmark' : '\\times'}`),
-        eq(String.raw`n = ${r.bars}\ \text{–}\ \varnothing${i.barDia}\ (\text{layers } [${r.layers.join(', ')}]),\quad s_{clear} = ${sn0(r.sClear)} \ge ${sn0(r.sClearMin)}\ \text{mm}`),
+        eq(String.raw`A_{s,req} = ${sn0(r.As)}\ \text{mm}^2`),
+        eq(String.raw`n = ${r.bars}\ \text{–}\ \varnothing${i.barDia}\ (\text{layers } [${r.layers.join(', ')}]) \Rightarrow A_{s,prov} = ${sn0(AsProv)}\ \text{mm}^2,\quad s_{clear} = ${sn0(r.sClear)} \ge ${sn0(r.sClearMin)}\ \text{mm}`),
+        eq(String.raw`A_{s,prov} = ${sn0(AsProv)} \;${AsProv <= r.AsMax ? '\\le' : '>'}\; A_{s,max}(\varepsilon_t = 0.005) = ${sn0(r.AsMax)}\ \text{mm}^2\ ${AsProv <= r.AsMax ? '\\checkmark' : '\\times'}`),
+      ],
+    },
+  )
+  if (r.layers.length > 1) steps.push({
+    title: 'Effective depth of the stacked cage',
+    clause: 'ACI 318-14 §25.2.2 / Varignon',
+    lines: [
+      txt(`The bars do not all fit in one layer, so the tension resultant acts at the centroid of the ${r.layers.length}-layer group, not at the extreme layer. Layers are pitched db + 25 mm apart.`),
+      eq(String.raw`\bar{y} = \dfrac{\sum n_k\, y_k}{\sum n_k} = ${sn1(r.dt - r.d)}\ \text{mm},\qquad d = d_t - \bar{y} = ${sn1(r.dt)} - ${sn1(r.dt - r.d)} = ${sn1(r.d)}\ \text{mm}`),
+      txt(`A smaller d demands more steel, which can add another bar and drop d again, so As and the layout are solved together — ${r.layerIters} pass${r.layerIters === 1 ? '' : 'es'} here. Every As above is the converged value, at this d.`),
+    ],
+  })
+  steps.push(
+    {
+      title: 'Depth of the stress block a — from C = T',
+      clause: 'ACI 318-14 §22.2.2.4',
+      lines: [
+        txt('a is not assumed; it is solved from horizontal equilibrium of the section, C = T. Which concrete area supplies C is the only difference between the two cases.'),
+        eq(String.raw`T = A_{s,prov} f_y = ${sn0(AsProv)} \times ${sn0(i.fy)} = ${sn1((AsProv * i.fy) / 1e3)}\ \text{kN}`),
+        ...(r.tBehavior ? [
+          txt('The flange alone cannot supply C, so the overhangs are fully stressed over their whole depth hf and only the web carries the remainder:'),
+          eq(String.raw`C = \underbrace{0.85 f'_c (b_f - b_w) h_f}_{\text{overhangs, full}} + \underbrace{0.85 f'_c\, b_w\, a}_{\text{web}} = T`),
+          eq(String.raw`a = \dfrac{T - 0.85 f'_c (b_f - b_w) h_f}{0.85 f'_c\, b_w} = ${sn1(r.a)}\ \text{mm} \;>\; h_f = ${sn0(i.hf)}\ \text{mm}`),
+        ] : [
+          txt(hog
+            ? `The flange is in tension, so the compression zone is the web alone — a plain rectangle of width b = bw = ${sn0(i.bw)} mm.`
+            : `The block stays inside the flange, so the compression zone is a plain rectangle of width b = bf = ${sn0(r.bf)} mm.`),
+          eq(String.raw`C = 0.85 f'_c\, b\, a = T \;\Rightarrow\; a = \dfrac{T}{0.85 f'_c\, b} = ${sn1(r.a)}\ \text{mm}${hog ? '' : String.raw` \;\le\; h_f = ${sn0(i.hf)}\ \text{mm}`}`),
+        ]),
+        eq(String.raw`\text{check: } C = ${sn1(Ccheck / 1e3)}\ \text{kN} = T = ${sn1((AsProv * i.fy) / 1e3)}\ \text{kN}\ \checkmark`),
       ],
     },
     {
@@ -53,7 +99,7 @@ export function buildTBeamSolution(i: TBeamInput, r: TBeamResult): SolutionStep[
       clause: 'ACI 318-14 §21.2.2',
       pass: r.ok,
       lines: [
-        eq(String.raw`a = ${sn1(r.a)}\ \text{mm}\ (${r.tBehavior ? 'a > h_f' : 'a \\le h_f'}),\quad c = a/\beta_1 = ${sn1(r.c)}\ \text{mm}\ (\beta_1 = ${sn2(beta1(i.fc))})`),
+        eq(String.raw`c = a/\beta_1 = ${sn1(r.a)}/${sn2(beta1(i.fc))} = ${sn1(r.c)}\ \text{mm}`),
         eq(String.raw`\varepsilon_t = 0.003\,\tfrac{d_t - c}{c} = ${sn4(r.et)} \Rightarrow \phi = ${sn2(r.phi)}`),
         eq(String.raw`\phi M_n = ${sn1(r.phiMn)}\ \text{kN·m}\ ${r.phiMn >= Math.abs(i.Mu) ? '\\ge' : '<'}\ M_u = ${sn1(Math.abs(i.Mu))}\ \text{kN·m}\ ${r.ok ? '\\checkmark' : '\\times'}`),
       ],

--- a/webapp/src/pages/TBeamDesign.tsx
+++ b/webapp/src/pages/TBeamDesign.tsx
@@ -29,6 +29,11 @@ export default function TBeamDesign() {
   const r = useMemo(() => { try { return designTBeam(inp) } catch { return null } }, [inp])
   const steps = useMemo(() => (r ? buildTBeamSolution(inp, r) : []), [inp, r])
   const badges = ['ACI 318-14', 'NSCP 2015']
+  // Steel the detailed cage actually has. The summary printed "6-⌀25 (2112 mm²)"
+  // — the bar count beside the area REQUIRED, which reads as the area those bars
+  // supply and is not. The tension-controlled ratio has the same problem: the cap
+  // applies to the steel that gets built.
+  const AsProv = r ? r.bars * (Math.PI / 4) * barDia ** 2 : 0
 
   return (
     <div className="min-h-screen">
@@ -39,17 +44,18 @@ export default function TBeamDesign() {
           governing={`${r.tBehavior ? 'true T behaviour' : 'rectangular behaviour'} · utilization ${(Math.abs(Mu) / Math.max(r.phiMn, 1e-9)).toFixed(2)}`}
           lh={lh}
           stats={[
-            { label: 'Steel', value: `${r.bars}-⌀${barDia}` },
+            { label: 'Steel', value: `${r.bars}-⌀${barDia}`, unit: `(${f0(AsProv)} mm²)` },
             { label: 'φMn', value: f1(r.phiMn), unit: 'kN·m' },
             { label: 'bf', value: f0(r.bf), unit: 'mm' },
           ]}
           checks={[
             { name: 'Flexure Mu/φMn', ratio: Math.abs(Mu) / Math.max(r.phiMn, 1e-9), ok: r.phiMn >= Math.abs(Mu) },
-            { name: 'Tension-controlled', ratio: r.As / Math.max(r.AsMax, 1e-9), ok: r.As <= r.AsMax },
+            { name: 'Tension-controlled', ratio: AsProv / Math.max(r.AsMax, 1e-9), ok: AsProv <= r.AsMax },
           ]}
           data={[
             ['Type', kind], ['Web bw × h', `${bw} × ${h} mm`], ['Flange bf × hf', `${f0(r.bf)} × ${hf} mm`],
             ["f'c / fy", `${fc} / ${fy} MPa`], ['Mu', `${Mu} kN·m`], ['d / dt', `${f1(r.d)} / ${f1(r.dt)} mm`],
+            ['As req / prov', `${f0(r.As)} / ${f0(AsProv)} mm²`],
           ]}
           steps={steps}
           drawing={<TSection bf={r.bf} bw={bw} h={h} hf={hf} a={r.a} bars={r.bars} barDia={barDia} layers={r.layers} cover={cover} stirrupDia={stirrupDia} />}
@@ -88,13 +94,13 @@ export default function TBeamDesign() {
               <VerdictPanel ok={r.ok} headline={r.ok ? 'DESIGN OK' : 'CHECK FAILED'}
                 governing={`${r.tBehavior ? 'true T (a > hf)' : Mu < 0 ? 'web rectangle (hogging)' : 'rectangular (a ≤ hf)'} · bf ${f0(r.bf)} mm`}
                 stats={[
-                  { label: 'Steel', value: `${r.bars}-⌀${barDia}`, unit: `mm (${f0(r.As)} mm²)` },
+                  { label: 'Steel', value: `${r.bars}-⌀${barDia}`, unit: `mm (${f0(AsProv)} mm² prov · ${f0(r.As)} req)` },
                   { label: 'φMn', value: f1(r.phiMn), unit: 'kN·m' },
                   { label: 'εt / φ', value: `${r.et.toFixed(4)} / ${r.phi.toFixed(2)}` },
                 ]}
                 checks={[
                   { name: 'Flexure Mu/φMn', ratio: r.phiMn > 0 ? Math.abs(Mu) / r.phiMn : 99 },
-                  { name: 'Tension-controlled As/As,max', ratio: r.AsMax > 0 ? r.As / r.AsMax : 99 },
+                  { name: 'Tension-controlled As,prov/As,max', ratio: r.AsMax > 0 ? AsProv / r.AsMax : 99 },
                 ]}
                 footnote={r.notes.join(' · ') || undefined} />
             )}


### PR DESCRIPTION
Started as a question — *how is `a` derived in a T-beam, rectangular and not, and does it satisfy C = T?* The answer is **yes, exactly, in both branches**. Verifying it found a design defect sitting next to it, and three more on the way.

## 1. How `a` is derived — the answer, and it was already right

`a` is never assumed. It is solved from horizontal equilibrium; the two branches differ only in **which concrete area supplies C**.

| case | compression zone | solved a |
|---|---|---|
| `a ≤ hf` | rectangle of width **bf** | `a = T / (0.85 f'c bf)` |
| `a > hf` | overhangs **full** at hf + web block | `a = (T − 0.85 f'c (bf−bw) hf) / (0.85 f'c bw)` |

Hogging is passed `bf = bw`, so the overhang term vanishes and the second form degenerates into the first — one equation, not a special case.

```
rect (a < hf)     bf 1200  As 1500    a  21.80   T 622.5 kN   C 622.5 kN   0.0000%
rect, heavier     bf 1200  As 4000    a  58.12   T 1660.0     C 1660.0     0.0000%
T (a > hf)        bf 1200  As 8000    a 164.99   T 3320.0     C 3320.0     0.0000%
T, deep           bf 1200  As 12000   a 397.48   T 4980.0     C 4980.0     0.0000%
hogging: bf = bw  bf  300  As 3000    a 174.37   T 1245.0     C 1245.0     0.0000%
```

`a = β1·c` exact throughout. **No change was needed here** — this part is now pinned by a test across 20 combinations instead of being taken on trust.

## 2. What the verification found: As solved at a depth the cage then destroys

`designTBeam` computed `As` at `d = dt`, laid the bars out, and **only then** dropped `d` to the bar-group centroid — never redesigning. `designBeam` has iterated both faces all along (`layerIters`, "layout → Varignon d & d′ → redesign, until the layer arrangement stops changing"); this engine never did.

The cage came back sized for a lever arm the cage itself had destroyed:

```
bf 600  hf 80  Mu 700   As 2905 → 2945 provided   φMn  690.7   ✗
bf 600  hf 80  Mu 900   As 3842 → 3927 provided   φMn  880.5   ✗
bf 1200 hf 100 Mu 1900  As 8153 → 8836 provided   φMn 1732.6   ✗   d fell 89 mm
bf 700  hf 90  Mu 1100  As 4716 → 4909 provided   φMn 1064.6   ✗
```

**More steel than the `As` printed beside it, and still short of `Mu`.** φ was 0.90 in the first and last, so nothing but `d` explained it. `ok = false` was at least honest, but the engine's job is to return steel that works.

The layout and `As` are now solved together. The map `d ↦ d_next` is monotone — deeper `d` needs less steel, hence fewer bars, hence a shallower stack, hence a deeper `d_next` — and starts at `d = dt`, the largest `d` the section has, so the sequence only falls; the integer bar count makes it settle. **Two passes** in every ordinary case.

Case 1 above now returns `φMn 755.8 ≥ 700, ok`. Cases 2 and 4 are genuinely past εt = 0.005 and now say so with that reason rather than an unexplained shortfall.

## 3. Three more, all found by driving the page

| where | what was wrong |
|---|---|
| `designTBeam` | The loop's one non-monotone case **oscillated forever**: when the web runs out of singly-reinforced capacity the radicand goes negative, `As` collapses to `Asf` — a *lighter* cage the worse the overload — and the stack springs back up. That is a failed design, not a convergence problem. `Asw` is now reported at the tension-controlled ceiling (`AsMax − Asf`) and the loop stops with the right note. |
| `designTBeam` | **Hogging was reported as "true T".** `tBeamCapacity` is handed `bf = bw` there, so its own `a > hf` flag compares a web block depth against a flange thickness that plays no part in the section. A 700×75 flange under `Mu = −150` came out "true T" on that accident — and the worked solution then printed the *overhang* formula for a section whose flange is in **tension**. The number was right; the derivation shown was not. |
| `TBeamDesign` | The summary read `6-⌀25 (2112 mm²)` — the bar count beside the area **required**, which reads as the area those bars supply (2945). The tension-controlled bar had the same problem: it compared the demand against a cap that governs **what gets built**, showing 0.24 where 0.34 was true. |

`designTBeam` also gained §25.2.1's **4/3·d_agg** term that `designBeam` got in #539 — this engine was still packing layers on `max(db, 25)`.

## 4. β1, finally down to one copy

#530 fixed `matRebarOptimize`. Three copies of `max(0.65, sloped-row)` survived it: `loads.ts` (feeding `beamDesign`, `columnDesign`, `scwb`, `columnSolution`), `tbeam.ts` and `prestressedBeam.ts`. All three now re-export `flexure.beta1`. ACI Table 22.2.2.4.3 (SI) is **not continuous** — the slope covers 28 < f′c < 55 and the last row is a flat 0.65; the slope at 55 reads 0.657, the wrong row.

## 5. The worked solution now shows the derivation that was asked about

`/tbeam-design` gained two steps: **"Depth of the stress block a — from C = T"** (T, the C expression for the branch actually taken, `a` solved from it, and a closing `C = T` check) and **"Effective depth of the stacked cage"** (the Varignon `y̅`, `d = dt − y̅`, and how many passes it took), shown only when the bars need more than one layer.

Rendered at `/tbeam-design`, TeX read straight out of the DOM:

**default, rectangular**
```
n = 6 – ⌀25 (layers [4, 2]) ⇒ As,prov = 2945 mm², s_clear = 33 ≥ 27 mm
ȳ = 16.7 mm,  d = dt − ȳ = 537.5 − 16.7 = 520.8 mm
T = As,prov fy = 2945 × 415 = 1222.3 kN
C = 0.85 f'c b a = T ⇒ a = T/(0.85 f'c b) = 38.0 mm ≤ hf = 100 mm
check: C = 1222.3 kN = T = 1222.3 kN ✓
φMn = 552.0 kN·m ≥ Mu = 400.0 kN·m ✓
```

**true T** (bf 700, hf 75, Mu 520)
```
C = 0.85 f'c (bf − bw) hf + 0.85 f'c bw a = T
a = (T − 0.85 f'c (bf − bw) hf)/(0.85 f'c bw) = 128.2 mm > hf = 75 mm
check: C = 1222.3 kN = T = 1222.3 kN ✓        φMn = 570.2 ≥ 520.0 ✓
```

**hogging** (Mu = −150) — the rectangle `b = bw`, with no bogus `hf` comparison
```
C = 0.85 f'c b a = T ⇒ a = T/(0.85 f'c b) = 76.1 mm
check: C = 407.4 kN = T = 407.4 kN ✓          φMn = 201.5 ≥ 150.0 ✓
```

**deliberately overloaded** (bf 1200, Mu 1900) — both reasons given, cap failed on provided steel
```
Asw = 2828 mm² (capped at As,max − Asf — see the note)
As,prov = 6872 > As,max(εt = 0.005) = 6699 mm² ×
φMn = 1335.7 kN·m < Mu = 1900.0 kN·m ×
notes: web remainder exceeds singly-reinforced capacity · 4 bar layers —
       d reduced to the group centroid (687.5 → 623.2 mm) · As exceeds the
       tension-controlled cap
```

Zero console errors or warnings on every case.

## Verification

**+5 cases.** Equilibrium holds at 0.0000 % across 4 flange widths × 5 steel areas including the hogging degeneration, with `a = β1·c`; β1 is the table step, not the clamped slope; the four true-T designs stack, drop `d`, and any that reports `ok` covers its `Mu`; a reported-ok design is self-consistent — solving `As` at the **returned** `d` still fits the returned bars, swept over 5 flange widths × 11 moments; hogging is never flagged true T however deep its block gets.

The existing `A_s` hand-calc case pinned the *pre-fix* behaviour (solved at `dt`) and now states the converged `d = 537.5 − 16.667 = 520.833` explicitly rather than reading it back off the result.

`npm test` — 203 files, **3501 passed**. `npx tsc -b`, `eslint --max-warnings 0`, `npm run build` green.

Engine layer **6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_