### PR TITLE
feat(soils): engine notes carry a severity, and warnings reach the report

### DIFF
--- a/webapp/src/engine/soils/aashto.test.ts
+++ b/webapp/src/engine/soils/aashto.test.ts
@@ -146,7 +146,7 @@ describe('boundaries and missing data', () => {
 
   it('notes a grading where passing increases with sieve size', () => {
     const r = classifyAASHTO({ passing10: 40, passing40: 60, passing200: 20, liquidLimit: 25, plasticityIndex: 4 })
-    expect(r.notes.join(' ')).toMatch(/must not increase with sieve size/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/must not increase with sieve size/)
   })
 })
 

--- a/webapp/src/engine/soils/aashto.ts
+++ b/webapp/src/engine/soils/aashto.ts
@@ -20,6 +20,8 @@
 // UNITS: percentages 0–100; LL and PI in %.
 // ─────────────────────────────────────────────────────────────────────────
 
+import { type LabNote, warn } from './notes'
+
 export interface AashtoInput {
   /** Percent passing the 2.00 mm (No. 10) sieve, %. */
   passing10: number
@@ -46,7 +48,7 @@ export interface AashtoResult {
   /** Granular when 35% or less passes the No. 200 sieve. */
   granular: boolean
   reason: string
-  notes: string[]
+  notes: LabNote[]
 }
 
 /**
@@ -81,13 +83,13 @@ export function partialGroupIndex(passing200: number, PI: number): number {
 }
 
 export function classifyAASHTO(i: AashtoInput): AashtoResult {
-  const notes: string[] = []
+  const notes: LabNote[] = []
   const { passing10, passing40, passing200 } = i
   const LL = i.liquidLimit
   const PI = i.plasticityIndex
 
   if (passing200 > passing40 + 1e-9 || passing40 > passing10 + 1e-9) {
-    notes.push('Percent passing must not increase with sieve size — check the grading before relying on this.')
+    notes.push(warn('Percent passing must not increase with sieve size — check the grading before relying on this.'))
   }
 
   const granular = passing200 <= 35
@@ -168,7 +170,7 @@ export function classifyAASHTO(i: AashtoInput): AashtoResult {
 }
 
 function granularResult(
-  group: string, gi: number, granular: boolean, notes: string[], reason: string,
+  group: string, gi: number, granular: boolean, notes: LabNote[], reason: string,
 ): AashtoResult {
   return {
     group,

--- a/webapp/src/engine/soils/atterberg.test.ts
+++ b/webapp/src/engine/soils/atterberg.test.ts
@@ -52,7 +52,7 @@ describe('non-plastic is not PI = 0', () => {
   it('marks a soil with no obtainable plastic limit as non-plastic', () => {
     const r = atterberg({ liquidLimit: 22, nonPlastic: true })
     expect(r.nonPlastic).toBe(true)
-    expect(r.notes.join(' ')).toMatch(/not the same as PI = 0/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/not the same as PI = 0/)
   })
 
   it('treats a missing plastic limit as non-plastic rather than assuming zero', () => {
@@ -75,13 +75,13 @@ describe('liquidity index', () => {
   it('warns when the soil is at or above its liquid limit', () => {
     const r = atterberg({ liquidLimit: 42, plasticLimit: 23, naturalMoisture: 50 })
     expect(r.liquidityIndex!).toBeGreaterThan(1)
-    expect(r.notes.join(' ')).toMatch(/sensitive or quick/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/sensitive or quick/)
   })
 
   it('warns when the soil is drier than its plastic limit', () => {
     const r = atterberg({ liquidLimit: 42, plasticLimit: 23, naturalMoisture: 15 })
     expect(r.liquidityIndex!).toBeLessThan(0)
-    expect(r.notes.join(' ')).toMatch(/desiccated|overconsolidated/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/desiccated|overconsolidated/)
   })
 
   it('maps LI onto a consistency description', () => {
@@ -116,7 +116,7 @@ describe('liquid limit from a multipoint flow curve (D4318 Method A)', () => {
       flowPoints: [{ blows: 30, moisture: 48 }, { blows: 38, moisture: 46 }],
       plasticLimit: 22,
     })
-    expect(r.notes.join(' ')).toMatch(/extrapolated/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/extrapolated/)
   })
 
   it('warns when a trial falls outside the 15–40 blow range D4318 asks for', () => {
@@ -124,7 +124,7 @@ describe('liquid limit from a multipoint flow curve (D4318 Method A)', () => {
       flowPoints: [{ blows: 12, moisture: 52 }, { blows: 25, moisture: 50 }, { blows: 44, moisture: 47 }],
       plasticLimit: 22,
     })
-    expect(r.notes.join(' ')).toMatch(/15 and 40/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/15 and 40/)
   })
 
   it('refuses a flow curve with fewer than two usable trials', () => {
@@ -148,13 +148,13 @@ describe('bad data is reported, not silently absorbed', () => {
   it('clamps a negative PI to zero AND says why', () => {
     const r = atterberg({ liquidLimit: 35, plasticLimit: 40 })
     expect(r.plasticityIndex).toBe(0)
-    expect(r.notes.join(' ')).toMatch(/plastic limit exceeds the liquid limit/i)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/plastic limit exceeds the liquid limit/i)
   })
 
   it('flags a point above the U-line', () => {
     const r = atterberg({ liquidLimit: 30, plasticLimit: 2 })   // PI 28 vs U-line 19.8
     expect(r.chart.aboveULine).toBe(true)
-    expect(r.notes.join(' ')).toMatch(/above the U-line/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/above the U-line/)
   })
 
   it('refuses to run with neither a liquid limit nor a flow curve', () => {

--- a/webapp/src/engine/soils/atterberg.ts
+++ b/webapp/src/engine/soils/atterberg.ts
@@ -18,6 +18,8 @@
 // UNITS: all water contents in %, i.e. 0–100, not 0–1.
 // ─────────────────────────────────────────────────────────────────────────
 
+import { type LabNote, info, warn } from './notes'
+
 /** One trial in a multipoint liquid-limit determination (D4318 Method A). */
 export interface FlowPoint {
   /** Blow count at closure, 25 ± range. */
@@ -54,7 +56,7 @@ export interface AtterbergResult {
   /** Position relative to the A-line and U-line. */
   chart: ChartPosition
   /** Advisory notes — an LI above 1, a point above the U-line, and so on. */
-  notes: string[]
+  notes: LabNote[]
 }
 
 // ── Casagrande chart lines ────────────────────────────────────────────────
@@ -135,7 +137,7 @@ export function liquidLimitFromFlow(points: FlowPoint[]): { liquidLimit: number;
 // ── Main entry ────────────────────────────────────────────────────────────
 
 export function atterberg(i: AtterbergInput): AtterbergResult {
-  const notes: string[] = []
+  const notes: LabNote[] = []
 
   let flowIndex: number | undefined
   let LL: number
@@ -145,10 +147,10 @@ export function atterberg(i: AtterbergInput): AtterbergResult {
     flowIndex = fit.flowIndex
     const spread = i.flowPoints.map((p) => p.blows)
     if (Math.min(...spread) > 25 || Math.max(...spread) < 25) {
-      notes.push('All trials fall on one side of 25 blows — the liquid limit is extrapolated, not interpolated.')
+      notes.push(warn('All trials fall on one side of 25 blows — the liquid limit is extrapolated, not interpolated.'))
     }
     if (i.flowPoints.some((p) => p.blows < 15 || p.blows > 40)) {
-      notes.push('D4318 asks for trials between 15 and 40 blows; a point outside that range weakens the fit.')
+      notes.push(warn('D4318 asks for trials between 15 and 40 blows; a point outside that range weakens the fit.'))
     }
   } else if (i.liquidLimit != null) {
     LL = i.liquidLimit
@@ -163,25 +165,25 @@ export function atterberg(i: AtterbergInput): AtterbergResult {
   const PI = nonPlastic ? 0 : Math.max(LL - PL, 0)
 
   if (!nonPlastic && LL - PL < 0) {
-    notes.push('The plastic limit exceeds the liquid limit — one of the two determinations is wrong.')
+    notes.push(warn('The plastic limit exceeds the liquid limit — one of the two determinations is wrong.'))
   }
 
   let liquidityIndex: number | undefined
   if (!nonPlastic && PI > 0 && i.naturalMoisture != null) {
     liquidityIndex = (i.naturalMoisture - PL) / PI
     if (liquidityIndex > 1) {
-      notes.push('Natural moisture is above the liquid limit (LI > 1) — the soil may be sensitive or quick.')
+      notes.push(info('Natural moisture is above the liquid limit (LI > 1) — the soil may be sensitive or quick.'))
     } else if (liquidityIndex < 0) {
-      notes.push('Natural moisture is below the plastic limit (LI < 0) — the soil is in a desiccated or overconsolidated state.')
+      notes.push(info('Natural moisture is below the plastic limit (LI < 0) — the soil is in a desiccated or overconsolidated state.'))
     }
   }
 
   const chart = chartPosition(LL, PI)
   if (chart.aboveULine && !nonPlastic) {
-    notes.push('The point plots above the U-line, which no natural soil does — re-run the limits before classifying.')
+    notes.push(warn('The point plots above the U-line, which no natural soil does — re-run the limits before classifying.'))
   }
   if (nonPlastic) {
-    notes.push('Reported non-plastic: no thread could be rolled, so the soil has no plastic range. This is not the same as PI = 0.')
+    notes.push(info('Reported non-plastic: no thread could be rolled, so the soil has no plastic range. This is not the same as PI = 0.'))
   }
 
   return {

--- a/webapp/src/engine/soils/classifySample.test.ts
+++ b/webapp/src/engine/soils/classifySample.test.ts
@@ -112,7 +112,7 @@ describe('choosing which test counts', () => {
     const newer = sieveTest(SIEVE_DATA, { testDate: '2026-06-20' })
     const s = sample([older, newer, atterbergTest({ liquidLimit: 42, plasticLimit: 23 })])
     expect(governingTest(s, 'sieve').test!.id).toBe(newer.id)
-    expect(classifySample(s).notes.join(' ')).toMatch(/2 sieve analyses.*most recent complete one was used/)
+    expect(classifySample(s).notes.map((n) => n.text).join(' ')).toMatch(/2 sieve analyses.*most recent complete one was used/)
   })
 
   it('falls back to a non-void test when none is complete', () => {
@@ -144,7 +144,7 @@ describe('classifying from the laboratory record', () => {
     const c = classifySample(full)
     // The stack has >10% fines, so D10 is off the curve and the gradation
     // module says a hydrometer would complete it.
-    expect(c.notes.join(' ')).toMatch(/hydrometer/)
+    expect(c.notes.map((n) => n.text).join(' ')).toMatch(/hydrometer/)
   })
 
   it('does NOT list a hydrometer as missing when it would not change the symbol', () => {
@@ -189,7 +189,7 @@ describe('it will not invent a missing input', () => {
     const c = classifySample(sample([atterbergTest({ liquidLimit: 42, plasticLimit: 23 })]))
     expect(c.uscs).toBeUndefined()
     expect(c.missing).toContain('sieve')
-    expect(c.notes.join(' ')).toMatch(/gravel\/sand\/fines split is unknown/)
+    expect(c.notes.map((n) => n.text).join(' ')).toMatch(/gravel\/sand\/fines split is unknown/)
   })
 
   it('names the Atterberg test when a fine-grained soil lacks it', () => {
@@ -206,7 +206,7 @@ describe('it will not invent a missing input', () => {
       atterbergTest({ liquidLimit: 42, plasticLimit: 23 }),
     ])
     const c = classifySample(broken)
-    expect(c.notes.join(' ')).toMatch(/could not be evaluated/)
+    expect(c.notes.map((n) => n.text).join(' ')).toMatch(/could not be evaluated/)
     expect(c.uscs).toBeUndefined()
   })
 })
@@ -290,19 +290,19 @@ describe('the USDA texture needs a sedimentation test, and says so when there is
     // test exists. Once it does, the joined curve either reached D₁₀ or did
     // not, and saying both at once reads as a contradiction.
     const withOut = classifySample(sample([sieveTest(), atterbergTest({ liquidLimit: 42, plasticLimit: 23 })]))
-    expect(withOut.notes.join(' ')).toMatch(/need a hydrometer analysis/)
+    expect(withOut.notes.map((n) => n.text).join(' ')).toMatch(/need a hydrometer analysis/)
     expect(withOut.curve!.combined).toBe(false)
     expect(withOut.curve!.d10).toBeUndefined()
 
     const withIt = classifySample(sample([
       sieveTest(), atterbergTest({ liquidLimit: 42, plasticLimit: 23 }), hydrometerTest(),
     ]))
-    expect(withIt.notes.join(' ')).not.toMatch(/need a hydrometer analysis/)
+    expect(withIt.notes.map((n) => n.text).join(' ')).not.toMatch(/need a hydrometer analysis/)
     // The sieve alone still cannot reach it; the JOINED curve can. That is the
     // whole point of the merge.
     expect(withIt.gradation!.d10).toBeUndefined()
     expect(withIt.curve!.d10).toBeDefined()
-    expect(withIt.notes.join(' ')).toMatch(/comes from the sedimentation run/)
+    expect(withIt.notes.map((n) => n.text).join(' ')).toMatch(/comes from the sedimentation run/)
   })
 
   it('completes the dual symbol D2487 could not finish from a sieve alone', () => {
@@ -360,7 +360,7 @@ describe('the USDA texture needs a sedimentation test, and says so when there is
     // The triangle itself sums over the fine earth only.
     const { sand, silt, clay } = c.usda!.composition
     expect(sand + silt + clay).toBeCloseTo(100, 6)
-    expect(c.notes.join(' ')).toMatch(/keeps that out of the triangle/)
+    expect(c.notes.map((n) => n.text).join(' ')).toMatch(/keeps that out of the triangle/)
   })
 
   it('reports an unreadable sedimentation run rather than classifying around it', () => {
@@ -370,7 +370,7 @@ describe('the USDA texture needs a sedimentation test, and says so when there is
     ]))
     expect(c.uscs!.symbol).toBe('SC')             // the sieve is still good
     expect(c.usda).toBeUndefined()
-    expect(c.notes.join(' ')).toMatch(/Hydrometer analysis could not be evaluated/)
+    expect(c.notes.map((n) => n.text).join(' ')).toMatch(/Hydrometer analysis could not be evaluated/)
   })
 })
 

--- a/webapp/src/engine/soils/classifySample.ts
+++ b/webapp/src/engine/soils/classifySample.ts
@@ -38,6 +38,7 @@ import { classifyAASHTO, type AashtoResult } from './aashto'
 import { usdaFromPassing, type UsdaResult } from './usda'
 import { combineGrading, passingOnCurve, passingOrClamp, type CombinedGrading } from './grading'
 import { evaluateTest } from './lab'
+import { type LabNote, warn, info } from './notes'
 import { passingAt, type GradationResult } from './sieve'
 import type { AtterbergResult } from './atterberg'
 import type { HydrometerResult } from './lab/hydrometer'
@@ -60,7 +61,7 @@ export interface SampleClassification {
   /** Tests that would complete or improve the classification. */
   missing: LabTestType[]
   /** How the inputs were chosen, and anything odd about them. */
-  notes: string[]
+  notes: LabNote[]
 }
 
 /**
@@ -82,8 +83,20 @@ export function governingTest(sample: Sample, type: LabTestType): {
   return { test: sorted[sorted.length - 1], superseded: candidates.length - 1 }
 }
 
+/**
+ * The sieve engine's "a hydrometer analysis would complete the grading",
+ * which stops being true the moment one is on file.
+ *
+ * Exported because TWO places have to suppress it — this module, and the
+ * report's laboratory section, which tabulates each test on its own and would
+ * otherwise print the advice beside the very sedimentation run that answers
+ * it. One definition, so they cannot drift; matching on the text is the
+ * deliberate trade named in the header.
+ */
+export const isStaleHydrometerAdvice = (n: LabNote): boolean => /hydrometer/i.test(n.text)
+
 export function classifySample(sample: Sample): SampleClassification {
-  const notes: string[] = []
+  const notes: LabNote[] = []
   const missing: LabTestType[] = []
 
   // ── Gradation ──
@@ -91,12 +104,12 @@ export function classifySample(sample: Sample): SampleClassification {
   let grad: GradationResult | undefined
   if (sieve.test) {
     const { outcome, error } = evaluateTest(sieve.test)
-    if (error) notes.push(`Sieve analysis could not be evaluated: ${error}`)
+    if (error) notes.push(warn(`Sieve analysis could not be evaluated: ${error}`))
     else if (outcome?.kind === 'sieve') grad = outcome.result
     if (sieve.superseded > 0) {
-      notes.push(
+      notes.push(warn(
         `${sieve.superseded + 1} sieve analyses on this sample — the most recent complete one was used. Void the others if they should not count.`,
-      )
+      ))
     }
   } else {
     missing.push('sieve')
@@ -107,12 +120,12 @@ export function classifySample(sample: Sample): SampleClassification {
   let limits: AtterbergResult | undefined
   if (atter.test) {
     const { outcome, error } = evaluateTest(atter.test)
-    if (error) notes.push(`Atterberg limits could not be evaluated: ${error}`)
+    if (error) notes.push(warn(`Atterberg limits could not be evaluated: ${error}`))
     else if (outcome?.kind === 'atterberg') limits = outcome.result
     if (atter.superseded > 0) {
-      notes.push(
+      notes.push(warn(
         `${atter.superseded + 1} Atterberg determinations on this sample — the most recent complete one was used.`,
-      )
+      ))
     }
   } else {
     missing.push('atterberg')
@@ -126,7 +139,7 @@ export function classifySample(sample: Sample): SampleClassification {
   let hyd: HydrometerResult | undefined
   if (hydro.test) {
     const { outcome, error } = evaluateTest(hydro.test)
-    if (error) notes.push(`Hydrometer analysis could not be evaluated: ${error}`)
+    if (error) notes.push(warn(`Hydrometer analysis could not be evaluated: ${error}`))
     else if (outcome?.kind === 'hydrometer') hyd = outcome.result
   }
 
@@ -134,7 +147,7 @@ export function classifySample(sample: Sample): SampleClassification {
     return {
       atterberg: limits, missing, notes: [
         ...notes,
-        'No usable sieve analysis on this sample, so the gravel/sand/fines split is unknown and neither system can classify it.',
+        warn('No usable sieve analysis on this sample, so the gravel/sand/fines split is unknown and neither system can classify it.'),
       ],
     }
   }
@@ -179,19 +192,19 @@ export function classifySample(sample: Sample): SampleClassification {
   // replaced rather than stacked. Matching on the text is deliberate and
   // pinned by a test: the two modules are siblings, and the alternative is a
   // flag the sieve engine would have to keep in step with wording it owns.
-  const gradNotes = curve.combined ? grad.notes.filter((n) => !/hydrometer/i.test(n)) : grad.notes
+  const gradNotes = curve.combined ? grad.notes.filter((n) => !isStaleHydrometerAdvice(n)) : grad.notes
   if (gradNotes.length) notes.push(...gradNotes)
   if (curve.notes.length) notes.push(...curve.notes)
   if (curve.combined && curve.d10 == null) {
-    notes.push(
+    notes.push(info(
       'Even joined with the sedimentation run the curve does not reach 10% passing, so D₁₀, Cu and Cc remain unavailable. On a soil this fine that is the expected answer rather than a gap in the testing.',
-    )
+    ))
   }
   if (limits?.notes.length) notes.push(...limits.notes)
   if (usda?.notes.length) notes.push(...usda.notes)
 
   if (!uscs.symbol && !missing.includes('atterberg') && curve.d10 == null && !curve.combined) {
-    notes.push('The gradation curve does not reach 10% passing, so Cu and Cc are unavailable — a hydrometer analysis would complete it.')
+    notes.push(warn('The gradation curve does not reach 10% passing, so Cu and Cc are unavailable — a hydrometer analysis would complete it.'))
     if (!missing.includes('hydrometer')) missing.push('hydrometer')
   }
 

--- a/webapp/src/engine/soils/grading.test.ts
+++ b/webapp/src/engine/soils/grading.test.ts
@@ -75,7 +75,7 @@ describe('joining the curves is what produces D₁₀', () => {
     expect(c.d10!).toBeLessThan(0.075)     // below the finest sieve, by definition
     expect(c.cu).toBeCloseTo(c.d60! / c.d10!, 9)
     expect(c.cc).toBeCloseTo((c.d30! * c.d30!) / (c.d10! * c.d60!), 9)
-    expect(c.notes.join(' ')).toMatch(/D₁₀ = .* comes from the sedimentation run/)
+    expect(c.notes.map((n) => n.text).join(' ')).toMatch(/D₁₀ = .* comes from the sedimentation run/)
   })
 
   it('keeps the D2487 fractions where the sieve put them', () => {
@@ -122,7 +122,7 @@ describe('the join is policed, not papered over', () => {
       ],
     }))
     expect(c.points.filter((p) => p.source === 'hydrometer').every((p) => p.size < 0.075)).toBe(true)
-    expect(c.notes.join(' ')).toMatch(/coarser than the 0.075 mm sieve and .* dropped/)
+    expect(c.notes.map((n) => n.text).join(' ')).toMatch(/coarser than the 0.075 mm sieve and .* dropped/)
   })
 
   it('measures the disagreement at an overlapping join rather than averaging it', () => {
@@ -138,12 +138,12 @@ describe('the join is policed, not papered over', () => {
     }))
     expect(c.joinMismatch).toBeDefined()
     expect(c.joinMismatch!).toBeGreaterThan(2)
-    expect(c.notes.join(' ')).toMatch(/disagreement of .* points on one specimen/)
+    expect(c.notes.map((n) => n.text).join(' ')).toMatch(/disagreement of .* points on one specimen/)
   })
 
   it('refuses to let a subset of the sample be larger than the sample', () => {
     const c = combineGrading(gradation(DUAL_BAND), hyd({ fractionOfTotal: 90 }))
-    expect(c.notes.join(' ')).toMatch(/cannot be larger than the sample/)
+    expect(c.notes.map((n) => n.text).join(' ')).toMatch(/cannot be larger than the sample/)
   })
 
   it('names an unmeasured band at the join and flags a D-value read across it', () => {
@@ -156,9 +156,9 @@ describe('the join is policed, not papered over', () => {
       ],
     }))
     expect(c.joinGap!).toBeGreaterThan(3)
-    expect(c.notes.join(' ')).toMatch(/Nothing was measured between/)
+    expect(c.notes.map((n) => n.text).join(' ')).toMatch(/Nothing was measured between/)
     expect(c.dAcrossGap).toBe(true)
-    expect(c.notes.join(' ')).toMatch(/read off the interpolation rather than off a measurement/)
+    expect(c.notes.map((n) => n.text).join(' ')).toMatch(/read off the interpolation rather than off a measurement/)
   })
 
   it('says when even the joined curve never reaches 0.002 mm', () => {
@@ -171,7 +171,7 @@ describe('the join is policed, not papered over', () => {
     }))
     expect(c.clay).toBeUndefined()
     expect(c.silt).toBeUndefined()
-    expect(c.notes.join(' ')).toMatch(/above the 0.002 mm clay boundary/)
+    expect(c.notes.map((n) => n.text).join(' ')).toMatch(/above the 0.002 mm clay boundary/)
   })
 })
 

--- a/webapp/src/engine/soils/grading.ts
+++ b/webapp/src/engine/soils/grading.ts
@@ -37,6 +37,8 @@
 // UNITS: sizes mm; percentages 0–100, of the WHOLE sample.
 // ─────────────────────────────────────────────────────────────────────────
 
+import { type LabNote, info, warn } from './notes'
+
 import { type GradationResult, type SizePassing, interpolateD, passingAt } from './sieve'
 import type { HydrometerResult } from './lab/hydrometer'
 
@@ -80,7 +82,7 @@ export interface CombinedGrading {
   clay?: number
   /** Between 0.002 mm and the No. 200 sieve, % of the whole sample. */
   silt?: number
-  notes: string[]
+  notes: LabNote[]
 }
 
 /**
@@ -91,7 +93,7 @@ export interface CombinedGrading {
  * of these and never branch on whether a sedimentation run exists.
  */
 export function combineGrading(g: GradationResult, h?: HydrometerResult): CombinedGrading {
-  const notes: string[] = []
+  const notes: LabNote[] = []
   const sievePoints: GradingPoint[] = [...g.rows]
     .filter((r) => r.size > 0)
     .sort((a, b) => b.size - a.size)
@@ -127,27 +129,27 @@ export function combineGrading(g: GradationResult, h?: HydrometerResult): Combin
     if (atJoin != null) {
       joinMismatch = atJoin - passingAtJoin
       if (Math.abs(joinMismatch) > 2) {
-        notes.push(
+        notes.push(warn(
           `At the ${joinSize} mm join the sieve says ${passingAtJoin.toFixed(1)}% passed and the suspension says ${atJoin.toFixed(1)}% is finer — a disagreement of ${joinMismatch.toFixed(1)} points on one specimen. The usual cause is the fraction of the whole sample the suspension represents; check it before reading anything off the fine end of this curve.`,
-        )
+        ))
       }
     }
-    notes.push(
+    notes.push(info(
       `${overlap.length} sedimentation reading${overlap.length === 1 ? ' is' : 's are'} coarser than the ${joinSize} mm sieve and ${overlap.length === 1 ? 'was' : 'were'} dropped: the sieve weighed those grains directly, which beats inferring them from a settling velocity.`,
-    )
+    ))
   } else if (below.length) {
     joinGap = joinSize / below[0].diameter
     if (joinGap > 3) {
-      notes.push(
+      notes.push(warn(
         `Nothing was measured between ${joinSize} mm and ${below[0].diameter.toFixed(4)} mm — a factor of ${joinGap.toFixed(1)} in size. The curve is drawn across it, but an earlier first reading would measure that band instead of interpolating it.`,
-      )
+      ))
     }
   }
 
   if (below.length && below[0].percentFiner > passingAtJoin + 0.5) {
-    notes.push(
+    notes.push(warn(
       `The suspension reports ${below[0].percentFiner.toFixed(1)}% finer than ${below[0].diameter.toFixed(4)} mm, which is more than the ${passingAtJoin.toFixed(1)}% that passed the ${joinSize} mm sieve. A subset of the sample cannot be larger than the sample; the scaling to the whole specimen is wrong.`,
-    )
+    ))
   }
 
   const points: GradingPoint[] = [
@@ -168,24 +170,24 @@ export function combineGrading(g: GradationResult, h?: HydrometerResult): Combin
     d != null && below.length > 0 && d < joinSize && d > below[0].diameter
   const dAcrossGap = Boolean(joinGap && joinGap > 3 && [d10, d30, d60].some(inGap))
   if (dAcrossGap) {
-    notes.push(
+    notes.push(warn(
       'One of D₁₀, D₃₀ or D₆₀ falls inside the unmeasured band at the join, so Cu and Cc below are read off the interpolation rather than off a measurement.',
-    )
+    ))
   }
 
   if (g.d10 == null && d10 != null) {
-    notes.push(
+    notes.push(info(
       `D₁₀ = ${d10.toFixed(4)} mm comes from the sedimentation run — the sieve curve alone stopped at ${passingAtJoin.toFixed(0)}% passing and could not reach it.`,
-    )
+    ))
   }
 
   // ── Size-based silt and clay ──
   const clay = passingOnCurve(points, CLAY_SIZE)
   const silt = clay != null ? Math.max(g.fines - clay, 0) : undefined
   if (clay == null) {
-    notes.push(
+    notes.push(warn(
       `The combined curve stops at ${points[points.length - 1].size.toFixed(4)} mm, above the 0.002 mm clay boundary, so the clay fraction is still unknown. A longer sedimentation run — the 24-hour reading — is what reaches it.`,
-    )
+    ))
   }
 
   return {

--- a/webapp/src/engine/soils/lab/cbr.ts
+++ b/webapp/src/engine/soils/lab/cbr.ts
@@ -33,6 +33,8 @@
 // UNITS: penetration mm; stress MPa; CBR %.
 // ─────────────────────────────────────────────────────────────────────────
 
+import { type LabNote, info, warn } from '../notes'
+
 /** Standard crushed-stone stresses, MPa, at the two reference penetrations. */
 export const STANDARD_STRESS = { at2_54: 6.9, at5_08: 10.3 } as const
 
@@ -69,7 +71,7 @@ export interface CbrResult {
   governing: 2.54 | 5.08
   soaked: boolean
   swell?: number
-  notes: string[]
+  notes: LabNote[]
 }
 
 /** Linear interpolation of stress at a penetration, on the corrected curve. */
@@ -119,7 +121,7 @@ export function originCorrection(points: CbrPoint[]): number {
 }
 
 export function cbr(d: CbrData): CbrResult {
-  const notes: string[] = []
+  const notes: LabNote[] = []
   const points = [...d.points]
     .filter((p) => Number.isFinite(p.penetration) && Number.isFinite(p.stress))
     .sort((a, b) => a.penetration - b.penetration)
@@ -146,33 +148,33 @@ export function cbr(d: CbrData): CbrResult {
   const value = governing === 5.08 ? cbr5_08 : cbr2_54
 
   if (originShift > 0) {
-    notes.push(
+    notes.push(info(
       `The curve was concave upward at the start, so the D1883 origin correction moved the zero by ${originShift.toFixed(2)} mm — the straight portion extended back to zero load. Without it this CBR would read ${((stressAt(points, 2.54) / STANDARD_STRESS.at2_54) * 100).toFixed(1)}% instead of ${cbr2_54.toFixed(1)}%.`,
-    )
+    ))
   }
   if (governing === 5.08) {
-    notes.push(
+    notes.push(warn(
       `CBR at 5.08 mm (${cbr5_08.toFixed(1)}%) exceeds the value at 2.54 mm (${cbr2_54.toFixed(1)}%). D1883 §11.3 asks for the test to be RE-RUN in that case; if the re-run repeats it, the 5.08 mm value is the one reported — which is what is reported here.`,
-    )
+    ))
   }
   const maxPen = corrected[corrected.length - 1].penetration
   if (maxPen < 5.08) {
-    notes.push(
+    notes.push(warn(
       `The curve stops at ${maxPen.toFixed(2)} mm of corrected penetration, so the 5.08 mm ordinate is EXTRAPOLATED along the last segment rather than read. D1883 takes readings to 7.62 mm; run the plunger further before trusting the 5.08 mm value.`,
-    )
+    ))
   }
 
   const soaked = d.soaked ?? false
-  notes.push(
+  notes.push(info(
     soaked
       ? 'Soaked (four-day) CBR — the condition a subgrade reaches under a pavement in the wet season, and the value pavement design normally uses.'
       : 'UNSOAKED CBR. On a plastic subgrade the soaked value can be a third of this one, and a pavement designed on an unsoaked number is designed for a dry season it will not always have. State the condition wherever this value is quoted.',
-  )
+  ))
   if (d.swell != null && d.swell > 3) {
-    notes.push(`Swell of ${d.swell.toFixed(1)}% during soaking is high — above about 3% the subgrade is expansive, and CBR alone does not describe how it will behave under a pavement.`)
+    notes.push(warn(`Swell of ${d.swell.toFixed(1)}% during soaking is high — above about 3% the subgrade is expansive, and CBR alone does not describe how it will behave under a pavement.`))
   }
   if (d.dryDensity == null) {
-    notes.push('No dry density recorded with this CBR. A bearing ratio belongs to a compaction state — the same soil at 90% and 95% of maximum dry density gives very different values, so the number is not transferable without it.')
+    notes.push(warn('No dry density recorded with this CBR. A bearing ratio belongs to a compaction state — the same soil at 90% and 95% of maximum dry density gives very different values, so the number is not transferable without it.'))
   }
 
   return {

--- a/webapp/src/engine/soils/lab/compaction.test.ts
+++ b/webapp/src/engine/soils/lab/compaction.test.ts
@@ -111,12 +111,12 @@ describe('the peak is recovered from a curve it was planted in', () => {
     expect(r.peakFrom).toBe('highest-point')
     expect(r.optimumMoisture).toBe(11)
     expect(r.fit).toBeUndefined()
-    expect(r.notes.join(' ')).toMatch(/HIGHEST MEASURED point/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/HIGHEST MEASURED point/)
   })
 
   it('flags a peak held by too few points on one side', () => {
     const r = compaction({ ...MOULD, points: plantedCurve(a, b, c, [14, 15, 16.5, 18, 20]) })
-    expect(r.notes.join(' ')).toMatch(/dry of the optimum/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/dry of the optimum/)
   })
 })
 
@@ -142,16 +142,16 @@ describe('the zero-air-voids bound', () => {
     // and pushes the wet-side points through full saturation.
     const pts = plantedCurve(-0.006, 0.18, 0.43, [10, 12.5, 15, 17.5, 20])
     const r = compaction({ mouldVolume: 844, mouldMass: MOULD.mouldMass, specificGravity: 2.65, points: pts })
-    const flagged = r.notes.filter((n) => /ABOVE the zero-air-voids/.test(n))
+    const flagged = r.notes.filter((n) => /ABOVE the zero-air-voids/.test(n.text))
     expect(flagged.length).toBeGreaterThan(0)
-    expect(flagged[0]).toMatch(/S = 1\d\d%/)          // saturation above 100
-    expect(flagged[0]).toMatch(/mould volume/)
+    expect(flagged[0].text).toMatch(/S = 1\d\d%/)          // saturation above 100
+    expect(flagged[0].text).toMatch(/mould volume/)
   })
 
   it('says the check cannot run when no specific gravity was given', () => {
     const r = compaction({ ...MOULD, points: plantedCurve(-0.006, 0.18, 0.43, [10, 12.5, 15, 17.5, 20]) })
     expect(r.rows.every((x) => x.zavDensity === undefined)).toBe(true)
-    expect(r.notes.join(' ')).toMatch(/no zero-air-voids curve/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/no zero-air-voids curve/)
   })
 
   it('a real compaction point sits below the bound and under 100% saturation', () => {
@@ -159,7 +159,7 @@ describe('the zero-air-voids bound', () => {
       ...MOULD, specificGravity: 2.68,
       points: plantedCurve(-0.006, 0.18, 0.43, [10, 12.5, 15, 17.5, 20]),
     })
-    expect(r.notes.some((n) => /ABOVE the zero-air-voids/.test(n))).toBe(false)
+    expect(r.notes.some((n) => /ABOVE the zero-air-voids/.test(n.text))).toBe(false)
     for (const row of r.rows) {
       expect(row.dryDensity).toBeLessThan(row.zavDensity!)
       expect(row.saturation!).toBeLessThan(100)
@@ -182,14 +182,14 @@ describe('effort is carried, never assumed away', () => {
   it('defaults to standard and says which specification that answers', () => {
     const r = compaction({ ...MOULD, points: pts })
     expect(r.effort).toBe('standard')
-    expect(r.notes.join(' ')).toMatch(/D698/)
-    expect(r.notes.join(' ')).toMatch(/D1557/)      // and warns the other exists
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/D698/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/D1557/)      // and warns the other exists
   })
 
   it('modified effort says a D698-written 95% is not satisfied by 95% of it', () => {
     const r = compaction({ ...MOULD, effort: 'modified', points: pts })
     expect(r.effort).toBe('modified')
-    expect(r.notes.join(' ')).toMatch(/NOT satisfied/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/NOT satisfied/)
   })
 })
 

--- a/webapp/src/engine/soils/lab/compaction.ts
+++ b/webapp/src/engine/soils/lab/compaction.ts
@@ -38,6 +38,8 @@
 // kN/m³; water content % (0–100).
 // ─────────────────────────────────────────────────────────────────────────
 
+import { type LabNote, info, warn } from '../notes'
+
 /** Gravity used to turn a density (Mg/m³) into a unit weight (kN/m³). */
 export const G = 9.807
 
@@ -110,7 +112,7 @@ export interface CompactionResult {
   fit?: { a: number; b: number; c: number }
   /** Degree of saturation at the optimum, %. Needs Gs. */
   saturationAtOptimum?: number
-  notes: string[]
+  notes: LabNote[]
 }
 
 /**
@@ -167,7 +169,7 @@ function fitQuadratic(xs: number[], ys: number[]): { a: number; b: number; c: nu
 }
 
 export function compaction(d: CompactionData): CompactionResult {
-  const notes: string[] = []
+  const notes: LabNote[] = []
   if (!(d.mouldVolume > 0)) throw new Error('Mould volume must be greater than zero.')
   if (!(d.mouldMass >= 0)) throw new Error('Mould mass cannot be negative.')
 
@@ -227,23 +229,23 @@ export function compaction(d: CompactionData): CompactionResult {
   }
 
   if (peakFrom === 'highest-point') {
-    notes.push(
+    notes.push(warn(
       'No downward parabola with its vertex inside the water contents tested fits these points, so the HIGHEST MEASURED point is reported instead of an interpolated peak. The true optimum is at or beyond one end of the range — run points on the missing side before accepting γd,max.',
-    )
+    ))
   }
 
   // ── Checks worth failing on ─────────────────────────────────────────────
   if (gs) {
     const impossible = rows.filter((r) => r.dryDensity > (r.zavDensity ?? Infinity) + 1e-9)
     for (const r of impossible) {
-      notes.push(
+      notes.push(warn(
         `The point at w = ${r.moisture.toFixed(1)}% plots ABOVE the zero-air-voids curve (ρd = ${r.dryDensity.toFixed(3)} vs ZAV ${(r.zavDensity ?? 0).toFixed(3)} Mg/m³, implying S = ${(r.saturation ?? 0).toFixed(0)}%). That is impossible, not merely dense — check the mould volume, the specific gravity, and that this point's water content came from its own specimen.`,
-      )
+      ))
     }
   } else {
-    notes.push(
+    notes.push(warn(
       'No specific gravity given, so no zero-air-voids curve can be drawn and the one check that can prove a point impossible — a dry density above full saturation — cannot run.',
-    )
+    ))
   }
 
   // Points ON the optimum support neither arm, and the vertex lands a rounding
@@ -253,19 +255,19 @@ export function compaction(d: CompactionData): CompactionResult {
   const below = rows.filter((r) => r.moisture < optimumMoisture - AT_PEAK).length
   const above = rows.filter((r) => r.moisture > optimumMoisture + AT_PEAK).length
   if (below < 2 || above < 2) {
-    notes.push(
+    notes.push(warn(
       `Only ${below} point(s) dry of the optimum and ${above} wet of it. D698 asks for enough points to define both arms — with fewer than two on a side the peak is held by one measurement, and a single bad specimen moves γd,max and OMC together.`,
-    )
+    ))
   }
   if (rows.length < 4) {
-    notes.push(`Only ${rows.length} points. D698 §10 expects at least four, and five is the usual practice.`)
+    notes.push(warn(`Only ${rows.length} points. D698 §10 expects at least four, and five is the usual practice.`))
   }
 
-  notes.push(
+  notes.push(info(
     effort === 'modified'
       ? 'Modified effort (D1557, 2 700 kN·m/m³). This curve sits higher and drier than the standard-effort curve for the same soil, so a "95% compaction" specification written against D698 is NOT satisfied by 95% of this value.'
       : 'Standard effort (D698, 600 kN·m/m³). A specification written against modified effort (D1557) refers to a higher, drier curve — state which one the field densities are being judged against.',
-  )
+  ))
 
   return {
     effort,

--- a/webapp/src/engine/soils/lab/consolidation.test.ts
+++ b/webapp/src/engine/soils/lab/consolidation.test.ts
@@ -109,9 +109,9 @@ describe('preconsolidation pressure — an estimate, not a measurement', () => {
 
   it('says in as many words that it is an estimate, and not Casagrande', () => {
     const r = consolidation(curveWithBreak())
-    expect(r.notes.join(' ')).toMatch(/ESTIMATE from a two-segment fit, not a measurement/)
-    expect(r.notes.join(' ')).toMatch(/not the graphical Casagrande construction/)
-    expect(r.notes.join(' ')).toMatch(/changes a prediction by a factor/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/ESTIMATE from a two-segment fit, not a measurement/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/not the graphical Casagrande construction/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/changes a prediction by a factor/)
   })
 
   it('returns undefined for a curve with no break, and explains both causes', () => {
@@ -125,8 +125,8 @@ describe('preconsolidation pressure — an estimate, not a measurement', () => {
     })
     const r = consolidation({ ...SPECIMEN, points })
     expect(r.preconsolidationPressure).toBeUndefined()
-    expect(r.notes.join(' ')).toMatch(/normally consolidated/)
-    expect(r.notes.join(' ')).toMatch(/too few increments were run below the break/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/normally consolidated/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/too few increments were run below the break/)
   })
 
   it('will not report a σ′p outside the stresses actually applied', () => {
@@ -202,7 +202,7 @@ describe('warnings that matter', () => {
       return { stress, compression: SPECIMEN.initialHeight - (1 + e) * hs }
     })
     const r = consolidation({ ...SPECIMEN, points })
-    expect(r.notes.join(' ')).toMatch(/wrong way round/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/wrong way round/)
   })
 
   it('says the RATE is unavailable without t50, but the magnitude is not', () => {
@@ -210,12 +210,12 @@ describe('warnings that matter', () => {
     d.points = d.points.map(({ stress, compression }) => ({ stress, compression }))
     const r = consolidation(d)
     expect(r.rows.every((x) => x.cv === undefined)).toBe(true)
-    expect(r.notes.join(' ')).toMatch(/RATE of settlement — cannot be computed. The magnitude can/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/RATE of settlement — cannot be computed. The magnitude can/)
   })
 
   it('warns when too few increments were run', () => {
     const d = curveWithBreak()
     d.points = d.points.slice(0, 4)
-    expect(consolidation(d).notes.join(' ')).toMatch(/Only 4 increments/)
+    expect(consolidation(d).notes.map((n) => n.text).join(' ')).toMatch(/Only 4 increments/)
   })
 })

--- a/webapp/src/engine/soils/lab/consolidation.ts
+++ b/webapp/src/engine/soils/lab/consolidation.ts
@@ -20,6 +20,8 @@
 // UNITS: stress kPa; heights mm; masses g; void ratio and indices dimensionless.
 // ─────────────────────────────────────────────────────────────────────────
 
+import { type LabNote, info, warn } from '../notes'
+
 /** One load increment held to the end of primary consolidation. */
 export interface ConsolidationPoint {
   /** Applied effective vertical stress, kPa. */
@@ -67,7 +69,7 @@ export interface ConsolidationResult {
   preconsolidationPressure?: number
   /** Points used for the Cc fit, for a plot to highlight. */
   virginRange?: { from: number; to: number }
-  notes: string[]
+  notes: LabNote[]
 }
 
 /**
@@ -184,7 +186,7 @@ export function fitBreak(rows: ConsolidationRow[]): BreakFit | undefined {
 }
 
 export function consolidation(d: ConsolidationData): ConsolidationResult {
-  const notes: string[] = []
+  const notes: LabNote[] = []
   if (!(d.initialHeight > 0)) throw new Error('Initial specimen height must be greater than zero.')
   if (!(d.diameter > 0)) throw new Error('Specimen diameter must be greater than zero.')
 
@@ -235,26 +237,26 @@ export function consolidation(d: ConsolidationData): ConsolidationResult {
   const preconsolidationPressure = fit?.sigmaP
 
   if (preconsolidationPressure == null) {
-    notes.push(
+    notes.push(warn(
       'No break in the curve fits materially better than a single straight line. That is the honest result for a normally consolidated clay, where σ′p sits at or below the lowest stress applied — but it also happens when too few increments were run below the break, so check the plot before concluding either.',
-    )
+    ))
   } else {
-    notes.push(
+    notes.push(info(
       `σ′p = ${preconsolidationPressure.toFixed(0)} kPa is an ESTIMATE from a two-segment fit, not a measurement, and not the graphical Casagrande construction — the two agree on a sharp break and diverge on a rounded one. Settlement below σ′p follows Cr and above it follows Cc, which is several times larger, so where the break is placed changes a prediction by a factor rather than a percentage. Check it against the plotted curve.`,
-    )
+    ))
   }
 
   if (cr != null && cr >= cc) {
-    notes.push('The recompression index is not smaller than the compression index, which no real soil does — the two branches have probably been read the wrong way round.')
+    notes.push(warn('The recompression index is not smaller than the compression index, which no real soil does — the two branches have probably been read the wrong way round.'))
   }
   if (cc <= 0) {
-    notes.push('The compression index came out zero or negative: the specimen did not compress with increasing stress. Check the compression column.')
+    notes.push(warn('The compression index came out zero or negative: the specimen did not compress with increasing stress. Check the compression column.'))
   }
   if (rows.length < 6) {
-    notes.push(`Only ${rows.length} increments. D2435 asks for enough to define both branches and the break between them; with this few the Casagrande construction is poorly constrained.`)
+    notes.push(warn(`Only ${rows.length} increments. D2435 asks for enough to define both branches and the break between them; with this few the Casagrande construction is poorly constrained.`))
   }
   if (!rows.some((r) => r.cv != null)) {
-    notes.push('No t50 recorded on any increment, so cv — and therefore the RATE of settlement — cannot be computed. The magnitude can.')
+    notes.push(warn('No t50 recorded on any increment, so cv — and therefore the RATE of settlement — cannot be computed. The magnitude can.'))
   }
 
   return {

--- a/webapp/src/engine/soils/lab/directShear.ts
+++ b/webapp/src/engine/soils/lab/directShear.ts
@@ -23,6 +23,8 @@
 // UNITS: stresses kPa; angles degrees.
 // ─────────────────────────────────────────────────────────────────────────
 
+import { type LabNote, info, warn } from '../notes'
+
 export interface ShearPoint {
   /** Effective normal stress on the shear plane, kPa. */
   normalStress: number
@@ -55,7 +57,7 @@ export interface DirectShearResult {
   residual?: Envelope
   /** Lowest and highest normal stress tested, kPa. */
   stressRange: { min: number; max: number }
-  notes: string[]
+  notes: LabNote[]
 }
 
 /**
@@ -105,14 +107,14 @@ export function fitEnvelope(points: { x: number; y: number }[]): Envelope {
 }
 
 export function directShear(d: DirectShearData): DirectShearResult {
-  const notes: string[] = []
+  const notes: LabNote[] = []
   const pts = d.points.filter((p) => Number.isFinite(p.normalStress) && Number.isFinite(p.peakShear))
 
   if (pts.length < 2) {
     throw new Error('A direct-shear envelope needs at least two specimens with a normal and a peak shear stress.')
   }
   if (pts.length < 3) {
-    notes.push('Only two specimens. D3080 asks for at least three so the envelope can be seen to be straight — with two, any scatter is invisible.')
+    notes.push(warn('Only two specimens. D3080 asks for at least three so the envelope can be seen to be straight — with two, any scatter is invisible.'))
   }
 
   const peak = fitEnvelope(pts.map((p) => ({ x: p.normalStress, y: p.peakShear })))
@@ -126,25 +128,25 @@ export function directShear(d: DirectShearData): DirectShearResult {
   const stressRange = { min: Math.min(...stresses), max: Math.max(...stresses) }
 
   if (peak.refittedThroughOrigin) {
-    notes.push(
+    notes.push(warn(
       'The free fit gave a NEGATIVE cohesion intercept, which is a fitting artefact rather than a soil property. The envelope was refitted through the origin and c′ reported as 0.',
-    )
+    ))
   }
   if (peak.r2 < 0.95) {
-    notes.push(
+    notes.push(warn(
       `The envelope fits poorly (R² = ${peak.r2.toFixed(3)}). Either the soil's envelope is curved over this stress range, or one specimen is an outlier — plot the points before trusting c′ and φ′.`,
-    )
+    ))
   }
   if (peak.frictionAngle > 45) {
-    notes.push(`φ′ = ${peak.frictionAngle.toFixed(1)}° is above the range most soils reach. Verify the shear-box area correction.`)
+    notes.push(warn(`φ′ = ${peak.frictionAngle.toFixed(1)}° is above the range most soils reach. Verify the shear-box area correction.`))
   }
   if (residual && residual.frictionAngle > peak.frictionAngle + 0.5) {
-    notes.push('The residual friction angle exceeds the peak, which cannot happen in a real soil — check which column is which.')
+    notes.push(warn('The residual friction angle exceeds the peak, which cannot happen in a real soil — check which column is which.'))
   }
 
-  notes.push(
+  notes.push(info(
     `c′ and φ′ are fitted over ${stressRange.min.toFixed(0)}–${stressRange.max.toFixed(0)} kPa and are valid only there. A real envelope is curved; extrapolating to a much higher footing stress overestimates strength.`,
-  )
+  ))
 
   return { peak, residual, stressRange, notes }
 }

--- a/webapp/src/engine/soils/lab/hydrometer.test.ts
+++ b/webapp/src/engine/soils/lab/hydrometer.test.ts
@@ -117,7 +117,7 @@ describe('the reading sets the percent finer', () => {
     ] })
     expect(fines.rows[0].percentFinerOfSpecimen).toBeCloseTo(whole.rows[0].percentFinerOfSpecimen, 10)
     expect(fines.rows[0].percentFiner).toBeCloseTo(whole.rows[0].percentFiner * 0.4, 10)
-    expect(fines.notes.join(' ')).toMatch(/same basis as the sieve curve/)
+    expect(fines.notes.map((n) => n.text).join(' ')).toMatch(/same basis as the sieve curve/)
   })
 
   it('refuses a fraction outside 0–100%', () => {
@@ -141,12 +141,12 @@ describe('what the curve refuses to hide', () => {
 
   it('flags a reading that is all correction and no soil', () => {
     const r = run({ compositeCorrection: 14 })
-    expect(r.notes.join(' ')).toMatch(/at or below the composite correction/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/at or below the composite correction/)
   })
 
   it('flags more soil in suspension than was put in', () => {
     const r = run({ dryMass: 10 })
-    expect(r.notes.join(' ')).toMatch(/more soil than was put in the cylinder/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/more soil than was put in the cylinder/)
   })
 
   it('flags a curve that climbs, which sedimentation cannot do', () => {
@@ -154,7 +154,7 @@ describe('what the curve refuses to hide', () => {
       { time: 2, reading: 20, temperature: 20 },
       { time: 60, reading: 30, temperature: 20 },     // more in suspension, later
     ] })
-    expect(r.notes.join(' ')).toMatch(/cannot climb/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/cannot climb/)
   })
 
   it('flags a bath that drifted', () => {
@@ -162,11 +162,11 @@ describe('what the curve refuses to hide', () => {
       { time: 2, reading: 30, temperature: 19 },
       { time: 1440, reading: 12, temperature: 26 },
     ] })
-    expect(r.notes.join(' ')).toMatch(/moved 7\.0 °C/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/moved 7\.0 °C/)
   })
 
   it('always says the diameters are equivalent, not measured', () => {
-    expect(run({}).notes.join(' ')).toMatch(/EQUIVALENT SPHERICAL diameter/)
+    expect(run({}).notes.map((n) => n.text).join(' ')).toMatch(/EQUIVALENT SPHERICAL diameter/)
   })
 
   it('needs two readings to be a curve at all', () => {

--- a/webapp/src/engine/soils/lab/hydrometer.ts
+++ b/webapp/src/engine/soils/lab/hydrometer.ts
@@ -30,6 +30,8 @@
 // percentages 0–100.
 // ─────────────────────────────────────────────────────────────────────────
 
+import { type LabNote, info, warn } from '../notes'
+
 /** One reading: elapsed time, hydrometer scale, temperature. */
 export interface HydrometerReading {
   /** Elapsed time from the start of sedimentation, minutes. */
@@ -86,7 +88,7 @@ export interface HydrometerResult {
   d50?: number
   /** Clay fraction, % of the whole sample finer than 0.002 mm. */
   clayFraction?: number
-  notes: string[]
+  notes: LabNote[]
 }
 
 /** Dynamic viscosity of water, poise (dyne·s/cm²), from the Vogel equation. */
@@ -135,7 +137,7 @@ export function stokesDiameter(L: number, timeMin: number, gs: number, tempC: nu
 }
 
 export function hydrometer(d: HydrometerData): HydrometerResult {
-  const notes: string[] = []
+  const notes: LabNote[] = []
   if (!(d.dryMass > 0)) throw new Error('The dry mass of soil in suspension must be greater than zero.')
   const a = gravityFactor(d.specificGravity)
   const scale = (d.fractionOfTotal ?? 100) / 100
@@ -169,35 +171,35 @@ export function hydrometer(d: HydrometerData): HydrometerResult {
   // ── What the numbers can and cannot be ──
   const negative = rows.filter((r) => r.correctedReading <= 0)
   if (negative.length) {
-    notes.push(
+    notes.push(warn(
       `${negative.length} reading(s) fall at or below the composite correction of ${d.compositeCorrection} g/L, which puts no solid in suspension above the bulb. Either sedimentation was complete or the correction is wrong — read it again on the control cylinder before using this curve.`,
-    )
+    ))
   }
   const over = rows.filter((r) => r.percentFinerOfSpecimen > 100.5)
   if (over.length) {
-    notes.push(
+    notes.push(warn(
       `A reading gives ${Math.max(...over.map((r) => r.percentFinerOfSpecimen)).toFixed(0)}% finer, which is more soil than was put in the cylinder. Check the dry mass and the composite correction — those two set the whole curve's height.`,
-    )
+    ))
   }
   if (rows.some((r, i) => i > 0 && r.percentFiner > rows[i - 1].percentFiner + 1e-9)) {
-    notes.push(
+    notes.push(warn(
       'The percent finer RISES between two readings. Sedimentation only removes particles from suspension, so the curve cannot climb — a reading was taken at the wrong time, or the suspension was disturbed.',
-    )
+    ))
   }
   const temps = rows.map((r) => r.temperature)
   if (Math.max(...temps) - Math.min(...temps) > 2) {
-    notes.push(
+    notes.push(warn(
       `The suspension moved ${(Math.max(...temps) - Math.min(...temps)).toFixed(1)} °C during the run. Viscosity, and therefore every diameter, follows it — D7928 asks for a bath held within about 1 °C.`,
-    )
+    ))
   }
   if (d.fractionOfTotal != null && d.fractionOfTotal < 100) {
-    notes.push(
+    notes.push(info(
       `Percentages are scaled to ${d.fractionOfTotal}% of the whole sample — the fines this suspension was taken from — so they sit on the same basis as the sieve curve and the two join at 0.075 mm.`,
-    )
+    ))
   }
-  notes.push(
+  notes.push(info(
     'Every diameter is an EQUIVALENT SPHERICAL diameter: the size of a sphere that would settle at the speed this fraction settled. Clay platelets are not spheres, so the fine end of this curve describes settling behaviour rather than a measured dimension.',
-  )
+  ))
 
   // D50 and the clay fraction, by interpolation on the log-size curve.
   const asc = [...rows].sort((x, y) => x.diameter - y.diameter)

--- a/webapp/src/engine/soils/lab/lab.test.ts
+++ b/webapp/src/engine/soils/lab/lab.test.ts
@@ -31,7 +31,7 @@ describe('water content (ASTM D2216)', () => {
     // A soft organic clay holding more water than solids by mass.
     const r = moistureContent({ containerMass: 20, wetMass: 140, dryMass: 70 })
     expect(r.waterContent).toBeCloseTo(140, 10)
-    expect(r.notes.join(' ')).toMatch(/organic/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/organic/)
   })
 
   it('does not clamp a high water content', () => {
@@ -53,17 +53,17 @@ describe('water content (ASTM D2216)', () => {
 
   it('notes a non-standard drying temperature', () => {
     const r = moistureContent({ containerMass: 25, wetMass: 85, dryMass: 75, temperature: 90 })
-    expect(r.notes.join(' ')).toMatch(/110 ± 5 °C/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/110 ± 5 °C/)
   })
 
   it('does not complain about 60 °C, which D2216 allows for organics', () => {
     const r = moistureContent({ containerMass: 25, wetMass: 85, dryMass: 75, temperature: 60 })
-    expect(r.notes.join(' ')).not.toMatch(/110 ± 5/)
+    expect(r.notes.map((n) => n.text).join(' ')).not.toMatch(/110 ± 5/)
   })
 
   it('notes a specimen too small to weigh reliably', () => {
     const r = moistureContent({ containerMass: 25, wetMass: 31, dryMass: 30 })
-    expect(r.notes.join(' ')).toMatch(/proportional weighing error/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/proportional weighing error/)
   })
 })
 
@@ -80,7 +80,7 @@ describe('averaging determinations', () => {
   it('flags duplicates that disagree instead of averaging them silently', () => {
     // Usually a tare or transcription error rather than natural variation.
     const r = meanWaterContent([at(20), at(28)])
-    expect(r.notes.join(' ')).toMatch(/check the tare masses before averaging/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/check the tare masses before averaging/)
   })
 
   it('refuses an empty set', () => {
@@ -119,7 +119,7 @@ describe('specific gravity (ASTM D854)', () => {
     })
     expect(warm.k).toBeLessThan(1)
     expect(warm.gs).toBeLessThan(warm.gsAtTest)
-    expect(warm.notes.join(' ')).toMatch(/Corrected from 25\.0 °C to 20 °C/)
+    expect(warm.notes.map((n) => n.text).join(' ')).toMatch(/Corrected from 25\.0 °C to 20 °C/)
   })
 
   it('rejects solids that displaced no water', () => {
@@ -136,12 +136,12 @@ describe('specific gravity (ASTM D854)', () => {
     // Under-de-aired suspensions trap air, displace too little, and read LOW.
     const low = specificGravity({ solidMass: 25, pycWaterMass: 675, pycWaterSolidMass: 689 })
     expect(low.gs).toBeLessThan(2.4)
-    expect(low.notes.join(' ')).toMatch(/de-airing.*reads low/i)
+    expect(low.notes.map((n) => n.text).join(' ')).toMatch(/de-airing.*reads low/i)
   })
 
   it('notes a specimen small enough to magnify the weighing error', () => {
     const r = specificGravity({ solidMass: 5, pycWaterMass: 675, pycWaterSolidMass: 678.1 })
-    expect(r.notes.join(' ')).toMatch(/magnifies every weighing error/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/magnifies every weighing error/)
   })
 })
 

--- a/webapp/src/engine/soils/lab/moisture.ts
+++ b/webapp/src/engine/soils/lab/moisture.ts
@@ -19,6 +19,8 @@
 // UNITS: masses g (any consistent unit — only ratios are used); w in %.
 // ─────────────────────────────────────────────────────────────────────────
 
+import { type LabNote, warn } from '../notes'
+
 export interface MoistureData {
   /** Specimen identifier on the tin, e.g. 'A-14'. */
   container?: string
@@ -39,11 +41,11 @@ export interface MoistureResult {
   solidMass: number
   /** Water content, %. Can legitimately exceed 100. */
   waterContent: number
-  notes: string[]
+  notes: LabNote[]
 }
 
 export function moistureContent(d: MoistureData): MoistureResult {
-  const notes: string[] = []
+  const notes: LabNote[] = []
 
   const waterMass = d.wetMass - d.dryMass
   const solidMass = d.dryMass - d.containerMass
@@ -63,15 +65,15 @@ export function moistureContent(d: MoistureData): MoistureResult {
 
   const temp = d.temperature ?? 110
   if (temp > 60 && waterContent > 100) {
-    notes.push(
+    notes.push(warn(
       'Water content above 100% — ordinary in a soft or organic clay, where the soil holds more water than solids by mass. If the soil is organic, D2216 asks for drying at 60 °C instead; structural water is lost at 110 °C and the result reads high.',
-    )
+    ))
   }
   if (temp < 105 && temp !== 60) {
-    notes.push(`Dried at ${temp} °C. D2216 specifies 110 ± 5 °C unless the soil is organic or gypsiferous, in which case 60 °C and a stated deviation.`)
+    notes.push(warn(`Dried at ${temp} °C. D2216 specifies 110 ± 5 °C unless the soil is organic or gypsiferous, in which case 60 °C and a stated deviation.`))
   }
   if (solidMass < 10) {
-    notes.push(`Only ${solidMass.toFixed(1)} g of solids — D2216 asks for a minimum specimen mass that grows with particle size, and a small specimen carries a large proportional weighing error.`)
+    notes.push(warn(`Only ${solidMass.toFixed(1)} g of solids — D2216 asks for a minimum specimen mass that grows with particle size, and a small specimen carries a large proportional weighing error.`))
   }
 
   return { waterMass, solidMass, waterContent, notes }
@@ -83,18 +85,18 @@ export function moistureContent(d: MoistureData): MoistureResult {
  * usually a tare or a transcription error rather than natural variation.
  */
 export function meanWaterContent(results: MoistureResult[]): {
-  mean: number; range: number; notes: string[]
+  mean: number; range: number; notes: LabNote[]
 } {
   if (!results.length) throw new Error('No determinations to average.')
   const ws = results.map((r) => r.waterContent)
   const mean = ws.reduce((s, w) => s + w, 0) / ws.length
   const range = Math.max(...ws) - Math.min(...ws)
-  const notes: string[] = []
+  const notes: LabNote[] = []
   // 2 percentage points is a common repeatability expectation for duplicates.
   if (ws.length > 1 && range > 2) {
-    notes.push(
+    notes.push(warn(
       `The determinations spread ${range.toFixed(1)} percentage points. That is wider than duplicate repeatability — check the tare masses before averaging.`,
-    )
+    ))
   }
   return { mean, range, notes }
 }

--- a/webapp/src/engine/soils/lab/permeability.test.ts
+++ b/webapp/src/engine/soils/lab/permeability.test.ts
@@ -40,8 +40,8 @@ describe('constant head (ASTM D2434)', () => {
       method: 'constant-head', length: 100, area: 7854, head: 400, volume: 0.02, time: 3600,
     })
     expect(r.k20).toBeLessThan(1e-5)
-    expect(r.notes.join(' ')).toMatch(/below the range a constant-head test measures/)
-    expect(r.notes.join(' ')).toMatch(/the number is the apparatus, not the soil/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/below the range a constant-head test measures/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/the number is the apparatus, not the soil/)
   })
 
   it('warns when the gradient is steep enough to break Darcy', () => {
@@ -49,7 +49,7 @@ describe('constant head (ASTM D2434)', () => {
       method: 'constant-head', length: 100, area: 7854, head: 5000, volume: 500, time: 60,
     })
     expect(r.gradient).toBeCloseTo(50, 8)
-    expect(r.notes.join(' ')).toMatch(/turbulent/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/turbulent/)
   })
 })
 
@@ -63,7 +63,7 @@ describe('falling head (ASTM D5084)', () => {
       headStart: 900, headEnd: 400, time: 600,
     })
     expect(r.k).toBeCloseTo(1.3508620e-6, 13)
-    expect(r.notes.join(' ')).toMatch(/No water temperature recorded/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/No water temperature recorded/)
   })
 
   it('refuses a head that rises', () => {
@@ -79,7 +79,7 @@ describe('falling head (ASTM D5084)', () => {
       headStart: 900, headEnd: 100, time: 10,
     })
     expect(r.k20).toBeGreaterThan(1e-4)
-    expect(r.notes.join(' ')).toMatch(/faster than it can be read/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/faster than it can be read/)
   })
 })
 
@@ -103,7 +103,7 @@ describe('the 20 °C correction', () => {
     expect(at30.temperatureFactor).toBeCloseTo(viscosityRatio(30), 12)
     expect(at30.k20).toBeCloseTo(at30.k * viscosityRatio(30), 12)
     expect(at30.k20).toBeLessThan(at30.k)
-    expect(at30.notes.join(' ')).toMatch(/Corrected to 20 °C/)
+    expect(at30.notes.map((n) => n.text).join(' ')).toMatch(/Corrected to 20 °C/)
   })
 
   it('rejects a temperature at or below freezing', () => {
@@ -139,8 +139,8 @@ describe('the D1883 origin correction', () => {
     expect(r.stress2_54).toBeCloseTo(5.08, 6)
     expect(r.cbr2_54).toBeCloseTo((5.08 / STANDARD_STRESS.at2_54) * 100, 6)
     expect(r.cbr2_54).toBeCloseTo(73.6, 1)
-    expect(r.notes.join(' ')).toMatch(/origin correction moved the zero by 0\.50 mm/)
-    expect(r.notes.join(' ')).toMatch(/59\.1%/)      // what it would have read
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/origin correction moved the zero by 0\.50 mm/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/59\.1%/)      // what it would have read
   })
 })
 
@@ -173,8 +173,8 @@ describe('CBR (ASTM D1883)', () => {
     })
     expect(r.governing).toBe(5.08)
     expect(r.cbr).toBeCloseTo(60, 6)
-    expect(r.notes.join(' ')).toMatch(/RE-RUN/)
-    expect(r.notes.join(' ')).toMatch(/§11\.3/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/RE-RUN/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/§11\.3/)
   })
 
   it('says when the 5.08 mm ordinate was extrapolated', () => {
@@ -186,7 +186,7 @@ describe('CBR (ASTM D1883)', () => {
         { penetration: 3.81, stress: 4.4 },
       ],
     })
-    expect(r.notes.join(' ')).toMatch(/EXTRAPOLATED/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/EXTRAPOLATED/)
   })
 
   it('never lets an unsoaked value pass without saying so', () => {
@@ -194,10 +194,10 @@ describe('CBR (ASTM D1883)', () => {
       { penetration: 0, stress: 0 }, { penetration: 2.54, stress: 3.45 },
       { penetration: 5.08, stress: 5.15 }, { penetration: 7.62, stress: 6 },
     ]
-    expect(cbr({ points: pts }).notes.join(' ')).toMatch(/UNSOAKED/)
-    expect(cbr({ points: pts, soaked: true }).notes.join(' ')).toMatch(/Soaked \(four-day\)/)
-    expect(cbr({ points: pts, soaked: true, swell: 4.5 }).notes.join(' ')).toMatch(/expansive/)
-    expect(cbr({ points: pts }).notes.join(' ')).toMatch(/belongs to a compaction state/)
+    expect(cbr({ points: pts }).notes.map((n) => n.text).join(' ')).toMatch(/UNSOAKED/)
+    expect(cbr({ points: pts, soaked: true }).notes.map((n) => n.text).join(' ')).toMatch(/Soaked \(four-day\)/)
+    expect(cbr({ points: pts, soaked: true, swell: 4.5 }).notes.map((n) => n.text).join(' ')).toMatch(/expansive/)
+    expect(cbr({ points: pts }).notes.map((n) => n.text).join(' ')).toMatch(/belongs to a compaction state/)
   })
 
   it('refuses a curve too short to read', () => {

--- a/webapp/src/engine/soils/lab/permeability.ts
+++ b/webapp/src/engine/soils/lab/permeability.ts
@@ -31,6 +31,8 @@
 // in.
 // ─────────────────────────────────────────────────────────────────────────
 
+import { type LabNote, info, warn } from '../notes'
+
 export type PermeabilityMethod = 'constant-head' | 'falling-head'
 
 export interface ConstantHeadData {
@@ -78,7 +80,7 @@ export interface PermeabilityResult {
   temperatureFactor: number
   /** Hydraulic gradient i = h/L (constant head) or the mean over the interval. */
   gradient: number
-  notes: string[]
+  notes: LabNote[]
 }
 
 /**
@@ -98,7 +100,7 @@ export function viscosityRatio(tempC: number): number {
 const PLAUSIBLE = { min: 1e-12, max: 1e-1 }
 
 export function permeability(d: PermeabilityData): PermeabilityResult {
-  const notes: string[] = []
+  const notes: LabNote[] = []
   if (!(d.length > 0)) throw new Error('Specimen length must be greater than zero.')
   if (!(d.area > 0)) throw new Error('Specimen area must be greater than zero.')
   if (!(d.time > 0)) throw new Error('Elapsed time must be greater than zero.')
@@ -130,40 +132,40 @@ export function permeability(d: PermeabilityData): PermeabilityResult {
   const k20 = kMps * temperatureFactor
 
   if (d.temperature == null) {
-    notes.push(
+    notes.push(warn(
       'No water temperature recorded, so k is reported as measured. Water is about 30% less viscous at 30 °C than at 10 °C and k scales with 1/η, so an uncorrected value carries the laboratory\'s room temperature in it.',
-    )
+    ))
   } else if (Math.abs(temperatureFactor - 1) > 0.02) {
-    notes.push(
+    notes.push(info(
       `Corrected to 20 °C by RT = η_T/η_20 = ${temperatureFactor.toFixed(3)} (D5084) — a ${((temperatureFactor - 1) * 100).toFixed(0)}% change from the value measured at ${d.temperature} °C.`,
-    )
+    ))
   }
 
   // ── Is this the right apparatus for the answer it produced? ──
   if (d.method === 'constant-head' && k20 < 1e-5) {
-    notes.push(
+    notes.push(warn(
       `k = ${k20.toExponential(1)} m/s is below the range a constant-head test measures (D2434 is for clean sands and gravels, k > 1e-5 m/s). At this permeability the volume collected is comparable with evaporation and temperature drift in the burette — the number is the apparatus, not the soil. Use a falling-head or flexible-wall test.`,
-    )
+    ))
   }
   if (d.method === 'falling-head' && k20 > 1e-4) {
-    notes.push(
+    notes.push(warn(
       `k = ${k20.toExponential(1)} m/s is above the range a falling-head test resolves: the head drops faster than it can be read, so the timed interval is dominated by reading error. A constant-head test (D2434) is the right apparatus here.`,
-    )
+    ))
   }
   if (k20 > PLAUSIBLE.max || k20 < PLAUSIBLE.min) {
-    notes.push(
+    notes.push(warn(
       `k = ${k20.toExponential(1)} m/s is outside the range real soils occupy (about 1e-12 for an intact clay to 1e-1 for an open gravel). Check the units on the specimen dimensions and the volume before reading anything into this.`,
-    )
+    ))
   }
   if (gradient > 30) {
-    notes.push(
+    notes.push(warn(
       `The hydraulic gradient is ${gradient.toFixed(0)}. High gradients turn the flow turbulent, and Darcy's law — which every form of this test rearranges — assumes it is laminar. D2434 suggests gradients under about 5 for coarse soils; a result from a steep gradient reads LOW.`,
-    )
+    ))
   }
 
-  notes.push(
+  notes.push(info(
     'Permeability spans ten orders of magnitude across soils, and a good laboratory value is trusted to within a factor of two or three — not to three significant figures. A laboratory k also measures the specimen, not the deposit: fabric, layering and fissures make the field value larger, often by an order of magnitude.',
-  )
+  ))
 
   return {
     method: d.method,

--- a/webapp/src/engine/soils/lab/specificGravity.ts
+++ b/webapp/src/engine/soils/lab/specificGravity.ts
@@ -17,6 +17,8 @@
 // UNITS: masses g; temperature °C; Gs dimensionless.
 // ─────────────────────────────────────────────────────────────────────────
 
+import { type LabNote, info, warn } from '../notes'
+
 export interface SpecificGravityData {
   /** Pycnometer identifier. */
   pycnometer?: string
@@ -39,7 +41,7 @@ export interface SpecificGravityResult {
   k: number
   /** Gs corrected to 20 °C — the reported value. */
   gs: number
-  notes: string[]
+  notes: LabNote[]
 }
 
 /**
@@ -58,7 +60,7 @@ export const temperatureCorrection = (tempC: number): number =>
   waterDensity(tempC) / waterDensity(20)
 
 export function specificGravity(d: SpecificGravityData): SpecificGravityResult {
-  const notes: string[] = []
+  const notes: LabNote[] = []
   const { solidMass: Ms, pycWaterMass: Mpw, pycWaterSolidMass: Mpws } = d
 
   if (!(Ms > 0)) throw new Error('The oven-dry mass of solids must be greater than zero.')
@@ -76,19 +78,19 @@ export function specificGravity(d: SpecificGravityData): SpecificGravityResult {
   const gs = gsAtTest * k
 
   if (gs < 2.4 || gs > 2.9) {
-    notes.push(
+    notes.push(warn(
       `Gs = ${gs.toFixed(3)} falls outside the 2.60–2.80 range most mineral soils occupy. Below it suggests organic matter or trapped air from incomplete de-airing, which reads low; above it suggests heavy minerals. Verify before using this in a void-ratio calculation.`,
-    )
+    ))
   }
   if (Math.abs(temp - 20) > 0.1) {
-    notes.push(
+    notes.push(info(
       `Corrected from ${temp.toFixed(1)} °C to 20 °C with K = ${k.toFixed(5)}. D854 reports Gs at 20 °C.`,
-    )
+    ))
   }
   if (Ms < 10) {
-    notes.push(
+    notes.push(warn(
       `Only ${Ms.toFixed(1)} g of solids. Gs is a difference between two nearly equal masses, so a small specimen magnifies every weighing error.`,
-    )
+    ))
   }
 
   return { displacedMass, gsAtTest, k, gs, notes }

--- a/webapp/src/engine/soils/lab/strength.test.ts
+++ b/webapp/src/engine/soils/lab/strength.test.ts
@@ -62,12 +62,12 @@ describe('direct shear (ASTM D3080)', () => {
     expect(r.peak.cohesion).toBeCloseTo(20, 0)
     expect(r.peak.frictionAngle).toBeCloseTo(30, 0)
     expect(r.stressRange).toEqual({ min: 50, max: 200 })
-    expect(r.notes.join(' ')).toMatch(/valid only there/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/valid only there/)
   })
 
   it('warns when only two specimens were run', () => {
     const r = directShear({ points: clean.points.slice(0, 2) })
-    expect(r.notes.join(' ')).toMatch(/at least three/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/at least three/)
   })
 
   it('says when it refitted through the origin', () => {
@@ -79,7 +79,7 @@ describe('direct shear (ASTM D3080)', () => {
       ],
     })
     expect(r.peak.cohesion).toBe(0)
-    expect(r.notes.join(' ')).toMatch(/NEGATIVE cohesion intercept.*fitting artefact/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/NEGATIVE cohesion intercept.*fitting artefact/)
   })
 
   it('warns on a poor fit rather than reporting c′ and φ′ as if they were solid', () => {
@@ -91,7 +91,7 @@ describe('direct shear (ASTM D3080)', () => {
       ],
     })
     expect(r.peak.r2).toBeLessThan(0.95)
-    expect(r.notes.join(' ')).toMatch(/plot the points before trusting/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/plot the points before trusting/)
   })
 
   it('fits a residual envelope when residual stresses were recorded', () => {
@@ -109,7 +109,7 @@ describe('direct shear (ASTM D3080)', () => {
         { normalStress: 200, peakShear: 60, residualShear: 160 },
       ],
     })
-    expect(r.notes.join(' ')).toMatch(/cannot happen in a real soil/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/cannot happen in a real soil/)
   })
 
   it('refuses a single specimen', () => {
@@ -154,14 +154,14 @@ describe('unconfined compression (ASTM D2166)', () => {
   it('says how much the correction moved the answer', () => {
     // Omitting it would overstate the strength — always unconservatively.
     const r = ucs(spec)
-    expect(r.notes.join(' ')).toMatch(/lowering qu from 106 to 97 kPa/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/lowering qu from 106 to 97 kPa/)
   })
 
   it('halves qu for a saturated cohesive soil and states the assumption', () => {
     const r = ucs(spec)
     expect(r.cu).toBeCloseTo(r.qu / 2, 10)
-    expect(r.notes.join(' ')).toMatch(/assumes φ = 0/)
-    expect(r.notes.join(' ')).toMatch(/LOWER BOUND/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/assumes φ = 0/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/LOWER BOUND/)
   })
 
   it('DECLINES cu when the φ = 0 assumption does not hold', () => {
@@ -176,12 +176,12 @@ describe('unconfined compression (ASTM D2166)', () => {
   })
 
   it('warns about a specimen outside the 2.0–2.5 slenderness range', () => {
-    expect(ucs({ ...spec, height: 60 }).notes.join(' ')).toMatch(/restrained by the platens/)
-    expect(ucs({ ...spec, height: 76 }).notes.join(' ')).not.toMatch(/2\.0–2\.5/)
+    expect(ucs({ ...spec, height: 60 }).notes.map((n) => n.text).join(' ')).toMatch(/restrained by the platens/)
+    expect(ucs({ ...spec, height: 76 }).notes.map((n) => n.text).join(' ')).not.toMatch(/2\.0–2\.5/)
   })
 
   it('warns past 20% strain, where the specimen is barrelling not shearing', () => {
-    expect(ucs({ ...spec, failureDeformation: 18 }).notes.join(' ')).toMatch(/barrelling/)
+    expect(ucs({ ...spec, failureDeformation: 18 }).notes.map((n) => n.text).join(' ')).toMatch(/barrelling/)
   })
 
   it('rejects impossible geometry rather than returning nonsense', () => {

--- a/webapp/src/engine/soils/lab/swell.test.ts
+++ b/webapp/src/engine/soils/lab/swell.test.ts
@@ -28,28 +28,28 @@ describe('the strain on wetting, signed', () => {
     const r = swell({ ...base, method: 'B', wettedHeight: 19.64 })
     expect(r.strain).toBeCloseTo(-1.8, 10)
     expect(r.behaviour).toBe('collapse')
-    expect(r.notes.join(' ')).toMatch(/COLLAPSED on wetting/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/COLLAPSED on wetting/)
     // and it says which way a foundation moves, since that is the point
-    expect(r.notes.join(' ')).toMatch(/settles when the ground gets wet; it does not heave/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/settles when the ground gets wet; it does not heave/)
   })
 
   it('calls a hair of movement negligible rather than a behaviour', () => {
     const r = swell({ ...base, method: 'B', wettedHeight: 20.01 })
     expect(r.behaviour).toBe('negligible')
-    expect(r.notes.join(' ')).toMatch(/neither expansive nor collapsible/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/neither expansive nor collapsible/)
   })
 
   it('carries the inundation stress into the result and the note', () => {
     const r = swell({ initialHeight: 20, inundationStress: 7, method: 'A', wettedHeight: 21.4 })
     expect(r.inundationStress).toBe(7)
-    expect(r.notes.join(' ')).toMatch(/under 7\.0 kPa/)
-    expect(r.notes.join(' ')).toMatch(/belongs to that stress and to no other/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/under 7\.0 kPa/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/belongs to that stress and to no other/)
   })
 
   it('distinguishes free swell (A) from swell at the in-situ stress (B)', () => {
-    expect(swell({ ...base, method: 'A', wettedHeight: 21 }).notes.join(' '))
+    expect(swell({ ...base, method: 'A', wettedHeight: 21 }).notes.map((n) => n.text).join(' '))
       .toMatch(/FREE swell — the largest figure this soil can produce/)
-    expect(swell({ ...base, method: 'B', wettedHeight: 21 }).notes.join(' '))
+    expect(swell({ ...base, method: 'B', wettedHeight: 21 }).notes.map((n) => n.text).join(' '))
       .toMatch(/estimated in-situ vertical stress/)
   })
 
@@ -88,8 +88,8 @@ describe('swelling pressure', () => {
     const r = swell({ ...base, method: 'B', wettedHeight: 20.9, points })
     expect(r.swellPressure).toBeCloseTo(141.42, 2)
     expect(r.swellPressureFrom).toBe('reload-to-original-height')
-    expect(r.notes.join(' ')).toMatch(/INFERRED by re-loading/)
-    expect(r.notes.join(' ')).toMatch(/usually reports a higher value/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/INFERRED by re-loading/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/usually reports a higher value/)
   })
 
   it('declines to extrapolate when the loading never gets back there', () => {
@@ -101,8 +101,8 @@ describe('swelling pressure', () => {
     expect(reloadPressure(20, points)).toBeUndefined()
     const r = swell({ ...base, method: 'B', wettedHeight: 20.9, points })
     expect(r.swellPressure).toBeUndefined()
-    expect(r.notes.join(' ')).toMatch(/GREATER than that and is not reported/)
-    expect(r.notes.join(' ')).toMatch(/would invent it/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/GREATER than that and is not reported/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/would invent it/)
   })
 
   it('method C measures it directly, and its zero strain is by construction', () => {
@@ -110,7 +110,7 @@ describe('swelling pressure', () => {
     expect(r.swellPressure).toBe(180)
     expect(r.swellPressureFrom).toBe('constant-volume')
     expect(r.strain).toBe(0)
-    expect(r.notes.join(' ')).toMatch(/zero BY CONSTRUCTION and carries no information/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/zero BY CONSTRUCTION and carries no information/)
   })
 
   it('refuses method C without the pressure it exists to measure', () => {
@@ -120,7 +120,7 @@ describe('swelling pressure', () => {
   it('says so when there is no re-loading curve at all', () => {
     const r = swell({ ...base, method: 'B', wettedHeight: 20.9 })
     expect(r.swellPressure).toBeUndefined()
-    expect(r.notes.join(' ')).toMatch(/No re-loading curve, so no swelling pressure/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/No re-loading curve, so no swelling pressure/)
   })
 
   it('reports the remaining strain at every re-loading stress', () => {
@@ -134,7 +134,7 @@ describe('swelling pressure', () => {
   })
 
   it('always warns that swell belongs to a fabric, not just a mineralogy', () => {
-    expect(swell({ ...base, method: 'A', wettedHeight: 21 }).notes.join(' '))
+    expect(swell({ ...base, method: 'A', wettedHeight: 21 }).notes.map((n) => n.text).join(' '))
       .toMatch(/remoulded or disturbed specimen does not answer for the ground/)
   })
 })

--- a/webapp/src/engine/soils/lab/swell.ts
+++ b/webapp/src/engine/soils/lab/swell.ts
@@ -31,6 +31,8 @@
 // UNITS: heights mm; stresses kPa; strains % (positive = swell).
 // ─────────────────────────────────────────────────────────────────────────
 
+import { type LabNote, info, warn } from '../notes'
+
 export type SwellMethod = 'A' | 'B' | 'C'
 
 /** One point on the re-loading curve after the specimen has swollen. */
@@ -76,7 +78,7 @@ export interface SwellResult {
   swellPressureFrom?: 'constant-volume' | 'reload-to-original-height'
   /** Re-loading rows, when supplied: stress and the strain still remaining. */
   rows?: { stress: number; height: number; strain: number }[]
-  notes: string[]
+  notes: LabNote[]
 }
 
 /** Strain, %, of a height change against the original. Signed. */
@@ -109,7 +111,7 @@ export function reloadPressure(h0: number, points: SwellPoint[]): number | undef
 }
 
 export function swell(d: SwellData): SwellResult {
-  const notes: string[] = []
+  const notes: LabNote[] = []
   if (!(d.initialHeight > 0)) throw new Error('The initial specimen height must be greater than zero.')
   if (d.inundationStress < 0) throw new Error('The inundation stress cannot be negative.')
 
@@ -126,9 +128,9 @@ export function swell(d: SwellData): SwellResult {
     }
     swellPressure = d.constantVolumePressure
     swellPressureFrom = 'constant-volume'
-    notes.push(
+    notes.push(info(
       'Method C holds the height constant, so the strain is zero BY CONSTRUCTION and carries no information — the measurement is the pressure required to hold it.',
-    )
+    ))
   } else {
     if (d.wettedHeight == null) {
       throw new Error('Methods A and B need the height after wetting; without it there is no strain to report.')
@@ -140,9 +142,9 @@ export function swell(d: SwellData): SwellResult {
       swellPressureFrom = swellPressure != null ? 'reload-to-original-height' : undefined
       if (swellPressure == null) {
         const maxStress = Math.max(...d.points.map((p) => p.stress))
-        notes.push(
+        notes.push(warn(
           `Re-loading to ${maxStress.toFixed(0)} kPa never brought the specimen back to its original height, so the swelling pressure is GREATER than that and is not reported. Extrapolating the curve past the last point would invent it.`,
-        )
+        ))
       }
     }
   }
@@ -158,42 +160,42 @@ export function swell(d: SwellData): SwellResult {
 
   // ── What the number does and does not say ──
   if (behaviour === 'collapse') {
-    notes.push(
+    notes.push(info(
       `The specimen COLLAPSED on wetting: ${Math.abs(strain).toFixed(2)}% of its height, downward. This is the opposite behaviour to swelling and the same test measures both — a loose or dry-of-optimum fabric loses the suction holding it open the moment water arrives. A foundation on this soil settles when the ground gets wet; it does not heave.`,
-    )
+    ))
   } else if (behaviour === 'swell') {
-    notes.push(
+    notes.push(info(
       `The specimen SWELLED ${strain.toFixed(2)}% under ${d.inundationStress.toFixed(1)} kPa. That percentage belongs to that stress and to no other: the same soil swells several times more at a seating load than under a real surcharge, because the surcharge does the work the swelling pressure must overcome.`,
-    )
+    ))
   } else if (d.method !== 'C') {
-    notes.push(
+    notes.push(info(
       `The height barely moved (${strain.toFixed(3)}%). At ${d.inundationStress.toFixed(1)} kPa this soil is neither expansive nor collapsible — but a specimen wetted under a heavy surcharge can read flat while the same soil at a seating load does not, so the stress is part of the answer.`,
-    )
+    ))
   }
 
   if (d.method === 'A') {
-    notes.push(
+    notes.push(info(
       'Method A wets at a token seating pressure, which gives FREE swell — the largest figure this soil can produce and an upper bound rather than a prediction. What a footing will see is method B, at the stress the ground will actually carry.',
-    )
+    ))
   } else if (d.method === 'B') {
-    notes.push(
+    notes.push(info(
       'Method B wets at the estimated in-situ vertical stress, so the strain is what that depth would do if it got wet — provided the estimate was right. A stress guessed too high reports too little swell.',
-    )
+    ))
   }
 
   if (swellPressureFrom === 'reload-to-original-height') {
-    notes.push(
+    notes.push(info(
       `Swelling pressure ${swellPressure!.toFixed(0)} kPa, INFERRED by re-loading the swollen specimen back to its original height. That is a different stress path from method C's constant-volume measurement and usually reports a higher value, so quote the method with the number.`,
-    )
+    ))
   }
 
   if (d.method !== 'C' && !d.points?.length) {
-    notes.push('No re-loading curve, so no swelling pressure — the strain on wetting is the whole result. Method C measures the pressure directly if that is the number needed.')
+    notes.push(warn('No re-loading curve, so no swelling pressure — the strain on wetting is the whole result. Method C measures the pressure directly if that is the number needed.'))
   }
 
-  notes.push(
+  notes.push(info(
     'Swell and collapse are properties of a FABRIC as much as a mineralogy: a remoulded or disturbed specimen does not answer for the ground it came from, and a compacted fill answers only for the density and water content it was compacted at.',
-  )
+  ))
 
   return {
     method: d.method,

--- a/webapp/src/engine/soils/lab/triaxial.test.ts
+++ b/webapp/src/engine/soils/lab/triaxial.test.ts
@@ -105,7 +105,7 @@ describe('the envelope is the common tangent to the circles', () => {
       specimens: [{ cellPressure: 0, deviatorStress: 100 }, { cellPressure: 0.001, deviatorStress: 300 }],
     })
     expect(r.total!.frictionAngle).toBeGreaterThan(80)
-    expect(r.notes.join(' ')).toMatch(/above anything a soil sustains/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/above anything a soil sustains/)
   })
 })
 
@@ -224,15 +224,15 @@ describe('UU on a saturated clay', () => {
       ],
     })
     expect(r.total!.frictionAngle).toBeGreaterThan(2)
-    expect(r.notes.join(' ')).toMatch(/not fully saturated/)
-    expect(r.notes.join(' ')).toMatch(/Use su/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/not fully saturated/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/Use su/)
   })
 
   it('reports su but no envelope from a single specimen', () => {
     const r = triaxial({ testType: 'UU', specimens: [{ cellPressure: 100, deviatorStress: 90 }] })
     expect(r.total).toBeUndefined()
     expect(r.undrainedStrength).toBeCloseTo(45, 10)
-    expect(r.notes.join(' ')).toMatch(/infinitely many tangents/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/infinitely many tangents/)
   })
 })
 
@@ -254,7 +254,7 @@ describe('CU: total and effective are two envelopes of one test', () => {
     expect(r.effective!.cohesion).toBeCloseTo(5, 8)
     expect(r.total).toBeDefined()
     expect(r.total!.frictionAngle).toBeLessThan(r.effective!.frictionAngle)
-    expect(r.notes.join(' ')).toMatch(/not interchangeable/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/not interchangeable/)
   })
 
   it('shifts the circles left by u without changing their diameter', () => {
@@ -276,7 +276,7 @@ describe('CU: total and effective are two envelopes of one test', () => {
     })
     expect(r.effective).toBeUndefined()
     expect(r.effectiveCircles).toBeUndefined()
-    expect(r.notes.join(' ')).toMatch(/2 of 3 specimens/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/2 of 3 specimens/)
   })
 
   it('says total-stress parameters from a CU test apply to nothing in particular', () => {
@@ -284,7 +284,7 @@ describe('CU: total and effective are two envelopes of one test', () => {
       testType: 'CU',
       specimens: [100, 200, 300].map((s3) => tangentSpecimen(s3, 10, 20)),
     })
-    expect(r.notes.join(' ')).toMatch(/neither the drained strength nor su/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/neither the drained strength nor su/)
   })
 
   it('flags a pore pressure that puts σ′3 below zero', () => {
@@ -296,7 +296,7 @@ describe('CU: total and effective are two envelopes of one test', () => {
         { cellPressure: 300, deviatorStress: 320, porePressure: 130 },
       ],
     })
-    expect(r.notes.join(' ')).toMatch(/cannot sustain tension/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/cannot sustain tension/)
   })
 })
 
@@ -314,7 +314,7 @@ describe('input the engine refuses', () => {
   })
   it('warns that two specimens fit a line with nothing left over', () => {
     const r = triaxial({ testType: 'CD', specimens: [100, 200].map((s) => tangentSpecimen(s, 10, 30)) })
-    expect(r.notes.join(' ')).toMatch(/no residual/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/no residual/)
   })
 })
 

--- a/webapp/src/engine/soils/lab/triaxial.ts
+++ b/webapp/src/engine/soils/lab/triaxial.ts
@@ -38,6 +38,8 @@
 // UNITS: stresses kPa; angles degrees.
 // ─────────────────────────────────────────────────────────────────────────
 
+import { type LabNote, info, warn } from '../notes'
+
 import { fitEnvelope } from './directShear'
 
 export type TriaxialType = 'UU' | 'CU' | 'CD'
@@ -132,7 +134,7 @@ export interface TriaxialResult {
   undrainedStrength?: number
   /** Cell pressures tested, kPa — the range c and φ may be trusted over. */
   cellRange: { min: number; max: number }
-  notes: string[]
+  notes: LabNote[]
 }
 
 const DEG = 180 / Math.PI
@@ -195,7 +197,7 @@ const withFailure = (circles: MohrCircle[], e?: TriaxialEnvelope): MohrCircle[] 
   (e ? circles.map((c) => ({ ...c, failure: failurePoint(c, e) })) : circles)
 
 export function triaxial(d: TriaxialData): TriaxialResult {
-  const notes: string[] = []
+  const notes: LabNote[] = []
   const specimens = [...d.specimens]
     .filter((s) => Number.isFinite(s.cellPressure) && Number.isFinite(s.deviatorStress))
     .sort((a, b) => a.cellPressure - b.cellPressure)
@@ -222,31 +224,31 @@ export function triaxial(d: TriaxialData): TriaxialResult {
   if (withU.length === specimens.length && specimens.length > 0) {
     effectiveCircles = specimens.map((s) => circleOf(s.cellPressure - (s.porePressure ?? 0), s.deviatorStress))
     if (effectiveCircles.some((c) => c.sigma3 < 0)) {
-      notes.push(
+      notes.push(warn(
         'A pore pressure at failure exceeds its cell pressure, which puts an effective minor principal stress below zero. Soil cannot sustain tension — check the sign convention on the pore-pressure column (a NEGATIVE u, from a dilating dense soil, is normal and shifts the circle to the RIGHT).',
-      )
+      ))
     }
   } else if (withU.length > 0) {
-    notes.push(
+    notes.push(warn(
       `Pore pressure recorded on ${withU.length} of ${specimens.length} specimens, so no effective-stress envelope is drawn. Fitting one through a mixture of total and effective circles would not be an envelope of anything.`,
-    )
+    ))
   }
 
   const total = fitTangent(circles)
   const effective = effectiveCircles ? fitTangent(effectiveCircles) : undefined
 
   if (specimens.length === 1) {
-    notes.push('One specimen gives one circle, and one circle has infinitely many tangents — su is reported, c and φ are not. A series needs three.')
+    notes.push(warn('One specimen gives one circle, and one circle has infinitely many tangents — su is reported, c and φ are not. A series needs three.'))
   } else if (specimens.length === 2) {
-    notes.push('Two specimens fix a line exactly, so the fit has no residual and R² carries no information about whether the envelope is straight. Three is the minimum that can disagree with itself.')
+    notes.push(warn('Two specimens fix a line exactly, so the fit has no residual and R² carries no information about whether the envelope is straight. Three is the minimum that can disagree with itself.'))
   }
   if (!total && specimens.length >= 2) {
-    notes.push('The fitted Kf line is at or beyond 45°, which converts to sin φ ≥ 1 — no soil has that. Check the cell pressures and deviator stresses for a transcription error.')
+    notes.push(warn('The fitted Kf line is at or beyond 45°, which converts to sin φ ≥ 1 — no soil has that. Check the cell pressures and deviator stresses for a transcription error.'))
   }
   if (total && total.frictionAngle > 50) {
-    notes.push(
+    notes.push(warn(
       `φ = ${total.frictionAngle.toFixed(1)}° is above anything a soil sustains — dense angular gravel reaches the high forties. The arithmetic is valid, so the input is what to check: a cell pressure entered as a total stress, or a deviator stress that is really σ1.`,
-    )
+    ))
   }
 
   const meanRadius = circles.reduce((s, c) => s + c.radius, 0) / circles.length
@@ -256,36 +258,36 @@ export function triaxial(d: TriaxialData): TriaxialResult {
     undrainedStrength = meanRadius
     const spread = Math.max(...circles.map((c) => c.radius)) - Math.min(...circles.map((c) => c.radius))
     const relative = meanRadius > 0 ? spread / meanRadius : 0
-    notes.push(
+    notes.push(info(
       `Unconsolidated–undrained: on a SATURATED specimen every circle has the same diameter whatever the cell pressure, the envelope is horizontal, and c = su = ${meanRadius.toFixed(1)} kPa with φ = 0.`,
-    )
+    ))
     if (specimens.length > 1 && relative > 0.1 && total && total.frictionAngle > 2) {
-      notes.push(
+      notes.push(warn(
         `The deviator stress at failure varies by ${(relative * 100).toFixed(0)}% across the cell pressures and the fit returns φ = ${total.frictionAngle.toFixed(1)}°. In a UU test that is not a friction angle — it says the specimens were not fully saturated, or were not all the same soil. Use su, and check B before quoting anything else.`,
-      )
+      ))
     }
   } else if (specimens.length === 1) {
     undrainedStrength = meanRadius
   }
 
   if (d.testType === 'CU' && !effective) {
-    notes.push(
+    notes.push(warn(
       'A consolidated–undrained test without pore pressures gives only the TOTAL envelope, and total-stress parameters from a CU test apply to nothing in particular — they are neither the drained strength nor su. Record u at failure, or run CD.',
-    )
+    ))
   }
   if (d.testType === 'CU' && effective && total) {
-    notes.push(
+    notes.push(info(
       `Effective φ′ = ${effective.frictionAngle.toFixed(1)}° with c′ = ${effective.cohesion.toFixed(1)} kPa, against total φ = ${total.frictionAngle.toFixed(1)}° and c = ${total.cohesion.toFixed(1)} kPa. These are two descriptions of the same specimens and are not interchangeable: use the effective pair with effective stresses in a drained analysis, the total pair only in the short term.`,
-    )
+    ))
   }
   if (d.testType === 'CD' && withU.length) {
-    notes.push('A drained test is run slowly so that u stays at the back pressure; its circles are already effective, and the pore pressures recorded here have not been subtracted a second time.')
+    notes.push(info('A drained test is run slowly so that u stays at the back pressure; its circles are already effective, and the pore pressures recorded here have not been subtracted a second time.'))
   }
   if (total && total.refittedThroughOrigin) {
-    notes.push('The free fit gave a NEGATIVE cohesion intercept, which is an artefact of scatter rather than a soil property, so the envelope was refitted through the origin — the c = 0 a cohesionless soil actually has.')
+    notes.push(warn('The free fit gave a NEGATIVE cohesion intercept, which is an artefact of scatter rather than a soil property, so the envelope was refitted through the origin — the c = 0 a cohesionless soil actually has.'))
   }
   if (total && specimens.length >= 3 && total.r2 < 0.95) {
-    notes.push(`R² = ${total.r2.toFixed(3)} on the Kf line. A real envelope curves, and over a wide range of cell pressures a straight line through it is an approximation — check the plotted circles before quoting a single c and φ.`)
+    notes.push(warn(`R² = ${total.r2.toFixed(3)} on the Kf line. A real envelope curves, and over a wide range of cell pressures a straight line through it is an approximation — check the plotted circles before quoting a single c and φ.`))
   }
 
   return {

--- a/webapp/src/engine/soils/lab/ucs.ts
+++ b/webapp/src/engine/soils/lab/ucs.ts
@@ -22,6 +22,8 @@
 // UNITS: dimensions mm; load N; stresses kPa; strain as a fraction.
 // ─────────────────────────────────────────────────────────────────────────
 
+import { type LabNote, info, warn } from '../notes'
+
 export interface UcsData {
   /** Initial specimen diameter, mm. */
   diameter: number
@@ -54,7 +56,7 @@ export interface UcsResult {
   cuDeclined?: string
   /** Descriptive consistency from qu (Terzaghi & Peck). */
   consistency: string
-  notes: string[]
+  notes: LabNote[]
 }
 
 /** Consistency of a cohesive soil from qu, kPa (Terzaghi & Peck). */
@@ -68,7 +70,7 @@ export function consistencyFromQu(qu: number): string {
 }
 
 export function ucs(d: UcsData, soil: UcsSoil = 'saturated-cohesive'): UcsResult {
-  const notes: string[] = []
+  const notes: LabNote[] = []
 
   if (!(d.diameter > 0) || !(d.height > 0)) {
     throw new Error('Specimen diameter and height must both be greater than zero.')
@@ -89,33 +91,33 @@ export function ucs(d: UcsData, soil: UcsSoil = 'saturated-cohesive'): UcsResult
 
   const ratio = d.height / d.diameter
   if (ratio < 2 || ratio > 2.5) {
-    notes.push(
+    notes.push(warn(
       `Height/diameter is ${ratio.toFixed(2)}. D2166 asks for 2.0–2.5: a squatter specimen is restrained by the platens and reads high, a slenderer one can buckle.`,
-    )
+    ))
   }
   if (strain > 0.20) {
-    notes.push(
+    notes.push(warn(
       `Failure strain is ${(strain * 100).toFixed(1)}%. Beyond about 20% the specimen is barrelling rather than shearing, and the area correction stops describing it.`,
-    )
+    ))
   }
   if (strain > 0.05) {
-    notes.push(
+    notes.push(info(
       `The area correction raised the area by ${(((correctedArea / initialArea) - 1) * 100).toFixed(1)}%, lowering qu from ${quUncorrected.toFixed(0)} to ${qu.toFixed(0)} kPa. Omitting it would overstate the strength.`,
-    )
+    ))
   }
 
   let cu: number | undefined
   let cuDeclined: string | undefined
   if (soil === 'saturated-cohesive') {
     cu = qu / 2
-    notes.push('cu = qu/2 assumes φ = 0 — a saturated cohesive soil sheared undrained. A UCS is also a LOWER BOUND on the in-situ strength, since sampling disturbance only ever weakens a specimen.')
+    notes.push(info('cu = qu/2 assumes φ = 0 — a saturated cohesive soil sheared undrained. A UCS is also a LOWER BOUND on the in-situ strength, since sampling disturbance only ever weakens a specimen.'))
   } else {
     cuDeclined = {
       fissured: 'The specimen is fissured, so it fails on a discontinuity rather than through the matrix. qu/2 would overstate the operational strength.',
       'partly-saturated': 'The soil is partly saturated, so suction contributes to the measured strength and φ = 0 does not hold. qu/2 would be unconservative.',
       granular: 'A granular soil has no unconfined strength to speak of, and φ = 0 does not apply. Use a triaxial or direct shear test.',
     }[soil]
-    notes.push(cuDeclined)
+    notes.push(warn(cuDeclined))
   }
 
   return {

--- a/webapp/src/engine/soils/notes.test.ts
+++ b/webapp/src/engine/soils/notes.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { warn, info, noteText, warningsOf, hasWarning } from './notes'
+import { sampleInvestigation } from './sample'
+import { evaluateTest } from './lab'
+import { buildSoilsReport } from './report'
+
+// ─────────────────────────────────────────────────────────────────────────
+// Severity is only worth having if `warning` stays scarce. The guard for
+// that is not a rule in a comment — it is the example investigation, whose
+// laboratory data is deliberately well-formed: a well-run test must produce
+// no warnings at all, or the field has degraded back into a `string[]`.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('the two severities', () => {
+  it('builds and reads back', () => {
+    const notes = [warn('re-weigh this'), info('percentages are of the fine earth')]
+    expect(noteText(notes)).toEqual(['re-weigh this', 'percentages are of the fine earth'])
+    expect(warningsOf(notes)).toEqual([{ severity: 'warning', text: 're-weigh this' }])
+    expect(hasWarning(notes)).toBe(true)
+    expect(hasWarning([info('x')])).toBe(false)
+    expect(hasWarning([])).toBe(false)
+  })
+})
+
+describe('a well-run test produces no warnings', () => {
+  const results = () => sampleInvestigation().boreholes.flatMap((b) =>
+    b.samples.flatMap((s) => s.tests.map((t) => ({ b, s, t, ...evaluateTest(t) }))))
+
+  it('the example carries warnings ONLY where its data is genuinely short', () => {
+    // The three sieve stacks with more than 10% fines cannot reach D₁₀, and
+    // say so. Everything else in the example — a moisture content, a UCS, a
+    // consolidation curve, a sedimentation run — is clean data and is silent.
+    const warned = results()
+      .filter((r) => r.outcome && hasWarning(r.outcome.result.notes))
+      .map((r) => `${r.s.name} ${r.t.type}`)
+    expect(warned).toEqual(['S-01 sieve', 'S-02 sieve', 'S-01 sieve'])
+  })
+
+  it('but it is not silent — the caveats are all still there, as info', () => {
+    // The distinction is worthless if it were achieved by deleting notes.
+    const infos = results().flatMap((r) => r.outcome?.result.notes ?? [])
+      .filter((n) => n.severity === 'info')
+    expect(infos.length).toBeGreaterThan(5)
+    expect(noteText(infos).join(' ')).toMatch(/EQUIVALENT SPHERICAL diameter/)
+  })
+})
+
+describe('warnings reach the report', () => {
+  const s8 = () => buildSoilsReport(sampleInvestigation()).sections.find((s) => s.no === 8)!
+
+  it('carries every engine warning, named by the specimen it belongs to', () => {
+    const notes = s8().notes
+    expect(notes.length).toBeGreaterThan(0)
+    expect(notes.every((n) => n.severity === 'warning')).toBe(true)
+    for (const n of notes) expect(n.text).toMatch(/^BH-\d+ \/ S-\d+, .+: /)
+  })
+
+  it('leaves the info notes out — a dozen caveats is how the warnings get skimmed', () => {
+    const all = sampleInvestigation().boreholes
+      .flatMap((b) => b.samples.flatMap((s) => s.tests))
+      .flatMap((t) => evaluateTest(t).outcome?.result.notes ?? [])
+    expect(all.some((n) => n.severity === 'info')).toBe(true)
+    expect(noteText(s8().notes).join(' ')).not.toMatch(/EQUIVALENT SPHERICAL/)
+  })
+
+  it('does NOT advise a hydrometer on the one sample that has one', () => {
+    // The sieve engine cannot see the sedimentation run beside it. Printing
+    // its advice next to that run's own result is the contradiction this
+    // suppression exists to stop, and it is suppressed from the same
+    // definition the classification uses.
+    const texts = noteText(s8().notes).join(' ')
+    expect(texts).toMatch(/S-01, Sieve analysis: The curve does not reach 10% passing/)
+    expect(texts).not.toMatch(/S-02, Sieve analysis/)
+  })
+})

--- a/webapp/src/engine/soils/notes.ts
+++ b/webapp/src/engine/soils/notes.ts
@@ -1,0 +1,75 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Engine notes, and what they are worth. Layer 8.
+//
+// Every soils engine returns prose alongside its numbers, and until now that
+// prose was a flat `string[]` — which meant the report had no way to tell
+// these two apart:
+//
+//   "Every diameter is an EQUIVALENT SPHERICAL diameter: the size of a sphere
+//    that would settle at the speed this fraction settled."
+//   "Mass balance is off by 25% — D6913 requires closure within 1%. Re-weigh
+//    before using this grading."
+//
+// The first is a caveat about the METHOD, true of every hydrometer ever run,
+// and a reader who does not already know it should. The second says THIS
+// RESULT MAY BE WRONG. Printing them in the same grey italic teaches the
+// reader to skim both, which is how a real warning gets missed.
+//
+// So a note carries its severity, and there are exactly two:
+//
+//   warning  the number beside it may be wrong, unreliable, or absent
+//            BECAUSE OF HOW THIS TEST WAS RUN OR REPORTED. There is
+//            something to do: re-weigh, re-run, run another test, check an
+//            input, or read a value off the plot before quoting it.
+//   info     everything else — a convention, a statement of what the method
+//            can and cannot do, the provenance of a number, or a finding
+//            about the soil. Always true of this run; nothing to fix.
+//
+// TWO CONSEQUENCES OF DRAWING THE LINE THERE, both deliberate:
+//
+//   • A NOTE THAT ALWAYS FIRES IS NEVER A WARNING. "Permeability is trusted
+//     to within a factor of two or three" is on every permeability result and
+//     matters enormously to how the number is used — but there is nothing
+//     about this run to check, so it is `info`. A warning that appears on
+//     every test is a `string[]` again with extra steps.
+//   • SEVERITY IS ABOUT THE RESULT, NOT ABOUT THE SOIL. "Natural moisture is
+//     above the liquid limit — the soil may be sensitive or quick" is a
+//     hazard, and it is `info`, because the measurement is sound and complete.
+//     Soil hazards belong to the parameters and recommendations sections,
+//     which reason about behaviour; this field only says how much to trust
+//     the number it sits beside.
+//
+// Severity is decided WHERE THE NOTE IS WRITTEN. The alternative — deciding
+// it later by matching on the wording — was tried once in `classifySample`
+// and needed a test to hold it in place; doing that across sixty notes would
+// be a second copy of every engine's judgement, kept in step by hand.
+//
+// Severity is decided WHERE THE NOTE IS WRITTEN. The alternative — deciding
+// it later by matching on the wording — was tried once in `classifySample`
+// and needed a test to hold it in place; doing that across sixty notes would
+// be a second copy of every engine's judgement, kept in step by hand.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type NoteSeverity = 'warning' | 'info'
+
+export interface LabNote {
+  severity: NoteSeverity
+  text: string
+}
+
+/** This result may be wrong, or rests on something that should be checked. */
+export const warn = (text: string): LabNote => ({ severity: 'warning', text })
+
+/** A caveat or convention. Always true of the method; nothing to fix here. */
+export const info = (text: string): LabNote => ({ severity: 'info', text })
+
+/** The prose alone, for a caller that only wants to print it. */
+export const noteText = (notes: readonly LabNote[]): string[] => notes.map((n) => n.text)
+
+/** Just the notes that cast doubt on a number. */
+export const warningsOf = (notes: readonly LabNote[]): LabNote[] =>
+  notes.filter((n) => n.severity === 'warning')
+
+/** True when anything in the list questions the result. */
+export const hasWarning = (notes: readonly LabNote[]): boolean =>
+  notes.some((n) => n.severity === 'warning')

--- a/webapp/src/engine/soils/report.ts
+++ b/webapp/src/engine/soils/report.ts
@@ -37,7 +37,8 @@ import { resolveParameters, PARAMETER_LABEL } from './parameters'
 import { describeProvenance, PROVENANCE_LABEL } from './provenance'
 import { validateInvestigation } from './validate'
 import { evaluateTest, summarise, LAB_TESTS } from './lab'
-import { classifySample } from './classifySample'
+import { classifySample, isStaleHydrometerAdvice } from './classifySample'
+import { type LabNote, info, warningsOf } from './notes'
 import { labChart } from './lab/testChart'
 import { combinedGradingChart } from './lab/plots'
 import { cite } from './standards'
@@ -66,7 +67,13 @@ export interface ReportSection {
   paragraphs: string[]
   tables: ReportTable[]
   figures: ReportFigure[]
-  notes: string[]
+  /**
+   * Remarks under the tables and figures. Typed rather than `string[]` so a
+   * WARNING carried up from an engine — "this specimen plots above the
+   * zero-air-voids curve, which is impossible" — is not printed in the same
+   * grey italic as a statement of what a method measures.
+   */
+  notes: LabNote[]
 }
 
 export interface SoilsReport {
@@ -201,7 +208,7 @@ function s5Stratigraphy(inv: Investigation): ReportSection {
           }]
         : []),
     ],
-    notes: section.holes.length > 1 ? section.notes : [],
+    notes: (section.holes.length > 1 ? section.notes : []).map(info),
   }
 }
 
@@ -275,7 +282,7 @@ function s7Spt(inv: Investigation): ReportSection {
     paragraphs: [
       `Blow counts are corrected for hammer energy, borehole diameter, sampler type and rod length to N₆₀, and for effective overburden to (N₁)₆₀ per ${cite('d1586')} and the NCEER recommendations.`,
     ],
-    tables, figures: [], notes,
+    tables, figures: [], notes: notes.map(info),
   }
 }
 
@@ -293,6 +300,28 @@ function s8Laboratory(inv: Investigation): ReportSection {
   const figures: ReportFigure[] = []
   let omittedPending = 0
   let omittedEmpty = 0
+
+  // WARNINGS CARRIED UP FROM THE ENGINES. A result of "γd,max = 1.78 Mg/m³"
+  // sitting alone in a table looks like a measurement; the engine's "no
+  // downward parabola fits these points, so the HIGHEST MEASURED point is
+  // reported instead" is what tells the reader it is not. Until now that note
+  // existed only on screen, and the report — the document somebody signs — was
+  // the one place it never reached.
+  //
+  // Only `warning` notes come through. The `info` ones are conventions and
+  // method caveats, correct and worth reading once, and reprinting a dozen of
+  // them per report is how the four that matter get skimmed past.
+  //
+  // One exception is filtered: the sieve engine advises a hydrometer whenever
+  // its curve stops short of 10% passing, and it cannot see that the sample
+  // already has one. `classifySample` suppresses that advice from the same
+  // definition, so the two cannot disagree.
+  const labWarnings: LabNote[] = []
+  const joined = new Map<string, boolean>()
+  const hasSedimentation = (id: string, sample: Parameters<typeof classifySample>[0]) => {
+    if (!joined.has(id)) joined.set(id, Boolean(classifySample(sample).curve?.combined))
+    return joined.get(id)!
+  }
 
   for (const { b, s, t } of all) {
     const spec = LAB_TESTS.find((x) => x.type === t.type)
@@ -325,6 +354,13 @@ function s8Laboratory(inv: Investigation): ReportSection {
           drawing,
         })
       }
+      // Prefixed with the specimen: a warning in a report is useless unless
+      // the reader can tell which row of the table above it belongs to.
+      const stale = t.type === 'sieve' && hasSedimentation(s.id, s)
+      for (const w of warningsOf(outcome.result.notes)) {
+        if (stale && isStaleHydrometerAdvice(w)) continue
+        labWarnings.push({ ...w, text: `${b.name} / ${s.name}, ${spec?.label ?? t.type}: ${w.text}` })
+      }
     }
   }
 
