### PR TITLE
feat(model): store the column bar count, and search both axes for it

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1642,3 +1642,50 @@ Three copies of `max(0.65, sloped-row)` remained after #530 — `loads.ts`
 `/tbeam-design` now shows the equilibrium derivation itself: T, the C expression
 for the branch taken, `a` solved from it, and a `C = T` closing check — plus a
 step for the stacked-cage `d` when the bars need more than one layer.
+
+# Bar count in the model schema — the column's second axis (August 2026)
+
+`RectSection` stored a diameter and no bar count, so the count was re-derived
+downstream by `designAxialColumn` on every read. That single missing field was
+what pinned model space to a **one-axis** column rebar search: `columnRebarOptimize`
+enumerates Ø × count, but the pipeline had to hand it
+`counts: (i, db) => [designAxialColumn({ ...i, barDia: db }).bars]` — pin the count
+to the one that will be re-derived — because a cage it adopted instead would be
+silently recomputed into a different one, and a P–M check that passed during the
+search would fail on the section that shipped.
+
+## What changed
+
+- **L1** `RectSection.barCount?: number` — absent ⇒ derived (old JSON loads
+  unchanged), present ⇒ the cage is the stored one.
+- **L1** `meshValidation` polices it: `BAR_COUNT` (whole number ≥ 4, §10.7.3.1),
+  `BAR_COUNT_SYMMETRY` (even — equal counts on opposing faces), `BAR_COUNT_MATERIAL`
+  (concrete only) as errors; `BAR_COUNT_RHO` (§10.6.1.1), `BAR_COUNT_SPACING`
+  (§25.2.3 clear spacing along b) and `BAR_COUNT_UNUSED` (a count on a section no
+  column carries) as warnings.
+- **L6** `selectBarDiameters` drops the pin and searches both axes; the winning
+  `{db, bars}` is stored. `designColumnFromPM` and `columnRowSolution` pass
+  `numBars: sec.barCount`, so schedule, drawings, take-off, PDF and the worked
+  solution all read the same cage.
+- Shared sections: the **worst** column governs (ordered on provided steel), the
+  same rule `buildUtilMap` uses when sections grow — a stored count no longer
+  adapts per member the way the derived one did.
+- A count is dropped, never carried, when the thing it was searched against
+  changes: `withSizes` on any b×h/shape change (ρ = n·Ab/Ag moves with the
+  concrete) and `applyMaterial` when the global Ø changes.
+
+## What it fixed, visible in the browser
+
+Default grid, one click of **Design structure**: the RC column schedule went from
+**"2 failed"** — `c1.0.1` and `c1.1.1` at `6⌀20`, **117 %** — to **"all passed"** at
+`8⌀20`, **92 %**. The 6-bar cage was the axially-derived one; the P–M gate could
+only reject it, never raise it, because there was nowhere to put the answer.
+
+## Left open
+
+- No per-section bar-count input in the Properties panel — the count is adopted by
+  the search and shown in the schedule. `applyMaterial` clears it on every run, so
+  a hand-set (or imported) count survives only until the next Design/Optimize,
+  exactly as a hand-set Ø does.
+- Spiral columns: `barCount` is validated against the tied minimum (4). §10.7.3.1's
+  6-bar spiral minimum arrives with spiral sections in model space.

--- a/webapp/src/engine/barSelectionAndGamma.test.ts
+++ b/webapp/src/engine/barSelectionAndGamma.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from 'vitest'
 import { generateGridModel, buildGravityLoads, refreshSelfWeight } from './modelBuilder'
 import { storeyWeights } from './seismic'
 import { designStructure, selectBarDiameters } from './pipeline'
-import type { RectSection, ModelLoad } from './model'
+import { validateMesh } from './meshValidation'
+import type { RectSection, ModelLoad, StructuralModel } from './model'
 
 const section: RectSection = { id: 'S1', name: '300×500', b: 300, h: 500, fc: 28, fy: 415, barDia: 20, tieDia: 10, cover: 40 }
 const soil = { qAllow: 200, gammaSoil: 18, gammaConc: 24, H: 1.5 }
