### PR TITLE
feat(soils): a step-by-step walkthrough that takes over the screen

### DIFF
--- a/webapp/src/components/GuidedTour.tsx
+++ b/webapp/src/components/GuidedTour.tsx
@@ -1,0 +1,179 @@
+// ─────────────────────────────────────────────────────────────────────────
+// A spotlight walkthrough that takes over the screen. Generic — it knows
+// nothing about soils, only about steps, anchors and tabs.
+//
+// HOW IT POINTS AT THINGS. Each step names a `data-tour` value; the overlay
+// measures that element and cuts a hole in the dimmer over it. Measuring on
+// every step (and on resize/scroll) rather than once is what keeps the hole on
+// target when switching tabs changes the layout underneath.
+//
+// AN ANCHOR THAT IS NOT THERE MUST NOT BREAK THE TOUR. A step whose element is
+// missing — a panel that needs data the user has not entered yet — degrades to
+// a centred card with the same words, rather than a spotlight over the corner
+// of the page or a crash mid-walkthrough. The tour is the thing a stuck user
+// reaches for, so it has to be the most robust screen in the app.
+//
+// It scrolls the anchor into view, traps Escape, and restores nothing else:
+// the tour never edits data, so leaving it at any point is always safe.
+// ─────────────────────────────────────────────────────────────────────────
+
+import { useCallback, useEffect, useState } from 'react'
+
+export interface TourStepView {
+  id: string
+  anchor?: string
+  title: string
+  body: string
+  why?: string
+}
+
+interface Rect { top: number; left: number; width: number; height: number }
+
+const PAD = 6
+
+export function GuidedTour({
+  step, index, total, onNext, onPrev, onClose,
+}: {
+  step: TourStepView
+  index: number
+  total: number
+  onNext: () => void
+  onPrev: () => void
+  onClose: () => void
+}) {
+  const [rect, setRect] = useState<Rect | null>(null)
+
+  const measure = useCallback(() => {
+    if (!step.anchor) { setRect(null); return }
+    const el = document.querySelector(`[data-tour="${step.anchor}"]`)
+    if (!el) { setRect(null); return }
+    const r = el.getBoundingClientRect()
+    // A zero-sized anchor is a hidden one; treat it as absent rather than
+    // spotlighting a point.
+    if (r.width < 1 || r.height < 1) { setRect(null); return }
+    setRect({ top: r.top - PAD, left: r.left - PAD, width: r.width + PAD * 2, height: r.height + PAD * 2 })
+  }, [step.anchor])
+
+  // Measured on the NEXT FRAME rather than synchronously: switching step also
+  // switches tab, and measuring before that paint reads the previous tab's
+  // geometry and puts the hole over the wrong element. The second pass covers
+  // the smooth scroll settling.
+  useEffect(() => {
+    document.querySelector(`[data-tour="${step.anchor}"]`)
+      ?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    const raf = requestAnimationFrame(measure)
+    const t = setTimeout(measure, 320)
+    return () => { cancelAnimationFrame(raf); clearTimeout(t) }
+  }, [measure, step.anchor])
+
+  useEffect(() => {
+    window.addEventListener('resize', measure)
+    window.addEventListener('scroll', measure, true)
+    return () => {
+      window.removeEventListener('resize', measure)
+      window.removeEventListener('scroll', measure, true)
+    }
+  }, [measure])
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+      else if (e.key === 'ArrowRight' || e.key === 'Enter') onNext()
+      else if (e.key === 'ArrowLeft') onPrev()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose, onNext, onPrev])
+
+  const last = index >= total - 1
+
+  /** Rough card height, for placement only — the card is clamped either way. */
+  const CARD_H = 280
+
+  // The card goes under the spotlight when there is room below it and above it
+  // when there is not: a card covering the thing it describes is worse than no
+  // card. Then it is CLAMPED into the viewport, because an anchor taller than
+  // the screen (a whole panel) otherwise pushes the card off the top and the
+  // walkthrough becomes unreadable at exactly the step that needed it.
+  const cardTop = (() => {
+    if (!rect) return null
+    const below = rect.top + rect.height + 12
+    const above = rect.top - CARD_H - 12
+    const preferred = below + CARD_H < window.innerHeight - 16 ? below
+      : above > 16 ? above
+        : below
+    return Math.min(Math.max(preferred, 16), Math.max(window.innerHeight - CARD_H - 16, 16))
+  })()
+
+  return (
+    <div className="fixed inset-0 z-[100]" role="dialog" aria-modal="true" aria-label="Guided walkthrough">
+      {/* Dimmer with a hole. Four panels rather than an SVG mask so the cut-out
+          stays crisp at any zoom and the anchor underneath is still clickable. */}
+      {rect ? (
+        <>
+          <div className="absolute left-0 right-0 top-0 bg-slate-900/55" style={{ height: Math.max(rect.top, 0) }} onClick={onClose} />
+          <div className="absolute left-0 bg-slate-900/55" style={{ top: rect.top, width: Math.max(rect.left, 0), height: rect.height }} onClick={onClose} />
+          <div className="absolute right-0 bg-slate-900/55" style={{ top: rect.top, left: rect.left + rect.width, height: rect.height }} onClick={onClose} />
+          <div className="absolute bottom-0 left-0 right-0 bg-slate-900/55" style={{ top: rect.top + rect.height }} onClick={onClose} />
+          <div
+            className="pointer-events-none absolute rounded-lg ring-2 ring-[#0056b3] ring-offset-2 ring-offset-transparent"
+            style={{ top: rect.top, left: rect.left, width: rect.width, height: rect.height }} />
+        </>
+      ) : (
+        <div className="absolute inset-0 bg-slate-900/55" onClick={onClose} />
+      )}
+
+      <div
+        className={`absolute w-[min(26rem,calc(100vw-2rem))] rounded-xl border border-slate-200 bg-white p-4 shadow-2xl ${
+          rect ? '' : 'left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2'}`}
+        style={{
+          maxHeight: 'calc(100vh - 2rem)',
+          overflowY: 'auto',
+          ...(rect ? {
+            top: cardTop ?? undefined,
+            left: Math.min(Math.max(rect.left, 16), Math.max(window.innerWidth - 432, 16)),
+          } : {}),
+        }}>
+        <p className="text-[10px] font-bold uppercase tracking-[0.14em] text-slate-400">
+          Step {index + 1} of {total}
+        </p>
+        <h2 className="mt-1 text-[15px] font-bold text-[#0056b3]">{step.title}</h2>
+        <p className="mt-1.5 text-[12.5px] leading-relaxed text-slate-700">{step.body}</p>
+        {step.why && <p className="mt-2 text-[11px] leading-relaxed text-slate-500">{step.why}</p>}
+
+        {/* The step names a control that is not on screen. Saying so beats a
+            centred card that reads as though the tour lost its place — the
+            control usually appears once the PREVIOUS step has been done. */}
+        {!rect && step.anchor && (
+          <p className="mt-2 rounded-md border border-amber-200 bg-amber-50 px-2 py-1.5 text-[11px] text-amber-900">
+            This control is not on screen yet — it appears once the previous step has been done.
+          </p>
+        )}
+
+        <div className="mt-3 flex items-center justify-between gap-2">
+          <button onClick={onClose} className="text-[11px] text-slate-500 hover:text-slate-800">
+            Close (Esc)
+          </button>
+          <div className="flex gap-2">
+            {index > 0 && (
+              <button onClick={onPrev}
+                className="rounded-md border border-slate-300 px-2.5 py-1 text-[12px] text-slate-700 hover:bg-slate-50">
+                Back
+              </button>
+            )}
+            <button onClick={last ? onClose : onNext}
+              className="rounded-md bg-[#0056b3] px-3 py-1 text-[12px] font-semibold text-white hover:bg-[#004a99]">
+              {last ? 'Done' : 'Next'}
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-3 flex gap-1">
+          {Array.from({ length: total }, (_, i) => (
+            <span key={i} className={`h-1 flex-1 rounded-full ${i <= index ? 'bg-[#0056b3]' : 'bg-slate-200'}`} />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/webapp/src/lib/soilsTour.test.ts
+++ b/webapp/src/lib/soilsTour.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { SOILS_TOUR, TOUR_ANCHORS, stepAt, nextIndex, prevIndex, isLast } from './soilsTour'
+
+// ─────────────────────────────────────────────────────────────────────────
+// A walkthrough is the screen a STUCK user reaches for, so its failure mode
+// matters more than most: a step pointing at an element that no longer exists
+// leaves a dimmed page and a card describing a button nobody can see.
+//
+// Anchors are matched against the page SOURCE rather than a rendered DOM.
+// That is deliberate — the anchors live on elements behind tab conditions and
+// empty-state guards, so half of them are absent from any single render, and
+// a render-based test would either pass vacuously or need the whole page
+// driven through nine tabs to say something a grep says exactly.
+// ─────────────────────────────────────────────────────────────────────────
+
+// Read through Vite's `?raw` glob, as `trialQuota.test.ts` and
+// `solverCoverage.test.ts` already do — `node:fs` is not in this tsconfig's
+// types, and a test that only `vitest` can compile is a test `tsc -b` cannot
+// defend.
+const PAGE = Object.values(
+  import.meta.glob('../pages/SoilInvestigation.tsx', { query: '?raw', import: 'default', eager: true }) as Record<string, string>,
+)[0]
+
+describe('every step points at something that exists', () => {
+  it('has a data-tour attribute in the page for each anchor', () => {
+    const missing = TOUR_ANCHORS.filter((a) => !PAGE.includes(`data-tour="${a}"`))
+    expect(missing, `anchors with no element: ${missing.join(', ')}`).toEqual([])
+  })
+
+  it('does not leave an anchor in the page that no step uses', () => {
+    // The other direction: a stale attribute is harmless but misleading to the
+    // next person deciding whether it is safe to delete.
+    const inPage = [...PAGE.matchAll(/data-tour="([^"]+)"/g)].map((m) => m[1])
+    const orphans = inPage.filter((a) => !TOUR_ANCHORS.includes(a))
+    expect(orphans, `anchors no step uses: ${orphans.join(', ')}`).toEqual([])
+  })
+
+  it('names only tabs the page actually has', () => {
+    const tabs = new Set(SOILS_TOUR.map((s) => s.tab))
+    for (const t of tabs) expect(PAGE, t).toContain(`tab === '${t}'`)
+  })
+})
+
+describe('the walkthrough covers the order that trips people up', () => {
+  it('reaches the sample step before the laboratory step', () => {
+    // The whole reason the tour exists: tests are booked against a SAMPLE, and
+    // the control for it is two tabs away from where a user looks for it.
+    const sample = SOILS_TOUR.findIndex((s) => s.id === 'sample')
+    const lab = SOILS_TOUR.findIndex((s) => s.id === 'lab')
+    expect(sample).toBeGreaterThan(-1)
+    expect(lab).toBeGreaterThan(sample)
+  })
+
+  it('walks the dependency order: borehole → layer → sample', () => {
+    const at = (id: string) => SOILS_TOUR.findIndex((s) => s.id === id)
+    expect(at('borehole')).toBeLessThan(at('layers'))
+    expect(at('layers')).toBeLessThan(at('sample'))
+  })
+
+  it('gives every step a title and a body worth reading', () => {
+    for (const s of SOILS_TOUR) {
+      expect(s.title.length, s.id).toBeGreaterThan(8)
+      expect(s.body.length, s.id).toBeGreaterThan(40)
+    }
+  })
+
+  it('uses each step id once', () => {
+    expect(new Set(SOILS_TOUR.map((s) => s.id)).size).toBe(SOILS_TOUR.length)
+  })
+})
+
+describe('navigation stops at the ends rather than wrapping', () => {
+  it('clamps forwards and backwards', () => {
+    expect(prevIndex(0)).toBe(0)
+    expect(nextIndex(SOILS_TOUR.length - 1)).toBe(SOILS_TOUR.length - 1)
+    expect(nextIndex(0)).toBe(1)
+    expect(prevIndex(3)).toBe(2)
+  })
+
+  it('reports the last step, so the button can read Done', () => {
+    expect(isLast(SOILS_TOUR.length - 1)).toBe(true)
+    expect(isLast(0)).toBe(false)
+  })
+
+  it('never returns undefined for an out-of-range index', () => {
+    expect(stepAt(-5)).toBe(SOILS_TOUR[0])
+    expect(stepAt(999)).toBe(SOILS_TOUR[SOILS_TOUR.length - 1])
+  })
+})

--- a/webapp/src/lib/soilsTour.ts
+++ b/webapp/src/lib/soilsTour.ts
@@ -1,0 +1,142 @@
+// ─────────────────────────────────────────────────────────────────────────
+// The guided walkthrough for /soils, as DATA. Layer: view-support.
+//
+// The soil-investigation page is the widest form in the app — nine tabs, and a
+// dependency order that is obvious once you know it and invisible before:
+//
+//     borehole → layer → SAMPLE → laboratory test → classification → report
+//
+// The step that hides is the sample. Laboratory tests are booked against a
+// SAMPLE, not a layer, so a user who logs strata and goes straight to the
+// Laboratory tab finds it empty with nothing on that tab to fix it — the
+// control they need is two tabs back, under Profile. That is the walkthrough's
+// reason for existing, and why the sample step spends the most words.
+//
+// THE STEPS ARE DATA, NOT JSX. Each names a DOM anchor (`data-tour="…"`) and
+// the tab it lives on, so the tour component is a generic spotlight with no
+// knowledge of soils, and this list can be tested without rendering anything.
+// A step whose anchor has been renamed away is caught by `soilsTour.test.ts`
+// against the page source rather than discovered by a user staring at an
+// overlay pointing into empty space.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** The tabs of the soil-investigation page a step can require. */
+export type TourTab =
+  | 'overview' | 'boreholes' | 'profile' | 'spt' | 'cpt'
+  | 'lab' | 'liquefaction' | 'classification' | 'parameters'
+
+export interface TourStep {
+  id: string
+  /** Tab that must be showing for the anchor to exist. */
+  tab: TourTab
+  /** `data-tour` value of the element to spotlight. Absent ⇒ centre the card. */
+  anchor?: string
+  title: string
+  /** What to do here, in one or two sentences. */
+  body: string
+  /** Why it works this way — shown smaller. Omit when the title says it all. */
+  why?: string
+}
+
+export const SOILS_TOUR: readonly TourStep[] = [
+  {
+    id: 'start',
+    tab: 'overview',
+    anchor: 'header-actions',
+    title: 'An investigation is built in one order',
+    body: 'Borehole → strata → sample → laboratory test → classification → report. Each step needs the one before it, so the tabs are worked left to right rather than picked at random.',
+    why: 'You can leave at any point with Esc; nothing here changes your data.',
+  },
+  {
+    id: 'meta',
+    tab: 'overview',
+    anchor: 'meta-card',
+    title: 'Name the investigation',
+    body: 'Give it a reference and a project name. These print on every page of the report and on the cover.',
+  },
+  {
+    id: 'borehole',
+    tab: 'boreholes',
+    anchor: 'add-borehole',
+    title: 'Add a borehole',
+    body: 'Add the hole, then set the depth it was drilled to and the depth to groundwater. Every layer, sample and blow count hangs off a hole.',
+    why: 'The termination depth is used to check that nothing is logged below the bottom of the hole.',
+  },
+  {
+    id: 'layers',
+    tab: 'profile',
+    anchor: 'add-layer',
+    title: 'Log the strata',
+    body: 'Add one layer per stratum, top and base depth first. Leave the USCS symbol blank — classifying a sample later fills it in for you.',
+    why: 'A guessed symbol is worse than a blank one: the report distinguishes “not classified” from “classified as”.',
+  },
+  {
+    id: 'sample',
+    tab: 'profile',
+    anchor: 'add-sample',
+    title: 'Add a sample — this is the step that catches people',
+    body: 'Laboratory tests are booked against a SAMPLE, not a layer, so nothing can be tested until one exists. Add it here, on the Profile tab, and set its depth and type.',
+    why: 'A split-spoon is driven and its fabric is destroyed — index tests only. Consolidation and triaxial need a Shelby tube or another undisturbed sample.',
+  },
+  {
+    id: 'sample-layer',
+    tab: 'profile',
+    anchor: 'samples-table',
+    title: 'Attribute the sample to a layer',
+    body: 'The Layer column defaults from the sample’s depth. Keep it set — it is what lets a classification be pushed back onto the stratum.',
+  },
+  {
+    id: 'lab',
+    tab: 'lab',
+    anchor: 'lab-panel',
+    title: 'Book a laboratory test',
+    body: 'Each sample gets an “+ add a test…” picker. Choose a test, then type the readings the apparatus gave — masses, dial gauges, times — and the result computes as you go.',
+    why: 'Measurements are stored, results are computed. That is what lets a corrected method re-derive every past result.',
+  },
+  {
+    id: 'classify',
+    tab: 'lab',
+    anchor: 'lab-panel',
+    title: 'Classify, and apply the symbol',
+    body: 'A sieve plus Atterberg limits gives a USCS symbol, an AASHTO group and — with a hydrometer — a USDA texture. Use the button on the classification card to apply the symbol to the layer.',
+  },
+  {
+    id: 'spt',
+    tab: 'spt',
+    anchor: 'spt-panel',
+    title: 'Enter the blow counts',
+    body: 'Record all three 150 mm increments per test. N₆₀ and (N₁)₆₀ are corrected from them for hammer energy, hole diameter, sampler and rod length.',
+    why: 'Storing all three increments is what makes the seating drive discardable and the correction re-derivable.',
+  },
+  {
+    id: 'parameters',
+    tab: 'parameters',
+    anchor: 'parameters-panel',
+    title: 'Check the design parameters',
+    body: 'Each parameter shows whether it was MEASURED in the laboratory, DERIVED, CORRELATED from field testing, or ASSUMED. A measurement always beats a correlation.',
+  },
+  {
+    id: 'report',
+    tab: 'overview',
+    anchor: 'report-button',
+    title: 'Generate the report',
+    body: 'The PDF assembles all 22 sections. Sections with nothing behind them are still printed, saying what would be needed — so a reader can tell “no liquefaction risk” from “never assessed”.',
+  },
+]
+
+/** Step at an index, clamped. Returns undefined only for an empty tour. */
+export const stepAt = (i: number): TourStep | undefined =>
+  SOILS_TOUR[Math.min(Math.max(i, 0), SOILS_TOUR.length - 1)]
+
+/** Next index, stopping at the end rather than wrapping. */
+export const nextIndex = (i: number): number => Math.min(i + 1, SOILS_TOUR.length - 1)
+
+/** Previous index, stopping at the start. */
+export const prevIndex = (i: number): number => Math.max(i - 1, 0)
+
+/** True when this index is the last step, so the button reads “Done”. */
+export const isLast = (i: number): boolean => i >= SOILS_TOUR.length - 1
+
+/** Every distinct anchor the tour points at — used by the test and the page. */
+export const TOUR_ANCHORS: readonly string[] =
+  [...new Set(SOILS_TOUR.map((s) => s.anchor).filter((a): a is string => Boolean(a)))]

--- a/webapp/src/pages/SoilInvestigation.tsx
+++ b/webapp/src/pages/SoilInvestigation.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
+import { GuidedTour } from '../components/GuidedTour'
+import { SOILS_TOUR, nextIndex, prevIndex } from '../lib/soilsTour'
 import { useInvestigation } from '../lib/useInvestigation'
 import { useSoilsSync } from '../lib/useSoilsSync'
 import { buildBoreholeLog } from '../engine/soils/logRenderer'
@@ -245,6 +247,11 @@ export default function SoilInvestigation() {
   const api = useInvestigation()
   const { investigation: inv } = api
   const [tab, setTab] = useState<Tab>('overview')
+  // The walkthrough. `tourAt` is an index into SOILS_TOUR; the step's own `tab`
+  // drives the page, so advancing the tour navigates for the user rather than
+  // telling them to navigate.
+  const [tourOn, setTourOn] = useState(false)
+  const [tourAt, setTourAt] = useState(0)
   const [holeIdx, setHoleIdx] = useState(0)
   // Design earthquake, shared between the liquefaction tab and the report.
   // Undefined until the engineer enters one — the report then states that
@@ -338,7 +345,11 @@ export default function SoilInvestigation() {
         {inv.meta.site.location ? ` · ${inv.meta.site.location}` : ''}
       </p>
 
-      <div className="mt-4 flex flex-wrap items-center gap-2">
+      <div className="mt-4 flex flex-wrap items-center gap-2" data-tour="header-actions">
+        <button onClick={() => { setTourAt(0); setTab(SOILS_TOUR[0].tab as Tab); setTourOn(true) }}
+          className="rounded-md border border-[#0056b3] px-2.5 py-1 text-[12px] font-semibold text-[#0056b3] hover:bg-[#0056b3]/5">
+          Step-by-step guide
+        </button>
         <button onClick={() => api.newInvestigation()}
           className="rounded-md border border-slate-300 px-2.5 py-1 text-[12px] font-medium text-slate-700 hover:bg-slate-50">
           New
@@ -372,7 +383,8 @@ export default function SoilInvestigation() {
               preparedBy: inv.meta.engineer,
             }))
           }}
-          className="rounded-md bg-[#0056b3] px-2.5 py-1 text-[12px] font-semibold text-white hover:bg-[#004a99]">
+          className="rounded-md bg-[#0056b3] px-2.5 py-1 text-[12px] font-semibold text-white hover:bg-[#004a99]"
+          data-tour="report-button">
           Report PDF
         </button>
         <label className="cursor-pointer rounded-md border border-slate-300 px-2.5 py-1 text-[12px] font-medium text-slate-700 hover:bg-slate-50">
@@ -426,7 +438,7 @@ export default function SoilInvestigation() {
               value={String(inv.boreholes.reduce((n, b) => n + b.samples.reduce((m, s) => m + s.tests.length, 0), 0))} />
           </div>
 
-          <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm" data-tour="meta-card">
             <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Investigation</h2>
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               {([
@@ -494,7 +506,8 @@ export default function SoilInvestigation() {
                 })
                 setHoleIdx(inv.boreholes.length)
               }}
-              className="rounded-md border border-dashed border-slate-300 px-2.5 py-1 text-[12px] text-slate-600 hover:bg-slate-50">
+              className="rounded-md border border-dashed border-slate-300 px-2.5 py-1 text-[12px] text-slate-600 hover:bg-slate-50"
+              data-tour="add-borehole">
               + borehole
             </button>
           </div>
@@ -559,7 +572,8 @@ export default function SoilInvestigation() {
                     depthTop: top, depthBottom: top + 1, name: 'New layer',
                   })
                 })}