@@ -349,7 +385,7 @@ function s8Laboratory(inv: Investigation): ReportSection {
       'The laboratory programme and its results are tabulated below, followed by the plot for every test whose result is read off a curve. Tests that produced no result are excluded from the table and accounted for above; a specimen that failed on a seating error is reported with its error rather than dropped, because that is part of the history of the sample.',
     ],
     tables: [{ head: ['Hole', 'Sample', 'Test', 'Standard', 'Status', 'Result'], rows }],
-    figures, notes: [],
+    figures, notes: labWarnings,
   }
 }
 
@@ -398,7 +434,7 @@ function s10Parameters(inv: Investigation): ReportSection {
     }],
     figures: [],
     notes: correlated || assumed
-      ? ['A correlated or assumed parameter carries far more scatter than a measured one. Where such a parameter governs the design, targeted laboratory testing is the cheapest way to reduce risk.']
+      ? [info('A correlated or assumed parameter carries far more scatter than a measured one. Where such a parameter governs the design, targeted laboratory testing is the cheapest way to reduce risk.')]
       : [],
   }
 }
@@ -467,7 +503,7 @@ function s12Liquefaction(inv: Investigation, opts: ReportOptions): ReportSection
     status: anyEvaluated ? 'complete' : 'partial',
     gap: anyEvaluated ? undefined
       : 'No test met the conditions for a triggering check — all lay above the water table, in cohesive soil, or without a usable blow count. The profile is empty rather than clear.',
