### PR TITLE
fix(pages): one compact letterhead card, at the top, on every calculator

### DIFF
--- a/webapp/src/components/calc.tsx
+++ b/webapp/src/components/calc.tsx
@@ -130,25 +130,27 @@ export function LetterheadCard({ lh, onChange, action }: {
 }) {
   const today = new Date().toISOString().slice(0, 10)
   const cell = (label: string, value: string, key: keyof LetterheadState, ph: string, mono = false) => (
-    <div>
-      <span className="text-[10px] font-semibold uppercase tracking-widest text-[#a39d8d]">{label}</span>
+    <div className="min-w-0">
+      <span className="text-[9.5px] font-semibold uppercase tracking-widest text-[#a39d8d]">{label}</span>
       <input value={value} onChange={(e) => onChange({ [key]: e.target.value })} placeholder={ph}
-        className={`mt-0.5 w-full !border-0 !bg-transparent !p-0 text-[12px] font-semibold text-[#0f1b2a] !shadow-none placeholder:text-[#c8c2b4] ${mono ? 'font-mono font-medium' : ''}`} />
+        className={`w-full !border-0 !bg-transparent !p-0 text-[12px] font-semibold leading-[1.35] text-[#0f1b2a] !shadow-none placeholder:text-[#c8c2b4] ${mono ? 'font-mono font-medium' : ''}`} />
     </div>
   )
+  // Four fields on ONE row from `sm` up — the two-row grid was the whole of the
+  // card's height, and none of these values is long enough to need half a card.
   return (
-    <section className="rail-card no-print rounded-lg border border-[#e3e1da] bg-white p-4">
+    <section className="rail-card no-print rounded-lg border border-[#e3e1da] bg-white px-4 py-3">
       <div className="flex items-center justify-between gap-3">
-        <h2 className="text-[13.5px] font-bold text-[#0f1b2a]">Report letterhead</h2>
+        <h2 className="text-[12.5px] font-bold text-[#0f1b2a]">Report letterhead</h2>
         {action ?? <span className="font-mono text-[10px] text-[#a39d8d]">prints on the calc sheet</span>}
       </div>
-      <div className="mt-2.5 grid grid-cols-2 gap-x-3.5 gap-y-2">
+      <div className="mt-2 grid grid-cols-2 gap-x-5 gap-y-1.5 sm:grid-cols-4">
         {cell('Project', lh.project, 'project', 'Lot 12 Residence')}
         {cell('Sheet', lh.sheet, 'sheet', 'F-01 · Rev A', true)}
         {cell('Prepared by', lh.preparedBy, 'preparedBy', 'Engineer, CE')}
-        <div>
-          <span className="text-[10px] font-semibold uppercase tracking-widest text-[#a39d8d]">Date</span>
-          <p className="mt-0.5 font-mono text-[12px] font-medium text-[#0f1b2a]">{today}</p>
+        <div className="min-w-0">
+          <span className="text-[9.5px] font-semibold uppercase tracking-widest text-[#a39d8d]">Date</span>
+          <p className="font-mono text-[12px] font-medium leading-[1.35] text-[#0f1b2a]">{today}</p>
         </div>
       </div>
     </section>
@@ -161,10 +163,12 @@ export interface ReportCheckRow { name: string; ratio: number; ok: boolean }
 const SectionRule = ({ n, title }: { n: number; title: string }) => (
   <h2 className="mt-6 border-b-2 border-[#0f1b2a] pb-1.5 text-[12px] font-extrabold uppercase tracking-[.12em] text-[#0f1b2a]">{n} · {title}</h2>
 )
-export function PrintReport({ docTitle, docCode, badges, ok, governing, lh, stats = [], checks = [], data = [], steps, drawing, drawingTitle }: {
+export function PrintReport({ docTitle, docCode, badges, ok, governing, lh, onLhChange, stats = [], checks = [], data = [], steps, drawing, drawingTitle }: {
   docTitle: string; docCode: string; badges: string[]
   ok: boolean; governing: string
   lh: LetterheadState
+  /** Edit handler for the on-screen letterhead this component now renders. */
+  onLhChange?: (p: Partial<LetterheadState>) => void
   stats?: VerdictStat[]; checks?: ReportCheckRow[]
   data?: [string, string][]
   steps?: SolutionStep[]
@@ -179,26 +183,26 @@ export function PrintReport({ docTitle, docCode, badges, ok, governing, lh, stat
   return (
     <>
     {/*
-      Export bar — rendered HERE rather than wired into each page's header
-      because this component already receives every field the PDF needs.
-      Hoisting the same prop soup out of eight pages to pass it to a second
-      component would be eight chances to let the printed sheet and the
+      Letterhead + export, in ONE card — rendered HERE rather than wired into
+      each page because this component already receives every field the PDF
+      needs. Hoisting the same prop soup out of eight pages to pass it to a
+      second component would be eight chances to let the printed sheet and the
       generated PDF drift apart; taking both from one props object means they
       cannot.
+
+      It used to be a separate "Calculation report" bar BELOW the page's own
+      letterhead card — two cards where `ReportControls` (slab, stair, water
+      tank, torsion, dev & splice, punching shear) has always had one, and
+      wherever the page happened to place `PrintReport`: on the column page,
+      the bottom. Same card, same place, on every calculator now.
     */}
-    <div className="no-print mt-4 flex items-center justify-between gap-3 rounded-lg border border-[#e3e1da] bg-white px-4 py-3">
-      <div>
-        <p className="text-[13px] font-bold text-[#0f1b2a]">Calculation report</p>
-        <p className="mt-0.5 text-[11.5px] text-[#5c6675]">
-          {docTitle} · {badges.join(' · ')} — summary, design data, worked solution
-          {drawing ? ' and drawing' : ''}, as an A4 PDF.
-        </p>
-      </div>
-      <ExportPdfButton
-        docTitle={docTitle} docCode={docCode} badges={badges} ok={ok} governing={governing} lh={lh}
-        stats={stats} checks={checks} data={data} steps={steps} drawingTitle={drawingTitle}
-        className="flex-none rounded-md bg-[#0f4c92] px-4 py-2 text-[12.5px] font-semibold text-white hover:bg-[#0d3f78] disabled:opacity-50"
-      />
+    <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7">
+      <LetterheadCard lh={lh} onChange={onLhChange ?? (() => {})}
+        action={<ExportPdfButton
+          docTitle={docTitle} docCode={docCode} badges={badges} ok={ok} governing={governing} lh={lh}
+          stats={stats} checks={checks} data={data} steps={steps} drawingTitle={drawingTitle}
+          className="inline-flex flex-none items-center gap-2 rounded-md bg-[#0f4c92] px-3.5 py-1.5 text-[12.5px] font-semibold text-white hover:bg-[#0d3f78] disabled:opacity-50"
+        />} />
     </div>
     <div className="print-only">
       <div className="flex items-baseline justify-between border-b border-[#eeece5] pb-1.5 font-mono text-[9px] text-[#a39d8d]">

--- a/webapp/src/pages/BeamDesign.tsx
+++ b/webapp/src/pages/BeamDesign.tsx
@@ -194,6 +194,7 @@ export default function BeamDesign() {
     ok: allOK,
     governing: `Governing: flexure · utilization ${cap ? (demand.Mu / cap.phiMn).toFixed(2) : '—'}${r.mode === 'DRRB' ? ' · DRRB' : ''}`,
     lh,
+    onLhChange: (patch: Partial<LetterheadState>) => setLh((v) => ({ ...v, ...patch })),
     stats: [
       { label: hogging ? 'Tension (top)' : 'Tension steel', value: `${r.bars}-⌀${fd.barDia}` },
       { label: 'Stirrups', value: r.sAdopt > 0 ? `⌀${f.stirrupDia} @${f0(r.sAdopt)}` : REGION[r.region] },
@@ -224,7 +225,9 @@ export default function BeamDesign() {
             ))}
           </div>
         } />
-        <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
+        {/* PrintReport carries the letterhead card AND the export button in one; this
+          bare one is the fallback for when the design has not solved. */}
+      {!(reportData) && <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>}
         {reportData && (
           <PrintReport {...reportData}
             drawing={<BeamSchematic b={fd.b} h={fd.h} cover={fd.cover} barDia={fd.barDia} stirrupDia={fd.stirrupDia}

--- a/webapp/src/pages/ColumnDesign.tsx
+++ b/webapp/src/pages/ColumnDesign.tsx
@@ -189,7 +189,42 @@ export default function ColumnDesign() {
   return (
     <div>
       <PageHeader title="RC Column" badges={['ACI 318-14', 'NSCP 2015']} />
-      <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
+      {/* PrintReport carries the letterhead card AND the export button in one; this
+          bare one is the fallback for when the design has not solved. It lives HERE,
+          under the page header, because the report card had been rendering at the very
+          bottom of the column page while every other calculator puts it at the top. */}
+      {!(axial && solution.length > 0) && <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>}
+      {axial && solution.length > 0 && (
+        <PrintReport
+          docTitle={tied ? 'Tied RC Column' : 'Spiral RC Column'} docCode="C-01" badges={['ACI 318-14', 'NSCP 2015']}
+          ok={(eccentric ? util !== null && util <= 1 && !unstable : axial.axialOK) && axial.rhoOK}
+          governing={eccentric
+            ? (unstable ? 'Slender column unstable — Pu ≥ 0.75·Pc' : `P–M interaction · utilization ${util !== null ? util.toFixed(2) : '—'}`)
+            : `Axial φPn,max = ${f1(axial.phiPnMax)} kN`}
+          lh={lh} onLhChange={(patch) => setLh((v) => ({ ...v, ...patch }))}
+          stats={[
+            { label: 'Bars', value: `${axial.bars}-⌀${dbEff}` },
+            { label: tied ? 'Ties' : 'Spiral pitch', value: tied ? `⌀${Math.max(tieDia, axial.tieDiaMin)} @${f0(axial.tieSpacingFinal)}` : `@${f0(axial.spiralPitch)}`, unit: 'mm' },
+            { label: 'φPn,max', value: f1(axial.phiPnMax), unit: 'kN' },
+            ...(eccentric && slender ? [{
+              label: 'Column class',
+              value: slender.slender ? 'LONG (slender)' : 'SHORT',
+            }] : []),
+          ]}
+          checks={eccentric && util !== null ? [{ name: 'P–M interaction Pu/φPn', ratio: util, ok: util <= 1.0001 }] : []}
+          data={[
+            ['Section', tied ? `${b} × ${h} mm (tied)` : `⌀${D} mm (spiral)`], ['Clear cover', `${cover} mm`],
+            ["Concrete f'c", `${fc} MPa`], ['Steel fy / fyt', `${fy} / ${fyt} MPa`],
+            ['Bar ⌀ / tie ⌀', `${barDia} / ${tieDia} mm`], ['ρ provided', `${(axial.rho * 100).toFixed(2)} %`],
+            ['Pu', `${f1(Pu)} kN`], ...(eccentric ? [['Mu', `${f1(Mu)} kN·m`] as [string, string]] : []),
+          ]}
+          steps={solution}
+          drawingTitle="Column Section"
+          drawing={<ColumnSchematic shape={tied ? 'tied' : 'spiral'} b={b} h={h} D={D} cover={cover}
+            barDia={barDia} tieDia={tieDia} bars={axial.bars}
+            tieSpacing={tied ? axial.tieSpacingFinal : axial.spiralPitch} />}
+        />
+      )}
       <div className="mx-auto max-w-[1500px] px-5 pb-8 sm:px-7">
 
       <div className="no-print mt-5 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]">
@@ -416,37 +451,6 @@ export default function ColumnDesign() {
       )}
 
       <div className="no-print">{solution.length > 0 && <WorkedSolution steps={solution} title="Calculation report — worked solution" />}</div>
-      {axial && solution.length > 0 && (
-        <PrintReport
-          docTitle={tied ? 'Tied RC Column' : 'Spiral RC Column'} docCode="C-01" badges={['ACI 318-14', 'NSCP 2015']}
-          ok={(eccentric ? util !== null && util <= 1 && !unstable : axial.axialOK) && axial.rhoOK}
-          governing={eccentric
-            ? (unstable ? 'Slender column unstable — Pu ≥ 0.75·Pc' : `P–M interaction · utilization ${util !== null ? util.toFixed(2) : '—'}`)
-            : `Axial φPn,max = ${f1(axial.phiPnMax)} kN`}
-          lh={lh}
-          stats={[
-            { label: 'Bars', value: `${axial.bars}-⌀${dbEff}` },
-            { label: tied ? 'Ties' : 'Spiral pitch', value: tied ? `⌀${Math.max(tieDia, axial.tieDiaMin)} @${f0(axial.tieSpacingFinal)}` : `@${f0(axial.spiralPitch)}`, unit: 'mm' },
-            { label: 'φPn,max', value: f1(axial.phiPnMax), unit: 'kN' },
-            ...(eccentric && slender ? [{
-              label: 'Column class',
-              value: slender.slender ? 'LONG (slender)' : 'SHORT',
-            }] : []),
-          ]}
-          checks={eccentric && util !== null ? [{ name: 'P–M interaction Pu/φPn', ratio: util, ok: util <= 1.0001 }] : []}
-          data={[
-            ['Section', tied ? `${b} × ${h} mm (tied)` : `⌀${D} mm (spiral)`], ['Clear cover', `${cover} mm`],
-            ["Concrete f'c", `${fc} MPa`], ['Steel fy / fyt', `${fy} / ${fyt} MPa`],
-            ['Bar ⌀ / tie ⌀', `${barDia} / ${tieDia} mm`], ['ρ provided', `${(axial.rho * 100).toFixed(2)} %`],
-            ['Pu', `${f1(Pu)} kN`], ...(eccentric ? [['Mu', `${f1(Mu)} kN·m`] as [string, string]] : []),
-          ]}
-          steps={solution}
-          drawingTitle="Column Section"
-          drawing={<ColumnSchematic shape={tied ? 'tied' : 'spiral'} b={b} h={h} D={D} cover={cover}
-            barDia={barDia} tieDia={tieDia} bars={axial.bars}
-            tieSpacing={tied ? axial.tieSpacingFinal : axial.spiralPitch} />}
-        />
-      )}
       </div>
     </div>
   )

--- a/webapp/src/pages/CombinedFootingDesign.tsx
+++ b/webapp/src/pages/CombinedFootingDesign.tsx
@@ -170,13 +170,15 @@ export default function CombinedFootingDesign() {
   return (
     <div>
       <PageHeader title="Combined Footing" badges={['ACI 318-14', 'NSCP 2015']} />
-      <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
+      {/* PrintReport carries the letterhead card AND the export button in one; this
+          bare one is the fallback for when the design has not solved. */}
+      {!(result && solutionSteps) && <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>}
       {result && solutionSteps && (
         <PrintReport
           docTitle={result.shape === 'Trapezoidal (CTF)' ? 'Combined Footing (Trapezoidal)' : 'Combined Footing (Rectangular)'}
           docCode="F-02" badges={['ACI 318-14', 'NSCP 2015']}
           ok={result.qNet > 0} governing="Rigid (conventional) method — resultant matched to factored column loads"
-          lh={lh}
+          lh={lh} onLhChange={(patch) => setLh((v) => ({ ...v, ...patch }))}
           stats={[
             { label: 'Plan', value: result.shape === 'Trapezoidal (CTF)' ? `${f2(result.Bx)} × ${f2(result.By1)}→${f2(result.By2)}` : `${f2(result.Bx)} × ${f2(result.By)}`, unit: 'm' },
             { label: 'Thickness Dc', value: f0(result.Dc), unit: 'mm' },

--- a/webapp/src/pages/FoundationDesign.tsx
+++ b/webapp/src/pages/FoundationDesign.tsx
@@ -326,12 +326,14 @@ export default function FoundationDesign() {
             ⎙ Export report
           </button>
         } />
-        <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
+        {/* PrintReport carries the letterhead card AND the export button in one; this
+          bare one is the fallback for when the design has not solved. */}
+      {!(view && solutionSteps) && <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>}
         {view && solutionSteps && (
           <PrintReport
             docTitle="Isolated Footing" docCode="F-01" badges={['ACI 318-14', 'NSCP 2015']}
             ok={allOK} governing={`Governing: ${governing} · ${globalThis.Math.max(punchRatio, beamRatio).toFixed(2)}`}
-            lh={lh}
+            lh={lh} onLhChange={(patch) => setLh((v) => ({ ...v, ...patch }))}
             stats={[
               { label: 'Plan size', value: `${f2(view.Bx)} × ${f2(view.By)}`, unit: 'm' },
               { label: 'Thickness Dc', value: f0(view.Dc), unit: 'mm' },

--- a/webapp/src/pages/PileCapDesign.tsx
+++ b/webapp/src/pages/PileCapDesign.tsx
@@ -162,7 +162,9 @@ export default function PileCapDesign() {
   return (
     <div>
       <PageHeader title="Pile Cap" badges={['ACI 318-14', 'NSCP 2015']} />
-      <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
+      {/* PrintReport carries the letterhead card AND the export button in one; this
+          bare one is the fallback for when the design has not solved. */}
+      {!(result) && <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>}
       {result && (
         <PrintReport
           docTitle="Pile Cap" docCode="PC-01" badges={['ACI 318-14', 'NSCP 2015']}
@@ -170,7 +172,7 @@ export default function PileCapDesign() {
           governing={`Governing ratio ${globalThis.Math.max(
             result.VuPunchCol / result.phiVcPunchCol, result.VuPunchPile / result.phiVcPunchPile,
             result.VuBeamX / result.phiVcBeamX, result.VuBeamY / result.phiVcBeamY).toFixed(2)} across punching / beam shear`}
-          lh={lh}
+          lh={lh} onLhChange={(patch) => setLh((v) => ({ ...v, ...patch }))}
           stats={[
             { label: 'Cap plan', value: `${f2(result.capBx)} × ${f2(result.capBy)}`, unit: 'm' },
             { label: 'Thickness Dc', value: f0(result.Dc), unit: 'mm' },

--- a/webapp/src/pages/PrestressedBeam.tsx
+++ b/webapp/src/pages/PrestressedBeam.tsx
@@ -75,11 +75,13 @@ export default function PrestressedBeam() {
   return (
     <div className="min-h-screen">
       <PageHeader title="Prestressed Beam" badges={[...badges, `class ${klass}`]} />
-      <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(p) => setLh((s) => ({ ...s, ...p }))} /></div>
+      {/* PrintReport carries the letterhead card AND the export button in one; this
+          bare one is the fallback for when the design has not solved. */}
+      {!(r) && <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(p) => setLh((s) => ({ ...s, ...p }))} /></div>}
       {r && (
         <PrintReport docTitle="Prestressed Beam" docCode="PS-01" badges={badges} ok={r.ok}
           governing={`losses ${r.lossPct.toFixed(1)}% · utilization ${(r.Mu / Math.max(r.phiMn, 1e-9)).toFixed(2)}`}
-          lh={lh}
+          lh={lh} onLhChange={(p) => setLh((s) => ({ ...s, ...p }))}
           stats={[
             { label: 'φMn', value: f1(r.phiMn), unit: 'kN·m' },
             { label: 'fse', value: f1(r.fse), unit: 'MPa' },

--- a/webapp/src/pages/RetainingWall.tsx
+++ b/webapp/src/pages/RetainingWall.tsx
@@ -50,13 +50,15 @@ export default function RetainingWall() {
   return (
     <div>
       <PageHeader title="Cantilever Retaining Wall" badges={['NSCP 2015', 'ACI 318-14']} />
-      <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>
+      {/* PrintReport carries the letterhead card AND the export button in one; this
+          bare one is the fallback for when the design has not solved. */}
+      {!(r) && <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(patch) => setLh((v) => ({ ...v, ...patch }))} /></div>}
       {r && (
         <PrintReport
           docTitle="Cantilever Retaining Wall" docCode="RW-01" badges={['NSCP 2015', 'ACI 318-14']}
           ok={r.stableSL && r.stableOT && r.bearingOK && r.tensionOK && r.shearOK && r.toe.shearOK && r.heel.shearOK}
           governing={`FS sliding ${f2(r.FS_SL)} · FS overturning ${f2(r.FS_OT)} · q,max ${f1(r.q_max)} kPa`}
-          lh={lh}
+          lh={lh} onLhChange={(patch) => setLh((v) => ({ ...v, ...patch }))}
           stats={[
             // B and H are ALREADY in metres — dividing by 1000 again printed
             // a 2.3 m base as "0.00 m" on every report this page produced.

--- a/webapp/src/pages/TBeamDesign.tsx
+++ b/webapp/src/pages/TBeamDesign.tsx
@@ -38,11 +38,13 @@ export default function TBeamDesign() {
   return (
     <div className="min-h-screen">
       <PageHeader title="T-Beam Design" badges={[...badges, kind]} />
-      <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(p) => setLh((s) => ({ ...s, ...p }))} /></div>
+      {/* PrintReport carries the letterhead card AND the export button in one;
+          this bare one is the fallback for when the design has not solved. */}
+      {!r && <div className="no-print mx-auto max-w-[1500px] px-5 pt-5 sm:px-7"><LetterheadCard lh={lh} onChange={(p) => setLh((s) => ({ ...s, ...p }))} /></div>}
       {r && (
         <PrintReport docTitle="T-Beam" docCode="TB-01" badges={badges} ok={r.ok}
           governing={`${r.tBehavior ? 'true T behaviour' : 'rectangular behaviour'} · utilization ${(Math.abs(Mu) / Math.max(r.phiMn, 1e-9)).toFixed(2)}`}
-          lh={lh}
+          lh={lh} onLhChange={(p) => setLh((s) => ({ ...s, ...p }))}
           stats={[
             { label: 'Steel', value: `${r.bars}-⌀${barDia}`, unit: `(${f0(AsProv)} mm²)` },
             { label: 'φMn', value: f1(r.phiMn), unit: 'kN·m' },


### PR DESCRIPTION
Three reported problems, one cause.

`PrintReport` rendered its export control as a **separate "Calculation report" bar**, below the page's own letterhead card, wherever the page happened to place the component. `ReportControls` — slab, stair, water tank, torsion, dev & splice, punching shear — has always composed the two into **one** card. So:

1. **The beam pages didn't match the slab/stair pages.** Two cards vs one, on beam, T-beam, prestressed beam, column, isolated footing, pile cap, combined footing and retaining wall.
2. **The column page's report card was at the bottom.** Measured: `y = 3539` — past the entire worked solution.
3. **The card was taller than it needed to be** — four fields on a two-row grid, none of them long enough to want half a card.

## The fix

`PrintReport` now renders the shared `LetterheadCard` with the `ExportPdfButton` in its `action` slot — the exact composition `ReportControls` already used — wrapped in the same `max-w-[1500px]` page gutter, so it lands directly under the header on every page. Pages drop their standalone card and keep a bare one as the **fallback for when the design has not solved**, so the letterhead never disappears.

That keeps the property the old comment was protecting: the printed sheet and the generated PDF still come from **one props object**, so they cannot drift.

`LetterheadCard` itself goes to four columns from `sm` up, with tighter padding and leading.

## Measured, not eyeballed

All 14 routes driven in headless Chromium:

```
route                cards  height  topY   export?  legacy-bar?
/beam-design         1      113     165    true     false
/tbeam-design        1      113     161    true     false
/prestressed-beam    1      113     161    true     false
/column-design       1      113     161    true     false
/foundation          1      113     165    true     false
/pile-cap            1      113     161    true     false
/combined            1      113     161    true     false
/retaining-wall      1      113     161    true     false
/slab-design         1      113     257    true     false
/stair               1      113     181    true     false
/water-tank          1      113     181    true     false
/torsion             1      113     209    true     false
/dev-length          1      113     233    true     false
/punching-shear      1      113     209    true     false
```

Against the same probe on `main`:

```
BEFORE /beam-design    card h=168 y=165   separate bar y=349  h=65
BEFORE /column-design  card h=168 y=161   separate bar y=3539 h=65   ← the reported one
BEFORE /slab-design    card h=179 y=257   (already merged, but taller)
```

**Card 168 → 113 px** (−33 %; the `ReportControls` pages were 179 → 113, −37 %), and the 65 px bar is gone entirely — **233 → 113 px** of vertical space on a beam page. Column now sits at `y = 161` with everything else. Zero console errors on any route.

The remaining `topY` spread is the pages' own intro paragraphs above the card, which is pre-existing and intentional.

## Verification

`npm test` — 203 files, **3502 passed**. `npx tsc -b`, `eslint --max-warnings 0`, `npm run build` green.

No engine layer — presentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149HNfgXFF8zFL2BGuzUqnm)_