### PR TITLE
feat(design): worked solutions for the weld group, pile cap and wood slab

### DIFF
--- a/webapp/src/engine/pileCap.test.ts
+++ b/webapp/src/engine/pileCap.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { designPileCap, pileCentres } from './pileCap';
+import { designPileCap, pileCapSolution, pileCentres } from './pileCap';
 
 // Shared base inputs — 4-pile square cap, concentric load
 const BASE = {
@@ -131,5 +131,60 @@ describe('designPileCap — 9-pile cap', () => {
     expect(r.coords).toHaveLength(9);
     expect(r.Dc).toBeGreaterThan(0);
     expect(r.capacityOK).toBe(true);
+  });
+});
+
+describe('pileCapSolution — the printed report', () => {
+  // Four failure modes size the cap and the report has to show all four, so
+  // the step list is asserted by name, not just by count.
+  it('shows every check that sized the cap', () => {
+    const r = designPileCap(BASE);
+    const s = pileCapSolution(BASE, r);
+    const titles = s.map(st => st.title);
+    expect(titles).toEqual([
+      'Cap plan dimensions',
+      'Service pile reactions',
+      'Cap thickness',
+      'Two-way (punching) shear at the column',
+      'Two-way (punching) shear at a pile',
+      'One-way (beam) shear, both directions',
+      'Flexure at the column face',
+      'Development of the bottom bars',
+    ]);
+  });
+
+  it('every PASS chip matches the result it reports', () => {
+    // An overloaded group and a well-behaved one, so both polarities run.
+    for (const inp of [BASE, { ...BASE, serviceLoad: 4000, ultimateLoad: 5600 }]) {
+      const r = designPileCap(inp);
+      const s = pileCapSolution(inp, r);
+      const pass = (t: string) => s.find(st => st.title === t)!.pass;
+      expect(pass('Service pile reactions')).toBe(r.capacityOK);
+      expect(pass('Two-way (punching) shear at the column')).toBe(r.punchColOK);
+      expect(pass('Two-way (punching) shear at a pile')).toBe(r.punchPileOK);
+      expect(pass('One-way (beam) shear, both directions')).toBe(r.beamXOK && r.beamYOK);
+      expect(pass('Development of the bottom bars')).toBe(r.ldOK);
+    }
+    expect(designPileCap({ ...BASE, serviceLoad: 4000, ultimateLoad: 5600 }).capacityOK).toBe(false);
+  });
+
+  it('prints the solver’s own dimensions, steel and no undefined', () => {
+    const r = designPileCap(BASE);
+    const text = pileCapSolution(BASE, r)
+      .flatMap(st => st.lines.map(ln => ('tex' in ln ? ln.tex : ln.text))).join('\n');
+    expect(text).not.toMatch(/undefined|NaN/);
+    expect(text).toContain(String(r.capBx));
+    expect(text).toContain(String(r.Dc));
+    expect(text).toContain(`${r.steelX.bars}–⌀${BASE.barDia}`);
+    expect(text).toContain(`${r.steelY.bars}–⌀${BASE.barDia}`);
+  });
+
+  it('calls out uplift when a pile goes into tension', () => {
+    // Big overturning moment on a 2-pile cap ⇒ one reaction negative.
+    const inp = { ...BASE, nPiles: 2 as const, serviceMomX: 0, serviceMomY: 2000 };
+    const r = designPileCap(inp);
+    expect(Math.min(...r.reactions)).toBeLessThan(0);
+    const step = pileCapSolution(inp, r).find(st => st.title === 'Service pile reactions')!;
+    expect(JSON.stringify(step.lines)).toMatch(/uplift/i);
   });
 });

--- a/webapp/src/engine/pileCap.ts
+++ b/webapp/src/engine/pileCap.ts
@@ -7,6 +7,7 @@
 
 import { twoWayVc, oneWayVc } from './shear';
 import { flexuralSteel, matLayout } from './flexure';
+import { type SolutionStep, sn0, sn1, sn2 } from '../lib/solution';
 
 const PHI_V = 0.75;
 
@@ -271,4 +272,94 @@ export function designPileCap(inp: PileCapInput): PileCapResult {
     steelY: { As: flexY.As, rho: flexY.rho, bars: layoutY.n, spacing: layoutY.spacing, usedMin: flexY.usedMin },
     ldRequired: ldReq, ldAvailable: ldAvail, ldOK: ldAvail >= ldReq,
   };
