### PR TITLE
fix(soils): samples can be added — the laboratory module was unreachable

### DIFF
--- a/webapp/src/engine/soils/model.ts
+++ b/webapp/src/engine/soils/model.ts
@@ -183,6 +183,50 @@ export interface SoilLayer {
 export type SampleType =
   | 'disturbed' | 'undisturbed' | 'split-spoon' | 'shelby-tube' | 'bulk' | 'core'
 
+/**
+ * The sample types, with what each one can answer for — ordered as a driller
+ * would meet them, and carrying `undisturbed` so a UI can warn before a
+ * consolidation test is booked against a split-spoon specimen.
+ *
+ * A list rather than a bare union because a picker has to render one, and a
+ * hand-typed `<option>` list is how a seventh type ends up unselectable.
+ */
+export const SAMPLE_TYPES: readonly {
+  type: SampleType
+  label: string
+  /** Whether the fabric survives recovery — strength and compressibility need it. */
+  undisturbed: boolean
+  /** The sampling standard usually cited for it. */
+  standard?: StandardId
+  hint: string
+}[] = [
+  {
+    type: 'split-spoon', label: 'Split-spoon (SPT)', undisturbed: false, standard: 'd1586',
+    hint: 'Driven with the SPT hammer. Index tests only — the driving destroys the fabric.',
+  },
+  {
+    type: 'shelby-tube', label: 'Shelby tube', undisturbed: true, standard: 'd1587',
+    hint: 'Pushed thin-wall tube. The usual source for consolidation and triaxial specimens.',
+  },
+  {
+    type: 'undisturbed', label: 'Undisturbed (other)', undisturbed: true,
+    hint: 'Block or piston sample where the fabric is preserved by another means.',
+  },
+  {
+    type: 'disturbed', label: 'Disturbed', undisturbed: false,
+    hint: 'Cuttings or a bag sample. Water content, gradation and Atterberg limits only.',
+  },
+  {
+    type: 'bulk', label: 'Bulk', undisturbed: false,
+    hint: 'Large disturbed sample, for compaction and CBR where a remoulded specimen is the point.',
+  },
+  {
+    type: 'core', label: 'Rock core', undisturbed: true, standard: 'd2113',
+    hint: 'Rotary-cored rock. Logged with RQD rather than an SPT count.',
+  },
+]
+
+
 export interface Sample {
   id: string
   /** Sample designation on the log, e.g. 'S-03'. */

--- a/webapp/src/engine/soils/sampleTypes.test.ts
+++ b/webapp/src/engine/soils/sampleTypes.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { SAMPLE_TYPES, type SampleType } from './model'
+import { STANDARDS } from './standards'
+
+// ─────────────────────────────────────────────────────────────────────────
+// The picker list is what a UI renders, so a type missing from it is a type
+// nobody can choose — which is the defect this whole change fixes, in
+// miniature. These pin the list against the union it claims to cover.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('the sample-type catalogue', () => {
+  it('covers every SampleType exactly once', () => {
+    const all: SampleType[] = ['disturbed', 'undisturbed', 'split-spoon', 'shelby-tube', 'bulk', 'core']
+    expect(SAMPLE_TYPES.map((t) => t.type).slice().sort()).toEqual([...all].sort())
+  })
+
+  it('cites only standards the catalogue knows', () => {
+    for (const t of SAMPLE_TYPES) {
+      if (t.standard) expect(STANDARDS[t.standard], t.type).toBeDefined()
+    }
+  })
+
+  it('marks exactly the types whose fabric survives recovery', () => {
+    // The distinction decides whether a consolidation or triaxial specimen can
+    // be cut from the sample at all — a driven split-spoon has already sheared
+    // the soil it recovered.
+    const undisturbed = SAMPLE_TYPES.filter((t) => t.undisturbed).map((t) => t.type).slice().sort()
+    expect(undisturbed).toEqual(['core', 'shelby-tube', 'undisturbed'])
+  })
+
+  it('gives every type a label and a hint worth reading', () => {
+    for (const t of SAMPLE_TYPES) {
+      expect(t.label.length, t.type).toBeGreaterThan(3)
+      expect(t.hint.length, t.type).toBeGreaterThan(30)
+    }
+  })
+})

--- a/webapp/src/engine/soils/standards.ts
+++ b/webapp/src/engine/soils/standards.ts
@@ -137,6 +137,10 @@ export const STANDARDS = {
     designation: 'ASTM D1587', body: 'ASTM', category: 'field',
     title: 'Thin-Walled Tube Sampling of Fine-Grained Soils for Geotechnical Purposes',
   },
