### PR TITLE
feat(soils): the example investigation carries real laboratory data

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1386,12 +1386,25 @@ test card and the report read it — a report whose compaction curve differed
 from the one on screen would be worse than a report with no curve at all. That
 is the fourth time this module has needed the one-rule-one-home fix.
 
-**Note for anyone demoing:** the bundled example fixture books 10 laboratory
-tests and enters data for NONE, so the example report's §8 now reads "10 booked
-tests produced no result" rather than showing a table. Entering data for one
-test is enough to see the table and its plot. Giving the fixture real
-laboratory data would make the example far better, and is not done here because
-it shifts every classification-dependent assertion that leans on it.
+**The example fixture now carries real laboratory data (Aug 2026).** It books 14
+tests and enters data for 13 — moisture, sieve and Atterberg pairs, a UCS and a
+full consolidation curve — leaving ONE planned triaxial unrun so the report's
+"not tabulated" path is exercised by the example itself. Every sample classifies
+and each agrees with the name it was logged under: S-01 SM "Silty sand", S-02 and
+BH-02/S-01 CL "Lean clay with sand", S-03 SP "Poorly graded sand". The four
+layers a sample speaks for carry their group symbol; the Fill layers and BH-02's
+sand do not, because nothing was tested in them — a real gap, left visible.
+
+The consolidation curve is planted to be lightly overconsolidated: Cc = 0.332
+against 0.009(LL-10) = 0.315 for its LL of 45, Cr = 0.042, and s'p ~ 127 kPa
+against ~85 kPa of effective overburden at 5 m. The example report runs to 11
+pages with five plots in section 8, and the fixture still validates with zero
+errors and zero warnings.
+
+An Atterberg blob needs a LIQUID LIMIT to be readable at all: `nonPlastic: true`
+alone is rejected by the guard, because non-plastic means the PLASTIC limit could
+not be obtained, not that nothing was measured. Two fixture tests were silently
+producing no result until that was fixed.
 
 **Supabase: SETTLED AGAINST THE LIVE DATABASE, 6 Aug.** Egress to
 `*.supabase.co` was opened on the environment and took effect without a new

--- a/webapp/src/engine/soils/parameters.test.ts
+++ b/webapp/src/engine/soils/parameters.test.ts
@@ -169,10 +169,21 @@ describe('correlations respect the soil they were fitted to', () => {
     expect(r.notes.join(' ')).toMatch(/this layer is cohesive/)
   })
 
