### PR TITLE
fix(3d): the Steel Design scenes — fit, orientation, arrows, bolts

### DIFF
--- a/webapp/src/components/FitView.tsx
+++ b/webapp/src/components/FitView.tsx
@@ -4,9 +4,17 @@ import * as THREE from 'three'
 import type { OrbitControls as OrbitControlsImpl } from 'three-stdlib'
 
 /**
- * Zoom-to-extents: on mount (and whenever the model bounds change) frame the
- * whole model so every member is visible. Keeps a fixed viewing direction and
- * recentres the default OrbitControls on the model. Render inside a <Canvas>.
+ * Zoom-to-extents: on mount (and whenever the model bounds or the viewport
+ * change) frame the whole model so every member is visible. Keeps a fixed
+ * viewing direction and recentres the default OrbitControls. Render inside a
+ * <Canvas>.
+ *
+ * The fit projects the box's eight corners onto the CAMERA BASIS and honours
+ * the viewport aspect, rather than fitting a sphere of the box's diagonal.
+ * The sphere version was badly wrong for anything long and thin — which is
+ * most of what this app draws. A 6 m beam 0.3 m deep has a half-diagonal of
+ * 3.4 m against a half-height of 0.95 m, so the camera was pulled back ~3.5×
+ * further than needed and the member rendered at a fifth of the frame.
  */
 export function FitView({ box, dir = [1, 0.8, 1], margin = 1.3 }: {
   box: { min: [number, number, number]; max: [number, number, number] } | null
@@ -14,20 +22,42 @@ export function FitView({ box, dir = [1, 0.8, 1], margin = 1.3 }: {
   margin?: number
 }) {
   const camera = useThree((s) => s.camera)
+  const size = useThree((s) => s.size)
   const controls = useThree((s) => s.controls) as OrbitControlsImpl | null
   const minKey = box ? box.min.join(',') : ''
   const maxKey = box ? box.max.join(',') : ''
 
   useEffect(() => {
-    if (!box) return
+    if (!box || size.width === 0 || size.height === 0) return
     const min = new THREE.Vector3(...box.min), max = new THREE.Vector3(...box.max)
     const center = min.clone().add(max).multiplyScalar(0.5)
-    const radius = Math.max(max.clone().sub(min).length() / 2, 0.5)
     const persp = camera as THREE.PerspectiveCamera
-    const fov = ((persp.fov ?? 45) * Math.PI) / 180
-    const dist = (radius / Math.sin(fov / 2)) * margin
-    const d = new THREE.Vector3(...dir).normalize()
-    persp.position.copy(center.clone().add(d.multiplyScalar(dist)))
+
+    // Camera basis. `forward` points from the model TOWARDS the camera, so a
+    // corner with a positive `forward` component is nearer and needs the
+    // camera pushed back by that much on top of its own framing distance.
+    const forward = new THREE.Vector3(...dir).normalize()
+    const worldUp = Math.abs(forward.y) > 0.999 ? new THREE.Vector3(0, 0, 1) : new THREE.Vector3(0, 1, 0)
+    const right = new THREE.Vector3().crossVectors(worldUp, forward).normalize()
+    const up = new THREE.Vector3().crossVectors(forward, right).normalize()
+
+    const vFov = ((persp.fov ?? 45) * Math.PI) / 180
+    const tanV = Math.tan(vFov / 2)
+    const tanH = tanV * (size.width / size.height)
+
+    let dist = 0
+    for (const cx of [min.x, max.x]) {
+      for (const cy of [min.y, max.y]) {
+        for (const cz of [min.z, max.z]) {
+          const p = new THREE.Vector3(cx, cy, cz).sub(center)
+          const f = p.dot(forward)
+          dist = Math.max(dist, f + Math.abs(p.dot(right)) / tanH, f + Math.abs(p.dot(up)) / tanV)
+        }
+      }
+    }
+    dist = Math.max(dist * margin, 0.5)
+
+    persp.position.copy(center.clone().add(forward.clone().multiplyScalar(dist)))
     // The three.js camera is an external mutable object owned by the r3f
     // renderer, not React state — repositioning it imperatively is the whole
     // point of this component, and there is no declarative equivalent.
@@ -38,7 +68,7 @@ export function FitView({ box, dir = [1, 0.8, 1], margin = 1.3 }: {
     if (controls) { controls.target.copy(center); controls.update() }
     else persp.lookAt(center)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [minKey, maxKey, controls, camera])
+  }, [minKey, maxKey, controls, camera, size.width, size.height])
 
   return null
 }

--- a/webapp/src/components/SceneText.test.ts
+++ b/webapp/src/components/SceneText.test.ts
@@ -100,3 +100,49 @@ describe('bundled scene font', () => {
     expect(covered.size).toBeGreaterThan(SCENE_FONT_REQUIRED.length)
   })
 })
+
+// ── What the scenes actually ask for ──────────────────────────────────────
+// The test above proves the font covers the characters we DECLARED. This one
+// proves the scenes only ask for those: a `<SceneText>` holding a character
+// outside the subset renders NOTHING — troika goes to the CDN, the fetch is
+// blocked, and the per-label <Suspense> falls back to null forever. The label
+// just is not there, with no error anywhere, which is close to undiagnosable
+// from a screenshot. A `kN·m` label was shipped and lost exactly this way.
+describe('scene labels stay inside the bundled subset', () => {
+  const sources = import.meta.glob('../{components,pages}/*.tsx', { query: '?raw', import: 'default', eager: true }) as Record<string, string>
+  const covered = coveredCodePoints(FONT)
+
+  /** Text nodes and `{`…`}` template children of a <SceneText> element. */
+  function sceneStrings(src: string): string[] {
+    const out: string[] = []
+    const re = /<SceneText\b[^>]*>([\s\S]*?)<\/SceneText>/g
+    for (let m = re.exec(src); m; m = re.exec(src)) {
+      // Strip `${…}` holes — those are numbers and section names at runtime —
+      // and JSX comment blocks, keeping the literal characters around them.
+      out.push(m[1].replace(/\$\{[^}]*\}/g, '').replace(/\{\/\*[\s\S]*?\*\/\}/g, ''))
+    }
+    return out
+  }
+
+  it('every literal character in a <SceneText> is in the bundled font', () => {
+    const bad: string[] = []
+    for (const [path, src] of Object.entries(sources)) {
+      for (const s of sceneStrings(src)) {
+        for (const ch of s) {
+          const cp = ch.codePointAt(0)!
+          if (cp === 0x0a || cp === 0x0d || cp === 0x09) continue          // layout whitespace
+          if (ch === '`' || ch === '{' || ch === '}') continue             // template syntax
+          if (!covered.has(cp)) {
+            bad.push(`${path}: "${ch}" U+${cp.toString(16).toUpperCase().padStart(4, '0')}`)
+          }
+        }
+      }
+    }
+    expect([...new Set(bad)]).toEqual([])
+  })
+
+  it('finds the SceneText elements at all (the regex still matches)', () => {
+    const total = Object.values(sources).reduce((n, s) => n + sceneStrings(s).length, 0)
+    expect(total).toBeGreaterThan(5)
+  })
+})