@@ -71,5 +72,67 @@ describe('selectBarDiameters — bar choice is a pure detailing pass', () => {
   it('keeps chosen diameters within the standard ladder', () => {
     const allowed = new Set([16, 20, 25, 28, 32])
     for (const s of picked.sections) expect(allowed.has(s.barDia)).toBe(true)
+  })
+})
+
+// ── The count axis (L1 `RectSection.barCount`) ─────────────────────────────
+describe('selectBarDiameters — the column search adopts a COUNT, not just a Ø', () => {
+  const m = makeModel()
+  const big = { ...m, sections: m.sections.map((s) => ({ ...s, barDia: 32 })) }
+  const picked = selectBarDiameters(big, soil, {}, {}, designStructure(big, soil)!)
+  const colSecs = picked.sections.filter((s) => picked.members.some((x) => x.id === s.id && x.role === 'column'))
+
+  it('stores a cage on every column section it searched', () => {
+    expect(colSecs.length).toBeGreaterThan(0)
+    for (const s of colSecs) {
+      expect(s.barCount, s.id).toBeDefined()
+      expect(s.barCount! % 2, s.id).toBe(0)          // symmetric
+      expect(s.barCount!, s.id).toBeGreaterThanOrEqual(4)   // §10.7.3.1
+    }
+  })
+
+  it('leaves beam sections without one — a beam count follows As per section', () => {
+    const beamSecs = picked.sections.filter((s) => picked.members.some((x) => x.id === s.id && x.role !== 'column'))
+    for (const s of beamSecs) expect(s.barCount, s.id).toBeUndefined()
+  })
+
+  it('the schedule details the stored cage, bar for bar', () => {
+    // This is what the field is for: before it, the count was pinned to the one
+    // `designAxialColumn` re-derives, because anything else was recomputed here.
+    const d = designStructure(picked, soil)!
+    const secOf = new Map(picked.members.map((x) => [x.id, x.section]))
+    for (const row of d.columns) {
+      const sec = picked.sections.find((s) => s.id === secOf.get(row.id))!
+      expect(row.bars, row.id).toBe(sec.barCount)
+    }
+  })
+
+  it('every cage it stores passes the L1 rules that police one', () => {
+    const bad = validateMesh(picked).filter((i) => i.code.startsWith('BAR_COUNT'))
+    expect(bad.map((i) => `${i.code} ${i.refs.join(',')}`)).toEqual([])
+  })
+})
+
+describe('a stored cage is ANALYSED, not re-designed', () => {
+  const m = makeModel()
+  const colId = m.members.find((x) => x.role === 'column')!.id
+
+  const withCage = (n: number | undefined): StructuralModel =>
+    ({ ...m, sections: m.sections.map((s) => (s.id === colId ? { ...s, barCount: n } : s)) })
+
+  it('the column schedule reports the bars the section carries', () => {
+    const derived = designStructure(m, soil)!.columns.find((c) => c.id === colId)!
+    const forced = designStructure(withCage(derived.bars + 4), soil)!.columns.find((c) => c.id === colId)!
+    expect(forced.bars).toBe(derived.bars + 4)
+    expect(forced.phiPn).toBeGreaterThan(derived.phiPn)  // more steel, more capacity
+    expect(forced.Pu).toBeCloseTo(derived.Pu, 6)         // and the demand is untouched
+  })
+
+  it('an undersized cage is REPORTED as failing, not quietly repaired', () => {
+    // 4⌀20 in this column is under §10.6.1.1's ρmin = 1%; the derived cage
+    // never is, because AstReq starts at 0.01·Ag.
+    const row = designStructure(withCage(4), soil)!.columns.find((c) => c.id === colId)!
+    expect(row.bars).toBe(4)
+    expect(row.ok).toBe(false)
   })
 })

--- a/webapp/src/engine/columnRebarOptimize.ts
+++ b/webapp/src/engine/columnRebarOptimize.ts
@@ -83,13 +83,12 @@ export interface ColumnRebarOptions {
    * Which bar counts to consider for a diameter. Defaults to the full even
    * sweep, which is the two-axis search this module exists for.
    *
-   * A caller that cannot STORE a count must narrow it. The model-space
-   * pipeline is one: `RectSection` carries `barDia` and no bar count, so the
-   * count is re-derived downstream by `designAxialColumn`. Searching a count
-   * there would adopt a cage the schedule then silently recomputes into a
-   * different one — and a P–M check that passed during the search would fail
-   * on the section that actually shipped. It pins the count to the one the
-   * final design will use, and gets the scoring without the mismatch.
+   * A caller that cannot STORE a count must narrow it to the one its own
+   * downstream will re-derive — otherwise the search adopts a cage that is
+   * silently recomputed into a different one, and a P–M check that passed
+   * during the search fails on the section that actually shipped. The
+   * model-space pipeline used to be exactly that caller; `RectSection.barCount`
+   * now carries the count, so it searches both axes and stores the winner.
    */
   counts?: (i: AxialColumnInput, db: number) => readonly number[]
 }

--- a/webapp/src/engine/meshValidation.test.ts
+++ b/webapp/src/engine/meshValidation.test.ts
@@ -99,3 +99,81 @@ describe('validateMesh — advisory warnings', () => {
     expect(issues.some((i) => i.code === 'duplicate-member')).toBe(true)
   })
 })