+  d2113: {
+    designation: 'ASTM D2113', body: 'ASTM', category: 'field',
+    title: 'Rock Core Drilling and Sampling of Rock for Site Exploration',
+  },
   d2573: {
     designation: 'ASTM D2573', body: 'ASTM', category: 'field',
     title: 'Field Vane Shear Test in Saturated Fine-Grained Soils',

--- a/webapp/src/pages/SoilInvestigation.tsx
+++ b/webapp/src/pages/SoilInvestigation.tsx
@@ -27,7 +27,7 @@ import { buildSection, sectionDrawing } from '../engine/soils/section'
 import {
   processSounding, sbtProfile, relativeDensity, frictionAngle, undrainedStrength,
 } from '../engine/soils/cpt'
-import { layerThickness as _lt } from '../engine/soils/model'
+import { layerThickness as _lt, SAMPLE_TYPES, layerAtDepth } from '../engine/soils/model'
 import { liquefactionProfile } from '../engine/soils/liquefaction'
 import { liquefactionChart, skipText } from '../engine/soils/liquefactionPlot'
 import { finesByLayer, finesMap } from '../engine/soils/finesContent'
@@ -121,6 +121,98 @@ function LayerRow({
         <input value={layer.description ?? ''}
           onChange={(e) => onChange({ description: e.target.value || undefined })}
           className="w-full min-w-[12rem] rounded border border-slate-200 px-1 py-0.5" />
+      </td>
+      <td className="py-0.5 text-right">
+        <button onClick={onRemove} className="rounded px-1.5 py-0.5 text-[11px] text-red-600 hover:bg-red-50">
+          remove
+        </button>
+      </td>
+    </tr>
+  )
+}
+
+/** A standard SPT drive, m — the default length of a new split-spoon sample. */
+const SPT_DRIVE = 0.45
+
+/**
+ * One editable sample row.
+ *
+ * WHY THIS EXISTS AT ALL: until now samples could only arrive with the bundled
+ * example. A borehole built from scratch had `samples: []` and no way to add to
+ * it, so the Laboratory tab — and with it every lab engine, the classification
+ * and §8 of the report — was unreachable for a real investigation.
+ *
+ * The layer column is a PICKER, not free text, and defaults from the sample's
+ * mid-depth. An unattributed sample still classifies, but its symbol has no
+ * stratum to be applied to, which is most of the value.
+ */
+function SampleRow({
+  sample, layers, onChange, onRemove,
+}: {
+  sample: Sample
+  layers: SoilLayer[]
+  onChange: (patch: Partial<Sample>) => void
+  onRemove: () => void
+}) {
+  const rec = recoveryRatio(sample)
+  const spec = SAMPLE_TYPES.find((t) => t.type === sample.type)
+  // A strength or compressibility test needs an intact fabric. Flagging it on
+  // the row is cheaper than letting the validator find it later.
+  const disturbedWithUndisturbedTest = spec && !spec.undisturbed
+    && sample.tests.some((t) => t.type === 'consolidation' || t.type === 'triaxial' || t.type === 'ucs')
+
+  return (
+    <tr className="border-b border-slate-100">
+      <td className="py-0.5 pr-2">
+        <input value={sample.name} onChange={(e) => onChange({ name: e.target.value })}
+          className="w-20 rounded border border-slate-200 px-1 py-0.5 font-mono" />
+      </td>
+      <td className="py-0.5 pr-2">
+        <select value={sample.type} title={spec?.hint}
+          onChange={(e) => {
+            const next = SAMPLE_TYPES.find((t) => t.type === e.target.value)!
+            onChange({ type: next.type, standard: next.standard })
+          }}
+          className="rounded border border-slate-200 px-1 py-0.5">
+          {SAMPLE_TYPES.map((t) => <option key={t.type} value={t.type}>{t.label}</option>)}
+        </select>
+      </td>
+      <td className="py-0.5 pr-2">
+        <input type="number" step="0.1" value={sample.depthTop}
+          onChange={(e) => onChange({ depthTop: num(e.target.value) })}
+          className="w-16 rounded border border-slate-200 px-1 py-0.5 text-right font-mono" />
+      </td>
+      <td className="py-0.5 pr-2">
+        <input type="number" step="0.1" value={sample.depthBottom}
+          onChange={(e) => onChange({ depthBottom: num(e.target.value) })}
+          className="w-16 rounded border border-slate-200 px-1 py-0.5 text-right font-mono" />
+      </td>
+      <td className="py-0.5 pr-2">
+        <input type="number" step="0.01" value={sample.recoveryLength ?? ''} placeholder="—"
+          onChange={(e) => onChange({ recoveryLength: e.target.value === '' ? undefined : num(e.target.value) })}
+          className="w-16 rounded border border-slate-200 px-1 py-0.5 text-right font-mono" />
+      </td>
+      <td className="py-0.5 pr-2">
+        <input type="number" step="0.01" value={sample.driveLength ?? ''} placeholder="—"
+          onChange={(e) => onChange({ driveLength: e.target.value === '' ? undefined : num(e.target.value) })}
+          className="w-16 rounded border border-slate-200 px-1 py-0.5 text-right font-mono" />
+      </td>
+      <td className={`py-0.5 pr-2 text-right font-mono ${rec != null && rec < 50 ? 'text-amber-700' : 'text-slate-500'}`}>
+        {rec == null ? '—' : `${f0(rec)} %`}
+      </td>
+      <td className="py-0.5 pr-2">
+        <select value={sample.layerId ?? ''}
+          onChange={(e) => onChange({ layerId: e.target.value || undefined })}
+          className="max-w-[9rem] rounded border border-slate-200 px-1 py-0.5">
+          <option value="">— unattributed —</option>
+          {layers.map((l) => <option key={l.id} value={l.id}>{l.name}</option>)}
+        </select>
+      </td>
+      <td className="py-0.5 pr-2 text-[11px] text-slate-600">
+        {sample.tests.length ? `${sample.tests.length} booked` : '—'}
+        {disturbedWithUndisturbedTest && (
+          <span className="ml-1 font-bold text-amber-700" title="Strength and compressibility need an undisturbed specimen.">!</span>
+        )}
       </td>
       <td className="py-0.5 text-right">
         <button onClick={onRemove} className="rounded px-1.5 py-0.5 text-[11px] text-red-600 hover:bg-red-50">
@@ -497,36 +589,61 @@ export default function SoilInvestigation() {
           </div>
 
           <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-            <h2 className="mb-2 text-[1.05rem] font-bold text-[#0056b3]">Samples</h2>
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-[1.05rem] font-bold text-[#0056b3]">{bh.name} — samples</h2>
+              <button
+                onClick={() => set((d) => {
+                  const hole = d.boreholes[holeIdx]
+                  // Start where the last sample ended, or at the top of the hole
+                  // — a driller works down, and a new row at 0 m every time is a
+                  // depth the user has to retype on every sample.
+                  const last = hole.samples[hole.samples.length - 1]
+                  const top = last ? last.depthBottom : 0
+                  const bottom = top + SPT_DRIVE
+                  hole.samples.push({
+                    id: `s_${Date.now().toString(36)}`,
+                    name: `S-${String(hole.samples.length + 1).padStart(2, '0')}`,
+                    type: 'split-spoon', standard: 'd1586',
+                    depthTop: top, depthBottom: bottom,
+                    // Attributed by DEPTH rather than left blank: the layer is
+                    // knowable from the log, and an unattributed sample cannot
+                    // push its classification back onto a stratum.
+                    layerId: layerAtDepth(hole, (top + bottom) / 2)?.id,
+                    tests: [],
+                  })
+                })}
+                className="rounded-md border border-dashed border-slate-300 px-2.5 py-1 text-[12px] text-slate-600 hover:bg-slate-50">
+                + sample
+              </button>
+            </div>
             <div className="overflow-x-auto">
               <table className="w-full text-left text-[12px]">
                 <thead className="text-slate-500">
                   <tr className="border-b border-slate-200">
-                    <th className="py-1 pr-3">Sample</th><th className="py-1 pr-3">Type</th>
-                    <th className="py-1 pr-3">Depth (m)</th><th className="py-1 pr-3 text-right">Recovery</th>
-                    <th className="py-1 pr-3">Tests</th>
+                    <th className="py-1 pr-2">Sample</th><th className="py-1 pr-2">Type</th>
+                    <th className="py-1 pr-2">Top (m)</th><th className="py-1 pr-2">Base (m)</th>
+                    <th className="py-1 pr-2">Rec. (m)</th><th className="py-1 pr-2">Drive (m)</th>
+                    <th className="py-1 pr-2 text-right">Recovery</th>
+                    <th className="py-1 pr-2">Layer</th><th className="py-1 pr-2">Tests</th><th />
                   </tr>
                 </thead>
-                <tbody className="font-mono">
-                  {bh.samples.map((s) => (
-                    <tr key={s.id} className="border-b border-slate-100">
-                      <td className="py-0.5 pr-3">{s.name}</td>
-                      <td className="py-0.5 pr-3">{s.type}</td>
-                      <td className="py-0.5 pr-3">{f2(s.depthTop)}–{f2(s.depthBottom)}</td>
-                      <td className="py-0.5 pr-3 text-right">
-                        {recoveryRatio(s) == null ? '—' : `${f0(recoveryRatio(s))} %`}
-                      </td>
-                      <td className="py-0.5 pr-3 font-sans">
-                        {s.tests.length
-                          ? s.tests.map((t) => `${t.type}${t.status === 'complete' ? '' : ` (${t.status})`}`).join(', ')
-                          : '—'}
-                      </td>
-                    </tr>
+                <tbody>
+                  {bh.samples.map((s, i) => (
+                    <SampleRow key={s.id} sample={s} layers={bh.layers}
+                      onChange={(patch) => set((d) => {
+                        Object.assign(d.boreholes[holeIdx].samples[i], patch)
+                      })}
+                      onRemove={() => set((d) => { d.boreholes[holeIdx].samples.splice(i, 1) })} />
                   ))}
                 </tbody>
               </table>
             </div>
-            {!bh.samples.length && <p className="mt-3 text-[12px] text-slate-500">No samples recorded.</p>}
+            {!bh.samples.length && (
+              <p className="mt-3 text-[12px] text-slate-500">
+                No samples recorded. Add one here first — laboratory tests are booked against a
+                SAMPLE, not a layer, so the Laboratory tab stays empty until a sample exists.
+              </p>
+            )}
           </div>
         </section>
       )}


### PR DESCRIPTION
Reported as "I tried to create a soil investigation from scratch but it was hard, I don't know how to add soil samples." It is not a discoverability problem. **There was no way to add a sample.**

`samples.push` appeared nowhere in the UI. A borehole created from scratch got `samples: []` and stayed that way forever. The Profile tab rendered a **read-only** samples table that could only ever say *"No samples recorded"*, and the Laboratory tab correctly explained that tests are booked against a sample rather than a layer — while offering nothing that could create one.

**So for any investigation not loaded from the bundled example, the entire laboratory module was unreachable:** 13 lab engines, the USCS/AASHTO/USDA classification, the combined grading curve, and §8 of the report, all behind a button that did not exist.

## The fix

The Profile tab's samples table is now editable, with **`+ sample`** beside the existing `+ layer`:

| column | behaviour |
|---|---|
| Sample | free text, defaults `S-01`, `S-02`, … |
| Type | picker over all six types, with a hint on each |
| Top / Base | starts where the last sample ended, default 0.45 m — a standard SPT drive |
| Rec. / Drive | optional; recovery ratio computes and turns amber below 50% |
| Layer | picker, **defaulted from the sample's mid-depth** |
| Tests | count, with a marker when the booking is a category error |

Two decisions worth naming:

**The layer is attributed by depth, not left blank.** An unattributed sample still classifies, but its symbol has no stratum to be applied to — which is most of the value, since applying it is what turns a lab result into a logged layer.

**A new sample starts where the last one ended.** A driller works down the hole; a row that appears at 0 m every time is a depth the user retypes on every sample.

## Also

`SAMPLE_TYPES` moves the six types out of the bare union and into the model as a catalogue carrying a label, the sampling standard, a hint, and whether the fabric survives recovery. A hand-typed `<option>` list is exactly how a seventh type ends up unselectable — the same class of defect as this bug. The row uses `undisturbed` to flag a consolidation, triaxial or UCS test booked against a split-spoon or bag sample, which is a category error the validator would otherwise catch much later.

Adds ASTM D2113 (rock core drilling) to the standards catalogue, cited by the `core` sample type.

## Verification

Driven in a headless browser **from scratch with `localStorage` cleared**, which is the state the bug was reported in:

new investigation → `+ borehole` → `+ layer` → `+ sample` → Laboratory tab lists **`S-01 0.00–0.45 m · split-spoon`** → `+ add a test…` → sieve → result card renders. No console errors.

`sampleTypes.test.ts` pins the catalogue against the `SampleType` union, so a type added to one and not the other fails the build. Suite **3796 passed**, `tsc -b` and `lint` clean.

**Next, separately:** the guided walkthrough that was also asked for. It is a second PR because it depends on this one — a tour whose fifth step points at `+ sample` needs the button to exist first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmPbtTVsjNBXVpiQVBYBnz)_