-    paragraphs, tables, figures, notes,
+    paragraphs, tables, figures, notes: notes.map(info),
   }
 }
 
@@ -600,7 +636,7 @@ function s9Classification(inv: Investigation): ReportSection {
   // an agronomic name would tell an engineer their report is short of something
   // it never needed.
   const notes = noTexture
-    ? [`${noTexture} of ${rows.length} layers carry no USDA texture. The triangle is drawn on the clay fraction finer than 0.002 mm, which no sieve reaches — a hydrometer analysis (${cite('d7928')}) on a sample from each layer is what supplies it.`]
+    ? [info(`${noTexture} of ${rows.length} layers carry no USDA texture. The triangle is drawn on the clay fraction finer than 0.002 mm, which no sieve reaches — a hydrometer analysis (${cite('d7928')}) on a sample from each layer is what supplies it.`)]
     : []
 
   // The JOINED grading curve is a property of the sample, not of either test,

--- a/webapp/src/engine/soils/sieve.test.ts
+++ b/webapp/src/engine/soils/sieve.test.ts
@@ -39,7 +39,7 @@ describe('gradation table', () => {
 
   it('closes the mass balance', () => {
     expect(r.massError).toBeCloseTo(0, 10)
-    expect(r.notes.join(' ')).not.toMatch(/Mass balance/)
+    expect(r.notes.map((n) => n.text).join(' ')).not.toMatch(/Mass balance/)
   })
 
   it('splits gravel, sand and fines at the D2487 boundaries', () => {
@@ -55,7 +55,7 @@ describe('mass balance is reported, never silently corrected', () => {
   it('flags a stack that does not close within 1%', () => {
     const r = gradation({ ...wellGradedSand, panMass: 60 })   // 40 g surplus = 8%
     expect(Math.abs(r.massError)).toBeGreaterThan(1)
-    expect(r.notes.join(' ')).toMatch(/Mass balance is off by 8\.0%/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/Mass balance is off by 8\.0%/)
   })
 
   it('never prints a negative percent passing', () => {
@@ -67,7 +67,7 @@ describe('mass balance is reported, never silently corrected', () => {
       readings: [{ size: 4.75, massRetained: 80 }, { size: 0.075, massRetained: 40 }],
     })
     expect(r.rows.every((x) => x.percentPassing >= 0)).toBe(true)
-    expect(r.notes.join(' ')).toMatch(/Mass balance/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/Mass balance/)
   })
 
   it('refuses a zero or negative total mass', () => {
@@ -115,7 +115,7 @@ describe('D-sizes interpolate on a LOG scale', () => {
     expect(r.d10).toBeUndefined()
     expect(r.cu).toBeUndefined()
     expect(r.cc).toBeUndefined()
-    expect(r.notes.join(' ')).toMatch(/hydrometer/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/hydrometer/)
   })
 })
 
@@ -179,6 +179,6 @@ describe('cobbles', () => {
     expect(r.gravel).toBeCloseTo(50, 10)
     expect(r.sand).toBeCloseTo(25, 10)
     expect(r.fines).toBeCloseTo(5, 10)
-    expect(r.notes.join(' ')).toMatch(/coarser than 75 mm/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/coarser than 75 mm/)
   })
 })

--- a/webapp/src/engine/soils/sieve.ts
+++ b/webapp/src/engine/soils/sieve.ts
@@ -17,6 +17,8 @@
 // used); percentages 0–100.
 // ─────────────────────────────────────────────────────────────────────────
 
+import { type LabNote, info, warn } from './notes'
+
 /** Standard sieve boundaries used by ASTM D2487, mm. */
 export const SIEVE_75MM = 75      // gravel / cobble boundary
 export const SIEVE_NO4 = 4.75     // gravel / sand boundary
@@ -78,7 +80,7 @@ export interface GradationResult {
   cc?: number
   /** Mass balance error, % of the total. */
   massError: number
-  notes: string[]
+  notes: LabNote[]
 }
 
 /**
@@ -124,7 +126,7 @@ export function passingAt(rows: SizePassing[], size: number): number {
 }
 
 export function gradation(i: SieveInput): GradationResult {
-  const notes: string[] = []
+  const notes: LabNote[] = []
   if (!(i.totalMass > 0)) throw new Error('Total specimen mass must be greater than zero.')
 
   const sorted = [...i.readings].sort((a, b) => b.size - a.size)
@@ -151,9 +153,9 @@ export function gradation(i: SieveInput): GradationResult {
   const accounted = sorted.reduce((s, r) => s + r.massRetained, 0) + pan
   const massError = ((accounted - i.totalMass) / i.totalMass) * 100
   if (Math.abs(massError) > 1) {
-    notes.push(
+    notes.push(warn(
       `Mass balance is off by ${massError.toFixed(1)}% — D6913 requires closure within 1%. Re-weigh before using this grading.`,
-    )
+    ))
   }
 
   const passing75 = passingAt(rows, SIEVE_75MM)
@@ -173,14 +175,14 @@ export function gradation(i: SieveInput): GradationResult {
   const cc = d10 && d30 && d60 ? (d30 * d30) / (d10 * d60) : undefined
 
   if (d10 == null && fines > 10) {
-    notes.push(
+    notes.push(warn(
       `The curve does not reach 10% passing (${fines.toFixed(0)}% fines) — D₁₀, Cu and Cc need a hydrometer analysis to complete the grading.`,
-    )
+    ))
   }
   if (cobbles > 0) {
-    notes.push(
+    notes.push(info(
       `${cobbles.toFixed(0)}% is coarser than 75 mm. D2487 classifies the minus-75 mm fraction and reports cobbles and boulders separately.`,
-    )
+    ))
   }
 
   return { rows, gravel, sand, fines, cobbles, d10, d30, d60, cu, cc, massError, notes }

--- a/webapp/src/engine/soils/uscs.test.ts
+++ b/webapp/src/engine/soils/uscs.test.ts
@@ -188,12 +188,12 @@ describe('the result always explains itself', () => {
 describe('data sanity', () => {
   it('notes fractions that do not sum to 100%', () => {
     const r = classifyUSCS({ gravel: 10, sand: 50, fines: 30, liquidLimit: 40, plasticityIndex: 20 })
-    expect(r.notes.join(' ')).toMatch(/sum to 90%/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/sum to 90%/)
   })
 
   it('notes a fine-grained point above the U-line', () => {
     const r = classifyUSCS({ gravel: 0, sand: 10, fines: 90, liquidLimit: 30, plasticityIndex: 30 })
-    expect(r.notes.join(' ')).toMatch(/above the U-line/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/above the U-line/)
   })
 })
 

--- a/webapp/src/engine/soils/uscs.ts
+++ b/webapp/src/engine/soils/uscs.ts
@@ -21,6 +21,8 @@
 // — the module keeps them apart rather than blurring them.
 // ─────────────────────────────────────────────────────────────────────────
 
+import { type LabNote, warn } from './notes'
+
 import { aLine, uLine } from './atterberg'
 import { isWellGraded } from './sieve'
 
@@ -52,7 +54,7 @@ export interface UscsResult {
   coarseGrained: boolean
   /** Why the classification came out as it did, or what is missing. */
   reason: string
-  notes: string[]
+  notes: LabNote[]
 }
 
 /** Fines plot as clay (on/above A-line, PI > 7) rather than silt. */
@@ -74,11 +76,11 @@ function coarseModifier(primary: 'gravel' | 'sand', gravel: number, sand: number
 }
 
 export function classifyUSCS(i: UscsInput): UscsResult {
-  const notes: string[] = []
+  const notes: LabNote[] = []
   const { gravel, sand, fines } = i
   const total = gravel + sand + fines
   if (Math.abs(total - 100) > 1) {
-    notes.push(`Fractions sum to ${total.toFixed(0)}%, not 100% — check the grading before relying on this.`)
+    notes.push(warn(`Fractions sum to ${total.toFixed(0)}%, not 100% — check the grading before relying on this.`))
   }
 
   const coarseGrained = fines < 50
@@ -167,10 +169,10 @@ export function classifyUSCS(i: UscsInput): UscsResult {
 }
 
 function classifyFine(
-  LL: number, PI: number, gravel: number, sand: number, organic: boolean, notes: string[],
+  LL: number, PI: number, gravel: number, sand: number, organic: boolean, notes: LabNote[],
 ): UscsResult {
   if (PI > uLine(LL)) {
-    notes.push('The point plots above the U-line — no natural soil does. Re-run the limits before accepting this classification.')
+    notes.push(warn('The point plots above the U-line — no natural soil does. Re-run the limits before accepting this classification.'))
   }
 
   const high = LL >= 50

--- a/webapp/src/engine/soils/usda.test.ts
+++ b/webapp/src/engine/soils/usda.test.ts
@@ -71,8 +71,8 @@ describe('what it does with fractions that do not sum to 100', () => {
     // with 20% gravel still in it.
     const r = classifyUSDA({ sand: 30, silt: 30, clay: 20 })
     expect(r.composition.sand).toBeCloseTo(37.5, 6)
-    expect(r.notes.join(' ')).toMatch(/rather than 100%/)
-    expect(r.notes.join(' ')).toMatch(/gravel was left in/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/rather than 100%/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/gravel was left in/)
   })
 
   it('refuses an empty composition rather than dividing by zero', () => {
@@ -115,7 +115,7 @@ describe('from a grading curve', () => {
     expect(r.texture).toBe('loam')
     expect(r.name).toBe('very gravelly loam')
     expect(r.gravel).toBeCloseTo(40, 9)
-    expect(r.notes.join(' ')).toMatch(/keeps that out of the triangle/)
+    expect(r.notes.map((n) => n.text).join(' ')).toMatch(/keeps that out of the triangle/)
   })
 
   it('leaves the name alone below 15% gravel', () => {

--- a/webapp/src/engine/soils/usda.ts
+++ b/webapp/src/engine/soils/usda.ts
@@ -37,6 +37,8 @@
 // UNITS: sizes mm; percentages 0–100.
 // ─────────────────────────────────────────────────────────────────────────
 
+import { type LabNote, info, warn } from './notes'
+
 /** The twelve textures of the USDA triangle. */
 export type UsdaTexture =
   | 'sand' | 'loamy sand' | 'sandy loam' | 'loam' | 'silt loam' | 'silt'
@@ -59,7 +61,7 @@ export interface UsdaResult {
   gravel: number
   /** Why this texture and not its neighbours. */
   reason: string
-  notes: string[]
+  notes: LabNote[]
 }
 
 /** USDA size boundaries, mm — named because they differ from every other system. */
@@ -87,13 +89,13 @@ function gravelModifier(gravel: number): string {
  * says it does.
  */
 export function classifyUSDA(c: UsdaComposition): UsdaResult {
-  const notes: string[] = []
+  const notes: LabNote[] = []
   const total = c.sand + c.silt + c.clay
   if (!(total > 0)) throw new Error('Sand, silt and clay must sum to more than zero.')
   if (Math.abs(total - 100) > 1) {
-    notes.push(
+    notes.push(warn(
       `The three fractions sum to ${total.toFixed(1)}% rather than 100%; they have been normalised. A gap this size usually means the gravel was left in, or the hydrometer and sieve were read on different bases.`,
-    )
+    ))
   }
   // Normalise so a caller that passes fractions of the whole sample still lands
   // in the right region rather than off the triangle entirely.
@@ -192,9 +194,9 @@ export function usdaFromPassing(passing: Parameters<typeof usdaFractions>[0]): U
   const r = classifyUSDA(f.composition)
   const prefix = gravelModifier(f.gravel)
   if (prefix) {
-    r.notes.push(
+    r.notes.push(info(
       `${f.gravel.toFixed(0)}% of the whole sample is coarser than 2 mm. USDA keeps that out of the triangle and names it as a modifier, so the texture describes the fine earth only.`,
-    )
+    ))
   }
   return { ...r, gravel: f.gravel, name: prefix + r.texture }
 }

--- a/webapp/src/lib/soilsPdf.ts
+++ b/webapp/src/lib/soilsPdf.ts
@@ -177,6 +177,24 @@ function emitSection(s: ReturnType<typeof createSheet>, sec: ReportSection): voi
     s.y = (s.lastY() ?? s.y) + 5
   }
 
+  // NOTES COME BEFORE THE FIGURES because they annotate the TABLE. A section
+  // with five plots in it pushes its remarks three pages past the rows they
+  // are about, and a warning the reader has to hunt for is a warning that does
+  // not work.
+  //
+  // A note's SEVERITY is drawn, not just stored. An engine warning printed in
+  // the same grey italic as a methodological caveat is a warning nobody reads;
+  // these get the failure colour and a marker so they are findable by eye when
+  // the reader is flicking through the section rather than reading it.
+  for (const n of sec.notes) {
+    const isWarning = n.severity === 'warning'
+    s.setF('sans', isWarning ? 'bold' : 'normal', 7.8, isWarning ? FAIL_FG : MUTED)
+    const lines = doc.splitTextToSize(`${isWarning ? '! ' : '— '}${n.text}`, CONTENT_W) as string[]
+    s.ensure(lines.length * 3.8 + 3)
+    doc.text(lines, M, s.y)
+    s.y += lines.length * 3.8 + 2
+  }
+
   for (const f of sec.figures) {
     const box = { x: M, y: s.y + 4, w: Math.min(CONTENT_W, 150), maxH: 165 }
     const size = paintedSize(f.drawing, box)
@@ -190,14 +208,6 @@ function emitSection(s: ReturnType<typeof createSheet>, sec: ReportSection): voi
     s.setF('sans', 'normal', 7.6, MUTED)
     doc.text(f.caption, PAGE_W / 2, s.y, { align: 'center' })
     s.y += 6
-  }
-
-  for (const n of sec.notes) {
-    s.setF('sans', 'normal', 7.8, MUTED)
-    const lines = doc.splitTextToSize(`— ${n}`, CONTENT_W) as string[]
-    s.ensure(lines.length * 3.8 + 3)
-    doc.text(lines, M, s.y)
-    s.y += lines.length * 3.8 + 2
   }
 }
 

--- a/webapp/src/pages/SoilInvestigation.tsx
+++ b/webapp/src/pages/SoilInvestigation.tsx
@@ -20,6 +20,7 @@ import {
 } from '../engine/soils/lab'
 import { classifySample } from '../engine/soils/classifySample'
 import type { CombinedGrading } from '../engine/soils/grading'
+import type { LabNote } from '../engine/soils/notes'
 import { combinedGradingChart } from '../engine/soils/lab/plots'
 import { labChart } from '../engine/soils/lab/testChart'
 import { buildSection, sectionDrawing } from '../engine/soils/section'
@@ -1292,8 +1293,10 @@ function ClassificationPanel() {
           {result.reason}
         </p>
         {result.notes.map((n, k) => (
-          <p key={k} className="mt-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[11px] text-amber-900">
-            {n}
+          <p key={k} className={n.severity === 'warning'
+            ? 'mt-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[11px] text-amber-900'
+            : 'mt-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-[11px] text-slate-600'}>
+            {n.text}
           </p>
         ))}
         {!result.symbol && (
@@ -1550,9 +1553,7 @@ function TestCard({
               <p className="font-mono text-[13px] font-semibold text-emerald-900">
                 {formatOutcome(summarise(outcome))}
               </p>
-              {outcome.result.notes.map((n, k) => (
-                <p key={k} className="mt-1 text-[10px] text-amber-900">{n}</p>
-              ))}
+              <EngineNotes notes={outcome.result.notes} />
             </div>
           )}
 
@@ -1713,6 +1714,30 @@ function SieveStack({
   )
 }
 
+/**
+ * Engine notes, told apart by severity.
+ *
+ * Every note used to render in the same amber, which is how a real warning
+ * gets skimmed: "this specimen plots above the zero-air-voids curve, which is
+ * impossible" looked exactly like "percentages are of the fine earth". A
+ * warning keeps the amber; a caveat about the method goes quiet.
+ */
+function EngineNotes({ notes, className = '' }: { notes: LabNote[]; className?: string }) {
+  if (!notes.length) return null
+  return (
+    <div className={className}>
+      {notes.map((n, k) => (
+        <p key={k} className={n.severity === 'warning'
+          ? 'mt-1 text-[10px] text-amber-900'
+          : 'mt-1 text-[10px] text-slate-500'}>
+          {n.severity === 'warning' && <span className="font-bold">! </span>}
+          {n.text}
+        </p>
+      ))}
+    </div>
+  )
+}
+
 // ── Sample classification ─────────────────────────────────────────────────
 
 function SampleClassificationCard({
@@ -1786,9 +1811,7 @@ function SampleClassificationCard({
 
       {c.curve?.combined && <CombinedCurve curve={c.curve} />}
 
-      {c.notes.map((n, k) => (
-        <p key={k} className="mt-1 text-[10px] text-amber-900">{n}</p>
-      ))}
+      <EngineNotes notes={c.notes} />
 
       {symbol && layer && (
         layer.symbol === symbol ? (


### PR DESCRIPTION
**Layer 8** (all soils engines) + report + PDF + page.

Every soils engine returned its prose as a flat `string[]`, so nothing downstream could tell these two apart:

> "Every diameter is an EQUIVALENT SPHERICAL diameter: the size of a sphere that would settle at the speed this fraction settled."

> "Mass balance is off by 25% — D6913 requires closure within 1%. Re-weigh before using this grading."

The first is true of every hydrometer ever run. The second says **this result may be wrong**. Printed in the same grey italic, the second is the one that gets skimmed — and until now it never reached the report at all.

## The rule, and why it is written down

`notes.ts` states it, so severity is a judgement made once rather than argued per note:

| | means |
|---|---|
| **warning** | the number beside it may be wrong, unreliable, or absent **because of how this test was run or reported**. There is something to do: re-weigh, re-run, run another test, check an input. |
| **info** | everything else — a convention, what the method can and cannot do, the provenance of a number, or a finding about the soil. Nothing to fix. |

Two consequences are called out in the header because both are counter-intuitive and both are deliberate:

- **A note that always fires is never a warning.** *"Permeability is trusted to within a factor of two or three, not to three significant figures"* matters enormously to how the number is used — and there is nothing about this run to check, so it is `info`. A warning that appears on every test is a `string[]` again with extra steps.
- **Severity is about the result, not about the soil.** *"Natural moisture is above the liquid limit — the soil may be sensitive or quick"* is a hazard, and it is `info`, because the measurement is sound and complete. Soil hazards belong to the parameters and recommendations sections, which reason about behaviour; this field only says how much to trust the number it sits beside.

All **60 notes across 17 engines** are classified **where they are written**. Deciding severity later by matching on wording was tried once (in `classifySample`) and needed a test to hold it in place; doing that sixty times would be a second copy of every engine's judgement, kept in step by hand.

## Where it shows up

- **Report §8** carries every engine warning, each prefixed with the specimen it belongs to, and leaves the info notes out. The sieve's *"a hydrometer would complete this"* is suppressed on the one sample that has a hydrometer — from the single definition `classifySample` already used, exported rather than re-implemented.
- **`ReportSection.notes` is typed too**, and the PDF draws warnings in the failure colour with a `!` marker.
- **Notes now render BEFORE the figures.** A section with five plots in it was pushing its remarks three pages past the rows they annotate, and a warning the reader has to hunt for is a warning that does not work.
- **`/soils`** styles warnings amber and caveats grey. Previously *everything* was amber, which is the same failure in the other direction.

## The guard that keeps `warning` scarce

Not a rule in a comment — the example investigation. Its laboratory data is deliberately well-formed, so:

- one test asserts the **only** warnings it produces are the three sieve stacks that genuinely cannot reach D₁₀;
- a second asserts the caveats are **all still present as info**, so the split was not achieved by quietly deleting notes.

If a future engine starts warning on clean data, the first test fails.

## Verification

In-browser: the lean-clay card carries no amber at all (its one note is a grey caveat) while the silty-sand card shows its `!` warning; the report's §8 prints two red warnings directly beneath the table, named by specimen, with S-02's correctly absent.

Suite **3791 passed**, `tsc -b` and `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmPbtTVsjNBXVpiQVBYBnz)_