### PR TITLE
refactor(ui): one card system across the calculator pages

### DIFF
--- a/webapp/src/components/calc.tsx
+++ b/webapp/src/components/calc.tsx
@@ -23,6 +23,31 @@ export function PageHeader({ title, badges, actions }: { title: string; badges: 
   )
 }
 
+/**
+ * The standard calculation-page body: full-width container, inputs rail on the
+ * left, results on the right.
+ *
+ * WHY THIS EXISTS. Ten pages were still on `max-w-3xl`, a width chosen when
+ * they were single-column forms. Everything since — the numbered input cards,
+ * the verdict panel, the worked solution with its chips — is laid out for the
+ * 1500px two-column rail the foundation pages use, and cramming it into 768px
+ * is what makes the chips wrap out of their card. The container is the defect,
+ * not the cards inside it.
+ *
+ * Pass two children: the left rail, then the right column. One child fills the
+ * width, for a page that has no results side.
+ */
+export function CalcBody({ children, wide = false }: { children: ReactNode; wide?: boolean }) {
+  return (
+    <div className="mx-auto max-w-[1500px] px-5 py-5 sm:px-7">
+      <div className={`grid grid-cols-1 items-start gap-5 ${
+        wide ? '' : 'lg:grid-cols-[minmax(0,1.35fr)_minmax(340px,1fr)]'}`}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
 export function CalcSection({ num, title, hint, children, grid = true }: {
   num: string; title: string; hint?: string; children: ReactNode; grid?: boolean
 }) {

--- a/webapp/src/components/qty.tsx
+++ b/webapp/src/components/qty.tsx
@@ -50,7 +50,18 @@ export function ClassPick({ value, onChange }: { value: ConcreteClass; onChange:
 /** Numbered input card (Foundation mockup): mono counter + title header row,
  *  hairline divider, field grid. Numbers auto-increment in DOM order via the
  *  `calc-card` CSS counter in index.css — no per-page wiring. */
-export function Card({ title, hint, children }: { title: ReactNode; hint?: ReactNode; children: ReactNode }) {
+export function Card({ title, hint, grid = true, children }: {
+  title: ReactNode; hint?: ReactNode
+  /**
+   * Lay the children out as a field grid. Off for a card holding a LIST — a
+   * repeating node/member/load editor — where a three-column grid would deal
+   * the rows across columns instead of stacking them. `CalcSection` has had
+   * this escape hatch since the mockup; `Card` needed it the moment the
+   * analysis pages stopped using bespoke fieldsets.
+   */
+  grid?: boolean
+  children: ReactNode
+}) {
   return (
     <section className="calc-card rail-card print-avoid-break rounded-lg border border-[#e3e1da] bg-white">
       <div className="flex items-baseline gap-2.5 border-b border-[#eeece5] px-4 py-3">
@@ -58,7 +69,7 @@ export function Card({ title, hint, children }: { title: ReactNode; hint?: React
         <h2 className="text-[13.5px] font-bold text-[#0f1b2a]">{title}</h2>
         {hint && <span className="ml-auto text-[11px] text-[#a39d8d]">{hint}</span>}
       </div>
-      <div className="grid grid-cols-1 gap-3.5 p-4 sm:grid-cols-2 lg:grid-cols-3">{children}</div>
+      <div className={grid ? 'grid grid-cols-1 gap-3.5 p-4 sm:grid-cols-2 lg:grid-cols-3' : 'p-4'}>{children}</div>
     </section>
   )
 }

--- a/webapp/src/lib/plans.test.ts
+++ b/webapp/src/lib/plans.test.ts
@@ -208,7 +208,7 @@ describe('checkout', () => {
 describe('pricing', () => {
   const paid = PLANS.filter((p) => p.priceMonthly)
 
-  it('prices everything in pesos, because that is what PayMongo settles in', () => {
+  it('prices everything in pesos, because that is what the provider settles in', () => {
     expect(CURRENCY).toBe('PHP')
     expect(formatPeso(1399)).toBe('₱1,399')
     expect(formatPeso(15099)).toBe('₱15,099')

--- a/webapp/src/lib/plans.ts
+++ b/webapp/src/lib/plans.ts
@@ -11,7 +11,7 @@
 // questions and conflating them is how a paywall ends up inconsistent, with a
 // page reachable but its main button dead for no stated reason.
 //
-// PRICED IN PESOS, because PayMongo settles in pesos. Showing a dollar figure
+// PRICED IN PESOS, because Xendit settles in pesos. Showing a dollar figure
 // while charging a peso one is how a customer ends up disputing a card charge
 // they did not recognise.
 //
@@ -49,7 +49,7 @@ export type BillingPeriod = 'monthly' | 'annual'
 /**
  * Everything is priced in Philippine pesos.
  *
- * Not a cosmetic choice: PayMongo settles in PHP, and a page quoting dollars
+ * Not a cosmetic choice: Xendit settles in PHP, and a page quoting dollars
  * while the card statement reads pesos is a support ticket at best and a
  * chargeback at worst. The currency the customer is shown must be the currency
  * they are charged.

--- a/webapp/src/lib/siteConfig.test.ts
+++ b/webapp/src/lib/siteConfig.test.ts
@@ -78,3 +78,31 @@ describe('businessName', () => {
     expect(businessName().length).toBeGreaterThan(0)
   })
 })
+
+describe('the shipped configuration is complete', () => {
+  it('has every customer-facing detail filled in', () => {
+    // The business is registered, so the legal pages must no longer be showing
+    // a list of holes. This is the assertion that turns "we filled the form in"
+    // into something that stays true.
+    expect(missingSiteFields()).toEqual([])
+    expect(isSiteConfigured()).toBe(true)
+  })
+
+  it('carries the registration details the provider application was filed with', () => {
+    // These are checked against the DTI certificate during onboarding, so a
+    // drifting legal name or address is a held application rather than a typo.
+    expect(SITE.legalName).toBe('CIVENGG WEBSITE APPLICATION SERVICE')
+    expect(SITE.registrationNumber).toBe('8408482')
+    expect(SITE.tin).toMatch(/^\d{9}$/)
+    expect(addressOneLine()).toBe('14 Yangco Road, Baguio City, Benguet 2600, Philippines')
+  })
+
+  it('uses the registered name in prose, not the trade name', () => {
+    expect(businessName()).toBe(SITE.legalName)
+  })
+
+  it('gives a site URL that is an origin, with no trailing slash', () => {
+    // It is concatenated into canonical links; a trailing slash produces '//'.
+    expect(SITE.siteUrl).toMatch(/^https:\/\/[^/]+$/)
+  })
+})

--- a/webapp/src/lib/siteConfig.ts
+++ b/webapp/src/lib/siteConfig.ts
@@ -6,14 +6,16 @@
 // is right in four places and stale in the fifth is worse than one that is
 // obviously missing everywhere.
 //
-// NOTHING HERE IS INVENTED. The blank fields are blank because they are facts
-// only the business owner knows — a registered name, a TIN, a real street
-// address. They appear in documents a customer and a payment provider will
-// rely on, so a plausible-looking placeholder would be a lie printed under a
-// heading that says "Terms and Conditions". `missingSiteFields()` lists what is
-// still unset, and the legal pages show that list rather than pretending.
+// NOTHING HERE IS INVENTED. Every value below is transcribed from the DTI
+// registration and the payment-provider application; a plausible-looking
+// placeholder would be a lie printed under a heading that says "Terms and
+// Conditions". `missingSiteFields()` lists anything still unset, and the legal
+// pages show that list rather than pretending.
 //
-// Fill these in before taking a single payment.
+// THESE MUST MATCH THE PROVIDER APPLICATION CHARACTER FOR CHARACTER. The legal
+// name, address and phone number are checked against the registration during
+// onboarding, so "CivEngg Website Application Service" in one place and
+// "CIVENGG WEBSITE APPLICATION SERVICE" in the other is a held application.
 // ─────────────────────────────────────────────────────────────────────────
 
 export interface PostalAddress {
@@ -30,11 +32,13 @@ export interface SiteConfig {
   tradeName: string
   /** Registered business name — DTI/SEC. Blank until registered. */
   legalName: string
-  /** Registered business address. Must match the PayMongo application. */
+  /** DTI/SEC business registration number, as printed on the certificate. */
+  registrationNumber: string
+  /** Registered business address. Must match the payment-provider application. */
   address: PostalAddress
   /** Where customers reach a human. */
   supportEmail: string
-  /** Customer-service number given to PayMongo; shown to payers. */
+  /** Customer-service number given to the payment provider; shown to payers. */
   supportPhone: string
   /** BIR Tax Identification Number. */
   tin: string
@@ -49,23 +53,29 @@ export interface SiteConfig {
 export const SITE: SiteConfig = {
   tradeName: 'CivEngg Toolkit',
 
-  // ── FILL THESE IN ────────────────────────────────────────────────────
-  legalName: '',
+  // Registered as a sole proprietorship, 9 August 2026. These are the details
+  // the payment provider's application was filed against, so they must match
+  // it exactly — a legal name or address that disagrees with the DTI
+  // certificate is the usual reason an application is held.
+  legalName: 'CIVENGG WEBSITE APPLICATION SERVICE',
+  registrationNumber: '8408482',
   address: {
-    line1: '',
-    city: '',
-    province: '',
-    postalCode: '',
+    line1: '14 Yangco Road',
+    city: 'Baguio City',
+    province: 'Benguet',
+    postalCode: '2600',
     country: 'Philippines',
   },
-  supportPhone: '',
-  tin: '',
-  siteUrl: '',
-  // ─────────────────────────────────────────────────────────────────────
+  supportPhone: '+63 992 280 4146',
+  // BIR TIN. Kept here because the provider application and the BIR need it;
+  // NOTHING RENDERS IT, and publishing it is a deliberate choice rather than a
+  // default — see `missingSiteFields`, which excludes it on purpose.
+  tin: '684281205',
+  siteUrl: 'https://civil-engineering-zeta.vercel.app',
 
-  // Already known: this is the support address given on the PayMongo
-  // application. A domain address reads better to customers, but this is real
-  // and reachable, which matters more than it looks.
+  // The support address given on the provider application. A domain address
+  // reads better to customers, but this is real and reachable, which matters
+  // more than it looks.
   supportEmail: 'raymval246@gmail.com',
 
   supportHours: 'Monday to Friday, 9:00–18:00 (PST, UTC+8)',
@@ -87,7 +97,7 @@ const REQUIRED: [keyof SiteConfig | 'address', string][] = [
  * Empty array means the public pages are complete. Anything else is rendered on
  * the page itself — the point is that an unfinished policy is visibly
  * unfinished rather than quietly wrong. TIN is deliberately NOT in this list:
- * it is needed for PayMongo onboarding and the BIR, not for a customer-facing
+ * it is needed for provider onboarding and the BIR, not for a customer-facing
  * policy, and printing it publicly is a choice the owner should make
  * deliberately rather than by default.
  */

--- a/webapp/src/pages/BeamAnalysis.tsx
+++ b/webapp/src/pages/BeamAnalysis.tsx
@@ -124,8 +124,7 @@ export default function BeamAnalysis() {
             <Num label="Inertia I" unit="mm⁴" value={I} onChange={setI} />
           </Card>
 
-          <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-            <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">Supports</legend>
+          <Card title="Supports" grid={false}>
             <div className="no-print mb-3 flex flex-wrap gap-2">
               {(['pin', 'roller', 'fixed', 'spring'] as SupportType[]).map((t) => (
                 <button key={t} type="button" onClick={() => addSupport(t)}
@@ -145,10 +144,9 @@ export default function BeamAnalysis() {
                 </ItemShell>
               ))}
             </div>
-          </fieldset>
+          </Card>
 
-          <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-            <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">Loads</legend>
+          <Card title="Loads" grid={false}>
             <div className="no-print mb-3 flex flex-wrap gap-2">
               {([['point', '+ Point'], ['udl', '+ UDL'], ['vdl', '+ VDL'], ['moment', '+ Moment']] as const).map(([t, lbl]) => (
                 <button key={t} type="button" onClick={() => addLoad(t)}
@@ -184,7 +182,7 @@ export default function BeamAnalysis() {
                 </ItemShell>
               ))}
             </div>
-          </fieldset>
+          </Card>
         </div>
 
         <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
@@ -258,20 +256,20 @@ export default function BeamAnalysis() {
 
       {r && shown && (
         <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
-          <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
             <Diagram xs={r.xs} ys={r.V} title={`SHEAR — ${shown.combo.name}`} unit="kN" color="#1f77b4" vlines={vlines} decimals={1} />
           </div>
-          <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
             <Diagram xs={r.xs} ys={r.M} title="MOMENT" unit="kN·m" color="#d62728" vlines={vlines} decimals={1} />
           </div>
-          <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
             <Diagram xs={r.xs} ys={r.D} title="DEFLECTION" unit="mm" color="#2ca02c" vlines={vlines} decimals={2} />
           </div>
         </div>
       )}
 
       {res?.tmt && (
-        <div className="mt-6 rounded-xl border border-slate-200 bg-white p-4 shadow-sm print-avoid-break">
+        <div className="rail-card mt-6 rounded-lg border border-[#e3e1da] bg-white p-4 print-avoid-break">
           <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">
             Three-moment theorem check <span className="text-xs font-normal text-slate-500">Clapeyron — governing combo, interior support moments</span>
           </h2>

--- a/webapp/src/pages/BoltedConnection.tsx
+++ b/webapp/src/pages/BoltedConnection.tsx
@@ -49,7 +49,7 @@ export default function BoltedConnection() {
   return (
         <div>
       <PageHeader title="Eccentric bolted connection" badges={['AISC 360-16']} />
-      <main className="mx-auto max-w-[1400px] px-5 py-6">
+      <main className="mx-auto max-w-[1500px] px-5 py-5 sm:px-7">
       <ReportControls title="Bolted Connection Report" badges={['AISC 360-16']} />
       <p className="mt-2 max-w-3xl text-sm text-slate-600">
         Elastic (vector) method for an eccentrically-loaded bolt group. Each bolt carries the direct
@@ -58,9 +58,9 @@ export default function BoltedConnection() {
       </p>
 
       <div className="mt-6 grid gap-5 lg:grid-cols-[1.1fr_1fr]">
-        <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <section className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
           <div className="mb-3 flex items-center justify-between">
-            <h2 className="text-[1.05rem] font-bold text-[#0056b3]">Bolt pattern (mm)</h2>
+            <h2 className="text-[13.5px] font-bold text-[#0f1b2a]">Bolt pattern (mm)</h2>
             <button type="button" onClick={addBolt} className="rounded-md border border-slate-300 px-2.5 py-1 text-xs font-semibold text-[#0056b3] hover:bg-blue-50">+ Add bolt</button>
           </div>
           <div className="max-h-60 overflow-auto">
@@ -84,7 +84,7 @@ export default function BoltedConnection() {
             </table>
           </div>
 
-          <h2 className="mb-2 mt-4 text-[1.05rem] font-bold text-[#0056b3]">Load &amp; bolts</h2>
+          <h2 className="mb-2 mt-4 text-[13.5px] font-bold text-[#0f1b2a]">Load &amp; bolts</h2>
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
             {([['Load P (kN)', P, setP], ['Angle (° from +X)', angle, setAngle], ['Bolt Ø (mm)', dia, setDia],
               ['Load at x (mm)', px, setPx], ['Load at y (mm)', py, setPy], ['Allow. τ (MPa)', allow, setAllow]] as const).map(([lbl, val, set]) => (
@@ -103,12 +103,12 @@ export default function BoltedConnection() {
         </section>
 
         <section className="space-y-4">
-          <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+          <div className="rounded-lg border border-[#e3e1da] bg-[#faf9f6] p-3">
             <ConnectionDrawing geom={r.geom} db={dia} boltForces={r.bolts} critical={r.criticalId}
               Vu={r.Py} Hu={r.Px} ex_load={r.ex} ey_load={r.ey} />
           </div>
-          <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm text-sm">
-            <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Results</h2>
+          <div className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4 text-sm">
+            <h2 className="mb-2 text-[13.5px] font-bold text-[#0f1b2a]">Results</h2>
             {[['Load components Pₓ / Pᵧ', `${f2(r.Px)} / ${f2(r.Py)} kN`],
               ['Eccentricity eₓ / e_y', `${f2(r.ex)} / ${f2(r.ey)} mm`],
               ['Torsion T = Pᵧ·eₓ − Pₓ·e_y', `${f2(r.T / 1000)} kN·m`],
@@ -129,10 +129,10 @@ export default function BoltedConnection() {
         </section>
       </div>
 
-      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+      <section className="rail-card mt-5 rounded-lg border border-[#e3e1da] bg-white p-4">
         <label className="flex cursor-pointer items-center gap-2">
           <input type="checkbox" checked={showOOP} onChange={(e) => setShowOOP(e.target.checked)} className="h-4 w-4" />
-          <span className="text-[1.05rem] font-bold text-[#0056b3]">Out-of-plane eccentricity &amp; prying (§J3.7 / §J3.9)</span>
+          <span className="text-[13.5px] font-bold text-[#0f1b2a]">Out-of-plane eccentricity &amp; prying (§J3.7 / §J3.9)</span>
         </label>
         {showOOP && (
           <>
@@ -193,7 +193,7 @@ export default function BoltedConnection() {
                 </div>
               </div>
 
-              <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm">
+              <div className="rounded-lg border border-[#e3e1da] bg-[#faf9f6] p-4 text-sm">
                 <h3 className="mb-1 text-sm font-bold text-[#0056b3]">Prying — critical bolt {oop.critical}</h3>
                 {[['Required tension T', `${f2(oop.Tmax)} kN`],
                   ['Available φBn', `${f2(oop.phiTn_crit)} kN`],

--- a/webapp/src/pages/CombinedFootingDesign.tsx
+++ b/webapp/src/pages/CombinedFootingDesign.tsx
@@ -3,6 +3,7 @@ import { designCombinedFooting, type CombinedFootingInput } from '../engine/comb
 import { designFlexibleCombinedFooting } from '../engine/flexibleCombinedFooting'
 import { CombinedFootingSchematic } from '../components/CombinedFootingSchematic'
 import { PageHeader, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
+import { Card } from '../components/qty'
 import { initialLetterhead } from '../lib/letterhead'
 import { Diagram } from '../components/Diagram'
 import { WorkedSolution } from '../components/WorkedSolution'
@@ -100,21 +101,14 @@ function Select<T extends string>({ label, value, onChange, options }: {
   )
 }
 
-function Card({ title, children }: { title: string; children: ReactNode }) {
-  return (
-    <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-      <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">{title}</legend>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">{children}</div>
-    </fieldset>
-  )
-}
-
+/** Result row. `check` is a third column the shared `Row` calls `sub`; the name
+ *  differs but the palette must not — this matches `components/qty`. */
 function Row({ label, value, check }: { label: ReactNode; value: ReactNode; check?: ReactNode }) {
   return (
-    <div className="flex items-baseline justify-between gap-3 border-b border-slate-100 py-1.5 last:border-0">
-      <span className="text-sm text-slate-600">{label}</span>
-      <span className="text-right text-sm font-semibold text-slate-800">{value}</span>
-      {check ? <span className="w-36 text-right text-xs text-slate-500">{check}</span> : null}
+    <div className="flex items-baseline justify-between gap-3 border-b border-[#f3f1ea] py-1.5 last:border-0">
+      <span className="text-[12px] text-[#5c6675]">{label}</span>
+      <span className="text-right font-mono text-[12.5px] font-semibold text-[#0f1b2a]">{value}</span>
+      {check ? <span className="w-32 text-right text-[10.5px] text-[#a39d8d]">{check}</span> : null}
     </div>
   )
 }

--- a/webapp/src/pages/FrameAnalysis.tsx
+++ b/webapp/src/pages/FrameAnalysis.tsx
@@ -109,8 +109,7 @@ export default function FrameAnalysis() {
             </p>
           </Card>
 
-          <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-            <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">Nodes</legend>
+          <Card title="Nodes" grid={false}>
             <button type="button" onClick={() => setNodes((ns) => [...ns, { uid: uid++, id: `N${ns.length + 1}`, x: 0, y: 0 }])}
               className="no-print mb-3 rounded-md border border-[#cddcf0] bg-[#eaf1f9] px-3 py-1.5 text-sm font-semibold text-[#0f4c92] hover:bg-[#dce9f7]">+ Node</button>
             <div className="space-y-3">
@@ -126,10 +125,9 @@ export default function FrameAnalysis() {
                 </Shell>
               ))}
             </div>
-          </fieldset>
+          </Card>
 
-          <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-            <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">Members</legend>
+          <Card title="Members" grid={false}>
             <button type="button" onClick={() => setMembers((ms) => [...ms, { uid: uid++, id: `m${ms.length + 1}`, i: nodeIds[0] ?? '', j: nodeIds[1] ?? '' }])}
               className="no-print mb-3 rounded-md border border-[#cddcf0] bg-[#eaf1f9] px-3 py-1.5 text-sm font-semibold text-[#0f4c92] hover:bg-[#dce9f7]">+ Member</button>
             <div className="space-y-3">
@@ -145,10 +143,9 @@ export default function FrameAnalysis() {
                 </Shell>
               ))}
             </div>
-          </fieldset>
+          </Card>
 
-          <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-            <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">Supports</legend>
+          <Card title="Supports" grid={false}>
             <button type="button" onClick={() => setSupports((ss) => [...ss, { uid: uid++, node: nodeIds[0] ?? '', type: 'pin' }])}
               className="no-print mb-3 rounded-md border border-[#cddcf0] bg-[#eaf1f9] px-3 py-1.5 text-sm font-semibold text-[#0f4c92] hover:bg-[#dce9f7]">+ Support</button>
             <div className="space-y-3">
@@ -160,10 +157,9 @@ export default function FrameAnalysis() {
                 </Shell>
               ))}
             </div>
-          </fieldset>
+          </Card>
 
-          <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-            <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">Loads</legend>
+          <Card title="Loads" grid={false}>
             <div className="no-print mb-3 flex flex-wrap gap-2">
               <button type="button" onClick={() => setLoads((ls) => [...ls, { uid: uid++, kind: 'node', node: nodeIds[0] ?? '', Fx: 0, Fy: -50, Mz: 0, cat: 'D' }])}
                 className="rounded-md border border-[#cddcf0] bg-[#eaf1f9] px-3 py-1.5 text-sm font-semibold text-[#0f4c92] hover:bg-[#dce9f7]">+ Node load</button>
@@ -194,7 +190,7 @@ export default function FrameAnalysis() {
                 </Shell>
               ))}
             </div>
-          </fieldset>
+          </Card>
         </div>
 
         <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
@@ -248,7 +244,7 @@ export default function FrameAnalysis() {
       {r && mem && (
         <div className="mt-6">
           <div className="mb-2 flex flex-wrap items-center gap-3">
-            <h2 className="text-[1.02rem] font-bold text-[#0056b3]">Member diagrams</h2>
+            <h2 className="text-[13.5px] font-bold text-[#0f1b2a]">Member diagrams</h2>
             <select value={selMember} onChange={(e) => setSelMember(e.target.value)}
               className="rounded-md border border-slate-300 px-2.5 py-1.5 text-sm">
               {r.members.map((m) => <option key={m.id} value={m.id}>{m.id}</option>)}
@@ -256,13 +252,13 @@ export default function FrameAnalysis() {
             <span className="text-xs text-slate-500">local x from node i · N &gt; 0 tension</span>
           </div>
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-            <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
               <Diagram xs={mem.xs} ys={mem.N} title={`AXIAL — ${mem.id}`} unit="kN" color="#7c3aed" decimals={1} />
             </div>
-            <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
               <Diagram xs={mem.xs} ys={mem.V} title="SHEAR" unit="kN" color="#1f77b4" decimals={1} />
             </div>
-            <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
               <Diagram xs={mem.xs} ys={mem.M} title="MOMENT" unit="kN·m" color="#d62728" decimals={1} />
             </div>
           </div>

--- a/webapp/src/pages/LateralPile.tsx
+++ b/webapp/src/pages/LateralPile.tsx
@@ -6,7 +6,8 @@ import {
 } from '../engine/lateralPile'
 import { buildLateralPileSolution } from '../lib/lateralPileSolution'
 import { WorkedSolution } from '../components/WorkedSolution'
-import { PageHeader } from '../components/calc'
+import { PageHeader, CalcBody } from '../components/calc'
+import { Card, ResultCard } from '../components/qty'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -166,7 +167,8 @@ export default function LateralPile() {
   return (
         <div>
       <PageHeader title="Laterally loaded pile" badges={['Broms', 'Matlock', 'API RP 2A']} />
-      <main className="mx-auto max-w-3xl px-5 py-6">
+      <CalcBody wide>
+        <div className="space-y-5">
       <ReportControls title="Laterally Loaded Pile" badges={['Broms', 'Matlock', 'API RP 2A']} report={report} />
       <p className="mt-2 text-sm text-slate-600">
         Two questions, two methods. <strong>Broms</strong> gives the ultimate lateral capacity in closed form and
@@ -174,9 +176,8 @@ export default function LateralPile() {
         nonlinear soil springs and gives what Broms cannot — head deflection, and where the maximum moment sits.
       </p>
 
-      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Pile &amp; loading</h2>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <Card title="Pile & loading">
+        <div className="col-span-full grid grid-cols-2 gap-3 sm:grid-cols-4">
           <Field label="Embedded length L" unit="m" value={L} onChange={setL} step="0.5" />
           <Field label="Diameter D" unit="m" value={D} onChange={setD} step="0.05" />
           <Field label="Rigidity EI" unit="kN·m²" value={EI} onChange={setEI} step="10000" />
@@ -200,9 +201,10 @@ export default function LateralPile() {
             </select>
           </label>
         </div>
+      </Card>
 
-        <h2 className="mb-3 mt-5 text-[1.05rem] font-bold text-[#0056b3]">Soil</h2>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <Card title="Soil">
+        <div className="col-span-full grid grid-cols-2 gap-3 sm:grid-cols-4">
           <Field label="Unit weight γ′" unit="kN/m³" value={gamma} onChange={setGamma} step="0.5" />
           {soilKind === 'clay' ? (
             <>
@@ -221,10 +223,9 @@ export default function LateralPile() {
             A fixed head has no free rotation, so the load height e is not used by either method.
           </p>
         )}
-      </section>
+      </Card>
 
-      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Ultimate capacity — Broms</h2>
+      <ResultCard title="Ultimate capacity — Broms">
         <BromsCard r={broms} title={soilKind === 'clay' ? 'Cohesive (9·cu·d below 1.5d)' : 'Cohesionless (3·Kp·γ·z·d)'} />
         <div className="mt-3">
           <Out label="Applied H / Hu" value={f2(util)} ok={util <= 1}
@@ -235,10 +236,9 @@ export default function LateralPile() {
           this is — &ldquo;short&rdquo; is a verdict, not a length. Broms is an ultimate check: apply your own factor
           of safety, typically 2 to 3 on Hu for a working load.
         </p>
-      </section>
+      </ResultCard>
 
-      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Response at working load — p-y</h2>
+      <ResultCard title="Response at working load — p-y">
         <PyProfiles res={py} L={L} />
         <div className="mt-3">
           <Out label="Head deflection" value={`${f2(py.yHead)} mm`} ok={headOK}
@@ -254,12 +254,13 @@ export default function LateralPile() {
           elements on nonlinear springs and solved by Newton; the residual is reported so a solve that fell short is
           visible rather than silently presented as an answer. Deflections are relative to the undeflected pile axis.
         </p>
-      </section>
+      </ResultCard>
       {/* The step-by-step already existed and only ever reached the PDF. */}
       <div className="mt-5">
         <WorkedSolution steps={solution} title="Calculation report — worked solution" />
       </div>
-    </main>
+        </div>
+      </CalcBody>
     </div>
   )
 }

--- a/webapp/src/pages/LoadPath.tsx
+++ b/webapp/src/pages/LoadPath.tsx
@@ -69,8 +69,7 @@ export default function LoadPath() {
             </p>
           </Card>
 
-          <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-            <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">Area loads</legend>
+          <Card title="Area loads" grid={false}>
             <button type="button" onClick={() => setAreaLoads((ls) => [...ls, { id: uid++, q: 2, cat: 'L' }])}
               className="no-print mb-3 rounded-md border border-[#cddcf0] bg-[#eaf1f9] px-3 py-1.5 text-sm font-semibold text-[#0f4c92] hover:bg-[#dce9f7]">+ Area load</button>
             <div className="space-y-3">
@@ -91,7 +90,7 @@ export default function LoadPath() {
                 </div>
               ))}
             </div>
-          </fieldset>
+          </Card>
 
           <Card title="Wall on the edge beam (optional)">
             <Pick label="Include wall" value={wallOn ? 'yes' : 'no'} onChange={(v) => setWallOn(v === 'yes')}

--- a/webapp/src/pages/Micropile.tsx
+++ b/webapp/src/pages/Micropile.tsx
@@ -3,7 +3,8 @@ import { designMicropile } from '../engine/micropile'
 import { ReportControls } from '../components/ReportControls'
 import { buildMicropileSolution } from '../lib/geotechSolutions'
 import { WorkedSolution } from '../components/WorkedSolution'
-import { PageHeader } from '../components/calc'
+import { PageHeader, CalcBody } from '../components/calc'
+import { Card, ResultCard } from '../components/qty'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -84,66 +85,58 @@ export default function Micropile() {
   return (
         <div>
       <PageHeader title="Micropile — axial capacity" badges={['FHWA-NHI-05-039']} />
-      <main className="mx-auto max-w-3xl px-5 py-6">
       <ReportControls title="Micropile" badges={['FHWA-NHI-05-039']} report={report} />
-      <p className="mt-2 text-sm text-slate-600">
-        FHWA-NHI-05-039 allowable-stress check: structural capacity of the bar/casing/grout vs the
-        grout-ground bond capacity of the bonded zone. Governing allowable = the smaller of the two.
-      </p>
+      <CalcBody>
+        <div className="space-y-5">
+          <p className="text-[13px] text-[#5c6675]">
+            FHWA-NHI-05-039 allowable-stress check: structural capacity of the bar/casing/grout vs the
+            grout-ground bond capacity of the bonded zone. Governing allowable = the smaller of the two.
+          </p>
 
-      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Section</h2>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <Field label="Bar Ø" unit="mm" value={barDia} onChange={setBarDia} />
-          <Field label="Fy bar" unit="MPa" value={fyBar} onChange={setFyBar} />
-          <Field label="Grout Ø (drill)" unit="mm" value={groutDia} onChange={setGroutDia} />
-          <Field label="f′c grout" unit="MPa" value={fcGrout} onChange={setFcGrout} />
-        </div>
-        <label className="mt-3 flex items-center gap-2 text-sm">
-          <input type="checkbox" checked={casing} onChange={(e) => setCasing(e.target.checked)} />
-          <span>Permanent steel casing</span>
-        </label>
-        {casing && (
-          <div className="mt-2 grid grid-cols-2 gap-3 sm:grid-cols-3">
-            <Field label="Casing OD" unit="mm" value={casingOD} onChange={setCasingOD} />
-            <Field label="Casing ID" unit="mm" value={casingID} onChange={setCasingID} />
-            <Field label="Fy casing" unit="MPa" value={fyCasing} onChange={setFyCasing} />
-          </div>
-        )}
-        <h2 className="mb-3 mt-5 text-[1.05rem] font-bold text-[#0056b3]">Bond zone &amp; demand</h2>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <label className="flex flex-col text-sm">
-            <span className="mb-1 font-medium text-slate-600">Load mode</span>
-            <select value={mode} onChange={(e) => setMode(e.target.value as 'compression' | 'tension')}
-              className="rounded-md border border-slate-300 px-2.5 py-1.5">
-              <option value="compression">Compression</option>
-              <option value="tension">Tension</option>
-            </select>
-          </label>
-          <Field label="Bond Ø" unit="m" value={bondDia} onChange={setBondDia} step="0.01" />
-          <Field label="Bond length" unit="m" value={bondLength} onChange={setBondLength} />
-          <Field label="αbond" unit="kPa" value={alphaBond} onChange={setAlphaBond} />
-          <Field label="Axial demand P" unit="kN" value={P} onChange={setP} />
-        </div>
-      </section>
+          <Card title="Section">
+            <Field label="Bar Ø" unit="mm" value={barDia} onChange={setBarDia} />
+            <Field label="Fy bar" unit="MPa" value={fyBar} onChange={setFyBar} />
+            <Field label="Grout Ø (drill)" unit="mm" value={groutDia} onChange={setGroutDia} />
+            <Field label="f′c grout" unit="MPa" value={fcGrout} onChange={setFcGrout} />
+            <label className="col-span-full flex items-center gap-2 text-sm">
+              <input type="checkbox" checked={casing} onChange={(e) => setCasing(e.target.checked)} />
+              <span>Permanent steel casing</span>
+            </label>
+            {casing && <Field label="Casing OD" unit="mm" value={casingOD} onChange={setCasingOD} />}
+            {casing && <Field label="Casing ID" unit="mm" value={casingID} onChange={setCasingID} />}
+            {casing && <Field label="Fy casing" unit="MPa" value={fyCasing} onChange={setFyCasing} />}
+          </Card>
 
-      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Results</h2>
-        <Out label="Structural allowable" value={`${f0(r.structural)} kN`} />
-        <Out label="Bond Qult / allowable (FS 2)" value={`${f0(r.Qult)} / ${f0(r.Qbond)} kN`} />
-        <Out label={`Governing allowable (${r.governs})`} value={`${f0(r.allowable)} kN`} />
-        <Out label="FS (allowable / demand)" value={f2(r.fs)} ok={r.ok} />
-        <Out label="Bond length for FS = 2" value={`${f2(r.bondLengthReq)} m`} ok={bondLength >= r.bondLengthReq} />
-        <p className="mt-2 text-[10px] text-slate-500">
-          Structural: 0.40·f′c·Agrout + 0.47·Fy·As (compression), 0.55·Fy·As (tension). Bond:
-          π·Dbond·Lbond·αbond / FS. Verify buckling in very soft soils and group/settlement effects separately.
-        </p>
-      </section>
-      {/* The step-by-step already existed and only ever reached the PDF. */}
-      <div className="mt-5">
-        <WorkedSolution steps={solution} title="Calculation report — worked solution" />
-      </div>
-    </main>
+          <Card title="Bond zone & demand">
+            <label className="flex flex-col text-sm">
+              <span className="mb-1 text-[11.5px] font-semibold text-[#5c6675]">Load mode</span>
+              <select value={mode} onChange={(e) => setMode(e.target.value as 'compression' | 'tension')}
+                className="text-[13px]">
+                <option value="compression">Compression</option>
+                <option value="tension">Tension</option>
+              </select>
+            </label>
+            <Field label="Bond Ø" unit="m" value={bondDia} onChange={setBondDia} step="0.01" />
+            <Field label="Bond length" unit="m" value={bondLength} onChange={setBondLength} />
+            <Field label="αbond" unit="kPa" value={alphaBond} onChange={setAlphaBond} />
+            <Field label="Axial demand P" unit="kN" value={P} onChange={setP} />
+          </Card>
+
+          <WorkedSolution steps={solution} title="Calculation report — worked solution" />
+        </div>
+
+        <ResultCard title="Results">
+          <Out label="Structural allowable" value={`${f0(r.structural)} kN`} />
+          <Out label="Bond Qult / allowable (FS 2)" value={`${f0(r.Qult)} / ${f0(r.Qbond)} kN`} />
+          <Out label={`Governing allowable (${r.governs})`} value={`${f0(r.allowable)} kN`} />
+          <Out label="FS (allowable / demand)" value={f2(r.fs)} ok={r.ok} />
+          <Out label="Bond length for FS = 2" value={`${f2(r.bondLengthReq)} m`} ok={bondLength >= r.bondLengthReq} />
+          <p className="mt-2 text-[10px] text-[#a39d8d]">
+            Structural: 0.40·f′c·Agrout + 0.47·Fy·As (compression), 0.55·Fy·As (tension). Bond:
+            π·Dbond·Lbond·αbond / FS. Verify buckling in very soft soils and group/settlement effects separately.
+          </p>
+        </ResultCard>
+      </CalcBody>
     </div>
   )
 }

--- a/webapp/src/pages/PileCapDesign.tsx
+++ b/webapp/src/pages/PileCapDesign.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, type ReactNode } from 'react'
 import { designPileCap, type PileArrangement } from '../engine/pileCap'
 import { PileCapSchematic } from '../components/PileCapSchematic'
 import { PageHeader, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
+import { Card } from '../components/qty'
 import { initialLetterhead } from '../lib/letterhead'
 import { Math as KTex } from '../lib/math'
 import { f0, f2, f3 } from '../lib/format'
@@ -80,21 +81,14 @@ function SelectField<T extends string | number>({ label, value, onChange, option
   )
 }
 
-function Card({ title, children }: { title: string; children: ReactNode }) {
-  return (
-    <fieldset className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-      <legend className="px-2 text-[1.02rem] font-bold text-[#0056b3]">{title}</legend>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">{children}</div>
-    </fieldset>
-  )
-}
-
+/** Result row. `check` is a third column the shared `Row` calls `sub`; the name
+ *  differs but the palette must not — this matches `components/qty`. */
 function Row({ label, value, check }: { label: ReactNode; value: ReactNode; check?: ReactNode }) {
   return (
-    <div className="flex items-baseline justify-between gap-3 border-b border-slate-100 py-1.5 last:border-0">
-      <span className="text-sm text-slate-600">{label}</span>
-      <span className="text-right text-sm font-semibold text-slate-800">{value}</span>
-      {check ? <span className="w-36 text-right text-xs text-slate-500">{check}</span> : null}
+    <div className="flex items-baseline justify-between gap-3 border-b border-[#f3f1ea] py-1.5 last:border-0">
+      <span className="text-[12px] text-[#5c6675]">{label}</span>
+      <span className="text-right font-mono text-[12.5px] font-semibold text-[#0f1b2a]">{value}</span>
+      {check ? <span className="w-32 text-right text-[10.5px] text-[#a39d8d]">{check}</span> : null}
     </div>
   )
 }

--- a/webapp/src/pages/PlumbingDesign.tsx
+++ b/webapp/src/pages/PlumbingDesign.tsx
@@ -9,7 +9,7 @@ import { designDrainage, drainageSolution } from '../engine/drainage'
 import { designSepticTank, septicSolution } from '../engine/septicTank'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { ReportControls } from '../components/ReportControls'
-import { PageHeader } from '../components/calc'
+import { PageHeader, CalcBody } from '../components/calc'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -97,7 +97,8 @@ export default function PlumbingDesign() {
   return (
         <div>
       <PageHeader title="Plumbing System Design" badges={['RNPCP 2000']} />
-      <main className="mx-auto max-w-3xl px-5 py-6">
+      <CalcBody wide>
+        <div className="space-y-5">
       <ReportControls title="Plumbing Design Report" badges={['RNPCP 2000']} />
       <p className="mt-2 text-sm text-slate-600">
         Water supply, sanitary drainage (DWV) and on-site sewage treatment to the Revised National Plumbing Code
@@ -105,9 +106,9 @@ export default function PlumbingDesign() {
       </p>
 
       {/* Shared fixture schedule */}
-      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm" data-tour="fixture-schedule">
+      <section className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4" data-tour="fixture-schedule">
         <div className="mb-3 flex items-center justify-between">
-          <h2 className="text-[1.05rem] font-bold text-[#0056b3]">Fixture schedule</h2>
+          <h2 className="text-[13.5px] font-bold text-[#0f1b2a]">Fixture schedule</h2>
           <label className="flex items-center gap-2 text-sm">
             <span className="font-medium text-slate-600">Occupancy</span>
             <select value={occ} onChange={(e) => setOcc(e.target.value as Occupancy)}
@@ -143,8 +144,8 @@ export default function PlumbingDesign() {
 
       {tab === 'supply' && (
         <>
-          <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm" data-tour="supply-panel">
-            <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Supply run &amp; pressures</h2>
+          <section className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4" data-tour="supply-panel">
+            <h2 className="mb-3 text-[13.5px] font-bold text-[#0f1b2a]">Supply run &amp; pressures</h2>
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
               <Field label="Pipe length" unit="m" value={Lpipe} onChange={setLpipe} />
               <Field label="Fittings (equiv. L)" unit="m" value={fittingLength} onChange={setFittingLength} hint="Table A-2" />
@@ -171,8 +172,8 @@ export default function PlumbingDesign() {
             </div>
           </section>
 
-          <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-            <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Results</h2>
+          <section className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
+            <h2 className="mb-2 text-[13.5px] font-bold text-[#0f1b2a]">Results</h2>
             <Out label="Maximum demand (ΣFU×8)" value={`${f1(supply.demand.maxGpm)} gpm · ${f2(supply.demand.maxLps)} L/s`} />
             <Out label={`Design flow (${supply.flowSource === 'override' ? 'chart' : "Hunter's curve"})`} value={`${f1(supply.designFlowGpm)} gpm · ${f2(supply.designFlowLps)} L/s`} />
             <Out label="Static head (γw·Z)" value={`${f1(supply.staticKPa)} kPa`} />
@@ -194,8 +195,8 @@ export default function PlumbingDesign() {
 
       {tab === 'drainage' && (
         <>
-          <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm" data-tour="drainage-panel">
-            <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Drainage run</h2>
+          <section className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4" data-tour="drainage-panel">
+            <h2 className="mb-3 text-[13.5px] font-bold text-[#0f1b2a]">Drainage run</h2>
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
               <label className="flex flex-col text-sm">
                 <span className="mb-1 font-medium text-slate-600">Sewer slope</span>
@@ -208,8 +209,8 @@ export default function PlumbingDesign() {
               </label>
             </div>
           </section>
-          <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-            <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Results</h2>
+          <section className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
+            <h2 className="mb-2 text-[13.5px] font-bold text-[#0f1b2a]">Results</h2>
             <Out label="Drainage fixture units" value={`${f0(drainage.dfu)} DFU${slopePct <= 1 ? ` · design ${f1(drainage.effectiveDfu)} (1% ×1.25)` : ''}`} />
             <Out label="Drain (horizontal & vertical)" value={`${f0(drainage.drainMm)} mm`} ok={drainage.wcCount === 0 || drainage.drainMm >= 75} />
             <Out label="Vent" value={`${f0(drainage.ventMm)} mm`} ok={drainage.ventOK} />
@@ -226,15 +227,15 @@ export default function PlumbingDesign() {
       )}
       {tab === 'septic' && (
         <>
-          <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm" data-tour="septic-panel">
-            <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Tank geometry</h2>
+          <section className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4" data-tour="septic-panel">
+            <h2 className="mb-3 text-[13.5px] font-bold text-[#0f1b2a]">Tank geometry</h2>
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
               <Field label="Plan width" unit="m" value={tankWidth} onChange={setTankWidth} step="0.1" hint="≥ 0.9 m" />
               <Field label="Liquid depth" unit="m" value={liquidDepth} onChange={setLiquidDepth} step="0.1" hint="0.6–1.8 m" />
             </div>
           </section>
-          <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-            <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Results</h2>
+          <section className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
+            <h2 className="mb-2 text-[13.5px] font-bold text-[#0f1b2a]">Results</h2>
             <Out label="Drainage fixture units" value={`${f0(septic.dfu)} DFU`} />
             <Out label="Min capacity (Table B-2)" value={`${f0(septic.capacityL)} L · ${f2(septic.capacityL / 1000)} m³`} />
             <Out label="Plan length" value={`${f2(septic.length)} m`} ok={septic.capacityOK} />
@@ -255,7 +256,8 @@ export default function PlumbingDesign() {
         <GuidedTour step={tour.step} index={tour.at} total={tour.total}
           onNext={tour.next} onPrev={tour.prev} onClose={tour.close} />
       )}
-    </main>
+        </div>
+      </CalcBody>
     </div>
   )
 }

--- a/webapp/src/pages/PrestressedBeam.tsx
+++ b/webapp/src/pages/PrestressedBeam.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
 import { designPrestressed } from '../engine/prestressedBeam'
 import { buildPrestressedSolution } from '../lib/prestressedSolution'
 import { PageHeader, VerdictPanel, DrawingCard, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
@@ -104,7 +103,7 @@ export default function PrestressedBeam() {
       )}
       <div className="mx-auto max-w-[1500px] px-5 py-5 sm:px-7">
         <p className="no-print text-[13px] text-[#5c6675]">
-          <Link to="/" className="font-semibold text-[#0f4c92]">← Home</Link> · Pretensioned bonded beam: PCI losses
+          Pretensioned bonded beam: PCI losses
           (ES/CR/SH/RE), §24.5 transfer & service stress limits, fps per §20.3.2.3.1, φMn ≥ 1.2Mcr, Vci/Vcw, camber.
         </p>
         <div className="no-print mt-4 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.3fr)_minmax(330px,1fr)]">

--- a/webapp/src/pages/Pricing.tsx
+++ b/webapp/src/pages/Pricing.tsx
@@ -116,7 +116,7 @@ export default function Pricing() {
 
       {!CHECKOUT_ENABLED && (
         <div className="mt-5 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-[13px] leading-6 text-amber-900">
-          <strong>Paid plans are not open for sign-up yet.</strong> Payments are handled by PayMongo, and the
+          <strong>Paid plans are not open for sign-up yet.</strong> Payments are handled by Xendit, and the
           server that verifies a payment is in place — but nothing yet starts one, so no card details are collected
           anywhere in this app. Pro and Max are listed so you can see what they cover. Guest and Free are fully
           available.

--- a/webapp/src/pages/RockAnchor.tsx
+++ b/webapp/src/pages/RockAnchor.tsx
@@ -3,7 +3,8 @@ import { designRockAnchor } from '../engine/rockAnchor'
 import { ReportControls } from '../components/ReportControls'
 import { buildRockAnchorSolution } from '../lib/geotechSolutions'
 import { WorkedSolution } from '../components/WorkedSolution'
-import { PageHeader } from '../components/calc'
+import { PageHeader, CalcBody } from '../components/calc'
+import { Card, ResultCard } from '../components/qty'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -76,28 +77,29 @@ export default function RockAnchor() {
   return (
         <div>
       <PageHeader title="Rock / ground anchor" badges={['PTI DC35.1']} />
-      <main className="mx-auto max-w-3xl px-5 py-6">
       <ReportControls title="Rock Anchor" badges={['PTI DC35.1']} report={report} />
-      <p className="mt-2 text-sm text-slate-600">
-        PTI DC35.1 / FHWA-IF-99-015 check: prestressing-tendon design load (0.60·GUTS) and grout-ground
-        (rock socket) bond capacity vs the applied anchor tension. Governing allowable = the smaller.
-      </p>
+      <CalcBody>
+        <div className="space-y-5">
+          <p className="text-[13px] text-[#5c6675]">
+            PTI DC35.1 / FHWA-IF-99-015 check: prestressing-tendon design load (0.60·GUTS) and grout-ground
+            (rock socket) bond capacity vs the applied anchor tension. Governing allowable = the smaller.
+          </p>
 
-      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Tendon &amp; bond zone</h2>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-          <Field label="fpu" unit="MPa" value={fpu} onChange={setFpu} />
-          <Field label="Tendon area Aps" unit="mm²" value={Aps} onChange={setAps} />
-          <Field label="Axial demand T" unit="kN" value={T} onChange={setT} />
-          <Field label="Hole Ø" unit="m" value={holeDia} onChange={setHoleDia} step="0.005" />
-          <Field label="Bond length" unit="m" value={bondLength} onChange={setBondLength} />
-          <Field label="Bond τult" unit="kPa" value={tauUlt} onChange={setTauUlt} />
+          <Card title="Tendon & bond zone">
+            <Field label="fpu" unit="MPa" value={fpu} onChange={setFpu} />
+            <Field label="Tendon area Aps" unit="mm²" value={Aps} onChange={setAps} />
+            <Field label="Axial demand T" unit="kN" value={T} onChange={setT} />
+            <Field label="Hole Ø" unit="m" value={holeDia} onChange={setHoleDia} step="0.005" />
+            <Field label="Bond length" unit="m" value={bondLength} onChange={setBondLength} />
+            <Field label="Bond τult" unit="kPa" value={tauUlt} onChange={setTauUlt} />
+          </Card>
+
+
+          <WorkedSolution steps={solution} title="Calculation report — worked solution" />
         </div>
-      </section>
 
-      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Results</h2>
-        <Out label="GUTS = fpu·Aps" value={`${f0(r.GUTS)} kN`} />
+        <ResultCard title="Results">
+          <Out label="GUTS = fpu·Aps" value={`${f0(r.GUTS)} kN`} />
         <Out label="Tendon design load (0.60·GUTS)" value={`${f0(r.Td)} kN`} ok={r.tendonOK} />
         <Out label="Bond Qult / allowable (FS 2)" value={`${f0(r.Qult)} / ${f0(r.Qall)} kN`} ok={r.bondOK} />
         <Out label={`Governing allowable (${r.governs})`} value={`${f0(r.allowable)} kN`} ok={r.ok} />
@@ -108,12 +110,8 @@ export default function RockAnchor() {
           Td = 0.60·GUTS (PTI permanent max). Bond Qult = π·Dhole·Lbond·τult / FS. Proof load
           min(1.33·T, 0.80·GUTS). Provide the unbonded (free) length and corrosion protection separately.
         </p>
-      </section>
-      {/* The step-by-step already existed and only ever reached the PDF. */}
-      <div className="mt-5">
-        <WorkedSolution steps={solution} title="Calculation report — worked solution" />
-      </div>
-    </main>
+        </ResultCard>
+      </CalcBody>
     </div>
   )
 }

--- a/webapp/src/pages/SeismicWizard.tsx
+++ b/webapp/src/pages/SeismicWizard.tsx
@@ -4,7 +4,8 @@ import {
   nscpSeismicParams, baseShearCoeff, STRUCTURAL_SYSTEMS,
   type SoilProfile, type SeismicSource, type SeismicZone, type Occupancy,
 } from '../engine/nscpSeismic'
-import { PageHeader } from '../components/calc'
+import { PageHeader, CalcBody } from '../components/calc'
+import { ResultCard } from '../components/qty'
 
 const f3 = (n: number) => (Number.isFinite(n) ? n.toFixed(3) : '—')
 
@@ -59,7 +60,8 @@ export default function SeismicWizard() {
   return (
         <div>
       <PageHeader title="NSCP 208 Seismic Wizard" badges={['NSCP 2015 §208']} />
-      <main className="mx-auto max-w-3xl px-5 py-6">
+      <CalcBody wide>
+        <div className="space-y-5">
       <ReportControls title="Seismic Parameters Report" badges={['NSCP 2015 §208']} />
       <p className="mt-2 text-sm text-slate-600">
         Walk through the NSCP 2015 §208 static lateral-force tables — zone, soil, near-source, occupancy and
@@ -77,7 +79,7 @@ export default function SeismicWizard() {
         ))}
       </div>
 
-      <section className="mt-4 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+      <section className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
         {cur.key === 'zone' && (
           <>
             <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Seismic zone (§208.4.4.1)</h2>
@@ -157,8 +159,7 @@ export default function SeismicWizard() {
       </section>
 
       {/* live results summary */}
-      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="mb-2 text-[1.05rem] font-bold text-[#0056b3]">Seismic parameters</h2>
+      <ResultCard title="Seismic parameters">
         <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-sm sm:grid-cols-4">
           {[['Z', params.Z], ['Na', params.Na], ['Nv', params.Nv], ['Ca', params.Ca],
             ['Cv', params.Cv], ['I', params.I], ['R', params.R], ['T (s)', T]].map(([k, v]) => (
@@ -181,8 +182,9 @@ export default function SeismicWizard() {
           V = Cs·W (§208.5.2.1). Feed Ca, Cv, I, R into the 3D model space seismic generator for the
           full storey-force distribution. Verify the soil profile with a geotechnical investigation.
         </p>
-      </section>
-    </main>
+      </ResultCard>
+        </div>
+      </CalcBody>
     </div>
   )
 }

--- a/webapp/src/pages/Settlement.tsx
+++ b/webapp/src/pages/Settlement.tsx
@@ -9,7 +9,8 @@ import {
 import { buildSettlementSolution } from '../lib/settlementSolution'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { SoilProfile } from '../components/SoilProfile'
-import { PageHeader } from '../components/calc'
+import { PageHeader, CalcBody } from '../components/calc'
+import { Card, ResultCard } from '../components/qty'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -165,7 +166,8 @@ export default function Settlement() {
   return (
         <div>
       <PageHeader title="Foundation settlement" badges={['Boussinesq', 'Terzaghi', 'Schmertmann']} />
-      <main className="mx-auto max-w-3xl px-5 py-6">
+      <CalcBody wide>
+        <div className="space-y-5">
       <ReportControls title="Foundation Settlement" badges={['Boussinesq', 'Terzaghi', 'Schmertmann']} report={report} />
       <p className="mt-2 text-sm text-slate-600">
         Immediate (elastic and Schmertmann) plus primary consolidation settlement of a rectangular footing on a
@@ -173,9 +175,8 @@ export default function Settlement() {
         branch handled separately, so a stiff crust is not charged virgin compression it will never see.
       </p>
 
-      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Footing &amp; groundwater</h2>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <Card title="Footing & groundwater">
+        <div className="col-span-full grid grid-cols-2 gap-3 sm:grid-cols-4">
           <Field label="Bearing pressure q" unit="kPa" value={q} onChange={setQ} />
           <Field label="Width B" unit="m" value={B} onChange={setB} step="0.1" />
           <Field label="Length L" unit="m" value={L} onChange={setL} step="0.1" />
@@ -185,7 +186,7 @@ export default function Settlement() {
           <Field label="Poisson ν" value={nu} onChange={setNu} step="0.05" />
           <Field label="Time horizon" unit="yr" value={years} onChange={setYears} step="1" />
         </div>
-      </section>
+      </Card>
 
       <section data-pdf-drawing className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm
         [background-image:linear-gradient(#f0eee7_1px,transparent_1px),linear-gradient(90deg,#f0eee7_1px,transparent_1px)] [background-size:22px_22px]">
@@ -235,17 +236,15 @@ export default function Settlement() {
         </p>
       </section>
 
-      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Stress increase below the footing</h2>
+      <ResultCard title="Stress increase below the footing">
         <StressProfile q={q} B={B} L={L} Df={Df} zMax={Math.max(totalDepth, 2 * B)} />
         <p className="mt-2 text-[11px] text-slate-500">
           Boussinesq at the footing CENTRE, where the stress and therefore the settlement peak. The 2:1 rule is the
           average over the spread area, so it sits below the centre value and the two converge with depth.
         </p>
-      </section>
+      </ResultCard>
 
-      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="mb-2 text-[1.05rem] font-bold text-[#0056b3]">Settlement</h2>
+      <ResultCard title="Settlement">
         <Out label="Immediate — elastic" value={`${f1(elastic)} mm`} sub="q·B·(1−ν²)·If/Es" />
         <Out label="Immediate — Schmertmann" value={`${f1(schmert.settlement)} mm`}
           sub={`C₁ ${f2(schmert.C1)} · C₂ ${f2(schmert.C2)} · Izp ${f2(schmert.Izp)}`} />
@@ -257,10 +256,9 @@ export default function Settlement() {
         <Out label="Time to 90% consolidation"
           value={Number.isFinite(t90) ? `${f1(t90)} yr` : 'cv not given'}
           sub={govSoil ? `drainage path ${f2(drainagePath(govSoil))} m` : undefined} />
-      </section>
+      </ResultCard>
 
-      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="mb-2 text-[1.05rem] font-bold text-[#0056b3]">Consolidation by layer</h2>
+      <ResultCard title="Consolidation by layer">
         <div className="overflow-x-auto">
           <table className="w-full text-right text-[12px]">
             <thead className="text-slate-500">
@@ -294,12 +292,13 @@ export default function Settlement() {
           sampled at mid-height. Time factors are the standard closed-form fits to Terzaghi&rsquo;s series, good to
           about 1% — not the series itself.
         </p>
-      </section>
+      </ResultCard>
       {/* The step-by-step already existed and only ever reached the PDF. */}
       <div className="mt-5">
         <WorkedSolution steps={solution} title="Calculation report — worked solution" />
       </div>
-    </main>
+        </div>
+      </CalcBody>
     </div>
   )
 }

--- a/webapp/src/pages/ShotcreteFacing.tsx
+++ b/webapp/src/pages/ShotcreteFacing.tsx
@@ -3,7 +3,8 @@ import { designFacing } from '../engine/shotcreteFacing'
 import { ReportControls } from '../components/ReportControls'
 import { buildFacingSolution } from '../lib/geotechSolutions'
 import { WorkedSolution } from '../components/WorkedSolution'
-import { PageHeader } from '../components/calc'
+import { PageHeader, CalcBody } from '../components/calc'
+import { Card, ResultCard } from '../components/qty'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -83,38 +84,39 @@ export default function ShotcreteFacing() {
   return (
         <div>
       <PageHeader title="Soil-nail shotcrete facing" badges={['FHWA GEC-7']} />
-      <main className="mx-auto max-w-3xl px-5 py-6">
       <ReportControls title="Shotcrete Facing" badges={['FHWA GEC-7']} report={report} />
-      <p className="mt-2 text-sm text-slate-600">
-        FHWA GEC-7 facing check. The thin shotcrete panel spans <b>between</b> the nail heads, so earth
-        pressure bends it like a two-way slab on point supports — hogging over each nail, sagging at
-        midspan. This checks the facing flexural nail-head strength R<sub>FF</sub> and the punching-shear
-        strength R<sub>FP</sub> against the nail-head force.
-      </p>
+      <CalcBody>
+        <div className="space-y-5">
+          <p className="text-[13px] text-[#5c6675]">
+            FHWA GEC-7 facing check. The thin shotcrete panel spans <b>between</b> the nail heads, so earth
+            pressure bends it like a two-way slab on point supports — hogging over each nail, sagging at
+            midspan. This checks the facing flexural nail-head strength R<sub>FF</sub> and the punching-shear
+            strength R<sub>FP</sub> against the nail-head force.
+          </p>
 
-      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Layout &amp; facing</h2>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <Field label="Horiz. spacing SH" unit="m" value={SH} onChange={setSH} />
-          <Field label="Vert. spacing SV" unit="m" value={SV} onChange={setSV} />
-          <Field label="Facing thickness hc" unit="mm" value={hc} onChange={setHc} />
-          <Field label="Cover" unit="mm" value={cover} onChange={setCover} />
-          <Field label="Vert. steel As" unit="mm²/m" value={AsVert} onChange={setAsVert} />
-          <Field label="Horiz. steel As" unit="mm²/m" value={AsHoriz} onChange={setAsHoriz} />
-          <Field label="Bearing plate" unit="m" value={bearingPlate} onChange={setBearingPlate} step="0.05" />
-          <Field label="Pressure factor CF" value={CF} onChange={setCF} step="0.1" />
-        </div>
-        <h2 className="mb-3 mt-5 text-[1.05rem] font-bold text-[#0056b3]">Materials &amp; demand</h2>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-          <Field label="f′c" unit="MPa" value={fc} onChange={setFc} />
-          <Field label="fy" unit="MPa" value={fy} onChange={setFy} />
-          <Field label="Nail-head force" unit="kN" value={nailHeadForce} onChange={setNailHeadForce} />
-        </div>
-      </section>
+          <Card title="Layout & facing">
+            <Field label="Horiz. spacing SH" unit="m" value={SH} onChange={setSH} />
+            <Field label="Vert. spacing SV" unit="m" value={SV} onChange={setSV} />
+            <Field label="Facing thickness hc" unit="mm" value={hc} onChange={setHc} />
+            <Field label="Cover" unit="mm" value={cover} onChange={setCover} />
+            <Field label="Vert. steel As" unit="mm²/m" value={AsVert} onChange={setAsVert} />
+            <Field label="Horiz. steel As" unit="mm²/m" value={AsHoriz} onChange={setAsHoriz} />
+            <Field label="Bearing plate" unit="m" value={bearingPlate} onChange={setBearingPlate} step="0.05" />
+            <Field label="Pressure factor CF" value={CF} onChange={setCF} step="0.1" />
+          </Card>
 
-      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Results</h2>
-        <Out label="Panel moment m (vert / horiz)" value={`${f2(r.mVert)} / ${f2(r.mHoriz)} kN·m/m`} />
+          <Card title="Materials & demand">
+            <Field label="f′c" unit="MPa" value={fc} onChange={setFc} />
+            <Field label="fy" unit="MPa" value={fy} onChange={setFy} />
+            <Field label="Nail-head force" unit="kN" value={nailHeadForce} onChange={setNailHeadForce} />
+          </Card>
+
+
+          <WorkedSolution steps={solution} title="Calculation report — worked solution" />
+        </div>
+
+        <ResultCard title="Results">
+          <Out label="Panel moment m (vert / horiz)" value={`${f2(r.mVert)} / ${f2(r.mHoriz)} kN·m/m`} />
         <Out label="Flexural R_FF (vert / horiz)" value={`${f0(r.RffVert)} / ${f0(r.RffHoriz)} kN`} />
         <Out label="Punching R_FP" value={`${f0(r.Rfp)} kN`} />
         <Out label={`Governing facing strength (${r.governs})`} value={`${f0(r.strength)} kN`} ok={r.ok} />
@@ -124,12 +126,8 @@ export default function ShotcreteFacing() {
           around the bearing plate. C_F ≈ 2.0 thin → 1.0 thick facing (FHWA GEC-7 Table). Headed-stud
           tension (permanent facing) and temporary-vs-final facing stages are checked separately.
         </p>
-      </section>
-      {/* The step-by-step already existed and only ever reached the PDF. */}
-      <div className="mt-5">
-        <WorkedSolution steps={solution} title="Calculation report — worked solution" />
-      </div>
-    </main>
+        </ResultCard>
+      </CalcBody>
     </div>
   )
 }

--- a/webapp/src/pages/SlopeStability.tsx
+++ b/webapp/src/pages/SlopeStability.tsx
@@ -9,7 +9,8 @@ import { infiniteSlopeFS } from '../engine/geotech'
 import { buildInfiniteSlopeSolution } from '../lib/geotechPageSolutions'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { SoilLayerPicker } from '../components/SoilLayerPicker'
-import { PageHeader } from '../components/calc'
+import { PageHeader, CalcBody } from '../components/calc'
+import { Card, ResultCard } from '../components/qty'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -169,7 +170,8 @@ export default function SlopeStability() {
   return (
         <div>
       <PageHeader title="Slope stability — method of slices" badges={['Bishop', 'Fellenius', 'Janbu']} />
-      <main className="mx-auto max-w-3xl px-5 py-6">
+      <CalcBody wide>
+        <div className="space-y-5">
       <ReportControls title="Slope Stability" badges={['Bishop', 'Fellenius', 'Janbu']} report={report} />
       <p className="mt-2 text-sm text-slate-600">
         Circular-failure factor of safety by the method of slices — Fellenius/OMS, Bishop&rsquo;s simplified and
@@ -188,26 +190,27 @@ export default function SlopeStability() {
           }} />
       </section>
 
-      <section className="mt-4 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Slope geometry</h2>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <Card title="Slope geometry">
+        <div className="col-span-full grid grid-cols-2 gap-3 sm:grid-cols-4">
           <Field label="Height H" unit="m" value={H} onChange={setH} />
           <Field label="Face angle β" unit="°" value={beta} onChange={setBeta} />
           <Field label="Crest width" unit="m" value={crestW} onChange={setCrestW} />
           <Field label="Toe width" unit="m" value={toeW} onChange={setToeW} />
         </div>
-        <h2 className="mb-3 mt-5 text-[1.05rem] font-bold text-[#0056b3]">Soil &amp; water</h2>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        </Card>
+
+      <Card title="Soil & water">
+        <div className="col-span-full grid grid-cols-2 gap-3 sm:grid-cols-4">
           <Field label="Cohesion c′" unit="kPa" value={c} onChange={setC} />
           <Field label="Friction φ′" unit="°" value={phi} onChange={setPhi} />
           <Field label="Unit weight γ" unit="kN/m³" value={gamma} onChange={setGamma} />
           <Field label="Pore ratio ru" value={ru} onChange={setRu} step="0.05" />
         </div>
-      </section>
+      </Card>
 
-      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+      <section className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
         <div className="mb-2 flex items-center justify-between">
-          <h2 className="text-[1.05rem] font-bold text-[#0056b3]">Critical circle</h2>
+          <h2 className="text-[13.5px] font-bold text-[#0f1b2a]">Critical circle</h2>
           <label className="flex items-center gap-2 text-sm">
             <span className="text-slate-500">Governing method</span>
             <select value={method} onChange={(e) => setMethod(e.target.value as typeof method)}
@@ -239,8 +242,7 @@ export default function SlopeStability() {
       </section>
 
       {crit && (
-        <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-          <h2 className="mb-2 text-[1.05rem] font-bold text-[#0056b3]">Slices (critical circle)</h2>
+        <ResultCard title="Slices (critical circle)">
           <div className="overflow-x-auto">
             <table className="w-full text-right text-[12px]">
               <thead className="text-slate-500">
@@ -265,17 +267,17 @@ export default function SlopeStability() {
             Bishop: FS = Σ[(c·b + (W − u·b)·tanφ)/mα] / Σ[W·sinα], mα = cosα + sinα·tanφ/FS (iterated).
             Fellenius drops the inter-slice terms; Janbu uses force equilibrium × f₀.
           </p>
-        </section>
+        </ResultCard>
       )}
 
       {/* ── Infinite slope — the OTHER failure mode ────────────────────── */}
-      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="text-[1.05rem] font-bold text-[#0056b3]">Infinite slope — planar failure</h2>
+      <section className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
+        <h2 className="text-[13.5px] font-bold text-[#0f1b2a]">Infinite slope — planar failure</h2>
         <p className="mb-3 text-[11px] text-slate-500">
           A shallow soil mantle sliding on a plane parallel to the ground — over rock, or a firm
           stratum. Uses the same c, φ, γ and slope angle β entered above.
         </p>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <div className="col-span-full grid grid-cols-2 gap-3 sm:grid-cols-4">
           <label className="flex flex-col text-sm">
             <span className="mb-1 font-medium text-slate-600">Failure depth z (m)</span>
             <input type="number" step="0.5" value={infZ}
@@ -304,9 +306,11 @@ export default function SlopeStability() {
             </span>
           </span>
         </div>
-        <WorkedSolution steps={infSteps} title="Infinite slope — worked solution" />
       </section>
-    </main>
+
+      <WorkedSolution steps={infSteps} title="Infinite slope — worked solution" />
+        </div>
+      </CalcBody>
     </div>
   )
 }

--- a/webapp/src/pages/SoilNail.tsx
+++ b/webapp/src/pages/SoilNail.tsx
@@ -3,7 +3,8 @@ import { designSoilNail } from '../engine/soilNail'
 import { ReportControls } from '../components/ReportControls'
 import { buildSoilNailSolution } from '../lib/geotechSolutions'
 import { WorkedSolution } from '../components/WorkedSolution'
-import { PageHeader } from '../components/calc'
+import { PageHeader, CalcBody } from '../components/calc'
+import { Card, ResultCard } from '../components/qty'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -86,54 +87,50 @@ export default function SoilNail() {
   return (
         <div>
       <PageHeader title="Soil-nail wall — per-nail check" badges={['FHWA GEC-7']} />
-      <main className="mx-auto max-w-3xl px-5 py-6">
       <ReportControls title="Soil-Nail Wall" badges={['FHWA GEC-7']} report={report} />
-      <p className="mt-2 text-sm text-slate-600">
-        Preliminary FHWA GEC-7 checks for a single nail: tributary active demand vs bar-tensile and
-        grout-ground pullout capacities. Global (slip-surface) stability is separate — use the{' '}
-        <a href="/geotech" className="text-[#0056b3] underline">slope-stability tool</a>.
-      </p>
+      <CalcBody>
+        <div className="space-y-5">
+          <p className="text-[13px] text-[#5c6675]">
+            Preliminary FHWA GEC-7 checks for a single nail: tributary active demand vs bar-tensile and
+            grout-ground pullout capacities. Global (slip-surface) stability is separate — use the{' '}
+            <a href="/slope" className="text-[#0f4c92] underline">slope-stability tool</a>.
+          </p>
 
-      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Geometry &amp; soil</h2>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <Field label="Nail depth z" unit="m" value={z} onChange={setZ} />
-          <Field label="Horiz. spacing Sh" unit="m" value={Sh} onChange={setSh} />
-          <Field label="Vert. spacing Sv" unit="m" value={Sv} onChange={setSv} />
-          <Field label="γ" unit="kN/m³" value={gamma} onChange={setGamma} />
-          <Field label="φ" unit="°" value={phi} onChange={setPhi} />
-          <Field label="Surcharge q" unit="kPa" value={q} onChange={setQ} />
-        </div>
-        <h2 className="mb-3 mt-5 text-[1.05rem] font-bold text-[#0056b3]">Nail &amp; grout</h2>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <Field label="Bar Ø" unit="mm" value={barDia} onChange={setBarDia} />
-          <Field label="fy" unit="MPa" value={fy} onChange={setFy} />
-          <Field label="Drill hole DDH" unit="m" value={drillDia} onChange={setDrillDia} step="0.01" />
-          <Field label="Bond length Le" unit="m" value={bondLength} onChange={setBondLength} />
-          <Field label="Bond strength qu" unit="kPa" value={qu} onChange={setQu} />
-        </div>
-      </section>
+          <Card title="Geometry & soil">
+            <Field label="Nail depth z" unit="m" value={z} onChange={setZ} />
+            <Field label="Horiz. spacing Sh" unit="m" value={Sh} onChange={setSh} />
+            <Field label="Vert. spacing Sv" unit="m" value={Sv} onChange={setSv} />
+            <Field label="γ" unit="kN/m³" value={gamma} onChange={setGamma} />
+            <Field label="φ" unit="°" value={phi} onChange={setPhi} />
+            <Field label="Surcharge q" unit="kPa" value={q} onChange={setQ} />
+          </Card>
 
-      <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Results</h2>
-        <Out label="Ka (Rankine)" value={f2(r.Ka)} />
-        <Out label="Demand Tmax = Ka·(γz+q)·Sh·Sv" value={`${f2(r.Tmax)} kN`} />
-        <Out label="Bar tensile Tn = Ab·fy" value={`${f2(r.Tn)} kN`} />
-        <Out label="FS tensile (Tn / Tmax ≥ 1.8)" value={f2(r.fsTensile)} ok={r.tensileOK} />
-        <Out label="Pullout Qult = π·DDH·Le·qu" value={`${f2(r.Qult)} kN`} />
-        <Out label="FS pullout (Qult / Tmax ≥ 2.0)" value={f2(r.fsPullout)} ok={r.pulloutOK} />
-        <Out label="Bond length for FS = 2.0" value={`${f2(r.bondLengthReq)} m`} ok={bondLength >= r.bondLengthReq} />
-        <p className="mt-2 text-[10px] text-slate-500">
-          FHWA GEC-7. Tmax is the tributary active load on one nail at depth z. Allowable bar load Tn/1.8,
-          allowable pullout Qult/2.0. Provide Le ≥ the required bond length beyond the slip surface.
-          This is a preliminary component check — verify global stability separately.
-        </p>
-      </section>
-      {/* The step-by-step already existed and only ever reached the PDF. */}
-      <div className="mt-5">
-        <WorkedSolution steps={solution} title="Calculation report — worked solution" />
-      </div>
-    </main>
+          <Card title="Nail & grout">
+            <Field label="Bar Ø" unit="mm" value={barDia} onChange={setBarDia} />
+            <Field label="fy" unit="MPa" value={fy} onChange={setFy} />
+            <Field label="Drill hole DDH" unit="m" value={drillDia} onChange={setDrillDia} step="0.01" />
+            <Field label="Bond length Le" unit="m" value={bondLength} onChange={setBondLength} />
+            <Field label="Bond strength qu" unit="kPa" value={qu} onChange={setQu} />
+          </Card>
+
+          <WorkedSolution steps={solution} title="Calculation report — worked solution" />
+        </div>
+
+        <ResultCard title="Results">
+          <Out label="Ka (Rankine)" value={f2(r.Ka)} />
+          <Out label="Demand Tmax = Ka·(γz+q)·Sh·Sv" value={`${f2(r.Tmax)} kN`} />
+          <Out label="Bar tensile Tn = Ab·fy" value={`${f2(r.Tn)} kN`} />
+          <Out label="FS tensile (Tn / Tmax ≥ 1.8)" value={f2(r.fsTensile)} ok={r.tensileOK} />
+          <Out label="Pullout Qult = π·DDH·Le·qu" value={`${f2(r.Qult)} kN`} />
+          <Out label="FS pullout (Qult / Tmax ≥ 2.0)" value={f2(r.fsPullout)} ok={r.pulloutOK} />
+          <Out label="Bond length for FS = 2.0" value={`${f2(r.bondLengthReq)} m`} ok={bondLength >= r.bondLengthReq} />
+          <p className="mt-2 text-[10px] text-[#a39d8d]">
+            FHWA GEC-7. Tmax is the tributary active load on one nail at depth z. Allowable bar load Tn/1.8,
+            allowable pullout Qult/2.0. Provide Le ≥ the required bond length beyond the slip surface.
+            This is a preliminary component check — verify global stability separately.
+          </p>
+        </ResultCard>
+      </CalcBody>
     </div>
   )
 }

--- a/webapp/src/pages/TBeamDesign.tsx
+++ b/webapp/src/pages/TBeamDesign.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
 import { designTBeam, type TBeamKind } from '../engine/tbeam'
 import { buildTBeamSolution } from '../lib/tbeamSolution'
 import { PageHeader, VerdictPanel, DrawingCard, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
@@ -65,7 +64,7 @@ export default function TBeamDesign() {
       )}
       <div className="mx-auto max-w-[1500px] px-5 py-5 sm:px-7">
         <p className="no-print text-[13px] text-[#5c6675]">
-          <Link to="/" className="font-semibold text-[#0f4c92]">← Home</Link> · Flanged-beam flexure: §6.3.2 effective width,
+          Flanged-beam flexure: §6.3.2 effective width,
           rectangular vs true-T stress block, §9.6.1.2 minimum steel, εt/φ per §21.2.2. Positive Mu = flange in compression.
         </p>
         <div className="no-print mt-4 grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,1.3fr)_minmax(330px,1fr)]">

--- a/webapp/src/pages/TrussSpace.tsx
+++ b/webapp/src/pages/TrussSpace.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Link } from 'react-router-dom'
 import { Canvas } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 import { SceneText } from '../components/SceneText'
@@ -15,6 +14,7 @@ import { FitView } from '../components/FitView'
 import { buildSectionShapes } from '../lib/sectionShapes3d'
 import { Num, Pick, Card, ResultCard, Row } from '../components/qty'
 import { ReportControls } from '../components/ReportControls'
+import { PageHeader } from '../components/calc'
 import { f1, f2 } from '../lib/format'
 
 const TENSION = '#1d4ed8', COMPRESSION = '#dc2626', ZERO = '#94a3b8', SEL = '#f59e0b'
@@ -198,15 +198,13 @@ export default function TrussSpace() {
   const serviceLoad = deadLoad + liveLoad
 
   return (
-    <div className="mx-auto max-w-[1700px] p-4">
-      <div className="flex flex-wrap items-end justify-between gap-3">
-        <div>
-          <Link to="/" className="no-print text-sm text-[#0056b3] hover:underline">← Home</Link>
-          <h1 className="text-2xl font-extrabold tracking-tight text-[#0056b3]">Truss Space</h1>
-          <p className="text-xs text-slate-500">Planar pin-jointed truss — generate, analyse (axial forces) &amp; design (AISC LRFD).</p>
-        </div>
-        <ReportControls title="Truss Design Report" />
-      </div>
+    <div>
+      <PageHeader title="Truss Space" badges={['AISC LRFD']} />
+      <div className="mx-auto max-w-[1700px] px-5 py-5 sm:px-7">
+      <ReportControls title="Truss Design Report" />
+      <p className="mt-2 text-[13px] text-[#5c6675]">
+        Planar pin-jointed truss — generate, analyse (axial forces) &amp; design (AISC LRFD).
+      </p>
 
       <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-[3fr_2fr]">
         {/* 3D viewport */}
@@ -611,6 +609,7 @@ export default function TrussSpace() {
           </div>
         </div>
       )}
+      </div>
     </div>
   )
 }

--- a/webapp/src/pages/WeldedConnection.tsx
+++ b/webapp/src/pages/WeldedConnection.tsx
@@ -62,7 +62,7 @@ export default function WeldedConnection() {
   return (
         <div>
       <PageHeader title="Eccentric weld group" badges={['AISC 360-16']} />
-      <main className="mx-auto max-w-[1400px] px-5 py-6">
+      <main className="mx-auto max-w-[1500px] px-5 py-5 sm:px-7">
       <ReportControls title="Welded Connection Report" badges={['AISC 360-16']} />
       <p className="mt-2 max-w-3xl text-sm text-slate-600">
         Elastic (weld-as-a-line) method for an eccentrically-loaded fillet weld group. Each unit length
@@ -72,9 +72,9 @@ export default function WeldedConnection() {
       </p>
 
       <div className="mt-6 grid gap-5 lg:grid-cols-[1.1fr_1fr]">
-        <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <section className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
           <div className="mb-3 flex items-center justify-between">
-            <h2 className="text-[1.05rem] font-bold text-[#0056b3]">Weld segments (mm)</h2>
+            <h2 className="text-[13.5px] font-bold text-[#0f1b2a]">Weld segments (mm)</h2>
             <button type="button" onClick={addSeg} className="rounded-md border border-slate-300 px-2.5 py-1 text-xs font-semibold text-[#0056b3] hover:bg-blue-50">+ Add segment</button>
           </div>
           <div className="max-h-56 overflow-auto">
@@ -95,7 +95,7 @@ export default function WeldedConnection() {
             </table>
           </div>
 
-          <h2 className="mb-2 mt-4 text-[1.05rem] font-bold text-[#0056b3]">Load &amp; weld</h2>
+          <h2 className="mb-2 mt-4 text-[13.5px] font-bold text-[#0f1b2a]">Load &amp; weld</h2>
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
             {([['Load P (kN)', P, setP], ['Angle (° from +X)', angle, setAngle], ['Fillet leg w (mm)', size, setSize],
               ['Load at x (mm)', px, setPx], ['Load at y (mm)', py, setPy], ['F_EXX (MPa)', FEXX, setFEXX],
@@ -109,11 +109,11 @@ export default function WeldedConnection() {
         </section>
 
         <section className="space-y-4">
-          <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+          <div className="rounded-lg border border-[#e3e1da] bg-[#faf9f6] p-3">
             <WeldPlot r={r} segs={segs} px={px} py={py} />
           </div>
-          <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm text-sm">
-            <h2 className="mb-1 text-[1.05rem] font-bold text-[#0056b3]">Results</h2>
+          <div className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4 text-sm">
+            <h2 className="mb-2 text-[13.5px] font-bold text-[#0f1b2a]">Results</h2>
             {[['Total weld length L_w', `${f2(r.Lw)} mm`],
               ['Centroid C', `(${f2(r.Cx)}, ${f2(r.Cy)}) mm`],
               ['Load components Pₓ / Pᵧ', `${f2(r.Px)} / ${f2(r.Py)} kN`],

--- a/webapp/src/pages/WoodSlab.tsx
+++ b/webapp/src/pages/WoodSlab.tsx
@@ -4,7 +4,8 @@ import { speciesList, gradesOf, resolveWoodSpecies } from '../engine/woodDesign'
 import type { LoadDuration } from '../engine/woodDesign'
 import { costTimberRows } from '../engine/takeoff'
 import { ReportControls } from '../components/ReportControls'
-import { PageHeader } from '../components/calc'
+import { PageHeader, CalcBody } from '../components/calc'
+import { Card, ResultCard } from '../components/qty'
 
 function num(v: string, d = 0): number { const n = parseFloat(v); return Number.isFinite(n) ? n : d }
 const f2 = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : '—')
@@ -95,7 +96,8 @@ export default function WoodSlab() {
   return (
         <div>
       <PageHeader title="Wood slab — deck on joists" badges={['NDS 2018 §3', 'NSCP 2015 §6']} />
-      <main className="mx-auto max-w-3xl px-5 py-6">
+      <CalcBody wide>
+        <div className="space-y-5">
       <ReportControls title="Wood Slab Design Report" badges={['NDS 2018 §3', 'NSCP 2015 §6']} />
       <p className="mt-2 text-sm text-slate-600">
         ASD design of a wood floor slab: decking (planks or bamboo slats) spanning between repetitive
@@ -104,17 +106,18 @@ export default function WoodSlab() {
         from the decking (C_L = 1). Bamboo values are preliminary (ISO 22156 / published).
       </p>
 
-      <section className="mt-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="mb-3 text-[1.05rem] font-bold text-[#0056b3]">Plan &amp; loads</h2>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <Card title="Plan & loads">
+        <div className="col-span-full grid grid-cols-2 gap-3 sm:grid-cols-4">
           <Field label="Lx (joist span)" unit="m" value={Lx} onChange={setLx} />
           <Field label="Ly (joists repeat)" unit="m" value={Ly} onChange={setLy} />
           <Field label="Superimposed dead" unit="kPa" value={deadKpa} onChange={setDeadKpa} />
           <Field label="Live load" unit="kPa" value={liveKpa} onChange={setLiveKpa} />
         </div>
 
-        <h2 className="mb-3 mt-5 text-[1.05rem] font-bold text-[#0056b3]">Joists</h2>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        </Card>
+
+      <Card title="Joists">
+        <div className="col-span-full grid grid-cols-2 gap-3 sm:grid-cols-4">
           <label className="flex flex-col text-sm">
             <span className="mb-1 font-medium text-slate-600">Species</span>
             <select value={species} onChange={(e) => { setSpecies(e.target.value); const g = gradesOf(e.target.value); if (g.length) setGrade(g[0].grade) }}
@@ -142,8 +145,10 @@ export default function WoodSlab() {
           </label>
         </div>
 
-        <h2 className="mb-3 mt-5 text-[1.05rem] font-bold text-[#0056b3]">Decking</h2>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        </Card>
+
+      <Card title="Decking">
+        <div className="col-span-full grid grid-cols-2 gap-3 sm:grid-cols-4">
           <label className="flex flex-col text-sm">
             <span className="mb-1 font-medium text-slate-600">Material</span>
             <select value={deckMaterial} onChange={(e) => { const m = e.target.value as DeckMaterial; setDeckMaterial(m); setDeckWidth(m === 'bamboo-slat' ? 50 : 140) }}
@@ -164,8 +169,10 @@ export default function WoodSlab() {
           </label>
         </div>
 
-        <h2 className="mb-3 mt-5 text-[1.05rem] font-bold text-[#0056b3]">Service conditions</h2>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        </Card>
+
+      <Card title="Service conditions">
+        <div className="col-span-full grid grid-cols-2 gap-3 sm:grid-cols-4">
           <label className="flex flex-col text-sm">
             <span className="mb-1 font-medium text-slate-600">Load duration (C_D)</span>
             <select value={duration} onChange={(e) => setDuration(e.target.value as LoadDuration)}
@@ -186,16 +193,17 @@ export default function WoodSlab() {
             </select>
           </label>
         </div>
-      </section>
+      </Card>
 
       {r && (
-        <section className="mt-5 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-          <div className="mb-3 flex items-baseline justify-between">
-            <h2 className="text-[1.05rem] font-bold text-[#0056b3]">Results</h2>
-            <span className={`rounded px-2.5 py-1 text-sm font-bold ${r.ok ? 'bg-emerald-50 text-emerald-700' : 'bg-red-50 text-red-700'}`}>
+        <ResultCard title={
+          <span className="flex w-full items-baseline justify-between gap-3">
+            Results
+            <span className={`rounded px-2.5 py-1 text-[11px] font-bold ${r.ok ? 'bg-emerald-50 text-emerald-700' : 'bg-red-50 text-red-700'}`}>
               {r.ok ? 'SLAB OK' : 'INADEQUATE'} · governing {f2(r.ratio)}
             </span>
-          </div>
+          </span>
+        }>
           <div className="mb-3 grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
             <Out label="Deck self-wt" value={`${f2(r.loads.deckSelfKpa)} kPa`} />
             <Out label="Joist self-wt" value={`${f2(r.loads.joistSelfKpa)} kPa`} />
@@ -263,9 +271,10 @@ export default function WoodSlab() {
             wood-frame model bill of materials. Verify joist-to-support bearing, fastener schedule and
             diaphragm action separately.
           </p>
-        </section>
+        </ResultCard>
       )}
-    </main>
+        </div>
+      </CalcBody>
     </div>
   )
 }

--- a/webapp/src/pages/legal/Privacy.tsx
+++ b/webapp/src/pages/legal/Privacy.tsx
@@ -59,7 +59,7 @@ export default function Privacy() {
         <ul className="list-inside list-disc space-y-1">
           <li><strong>Supabase</strong> — accounts, authentication and saved projects.</li>
           <li><strong>Vercel</strong> — hosting and delivery of the website.</li>
-          <li><strong>PayMongo</strong> — payment processing. They are a separate controller of the
+          <li><strong>Xendit</strong> — payment processing. They are a separate controller of the
             payment details you give them; see their own privacy policy.</li>
         </ul>
         <p>


### PR DESCRIPTION
Items 1–3 of the to-do list. Layer: view / view-support only — no engine module is touched, so no new `*.test.ts` case is owed. The whole suite is re-run as the guard.

The list read as fourteen separate complaints ("cards too narrow", "legacy cards", "header is not the new default"). They are three causes:

## 1. Ten pages were locked to `max-w-3xl`

Micropile, Soil Nail, Rock Anchor, Shotcrete Facing, Lateral Pile, Settlement, Slope Stability, Seismic Wizard, Wood Slab and Plumbing Design each set their own narrow container, so their inputs stacked in one column on a screen with room for three.

A shared `CalcBody` now holds the standard `max-w-[1500px]` body and the results-rail grid, and those ten pages use it. Two follow-on fixes fell out of the move: Wood Slab was rendering "Results" twice (the verdict badge is now folded into the card title), and Slope Stability's worked solution was nested *inside* another card instead of beside it.

## 2. Cards predating the shared `Card`

- **Pile Cap** and **Combined Footing** each declared a local `function Card` — a `<fieldset>` with a blue `<legend>` — shadowing the shared one. Both deleted; their local `Row` restyled to the ink palette.
- **Bolted** and **Welded Connection** carried the old blue-heading white-card chrome inline. Restyled to `rail-card` + the 13.5 px ink heading, containers widened to match.
- **Frame Analysis** (4 panels), **Beam Analysis** (2) and **Load Path**'s "Area loads" fieldset now use the shared `Card`, so they pick up the auto-numbering (`01 Member section`, `02 Nodes`, …) the rest of the app has.

`Card` gains a `grid` escape hatch mirroring `CalcSection`'s: these panels hold tables and canvases rather than field rows, and the three-column field grid squeezes them.

**Foundation Design was deliberately left alone.** It also declares a local `Card`, but that one wraps `CalcSection` and is already the new style — it is not a legacy case.

## 3. Header and stray links

Truss Space had a bespoke header block; it now uses `PageHeader` like every other page. `← Home` is removed from Truss Space, Prestressed Beam and T-Beam Design — the sidebar is the way home.

## Verification

- `npx tsc -b` clean, `npm run lint` clean, **3823 tests / 214 files green**.
- Screenshotted `/frame` (numbered cards, results rail on the right) and `/truss` (new `PageHeader`, no Home link) in headless Chromium.

## Not in this PR

Still open from the same list, one PR each: missing worked solutions (Welded Connection, Pile Cap, Wood Slab); the three Steel Design 3D rendering bugs; the Model Space walkthrough's demo template + restore; and deriving the BOQ concrete class from the design f′c.

This branch also carries the earlier commit updating `siteConfig` to the registered business details and switching the named payment processor from PayMongo to Xendit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmPbtTVsjNBXVpiQVBYBnz)_