+
+// ── L1: RectSection.barCount ──────────────────────────────────────────────
+describe('validateMesh — column cage bar count', () => {
+  /** A 400×400 column section carrying 4 members' worth of grid, plus the id
+   *  of one column that uses it. `generateGridModel` clones a section per
+   *  member (id = member id), so 'c0.0.0' is the ground-storey column. */
+  const gridWith = (patch: Partial<RectSection>): StructuralModel => {
+    const m = generateGridModel({
+      baysX: [6], baysZ: [5], storeyH: [3],
+      column: { ...section, id: 'C', name: '400×400', b: 400, h: 400 },
+      beam: section, girder: section,
+    })
+    const col = m.sections.find((s) => s.id === 'c0.0.0')!
+    Object.assign(col, patch)
+    return m
+  }
+  const issuesFor = (patch: Partial<RectSection>) =>
+    validateMesh(gridWith(patch)).filter((i) => i.refs.includes('c0.0.0'))
+
+  it('a well-formed cage is silent', () => {
+    // 8⌀20 in 400×400: ρ = 8·314.2/160000 = 0.0157 ✓; four per face, clear
+    // (400 − 2·50 − 4·20)/3 = 73 mm ≥ max(1.5·20, 40) = 40 ✓
+    expect(issuesFor({ barCount: 8 })).toEqual([])
+  })
+
+  it('rejects a count below the §10.7.3.1 minimum, and a fractional one', () => {
+    expect(issuesFor({ barCount: 2 }).map((i) => i.code)).toContain('BAR_COUNT')
+    expect(issuesFor({ barCount: 6.5 }).map((i) => i.code)).toContain('BAR_COUNT')
+    expect(issuesFor({ barCount: 2 })[0].severity).toBe('error')
+  })
+
+  it('rejects an odd count — the cage must be symmetric', () => {
+    const i = issuesFor({ barCount: 7 })
+    expect(i.map((x) => x.code)).toContain('BAR_COUNT_SYMMETRY')
+    expect(i.find((x) => x.code === 'BAR_COUNT_SYMMETRY')!.severity).toBe('error')
+    // a well-formed count is not also reported as malformed
+    expect(i.map((x) => x.code)).not.toContain('BAR_COUNT')
+  })
+
+  it('rejects a bar count on a steel or timber section', () => {
+    expect(issuesFor({ barCount: 8, material: 'steel', shape: 'W310x38.7' }).map((i) => i.code))
+      .toContain('BAR_COUNT_MATERIAL')
+    expect(issuesFor({ barCount: 8, material: 'wood', woodSpecies: 'DFL-2' }).map((i) => i.code))
+      .toContain('BAR_COUNT_MATERIAL')
+  })
+
+  it('warns when ρ leaves §10.6.1.1 — 4⌀16 in 400×400 is under 1%', () => {
+    // 4·201.1/160000 = 0.0050 < 0.01
+    const i = issuesFor({ barCount: 4, barDia: 16 })
+    const rho = i.find((x) => x.code === 'BAR_COUNT_RHO')!
+    expect(rho.severity).toBe('warning')
+    expect(rho.message).toContain('0.0050')
+    // and above 8%: 24⌀32 → 24·804.2/160000 = 0.1206
+    expect(issuesFor({ barCount: 24, barDia: 32 }).map((x) => x.code)).toContain('BAR_COUNT_RHO')
+  })
+
+  it('warns when the bars cannot fit the face at §25.2.3 clear spacing', () => {
+    // 16⌀32 in 400: eight per face, clear (400 − 2·50 − 8·32)/7 = 6.3 mm < 48
+    const i = issuesFor({ barCount: 16, barDia: 32 })
+    const sp = i.find((x) => x.code === 'BAR_COUNT_SPACING')!
+    expect(sp.severity).toBe('warning')
+    expect(sp.message).toContain('48 mm')
+  })
+
+  it('warns when a count sits on a section no column uses', () => {
+    const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })
+    const beam = m.sections.find((s) => m.members.some((x) => x.id === s.id && x.role !== 'column'))!
+    beam.barCount = 8
+    const i = validateMesh(m).filter((x) => x.refs.includes(beam.id))
+    expect(i.map((x) => x.code)).toContain('BAR_COUNT_UNUSED')
+    expect(i.find((x) => x.code === 'BAR_COUNT_UNUSED')!.severity).toBe('warning')
+  })
+
+  it('says nothing at all when no section carries a count', () => {
+    const m = generateGridModel({ baysX: [6], baysZ: [5], storeyH: [3], section })
+    expect(validateMesh(m).filter((i) => i.code.startsWith('BAR_COUNT'))).toEqual([])
+  })
+})

--- a/webapp/src/engine/meshValidation.ts
+++ b/webapp/src/engine/meshValidation.ts
@@ -20,6 +20,7 @@
 // valid model with a false error.
 // ─────────────────────────────────────────────────────────────────────────
 import type { StructuralModel } from './model'
+import { RHO_MIN, RHO_MAX } from './columnDesign'
 import { barContinuityGroups } from './modelBuilder'
 import { WOOD_SPECIES } from './woodDesign'
 