--- a/webapp/src/components/SteelViewer3D.tsx
+++ b/webapp/src/components/SteelViewer3D.tsx
@@ -44,8 +44,15 @@ function Arrow({ from, to, color = '#16a34a', r = 0.04, headR = 0.10, headH = 0.
   const quat = new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 1, 0), dir.clone().normalize())
   return (
     <group position={[mid.x, mid.y, mid.z]} quaternion={quat}>
-      <mesh position={[0, -(len / 2 - (headH + r) / 2), 0]}>
-        <cylinderGeometry args={[r, r, len - headH, 8]} />
+      {/* The shaft runs from the tail to the base of the head: centred at
+          −headH/2 it spans −len/2 … len/2 − headH, which is exactly where the
+          cone starts. The old centre, −(len/2 − (headH+r)/2), put its TOP at
+          y = r/2 — the middle of the arrow — so every arrow longer than about
+          twice its head was drawn as a stick and a detached cone with a gap
+          between them. Short arrows hid it; the connection's reaction arrow
+          did not. */}
+      <mesh position={[0, -headH / 2, 0]}>
+        <cylinderGeometry args={[r, r, Math.max(len - headH, 1e-4), 8]} />
         <meshStandardMaterial color={color} />
       </mesh>
       <mesh position={[0, len / 2 - headH / 2, 0]}>
@@ -56,9 +63,15 @@ function Arrow({ from, to, color = '#16a34a', r = 0.04, headR = 0.10, headH = 0.
   )
 }
 
-function CanvasWrap({ children, box }: { children: React.ReactNode; box: { min:[number,number,number]; max:[number,number,number] } }) {
+function CanvasWrap({ children, box, dir = [1.2, 0.9, 1.5] }: {
+  children: React.ReactNode; box: { min:[number,number,number]; max:[number,number,number] }
+  /** Where the camera sits relative to the model. A member reads best at three
+   *  quarters; a bolt PATTERN reads best nearly face-on, or the pitch and gauge
+   *  it exists to show are foreshortened into a line. */
+  dir?: [number,number,number]
+}) {
   return (
-    <div className="no-print h-72 w-full overflow-hidden rounded-xl border border-slate-200 bg-white">
+    <div className="no-print h-80 w-full overflow-hidden rounded-lg border border-[#e3e1da] bg-white">
       <Canvas camera={{ fov: 45, near: 0.01, far: 500 }}>
         {/* The Canvas paints its own background, so the wrapper's colour never
             showed through — the viewport has to be told, not the div. */}
@@ -66,11 +79,18 @@ function CanvasWrap({ children, box }: { children: React.ReactNode; box: { min:[
         {/* Lighting rebalanced for a white ground: on the old dark background
             an ambient of 0.5 read as "lit", and against white the same member
             came out flat and washed. */}
-        <ambientLight intensity={0.75} />
+        <ambientLight intensity={1.05} />
         <directionalLight position={[5, 10, 5]} intensity={1.05} castShadow />
         <directionalLight position={[-5, -3, -5]} intensity={0.35} />
+        {/* Fill from the camera side. Without it the face TOWARDS the viewer is
+            lit only by ambient, so a thin plate viewed face-on (the connection)
+            came out several stops darker than the same steel on the beam, which
+            is seen at three quarters. */}
+        <directionalLight position={[2, 2, 8]} intensity={0.5} />
         <OrbitControls makeDefault enableDamping={false} />
-        <FitView box={box} dir={[1.2, 0.9, 1.5]} margin={1.4} />
+        {/* 1.4 was compensating for the old fit's over-estimate; with a fit
+            that actually measures the extents, 1.08 is the breathing room. */}
+        <FitView box={box} dir={dir} margin={1.08} />
         {children}
       </Canvas>
     </div>
@@ -79,21 +99,30 @@ function CanvasWrap({ children, box }: { children: React.ReactNode; box: { min:[
 
 // ─── Beam 3D ───────────────────────────────────────────────────────────────
 
-function DistLoad({ span, w, step = 0.6, scale = 0.5 }: {
-  span: number; w: number; step?: number; scale?: number
+function DistLoad({ span, w, top, step = 0.6, scale = 0.5 }: {
+  span: number; w: number; /** y of the top flange, so arrows land ON the beam */ top: number
+  step?: number; scale?: number
 }) {
-  const h = Math.min(0.9, 0.2 + Math.abs(w) * scale)
+  const h = top + Math.min(0.9, 0.2 + Math.abs(w) * scale)
   const positions: number[] = []
   for (let z = 0.1; z < span - 0.05; z += step) positions.push(z)
   return (
     <>
       {positions.map((z, i) => (
-        <Arrow key={i} from={[0, h * 0.85, z]} to={[0, 0.05, z]} color="#16a34a" r={0.025} headR={0.07} headH={0.18} />
+        <Arrow key={i} from={[0, h, z]} to={[0, top + 0.02, z]} color="#16a34a" r={0.025} headR={0.07} headH={0.18} />
       ))}
       <mesh position={[0, h + 0.02, span / 2]}>
         <boxGeometry args={[0.04, 0.04, span - 0.2]} />
         <meshStandardMaterial color="#16a34a" />
       </mesh>
+      {/* An unlabelled load is a decoration: 4 kN/m and 40 kN/m draw the same
+          picture, because the arrow height saturates at 0.9 m. Set above the
+          spine rather than across it, and turned to face the default camera
+          instead of edge-on to it. */}
+      <SceneText position={[0, h + 0.26, span / 2]} rotation={[0, Math.PI / 2, 0]}
+        fontSize={0.22} color="#15803d" anchorX="center">
+        {`w = ${w.toFixed(1)} kN/m`}
+      </SceneText>
     </>
   )
 }
@@ -137,11 +166,17 @@ export function BeamViewer3D({ shape, span, wDead, wLive }: {
           while everything else pointed elsewhere. (The COLUMN view rotates by
           +90° on purpose: a column should stand up.) */}
       <ExtrudedSection shapes={shapes} length={span} color="#8b9fc1" />
-      <DistLoad span={span} w={wDead + wLive} />
+      <DistLoad span={span} w={wDead + wLive} top={d} />
       <PinSupport3D pos={[0, -d, 0]} />
       <RollerSupport3D pos={[0, -d, span]} />
-      <SceneText position={[bf + 0.15, 0, span / 2]} rotation={[0, -Math.PI / 2, 0]} fontSize={0.18} color="#0f1b2a" anchorX="center">
-        {shape.name}
+      {/* +π/2 about Y turns the label's +Z face towards +X, which is where the
+          default camera is. At −π/2 it faced away and read mirrored. */}
+      <SceneText position={[bf + 0.05, -d - 0.30, span / 2]} rotation={[0, Math.PI / 2, 0]}
+        fontSize={0.2} color="#0f1b2a" anchorX="center">
+        {/* No U+00B7 separator, and kN-m rather than kN·m: the bundled scene
+            font (sceneFont.ts) does not cover the middle dot, and troika drops
+            the whole label rather than one glyph. */}
+        {`${shape.name}   -   L = ${span.toFixed(2)} m`}
       </SceneText>
     </CanvasWrap>
   )
@@ -153,30 +188,65 @@ export function ColumnViewer3D({ shape, L, Pu, Mux }: {
   shape: AiscShape; L: number; Pu: number; Mux: number
 }) {
   const shapes = useMemo(() => wShape(shape), [shape])
-  const d = (shape.d ?? 250) / 1000 / 2
   const bf = (shape.bf ?? 150) / 1000 / 2
 
+  // Wide enough for the annotations, not just the steel: the moment couple
+  // reaches ±0.75 m and the section label runs off to the right, and anything
+  // outside the box is what the fit crops.
   const box = useMemo<{ min:[number,number,number]; max:[number,number,number] }>(() => ({
-    min: [-bf * 3, -0.4, -bf * 3],
-    max: [ bf * 3, L + 1.2, bf * 3],
+    min: [-1.1, -0.4, -Math.max(bf * 2, 0.4)],
+    max: [ bf + 2.1, L + 1.35, Math.max(bf * 2, 0.4)],
   }), [bf, L])
 
   return (
     <CanvasWrap box={box}>
-      {/* column extrudes along Y — rotate section from XY to XZ plane */}
-      <group rotation={[0, 0, 0]} position={[-d, 0, -bf]}>
-        <group rotation={[Math.PI / 2, 0, 0]}>
+      {/* `ExtrudedSection` extrudes along +Z, so the column has to be stood up
+          by −90° about X (+Z → +Y). The old +90° sent it to −Y: the member hung
+          BELOW the ground plane while the base plate, the load arrows and the
+          label all sat above it, which is why the scene read as an empty box
+          with a stub at the bottom. No lateral offset either — the profiles
+          from `buildSectionShapes` are already centred on the member axis, so
+          the old [-d, 0, -bf] shifted the column off its own arrows. */}
+      <group rotation={[-Math.PI / 2, 0, 0]}>
+        {/* Spun a further 90° in its own plane so the section DEPTH lies in the
+            X–Y plane, which is the plane the Mux couple below is drawn in. Left
+            unspun, the picture showed a column bent about its weak axis while
+            the numbers beside it were a strong-axis check. */}
+        <group rotation={[0, 0, Math.PI / 2]}>
           <ExtrudedSection shapes={shapes} length={L} color="#8b9fc1" />
         </group>
       </group>
-      {/* axial load arrow */}
-      {Pu > 0 && <Arrow from={[0, L + 0.9, 0]} to={[0, L + 0.05, 0]} color="#dc2626" headR={0.13} headH={0.3} />}
-      {/* moment arrow: horizontal arrow at top */}
-      {Mux > 0 && <Arrow from={[-0.6, L + 0.1, 0]} to={[0.1, L + 0.1, 0]} color="#f59e0b" headR={0.10} headH={0.22} />}
+
+      {/* Axial load, with its magnitude — an arrow alone says "compression",
+          not "how much". */}
+      {Pu > 0 && (
+        <>
+          <Arrow from={[0, L + 0.9, 0]} to={[0, L + 0.05, 0]} color="#dc2626" headR={0.13} headH={0.3} />
+          <SceneText position={[0.28, L + 0.75, 0]} fontSize={0.2} color="#b91c1c" anchorX="left">
+            {`Pu = ${Pu.toFixed(0)} kN`}
+          </SceneText>
+        </>
+      )}
+
+      {/* End moment. Drawn as a COUPLE — two opposed arrows a lever apart —
+          because a single straight arrow reads as a transverse point load,
+          which is a different thing entirely. */}
+      {Mux > 0 && (
+        <>
+          <Arrow from={[-0.75, L + 0.20, 0]} to={[-0.05, L + 0.20, 0]} color="#f59e0b" r={0.03} headR={0.10} headH={0.22} />
+          <Arrow from={[ 0.75, L - 0.05, 0]} to={[ 0.05, L - 0.05, 0]} color="#f59e0b" r={0.03} headR={0.10} headH={0.22} />
+          {/* Below the couple, not above it: above, the text ran straight
+              through the Pu arrow and its label. */}
+          <SceneText position={[-1.05, L - 0.32, 0]} fontSize={0.2} color="#b45309" anchorX="left">
+            {`Mux = ${Mux.toFixed(0)} kN-m`}
+          </SceneText>
+        </>
+      )}
+
       {/* fixed base */}
       <mesh position={[0, -0.03, 0]}><boxGeometry args={[0.8, 0.06, 0.5]} /><meshStandardMaterial color="#0056b3" /></mesh>
-      <SceneText position={[bf + 0.35, L / 2, 0]} rotation={[0, 0, 0]} fontSize={0.18} color="#0f1b2a" anchorX="center">
-        {shape.name}
+      <SceneText position={[bf + 0.45, L / 2, 0]} fontSize={0.2} color="#0f1b2a" anchorX="left">
+        {`${shape.name}   L = ${L.toFixed(2)} m`}
       </SceneText>
     </CanvasWrap>
   )
@@ -190,42 +260,81 @@ export function ConnectionViewer3D({ geom, db, t_plate, critical }: {
   const W = geom.plateW / 1000, H = geom.plateH / 1000, T = t_plate / 1000
   const dbm = db / 1000
 
+  // The plate spans x = 0…W (it is drawn from its own left edge), the stub and
+  // the reaction arrow reach beyond it, and the bolts stick out ±(grip/2+head)
+  // in z. The old box started at −0.8W, which framed a strip of empty air to
+  // the left of the connection and pushed the connection itself off-centre.
   const box = useMemo<{ min:[number,number,number]; max:[number,number,number] }>(() => ({
-    min: [-W * 0.8, -0.1, -0.6],
-    max: [ W * 0.8 + 0.3, H + 0.1, 0.6],
+    min: [-0.06, -0.05, -0.09],
+    max: [ W + 0.30, H * 1.58, 0.09],
   }), [W, H])
 
   return (
-    <CanvasWrap box={box}>
+    // Nearly face-on: the pitch and gauge are the whole content of this view.
+    <CanvasWrap box={box} dir={[0.5, 0.32, 1]}>
       {/* shear tab plate */}
       <mesh position={[W / 2, H / 2, 0]}>
         <boxGeometry args={[W, H, T]} />
-        <meshStandardMaterial color="#a1a1aa" metalness={0.5} roughness={0.4} />
+        {/* Low metalness on purpose: there is no environment map in this scene,
+            and a metalness of 0.5+ has nothing to reflect, so it resolves to
+            near-black. The plate was rendering as a dark slab for that reason
+            alone. */}
+        <meshStandardMaterial color="#cfd4dc" metalness={0} roughness={0.6} />
       </mesh>
-      {/* bolts */}
+      {/* Bolts. A bare shank through the plate is not a bolt — it reads as a
+          pin, and the grip length is invisible. Each is drawn as head + shank
+          + nut, hexagonal (6-sided cylinders) and sized to the usual 1.5·db
+          across flats, so the fastener is recognisable at a glance and the two
+          plies it clamps are legible. */}
       {geom.bolts.map(b => {
         const bx = (b.x + geom.Cx) / 1000
         const by = (b.y + geom.Cy) / 1000
         const isCrit = b.id === critical
+        const grip = T + 0.008 + 0.004          // shear tab + web stub + a little slack
+        const hexR = dbm * 0.85, hexH = dbm * 0.65
+        const col = isCrit ? '#f59e0b' : '#c8a33a'
         return (
           <group key={b.id} position={[bx, by, 0]}>
+            {/* shank through the grip */}
             <mesh rotation={[Math.PI / 2, 0, 0]}>
-              <cylinderGeometry args={[dbm / 2, dbm / 2, 0.4, 12]} />
-              <meshStandardMaterial color={isCrit ? '#f59e0b' : '#d4a017'} metalness={0.7} roughness={0.3} />
+              <cylinderGeometry args={[dbm / 2, dbm / 2, grip + hexH, 14]} />
+              <meshStandardMaterial color={col} metalness={0.25} roughness={0.4} />
             </mesh>
-            <SceneText position={[dbm * 0.8, dbm * 0.8, 0.05]} fontSize={0.018} color={isCrit ? '#b45309' : '#0f1b2a'}>
+            {/* head, on the plate side; nut on the far side */}
+            <mesh position={[0, 0, -(grip / 2 + hexH / 2)]} rotation={[Math.PI / 2, 0, 0]}>
+              <cylinderGeometry args={[hexR, hexR, hexH, 6]} />
+              <meshStandardMaterial color={col} metalness={0.25} roughness={0.35} />
+            </mesh>
+            <mesh position={[0, 0, grip / 2 + hexH / 2]} rotation={[Math.PI / 2, 0, 0]}>
+              <cylinderGeometry args={[hexR, hexR, hexH, 6]} />
+              <meshStandardMaterial color={col} metalness={0.25} roughness={0.35} />
+            </mesh>
+            {/* In front of the tab (+z, where the camera is) — behind it the
+                mark was occluded by the very plate it annotates. */}
+            <SceneText position={[-hexR - 0.008, 0, grip / 2 + hexH + 0.006]} fontSize={0.022}
+              anchorX="right" color={isCrit ? '#b45309' : '#5c6675'}>
               {b.id}
             </SceneText>
           </group>
         )
       })}
-      {/* beam web stub (connected member) */}
-      <mesh position={[W + 0.06, H / 2, 0]}>
-        <boxGeometry args={[0.12, H * 1.3, 0.008]} />
-        <meshStandardMaterial color="#6b7280" metalness={0.4} roughness={0.5} />
+      {/* Beam web stub (the connected member). Offset to sit BESIDE the tab,
+          the way a web laps a shear tab rather than sharing its mid-plane —
+          and TRANSLUCENT, because the drawing exists to show the bolt group
+          and an opaque web laps straight over it. */}
+      <mesh position={[W + 0.05, H / 2, T / 2 + 0.004]}>
+        <boxGeometry args={[0.14, H * 1.35, 0.008]} />
+        <meshStandardMaterial color="#94a3b8" metalness={0.35} roughness={0.5}
+          transparent opacity={0.3} depthWrite={false} />
       </mesh>
-      {/* load arrow */}
-      <Arrow from={[W + 0.14, H * 1.1, 0]} to={[W + 0.14, H * 0.2, 0]} color="#16a34a" r={0.012} headR={0.035} headH={0.08} />
+      {/* Reaction on the supported beam. It belongs OUT on the stub, clear of
+          the bolt group — drawn over the plate it looked like a load applied to
+          the tab itself, and it hid the bolts it was meant to be loading. */}
+      <Arrow from={[W + 0.175, H * 1.5, T / 2 + 0.012]} to={[W + 0.175, H * 0.5, T / 2 + 0.012]}
+        color="#16a34a" r={0.007} headR={0.021} headH={0.05} />
+      <SceneText position={[W + 0.195, H * 1.22, T / 2 + 0.012]} fontSize={0.024} color="#15803d" anchorX="left">
+        Vu
+      </SceneText>
     </CanvasWrap>
   )
 }

--- a/webapp/src/pages/SteelDesign.tsx
+++ b/webapp/src/pages/SteelDesign.tsx
@@ -132,7 +132,8 @@ function BeamTab() {
   }, [res, shape, Fy, wD, wL, span, Lb, utilM])
 
   return (
-    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
+    <div>
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
       <div className="space-y-5">
         <Card title={<>Section & grade<CalcBadge loading={loading} error={error} /></>}>
           <ShapePick value={shapeName} onChange={setShapeName} />
@@ -178,8 +179,10 @@ function BeamTab() {
         </>)}
       </div>
 
+      </div>
+
       {res && (
-        <div className="col-span-full">
+        <div>
           <WorkedSolution steps={steps} title="Beam Design — step-by-step (AISC 360-16 §F, §G)" />
         </div>
       )}
@@ -257,7 +260,8 @@ function ColumnTab() {
   }, [res, shape, Pu, Mux, Muy, Kx, Ky, L, Fy, dead, live, dlMode])
 
   return (
-    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
+    <div>
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.4fr_1fr]">
       <div className="space-y-5">
         <Card title={<>Section & grade<CalcBadge loading={loading} error={error} /></>}>
           <ShapePick value={shapeName} onChange={setShapeName} />
@@ -303,8 +307,10 @@ function ColumnTab() {
         </>)}
       </div>
 
+      </div>
+
       {res && (
-        <div className="col-span-full">
+        <div>
           <WorkedSolution steps={steps} title="Column Design — step-by-step (AISC 360-16 §E3, §H1-1)" />
         </div>
       )}
@@ -441,7 +447,8 @@ function ConnectionTab() {
   }, [res, boltGrade, db, nRows, nCols, sy, ex_edge, tPlate, FuPlate, threads, Vu, Hu, ex_load, ey_load, e_out, b_gage])
 
   return (
-    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.2fr_0.9fr_1fr]">
+    <div>
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.2fr_0.9fr_1fr]">
       {/* ── inputs ── */}
       <div className="space-y-5">
         <Card title={<>Connection<CalcBadge loading={loading} error={error} /></>}>
@@ -636,8 +643,10 @@ function ConnectionTab() {
         )}
       </div>
 
+      </div>
+
       {res && connType === 'bolt' && (
-        <div className="col-span-full">
+        <div>
           <WorkedSolution steps={boltSteps} title="Connection Design — step-by-step (AISC 360-16 §J3, §J4)" />
         </div>
       )}


### PR DESCRIPTION
Item 5 of the to-do list — the three Steel Design rendering complaints. View layer only.

Behind the three symptoms were **six** defects, two of them in helpers shared with every other 3D view in the app.

## Shared — two root causes

**`FitView` never actually fitted.** It framed a *sphere of the box's diagonal*, so anything long and thin was pushed far too far back. A 6 m beam 0.3 m deep has a half-diagonal of 3.4 m against a half-height of 0.95 m — the camera sat ~3.5× further away than needed, and every scene rendered at about a fifth of its frame. It now projects the box's eight corners onto the camera basis and honours the viewport aspect. The per-scene margin drops 1.4 → 1.08, since 1.4 was compensating for the over-estimate.

**`Arrow` drew a stick and a detached cone.** The shaft was centred at `−(len/2 − (headH+r)/2)`, which puts its top at the *middle* of the arrow rather than at the base of the head. Short arrows hid it; the connection's reaction arrow did not.

## Beam

No magnitude on the load (arrow height saturates at 0.9 m, so 4 kN/m and 40 kN/m drew the same picture); arrows measured from `y = 0` instead of the top flange; and the section label rotated to face *away* from the default camera, so it read mirrored.

## Column

The member was rotated **+90° about X**, which sends the extrusion to −Y — the column hung *below* the ground while the base plate, the load arrows and the label all sat above it. It also carried a `[−d, 0, −bf]` offset even though `buildSectionShapes` already centres the profile on the member axis.

Now −90° with no offset, plus a further 90° in-plane so the section **depth** lies in the plane of the Mux couple — the old orientation drew weak-axis bending beside a strong-axis check. Pu and Mux are labelled with their values, and the moment is an actual **couple** rather than one straight arrow that read as a transverse point load.

## Connection

Bolts were bare cylinders through the plate — that reads as a pin and hides the grip. They are now head + shank + nut, hex, with the bolt mark in front of the tab instead of behind it. The web stub is translucent and offset the way a web laps a tab (it was opaque, straight over the bolt group the drawing exists to show), the reaction arrow is out clear of the bolts, and the view is nearly face-on because pitch and gauge are the whole content.

Metalness dropped 0.5–0.75 → 0.25: there is no environment map in these scenes, so high metalness has nothing to reflect and resolves to near-black.

## The "card z-index overlap"

It is the sticky results rail. `WorkedSolution` was a `col-span-full` **third row of the same grid**, so the rail's sticky containing block extended over it and the rail floated across the equations as you scrolled past. Reproduced at scroll ≈ 1600 px, where the rail cards sat on top of the flexural-capacity working. The solution now sits outside the grid on all three tabs.

## New test — the label that disappears

`<SceneText>` renders **nothing** when its string holds a character outside the bundled font subset: troika falls back to the CDN, the fetch is blocked, and the per-label `<Suspense>` never settles. No error, no warning — the label simply is not there, which is close to undiagnosable from a screenshot. A `kN·m` label was lost exactly this way while writing the column view.

`SceneText.test.ts` now scans every `<SceneText>` literal in the app against the shipped font's cmap and names the file and code point. Confirmed it fails on a reintroduced `·` (`./SteelViewer3D.tsx: "·" U+00B7`) and passes once removed.

## Verification

- `npx tsc -b` clean, `npm run lint` clean, **3836 tests / 214 files green**.
- All three Steel scenes screenshotted in headless Chromium, plus **Truss Space and Model Space** — the shared `FitView` change improves both and breaks neither.

## Remaining from the list

Two items, one PR each: the Model Space walkthrough's demo template + state restore, and deriving the BOQ concrete class from the design f′c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmPbtTVsjNBXVpiQVBYBnz)_