### PR TITLE
feat(soils): USDA texture beside USCS and AASHTO, in the page and the report

### DIFF
--- a/webapp/src/engine/soils/classifySample.test.ts
+++ b/webapp/src/engine/soils/classifySample.test.ts
@@ -233,6 +233,108 @@ describe('non-plastic fines are a finding, not a gap', () => {
   })
 })
 
+// ── USDA texture ──────────────────────────────────────────────────────────
+
+describe('the USDA texture needs a sedimentation test, and says so when there is none', () => {
+  const full = sample([sieveTest(), atterbergTest({ liquidLimit: 42, plasticLimit: 23 })])
+
+  it('gives USCS and AASHTO but no texture from a sieve alone', () => {
+    const c = classifySample(full)
+    expect(c.uscs!.symbol).toBe('SC')
+    expect(c.aashto!.group).toBeTruthy()
+    expect(c.usda).toBeUndefined()
+    expect(c.usdaGap).toMatch(/0\.002 mm/)
+    expect(c.usdaGap).toMatch(/D7928/)
+  })
+
+  const hydrometerTest = (over: Record<string, unknown> = {}) =>
+    test({
+      type: 'hydrometer', standard: 'd7928',
+      data: {
+        dryMass: 50, specificGravity: 2.7,
+        compositeCorrection: 5, meniscusCorrection: 1, fractionOfTotal: 33,
+        readings: [
+          { time: 2, reading: 50, temperature: 22 },
+          { time: 30, reading: 38, temperature: 22 },
+          { time: 250, reading: 26, temperature: 22 },
+          { time: 1440, reading: 18, temperature: 22 },
+        ],
+        ...over,
+      },
+    })
+
+  it('reads the 0.05 mm boundary ACROSS the join between the two curves', () => {
+    // The sieve stops at 0.075 mm and this run starts near 0.025 mm, so the
+    // USDA sand/silt boundary at 0.05 mm falls between them and is reached by
+    // interpolating the combined curve — the sieve's fines content is NOT it.
+    const c = classifySample(sample([
+      sieveTest(), atterbergTest({ liquidLimit: 42, plasticLimit: 23 }), hydrometerTest(),
+    ]))
+    expect(c.usda).toBeDefined()
+    const { sand, silt, clay } = c.usda!.composition
+    expect(sand + silt + clay).toBeCloseTo(100, 6)
+    // Everything between 0.05 and 0.075 mm is USDA sand but USCS fines, so the
+    // texture carries MORE sand than reading the boundary off the No. 200 sieve
+    // would give. Quoting one system's fraction inside the other's name is the
+    // error this guards.
+    const fineEarth = 100 - c.usda!.gravel
+    const sandIfSieveWereTheBoundary = ((fineEarth - c.gradation!.fines) / fineEarth) * 100
+    expect(sand).toBeGreaterThan(sandIfSieveWereTheBoundary)
+    // and the clay is a part of the fines, never all of them
+    expect(clay).toBeGreaterThan(0)
+    expect((clay * fineEarth) / 100).toBeLessThan(c.gradation!.fines)
+  })
+
+  it('stops advising a hydrometer once one is on file, and says what is still missing', () => {
+    // The sieve engine's "a hydrometer would complete it" is correct until the
+    // test exists; printing it beside the sedimentation result reads as a
+    // contradiction. It is replaced rather than stacked.
+    const withOut = classifySample(sample([sieveTest(), atterbergTest({ liquidLimit: 42, plasticLimit: 23 })]))
+    expect(withOut.notes.join(' ')).toMatch(/need a hydrometer analysis/)
+
+    const withIt = classifySample(sample([
+      sieveTest(), atterbergTest({ liquidLimit: 42, plasticLimit: 23 }), hydrometerTest(),
+    ]))
+    expect(withIt.notes.join(' ')).not.toMatch(/need a hydrometer analysis/)
+    expect(withIt.notes.join(' ')).toMatch(/still come from the sieve alone/)
+    expect(withIt.gradation!.d10).toBeUndefined()
+  })
+
+  it('keeps the gravel out of the triangle and names it as a modifier', () => {
+    const c = classifySample(sample([
+      // 30% gravel: 150 g of a 500 g stack retained above 2.0 mm.
+      sieveTest({
+        totalMass: 500,
+        readings: [
+          { size: 4.75, massRetained: 90 },
+          { size: 2.0, massRetained: 60 },
+          { size: 0.425, massRetained: 130 },
+          { size: 0.075, massRetained: 120 },
+        ],
+        panMass: 100,
+      }),
+      atterbergTest({ liquidLimit: 42, plasticLimit: 23 }),
+      hydrometerTest({ fractionOfTotal: 20 }),
+    ]))
+    expect(c.usda!.gravel).toBeCloseTo(30, 6)
+    expect(c.usda!.name).toMatch(/^gravelly /)
+    // The triangle itself sums over the fine earth only.
+    const { sand, silt, clay } = c.usda!.composition
+    expect(sand + silt + clay).toBeCloseTo(100, 6)
+    expect(c.notes.join(' ')).toMatch(/keeps that out of the triangle/)
+  })
+
+  it('reports an unreadable sedimentation run rather than classifying around it', () => {
+    const c = classifySample(sample([
+      sieveTest(), atterbergTest({ liquidLimit: 42, plasticLimit: 23 }),
+      hydrometerTest({ specificGravity: 0.5 }),   // Gs below water
+    ]))
+    expect(c.uscs!.symbol).toBe('SC')             // the sieve is still good
+    expect(c.usda).toBeUndefined()
+    expect(c.notes.join(' ')).toMatch(/Hydrometer analysis could not be evaluated/)
+  })
+})
+
 describe('an empty sample', () => {
   it('returns both tests as missing without throwing', () => {
     const c = classifySample(sample([]))

--- a/webapp/src/engine/soils/classifySample.ts
+++ b/webapp/src/engine/soils/classifySample.ts
@@ -18,19 +18,35 @@
 //     sample means no classification, and `missing` names the test to run
 //     rather than the classifier guessing from the fines content.
 //
+// THREE SYSTEMS, THREE QUESTIONS, ONE LABORATORY RECORD. USCS (D2487) asks what
+// the soil IS, AASHTO (M 145) how it will perform under a pavement, and USDA
+// what its grains ARE by size. They are computed from the same tests and
+// reported side by side, never reconciled — see each engine's header for why
+// they disagree by design.
+//
+// USDA IS THE ONE THAT CAN GO MISSING WHEN THE OTHER TWO DO NOT. Its triangle
+// is drawn on the 0.002 mm clay boundary, which no sieve reaches, so a sample
+// without a hydrometer gets a USCS symbol and an AASHTO group but no texture —
+// `usdaGap` says so in words rather than leaving a blank.
+//
 // UNITS: as the underlying engines — percentages 0–100, sizes mm.
 // ─────────────────────────────────────────────────────────────────────────
 
 import type { Sample, LabTest, LabTestType } from './model'
 import { classifyUSCS, type UscsResult } from './uscs'
 import { classifyAASHTO, type AashtoResult } from './aashto'
+import { usdaFromPassing, type UsdaResult } from './usda'
 import { evaluateTest } from './lab'
 import type { GradationResult } from './sieve'
 import type { AtterbergResult } from './atterberg'
+import type { HydrometerResult } from './lab/hydrometer'
 
 export interface SampleClassification {
   uscs?: UscsResult
   aashto?: AashtoResult
+  usda?: UsdaResult
+  /** Why there is no USDA texture, when there is none. */
+  usdaGap?: string
   /** The gradation the classification used, when one was found. */
   gradation?: GradationResult
   /** The limits the classification used, when they were found. */
@@ -96,6 +112,18 @@ export function classifySample(sample: Sample): SampleClassification {
     missing.push('atterberg')
   }
 
+  // ── Sedimentation, for the USDA triangle only ──
+  // Neither USCS nor AASHTO can use this curve: both stop at 0.075 mm and split
+  // the fines by plasticity instead. It is here because 0.002 mm exists nowhere
+  // else.
+  const hydro = governingTest(sample, 'hydrometer')
+  let hyd: HydrometerResult | undefined
+  if (hydro.test) {
+    const { outcome, error } = evaluateTest(hydro.test)
+    if (error) notes.push(`Hydrometer analysis could not be evaluated: ${error}`)
+    else if (outcome?.kind === 'hydrometer') hyd = outcome.result
+  }
+
   if (!grad) {
     return {
       atterberg: limits, missing, notes: [
@@ -130,18 +158,106 @@ export function classifySample(sample: Sample): SampleClassification {
     plasticityIndex: PI,
   })
 
-  if (grad.notes.length) notes.push(...grad.notes)
+  // ── USDA texture, off the combined sieve + sedimentation curve ──
+  const { usda, usdaGap } = textureFrom(grad, hyd)
+
+  // The sieve engine advises running a hydrometer when its curve stops short of
+  // 10% passing. Once one is on file that advice is stale, and printing it
+  // beside the note below reads as a contradiction — so it is replaced, not
+  // stacked. Matching on the text is deliberate and pinned by a test: the two
+  // modules are siblings, and the alternative is a flag the sieve engine would
+  // have to keep in step with wording it already owns.
+  const gradNotes = hyd ? grad.notes.filter((n) => !/hydrometer/i.test(n)) : grad.notes
+  if (gradNotes.length) notes.push(...gradNotes)
+  if (hyd && grad.d10 == null) {
+    // Its curve reached the USDA boundaries, but D10/Cu/Cc still come off the
+    // sieve alone — merging the two into one gradation is a separate change.
+    notes.push(
+      'The sedimentation curve was used for the USDA texture, but D₁₀, Cu and Cc above still come from the sieve alone and remain unavailable — merging the two curves into a single gradation is not yet done.',
+    )
+  }
   if (limits?.notes.length) notes.push(...limits.notes)
+  if (usda?.notes.length) notes.push(...usda.notes)
 
   if (!uscs.symbol && !missing.includes('atterberg') && grad.d10 == null) {
     notes.push('The gradation curve does not reach 10% passing, so Cu and Cc are unavailable — a hydrometer analysis would complete it.')
     if (!missing.includes('hydrometer')) missing.push('hydrometer')
   }
 
-  return { uscs, aashto, gradation: grad, atterberg: limits, missing, notes }
+  return { uscs, aashto, usda, usdaGap, gradation: grad, atterberg: limits, missing, notes }
 }
 
-/** Percent passing a sieve size, read off the computed gradation rows. */
+/** One point on a grading curve, whatever apparatus produced it. */
+interface CurvePoint { size: number; percentPassing: number }
+
+/**
+ * The USDA texture from the laboratory record, or the reason there isn't one.
+ *
+ * THE TWO CURVES ARE READ AS ONE. The sieve ends at 0.075 mm and the
+ * sedimentation run begins around 0.05–0.07 mm, so the 0.05 mm sand/silt
+ * boundary usually falls in the join between them — interpolating across it is
+ * how a combined grading curve is read off a chart, and it is why this is done
+ * here rather than inside `usda`, which takes finished percentages.
+ *
+ * Without a hydrometer there is no 0.002 mm point at any price, and this
+ * declines with a sentence rather than substituting the 0.075 mm fines content
+ * for a clay fraction — those are different populations by a factor of about
+ * two in a typical clay.
+ */
+function textureFrom(g: GradationResult, h?: HydrometerResult): {
+  usda?: UsdaResult; usdaGap?: string
+} {
+  if (!h) {
+    return {
+      usdaGap: 'A USDA texture needs the clay fraction finer than 0.002 mm, which is two orders of magnitude below the finest sieve. Run a hydrometer (ASTM D7928) on this sample and the texture follows; the fines content from the sieve is not a substitute for it.',
+    }
+  }
+  const curve: CurvePoint[] = [
+    ...g.rows.map((r) => ({ size: r.size, percentPassing: r.percentPassing })),
+    ...h.rows.map((r) => ({ size: r.diameter, percentPassing: r.percentFiner })),
+  ]
+  const clay = interpolatePassing(curve, 0.002) ?? h.clayFraction
+  const silt = interpolatePassing(curve, 0.05)
+  if (clay == null || silt == null) {
+    const ends = [...curve].sort((a, b) => b.size - a.size)
+    return {
+      usdaGap: `The combined grading curve runs from ${ends[0].size.toFixed(3)} mm down to ${ends[ends.length - 1].size.toFixed(4)} mm, which does not span both USDA boundaries (0.05 mm and 0.002 mm). Readings at either end of the sedimentation run would close it.`,
+    }
+  }
+  const usda = usdaFromPassing({
+    gravelBoundary: passingAtSize(g, 2.0),
+    sandBoundary: silt,
+    clayBoundary: clay,
+  })
+  return usda
+    ? { usda }
+    : { usdaGap: 'The combined grading curve does not descend with size across the USDA boundaries, so no texture can be read from it. Check that the hydrometer percentages were scaled to the whole sample.' }
+}
+
+/**
+ * Percent passing at a size, log-linear between the two bracketing points.
+ * Undefined off either end of the curve — extrapolating a grading curve past
+ * its finest reading is how a clay fraction gets invented.
+ */
+function interpolatePassing(points: CurvePoint[], size: number): number | undefined {
+  const sorted = [...points].sort((a, b) => b.size - a.size)
+  const exact = sorted.find((r) => Math.abs(r.size - size) < 1e-9)
+  if (exact) return exact.percentPassing
+  for (let i = 1; i < sorted.length; i++) {
+    const hi = sorted[i - 1], lo = sorted[i]
+    if (size <= hi.size && size >= lo.size && hi.size > lo.size) {
+      const f = (Math.log10(size) - Math.log10(lo.size)) / (Math.log10(hi.size) - Math.log10(lo.size))
+      return lo.percentPassing + f * (hi.percentPassing - lo.percentPassing)
+    }
+  }
+  return undefined
+}
+
+/**
+ * Percent passing a sieve size, read off the computed gradation rows. Clamps
+ * off the ends — a size coarser than the top sieve passes 100% of the sample,
+ * which is a fact rather than an extrapolation.
+ */
 function passingAtSize(g: GradationResult, size: number): number {
   const sorted = [...g.rows].sort((a, b) => b.size - a.size)
   const exact = sorted.find((r) => Math.abs(r.size - size) < 1e-9)
@@ -149,12 +265,5 @@ function passingAtSize(g: GradationResult, size: number): number {
   if (!sorted.length) return 0
   if (size >= sorted[0].size) return 100
   if (size <= sorted[sorted.length - 1].size) return sorted[sorted.length - 1].percentPassing
-  for (let i = 1; i < sorted.length; i++) {
-    const hi = sorted[i - 1], lo = sorted[i]
-    if (size <= hi.size && size >= lo.size) {
-      const f = (Math.log10(size) - Math.log10(lo.size)) / (Math.log10(hi.size) - Math.log10(lo.size))
-      return lo.percentPassing + f * (hi.percentPassing - lo.percentPassing)
-    }
-  }
-  return 0
+  return interpolatePassing(sorted, size) ?? 0
 }

--- a/webapp/src/engine/soils/report.ts
+++ b/webapp/src/engine/soils/report.ts
@@ -37,6 +37,7 @@ import { resolveParameters, PARAMETER_LABEL } from './parameters'
 import { describeProvenance, PROVENANCE_LABEL } from './provenance'
 import { validateInvestigation } from './validate'
 import { evaluateTest, summarise, LAB_TESTS } from './lab'
+import { classifySample } from './classifySample'
 import { labChart } from './lab/testChart'
 import { cite } from './standards'
 
@@ -563,21 +564,55 @@ function s9Classification(inv: Investigation): ReportSection {
   const layers = inv.boreholes.flatMap((b) => b.layers.map((l) => ({ b, l })))
   if (!layers.length) return missing(9, 'Soil classification', 'No strata to classify.')
 
-  const rows = layers.map(({ b, l }) => {
+  // THREE SYSTEMS SIDE BY SIDE, NOT RECONCILED. They answer different
+  // questions and disagree by design — see the header of each engine. A layer
+  // reads its systems off the sample that speaks for it; the USCS column keeps
+  // the LOGGED symbol, which may have come from a description rather than a
+  // test, and is the one column that survives with no laboratory data at all.
+  const withSample = layers.map(({ b, l }) => {
+    const classified = b.samples
+      .filter((s) => s.layerId === l.id)
+      .map((s) => classifySample(s))
+    return {
+      b, l,
+      usda: classified.find((c) => c.usda)?.usda,
+      aashto: classified.find((c) => c.aashto?.label)?.aashto,
+    }
+  })
+
+  const rows = withSample.map(({ b, l, usda, aashto }) => {
     const family = soilFamily(l.symbol, l.name)
     return [
-      `${b.name} / ${l.name}`, l.symbol ?? '—', family,
+      `${b.name} / ${l.name}`,
+      l.symbol ?? '—',
+      aashto?.label ?? '—',
+      usda?.name ?? '—',
+      family,
       isCohesive(family) ? 'cohesive' : family === 'unknown' ? '—' : 'cohesionless',
     ]
   })
-  const unknown = rows.filter((r) => r[2] === 'unknown').length
+
+  const unknown = rows.filter((r) => r[4] === 'unknown').length
+  const noTexture = rows.filter((r) => r[3] === '—').length
+
+  // A missing USDA texture is a NOTE, not a gap. It is supplementary to the
+  // engineering classification, and marking the section incomplete for want of
+  // an agronomic name would tell an engineer their report is short of something
+  // it never needed.
+  const notes = noTexture
+    ? [`${noTexture} of ${rows.length} layers carry no USDA texture. The triangle is drawn on the clay fraction finer than 0.002 mm, which no sieve reaches — a hydrometer analysis (${cite('d7928')}) on a sample from each layer is what supplies it.`]
+    : []
+
   return {
     no: 9, title: 'Soil classification',
     status: unknown ? 'partial' : 'complete',
     gap: unknown ? `${unknown} layer${unknown === 1 ? '' : 's'} could not be assigned a soil family from the description or symbol, so the cohesive/cohesionless split — which decides which methods apply — is undetermined for them.` : undefined,
-    paragraphs: [`Classification follows ${cite('d2487')}. The cohesive/cohesionless split governs which analysis methods apply: a sand method applied to a clay returns a number, and the number is wrong.`],
-    tables: [{ head: ['Layer', 'USCS', 'Family', 'Behaviour'], rows }],
-    figures: [], notes: [],
+    paragraphs: [
+      `Engineering classification follows ${cite('d2487')} (USCS) and ${cite('m145')} (AASHTO). The cohesive/cohesionless split governs which analysis methods apply: a sand method applied to a clay returns a number, and the number is wrong.`,
+      'The USDA texture (Soil Survey Manual, NRCS) is reported alongside for agricultural, drainage and erosion work. The three systems set their size boundaries in different places — USDA splits sand from silt at 0.05 mm where the other two use the 0.075 mm No. 200 sieve, and USDA and AASHTO name their fines by size where USCS names them by plasticity — so the three columns are not expected to agree and are not reconciled here.',
+    ],
+    tables: [{ head: ['Layer', 'USCS', 'AASHTO', 'USDA texture', 'Family', 'Behaviour'], rows }],
+    figures: [], notes,
   }
 }
 

--- a/webapp/src/engine/soils/sample.test.ts
+++ b/webapp/src/engine/soils/sample.test.ts
@@ -22,6 +22,21 @@ describe('the example investigation is clean', () => {
     // validator teaches every reader to ignore the validator.
     expect(validateInvestigation(inv())).toEqual([])
   })
+
+  it('every sieve stack closes its mass balance', () => {
+    // D6913 wants closure within 1%. An example that shows the engine's
+    // "re-weigh before using this grading" warning on every sample teaches the
+    // reader that the warning is background noise.
+    const sieves = inv().boreholes
+      .flatMap((b) => b.samples)
+      .flatMap((s) => s.tests.filter((t) => t.type === 'sieve'))
+    expect(sieves.length).toBeGreaterThan(3)
+    for (const t of sieves) {
+      const { outcome } = evaluateTest(t)
+      if (outcome?.kind !== 'sieve') throw new Error(`${t.id} produced no gradation`)
+      expect(Math.abs(outcome.result.massError), t.id).toBeLessThanOrEqual(1)
+    }
+  })
 })
 
 describe('its laboratory data agrees with its geology', () => {
@@ -45,6 +60,31 @@ describe('its laboratory data agrees with its geology', () => {
       // Fill and BH-02's sand were never tested; leaving them unclassified is
       // the honest record, and it keeps a real gap in the example.
       expect(Boolean(l.symbol), l.name).toBe(sampled.has(l.id))
+    }
+  })
+
+  it('shows all three classification systems disagreeing on one sample, as they should', () => {
+    // BH-01 S-02 is the only sample carrying a hydrometer, and it is there so
+    // the example can show what each system actually answers: USCS names the
+    // soil, AASHTO rates it under a pavement, USDA names its grains by size.
+    const c = classifySample(inv().boreholes[0].samples[1])
+    expect(c.uscs!.symbol).toBe('CL')
+    expect(c.aashto!.group).toBe('A-7-6')
+    expect(c.usda!.texture).toBe('clay loam')
+    // 34% finer than 0.002 mm against 75% finer than the No. 200 sieve — the
+    // gap between "fines" and "clay" that makes the hydrometer necessary.
+    expect(c.usda!.composition.clay).toBeCloseTo(33.6, 0)
+    expect(c.gradation!.fines).toBeCloseTo(75, 6)
+  })
+
+  it('the samples without a hydrometer get the two engineering systems and a reason for the third', () => {
+    const without = inv().boreholes.flatMap((b) => b.samples).filter((s) => s.id !== 'bh1-s2')
+    for (const s of without) {
+      const c = classifySample(s)
+      expect(c.uscs!.symbol, s.name).toBeTruthy()
+      expect(c.aashto!.group, s.name).toBeTruthy()
+      expect(c.usda, s.name).toBeUndefined()
+      expect(c.usdaGap, s.name).toMatch(/0\.002 mm/)
     }
   })
 
@@ -77,7 +117,7 @@ describe('it exercises both halves of the report', () => {
     // never show what an incomplete programme looks like.
     const s = lab()
     expect(s.status).toBe('partial')
-    expect(s.gap).toMatch(/1 of 14 booked tests produced no result/)
+    expect(s.gap).toMatch(/1 of 15 booked tests produced no result/)
     expect(s.gap).toMatch(/1 not yet run/)
   })
 })

--- a/webapp/src/engine/soils/sample.ts
+++ b/webapp/src/engine/soils/sample.ts
@@ -90,6 +90,7 @@ export function sampleInvestigation(): Investigation {
                     { size: 0.15, designation: 'No. 100', massRetained: 145 },
                     { size: 0.075, designation: 'No. 200', massRetained: 45 },
                   ],
+                  panMass: 125,
                 },                                                                  // 25% fines — a silty SAND
               },
               {
@@ -117,10 +118,32 @@ export function sampleInvestigation(): Investigation {
                   totalMass: 400,
                   readings: [
                     { size: 4.75, designation: 'No. 4', massRetained: 0 },
+                    { size: 2.0, designation: 'No. 10', massRetained: 0 },
                     { size: 0.425, designation: 'No. 40', massRetained: 28 },
                     { size: 0.075, designation: 'No. 200', massRetained: 72 },
                   ],
+                  panMass: 300,
                 },                                                                  // 75% fines ⇒ fine-grained
+              },
+              {
+                // The minus-No.200 fraction of the sieve above, so `fractionOfTotal`
+                // is its 75% fines and the two curves join at 0.075 mm. Carries the
+                // 0.002 mm split no sieve can reach, which is what makes a USDA
+                // texture possible on this sample and impossible on the others.
+                id: 'bh1-s2-t6', type: 'hydrometer', standard: 'd7928', status: 'complete', testDate: '2026-06-20',
+                data: {
+                  dryMass: 50, specificGravity: 2.7,
+                  compositeCorrection: 5, meniscusCorrection: 1, fractionOfTotal: 75,
+                  readings: [
+                    { time: 2, reading: 52, temperature: 22 },
+                    { time: 5, reading: 49, temperature: 22 },
+                    { time: 15, reading: 44, temperature: 22 },
+                    { time: 30, reading: 40, temperature: 22 },
+                    { time: 60, reading: 36, temperature: 22 },
+                    { time: 250, reading: 30, temperature: 22 },
+                    { time: 1440, reading: 24, temperature: 22 },
+                  ],
+                },                                                                  // clay 34% ⇒ USDA clay loam
               },
               {
                 id: 'bh1-s2-t3', type: 'ucs', standard: 'd2166', status: 'complete', testDate: '2026-06-22',
@@ -164,6 +187,7 @@ export function sampleInvestigation(): Investigation {
                     { size: 0.15, designation: 'No. 100', massRetained: 120 },
                     { size: 0.075, designation: 'No. 200', massRetained: 12 },
                   ],
+                  panMass: 8,
                 },                                                                  // 1.6% fines, uniform ⇒ SP
               },
               {
@@ -236,6 +260,7 @@ export function sampleInvestigation(): Investigation {
                     { size: 0.425, designation: 'No. 40', massRetained: 24 },
                     { size: 0.075, designation: 'No. 200', massRetained: 60 },
                   ],
+                  panMass: 316,
                 },                                                                  // 79% fines
               },
               { id: 'bh2-s1-t3', type: 'triaxial', standard: 'd4767', status: 'planned' },

--- a/webapp/src/engine/soils/usda.test.ts
+++ b/webapp/src/engine/soils/usda.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import { classifyUSDA, usdaFractions, usdaFromPassing, USDA_SIZES } from './usda'
+
+// ─────────────────────────────────────────────────────────────────────────
+// The triangle is checked at points read off the published USDA chart, one
+// per class, plus the boundaries where two classes meet — those are where a
+// hand-written region test goes wrong, and where a nearest-centroid lookup
+// disagrees with the Soil Survey Manual.
+// ─────────────────────────────────────────────────────────────────────────
+
+const t = (sand: number, silt: number, clay: number) => classifyUSDA({ sand, silt, clay }).texture
+
+describe('the twelve textures', () => {
+  it('names each class from a point inside it', () => {
+    expect(t(90, 5, 5)).toBe('sand')
+    expect(t(82, 10, 8)).toBe('loamy sand')
+    expect(t(65, 25, 10)).toBe('sandy loam')
+    expect(t(40, 40, 20)).toBe('loam')
+    expect(t(20, 70, 10)).toBe('silt loam')
+    expect(t(10, 85, 5)).toBe('silt')
+    expect(t(60, 15, 25)).toBe('sandy clay loam')
+    expect(t(33, 34, 33)).toBe('clay loam')
+    expect(t(10, 60, 30)).toBe('silty clay loam')
+    expect(t(55, 10, 35)).toBe('sandy clay')
+    expect(t(5, 47, 48)).toBe('silty clay')
+    expect(t(20, 20, 60)).toBe('clay')
+  })
+
+  it('the three fractions always sum to the composition it reports', () => {
+    const r = classifyUSDA({ sand: 30, silt: 45, clay: 25 })
+    const { sand, silt, clay } = r.composition
+    expect(sand + silt + clay).toBeCloseTo(100, 9)
+  })
+})
+
+describe('the boundaries, where the manual is explicit', () => {
+  it('clay needs sand ≤ 45 AND silt < 40 — otherwise it is a sandy or silty clay', () => {
+    expect(t(45, 15, 40)).toBe('clay')            // on both limits at once
+    expect(t(50, 5, 45)).toBe('sandy clay')       // sand over 45
+    expect(t(20, 40, 40)).toBe('silty clay')      // silt at 40
+  })
+
+  it('splits clay loam from silty clay loam at 20% sand, not at a clay content', () => {
+    expect(t(21, 45, 34)).toBe('clay loam')
+    expect(t(19, 47, 34)).toBe('silty clay loam')
+  })
+
+  it('takes the sand corner off the two sloping lines, not off a clay limit', () => {
+    // The 'sand' and 'loamy sand' boundaries are silt + 1.5·clay = 15 and
+    // silt + 2·clay = 30. A soil can carry more clay and still be a sand.
+    expect(t(88, 6, 6)).toBe('loamy sand')        // 6 + 9 = 15 is not < 15 …
+    expect(t(89, 6, 5)).toBe('sand')              // … but 6 + 7.5 = 13.5 is
+    expect(t(80, 12, 8)).toBe('loamy sand')       // 12 + 16 = 28 < 30
+    expect(t(78, 12, 10)).toBe('sandy loam')      // 12 + 20 = 32 ≥ 30
+  })
+
+  it('keeps loam off the sand side at 52% sand', () => {
+    expect(t(52, 33, 15)).toBe('loam')
+    expect(t(55, 30, 15)).toBe('sandy loam')
+  })
+
+  it('silt needs clay under 12 as well as silt over 80', () => {
+    expect(t(8, 80, 12)).toBe('silt loam')
+    expect(t(8, 81, 11)).toBe('silt')
+  })
+})
+
+describe('what it does with fractions that do not sum to 100', () => {
+  it('normalises them and says so', () => {
+    // Gravel left in is the usual cause: 30 + 30 + 20 is a whole-sample split
+    // with 20% gravel still in it.
+    const r = classifyUSDA({ sand: 30, silt: 30, clay: 20 })
+    expect(r.composition.sand).toBeCloseTo(37.5, 6)
+    expect(r.notes.join(' ')).toMatch(/rather than 100%/)
+    expect(r.notes.join(' ')).toMatch(/gravel was left in/)
+  })
+
+  it('refuses an empty composition rather than dividing by zero', () => {
+    expect(() => classifyUSDA({ sand: 0, silt: 0, clay: 0 })).toThrow(/more than zero/)
+  })
+})
+
+describe('from a grading curve', () => {
+  it('uses the USDA boundaries, which are not any other system’s', () => {
+    // 2.0 mm, 0.05 mm and 0.002 mm — the sand/silt split in particular is at
+    // 0.05, not the No. 200 sieve at 0.075 that USCS and AASHTO use.
+    expect(USDA_SIZES).toEqual({ gravel: 2.0, sand: 0.05, clay: 0.002 })
+  })
+
+  it('renormalises onto the fine earth, so gravel does not dilute the texture', () => {
+    // 20% gravel, then 40 sand / 25 silt / 15 clay of the WHOLE sample.
+    const f = usdaFractions({ gravelBoundary: 80, sandBoundary: 40, clayBoundary: 15 })!
+    expect(f.gravel).toBeCloseTo(20, 9)
+    // Of the fine earth: sand 40/80, silt 25/80, clay 15/80.
+    expect(f.composition.sand).toBeCloseTo(50, 9)
+    expect(f.composition.silt).toBeCloseTo(31.25, 9)
+    expect(f.composition.clay).toBeCloseTo(18.75, 9)
+  })
+
+  it('DECLINES without the 0.002 mm point — a sieve cannot reach it', () => {
+    // The whole reason a hydrometer is required for a USDA texture.
+    expect(usdaFractions({ gravelBoundary: 95, sandBoundary: 40 })).toBeUndefined()
+    expect(usdaFromPassing({ gravelBoundary: 95, sandBoundary: 40 })).toBeUndefined()
+  })
+
+  it('declines a curve that climbs with size', () => {
+    // More passing 0.002 mm than 0.05 mm is impossible; refuse rather than
+    // clamping a negative silt fraction to zero and classifying anyway.
+    expect(usdaFractions({ gravelBoundary: 90, sandBoundary: 30, clayBoundary: 45 })).toBeUndefined()
+  })
+
+  it('names the gravel as a modifier rather than putting it in the triangle', () => {
+    // 40% gravel over a loam fine earth.
+    const r = usdaFromPassing({ gravelBoundary: 60, sandBoundary: 36, clayBoundary: 12 })!
+    expect(r.texture).toBe('loam')
+    expect(r.name).toBe('very gravelly loam')
+    expect(r.gravel).toBeCloseTo(40, 9)
+    expect(r.notes.join(' ')).toMatch(/keeps that out of the triangle/)
+  })
+
+  it('leaves the name alone below 15% gravel', () => {
+    const r = usdaFromPassing({ gravelBoundary: 90, sandBoundary: 54, clayBoundary: 18 })!
+    expect(r.name).toBe(r.texture)
+  })
+})

--- a/webapp/src/engine/soils/usda.ts
+++ b/webapp/src/engine/soils/usda.ts
@@ -1,0 +1,200 @@
+// ─────────────────────────────────────────────────────────────────────────
+// USDA soil texture. Layer 8. USDA Soil Survey Manual (NRCS) textural triangle.
+//
+// The third classification this module speaks, and the one that answers a
+// different question from the other two. USCS and AASHTO are ENGINEERING
+// systems: they sort a soil by how it will behave under a load or a pavement,
+// and both lean on plasticity to do it. USDA is an AGRONOMIC system: it sorts
+// by what the grains ARE, purely by size, into the twelve textures a soil
+// scientist names — sandy loam, silty clay, and so on. It says nothing about
+// bearing capacity and is not a substitute for either engineering system; it is
+// what agricultural, drainage, erosion and land-capability work is written in.
+//
+// THE SIZE BOUNDARIES ARE NOT THE SAME, AND THAT IS THE WHOLE DIFFICULTY:
+//
+//                    gravel      sand              silt            clay
+//   USDA            > 2.0 mm    0.05–2.0        0.002–0.05       < 0.002
+//   AASHTO          > 2.0 mm    0.075–2.0       0.002–0.075      < 0.002
+//   USCS            > 4.75 mm   0.075–4.75      ── "fines", split by PLASTICITY ──
+//
+// So a USCS "sand" and a USDA "sand" are different populations, and the fines a
+// USCS classification calls silt or clay are decided by an Atterberg test
+// rather than by size at all. Quoting one system's fraction inside another's
+// name is the error this module refuses to make.
+//
+// A SIEVE ALONE CANNOT PRODUCE A USDA TEXTURE. The triangle needs the split at
+// 0.002 mm, which is two orders of magnitude below the finest practical sieve
+// (0.075 mm). That number comes from a sedimentation test — the hydrometer —
+// and without one this module declines to classify rather than guessing where
+// the silt ends. That is also why the hydrometer earns its place: it is not a
+// refinement of the sieve curve, it is the only route to a clay fraction.
+//
+// PERCENTAGES ARE OF THE FINE EARTH. USDA reports sand, silt and clay as
+// percentages of the < 2 mm fraction, with anything coarser named separately as
+// a modifier ("gravelly sandy loam"). A texture computed on the whole sample
+// instead is wrong by exactly the gravel content.
+//
+// UNITS: sizes mm; percentages 0–100.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** The twelve textures of the USDA triangle. */
+export type UsdaTexture =
+  | 'sand' | 'loamy sand' | 'sandy loam' | 'loam' | 'silt loam' | 'silt'
+  | 'sandy clay loam' | 'clay loam' | 'silty clay loam'
+  | 'sandy clay' | 'silty clay' | 'clay'
+
+/** Sand, silt and clay as percentages of the FINE EARTH (< 2 mm). */
+export interface UsdaComposition {
+  sand: number
+  silt: number
+  clay: number
+}
+
+export interface UsdaResult {
+  texture: UsdaTexture
+  /** With the gravel modifier applied, e.g. 'gravelly sandy loam'. */
+  name: string
+  composition: UsdaComposition
+  /** Gravel (> 2 mm) as a percentage of the WHOLE sample; it is not in the triangle. */
+  gravel: number
+  /** Why this texture and not its neighbours. */
+  reason: string
+  notes: string[]
+}
+
+/** USDA size boundaries, mm — named because they differ from every other system. */
+export const USDA_SIZES = { gravel: 2.0, sand: 0.05, clay: 0.002 } as const
+
+/**
+ * Gravel modifier on a texture name (Soil Survey Manual): 15–35% of the whole
+ * sample is "gravelly", 35–60% "very gravelly". Below 15% the coarse fraction
+ * does not change the name.
+ */
+function gravelModifier(gravel: number): string {
+  if (gravel >= 60) return 'extremely gravelly '
+  if (gravel >= 35) return 'very gravelly '
+  if (gravel >= 15) return 'gravelly '
+  return ''
+}
+
+/**
+ * The textural triangle.
+ *
+ * The classes are tested in order from the clay corner outward, because the
+ * regions overlap at their edges and the triangle is defined by which boundary
+ * you meet first. Written as the Soil Survey Manual states them rather than as
+ * a nearest-centroid lookup, so a point on a boundary lands where the manual
+ * says it does.
+ */
+export function classifyUSDA(c: UsdaComposition): UsdaResult {
+  const notes: string[] = []
+  const total = c.sand + c.silt + c.clay
+  if (!(total > 0)) throw new Error('Sand, silt and clay must sum to more than zero.')
+  if (Math.abs(total - 100) > 1) {
+    notes.push(
+      `The three fractions sum to ${total.toFixed(1)}% rather than 100%; they have been normalised. A gap this size usually means the gravel was left in, or the hydrometer and sieve were read on different bases.`,
+    )
+  }
+  // Normalise so a caller that passes fractions of the whole sample still lands
+  // in the right region rather than off the triangle entirely.
+  const sand = (c.sand / total) * 100
+  const silt = (c.silt / total) * 100
+  const clay = (c.clay / total) * 100
+  const comp = { sand, silt, clay }
+
+  const of = (texture: UsdaTexture, reason: string): UsdaResult =>
+    ({ texture, name: texture, composition: comp, gravel: 0, reason, notes })
+
+  // ── the clay corner ──
+  if (clay >= 40 && silt < 40 && sand <= 45) {
+    return of('clay', `clay ${clay.toFixed(0)}% ≥ 40 with sand ≤ 45 and silt < 40`)
+  }
+  if (clay >= 40 && silt >= 40) {
+    return of('silty clay', `clay ${clay.toFixed(0)}% ≥ 40 alongside silt ${silt.toFixed(0)}% ≥ 40`)
+  }
+  if (clay >= 35 && sand > 45) {
+    return of('sandy clay', `clay ${clay.toFixed(0)}% ≥ 35 with sand ${sand.toFixed(0)}% > 45`)
+  }
+  // ── the loam band ──
+  if (clay >= 27 && clay < 40 && sand > 20 && sand <= 45) {
+    return of('clay loam', `clay ${clay.toFixed(0)}% between 27 and 40 with sand ${sand.toFixed(0)}% between 20 and 45`)
+  }
+  if (clay >= 27 && clay < 40 && sand <= 20) {
+    return of('silty clay loam', `clay ${clay.toFixed(0)}% between 27 and 40 with sand ${sand.toFixed(0)}% ≤ 20`)
+  }
+  if (clay >= 20 && clay < 35 && silt < 28 && sand > 45) {
+    return of('sandy clay loam', `clay ${clay.toFixed(0)}% between 20 and 35 with silt < 28 and sand > 45`)
+  }
+  // ── the silt side ──
+  if (silt >= 80 && clay < 12) {
+    return of('silt', `silt ${silt.toFixed(0)}% ≥ 80 with clay < 12`)
+  }
+  if ((silt >= 50 && clay >= 12 && clay < 27) || (silt >= 50 && silt < 80 && clay < 12)) {
+    return of('silt loam', `silt ${silt.toFixed(0)}% ≥ 50 with clay ${clay.toFixed(0)}% below 27`)
+  }
+  if (clay >= 7 && clay < 27 && silt >= 28 && silt < 50 && sand <= 52) {
+    return of('loam', `clay ${clay.toFixed(0)}%, silt ${silt.toFixed(0)}% and sand ${sand.toFixed(0)}% all inside the loam block`)
+  }
+  // ── the sand side, where the two sloping boundaries decide it ──
+  if (silt + 1.5 * clay < 15) {
+    return of('sand', `silt + 1.5·clay = ${(silt + 1.5 * clay).toFixed(0)} < 15`)
+  }
+  if (silt + 2 * clay < 30) {
+    return of('loamy sand', `silt + 1.5·clay ≥ 15 but silt + 2·clay = ${(silt + 2 * clay).toFixed(0)} < 30`)
+  }
+  return of('sandy loam', `silt + 2·clay = ${(silt + 2 * clay).toFixed(0)} ≥ 30 with clay ${clay.toFixed(0)}% below 20`)
+}
+
+/**
+ * USDA fractions from a grading curve.
+ *
+ * Takes percent PASSING at the three USDA boundaries, on the whole-sample
+ * basis, and returns the triangle's composition (of the fine earth) plus the
+ * gravel that was set aside.
+ *
+ * Returns undefined when the 0.002 mm value is absent — see the module header:
+ * no sedimentation test, no clay fraction, no texture.
+ */
+export function usdaFractions(passing: {
+  /** % passing 2.0 mm. */
+  gravelBoundary: number
+  /** % passing 0.05 mm. */
+  sandBoundary: number
+  /** % passing 0.002 mm, from a hydrometer. */
+  clayBoundary?: number
+}): { composition: UsdaComposition; gravel: number } | undefined {
+  const { gravelBoundary: p2, sandBoundary: p05, clayBoundary: p002 } = passing
+  if (p002 == null || !Number.isFinite(p002)) return undefined
+  if (!(p2 > 0)) return undefined
+
+  const gravel = 100 - p2
+  const clay = p002
+  const silt = p05 - p002
+  const sand = p2 - p05
+  if (silt < -0.5 || sand < -0.5) return undefined     // a curve that goes backwards
+
+  // Renormalise onto the fine earth: the triangle knows nothing about gravel.
+  const fine = Math.max(p2, 1e-9)
+  return {
+    gravel,
+    composition: {
+      sand: (Math.max(sand, 0) / fine) * 100,
+      silt: (Math.max(silt, 0) / fine) * 100,
+      clay: (Math.max(clay, 0) / fine) * 100,
+    },
+  }
+}
+
+/** Classify straight from the boundaries, with the gravel modifier applied. */
+export function usdaFromPassing(passing: Parameters<typeof usdaFractions>[0]): UsdaResult | undefined {
+  const f = usdaFractions(passing)
+  if (!f) return undefined
+  const r = classifyUSDA(f.composition)
+  const prefix = gravelModifier(f.gravel)
+  if (prefix) {
+    r.notes.push(
+      `${f.gravel.toFixed(0)}% of the whole sample is coarser than 2 mm. USDA keeps that out of the triangle and names it as a modifier, so the texture describes the fine earth only.`,
+    )
+  }
+  return { ...r, gravel: f.gravel, name: prefix + r.texture }
+}

--- a/webapp/src/pages/SoilInvestigation.tsx
+++ b/webapp/src/pages/SoilInvestigation.tsx
@@ -1734,15 +1734,43 @@ function SampleClassificationCard({
         <div className="mt-1 flex flex-wrap items-baseline gap-x-3 gap-y-1">
           <span className="font-mono text-[16px] font-semibold text-[#0056b3]">{symbol}</span>
           <span className="text-[12px] text-slate-700">{c.uscs!.name}</span>
-          {c.aashto?.label && (
-            <span className="font-mono text-[11px] text-slate-500">AASHTO {c.aashto.label}</span>
-          )}
         </div>
       ) : (
         <p className="mt-1 text-[12px] text-slate-600">
           {c.uscs?.reason ?? 'Not enough laboratory data to classify this sample yet.'}
         </p>
       )}
+
+      {/* The two other systems, each answering its own question. They are shown
+          side by side and never reconciled — see the engine headers. */}
+      <dl className="mt-2 grid grid-cols-[64px_1fr] gap-x-2 gap-y-1 border-t border-slate-200 pt-2 text-[11px]">
+        <dt className="font-semibold text-slate-500">AASHTO</dt>
+        <dd className="text-slate-700">
+          {c.aashto?.label ? (
+            <>
+              <span className="font-mono">{c.aashto.label}</span>
+              <span className="text-slate-500"> — {c.aashto.rating} as subgrade</span>
+            </>
+          ) : (
+            <span className="text-slate-500">{c.aashto?.reason ?? 'Not enough data for a highway group.'}</span>
+          )}
+        </dd>
+        <dt className="font-semibold text-slate-500">USDA</dt>
+        <dd className="text-slate-700">
+          {c.usda ? (
+            <>
+              <span className="font-medium">{c.usda.name}</span>
+              <span className="text-slate-500">
+                {' '}— sand {c.usda.composition.sand.toFixed(0)}%, silt {c.usda.composition.silt.toFixed(0)}%,
+                clay {c.usda.composition.clay.toFixed(0)}% of the fine earth
+              </span>
+              <span className="block text-[10px] text-slate-500">{c.usda.reason}</span>
+            </>
+          ) : (
+            <span className="text-slate-500">{c.usdaGap}</span>
+          )}
+        </dd>
+      </dl>
 
       {c.missing.length > 0 && (
         <p className="mt-1.5 text-[11px] text-slate-600">


### PR DESCRIPTION
**Layer 8** (standalone soils engines) + report + page.

The module already spoke USCS and AASHTO. This adds the third system the user asked for — the **USDA textural triangle** — and puts all three side by side on the sample card and in report §9.

## The three systems answer different questions, and are not reconciled

| | asks | splits sand from silt at | names its fines by |
|---|---|---|---|
| **USCS** (D2487) | what the soil *is* | 0.075 mm (No. 200) | **plasticity** |
| **AASHTO** (M 145) | how it performs under a pavement | 0.075 mm | plasticity |
| **USDA** (Soil Survey Manual) | what the grains *are* | **0.05 mm** | **size** |

Quoting one system's fraction inside another's name is the error the new engine refuses to make, and §9 says so in prose rather than trying to make the columns agree.

## A USDA texture needs a hydrometer, and nothing else will do

The triangle is drawn on the 0.002 mm clay boundary — two orders of magnitude below the finest practical sieve. So `classifySample` now returns either a texture **or `usdaGap`**, a sentence naming the test to run. It does **not** substitute the No. 200 fines content for a clay fraction; in the example those are 75% and 34% of the same sample.

The 0.05 mm boundary is the interesting one: the sieve stops at 0.075 mm and a sedimentation run starts near 0.025 mm, so it lands **in the join between the two curves** and is reached by interpolating them as one. That's how a combined grading curve is read off a chart, and it's why the arithmetic lives in `classifySample` rather than in `usda`, which takes finished percentages.

## What ships

- **`usda.ts`** — twelve textures, tested in the Soil Survey Manual's order (clay corner outward) rather than as a nearest-centroid lookup, so a point *on* a boundary lands where the manual says. Gravel is kept out of the triangle and applied to the name as a modifier (`very gravelly loam`); percentages are of the fine earth.
- **`classifySample`** — `usda`, `usdaGap`, and the combined-curve read. Once a hydrometer is on file, the sieve engine's stale "run a hydrometer to complete Cu/Cc" advice is **replaced** rather than stacked beside the result (it read as a contradiction on screen); the replacement says plainly that D₁₀/Cu/Cc still come from the sieve alone.
- **Report §9** — `Layer | USCS | AASHTO | USDA texture | Family | Behaviour`. A missing texture is a **note, not a gap**: it's supplementary to the engineering classification, and marking the section incomplete for want of an agronomic name would tell an engineer their report is short of something it never needed.
- **Page** — the sample card shows AASHTO with its subgrade rating and USDA with its composition and the reason for that texture, or the gap sentence.

## The example now demonstrates all three disagreeing

BH-01 S-02 gains a hydrometer (7 readings, minus-No.200 suspension scaled by its own 75% fines so the curves join at 0.075 mm):

**USCS `CL` "Lean clay with sand" · AASHTO `A-7-6 (17)` fair to poor · USDA `clay loam`** — sand 27%, silt 39%, clay 34% of the fine earth.

Activity PI/clay = 23/34 = 0.68, which is where an illitic lean clay belongs. The other three samples keep no hydrometer on purpose, so the example also shows the gap sentence.

## Turned up on the way

**Every sieve stack in the example was failing its D6913 mass balance** — the fixture never carried `panMass`, so the engine reported errors of −25% to −75% on screen and in the report. Pan masses added and pinned by a test; an example that shows "re-weigh before using this grading" on every sample teaches the reader that the warning is background noise. Classification is unaffected (the pan only enters the balance check).

## Verification

Browser, with no manual data entry: the card renders all three systems ([screenshot in the thread]); the report runs to **12 pages**, §9 carries the six columns inside the margins with the note beneath, and §8 now plots the hydrometer curve reporting **clay 33.6%, D50 0.0067 mm, a = 0.989** — the same numbers the engine returns.

New tests: `usda.test.ts` (one point per class, the boundaries the manual is explicit about, the fine-earth renormalisation, the refusal with no 0.002 mm point) and five in `classifySample.test.ts` covering the join interpolation, the gravel modifier, an unreadable run, and the stale-advice replacement. Suite **3768 passed**, `tsc -b` and `lint` clean.

**Known, not fixed here:** D₁₀/Cu/Cc still come off the sieve alone when a hydrometer exists — merging the two into a single gradation is the queued sieve/hydrometer phase, which also reworks `gradingChart`'s "gravel | sand" label collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmPbtTVsjNBXVpiQVBYBnz)_