@@ -183,6 +184,46 @@ export function validateMesh(model: StructuralModel): MeshIssue[] {
       issues.push({ severity: 'error', code: 'PS_PARAMS', message: `section ${sec.id}: Aps, fpu and f'ci must be positive`, refs: [sec.id] })
     if (!(sec.ps.e > 0) || sec.ps.e > sec.h / 2 - 40)
       issues.push({ severity: 'error', code: 'PS_ECC', message: `section ${sec.id}: tendon eccentricity must satisfy 0 < e ≤ h/2 − 40 mm`, refs: [sec.id] })
+  }
+
+  // ── column cage bar count (L1 rule for RectSection.barCount) ────────────
+  // A stored count is a cage that ships as written — nothing downstream
+  // re-derives it — so the placement rules that make it buildable are checked
+  // here, upstream, against the section that carries it.
+  const columnSecs = new Set(model.members.filter((m) => m.role === 'column').map((m) => m.section))
+  for (const sec of model.sections) {
+    const n = sec.barCount
+    if (n === undefined) continue
+    const wellFormed = Number.isInteger(n) && n >= 4
+    if (!wellFormed)
+      issues.push({ severity: 'error', code: 'BAR_COUNT', refs: [sec.id],
+        message: `section ${sec.id}: bar count must be a whole number ≥ 4 (ACI 318-14 §10.7.3.1 — four bars minimum in a tied column); got ${n}` })
+    else if (n % 2 !== 0)
+      issues.push({ severity: 'error', code: 'BAR_COUNT_SYMMETRY', refs: [sec.id],
+        message: `section ${sec.id}: bar count ${n} is odd — a column cage needs equal counts on opposing faces, which is the section the P–M interaction is computed for` })
+    if (sec.material === 'steel' || sec.material === 'wood')
+      issues.push({ severity: 'error', code: 'BAR_COUNT_MATERIAL', refs: [sec.id],
+        message: `section ${sec.id}: a bar count is only meaningful on a concrete section` })
+    if (!columnSecs.has(sec.id))
+      issues.push({ severity: 'warning', code: 'BAR_COUNT_UNUSED', refs: [sec.id],
+        message: `section ${sec.id}: carries a bar count but no column — a beam's count follows As at each critical section, so the stored count is ignored` })
+    if (!wellFormed || !(sec.b > 0) || !(sec.h > 0)) continue
+    // ρ = n·Ab/Ag, §10.6.1.1 — the count and the concrete size have to agree.
+    const rho = (n * (Math.PI / 4) * sec.barDia ** 2) / (sec.b * sec.h)
+    if (rho < RHO_MIN - 1e-9 || rho > RHO_MAX + 1e-9)
+      issues.push({ severity: 'warning', code: 'BAR_COUNT_RHO', refs: [sec.id],
+        message: `section ${sec.id}: ${n}⌀${sec.barDia} in ${sec.b}×${sec.h} gives ρ = ${rho.toFixed(4)}, outside ACI 318-14 §10.6.1.1's ${RHO_MIN}–${RHO_MAX}` })
+    // §25.2.3 clear spacing, read TWO-FACE along b — the same reading
+    // `columnRebarOptimize.clearSpacingOf` makes, and the layout the pipeline
+    // designs the column for.
+    const perFace = Math.ceil(n / 2)
+    const sClear = perFace > 1
+      ? (sec.b - 2 * (sec.cover + sec.tieDia) - perFace * sec.barDia) / (perFace - 1)
+      : sec.b
+    const sMin = Math.max(1.5 * sec.barDia, 40)
+    if (sClear < sMin - 1e-6)
+      issues.push({ severity: 'warning', code: 'BAR_COUNT_SPACING', refs: [sec.id],
+        message: `section ${sec.id}: ${n}⌀${sec.barDia} leaves ${sClear.toFixed(0)} mm clear along the ${sec.b} mm face — ACI 318-14 §25.2.3 needs ≥ ${sMin.toFixed(0)} mm; use fewer, larger bars or widen the column` })
   }
 
   // ── tension-only / compression-only members (axialOnly active set) ──