+}
+
+// ── Worked solution ────────────────────────────────────────────────────────
+// A pile cap fails four different ways and the depth is sized by whichever
+// comes first, so the report has to show all four — a reader who sees only the
+// governing one cannot tell whether the cap is 500 mm deep because of column
+// punching or because a corner pile punched through.
+export function pileCapSolution(inp: PileCapInput, r: PileCapResult): SolutionStep[] {
+  const N = r.coords.length;
+  const rMax = Math.max(...r.reactions);
+  const rMin = Math.min(...r.reactions);
+  const boCol = 2 * (inp.colX + r.d) + 2 * (inp.colY + r.d);
+  const boPile = Math.PI * (inp.pileDia + r.d);
+  const util = (Vu: number, phiVc: number) => (phiVc > 0 ? Vu / phiVc : Infinity);
+  const le = (ok: boolean) => (ok ? '\\le' : '>');
+
+  return [
+    {
+      title: 'Cap plan dimensions', clause: 'Pile layout + edge distance',
+      lines: [
+        { text: `${N} piles at ${inp.spacing} mm c/c, ⌀${inp.pileDia} mm, ${inp.edgeDist} mm from the pile centre to the cap edge.` },
+        { tex: `B_x = 2(x_{max} + e) = ${r.capBx}\\ \\text{mm}, \\quad B_y = 2(y_{max} + e) = ${r.capBy}\\ \\text{mm}` },
+        { text: 'Both are rounded up to the next 25 mm. The cap centroid is taken at the pile-group centroid, so the column is assumed concentric with the group.' },
+      ],
+    },
+    {
+      title: 'Service pile reactions', clause: 'Elastic: Rᵢ = P/N + Mₓ·yᵢ/Σyᵢ² + Mᵧ·xᵢ/Σxᵢ²',
+      lines: [
+        { tex: `R_{max} = \\dfrac{P}{N} + \\dfrac{M_x y_i}{\\sum y_i^2} + \\dfrac{M_y x_i}{\\sum x_i^2} = ${sn1(rMax)}\\ \\text{kN} \\ ${le(r.capacityOK)} \\ R_{allow} = ${sn0(inp.pileCapacity)}\\ \\text{kN}` },
+        { text: `Service load ${sn0(inp.serviceLoad)} kN over ${N} piles; reactions range ${sn1(rMin)} … ${sn1(rMax)} kN.${rMin < 0 ? ' A NEGATIVE reaction is uplift — that pile needs a tension connection into the cap, which this calculator does not size.' : ''}` },
+        { text: 'The cap is taken as rigid, so reactions vary linearly across the group. That is the usual assumption, and it is unconservative for a thin cap on soft piles.' },
+      ],
+      pass: r.capacityOK,
+    },
+    {
+      title: 'Cap thickness', clause: 'ACI 318-14 §13.4.2.1',
+      lines: [
+        { tex: `D = ${r.Dc}\\ \\text{mm}, \\quad d = D - c - \\tfrac{d_b}{2} = ${r.Dc} - ${inp.cover} - \\tfrac{${inp.barDia}}{2} = ${sn1(r.d)}\\ \\text{mm}` },
+        { text: `The depth is searched upward until all four shear checks below pass, then rounded to 25 mm and taken at least ${inp.pileEmbed} mm (pile embedment) + cover + bar.` },
+      ],
+    },
+    {
+      title: 'Two-way (punching) shear at the column', clause: 'ACI §22.6.5 — critical section d/2 from the column face',
+      lines: [
+        { tex: `b_o = 2(c_x + d) + 2(c_y + d) = ${sn0(boCol)}\\ \\text{mm}` },
+        { tex: `V_u = P_u - \\sum R_{u,inside} = ${sn1(r.VuPunchCol)}\\ \\text{kN} \\ ${le(r.punchColOK)} \\ \\phi V_c = ${sn1(r.phiVcPunchCol)}\\ \\text{kN}` },
+        { text: `Utilisation ${sn2(util(r.VuPunchCol, r.phiVcPunchCol))}. Piles whose centres fall inside the critical perimeter are deducted — their reaction never crosses it.` },
+      ],
+      pass: r.punchColOK,
+    },
+    {
+      title: 'Two-way (punching) shear at a pile', clause: 'ACI §22.6.5 — perimeter π(dₚ + d)',
+      lines: [
+        { tex: `b_o = \\pi(d_p + d) = \\pi(${inp.pileDia} + ${sn1(r.d)}) = ${sn0(boPile)}\\ \\text{mm}` },
+        { tex: `V_u = R_{u,max} = ${sn1(r.VuPunchPile)}\\ \\text{kN} \\ ${le(r.punchPileOK)} \\ \\phi V_c = ${sn1(r.phiVcPunchPile)}\\ \\text{kN}` },
+        { text: `Utilisation ${sn2(util(r.VuPunchPile, r.phiVcPunchPile))}. β_c = 1 for a circular pile. This is the check that governs a widely-spaced group, and the easiest of the four to forget by hand.` },
+      ],
+      pass: r.punchPileOK,
+    },
+    {
+      title: 'One-way (beam) shear, both directions', clause: 'ACI §22.5 — critical section d from the column face',
+      lines: [
+        { tex: `\\text{x:}\\quad V_u = ${sn1(r.VuBeamX)}\\ \\text{kN} \\ ${le(r.beamXOK)} \\ \\phi V_c = ${sn1(r.phiVcBeamX)}\\ \\text{kN} \\quad (b = B_y = ${r.capBy}\\ \\text{mm})` },
+        { tex: `\\text{y:}\\quad V_u = ${sn1(r.VuBeamY)}\\ \\text{kN} \\ ${le(r.beamYOK)} \\ \\phi V_c = ${sn1(r.phiVcBeamY)}\\ \\text{kN} \\quad (b = B_x = ${r.capBx}\\ \\text{mm})` },
+        { text: 'Only the piles whose centres lie beyond the critical section contribute; a pile straddling it is taken as fully outside, which is the conservative side.' },
+      ],
+      pass: r.beamXOK && r.beamYOK,
+    },
+    {
+      title: 'Flexure at the column face', clause: 'ACI §13.4.2.1 / §9.6.1.2 (minimum steel)',
+      lines: [
+        { tex: `M_{ux} = \\sum R_u\\left(|x_i| - \\tfrac{c_x}{2}\\right) = ${sn1(r.MuX)}\\ \\text{kN·m} \\ \\to \\ A_s = ${sn0(r.steelX.As)}\\ \\text{mm}^2` },
+        { text: `x-direction: ${r.steelX.bars}–⌀${inp.barDia} at ${sn0(r.steelX.spacing)} mm over the ${r.capBy} mm width, ρ = ${r.steelX.rho.toFixed(4)}${r.steelX.usedMin ? ' — MINIMUM steel governs' : ''}.` },
+        { tex: `M_{uy} = ${sn1(r.MuY)}\\ \\text{kN·m} \\ \\to \\ A_s = ${sn0(r.steelY.As)}\\ \\text{mm}^2` },
+        { text: `y-direction: ${r.steelY.bars}–⌀${inp.barDia} at ${sn0(r.steelY.spacing)} mm over the ${r.capBx} mm width, ρ = ${r.steelY.rho.toFixed(4)}${r.steelY.usedMin ? ' — MINIMUM steel governs' : ''}.` },
+      ],
+    },
+    {
+      title: 'Development of the bottom bars', clause: 'ACI §25.4.2.3',
+      lines: [
+        { tex: `\\ell_d = \\dfrac{3f_y}{40\\lambda\\sqrt{f'_c}\\,(c_b/d_b)}\\,d_b = ${sn0(r.ldRequired)}\\ \\text{mm}` },
+        { tex: `\\ell_{avail} = \\dfrac{B}{2} - \\dfrac{c_{col}}{2} - \\text{cover} = ${sn0(r.ldAvailable)}\\ \\text{mm} \\ ${r.ldOK ? '\\ge' : '<'} \\ ${sn0(r.ldRequired)}\\ \\text{mm}` },
+        { text: r.ldOK
+            ? 'Straight bars develop within the cap.'
+            : 'Straight bars do NOT develop — hook the bar ends (§25.4.3) or widen the cap.' },
+      ],
+      pass: r.ldOK,
+      note: 'K_tr is taken as zero (no confining reinforcement counted), which is the conservative side.',
+    },
+  ];
 }