-  it('correlates cu in a clay and not in a sand', () => {
+  it('cu in a clay comes from the MEASUREMENT when there is one', () => {
+    // The fixture's clay sample carries a UCS test, and a measurement always
+    // beats the SPT correlation — they are never averaged.
     const clay = resolve(bh(), 2)
-    expect(find(clay, 'undrainedShearStrength')?.value.provenance.kind).toBe('correlated')
+    expect(find(clay, 'undrainedShearStrength')?.value.provenance.kind).toBe('measured')
+  })
 
+  it('falls back to the correlation in a clay with no test on it', () => {
+    const b = bh()
+    for (const s of b.samples) s.tests = s.tests.filter((t) => t.type !== 'ucs')
+    const clay = resolve(b, 2)
+    expect(find(clay, 'undrainedShearStrength')?.value.provenance.kind).toBe('correlated')
+  })
+
+  it('offers no cu at all in a sand — neither measured nor correlated', () => {
     const sand = resolve(bh(), 1)
     expect(find(sand, 'undrainedShearStrength')).toBeUndefined()
   })

--- a/webapp/src/engine/soils/sample.test.ts
+++ b/webapp/src/engine/soils/sample.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { sampleInvestigation } from './sample'
+import { validateInvestigation } from './validate'
+import { classifySample } from './classifySample'
+import { evaluateTest } from './lab'
+import { buildSoilsReport } from './report'
+
+// ─────────────────────────────────────────────────────────────────────────
+// The example investigation is what every new visitor sees first, so it is
+// load-bearing: if it does not demonstrate the module, the module looks
+// broken. These pin the three things that make it a demonstration rather
+// than a skeleton — it validates clean, its laboratory data agrees with the
+// geology it was logged as, and it exercises BOTH report paths (results
+// tabulated, and one test left out and accounted for).
+// ─────────────────────────────────────────────────────────────────────────
+
+const inv = () => sampleInvestigation()
+
+describe('the example investigation is clean', () => {
+  it('validates with zero errors and zero warnings', () => {
+    // The guard the module has kept since Phase 0: a fixture that trips its own
+    // validator teaches every reader to ignore the validator.
+    expect(validateInvestigation(inv())).toEqual([])
+  })
+})
+
+describe('its laboratory data agrees with its geology', () => {
+  const samples = () => inv().boreholes.flatMap((b) =>
+    b.samples.map((s) => ({ b, s, layer: b.layers.find((l) => l.id === s.layerId)! })))
+
+  it('every sample classifies, and the symbol matches the name it was logged under', () => {
+    const got = samples().map(({ s, layer }) => [layer.name, classifySample(s).uscs?.symbol])
+    expect(got).toEqual([
+      ['Silty Sand', 'SM'],
+      ['Lean Clay', 'CL'],
+      ['Poorly Graded Sand', 'SP'],
+      ['Lean Clay', 'CL'],
+    ])
+  })
+
+  it('a layer carries a group symbol only where a sample speaks for it', () => {
+    const layers = inv().boreholes.flatMap((b) => b.layers)
+    const sampled = new Set(inv().boreholes.flatMap((b) => b.samples.map((s) => s.layerId)))
+    for (const l of layers) {
+      // Fill and BH-02's sand were never tested; leaving them unclassified is
+      // the honest record, and it keeps a real gap in the example.
+      expect(Boolean(l.symbol), l.name).toBe(sampled.has(l.id))
+    }
+  })
+
+  it('the consolidation curve is lightly overconsolidated, as planted', () => {
+    const t = inv().boreholes[0].samples[1].tests.find((x) => x.type === 'consolidation')!
+    const { outcome } = evaluateTest(t)
+    expect(outcome?.kind).toBe('consolidation')
+    if (outcome?.kind !== 'consolidation') return
+    // Cc against Terzaghi's 0.009(LL − 10) = 0.315 for this sample's LL of 45
+    expect(outcome.result.cc).toBeGreaterThan(0.25)
+    expect(outcome.result.cc).toBeLessThan(0.40)
+    expect(outcome.result.cr).toBeLessThan(outcome.result.cc / 4)
+    // σ′p above the ~85 kPa effective overburden at 5 m, but not by much
+    expect(outcome.result.preconsolidationPressure).toBeGreaterThan(90)
+    expect(outcome.result.preconsolidationPressure).toBeLessThan(200)
+  })
+})
+
+describe('it exercises both halves of the report', () => {
+  const lab = () => buildSoilsReport(inv()).sections.find((s) => s.no === 8)!
+
+  it('tabulates the tests that produced a result, with their plots', () => {
+    const s = lab()
+    expect(s.tables[0].rows.length).toBeGreaterThan(10)
+    expect(s.figures.length).toBeGreaterThan(3)
+  })
+
+  it('leaves exactly one booked test out, and says so', () => {
+    // The planned triaxial is deliberately unrun: without it the example would
+    // never show what an incomplete programme looks like.
+    const s = lab()
+    expect(s.status).toBe('partial')
+    expect(s.gap).toMatch(/1 of 14 booked tests produced no result/)
+    expect(s.gap).toMatch(/1 not yet run/)
+  })
+})

--- a/webapp/src/engine/soils/sample.ts
+++ b/webapp/src/engine/soils/sample.ts
@@ -52,17 +52,17 @@ export function sampleInvestigation(): Investigation {
             colour: 'brown', density: 'loose', moisture: 'moist',
           },
           {
-            id: 'bh1-l2', depthTop: 1.5, depthBottom: 4.2, name: 'Silty Sand',
+            id: 'bh1-l2', symbol: 'SM', depthTop: 1.5, depthBottom: 4.2, name: 'Silty Sand',
             description: 'Medium dense silty fine to medium SAND, trace gravel.',
             colour: 'light brown', density: 'medium-dense', moisture: 'moist',
           },
           {
-            id: 'bh1-l3', depthTop: 4.2, depthBottom: 8.5, name: 'Lean Clay',
+            id: 'bh1-l3', symbol: 'CL', depthTop: 4.2, depthBottom: 8.5, name: 'Lean Clay',
             description: 'Soft to firm lean CLAY with sand, occasional organic partings.',
             colour: 'grey', consistency: 'soft', moisture: 'wet',
           },
           {
-            id: 'bh1-l4', depthTop: 8.5, depthBottom: 20, name: 'Poorly Graded Sand',
+            id: 'bh1-l4', symbol: 'SP', depthTop: 8.5, depthBottom: 20, name: 'Poorly Graded Sand',
             description: 'Dense to very dense poorly graded SAND, trace fines.',
             colour: 'grey-brown', density: 'dense', moisture: 'saturated',
           },
@@ -73,8 +73,29 @@ export function sampleInvestigation(): Investigation {
             depthTop: 1.5, depthBottom: 1.95, standard: 'd1586',
             recoveryLength: 0.38, driveLength: 0.45, sampleDate: '2026-06-15',
             tests: [
-              { id: 'bh1-s1-t1', type: 'moisture', standard: 'd2216', status: 'complete', testDate: '2026-06-18' },
-              { id: 'bh1-s1-t2', type: 'sieve', standard: 'd6913', status: 'complete', testDate: '2026-06-19' },
+              {
+                id: 'bh1-s1-t1', type: 'moisture', standard: 'd2216', status: 'complete', testDate: '2026-06-18',
+                data: { containerMass: 25.0, wetMass: 85.4, dryMass: 76.2 },        // w = 17.97%
+              },
+              {
+                id: 'bh1-s1-t2', type: 'sieve', standard: 'd6913', status: 'complete', testDate: '2026-06-19',
+                data: {
+                  totalMass: 500,
+                  readings: [
+                    { size: 9.5, designation: '3/8 in', massRetained: 0 },
+                    { size: 4.75, designation: 'No. 4', massRetained: 15 },
+                    { size: 2.0, designation: 'No. 10', massRetained: 25 },
+                    { size: 0.85, designation: 'No. 20', massRetained: 55 },
+                    { size: 0.425, designation: 'No. 40', massRetained: 90 },
+                    { size: 0.15, designation: 'No. 100', massRetained: 145 },
+                    { size: 0.075, designation: 'No. 200', massRetained: 45 },
+                  ],
+                },                                                                  // 25% fines — a silty SAND
+              },
+              {
+                id: 'bh1-s1-t3', type: 'atterberg', standard: 'd4318', status: 'complete', testDate: '2026-06-19',
+                data: { liquidLimit: 21, nonPlastic: true },   // NP fines ⇒ SM, not SC
+              },
             ],
           },
           {
@@ -82,10 +103,47 @@ export function sampleInvestigation(): Investigation {
             depthTop: 5, depthBottom: 5.75, standard: 'd1587',
             recoveryLength: 0.71, driveLength: 0.75, sampleDate: '2026-06-16',
             tests: [
-              { id: 'bh1-s2-t1', type: 'moisture', standard: 'd2216', status: 'complete', testDate: '2026-06-18' },
-              { id: 'bh1-s2-t2', type: 'atterberg', standard: 'd4318', status: 'complete', testDate: '2026-06-19' },
-              { id: 'bh1-s2-t3', type: 'ucs', standard: 'd2166', status: 'complete', testDate: '2026-06-22' },
-              { id: 'bh1-s2-t4', type: 'consolidation', standard: 'd2435', status: 'in-progress' },
+              {
+                id: 'bh1-s2-t1', type: 'moisture', standard: 'd2216', status: 'complete', testDate: '2026-06-18',
+                data: { containerMass: 25.0, wetMass: 92.5, dryMass: 73.0 },        // w = 40.6%
+              },
+              {
+                id: 'bh1-s2-t2', type: 'atterberg', standard: 'd4318', status: 'complete', testDate: '2026-06-19',
+                data: { liquidLimit: 45, plasticLimit: 22, naturalMoisture: 40.6 }, // PI 23, above the A-line ⇒ CL
+              },
+              {
+                id: 'bh1-s2-t5', type: 'sieve', standard: 'd6913', status: 'complete', testDate: '2026-06-19',
+                data: {
+                  totalMass: 400,
+                  readings: [
+                    { size: 4.75, designation: 'No. 4', massRetained: 0 },
+                    { size: 0.425, designation: 'No. 40', massRetained: 28 },
+                    { size: 0.075, designation: 'No. 200', massRetained: 72 },
+                  ],
+                },                                                                  // 75% fines ⇒ fine-grained
+              },
+              {
+                id: 'bh1-s2-t3', type: 'ucs', standard: 'd2166', status: 'complete', testDate: '2026-06-22',
+                data: {
+                  diameter: 38, height: 76, failureLoad: 120, failureDeformation: 6,
+                  unitWeight: 17.5, soil: 'saturated-cohesive',
+                },
+              },
+              {
+                id: 'bh1-s2-t4', type: 'consolidation', standard: 'd2435', status: 'complete', testDate: '2026-06-26',
+                data: {
+                  initialHeight: 20, diameter: 63.5, dryMass: 81.4, specificGravity: 2.7,
+                  points: [
+                    { stress: 12.5, compression: 0.10, t50: 3.1 },
+                    { stress: 25, compression: 0.18, t50: 3.4 },
+                    { stress: 50, compression: 0.30, t50: 3.8 },
+                    { stress: 100, compression: 0.46, t50: 4.2 },
+                    { stress: 200, compression: 1.10, t50: 5.0 },
+                    { stress: 400, compression: 2.05, t50: 5.6 },
+                    { stress: 800, compression: 3.00, t50: 6.1 },
+                  ],
+                },
+              },
             ],
           },
           {
@@ -93,7 +151,25 @@ export function sampleInvestigation(): Investigation {
             depthTop: 9, depthBottom: 9.45, standard: 'd1586',
             recoveryLength: 0.3, driveLength: 0.45, sampleDate: '2026-06-16',
             tests: [
-              { id: 'bh1-s3-t1', type: 'sieve', standard: 'd6913', status: 'complete', testDate: '2026-06-19' },
+              {
+                id: 'bh1-s3-t1', type: 'sieve', standard: 'd6913', status: 'complete', testDate: '2026-06-19',
+                data: {
+                  totalMass: 500,
+                  readings: [
+                    { size: 9.5, designation: '3/8 in', massRetained: 0 },
+                    { size: 4.75, designation: 'No. 4', massRetained: 10 },
+                    { size: 2.0, designation: 'No. 10', massRetained: 40 },
+                    { size: 0.85, designation: 'No. 20', massRetained: 120 },
+                    { size: 0.425, designation: 'No. 40', massRetained: 190 },
+                    { size: 0.15, designation: 'No. 100', massRetained: 120 },
+                    { size: 0.075, designation: 'No. 200', massRetained: 12 },
+                  ],
+                },                                                                  // 1.6% fines, uniform ⇒ SP
+              },
+              {
+                id: 'bh1-s3-t2', type: 'atterberg', standard: 'd4318', status: 'complete', testDate: '2026-06-19',
+                data: { liquidLimit: 19, nonPlastic: true },
+              },
             ],
           },
         ],
@@ -129,7 +205,7 @@ export function sampleInvestigation(): Investigation {
             description: 'Loose silty sand fill.', colour: 'brown', density: 'loose', moisture: 'moist',
           },
           {
-            id: 'bh2-l2', depthTop: 2.1, depthBottom: 9.4, name: 'Lean Clay',
+            id: 'bh2-l2', symbol: 'CL', depthTop: 2.1, depthBottom: 9.4, name: 'Lean Clay',
             description: 'Soft lean CLAY with sand.', colour: 'grey', consistency: 'soft', moisture: 'wet',
           },
           {
@@ -143,8 +219,25 @@ export function sampleInvestigation(): Investigation {
             depthTop: 4, depthBottom: 4.75, standard: 'd1587',
             recoveryLength: 0.68, driveLength: 0.75, sampleDate: '2026-06-18',
             tests: [
-              { id: 'bh2-s1-t1', type: 'moisture', standard: 'd2216', status: 'complete', testDate: '2026-06-21' },
-              { id: 'bh2-s1-t2', type: 'atterberg', standard: 'd4318', status: 'complete', testDate: '2026-06-22' },
+              {
+                id: 'bh2-s1-t1', type: 'moisture', standard: 'd2216', status: 'complete', testDate: '2026-06-21',
+                data: { containerMass: 25.0, wetMass: 90.8, dryMass: 72.5 },        // w = 38.5%
+              },
+              {
+                id: 'bh2-s1-t2', type: 'atterberg', standard: 'd4318', status: 'complete', testDate: '2026-06-22',
+                data: { liquidLimit: 48, plasticLimit: 24, naturalMoisture: 38.5 }, // PI 24 ⇒ CL
+              },
+              {
+                id: 'bh2-s1-t4', type: 'sieve', standard: 'd6913', status: 'complete', testDate: '2026-06-22',
+                data: {
+                  totalMass: 400,
+                  readings: [
+                    { size: 4.75, designation: 'No. 4', massRetained: 0 },
+                    { size: 0.425, designation: 'No. 40', massRetained: 24 },
+                    { size: 0.075, designation: 'No. 200', massRetained: 60 },
+                  ],
+                },                                                                  // 79% fines
+              },
               { id: 'bh2-s1-t3', type: 'triaxial', standard: 'd4767', status: 'planned' },
             ],
           },


### PR DESCRIPTION
The bundled example booked 10 laboratory tests and entered data for **none**, so every new visitor met a module that looked broken: no classification, no parameters worth the name, and — since #550 made the report show results rather than bookings — a §8 that said only that nothing had a result.

It now books 14 and enters data for 13, chosen so that the data **agrees with the geology it was logged as**. That's the point of a fixture: every sample classifies, and every symbol matches its layer's name.

| sample | logged as | classifies as | from |
|---|---|---|---|
| BH-01 S-01 | Silty Sand | **SM** "Silty sand" | 25% fines, non-plastic |
| BH-01 S-02 | Lean Clay | **CL** "Lean clay with sand" | LL 45 / PI 23, 75% fines |
| BH-01 S-03 | Poorly Graded Sand | **SP** "Poorly graded sand" | 1.6% fines, Cu < 6 |
| BH-02 S-01 | Lean Clay | **CL** "Lean clay with sand" | LL 48 / PI 24 |

**One planned triaxial is left unrun, deliberately.** Without it the example would never show what an incomplete programme looks like, and #550's "not tabulated, and here is what was left out" path would go undemonstrated in the one investigation everybody opens.

**Layers carry a group symbol only where a sample speaks for them.** The two Fill layers and BH-02's sand were never tested and stay unclassified — a real gap, left visible rather than filled with a plausible guess.

The consolidation curve is planted to be lightly overconsolidated and lands where a real one would: **Cc = 0.332** against Terzaghi's 0.009(LL−10) = 0.315 for its LL of 45, **Cr = 0.042**, and **σ′p ≈ 127 kPa** against ~85 kPa of effective overburden at 5 m.

## What it turned up

- **An Atterberg blob needs a liquid limit to be readable at all.** `nonPlastic: true` on its own is rejected by the guard — non-plastic means the *plastic* limit couldn't be obtained, not that nothing was measured. Two fixture tests were silently producing no result until I caught that.
- **`parameters.test.ts` asserted cu in the clay was `correlated`.** With a UCS test on that sample it's now `measured` — the engine preferring a measurement over a correlation, exactly as designed. I split the assertion into the three cases it was conflating: measured when a test exists, correlated when none does, refused outright in a sand.

## Verification

Generated the example's report in a browser with **no manual data entry** — it now runs to **11 pages with five plots in §8**, including the e–log σ′ with its σ′p marked. Fixture still validates with **zero errors and zero warnings**.

`sample.test.ts` is new (the fixture had no test of its own) and pins its role as the demo: validates clean, classifications agree with geology, consolidation numbers sit where planted, both report paths exercised.

Suite **3745 passed**, `tsc -b` and `lint` clean.

**Known, not fixed here:** `gradingChart`'s "gravel | sand" boundary label sits on the curve when the curve passes 100% at that size — visible now that the example has grading data. It's pre-existing and cosmetic; the sieve/hydrometer merge reworks that chart, so it's fixed there rather than twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WmPbtTVsjNBXVpiQVBYBnz)_