--- a/webapp/src/engine/model.ts
+++ b/webapp/src/engine/model.ts
@@ -19,6 +19,20 @@ export interface RectSection {
   b: number; h: number          // mm  (concrete/wood b × d; for steel a bounding box ≈ bf × d)
   fc: number; fy: number
   barDia: number; tieDia: number; cover: number
+  /** COLUMN cage: total number of longitudinal bars in the section.
+   *
+   *  Absent ⇒ the count is DERIVED from the required steel by
+   *  `designAxialColumn` (`max(minBars, ceil(AstReq/Ab))`) — how every model
+   *  behaved before this field, so old JSON loads unchanged. Present ⇒ the
+   *  cage is the stored one, which is what lets the two-axis (Ø × count)
+   *  column rebar search adopt a count instead of pinning it to the derived
+   *  one: 8⌀20 and 4⌀25 are different columns and only a stored count can tell
+   *  the schedule which was chosen.
+   *
+   *  Even and ≥ 4 (tied) — a cage is symmetric or the P–M interaction is not
+   *  the one it was computed for; `meshValidation` enforces it. BEAM sections
+   *  ignore it: a beam's count follows As at each critical section. */
+  barCount?: number
   /** Material of the member. Absent ⇒ 'concrete' (back-compatible). */
   material?: SectionMaterial
   /** AISC shape name (steel only), e.g. 'W310x38.7'. Resolved via aiscSections. */

--- a/webapp/src/engine/pipeline.test.ts
+++ b/webapp/src/engine/pipeline.test.ts
@@ -1121,10 +1121,10 @@ describe('model space and the calculator pages agree on bars', () => {
   })
 
   it('selection does not make a previously passing design fail', () => {
-    // The count axis is the trap: `RectSection` stores a diameter and no bar
-    // count, so a search that adopts a count has it silently recomputed
-    // downstream — and a P–M check that passed during the search fails on the
-    // section that shipped. Pinning the count is what keeps these equal.
+    // The count axis used to be the trap: with no place to store a count, a
+    // search that adopted one had it silently recomputed downstream, and a P–M
+    // check that passed during the search failed on the section that shipped.
+    // `RectSection.barCount` is what keeps the two equal now.
     const m0 = gridAt(28)
     const before = designStructure(m0, soil)!
     const after = designStructure(selectBarDiameters(m0, soil), soil)!
@@ -1141,6 +1141,66 @@ describe('model space and the calculator pages agree on bars', () => {
     for (const group of barContinuityGroups(m)) {
       const dias = new Set(group.map((mid) => secOf.get(memSec.get(mid) ?? '')?.barDia))
       expect(dias.size, group.join(',')).toBe(1)
+    }
+  })
+
+  it('a stack whose Ø the continuity guard raises does not keep the count searched at the old Ø', () => {
+    // Seed the stack base at ⌀32 so the guard has a diameter to push up
+    // through the storey above; the count that shipped with the smaller bar
+    // cannot ride along, or the cage nobody checked is the cage that gets
+    // detailed.
+    const m0 = gridAt(20)
+    m0.sections.find((s) => s.id === 'c0.0.0')!.barDia = 32
+    const m = selectBarDiameters(m0, soil)
+    const secOf = new Map(m.sections.map((s) => [s.id, s]))
+    const memSec = new Map(m.members.map((x) => [x.id, x.section]))
+    for (const group of barContinuityGroups(m)) {
+      const secs = group.map((mid) => secOf.get(memSec.get(mid) ?? '')!)
+      expect(new Set(secs.map((s) => s.barDia)).size, group.join(',')).toBe(1)
+    }
+    // every stored cage still satisfies the L1 rules at the Ø it ended on
+    expect(validateMesh(m).filter((i) => i.code.startsWith('BAR_COUNT'))).toEqual([])
+  })
+
+  it('a saved cage does not survive the size change that outgrew it', () => {
+    // 4⌀20 is fine in a 300×300 column (ρ = 0.0140) and under §10.6.1.1's ρmin
+    // the moment the optimizer grows the concrete. Frozen, it is a floor the
+    // column can never meet: growing makes ρ *smaller*, so the section chases
+    // the cast-in-place cap and the run ends with every column failing on a
+    // cage nothing asked for. Dropping it at the size change is what lets the
+    // derived cage take over.
+    const m0 = generateGridModel({ baysX: [7], baysZ: [6], storeyH: [3, 3], section, slabThickness: 200 })
+    m0.loads = m0.plates.flatMap((p): ModelLoad[] => [
+      { kind: 'area', plate: p.id, q: 9.0, cat: 'D' },
+      { kind: 'area', plate: p.id, q: 6.0, cat: 'L' },
+    ])
+    for (const s of m0.sections) if (s.id.startsWith('c')) { s.b = 300; s.h = 300; s.barCount = 4 }
+    const r = optimizeStructure(m0, soil)!         // no bar pass: nothing re-adopts a count
+    const colSecs = r.model.sections.filter((s) => s.id.startsWith('c'))
+    expect(colSecs.some((s) => s.h !== 300)).toBe(true)              // they did grow
+    for (const s of colSecs) expect(s.barCount, s.id).toBeUndefined()
+    expect(r.converged).toBe(true)
+    for (const c of r.design.columns) expect(c.ok, c.id).toBe(true)
+  })
+
+  it('the optimizer ends on a cage that fits the size it settled on', () => {
+    // ρ = n·Ab/(b·h) moves with the concrete, so a cage carried across a size
+    // change can land outside §10.6.1.1 — a section the optimizer itself built,
+    // then reported as failing. Every b×h change clears the count and the next
+    // bar pass re-adopts one, so the model that comes out is self-consistent.
+    const m0 = makeModel()
+    // start the columns small enough that the grow loop has to run first
+    for (const s of m0.sections) if (s.id.startsWith('c')) { s.b = 250; s.h = 300 }
+    const r = optimizeStructure(m0, soil, {}, 30, {}, true)!
+    const colSecs = r.model.sections.filter((s) => s.id.startsWith('c'))
+    expect(colSecs.some((s) => s.b !== 250 || s.h !== 300)).toBe(true)   // the columns did move
+    expect(validateMesh(r.model).filter((i) => i.code.startsWith('BAR_COUNT'))).toEqual([])
+    const secOf = new Map(r.model.members.map((x) => [x.id, x.section]))
+    for (const c of r.design.columns) {
+      const sec = r.model.sections.find((s) => s.id === secOf.get(c.id))!
+      expect(sec.barCount, c.id).toBeDefined()
+      expect(c.bars, c.id).toBe(sec.barCount)      // the schedule details what the model stores
+      expect(c.ok, c.id).toBe(true)
     }
   })
 })

--- a/webapp/src/engine/pipeline.ts
+++ b/webapp/src/engine/pipeline.ts
@@ -34,7 +34,7 @@ import { designBasePlate, adoptPlateThickness, type BasePlateResult } from './ba
 import { designSteelJoints, designBeamBeamJoints, type SteelJoint, type BeamBeamJoint } from './steelConnections'
 import { optimizeFootingRebar, optimizeSlabRebar, applySlabMats } from './matRebarOptimize'
 import { optimizeBeamMember } from './beamRebarOptimize'
-import { optimizeColumnRebar } from './columnRebarOptimize'
+import { optimizeColumnRebar, type ColumnRebarChoice } from './columnRebarOptimize'
 import type { RebarSelection } from './rebarScore'
 
 export interface SoilOptions {
@@ -628,6 +628,11 @@ function designColumnFromPM(
   const ax = designAxialColumn({
     shape: 'tied', b: sec.b, h: sec.h, cover: sec.cover,
     barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, Pu,
+    // A stored cage is ANALYSED, not re-designed: `barCount` is the count the
+    // two-axis search adopted (or the user set), and re-deriving it here would
+    // detail a different column than the one that passed the P–M gate. Absent
+    // ⇒ designAxialColumn sizes the steel, as it always did.
+    numBars: sec.barCount,
     system, columnLength,
   })
   const e = Pu > 1e-9 ? Mu / Pu : 0
@@ -1488,7 +1493,8 @@ export const BAR_LADDER_COLUMN = [20, 25, 28, 32]
  * Pick the most economical bar diameter for every beam/girder and column from a
  * candidate ladder: the smallest-steel size that still passes, falling back to
  * the section's current bar when none of the candidates work (so the section can
- * grow instead). Returns a new model with the chosen per-member section.barDia.
+ * grow instead). Returns a new model with the chosen per-member section.barDia,
+ * and for columns the `barCount` that went with it.
  * Pass `base` (an already-computed design of `model`) to skip the internal solve.
  */
 export function selectBarDiameters(
@@ -1499,7 +1505,8 @@ export function selectBarDiameters(
   if (!design) return model
   const secById = new Map(model.sections.map((s) => [s.id, s]))
   const memSecId = new Map(model.members.map((m) => [m.id, m.section]))
-  const chosen = new Map<string, number>()
+  /** Per section: the detailing adopted. `barCount` is columns only. */
+  const chosen = new Map<string, { barDia: number; barCount?: number }>()
   // candidate sizes, SMALLEST first — we adopt the first one that passes.
   const ladder = (cands: number[], current: number) => [...new Set([current, ...cands])].sort((a, b) => a - b)
 
@@ -1523,29 +1530,31 @@ export function selectBarDiameters(
       })),
       { sizes: ladder(BAR_LADDER_BEAM, sec.barDia) },
     )
