### PR TITLE
feat(soils): join the sieve and sedimentation curves into one grading

### DIFF
--- a/webapp/src/engine/soils/classifySample.test.ts
+++ b/webapp/src/engine/soils/classifySample.test.ts
@@ -285,19 +285,58 @@ describe('the USDA texture needs a sedimentation test, and says so when there is
     expect((clay * fineEarth) / 100).toBeLessThan(c.gradation!.fines)
   })
 
-  it('stops advising a hydrometer once one is on file, and says what is still missing', () => {
+  it('stops advising a hydrometer once one is on file, because the join answers it', () => {
     // The sieve engine's "a hydrometer would complete it" is correct until the
-    // test exists; printing it beside the sedimentation result reads as a
-    // contradiction. It is replaced rather than stacked.
+    // test exists. Once it does, the joined curve either reached D₁₀ or did
+    // not, and saying both at once reads as a contradiction.
     const withOut = classifySample(sample([sieveTest(), atterbergTest({ liquidLimit: 42, plasticLimit: 23 })]))
     expect(withOut.notes.join(' ')).toMatch(/need a hydrometer analysis/)
+    expect(withOut.curve!.combined).toBe(false)
+    expect(withOut.curve!.d10).toBeUndefined()
 
     const withIt = classifySample(sample([
       sieveTest(), atterbergTest({ liquidLimit: 42, plasticLimit: 23 }), hydrometerTest(),
     ]))
     expect(withIt.notes.join(' ')).not.toMatch(/need a hydrometer analysis/)
-    expect(withIt.notes.join(' ')).toMatch(/still come from the sieve alone/)
+    // The sieve alone still cannot reach it; the JOINED curve can. That is the
+    // whole point of the merge.
     expect(withIt.gradation!.d10).toBeUndefined()
+    expect(withIt.curve!.d10).toBeDefined()
+    expect(withIt.notes.join(' ')).toMatch(/comes from the sedimentation run/)
+  })
+
+  it('completes the dual symbol D2487 could not finish from a sieve alone', () => {
+    // 11% fines is the band where D2487 wants BOTH a gradation symbol and a
+    // fines symbol, and where the sieve curve never reaches 10% passing. This
+    // is the case the merge was built for.
+    const stack = {
+      totalMass: 500,
+      readings: [
+        { size: 4.75, massRetained: 25 },
+        { size: 2.0, massRetained: 150 },
+        { size: 0.425, massRetained: 180 },
+        { size: 0.075, massRetained: 90 },
+      ],
+      panMass: 55,
+    }
+    const limits = atterbergTest({ liquidLimit: 30, plasticLimit: 22 })
+
+    const sieveOnly = classifySample(sample([sieveTest(stack), limits]))
+    expect(sieveOnly.uscs!.symbol).toBeUndefined()
+    expect(sieveOnly.uscs!.reason).toMatch(/BOTH/)
+    expect(sieveOnly.missing).toContain('hydrometer')
+
+    const joined = classifySample(sample([
+      sieveTest(stack), limits, hydrometerTest({ fractionOfTotal: 11 }),
+    ]))
+    expect(joined.curve!.d10).toBeDefined()
+    // Cu is comfortably over the 6 a sand needs, but Cc lands above 3, so
+    // D2487 Table 1 calls it poorly graded — a verdict, where the sieve alone
+    // could only say "unknown".
+    expect(joined.curve!.cu!).toBeGreaterThan(6)
+    expect(joined.curve!.cc!).toBeGreaterThan(3)
+    expect(joined.uscs!.symbol).toBe('SP-SC')
+    expect(joined.missing).not.toContain('hydrometer')
   })
 
   it('keeps the gravel out of the triangle and names it as a modifier', () => {

--- a/webapp/src/engine/soils/classifySample.ts
+++ b/webapp/src/engine/soils/classifySample.ts
@@ -36,8 +36,9 @@ import type { Sample, LabTest, LabTestType } from './model'
 import { classifyUSCS, type UscsResult } from './uscs'
 import { classifyAASHTO, type AashtoResult } from './aashto'
 import { usdaFromPassing, type UsdaResult } from './usda'
+import { combineGrading, passingOnCurve, passingOrClamp, type CombinedGrading } from './grading'
 import { evaluateTest } from './lab'
-import type { GradationResult } from './sieve'
+import { passingAt, type GradationResult } from './sieve'
 import type { AtterbergResult } from './atterberg'
 import type { HydrometerResult } from './lab/hydrometer'
 
@@ -47,8 +48,13 @@ export interface SampleClassification {
   usda?: UsdaResult
   /** Why there is no USDA texture, when there is none. */
   usdaGap?: string
-  /** The gradation the classification used, when one was found. */
+  /** The sieve result on its own, as the laboratory reported it. */
   gradation?: GradationResult
+  /**
+   * The curve everything above was read off: the sieve joined to the
+   * sedimentation run when there is one, the sieve alone when there is not.
+   */
+  curve?: CombinedGrading
   /** The limits the classification used, when they were found. */
   atterberg?: AtterbergResult
   /** Tests that would complete or improve the classification. */
@@ -112,10 +118,10 @@ export function classifySample(sample: Sample): SampleClassification {
     missing.push('atterberg')
   }
 
-  // ── Sedimentation, for the USDA triangle only ──
-  // Neither USCS nor AASHTO can use this curve: both stop at 0.075 mm and split
-  // the fines by plasticity instead. It is here because 0.002 mm exists nowhere
-  // else.
+  // ── Sedimentation ──
+  // Joined to the sieve curve below. It is what carries the grading past the
+  // finest sieve — the only route to D₁₀ on a soil with more than ~10% fines,
+  // and the only route to the 0.002 mm boundary the USDA triangle is drawn on.
   const hydro = governingTest(sample, 'hydrometer')
   let hyd: HydrometerResult | undefined
   if (hydro.test) {
@@ -139,131 +145,95 @@ export function classifySample(sample: Sample): SampleClassification {
   const LL = limits?.liquidLimit
   const PI = limits?.plasticityIndex
 
+  // ── One curve, sieve and sedimentation together ──
+  // Everything downstream reads THIS rather than the sieve result, so a sample
+  // with a hydrometer gets shape parameters the sieve alone could not reach.
+  // With no hydrometer it is the sieve curve unchanged.
+  const curve = combineGrading(grad, hyd)
+
   const uscs = classifyUSCS({
-    gravel: grad.gravel,
-    sand: grad.sand,
-    fines: grad.fines,
-    cu: grad.cu,
-    cc: grad.cc,
+    gravel: curve.gravel,
+    sand: curve.sand,
+    fines: curve.fines,
+    cu: curve.cu,
+    cc: curve.cc,
     liquidLimit: LL,
     plasticityIndex: PI,
   })
 
   // AASHTO needs percent passing at three sieves rather than the fractions.
   const aashto = classifyAASHTO({
-    passing10: passingAtSize(grad, 2.0),
-    passing40: passingAtSize(grad, 0.425),
+    passing10: passingAt(grad.rows, 2.0),
+    passing40: passingAt(grad.rows, 0.425),
     passing200: grad.fines,
     liquidLimit: LL,
     plasticityIndex: PI,
   })
 
-  // ── USDA texture, off the combined sieve + sedimentation curve ──
-  const { usda, usdaGap } = textureFrom(grad, hyd)
+  // ── USDA texture, off the same joined curve ──
+  const { usda, usdaGap } = textureFrom(curve)
 
-  // The sieve engine advises running a hydrometer when its curve stops short of
-  // 10% passing. Once one is on file that advice is stale, and printing it
-  // beside the note below reads as a contradiction — so it is replaced, not
-  // stacked. Matching on the text is deliberate and pinned by a test: the two
-  // modules are siblings, and the alternative is a flag the sieve engine would
-  // have to keep in step with wording it already owns.
-  const gradNotes = hyd ? grad.notes.filter((n) => !/hydrometer/i.test(n)) : grad.notes
+  // The sieve engine advises running a hydrometer when its own curve stops
+  // short of 10% passing. Once one is on file that advice is stale — the join
+  // either reached D₁₀ or did not, and `curve.notes` says which — so it is
+  // replaced rather than stacked. Matching on the text is deliberate and
+  // pinned by a test: the two modules are siblings, and the alternative is a
+  // flag the sieve engine would have to keep in step with wording it owns.
+  const gradNotes = curve.combined ? grad.notes.filter((n) => !/hydrometer/i.test(n)) : grad.notes
   if (gradNotes.length) notes.push(...gradNotes)
-  if (hyd && grad.d10 == null) {
-    // Its curve reached the USDA boundaries, but D10/Cu/Cc still come off the
-    // sieve alone — merging the two into one gradation is a separate change.
+  if (curve.notes.length) notes.push(...curve.notes)
+  if (curve.combined && curve.d10 == null) {
     notes.push(
-      'The sedimentation curve was used for the USDA texture, but D₁₀, Cu and Cc above still come from the sieve alone and remain unavailable — merging the two curves into a single gradation is not yet done.',
+      'Even joined with the sedimentation run the curve does not reach 10% passing, so D₁₀, Cu and Cc remain unavailable. On a soil this fine that is the expected answer rather than a gap in the testing.',
     )
   }
   if (limits?.notes.length) notes.push(...limits.notes)
   if (usda?.notes.length) notes.push(...usda.notes)
 
-  if (!uscs.symbol && !missing.includes('atterberg') && grad.d10 == null) {
+  if (!uscs.symbol && !missing.includes('atterberg') && curve.d10 == null && !curve.combined) {
     notes.push('The gradation curve does not reach 10% passing, so Cu and Cc are unavailable — a hydrometer analysis would complete it.')
     if (!missing.includes('hydrometer')) missing.push('hydrometer')
   }
 
-  return { uscs, aashto, usda, usdaGap, gradation: grad, atterberg: limits, missing, notes }
+  return { uscs, aashto, usda, usdaGap, gradation: grad, curve, atterberg: limits, missing, notes }
 }
 
-/** One point on a grading curve, whatever apparatus produced it. */
-interface CurvePoint { size: number; percentPassing: number }
-
 /**
- * The USDA texture from the laboratory record, or the reason there isn't one.
+ * The USDA texture from the joined curve, or the reason there isn't one.
  *
- * THE TWO CURVES ARE READ AS ONE. The sieve ends at 0.075 mm and the
- * sedimentation run begins around 0.05–0.07 mm, so the 0.05 mm sand/silt
- * boundary usually falls in the join between them — interpolating across it is
- * how a combined grading curve is read off a chart, and it is why this is done
- * here rather than inside `usda`, which takes finished percentages.
+ * The 0.05 mm sand/silt boundary usually falls in the join between the finest
+ * sieve and the first sedimentation reading, and the 0.002 mm clay boundary
+ * lies well inside the sedimentation range — so this is a read off
+ * `combineGrading`'s curve rather than arithmetic of its own.
  *
- * Without a hydrometer there is no 0.002 mm point at any price, and this
+ * Without a sedimentation run there is no 0.002 mm point at any price, and this
  * declines with a sentence rather than substituting the 0.075 mm fines content
- * for a clay fraction — those are different populations by a factor of about
- * two in a typical clay.
+ * for a clay fraction — those differ by about a factor of two in a typical clay.
  */
-function textureFrom(g: GradationResult, h?: HydrometerResult): {
-  usda?: UsdaResult; usdaGap?: string
-} {
-  if (!h) {
+function textureFrom(c: CombinedGrading): { usda?: UsdaResult; usdaGap?: string } {
+  if (!c.combined) {
     return {
       usdaGap: 'A USDA texture needs the clay fraction finer than 0.002 mm, which is two orders of magnitude below the finest sieve. Run a hydrometer (ASTM D7928) on this sample and the texture follows; the fines content from the sieve is not a substitute for it.',
     }
   }
-  const curve: CurvePoint[] = [
-    ...g.rows.map((r) => ({ size: r.size, percentPassing: r.percentPassing })),
-    ...h.rows.map((r) => ({ size: r.diameter, percentPassing: r.percentFiner })),
-  ]
-  const clay = interpolatePassing(curve, 0.002) ?? h.clayFraction
-  const silt = interpolatePassing(curve, 0.05)
+  const clay = c.clay
+  const silt = passingOnCurve(c.points, USDA_SILT_SIZE)
   if (clay == null || silt == null) {
-    const ends = [...curve].sort((a, b) => b.size - a.size)
+    const ends = c.points
     return {
-      usdaGap: `The combined grading curve runs from ${ends[0].size.toFixed(3)} mm down to ${ends[ends.length - 1].size.toFixed(4)} mm, which does not span both USDA boundaries (0.05 mm and 0.002 mm). Readings at either end of the sedimentation run would close it.`,
+      usdaGap: `The joined grading curve runs from ${ends[0].size.toFixed(3)} mm down to ${ends[ends.length - 1].size.toFixed(4)} mm, which does not span both USDA boundaries (0.05 mm and 0.002 mm). Readings at either end of the sedimentation run would close it.`,
     }
   }
   const usda = usdaFromPassing({
-    gravelBoundary: passingAtSize(g, 2.0),
+    gravelBoundary: passingOrClamp(c, USDA_GRAVEL_SIZE),
     sandBoundary: silt,
     clayBoundary: clay,
   })
   return usda
     ? { usda }
-    : { usdaGap: 'The combined grading curve does not descend with size across the USDA boundaries, so no texture can be read from it. Check that the hydrometer percentages were scaled to the whole sample.' }
+    : { usdaGap: 'The joined grading curve does not descend with size across the USDA boundaries, so no texture can be read from it. Check that the hydrometer percentages were scaled to the whole sample.' }
 }
 
-/**
- * Percent passing at a size, log-linear between the two bracketing points.
- * Undefined off either end of the curve — extrapolating a grading curve past
- * its finest reading is how a clay fraction gets invented.
- */
-function interpolatePassing(points: CurvePoint[], size: number): number | undefined {
-  const sorted = [...points].sort((a, b) => b.size - a.size)
-  const exact = sorted.find((r) => Math.abs(r.size - size) < 1e-9)
-  if (exact) return exact.percentPassing
-  for (let i = 1; i < sorted.length; i++) {
-    const hi = sorted[i - 1], lo = sorted[i]
-    if (size <= hi.size && size >= lo.size && hi.size > lo.size) {
-      const f = (Math.log10(size) - Math.log10(lo.size)) / (Math.log10(hi.size) - Math.log10(lo.size))
-      return lo.percentPassing + f * (hi.percentPassing - lo.percentPassing)
-    }
-  }
-  return undefined
-}
-
-/**
- * Percent passing a sieve size, read off the computed gradation rows. Clamps
- * off the ends — a size coarser than the top sieve passes 100% of the sample,
- * which is a fact rather than an extrapolation.
- */
-function passingAtSize(g: GradationResult, size: number): number {
-  const sorted = [...g.rows].sort((a, b) => b.size - a.size)
-  const exact = sorted.find((r) => Math.abs(r.size - size) < 1e-9)
-  if (exact) return exact.percentPassing
-  if (!sorted.length) return 0
-  if (size >= sorted[0].size) return 100
-  if (size <= sorted[sorted.length - 1].size) return sorted[sorted.length - 1].percentPassing
-  return interpolatePassing(sorted, size) ?? 0
-}
+/** USDA size boundaries, mm — deliberately not the sieve openings. */
+const USDA_GRAVEL_SIZE = 2.0
+const USDA_SILT_SIZE = 0.05

--- a/webapp/src/engine/soils/grading.test.ts
+++ b/webapp/src/engine/soils/grading.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest'
+import { combineGrading, passingOnCurve, CLAY_SIZE } from './grading'
+import { gradation, type SieveInput } from './sieve'
+import { hydrometer, type HydrometerData } from './lab/hydrometer'
+
+// ─────────────────────────────────────────────────────────────────────────
+// The merge exists for one measurable reason: a soil with more than ~10%
+// fines has no D₁₀ from sieving, so no Cu, so no dual symbol. These check
+// that joining the curves produces it, that the join is policed rather than
+// papered over, and that a pass-through with no sedimentation run changes
+// nothing.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** 11% fines: the band where D2487 wants a dual symbol and sieving cannot finish. */
+const DUAL_BAND: SieveInput = {
+  totalMass: 500,
+  readings: [
+    { size: 4.75, massRetained: 25 },
+    { size: 2.0, massRetained: 150 },
+    { size: 0.425, massRetained: 180 },
+    { size: 0.075, massRetained: 90 },
+  ],
+  panMass: 55,
+}
+
+/** 33% fines, so the sieve curve stops well short of 10% passing. */
+const FINE: SieveInput = {
+  totalMass: 500,
+  readings: [
+    { size: 4.75, massRetained: 25 },
+    { size: 2.0, massRetained: 60 },
+    { size: 0.425, massRetained: 130 },
+    { size: 0.075, massRetained: 120 },
+  ],
+  panMass: 165,
+}
+
+const hyd = (over: Partial<HydrometerData> = {}) => hydrometer({
+  dryMass: 50, specificGravity: 2.7,
+  compositeCorrection: 5, meniscusCorrection: 1, fractionOfTotal: 11,
+  readings: [
+    { time: 1, reading: 50, temperature: 22 },
+    { time: 30, reading: 38, temperature: 22 },
+    { time: 250, reading: 26, temperature: 22 },
+    { time: 1440, reading: 16, temperature: 22 },
+  ],
+  ...over,
+})
+
+describe('with no sedimentation run it is a pass-through', () => {
+  it('returns the sieve curve and the sieve D-values unchanged', () => {
+    const g = gradation(FINE)
+    const c = combineGrading(g)
+    expect(c.combined).toBe(false)
+    expect(c.points).toHaveLength(g.rows.length)
+    expect(c.points.every((p) => p.source === 'sieve')).toBe(true)
+    expect(c.d10).toBe(g.d10)
+    expect(c.cu).toBe(g.cu)
+    expect(c.gravel).toBeCloseTo(g.gravel, 9)
+    expect(c.clay).toBeUndefined()
+    expect(c.notes).toEqual([])
+  })
+})
+
+describe('joining the curves is what produces D₁₀', () => {
+  it('reaches 10% passing where the sieve alone could not, and finishes Cu and Cc', () => {
+    const g = gradation(DUAL_BAND)
+    expect(g.fines).toBeCloseTo(11, 6)
+    expect(g.d10).toBeUndefined()          // the whole problem
+    expect(g.cu).toBeUndefined()
+
+    const c = combineGrading(g, hyd())
+    expect(c.combined).toBe(true)
+    expect(c.d10).toBeDefined()
+    expect(c.d10!).toBeLessThan(0.075)     // below the finest sieve, by definition
+    expect(c.cu).toBeCloseTo(c.d60! / c.d10!, 9)
+    expect(c.cc).toBeCloseTo((c.d30! * c.d30!) / (c.d10! * c.d60!), 9)
+    expect(c.notes.join(' ')).toMatch(/D₁₀ = .* comes from the sedimentation run/)
+  })
+
+  it('keeps the D2487 fractions where the sieve put them', () => {
+    // The merge extends the curve; it does not re-cut gravel, sand and fines,
+    // which are defined at sieve openings the sieve actually measured.
+    const g = gradation(DUAL_BAND)
+    const c = combineGrading(g, hyd())
+    expect(c.gravel).toBeCloseTo(g.gravel, 9)
+    expect(c.sand).toBeCloseTo(g.sand, 9)
+    expect(c.fines).toBeCloseTo(g.fines, 9)
+  })
+
+  it('orders the curve coarse to fine with the sieve first, never interleaved', () => {
+    const c = combineGrading(gradation(DUAL_BAND), hyd())
+    const sizes = c.points.map((p) => p.size)
+    expect(sizes).toEqual([...sizes].sort((a, b) => b - a))
+    const firstHydro = c.points.findIndex((p) => p.source === 'hydrometer')
+    expect(firstHydro).toBeGreaterThan(0)
+    expect(c.points.slice(firstHydro).every((p) => p.source === 'hydrometer')).toBe(true)
+  })
+
+  it('gives a size-based clay fraction, and the silt that is left over', () => {
+    const g = gradation(FINE)
+    const c = combineGrading(g, hyd({ fractionOfTotal: 33 }))
+    expect(c.clay).toBeDefined()
+    expect(c.clay!).toBeGreaterThan(0)
+    expect(c.clay!).toBeLessThan(g.fines)
+    expect(c.silt).toBeCloseTo(g.fines - c.clay!, 9)
+    // and it agrees with reading the curve directly at 0.002 mm
+    expect(passingOnCurve(c.points, CLAY_SIZE)).toBeCloseTo(c.clay!, 9)
+  })
+})
+
+describe('the join is policed, not papered over', () => {
+  it('drops sedimentation readings the sieve already weighed, and says so', () => {
+    // A first reading at 6 seconds sits above 0.075 mm: the sieve measured that
+    // size directly, and a settling velocity is the weaker of the two.
+    const c = combineGrading(gradation(DUAL_BAND), hyd({
+      readings: [
+        { time: 0.1, reading: 52, temperature: 22 },   // ~0.13 mm
+        { time: 1, reading: 50, temperature: 22 },
+        { time: 30, reading: 38, temperature: 22 },
+        { time: 1440, reading: 16, temperature: 22 },
+      ],
+    }))
+    expect(c.points.filter((p) => p.source === 'hydrometer').every((p) => p.size < 0.075)).toBe(true)
+    expect(c.notes.join(' ')).toMatch(/coarser than the 0.075 mm sieve and .* dropped/)
+  })
+
+  it('measures the disagreement at an overlapping join rather than averaging it', () => {
+    // Scaled to the whole sample as though the suspension were 40% of it when
+    // the sieve says 11% passed: the two curves cannot both be right.
+    const c = combineGrading(gradation(DUAL_BAND), hyd({
+      fractionOfTotal: 40,
+      readings: [
+        { time: 0.1, reading: 52, temperature: 22 },
+        { time: 30, reading: 38, temperature: 22 },
+        { time: 1440, reading: 16, temperature: 22 },
+      ],
+    }))
+    expect(c.joinMismatch).toBeDefined()
+    expect(c.joinMismatch!).toBeGreaterThan(2)
+    expect(c.notes.join(' ')).toMatch(/disagreement of .* points on one specimen/)
+  })
+
+  it('refuses to let a subset of the sample be larger than the sample', () => {
+    const c = combineGrading(gradation(DUAL_BAND), hyd({ fractionOfTotal: 90 }))
+    expect(c.notes.join(' ')).toMatch(/cannot be larger than the sample/)
+  })
+
+  it('names an unmeasured band at the join and flags a D-value read across it', () => {
+    // Sieve stops at 0.075 mm, first reading at 24 hours is near 0.001 mm: two
+    // decades with nothing in them, and D₁₀ lands inside.
+    const c = combineGrading(gradation(DUAL_BAND), hyd({
+      readings: [
+        { time: 1440, reading: 30, temperature: 22 },
+        { time: 2880, reading: 24, temperature: 22 },
+      ],
+    }))
+    expect(c.joinGap!).toBeGreaterThan(3)
+    expect(c.notes.join(' ')).toMatch(/Nothing was measured between/)
+    expect(c.dAcrossGap).toBe(true)
+    expect(c.notes.join(' ')).toMatch(/read off the interpolation rather than off a measurement/)
+  })
+
+  it('says when even the joined curve never reaches 0.002 mm', () => {
+    const c = combineGrading(gradation(FINE), hyd({
+      fractionOfTotal: 33,
+      readings: [
+        { time: 1, reading: 50, temperature: 22 },
+        { time: 5, reading: 45, temperature: 22 },
+      ],
+    }))
+    expect(c.clay).toBeUndefined()
+    expect(c.silt).toBeUndefined()
+    expect(c.notes.join(' ')).toMatch(/above the 0.002 mm clay boundary/)
+  })
+})
+
+describe('reading the joined curve', () => {
+  it('declines off either end rather than extrapolating', () => {
+    const c = combineGrading(gradation(DUAL_BAND), hyd())
+    const finest = c.points[c.points.length - 1].size
+    expect(passingOnCurve(c.points, finest / 10)).toBeUndefined()
+    expect(passingOnCurve(c.points, 100)).toBeUndefined()
+    expect(passingOnCurve(c.points, finest)).toBeCloseTo(c.points[c.points.length - 1].percentPassing, 9)
+  })
+})

--- a/webapp/src/engine/soils/grading.ts
+++ b/webapp/src/engine/soils/grading.ts
@@ -1,0 +1,241 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Combined grading: the sieve stack and the sedimentation run as ONE curve.
+// Layer 8. ASTM D6913 (sieving) + ASTM D7928 (sedimentation), read together
+// the way a combined particle-size analysis is reported.
+//
+// WHY THE TWO CURVES MUST BE ONE. A sieve stops at 0.075 mm. Any soil with
+// more than about 10% fines therefore never reaches 10% passing, so it has no
+// D₁₀ — and with no D₁₀ there is no Cu and no Cc, which is exactly what D2487
+// needs to finish a dual symbol in the 5–12% fines band. The sedimentation run
+// carries the curve two decades further down. Kept apart, the two tests answer
+// half a question each; joined, they answer it.
+//
+// WHO GOVERNS WHERE. The specimen for a sedimentation run is the material that
+// PASSED the finest sieve, so the two tests measure different populations and
+// the boundary between them is that sieve:
+//
+//     ≥ finest sieve opening   the sieve governs — it weighed those grains
+//     < finest sieve opening   the sedimentation run governs — the sieve
+//                              could not see them at all
+//
+// A sedimentation point coarser than the finest sieve is an OVERLAP, and the
+// two readings there should agree. The size of their disagreement is the one
+// honest check on whether `fractionOfTotal` was set correctly, so it is
+// measured and reported rather than averaged away.
+//
+// THE JOIN CAN ALSO HAVE A HOLE IN IT. A sieve ending at 0.075 mm and a first
+// hydrometer reading at 0.025 mm leave a factor-of-three band with no
+// measurement in it. The curve is still drawn across it, because that is what a
+// grading chart does, but a D-value that lands inside the gap is interpolated
+// through unmeasured ground and says so.
+//
+// SILT AND CLAY HERE ARE SIZES, NOT BEHAVIOUR. `clay` below is the fraction
+// finer than 0.002 mm. USCS decides silt from clay by PLASTICITY and would
+// disagree — a rock flour with 40% of its grains under 2 μm is an ML, not a
+// CL. The two meanings share a word and nothing else.
+//
+// UNITS: sizes mm; percentages 0–100, of the WHOLE sample.
+// ─────────────────────────────────────────────────────────────────────────
+
+import { type GradationResult, type SizePassing, interpolateD, passingAt } from './sieve'
+import type { HydrometerResult } from './lab/hydrometer'
+
+/** Clay/silt size boundary, mm — the sedimentation run's reason for existing. */
+export const CLAY_SIZE = 0.002
+
+export interface GradingPoint extends SizePassing {
+  /** Which apparatus measured this point. */
+  source: 'sieve' | 'hydrometer'
+  designation?: string
+}
+
+export interface CombinedGrading {
+  /** Coarse → fine. Sieve points then sedimentation points, never interleaved. */
+  points: GradingPoint[]
+  /** True when a sedimentation run contributed points. */
+  combined: boolean
+  /** Opening of the finest sieve, mm — where the sedimentation run takes over. */
+  joinSize?: number
+  /**
+   * Sedimentation minus sieve at the join, percentage points, when the two
+   * curves overlap there. Positive means the suspension holds more fine
+   * material than the sieve says passed, which cannot be true of one specimen.
+   */
+  joinMismatch?: number
+  /** Size ratio across an unmeasured band at the join, when there is one. */
+  joinGap?: number
+  /** Grain sizes at 10 / 30 / 60% passing on the COMBINED curve, mm. */
+  d10?: number
+  d30?: number
+  d60?: number
+  cu?: number
+  cc?: number
+  /** True when a D-value was interpolated across the unmeasured join band. */
+  dAcrossGap: boolean
+  /** D2487 fractions, from the sieve — the merge does not move them. */
+  gravel: number
+  sand: number
+  fines: number
+  /** Finer than 0.002 mm by SIZE, % of the whole sample. Needs sedimentation. */
+  clay?: number
+  /** Between 0.002 mm and the No. 200 sieve, % of the whole sample. */
+  silt?: number
+  notes: string[]
+}
+
+/**
+ * Join a gradation and a sedimentation result into one curve.
+ *
+ * Called with no hydrometer it is a pass-through: the same curve, the same
+ * D-values, `combined: false`. That is deliberate — every caller can build one
+ * of these and never branch on whether a sedimentation run exists.
+ */
+export function combineGrading(g: GradationResult, h?: HydrometerResult): CombinedGrading {
+  const notes: string[] = []
+  const sievePoints: GradingPoint[] = [...g.rows]
+    .filter((r) => r.size > 0)
+    .sort((a, b) => b.size - a.size)
+    .map((r) => ({ size: r.size, percentPassing: r.percentPassing, source: 'sieve', designation: r.designation }))
+
+  const base = {
+    combined: false, dAcrossGap: false,
+    gravel: g.gravel, sand: g.sand, fines: g.fines,
+  }
+
+  if (!h || !h.rows.length || !sievePoints.length) {
+    return {
+      ...base, points: sievePoints,
+      d10: g.d10, d30: g.d30, d60: g.d60, cu: g.cu, cc: g.cc,
+      notes,
+    }
+  }
+
+  const joinSize = sievePoints[sievePoints.length - 1].size
+  const passingAtJoin = sievePoints[sievePoints.length - 1].percentPassing
+
+  const hydro = [...h.rows]
+    .filter((r) => r.diameter > 0)
+    .sort((a, b) => b.diameter - a.diameter)
+  const overlap = hydro.filter((r) => r.diameter >= joinSize)
+  const below = hydro.filter((r) => r.diameter < joinSize)
+
+  // ── The join check ──
+  let joinMismatch: number | undefined
+  let joinGap: number | undefined
+  if (overlap.length) {
+    const atJoin = interpolateFiner(hydro, joinSize)
+    if (atJoin != null) {
+      joinMismatch = atJoin - passingAtJoin
+      if (Math.abs(joinMismatch) > 2) {
+        notes.push(
+          `At the ${joinSize} mm join the sieve says ${passingAtJoin.toFixed(1)}% passed and the suspension says ${atJoin.toFixed(1)}% is finer — a disagreement of ${joinMismatch.toFixed(1)} points on one specimen. The usual cause is the fraction of the whole sample the suspension represents; check it before reading anything off the fine end of this curve.`,
+        )
+      }
+    }
+    notes.push(
+      `${overlap.length} sedimentation reading${overlap.length === 1 ? ' is' : 's are'} coarser than the ${joinSize} mm sieve and ${overlap.length === 1 ? 'was' : 'were'} dropped: the sieve weighed those grains directly, which beats inferring them from a settling velocity.`,
+    )
+  } else if (below.length) {
+    joinGap = joinSize / below[0].diameter
+    if (joinGap > 3) {
+      notes.push(
+        `Nothing was measured between ${joinSize} mm and ${below[0].diameter.toFixed(4)} mm — a factor of ${joinGap.toFixed(1)} in size. The curve is drawn across it, but an earlier first reading would measure that band instead of interpolating it.`,
+      )
+    }
+  }
+
+  if (below.length && below[0].percentFiner > passingAtJoin + 0.5) {
+    notes.push(
+      `The suspension reports ${below[0].percentFiner.toFixed(1)}% finer than ${below[0].diameter.toFixed(4)} mm, which is more than the ${passingAtJoin.toFixed(1)}% that passed the ${joinSize} mm sieve. A subset of the sample cannot be larger than the sample; the scaling to the whole specimen is wrong.`,
+    )
+  }
+
+  const points: GradingPoint[] = [
+    ...sievePoints,
+    ...below.map((r) => ({ size: r.diameter, percentPassing: r.percentFiner, source: 'hydrometer' as const })),
+  ]
+
+  // ── Shape parameters, now off the whole curve ──
+  const d10 = interpolateD(points, 10)
+  const d30 = interpolateD(points, 30)
+  const d60 = interpolateD(points, 60)
+  const cu = d10 && d60 ? d60 / d10 : undefined
+  const cc = d10 && d30 && d60 ? (d30 * d30) / (d10 * d60) : undefined
+
+  // A D-value inside the unmeasured band is a reading of the interpolation, not
+  // of the soil. Worth saying, since Cu and Cc are quoted to two figures.
+  const inGap = (d?: number) =>
+    d != null && below.length > 0 && d < joinSize && d > below[0].diameter
+  const dAcrossGap = Boolean(joinGap && joinGap > 3 && [d10, d30, d60].some(inGap))
+  if (dAcrossGap) {
+    notes.push(
+      'One of D₁₀, D₃₀ or D₆₀ falls inside the unmeasured band at the join, so Cu and Cc below are read off the interpolation rather than off a measurement.',
+    )
+  }
+
+  if (g.d10 == null && d10 != null) {
+    notes.push(
+      `D₁₀ = ${d10.toFixed(4)} mm comes from the sedimentation run — the sieve curve alone stopped at ${passingAtJoin.toFixed(0)}% passing and could not reach it.`,
+    )
+  }
+
+  // ── Size-based silt and clay ──
+  const clay = passingOnCurve(points, CLAY_SIZE)
+  const silt = clay != null ? Math.max(g.fines - clay, 0) : undefined
+  if (clay == null) {
+    notes.push(
+      `The combined curve stops at ${points[points.length - 1].size.toFixed(4)} mm, above the 0.002 mm clay boundary, so the clay fraction is still unknown. A longer sedimentation run — the 24-hour reading — is what reaches it.`,
+    )
+  }
+
+  return {
+    ...base, combined: true, points,
+    joinSize, joinMismatch, joinGap,
+    d10, d30, d60, cu, cc, dAcrossGap,
+    clay, silt,
+    notes,
+  }
+}
+
+/** Percent finer at a size on the sedimentation rows alone, log-interpolated. */
+function interpolateFiner(
+  rows: { diameter: number; percentFiner: number }[], size: number,
+): number | undefined {
+  const sorted = [...rows].sort((a, b) => b.diameter - a.diameter)
+  for (let i = 1; i < sorted.length; i++) {
+    const hi = sorted[i - 1], lo = sorted[i]
+    if (size <= hi.diameter && size >= lo.diameter && hi.diameter > lo.diameter) {
+      const f = (Math.log10(size) - Math.log10(lo.diameter)) / (Math.log10(hi.diameter) - Math.log10(lo.diameter))
+      return lo.percentFiner + f * (hi.percentFiner - lo.percentFiner)
+    }
+  }
+  return undefined
+}
+
+/**
+ * Percent passing at a size on the combined curve — undefined off either end,
+ * unlike `passingAt`, which clamps. Extrapolating past the finest reading is
+ * how a clay fraction gets invented.
+ */
+export function passingOnCurve(points: SizePassing[], size: number): number | undefined {
+  const sorted = [...points].sort((a, b) => b.size - a.size)
+  const exact = sorted.find((r) => Math.abs(r.size - size) < 1e-12)
+  if (exact) return exact.percentPassing
+  for (let i = 1; i < sorted.length; i++) {
+    const hi = sorted[i - 1], lo = sorted[i]
+    if (size <= hi.size && size >= lo.size && hi.size > lo.size) {
+      const f = (Math.log10(size) - Math.log10(lo.size)) / (Math.log10(hi.size) - Math.log10(lo.size))
+      return lo.percentPassing + f * (hi.percentPassing - lo.percentPassing)
+    }
+  }
+  return undefined
+}
+
+/**
+ * Percent passing at a size, clamping off the ends — a size coarser than the
+ * top sieve genuinely passes 100% of the sample, which is a fact rather than an
+ * extrapolation.
+ */
+export function passingOrClamp(c: CombinedGrading, size: number): number {
+  return passingAt(c.points, size)
+}

--- a/webapp/src/engine/soils/lab/plots.test.ts
+++ b/webapp/src/engine/soils/lab/plots.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { shearEnvelopeChart, consolidationChart, gradingChart, decadeTicks, linearTicks, tickDp } from './plots'
+import {
+  shearEnvelopeChart, consolidationChart, gradingChart, combinedGradingChart,
+  decadeTicks, linearTicks, tickDp,
+} from './plots'
+import { combineGrading } from '../grading'
+import { hydrometer } from './hydrometer'
 import { directShear } from './directShear'
 import { consolidation, heightOfSolids } from './consolidation'
 import { gradation } from '../sieve'
@@ -238,6 +243,84 @@ describe('grading chart', () => {
   it('survives an empty grading', () => {
     const empty = gradation({ totalMass: 100, readings: [{ size: 1, massRetained: 100 }] })
     expect(planToSvg(gradingChart(empty))).not.toMatch(/NaN/)
+  })
+
+  it('keeps every boundary label clear of the curve', () => {
+    // The defect this replaces: 'gravel | sand' was pinned to the top of the
+    // frame, which is exactly where the curve sits when the soil has no
+    // gravel — so on most soils the label ran through the curve and the title.
+    for (const g of [GRADING, gradation({
+      totalMass: 100,
+      readings: [
+        { size: 4.75, massRetained: 0 },      // no gravel: curve at 100% on the boundary
+        { size: 0.425, massRetained: 60 },
+        { size: 0.075, massRetained: 30 },
+      ],
+      panMass: 10,
+    })]) {
+      const d = gradingChart(g)
+      const labels = d.primitives.filter(
+        (p): p is Extract<PlanPrimitive, { kind: 'text' }> => p.kind === 'text' && /\|/.test(p.text))
+      expect(labels.length).toBeGreaterThan(0)
+      const curve = d.primitives.filter((p): p is Extract<PlanPrimitive, { kind: 'circle' }> => p.kind === 'circle')
+      for (const l of labels) {
+        for (const dot of curve) {
+          const far = Math.abs(dot.cx - l.x) > 10 || Math.abs(dot.cy - l.y) > 4
+          expect(far, `${l.text} at ${l.x.toFixed(1)},${l.y.toFixed(1)}`).toBe(true)
+        }
+      }
+    }
+  })
+})
+
+describe('the joined sieve + sedimentation curve', () => {
+  const joined = () => combineGrading(
+    gradation({
+      totalMass: 500,
+      readings: [
+        { size: 4.75, massRetained: 25 },
+        { size: 2.0, massRetained: 150 },
+        { size: 0.425, massRetained: 180 },
+        { size: 0.075, massRetained: 90 },
+      ],
+      panMass: 55,
+    }),
+    hydrometer({
+      dryMass: 50, specificGravity: 2.7, compositeCorrection: 5, meniscusCorrection: 1,
+      fractionOfTotal: 11,
+      readings: [
+        { time: 1, reading: 50, temperature: 22 },
+        { time: 30, reading: 38, temperature: 22 },
+        { time: 250, reading: 26, temperature: 22 },
+        { time: 1440, reading: 16, temperature: 22 },
+      ],
+    }),
+  )
+
+  it('draws sedimentation points as open rings against the sieve dots', () => {
+    // The reader is being asked to trust two different apparatus on one curve;
+    // which half a point came from is not a detail.
+    const circles = combinedGradingChart(joined()).primitives
+      .filter((p): p is Extract<PlanPrimitive, { kind: 'circle' }> => p.kind === 'circle')
+    expect(circles.filter((c) => c.fill === '#ffffff')).toHaveLength(4)
+    expect(circles.filter((c) => c.fill !== '#ffffff')).toHaveLength(4)
+  })
+
+  it('reports the clay and silt the join makes available', () => {
+    expect(texts(combinedGradingChart(joined())).join(' ')).toMatch(/silt \d+%\s+clay \d+%/)
+  })
+
+  it('moves the statistics off a steep curve instead of covering it', () => {
+    // Bottom-left is the natural home and the wrong one here: this curve is at
+    // 11% by the No. 200 sieve, so the block would sit on top of it.
+    const d = combinedGradingChart(joined())
+    const stats = d.primitives.filter(
+      (p): p is Extract<PlanPrimitive, { kind: 'text' }> => p.kind === 'text' && /^gravel \d/.test(p.text))
+    expect(stats).toHaveLength(1)
+    const curve = d.primitives.filter((p): p is Extract<PlanPrimitive, { kind: 'circle' }> => p.kind === 'circle')
+    for (const dot of curve) {
+      expect(Math.abs(dot.cx - stats[0].x) > 12 || Math.abs(dot.cy - stats[0].y) > 4).toBe(true)
+    }
   })
 })
 

--- a/webapp/src/engine/soils/lab/plots.ts
+++ b/webapp/src/engine/soils/lab/plots.ts
@@ -29,7 +29,8 @@ import { type CompactionResult, zeroAirVoids } from './compaction'
 import type { TriaxialResult, MohrCircle, TriaxialEnvelope } from './triaxial'
 import { type CbrResult, type CbrPoint, STANDARD_STRESS } from './cbr'
 import type { HydrometerResult } from './hydrometer'
-import type { GradationResult } from '../sieve'
+import { type GradationResult, passingAt, SIEVE_NO4, SIEVE_NO200 } from '../sieve'
+import { combineGrading, CLAY_SIZE, type CombinedGrading } from '../grading'
 
 import {
   AXIS, GRID, INK, ACCENT, WARN, OK, BOX, frame, plate,
@@ -621,10 +622,21 @@ export function hydrometerChart(r: HydrometerResult): Drawing {
  * size axis runs backwards.
  */
 export function gradingChart(g: GradationResult): Drawing {
+  return combinedGradingChart(combineGrading(g))
+}
+
+/**
+ * The same chart for a JOINED curve. Sedimentation points are drawn as open
+ * rings against the sieve's filled dots, because the two halves of the curve
+ * were measured by completely different means — one weighed the grains, the
+ * other timed how fast they fell — and a reader deciding how much to trust the
+ * fine end needs to see where the apparatus changed.
+ */
+export function combinedGradingChart(c: CombinedGrading): Drawing {
   const box = BOX
   const p: PlanPrimitive[] = frame(box, 'particle size  (mm, log)', '% passing', 'Grain-size distribution')
 
-  const rows = [...g.rows].filter((r) => r.size > 0).sort((a, b) => b.size - a.size)
+  const rows = c.points.filter((r) => r.size > 0)
   if (!rows.length) return { primitives: p, bounds: { minX: 0, minY: 0, maxX: box.left + box.w + 4, maxY: box.top + box.h + 13 } }
 
   const dHi = rows[0].size * 1.5
@@ -636,19 +648,33 @@ export function gradingChart(g: GradationResult): Drawing {
 
   for (const t of decadeTicks(dLo, dHi)) {
     p.push({ kind: 'line', x1: X(t), y1: box.top, x2: X(t), y2: box.top + box.h, stroke: GRID, width: 0.2 })
-    p.push({ kind: 'text', x: X(t), y: box.top + box.h + 4, text: t < 1 ? t.toFixed(t < 0.1 ? 3 : 2) : String(t), size: 2.0, anchor: 'middle', color: AXIS })
+    p.push({ kind: 'text', x: X(t), y: box.top + box.h + 4, text: sizeTick(t), size: 2.0, anchor: 'middle', color: AXIS })
   }
   for (const pc of [0, 25, 50, 75, 100]) {
     p.push({ kind: 'line', x1: box.left, y1: Y(pc), x2: box.left + box.w, y2: Y(pc), stroke: GRID, width: 0.2 })
     p.push({ kind: 'text', x: box.left - 1.5, y: Y(pc) + 0.8, text: String(pc), size: 2.1, anchor: 'end', color: AXIS })
   }
 
-  // The D2487 fraction boundaries, which is where a reader's eye goes first.
-  for (const [size, label] of [[4.75, 'gravel | sand'], [0.075, 'sand | fines']] as [number, string][]) {
-    if (size <= dHi && size >= dLo) {
-      p.push({ kind: 'line', x1: X(size), y1: box.top, x2: X(size), y2: box.top + box.h, stroke: WARN, width: 0.4, dash: [2, 1.5] })
-      p.push({ kind: 'text', x: X(size), y: box.top - 0.5, text: label, size: 1.9, anchor: 'middle', color: WARN })
-    }
+  // ── The fraction boundaries, and where their labels can safely go ──
+  // A grading curve descends left to right, so at any given size ONE side of
+  // the curve is empty and the other is not. Each label goes to the middle of
+  // the empty side on an opaque patch. Placing them all along the top — the
+  // obvious choice — puts the gravel/sand label straight through the curve
+  // whenever the soil has no gravel, which is most soils.
+  const boundaries: [number, string][] = [
+    [SIEVE_NO4, 'gravel | sand'],
+    [SIEVE_NO200, 'sand | fines'],
+    [CLAY_SIZE, 'silt | clay'],
+  ]
+  for (const [size, label] of boundaries) {
+    if (size > dHi || size < dLo) continue
+    const x = X(size)
+    p.push({ kind: 'line', x1: x, y1: box.top, x2: x, y2: box.top + box.h, stroke: WARN, width: 0.4, dash: [2, 1.5] })
+    const pass = passingAt(rows, size)
+    const y = pass > 50 ? Y(pass / 2) : Y((100 + pass) / 2)
+    const near = 14
+    const anchor = x < box.left + near ? 'start' : x > box.left + box.w - near ? 'end' : 'middle'
+    p.push(...tag(x, y, label, anchor))
   }
 
   for (let i = 1; i < rows.length; i++) {
@@ -660,22 +686,96 @@ export function gradingChart(g: GradationResult): Drawing {
     })
   }
   for (const r of rows) {
-    p.push({ kind: 'circle', cx: X(r.size), cy: Y(r.percentPassing), r: 0.9, fill: INK })
+    // Filled = weighed on a sieve; open = inferred from a settling velocity.
+    p.push(r.source === 'hydrometer'
+      ? { kind: 'circle', cx: X(r.size), cy: Y(r.percentPassing), r: 1.0, stroke: INK, fill: '#ffffff', width: 0.35 }
+      : { kind: 'circle', cx: X(r.size), cy: Y(r.percentPassing), r: 0.9, fill: INK })
   }
 
   // The statistics go BOTTOM-left. A grading curve descends left to right, so
-  // the top-left corner is exactly where the curve and the gravel/sand boundary
-  // label already are — putting text there overlapped both.
-  const shape = g.cu != null && g.cc != null
-    ? `Cu = ${g.cu.toFixed(1)}   Cc = ${g.cc.toFixed(2)}`
+  // the top-left corner is exactly where the curve already is.
+  const shape = c.cu != null && c.cc != null
+    ? `Cu = ${c.cu.toFixed(1)}   Cc = ${c.cc.toFixed(2)}`
     : 'Cu, Cc unavailable — the curve does not reach 10% passing'
-  p.push(...plate(box.left + 2, box.top + box.h - 6.6, 2.3, [
-    { text: shape, color: g.cu != null ? INK : WARN },
-    { text: `gravel ${g.gravel.toFixed(0)}%   sand ${g.sand.toFixed(0)}%   fines ${g.fines.toFixed(0)}%` },
-  ]))
+  const lines: { text: string; color?: string }[] = [
+    { text: shape, color: c.cu != null ? INK : WARN },
+    { text: `gravel ${c.gravel.toFixed(0)}%   sand ${c.sand.toFixed(0)}%   fines ${c.fines.toFixed(0)}%` },
+  ]
+  if (c.combined) {
+    lines.push({
+      text: c.clay != null
+        ? `sieve ● + sedimentation ○   silt ${c.silt!.toFixed(0)}%   clay ${c.clay.toFixed(0)}%`
+        : 'sieve ● + sedimentation ○',
+      color: AXIS,
+    })
+  }
+  p.push(...statsPlate(box, X, Y, rows, lines))
 
   return {
     primitives: p,
     bounds: { minX: 0, minY: 0, maxX: box.left + box.w + 4, maxY: box.top + box.h + 13 },
   }
 }
+
+/**
+ * The statistics block, put where the CURVE is not.
+ *
+ * Bottom-left is right for most grading curves and wrong for steep ones: a
+ * sand with 11% fines drops to the bottom of the frame before the axis ends,
+ * and the block then covers the very point the reader came for. So both
+ * candidate corners are measured against the curve's own height over the width
+ * the block needs, and the one with clearance wins.
+ */
+function statsPlate(
+  box: typeof BOX,
+  X: (v: number) => number,
+  Y: (v: number) => number,
+  rows: { size: number; percentPassing: number }[],
+  lines: { text: string; color?: string }[],
+): PlanPrimitive[] {
+  const size = 2.3
+  const w = Math.max(...lines.map((l) => l.text.length)) * size * 0.52 + 1.4
+  const h = (lines.length - 1) * size * 1.5 + size * 1.9
+  const pad = 1.2
+
+  // Percent passing across an x band, sampled at its edges and at every point
+  // inside it — a segment can cross a band without putting a point in it.
+  const sizeAt = (x: number) => {
+    const t = (x - box.left) / box.w
+    const lo = Math.log10(rows[rows.length - 1].size), hi = Math.log10(rows[0].size)
+    return Math.pow(10, hi - t * (hi - lo))
+  }
+  const band = (x1: number, x2: number) => {
+    const inside = rows.filter((r) => X(r.size) >= x1 && X(r.size) <= x2).map((r) => r.percentPassing)
+    return [passingAt(rows, sizeAt(x1)), passingAt(rows, sizeAt(x2)), ...inside]
+  }
+
+  const bottomLeftFirst = box.top + box.h - pad - h + size * 0.95
+  const lowest = Math.min(...band(box.left, box.left + 2 + w))
+  if (Y(lowest) <= box.top + box.h - pad - h) return plate(box.left + 2, bottomLeftFirst, size, lines)
+
+  const right = box.left + box.w - w - 2
+  const highest = Math.max(...band(right, box.left + box.w))
+  if (box.top + pad + h <= Y(highest) - pad) return plate(right, box.top + pad + size * 0.95, size, lines)
+
+  return plate(box.left + 2, bottomLeftFirst, size, lines)
+}
+
+/** A boundary label on an opaque patch, so grid lines do not run through it. */
+function tag(x: number, y: number, text: string, anchor: 'start' | 'middle' | 'end'): PlanPrimitive[] {
+  const size = 1.9
+  const w = text.length * size * 0.52 + 1.2
+  const left = anchor === 'start' ? x + 0.6 : anchor === 'end' ? x - 0.6 - w : x - w / 2
+  return [
+    { kind: 'rect', x: left, y: y - size * 0.95, w, h: size * 1.7, fill: '#ffffff' },
+    {
+      kind: 'text', x: anchor === 'start' ? x + 1.2 : anchor === 'end' ? x - 1.2 : x,
+      y, text, size, anchor, color: WARN,
+    },
+  ]
+}
+
+/** Tick text for a size axis spanning sieves down to clay. */
+const sizeTick = (t: number): string =>
+  t >= 1 ? String(t) : t >= 0.1 ? t.toFixed(2) : t >= 0.001 ? t.toFixed(3) : t.toFixed(4)
+

--- a/webapp/src/engine/soils/report.ts
+++ b/webapp/src/engine/soils/report.ts
@@ -39,6 +39,7 @@ import { validateInvestigation } from './validate'
 import { evaluateTest, summarise, LAB_TESTS } from './lab'
 import { classifySample } from './classifySample'
 import { labChart } from './lab/testChart'
+import { combinedGradingChart } from './lab/plots'
 import { cite } from './standards'
 
 export type SectionStatus = 'complete' | 'partial' | 'not-assessed'
@@ -570,13 +571,12 @@ function s9Classification(inv: Investigation): ReportSection {
   // the LOGGED symbol, which may have come from a description rather than a
   // test, and is the one column that survives with no laboratory data at all.
   const withSample = layers.map(({ b, l }) => {
-    const classified = b.samples
-      .filter((s) => s.layerId === l.id)
-      .map((s) => classifySample(s))
+    const samples = b.samples.filter((s) => s.layerId === l.id)
+    const classified = samples.map((s) => ({ s, c: classifySample(s) }))
     return {
-      b, l,
-      usda: classified.find((c) => c.usda)?.usda,
-      aashto: classified.find((c) => c.aashto?.label)?.aashto,
+      b, l, classified,
+      usda: classified.find((x) => x.c.usda)?.c.usda,
+      aashto: classified.find((x) => x.c.aashto?.label)?.c.aashto,
     }
   })
 
@@ -603,6 +603,17 @@ function s9Classification(inv: Investigation): ReportSection {
     ? [`${noTexture} of ${rows.length} layers carry no USDA texture. The triangle is drawn on the clay fraction finer than 0.002 mm, which no sieve reaches — a hydrometer analysis (${cite('d7928')}) on a sample from each layer is what supplies it.`]
     : []
 
+  // The JOINED grading curve is a property of the sample, not of either test,
+  // so it belongs here beside the classification it produced rather than in §8
+  // with the sieve and sedimentation sheets it was built from.
+  const figures = withSample.flatMap(({ b, classified }) =>
+    classified
+      .filter((x) => x.c.curve?.combined)
+      .map((x) => ({
+        caption: `Combined grading, sieve + sedimentation — ${b.name}, ${x.s.name}`,
+        drawing: combinedGradingChart(x.c.curve!),
+      })))
+
   return {
     no: 9, title: 'Soil classification',
     status: unknown ? 'partial' : 'complete',
@@ -612,7 +623,7 @@ function s9Classification(inv: Investigation): ReportSection {
       'The USDA texture (Soil Survey Manual, NRCS) is reported alongside for agricultural, drainage and erosion work. The three systems set their size boundaries in different places — USDA splits sand from silt at 0.05 mm where the other two use the 0.075 mm No. 200 sieve, and USDA and AASHTO name their fines by size where USCS names them by plasticity — so the three columns are not expected to agree and are not reconciled here.',
     ],
     tables: [{ head: ['Layer', 'USCS', 'AASHTO', 'USDA texture', 'Family', 'Behaviour'], rows }],
-    figures: [], notes,
+    figures, notes,
   }
 }
 

--- a/webapp/src/engine/soils/sample.test.ts
+++ b/webapp/src/engine/soils/sample.test.ts
@@ -77,6 +77,22 @@ describe('its laboratory data agrees with its geology', () => {
     expect(c.gradation!.fines).toBeCloseTo(75, 6)
   })
 
+  it('joins the two curves into one grading, and §9 plots it', () => {
+    const c = classifySample(inv().boreholes[0].samples[1])
+    expect(c.curve!.combined).toBe(true)
+    // The sieve stopped at 75% passing; the sedimentation run carries the same
+    // curve down past the clay boundary.
+    expect(c.gradation!.rows[c.gradation!.rows.length - 1].size).toBe(0.075)
+    expect(c.curve!.points[c.curve!.points.length - 1].size).toBeLessThan(0.002)
+    expect(c.curve!.clay).toBeCloseTo(33.6, 0)
+    expect(c.curve!.silt).toBeCloseTo(c.gradation!.fines - c.curve!.clay!, 6)
+
+    const s9 = buildSoilsReport(inv()).sections.find((s) => s.no === 9)!
+    expect(s9.figures.map((f) => f.caption)).toEqual([
+      'Combined grading, sieve + sedimentation — BH-01, S-02',
+    ])
+  })
+
   it('the samples without a hydrometer get the two engineering systems and a reason for the third', () => {
     const without = inv().boreholes.flatMap((b) => b.samples).filter((s) => s.id !== 'bh1-s2')
     for (const s of without) {

--- a/webapp/src/engine/soils/sieve.ts
+++ b/webapp/src/engine/soils/sieve.ts
@@ -40,13 +40,22 @@ export interface SieveInput {
   panMass?: number
 }
 
-export interface SieveRow {
+/**
+ * The least a curve needs to be read: a size and how much passed it. The
+ * interpolators below take this rather than a `SieveRow`, so the same two
+ * functions serve the sieve curve and the sieve+sedimentation curve joined in
+ * `grading.ts` — one log-interpolation, not two that can drift apart.
+ */
+export interface SizePassing {
   size: number
+  percentPassing: number
+}
+
+export interface SieveRow extends SizePassing {
   designation?: string
   massRetained: number
   percentRetained: number
   cumulativeRetained: number
-  percentPassing: number
 }
 
 export interface GradationResult {
@@ -78,7 +87,7 @@ export interface GradationResult {
  * which is the honest answer: a soil with 15% fines has no D10 from sieving
  * alone and needs a hydrometer.
  */
-export function interpolateD(rows: SieveRow[], percent: number): number | undefined {
+export function interpolateD(rows: SizePassing[], percent: number): number | undefined {
   // Rows coarse → fine, so percentPassing decreases down the list.
   const sorted = [...rows].sort((a, b) => b.size - a.size)
   for (let i = 1; i < sorted.length; i++) {
@@ -95,7 +104,7 @@ export function interpolateD(rows: SieveRow[], percent: number): number | undefi
 }
 
 /** Percent passing a given size, log-interpolated. Used for the D2487 fractions. */
-export function passingAt(rows: SieveRow[], size: number): number {
+export function passingAt(rows: SizePassing[], size: number): number {
   const sorted = [...rows].sort((a, b) => b.size - a.size)
   const exact = sorted.find((r) => Math.abs(r.size - size) < 1e-9)
   if (exact) return exact.percentPassing

--- a/webapp/src/pages/SoilInvestigation.tsx
+++ b/webapp/src/pages/SoilInvestigation.tsx
@@ -19,6 +19,8 @@ import {
   type LabOutcome,
 } from '../engine/soils/lab'
 import { classifySample } from '../engine/soils/classifySample'
+import type { CombinedGrading } from '../engine/soils/grading'
+import { combinedGradingChart } from '../engine/soils/lab/plots'
 import { labChart } from '../engine/soils/lab/testChart'
 import { buildSection, sectionDrawing } from '../engine/soils/section'
 import {
@@ -1782,6 +1784,8 @@ function SampleClassificationCard({
         <p className="mt-1.5 text-[11px] text-slate-600">{c.uscs!.reason}</p>
       )}
 
+      {c.curve?.combined && <CombinedCurve curve={c.curve} />}
+
       {c.notes.map((n, k) => (
         <p key={k} className="mt-1 text-[10px] text-amber-900">{n}</p>
       ))}
@@ -1808,6 +1812,17 @@ function SampleClassificationCard({
       )}
     </div>
   )
+}
+
+/**
+ * The sieve and sedimentation curves drawn as one. It lives on the
+ * CLASSIFICATION card rather than on either test card because it belongs to
+ * neither test — it is the sample's grading, and it is what the symbols above
+ * were read off.
+ */
+function CombinedCurve({ curve }: { curve: CombinedGrading }) {
+  const svg = useMemo(() => planToSvg(combinedGradingChart(curve), 460), [curve])
+  return <div className="mt-2 overflow-x-auto" dangerouslySetInnerHTML={{ __html: svg }} />
 }
 
 // ── Direct-shear specimens ────────────────────────────────────────────────


### PR DESCRIPTION
**Layer 8** (standalone soils engines) + chart + report + page.

A sieve stops at 0.075 mm. Any soil with more than about 10% fines therefore never reaches 10% passing, so it has **no D₁₀** — and with no D₁₀ there is no Cu, no Cc, and no way to finish the dual symbol D2487 asks for in the 5–12% fines band. The sedimentation run carries the curve two decades further down. Kept apart, the two tests answer half a question each.

## Who governs where

The specimen for a sedimentation run is the material that *passed* the finest sieve, so the two tests measure different populations and that sieve is the boundary:

| | governs |
|---|---|
| **≥ finest sieve opening** | the sieve — it weighed those grains |
| **< finest sieve opening** | the sedimentation run — the sieve could not see them at all |

## The join is policed, not papered over

- **Overlapping readings are dropped, not averaged.** A sedimentation point coarser than the finest sieve duplicates a direct weighing, and their disagreement is the only honest check on whether `fractionOfTotal` was set right — so it is *measured and reported* rather than blended away.
- **A hole in the join gets named.** A sieve ending at 0.075 mm and a first reading at 0.025 mm leave a factor-of-three band with nothing in it. The curve is still drawn across it, but a D-value that lands *inside* the gap is flagged as a reading of the interpolation rather than of the soil.
- **A subset cannot exceed the whole.** More fine material in the suspension than passed the sieve is impossible on one specimen, and says so.

## What the merge actually buys

The case it was built for, pinned in `classifySample.test.ts`:

| | 11% fines, LL 30 / PL 22 |
|---|---|
| sieve alone | D₁₀ **undefined** → `uscs.symbol` undefined, reason *"needs BOTH"*, hydrometer listed as missing |
| **joined** | D₁₀ defined, Cu > 6, Cc > 3 → **`SP-SC`** |

Cu clears the 6 a sand needs but Cc lands above 3, so D2487 Table 1 calls it poorly graded — a verdict, where the sieve alone could only say *unknown*.

On the example's lean clay the joined curve reaches 0.001 mm and still does not hit 10% passing. That is the correct answer for a clay, and the note now says so plainly instead of advising a hydrometer that is already on file.

## Chart

`combinedGradingChart` plots the joined curve with **sedimentation points as open rings against the sieve's filled dots** — the reader is being asked to trust two different apparatus on one curve, and which half a point came from is not a detail. Silt and clay are reported alongside gravel/sand/fines.

Two label defects fixed while in there, both found by looking at renders:

- **`gravel | sand` ran through the curve** (the known issue flagged in #551). It was pinned to the top of the frame, which is exactly where the curve sits when the soil has no gravel — i.e. most soils. Boundary labels now go to the middle of whichever side of the curve is empty, on an opaque patch.
- **The statistics block covered the curve on steep gradings.** Bottom-left is right for most curves and wrong for a sand that reaches 11% by the No. 200 sieve. Both candidate corners are now measured against the curve's own height over the width the block needs, and the one with clearance wins.

## Where it surfaces

The joined curve belongs to the **sample**, not to either test, so it goes on the classification card and as a figure in **report §9** — not into §8 beside the sieve and sedimentation sheets it was built from.

## Also

`sieve.ts` gains `SizePassing`, and `interpolateD` / `passingAt` are widened to it, so the sieve curve and the joined curve share **one** log-interpolation rather than two that can drift apart. Three duplicated interpolators in `classifySample` were deleted in favour of it.

## Verification

Rendered all three chart cases (sieve-only, joined clay, joined sand) and read them before wiring anything — that is how both label defects were found. In-browser with no manual data entry: the card shows the joined curve, and the report's §9 carries it captioned *"Combined grading, sieve + sedimentation — BH-01, S-02"*.

New: `grading.test.ts` (11 cases — pass-through, D₁₀ from the join, fractions unmoved, ordering, overlap drop, mismatch, oversized subset, gap flagging, clay out of reach) plus chart and classification cases. Suite **3785 passed**, `tsc -b` and `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmPbtTVsjNBXVpiQVBYBnz)_