--- a/webapp/src/engine/weldedConnection.test.ts
+++ b/webapp/src/engine/weldedConnection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { solveWeldedConnection, type WeldSegment } from './weldedConnection'
+import { solveWeldedConnection, weldedConnectionSolution, type WeldSegment } from './weldedConnection'
 
 describe('solveWeldedConnection — elastic weld-line method', () => {
   it('single vertical weld, eccentric vertical load (hand check)', () => {
@@ -73,5 +73,45 @@ describe('solveWeldedConnection — elastic weld-line method', () => {
     })
     expect(big.ok).toBe(false)
     expect(big.reqSize).toBeGreaterThan(3)
+  })
+})
+
+describe('weldedConnectionSolution — the printed report', () => {
+  const P = {
+    segments: [{ id: 'w', x1: 0, y1: 0, x2: 0, y2: 300 }] as WeldSegment[],
+    size: 6, FEXX: 480, phi: 0.75,
+    load: { P: 100, angleDeg: 90, px: 100, py: 150 },
+  }
+
+  it('prints the same numbers the solver returned', () => {
+    // The report is the only place a reviewer sees the intermediate values, so
+    // a drifted format string is a real defect, not cosmetics.
+    const r = solveWeldedConnection(P)
+    const s = weldedConnectionSolution(P, r)
+    const tex = s.flatMap((st) => st.lines.map((ln) => ('tex' in ln ? ln.tex : ln.text))).join('\n')
+    expect(tex).not.toMatch(/undefined|NaN/)
+    expect(tex).toContain('300.0')                     // Lw
+    expect(tex).toContain(r.fMax.toFixed(2))           // governing resultant
+    expect(tex).toContain(r.capacityPerLen.toFixed(2)) // φRn per unit length
+    expect(tex).toContain(r.reqSize.toFixed(2))        // required leg
+  })
+
+  it('the verdict chip follows r.ok in both directions', () => {
+    const ok = solveWeldedConnection(P)
+    expect(ok.ok).toBe(true)
+    expect(weldedConnectionSolution(P, ok).at(-1)!.pass).toBe(true)
+
+    const overloaded = { ...P, load: { ...P.load, P: 1000 } }
+    const bad = solveWeldedConnection(overloaded)
+    expect(bad.ok).toBe(false)
+    expect(weldedConnectionSolution(overloaded, bad).at(-1)!.pass).toBe(false)
+  })
+
+  it('reports the endpoint the solver actually chose as critical', () => {
+    const r = solveWeldedConnection(P)
+    const crit = r.points[r.criticalIndex]
+    const s = weldedConnectionSolution(P, r)
+    const step = s.find((st) => st.title === 'Governing endpoint')!
+    expect(JSON.stringify(step.lines)).toContain(`(${Math.round(crit.x)},`)
   })
 })

--- a/webapp/src/engine/weldedConnection.ts
+++ b/webapp/src/engine/weldedConnection.ts
@@ -16,6 +16,8 @@
 // Units: coordinates mm; P kN; forces N/mm; FEXX MPa; weld size w mm.
 // ─────────────────────────────────────────────────────────────────────────
 
+import { type SolutionStep, sn0, sn1, sn2 } from '../lib/solution'
+
 /** A straight fillet-weld segment given by its two endpoints (plate mm coords). */
 export interface WeldSegment { id: string; x1: number; y1: number; x2: number; y2: number }
 