-    if (choice.db !== null && choice.db !== sec.barDia) chosen.set(sec.id, choice.db)
+    if (choice.db !== null && choice.db !== sec.barDia) chosen.set(sec.id, { barDia: choice.db })
   }
 
   // Columns: diameter AND count, the same two-axis search the Column Design
-  // page runs. `designAxialColumn` inside the optimiser sizes the cage; the
-  // moment is added here as an extra gate, because a model-space column
-  // carries Mu and the optimiser deliberately does not know about
-  // eccentricity. Same P–M capacity the schedule already reports — no second
-  // interaction implementation.
+  // page runs — and now adopted WHOLE. `RectSection.barCount` stores the
+  // count, so the cage that wins the search is the cage the schedule details;
+  // while the field did not exist the count had to be pinned to the derived
+  // one, because anything else was recomputed downstream into a different
+  // column than the one the gates had passed.
+  //
+  // The moment enters as an extra gate: `designAxialColumn` inside the
+  // optimiser is pure axial and a model-space column carries Mu. Same P–M
+  // capacity the schedule reports — no second interaction implementation.
+  const colSearch = new Map<string, (sizes: readonly number[]) => ColumnRebarChoice>()
+  /** Governing cage per section, ordered on provided steel (see below). */
+  const colBest = new Map<string, { barDia: number; barCount: number; Ast: number }>()
   for (const row of design.columns) {
     const sec = secById.get(memSecId.get(row.id) ?? ''); if (!sec) continue
-    const choice = optimizeColumnRebar(
+    const search = (sizes: readonly number[]) => optimizeColumnRebar(
       {
         shape: 'tied', b: sec.b, h: sec.h, cover: sec.cover, barDia: sec.barDia,
         tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, fyt: sec.fy, Pu: row.Pu,
       },
       {
-        sizes: ladder(BAR_LADDER_COLUMN, sec.barDia),
-        // `RectSection` stores a diameter and no bar count, so the count is
-        // re-derived downstream. Pin the search to the count the final design
-        // will use — searching it here adopts a cage the schedule then
-        // recomputes into a different one.
-        counts: (i, db) => [designAxialColumn({ ...i, barDia: db }).bars],
+        sizes,
         extraChecks: (i, r) => {
           const util = pmUtilisation(sec, i.barDia, r.bars, row.Pu, row.Mu)
           return [{
@@ -1558,7 +1567,22 @@ export function selectBarDiameters(
         },
       },
     )
-    if (choice.db !== null && choice.db !== sec.barDia) chosen.set(sec.id, choice.db)
+    colSearch.set(sec.id, search)
+    const choice = search(ladder(BAR_LADDER_COLUMN, sec.barDia))
+    if (choice.db === null || choice.bars === null) continue
+    // One section can carry several columns, and a stored count no longer
+    // adapts per member the way the derived one did — so the WORST column
+    // governs, the same rule `buildUtilMap` applies when sections grow.
+    // Provided steel orders them: a cage short for the heaviest column in the
+    // group is not repaired anywhere downstream.
+    const Ast = choice.bars * (Math.PI / 4) * choice.db ** 2
+    const prev = colBest.get(sec.id)
+    if (!prev || Ast > prev.Ast) colBest.set(sec.id, { barDia: choice.db, barCount: choice.bars, Ast })
+  }
+  for (const [id, best] of colBest) {
+    const sec = secById.get(id)!
+    if (best.barDia !== sec.barDia || best.barCount !== sec.barCount)
+      chosen.set(id, { barDia: best.barDia, barCount: best.barCount })
   }
 
   // ── Bar-diameter continuity guard: one Ø through each continuous beam line
@@ -1570,19 +1594,24 @@ export function selectBarDiameters(
   for (const group of barContinuityGroups(model)) {
     const diaOf = (mid: string) => {
       const sec = secById.get(memSecId.get(mid) ?? '')
-      return sec ? (chosen.get(sec.id) ?? sec.barDia) : 0
+      return sec ? (chosen.get(sec.id)?.barDia ?? sec.barDia) : 0
     }
     const dmax = Math.max(...group.map(diaOf))
     for (const mid of group) {
       const sec = secById.get(memSecId.get(mid) ?? '')
-      if (sec && diaOf(mid) !== dmax) chosen.set(sec.id, dmax)
+      if (!sec || diaOf(mid) === dmax) continue
+      // The count was searched at the Ø this section lost, so it cannot ship
+      // with the Ø it just gained. Re-run the column search pinned to dmax; if
+      // nothing there is compliant the count is dropped rather than left
+      // stale, which returns the section to the derived cage.
+      chosen.set(sec.id, { barDia: dmax, barCount: colSearch.get(sec.id)?.([dmax]).bars ?? undefined })
     }
   }
 
   if (chosen.size === 0) return model
   return {
     ...model,
-    sections: model.sections.map((s) => (chosen.has(s.id) ? { ...s, barDia: chosen.get(s.id)! } : s)),
+    sections: model.sections.map((s) => (chosen.has(s.id) ? { ...s, ...chosen.get(s.id)! } : s)),
   }
 }
 
@@ -1625,8 +1654,20 @@ const countFails = (d: StructureDesign): number =>
   + d.scwb.filter((x) => !x.ok).length
   + d.unchecked.length
 
+/** Swap in re-sized sections. A stored column cage belongs to the geometry it
+ *  was searched on — ρ = n·Ab/(b·h) moves with the concrete — so a section
+ *  whose b/h/shape changes drops its `barCount` and reverts to the derived
+ *  cage, until the next `selectBarDiameters` pass adopts one for the new size.
+ *  Keeping it would let the optimizer grow a column straight out of §10.6.1.1's
+ *  ρmin and then report the section it just built as failing. */
 const withSizes = (model: StructuralModel, sizes: Map<string, RectSection>): StructuralModel =>
-  ({ ...model, sections: model.sections.map((s) => sizes.get(s.id) ?? s) })
+  ({ ...model, sections: model.sections.map((s) => {
+    const t = sizes.get(s.id)
+    if (!t) return s
+    return t.barCount !== undefined && (t.b !== s.b || t.h !== s.h || t.shape !== s.shape)
+      ? { ...t, barCount: undefined }
+      : t
+  }) })
 
 /** True when any design geometry differs between two settled models — sections,
  *  slab thicknesses or wall thicknesses.

--- a/webapp/src/lib/modelSpaceSolutions.ts
+++ b/webapp/src/lib/modelSpaceSolutions.ts
@@ -27,6 +27,9 @@ export function columnRowSolution(sec: RectSection, row: ColumnScheduleRow): Sol
   const base = {
     shape: 'tied' as const, b: sec.b, h: sec.h, cover: sec.cover,
     barDia: sec.barDia, tieDia: sec.tieDia, fc: sec.fc, fy: sec.fy, Pu: row.Pu,
+    // the stored cage is analysed, not re-designed — same as the pipeline, so
+    // the printed solution shows the bars the schedule row reports
+    numBars: sec.barCount,
   }
   const ax = designAxialColumn(base)
   const steps: SolutionStep[] = []

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -1477,7 +1477,9 @@ export default function ModelSpace() {
    *  section and refresh the gravity loads with the current SDL/LL and γc — so
    *  Design/Optimize reflect Properties edits without regenerating the grid. */
   const applyMaterial = (m: StructuralModel): StructuralModel => {
-    const sections = m.sections.map((s) => ({ ...s, fc, fy, barDia, tieDia, cover }))
+    // barCount goes with the Ø it was searched at — a new Ø means a new cage,
+    // so drop it and let the design re-derive (or bar selection re-adopt) one.
+    const sections = m.sections.map((s) => ({ ...s, fc, fy, barDia, tieDia, cover, barCount: undefined }))
     const withMat = { ...m, sections }
     return { ...withMat, loads: buildGravityLoads(withMat, qD, qL, gammaC) }
   }


### PR DESCRIPTION
**Engine layer 1** (schema + `meshValidation`), consumed at **layer 6**.

`RectSection` carried a diameter and no bar count, so every reader re-derived the count from `designAxialColumn`. That one missing field is what pinned model space to a **one-axis** rebar search: `columnRebarOptimize` enumerates Ø × count, but the pipeline had to hand it

```ts
counts: (i, db) => [designAxialColumn({ ...i, barDia: db }).bars],
```

— pin the count to the one that will be re-derived — because a cage it adopted instead was silently recomputed downstream into a different one, and a P–M check that passed during the search failed on the section that shipped.

`barCount?: number` closes it. **Absent ⇒ derived**, exactly as before (old JSON loads unchanged); **present ⇒ the cage is the stored one**.

## What it fixed, measured in the browser

Default grid, one click of **Design structure** — headless Chromium, same model before and after:

| | RC column schedule | `c1.0.1` / `c1.1.1` |
|---|---|---|
| main | **2 failed** | `6⌀20` · **117 %** |
| this PR | **all passed** | `8⌀20` · **92 %** |

The 6-bar cage was the axially derived one. The P–M gate could only reject it, never raise it, because there was nowhere to put the answer. The worked-solution drawer reads 8 bars with it (`8 bars are detailed around the cage`, `ρ = 0.0157 ✓`, elevation `8⌀20`). No console errors.

## Changes

- **L1 `model.ts`** — `RectSection.barCount?: number`, JSON-serialisable, documented as columns-only (a beam's count follows As at each critical section).
- **L1 `meshValidation.ts`** — a stored count is a cage that ships as written, so the placement rules are checked upstream:
  - errors — `BAR_COUNT` (whole number ≥ 4, §10.7.3.1), `BAR_COUNT_SYMMETRY` (even; equal counts on opposing faces is the section the P–M interaction is computed for), `BAR_COUNT_MATERIAL` (concrete only)
  - warnings — `BAR_COUNT_RHO` (§10.6.1.1 0.01–0.08), `BAR_COUNT_SPACING` (§25.2.3 clear spacing, read two-face along `b` — the same reading `columnRebarOptimize.clearSpacingOf` makes), `BAR_COUNT_UNUSED` (a count on a section no column carries)
- **L6 `pipeline.ts`** — `selectBarDiameters` drops the pin and adopts the winning `{db, bars}` whole; `designColumnFromPM` passes `numBars: sec.barCount`, so schedule, drawings, take-off and PDF all detail one cage. `lib/modelSpaceSolutions.ts` does the same for the printed solution.
- **Shared sections** — one section can carry several columns, and a stored count no longer adapts per member the way the derived one did, so the **worst column governs**, ordered on provided steel: the rule `buildUtilMap` already applies when sections grow.
- **A count is dropped, never carried, when what it was searched against changes** — the continuity guard re-runs the search at the Ø it just raised a stack to; `withSizes` clears it on any b×h/shape change; `applyMaterial` clears it when the global Ø changes.

That last one is not hypothetical. ρ = n·Ab/Ag *falls* as the concrete grows, so a frozen cage is a floor a growing column can never meet. With a saved 4⌀20 in a 300×300 column that has to grow, the optimizer chased the 1000 mm cast-in-place cap and ended non-converged with all 12 columns failing; dropping the count at the size change converges at 300×550–600 with every column passing. That contrast is the regression test.

## Verification

- `npm test` — **3519 passed** (203 files), `npx tsc -b` clean, `npm run lint` clean.
- New tests: 8 `meshValidation` cases for the rules above; `barSelectionAndGamma` — a cage is stored on every column section and on no beam section, the schedule details it bar for bar, every stored cage passes the L1 rules, a stored cage is *analysed* not re-designed (an undersized one is reported failing, not quietly repaired); `pipeline` — the continuity guard case and the grow case above.
- Both new pipeline cases were confirmed to **fail** against the pre-fix behaviour before being kept.

## Left open

- No per-section bar-count input in the Properties panel. The count is adopted by the search and shown in the schedule; `applyMaterial` clears it on every run, so a hand-set or imported count survives only until the next Design/Optimize — exactly as a hand-set Ø does today.
- Spiral columns: `barCount` is validated against the tied minimum of 4. §10.7.3.1's 6-bar spiral minimum arrives when model space grows spiral sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WmPbtTVsjNBXVpiQVBYBnz)_