-                className="rounded-md border border-dashed border-slate-300 px-2.5 py-1 text-[12px] text-slate-600 hover:bg-slate-50">
+                className="rounded-md border border-dashed border-slate-300 px-2.5 py-1 text-[12px] text-slate-600 hover:bg-slate-50"
+                data-tour="add-layer">
                 + layer
               </button>
             </div>
@@ -612,11 +626,12 @@ export default function SoilInvestigation() {
                     tests: [],
                   })
                 })}
-                className="rounded-md border border-dashed border-slate-300 px-2.5 py-1 text-[12px] text-slate-600 hover:bg-slate-50">
+                className="rounded-md border border-dashed border-slate-300 px-2.5 py-1 text-[12px] text-slate-600 hover:bg-slate-50"
+                data-tour="add-sample">
                 + sample
               </button>
             </div>
-            <div className="overflow-x-auto">
+            <div className="overflow-x-auto" data-tour="samples-table">
               <table className="w-full text-left text-[12px]">
                 <thead className="text-slate-500">
                   <tr className="border-b border-slate-200">
@@ -650,7 +665,7 @@ export default function SoilInvestigation() {
 
       {/* ── SPT ── */}
       {tab === 'spt' && bh && profile && (
-        <section className="mt-5 space-y-4">
+        <section className="mt-5 space-y-4" data-tour="spt-panel">
           <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
             <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Unit weights for the stress profile</h2>
             <p className="mb-3 text-[11px] text-slate-500">
@@ -735,7 +750,7 @@ export default function SoilInvestigation() {
 
       {/* ── Classification ── */}
       {tab === 'lab' && bh && (
-        <section className="mt-5">
+        <section className="mt-5" data-tour="lab-panel">
           <LabPanel
             bh={bh}
             onAdd={(sampleId, type) => set((d) => {
@@ -792,7 +807,7 @@ export default function SoilInvestigation() {
       )}
 
       {tab === 'parameters' && bh && (
-        <section className="mt-5">
+        <section className="mt-5" data-tour="parameters-panel">
           <ParametersPanel bh={bh} unitWeights={unitWeights} stored={inv.parameters} />
         </section>
       )}
@@ -818,6 +833,23 @@ export default function SoilInvestigation() {
         </section>
       )}
 
+      {tourOn && (
+        <GuidedTour
+          step={SOILS_TOUR[tourAt]}
+          index={tourAt}
+          total={SOILS_TOUR.length}
+          onNext={() => {
+            const next = nextIndex(tourAt)
+            setTourAt(next)
+            setTab(SOILS_TOUR[next].tab as Tab)
+          }}
+          onPrev={() => {
+            const prev = prevIndex(tourAt)
+            setTourAt(prev)
+            setTab(SOILS_TOUR[prev].tab as Tab)
+          }}
+          onClose={() => setTourOn(false)} />
+      )}
     </main>
   )
 }


### PR DESCRIPTION
Second half of the "creating an investigation from scratch was hard" report. #555 fixed the missing control; this adds the guided walkthrough that was asked for.

## Why the page needs one

`/soils` is the widest form in the app — nine tabs, with a dependency order that is obvious once you know it and invisible before:

> **borehole → layer → SAMPLE → laboratory test → classification → report**

The step that hides is the sample. Tests are booked against a **sample**, so a user who logs strata and goes straight to the Laboratory tab finds it empty with nothing *on that tab* to fix it — the control they need is two tabs back, under Profile. That step gets the most words in the script, and its title says so outright: *"Add a sample — this is the step that catches people."*

## Design

**A `Step-by-step guide` button** in the page header starts an 11-step overlay: the page dims, a hole is cut over the relevant control, and a card explains it beside the highlight.

**Advancing a step switches the tab.** The tour navigates *for* the user rather than telling them where to click — the whole complaint was not knowing where to go.

**The steps are data, not JSX.** `lib/soilsTour.ts` holds each step as `{ tab, anchor, title, body, why }`; `components/GuidedTour.tsx` is a generic spotlight with no knowledge of soils. The script is testable without rendering anything, and the component is reusable by any other page that wants one.

**Anchors are pinned in both directions** by `soilsTour.test.ts`, matched against the page source: a step pointing at a deleted element fails the build, *and* so does a `data-tour` attribute no step uses. A walkthrough is what a stuck user reaches for, so an anchor pointing into empty space is the one defect it must not ship with. (Matched against source rather than a rendered DOM deliberately — the anchors sit behind tab conditions and empty-state guards, so no single render contains more than a few of them.)

## Two bugs found by looking at it, not by a passing test

- **An anchor taller than the viewport pushed the card off the top of the screen.** Spotlighting a whole panel made `bottom: innerHeight - rect.top` exceed the viewport. The card is now clamped into range and scrolls internally, so it is readable whatever it is pointing at.
- **A step whose control does not exist yet degraded to a bare centred card**, which reads as though the tour had lost its place. Since the Profile/Lab/SPT panels only render once a borehole exists, that is the *normal* state for someone starting from scratch — exactly this tour's audience. It now says the control appears once the previous step has been done.

## Verification

Walked all 11 steps in a headless browser against the loaded example: every step resolves its anchor and draws the spotlight, no console errors. Also walked from a cleared `localStorage` to confirm the missing-anchor path reads sensibly rather than looking broken.

Suite **3806 passed**, `tsc -b` and `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmPbtTVsjNBXVpiQVBYBnz)_