@@ -125,4 +127,64 @@ export function solveWeldedConnection(p: {
     fMax, criticalIndex, throat, capacityPerLen, reqSize, maxP,
     ok: fMax <= capacityPerLen + 1e-6,
   }
+}
+
+// ── Worked solution ────────────────────────────────────────────────────────
+// The elastic method is five moves, and four of them are geometry. Printing it
+// this way matters more here than on most pages: the answer is a WELD SIZE, and
+// a reviewer's only way to disagree with it is to disagree with the centroid,
+// the polar moment or which endpoint was taken as critical.
+export function weldedConnectionSolution(p: {
+  segments: WeldSegment[]; size: number; load: WeldConnLoad; FEXX?: number; phi?: number
+}, r: WeldConnResult): SolutionStep[] {
+  const FEXX = p.FEXX ?? 480
+  const phi = p.phi ?? 0.75
+  const crit = r.points[r.criticalIndex]
+  return [
+    {
+      title: 'Weld group — length and centroid', clause: 'Elastic (weld-as-a-line) method',
+      lines: [
+        { text: `${p.segments.length} segment${p.segments.length === 1 ? '' : 's'}, treated as a line of unit throat: the group is solved for force per unit length, and the throat is applied only at the end.` },
+        { tex: `L_w = \\sum L_i = ${sn1(r.Lw)}\\ \\text{mm}` },
+        { tex: `\\bar{x} = \\dfrac{\\sum L_i x_i}{L_w} = ${sn1(r.Cx)}\\ \\text{mm},\\quad \\bar{y} = \\dfrac{\\sum L_i y_i}{L_w} = ${sn1(r.Cy)}\\ \\text{mm}` },
+      ],
+    },
+    {
+      title: 'Unit-throat polar moment', clause: 'J/t about the group centroid',
+      lines: [
+        { tex: `\\dfrac{J}{t} = \\sum\\left[\\dfrac{L_i^3}{12} + L_i\\left(x_{c,i}^2 + y_{c,i}^2\\right)\\right] = ${sn0(r.Jt)}\\ \\text{mm}^3` },
+        { text: 'L³/12 is the segment’s own second moment about its midpoint. Because sin²θ + cos²θ = 1, that single term is correct for a segment at any orientation — no separate Ix and Iy are needed.' },
+      ],
+    },
+    {
+      title: 'Load, eccentricity and torsion',
+      lines: [
+        { tex: `P_x = P\\cos\\theta = ${sn2(r.Px)}\\ \\text{kN},\\quad P_y = P\\sin\\theta = ${sn2(r.Py)}\\ \\text{kN}\\quad (\\theta = ${sn0(p.load.angleDeg)}^\\circ)` },
+        { tex: `e_x = ${sn1(r.ex)}\\ \\text{mm},\\quad e_y = ${sn1(r.ey)}\\ \\text{mm}` },
+        { tex: `T = P_y e_x - P_x e_y = ${sn1(r.T)}\\ \\text{kN·mm}` },
+        { text: 'Eccentricity is measured from the group CENTROID, not from the column face — moving the weld pattern moves the centroid and so changes T.' },
+      ],
+    },
+    {
+      title: 'Governing endpoint', clause: 'f = √(fx² + fy²), max over all endpoints',
+      lines: [
+        { tex: `f_{dx} = \\dfrac{P_x}{L_w} = ${sn2((r.Px * 1000) / r.Lw)},\\quad f_{dy} = \\dfrac{P_y}{L_w} = ${sn2((r.Py * 1000) / r.Lw)}\\ \\text{N/mm}` },
+        { tex: `f_{tx} = \\dfrac{-T\\,y_c}{J/t},\\quad f_{ty} = \\dfrac{T\\,x_c}{J/t}` },
+        { tex: `\\text{at } (${sn0(crit.x)},\\,${sn0(crit.y)}):\\; f = \\sqrt{${sn2(crit.fx)}^2 + ${sn2(crit.fy)}^2} = ${sn2(r.fMax)}\\ \\text{N/mm}` },
+        { text: 'The torsional component is perpendicular to the radius from the centroid, so the extreme fibre — the endpoint furthest from the centroid on the side where the two components add — governs.' },
+      ],
+    },
+    {
+      title: 'Fillet capacity and required size', clause: 'NSCP 510.2.2 / AISC §J2.2',
+      lines: [
+        { tex: `t_e = 0.707w = 0.707\\times ${sn1(p.size)} = ${sn2(r.throat)}\\ \\text{mm}` },
+        { tex: `\\phi R_n = \\phi\\,0.60F_{EXX}\\,t_e = ${sn2(phi)}\\times 0.60\\times ${sn0(FEXX)}\\times ${sn2(r.throat)} = ${sn2(r.capacityPerLen)}\\ \\text{N/mm}` },
+        { tex: `f_{max} = ${sn2(r.fMax)} \\;${r.ok ? '\\le' : '>'}\\; ${sn2(r.capacityPerLen)}\\ \\text{N/mm}` },
+        { tex: `w_{req} = w\\dfrac{f_{max}}{\\phi R_n} = ${sn2(r.reqSize)}\\ \\text{mm};\\quad P_{max} = P\\dfrac{\\phi R_n}{f_{max}} = ${sn1(r.maxP)}\\ \\text{kN}` },
+        { text: 'f is linear in both the applied load and the weld size, so the required size and the maximum load follow by proportion — no second solve.' },
+      ],
+      pass: r.ok,
+      note: 'Base-metal shear rupture at the weld line and the minimum/maximum fillet sizes of §J2.2b are separate checks.',
+    },
+  ]
 }

--- a/webapp/src/engine/woodSlab.test.ts
+++ b/webapp/src/engine/woodSlab.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { designWoodSlab, woodSlabTimberSizes, BAMBOO_SLAT_REF, type WoodSlabInput } from './woodSlab'
+import { designWoodSlab, woodSlabSolution, woodSlabTimberSizes, BAMBOO_SLAT_REF, type WoodSlabInput } from './woodSlab'
 import { getWoodRef, woodSectionProps, woodAdjusted } from './woodDesign'
 import { BDFT_PER_M3, costTimberRows } from './takeoff'
 
@@ -129,5 +129,56 @@ describe('woodSlabTimberSizes — wood-frame BOM connection', () => {
     const r = designWoodSlab({ ...base, deckMaterial: 'bamboo-slat', deckWidth: 50 })
     const [, deck] = woodSlabTimberSizes({ ...base, deckMaterial: 'bamboo-slat', deckWidth: 50 }, r)
     expect(deck.species).toBe('bamboo')
+  })
+})
+
+describe('woodSlabSolution — the printed report', () => {
+  // The solution is presentation, so what can actually break is a PASS chip
+  // disagreeing with the result it claims to report, or a renamed field
+  // silently interpolating `undefined` into an equation. Both are tested.
+  const stepsFor = (i: WoodSlabInput) => woodSlabSolution(i, designWoodSlab(i))
+  const allText = (s: ReturnType<typeof stepsFor>) =>
+    s.flatMap((st) => st.lines.map((ln) => ('tex' in ln ? ln.tex : ln.text))).join('\n')
+
+  it('covers loads, both members and the governing ratio', () => {
+    const s = stepsFor(base)
+    expect(s).toHaveLength(8)   // loads + 3 deck + 3 joist + governing
+    expect(s[0].title).toMatch(/Loads/)
+    expect(s.filter((st) => st.title.startsWith('Deck'))).toHaveLength(3)
+    expect(s.filter((st) => st.title.startsWith('Joist'))).toHaveLength(3)
+    expect(s[7].title).toMatch(/Governing/)
+  })
+
+  it('every PASS chip matches the check it reports', () => {
+    // Force a failure so both polarities are exercised: 5 m joists at 1.9 kPa.
+    for (const i of [base, { ...base, Lx: 5.0, joistSpan: 5.0 }]) {
+      const r = designWoodSlab(i)
+      const s = woodSlabSolution(i, r)
+      const pass = (t: string) => s.find((st) => st.title === t)!.pass
+      expect(pass('Joist — bending')).toBe(r.joist.bendingRatio <= 1)
+      expect(pass('Joist — horizontal shear')).toBe(r.joist.shearRatio <= 1)
+      expect(pass('Joist — deflection')).toBe(r.joist.deflLiveRatio <= 1 && r.joist.deflTotalRatio <= 1)
+      expect(s[s.length - 1].pass).toBe(r.ok)
+    }
+    // and the long span really does fail, or the loop above proved nothing
+    expect(designWoodSlab({ ...base, Lx: 5.0, joistSpan: 5.0 }).ok).toBe(false)
+  })
+
+  it('names the member that governs, and prints no undefined or NaN', () => {
+    const s = stepsFor(base)
+    const r = designWoodSlab(base)
+    expect(allText(s)).not.toMatch(/undefined|NaN/)
+    const last = allText([s[s.length - 1]])
+    expect(last).toMatch(r.joist.ratio >= r.deck.ratio ? /joist/ : /deck/)
+  })
+
+  it('prints the continuous coefficient for a continuous run, not wL²/8', () => {
+    // The deck defaults to continuous; the joist to simple. The two must not
+    // print the same c_M, which is exactly the copy-paste this guards.
+    const s = stepsFor(base)
+    const deckBending = s.find((st) => /^Deck.*bending$/.test(st.title))!
+    const joistBending = s.find((st) => /^Joist.*bending$/.test(st.title))!
+    expect(JSON.stringify(deckBending.lines)).toContain('0.100')   // 1/10
+    expect(JSON.stringify(joistBending.lines)).toContain('0.125')  // 1/8
   })
 })

--- a/webapp/src/engine/woodSlab.ts
+++ b/webapp/src/engine/woodSlab.ts
@@ -26,6 +26,7 @@ import {
   woodAdjusted, woodSectionProps, woodUnitWeight, checkWoodBeam,
 } from './woodDesign'
 import { BDFT_PER_M3, type TimberSizeQty } from './takeoff'
+import { type SolutionStep, sn1, sn2, sn3, sn4 } from '../lib/solution'
 
 /** Indicative ASD allowable stresses for flattened / laminated STRUCTURAL BAMBOO
  *  (e.g. Guadua, Bambusa / kawayan).  NOT an NDS-tabulated species — these are
@@ -212,6 +213,90 @@ export function designWoodSlab(i: WoodSlabInput): WoodSlabResult {
     takeoff, ratio, ok: ratio <= 1,
     clause: 'NDS §3.3–§3.4 / NSCP §6 (ASD)',
   }
+}
+
+// ── Worked solution ────────────────────────────────────────────────────────
+// Both members are the same ASD check on a different span and tributary width,
+// so the bending / shear / deflection steps are generated once and reused. The
+// step titles name the member, because a reader scanning the report needs to
+// know whether a FAIL chip belongs to a 25 mm board or a 50×200 joist.
+
+/** The three checks on one flexural run, as steps. `cM`/`cD` are the UDL
+ *  coefficients actually used, so a continuous run prints wL²/10 not wL²/8. */
+function runSteps(name: string, c: FlexuralCheck, support: SlabSupport, tributary: string): SolutionStep[] {
+  const k = FLEX[support]
+  const S = (c.b * c.d * c.d) / 6                      // mm³
+  const { I } = woodSectionProps(c.b, c.d)             // mm⁴
+  const spanLabel = support === 'continuous' ? 'continuous (≥3 equal spans, end span governs)' : 'simple span'
+  return [
+    {
+      title: `${name} — bending`, clause: 'NDS §3.3 / NSCP §6',
+      lines: [
+        { text: `${c.b}×${c.d} mm over ${sn3(c.span)} m, ${spanLabel}. ${tributary}` },
+        { tex: `M = c_M\\,wL^2 = ${sn3(k.M)}\\times ${sn3(c.w)}\\times ${sn3(c.span)}^2 = ${sn3(c.M)}\\ \\text{kN·m}` },
+        { tex: `f_b = \\dfrac{M}{S} = \\dfrac{${sn3(c.M)}\\times 10^6}{${sn2(S)}} = ${sn2(c.fb)}\\ \\text{MPa} \\;${c.fb <= c.FbPrime ? '\\le' : '>'}\\; F_b' = ${sn2(c.FbPrime)}\\ \\text{MPa}` },
+        { text: `Utilisation ${sn2(c.bendingRatio)}. Fb′ is the reference Fb with every applicable NDS §4.3 adjustment; the compression edge is braced by the load it carries, so CL = 1.` },
+      ],
+      pass: c.bendingRatio <= 1,
+    },
+    {
+      title: `${name} — horizontal shear`, clause: 'NDS §3.4.2',
+      lines: [
+        { tex: `V = c_V\\,wL = ${sn2(k.V)}\\times ${sn3(c.w)}\\times ${sn3(c.span)} = ${sn3(c.V)}\\ \\text{kN}` },
+        { tex: `f_v = \\dfrac{3V}{2bd} = \\dfrac{3\\times ${sn3(c.V)}\\times 10^3}{2\\times ${c.b}\\times ${c.d}} = ${sn3(c.fv)}\\ \\text{MPa} \\;${c.fv <= c.FvPrime ? '\\le' : '>'}\\; F_v' = ${sn3(c.FvPrime)}\\ \\text{MPa}` },
+      ],
+      pass: c.shearRatio <= 1,
+      note: 'Shear rarely governs a floor member; deflection usually does.',
+    },
+    {
+      title: `${name} — deflection`, clause: 'NSCP Table 6 (L/360 live, L/240 total)',
+      lines: [
+        { tex: `\\Delta = c_\\Delta\\dfrac{wL^4}{E'I},\\quad c_\\Delta = ${sn4(k.D)},\\; I = ${sn2(I / 1e6)}\\times 10^6\\ \\text{mm}^4` },
+        { tex: `\\Delta_{L} = ${sn2(c.deflLive)}\\ \\text{mm} \\;${c.deflLiveRatio <= 1 ? '\\le' : '>'}\\; \\dfrac{L}{360} = ${sn2(c.deflLiveAllow)}\\ \\text{mm}` },
+        { tex: `\\Delta_{D+L} = ${sn2(c.deflTotal)}\\ \\text{mm} \\;${c.deflTotalRatio <= 1 ? '\\le' : '>'}\\; \\dfrac{L}{240} = ${sn2(c.deflTotalAllow)}\\ \\text{mm}` },
+        { text: 'Deflection uses the SERVICE modulus E′ — the load-duration factor CD raises stresses, never stiffness.' },
+      ],
+      pass: c.deflLiveRatio <= 1 && c.deflTotalRatio <= 1,
+    },
+  ]
+}
+
+/** Step-by-step ASD check of a wood slab, for the printable calculation report. */
+export function woodSlabSolution(i: WoodSlabInput, r: WoodSlabResult): SolutionStep[] {
+  const bamboo = i.deckMaterial === 'bamboo-slat'
+  const deckWidth = i.deckWidth ?? (bamboo ? 50 : 140)
+  const spacingM = i.joistSpacing / 1000
+  return [
+    {
+      title: 'Loads on the floor', clause: 'NSCP §204 / §205',
+      lines: [
+        { text: `Superimposed dead ${sn2(r.loads.deadKpa)} kPa, live ${sn2(r.loads.liveKpa)} kPa.` },
+        { tex: `w_{deck,self} = \\gamma t = ${sn3(woodUnitWeight((i.deckRef ?? (bamboo ? BAMBOO_SLAT_REF : i.joistRef)).G))}\\times \\dfrac{${i.deckThickness}}{1000} = ${sn3(r.loads.deckSelfKpa)}\\ \\text{kPa}` },
+        { tex: `w_{joist,self} = ${sn3(r.loads.joistSelfKpa)}\\ \\text{kPa}\\ \\text{(smeared over the } ${sn2(r.takeoff.area)}\\ \\text{m}^2 \\text{ floor)}` },
+        { tex: `w_{total} = ${sn3(r.loads.totalKpa)}\\ \\text{kPa}` },
+      ],
+      note: 'The deck carries finishes and its own weight only — it sits on the joists, so it never carries them.',
+    },
+    ...runSteps(
+      bamboo ? 'Deck (bamboo slat)' : 'Deck (plank)', r.deck, i.deckSupport ?? 'continuous',
+      `One board spans the ${i.joistSpacing} mm joist spacing and carries the floor pressure over its own ${deckWidth} mm face width.`,
+    ),
+    ...runSteps(
+      'Joist', r.joist, i.joistSupport ?? 'simple',
+      `Each joist carries a tributary strip one spacing wide (${sn3(spacingM)} m) plus its own weight; ${r.takeoff.joistCount} joists at ${i.joistSpacing} mm o.c.`,
+    ),
+    {
+      title: 'Governing utilisation', clause: r.clause,
+      lines: [
+        { tex: `\\text{ratio} = \\max(${sn2(r.deck.ratio)}_{deck},\\ ${sn2(r.joist.ratio)}_{joist}) = ${sn2(r.ratio)}` },
+        { text: r.ok
+          ? `The ${r.joist.ratio >= r.deck.ratio ? 'joist' : 'deck'} governs at ${sn1(r.ratio * 100)}% of its allowable.`
+          : `The ${r.joist.ratio >= r.deck.ratio ? 'joist' : 'deck'} is overstressed at ${sn1(r.ratio * 100)}% — increase the depth, or close the spacing.` },
+      ],
+      pass: r.ok,
+      note: 'Bearing at the joist supports, the fastener schedule and diaphragm action are separate checks, not covered here.',
+    },
+  ]
 }
 
 /** Express a wood-slab take-off as wood-frame BOM rows (TimberSizeQty, board-feet

--- a/webapp/src/pages/CombinedFootingDesign.tsx
+++ b/webapp/src/pages/CombinedFootingDesign.tsx
@@ -256,8 +256,8 @@ export default function CombinedFootingDesign() {
 
         {/* ── Results ── */}
         <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
-          <div data-pdf-drawing className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-            <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Plan</h2>
+          <div data-pdf-drawing className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
+            <h2 className="mb-2 text-[13.5px] font-bold text-[#0f1b2a]">Plan</h2>
             {result ? (
               <CombinedFootingSchematic
                 shape={result.shape} Bx={result.Bx} By={result.By} By1={result.By1} By2={result.By2}
@@ -269,8 +269,8 @@ export default function CombinedFootingDesign() {
           </div>
 
           {result && (
-            <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-              <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Results</h2>
+            <div className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
+              <h2 className="mb-2 text-[13.5px] font-bold text-[#0f1b2a]">Results</h2>
               <Row label="Shape" value={result.shape} />
               <Row label={<Math tex="q_{net}" />} value={`${f3(result.qNet)} kPa`} />
               <Row label="Plan size"
@@ -303,8 +303,8 @@ export default function CombinedFootingDesign() {
           )}
 
           {result && (
-            <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-              <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">
+            <div className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
+              <h2 className="mb-2 text-[13.5px] font-bold text-[#0f1b2a]">
                 Longitudinal flexure {flexible && <span className="text-xs font-normal text-slate-500">(from BEF moments)</span>}
               </h2>
               {(longSections ?? result.longSections).map((s) => (
@@ -312,7 +312,7 @@ export default function CombinedFootingDesign() {
                   value={`${s.bars} ⌀${form.barDia} @ ${f0(s.spacing)} mm`}
                   check={`Mu=${f0(s.Mu)} kN·m · ${s.top ? 'top' : 'bottom'}`} />
               ))}
-              <h2 className="mb-2 mt-4 text-[1.02rem] font-bold text-[#0056b3]">Transverse (under columns)</h2>
+              <h2 className="mb-2 mt-4 text-[13.5px] font-bold text-[#0f1b2a]">Transverse (under columns)</h2>
               {result.transverse.map((t) => (
                 <Row key={t.label} label={t.label}
                   value={`⌀${form.barDia} @ ${f0(t.spacing)} mm`}
@@ -326,20 +326,20 @@ export default function CombinedFootingDesign() {
       {/* ── Diagrams (full width) ── */}
       {samples && (
         <div className={`mt-6 grid grid-cols-1 gap-6 ${flexible && flex ? 'lg:grid-cols-2' : 'lg:grid-cols-3'}`}>
-          <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
             <Diagram xs={samples.x} ys={samples.w} title="SOIL REACTION (w)" unit="kN/m"
               color="#16a34a" vlines={vlines} markExtrema={!flexible} decimals={1} />
           </div>
-          <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
             <Diagram xs={samples.x} ys={samples.V} title="SHEAR (Vu)" unit="kN"
               color="#dc2626" vlines={vlines} decimals={0} />
           </div>
-          <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
             <Diagram xs={samples.x} ys={samples.M} title="MOMENT (Mu)" unit="kN·m"
               color="#0056b3" vlines={vlines} decimals={0} />
           </div>
           {flexible && flex && (
-            <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
               <Diagram xs={flex.samples.x} ys={flex.samples.y} title="SETTLEMENT (y, + down)" unit="mm"
                 color="#7c3aed" vlines={vlines} decimals={2} />
             </div>
@@ -347,8 +347,8 @@ export default function CombinedFootingDesign() {
         </div>
       )}
 
-      <div className="mt-6 rounded-xl border border-slate-200 bg-white p-4 text-sm text-slate-600 shadow-sm">
-        <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Basis</h2>
+      <div className="mt-6 rail-card rounded-lg border border-[#e3e1da] bg-white p-4 text-sm text-[#5c6675]">
+        <h2 className="mb-2 text-[13.5px] font-bold text-[#0f1b2a]">Basis</h2>
         <Math block tex={String.raw`q_{net} = q_a - \gamma_s D_s - \gamma_c D_c - q,\qquad P_u = \max(1.4D,\ 1.2D + 1.6L)`} />
         {flexible ? (
           <p className="mt-1 text-xs text-slate-500">

--- a/webapp/src/pages/PileCapDesign.tsx
+++ b/webapp/src/pages/PileCapDesign.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, type ReactNode } from 'react'
-import { designPileCap, type PileArrangement } from '../engine/pileCap'
+import { designPileCap, pileCapSolution, type PileArrangement, type PileCapInput } from '../engine/pileCap'
+import { WorkedSolution } from '../components/WorkedSolution'
 import { PileCapSchematic } from '../components/PileCapSchematic'
 import { PageHeader, LetterheadCard, PrintReport, type LetterheadState } from '../components/calc'
 import { Card } from '../components/qty'
@@ -126,9 +127,10 @@ export default function PileCapDesign() {
     && form.serviceLoad > 0 && form.ultimateLoad > 0
     && form.pileCapacity > 0 && form.spacing > 0 && form.edgeDist > 0
 
-  const result = useMemo(() => {
-    if (!valid) return null
-    return designPileCap({
+  // The solver input is memoised separately from the result: the worked
+  // solution needs the same inputs the solve used, and rebuilding the object
+  // at render would be a second source of truth.
+  const solverInput: PileCapInput = useMemo(() => ({
       serviceLoad: form.serviceLoad,
       serviceMomX: form.serviceMomX,
       serviceMomY: form.serviceMomY,
@@ -147,8 +149,9 @@ export default function PileCapDesign() {
       cover: form.cover,
       barDia: form.barDia,
       pileEmbed: form.pileEmbed,
-    })
-  }, [form, valid])
+  }), [form])
+
+  const result = useMemo(() => (valid ? designPileCap(solverInput) : null), [solverInput, valid])
 
   const allOK = result && result.capacityOK && result.punchColOK && result.punchPileOK
     && result.beamXOK && result.beamYOK && result.ldOK
@@ -241,8 +244,8 @@ export default function PileCapDesign() {
         {/* ── Results ── */}
         <div className="space-y-5 lg:sticky lg:top-6 lg:self-start">
           {/* Schematic */}
-          <div data-pdf-drawing className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-            <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Cap plan</h2>
+          <div data-pdf-drawing className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
+            <h2 className="mb-2 text-[13.5px] font-bold text-[#0f1b2a]">Cap plan</h2>
             {result ? (
               <PileCapSchematic d={result.d}
                 capBx={result.capBx}
@@ -261,15 +264,15 @@ export default function PileCapDesign() {
           {result && (
             <>
               {/* Summary banner */}
-              <div className={`rounded-xl border p-3 text-center text-sm font-semibold shadow-sm ${
+              <div className={`rounded-lg border p-3 text-center text-[12.5px] font-semibold ${
                 allOK ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-rose-200 bg-rose-50 text-rose-700'
               }`}>
                 {allOK ? '✓ All checks pass' : '✗ One or more checks fail — review results below'}
               </div>
 
               {/* Cap geometry */}
-              <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-                <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Cap geometry</h2>
+              <div className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
+                <h2 className="mb-2 text-[13.5px] font-bold text-[#0f1b2a]">Cap geometry</h2>
                 <Row label="Plan (Bx × By)"
                   value={`${f2(result.capBx / 1000)} × ${f2(result.capBy / 1000)} m`} />
                 <Row label={<>Thickness <KTex tex="D_c" /></>} value={`${f0(result.Dc)} mm`} />
@@ -277,8 +280,8 @@ export default function PileCapDesign() {
               </div>
 
               {/* Pile reactions */}
-              <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-                <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Pile reactions (service)</h2>
+              <div className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
+                <h2 className="mb-2 text-[13.5px] font-bold text-[#0f1b2a]">Pile reactions (service)</h2>
                 {result.reactions.map((r, i) => (
                   <Row key={i}
                     label={`Pile ${i + 1} (${(result.coords[i].x / 1000).toFixed(2)}, ${(result.coords[i].y / 1000).toFixed(2)}) m`}
@@ -293,8 +296,8 @@ export default function PileCapDesign() {
               </div>
 
               {/* Shear checks */}
-              <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-                <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Shear checks (factored)</h2>
+              <div className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
+                <h2 className="mb-2 text-[13.5px] font-bold text-[#0f1b2a]">Shear checks (factored)</h2>
                 <CheckRow label="Column punching" Vu={result.VuPunchCol} phiVc={result.phiVcPunchCol} ok={result.punchColOK} />
                 <CheckRow label="Pile punching (worst)" Vu={result.VuPunchPile} phiVc={result.phiVcPunchPile} ok={result.punchPileOK} />
                 <CheckRow label={<>Beam shear — <KTex tex="x" /></>} Vu={result.VuBeamX} phiVc={result.phiVcBeamX} ok={result.beamXOK} />
@@ -302,8 +305,8 @@ export default function PileCapDesign() {
               </div>
 
               {/* Flexure & steel */}
-              <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-                <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Flexure & reinforcement</h2>
+              <div className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
+                <h2 className="mb-2 text-[13.5px] font-bold text-[#0f1b2a]">Flexure & reinforcement</h2>
                 <Row label={<>Design moment <KTex tex="M_{u,x}" /></>} value={`${f3(result.MuX)} kN·m`} />
                 <Row label={<>Design moment <KTex tex="M_{u,y}" /></>} value={`${f3(result.MuY)} kN·m`} />
                 {steelRow(<>Bars — <KTex tex="x" />-direction (bottom)</>, result.steelX, form.barDia)}
@@ -311,8 +314,8 @@ export default function PileCapDesign() {
               </div>
 
               {/* Development length */}
-              <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-                <h2 className="mb-2 text-[1.02rem] font-bold text-[#0056b3]">Development length</h2>
+              <div className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4">
+                <h2 className="mb-2 text-[13.5px] font-bold text-[#0f1b2a]">Development length</h2>
                 <Row
                   label={<>Required <KTex tex="\ell_d" /></>}
                   value={`${f0(result.ldRequired)} mm`}
@@ -329,8 +332,8 @@ export default function PileCapDesign() {
               </div>
 
               {/* Basis */}
-              <div className="rounded-xl border border-slate-200 bg-white p-4 text-sm text-slate-600 shadow-sm">
-                <h2 className="mb-1 text-[1.02rem] font-bold text-[#0056b3]">Basis</h2>
+              <div className="rail-card rounded-lg border border-[#e3e1da] bg-white p-4 text-sm text-[#5c6675]">
+                <h2 className="mb-1 text-[13.5px] font-bold text-[#0f1b2a]">Basis</h2>
                 <KTex block tex={String.raw`R_i = \frac{P}{N} + \frac{M_x \cdot y_i}{\sum y_i^2} + \frac{M_y \cdot x_i}{\sum x_i^2}`} />
                 <p className="mt-1 text-xs text-slate-500">
                   NSCP 2015 / ACI 318-14. φ_v = 0.75, φ_f = 0.90.
@@ -343,6 +346,11 @@ export default function PileCapDesign() {
           )}
         </div>
       </div>
+
+      {/* The rail shows WHAT the checks came to; this shows HOW — and it is the
+          part that prints, so a reviewer can follow the depth back to whichever
+          of the four shear checks actually sized it. */}
+      {result && <WorkedSolution steps={pileCapSolution(solverInput, result)} />}
       </div>
     </div>
   )

--- a/webapp/src/pages/WeldedConnection.tsx
+++ b/webapp/src/pages/WeldedConnection.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
-import { solveWeldedConnection, type WeldSegment } from '../engine/weldedConnection'
+import { solveWeldedConnection, weldedConnectionSolution, type WeldSegment } from '../engine/weldedConnection'
+import { WorkedSolution } from '../components/WorkedSolution'
 import { ReportControls } from '../components/ReportControls'
 import { PageHeader } from '../components/calc'
 
@@ -139,6 +140,8 @@ export default function WeldedConnection() {
           </div>
         </section>
       </div>
+
+      <WorkedSolution steps={weldedConnectionSolution({ segments: segs, size, FEXX, phi, load: { P, angleDeg: angle, px, py } }, r)} />
     </main>
     </div>
   )

--- a/webapp/src/pages/WoodSlab.tsx
+++ b/webapp/src/pages/WoodSlab.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
-import { designWoodSlab, woodSlabTimberSizes, type DeckMaterial, type SlabSupport } from '../engine/woodSlab'
+import { designWoodSlab, woodSlabSolution, woodSlabTimberSizes, type DeckMaterial, type SlabSupport, type WoodSlabInput } from '../engine/woodSlab'
+import { WorkedSolution } from '../components/WorkedSolution'
 import { speciesList, gradesOf, resolveWoodSpecies } from '../engine/woodDesign'
 import type { LoadDuration } from '../engine/woodDesign'
 import { costTimberRows } from '../engine/takeoff'
@@ -87,11 +88,14 @@ export default function WoodSlab() {
   const speciesOptions = speciesList()
   const gradeOptions = gradesOf(species)
 
-  const r = joistRef ? designWoodSlab({
+  // Kept as one object so the worked solution is generated from exactly the
+  // input the solve used, not a re-assembled copy of it.
+  const input: WoodSlabInput | null = joistRef ? {
     Lx, Ly, joistRef, joistKind: sp!.kind, joistB, joistD, joistSpacing, joistSupport,
     deckMaterial, deckThickness, deckWidth, deckSupport,
     deadKpa, liveKpa, opts: { duration, wet },
-  }) : null
+  } : null
+  const r = input ? designWoodSlab(input) : null
 
   return (
         <div>
@@ -273,6 +277,8 @@ export default function WoodSlab() {
           </p>
         </ResultCard>
       )}
+
+      {input && r && <WorkedSolution steps={woodSlabSolution(input, r)} />}
         </div>
       </CalcBody>
     </div>


### PR DESCRIPTION
Item 4 of the to-do list. **Layer 7** (standalone design engines), following the `lib/solution.ts` worked-solution pattern: the engine owns the derivation, the page just renders it.

Three pages showed an answer and no arithmetic. Every other calculator prints a step-by-step a reviewer can follow; these did not, so the numbers had to be taken on trust.

## What each solution shows

**`weldedConnectionSolution`** — 5 steps. The output is a weld **size**, and the only way to disagree with it is to disagree with the centroid, `J/t`, or which endpoint was taken as critical — so all three are printed, with the governing endpoint's coordinates.

**`pileCapSolution`** — 8 steps. A cap fails four different ways and the depth is set by whichever comes first. Showing only the governing check leaves the reader unable to tell *why* the cap is as deep as it is, so all four print with their utilisation: column punching, pile punching, and one-way shear each way. Uplift is called out explicitly when a reaction goes negative.

**`woodSlabSolution`** — 8 steps. Deck and joist are the same ASD check on a different span and tributary width, so bending / shear / deflection are generated once and reused, with the member named in each title.

## Tests

The risk in a solution function is not the maths — it is a PASS chip that disagrees with the result it reports, or a renamed field interpolating `undefined` into an equation. Both are asserted for all three engines, each over a **passing and a failing case** so both polarities actually run (and the test asserts the failing case really fails, so the loop can't pass vacuously).

The wood-slab test additionally pins that a continuous run prints `wL²/10` and a simple one `wL²/8` — the coefficient is the copy-paste most likely to drift between the two members.

## Also in this PR — finishing #558

#558 said Pile Cap and Combined Footing were converted to the shared card. That was true of their **input** cards only; both **results rails** still carried the old white-card + blue-heading chrome (13 and 12 occurrences). Both rails are now on `rail-card` and the ink palette.

## Verification

- `npx tsc -b` clean, `npm run lint` clean, **3834 tests / 214 files green** (up from 3823).
- All three panels screenshotted in headless Chromium: KaTeX renders, no console errors, and no `undefined`/`NaN` in any step.

## Remaining from the list

One PR each: the three Steel Design 3D rendering bugs; the Model Space walkthrough's demo template + state restore; and deriving the BOQ concrete class from the design f′c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmPbtTVsjNBXVpiQVBYBnz)_