### PR TITLE
feat(boq): the take-off mix class follows the design f′c

### DIFF
--- a/webapp/src/engine/quantities.test.ts
+++ b/webapp/src/engine/quantities.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   concreteMaterials, barTakeoff, lateralTieTakeoff, tieWire,
   estimateSlab, estimateChb, estimateColumn, estimateBeam, estimateBoxCulvert,
+  concreteClassForFc, CONCRETE_CLASS_FC, CONCRETE_CLASS_FACTORS,
 } from './quantities';
 
 describe('shared helpers', () => {
@@ -95,5 +96,46 @@ describe('column / beam / box culvert', () => {
     expect(r.netArea).toBe(4);
     expect(r.volume).toBeCloseTo(20);
     expect(r.rsb.count).toBe(Math.ceil(5 / 0.2) + 1); // 26
+  });
+});
+
+describe('concreteClassForFc — mix class from the design strength', () => {
+  // DPWH Item 405: AA 27.58, A 20.68, B 17.24, C 13.79 MPa
+  // (4000 / 3000 / 2500 / 2000 psi).
+  it('picks the weakest class that still reaches f′c', () => {
+    expect(concreteClassForFc(13.79).klass).toBe('C');
+    expect(concreteClassForFc(17.24).klass).toBe('B');
+    expect(concreteClassForFc(20.68).klass).toBe('A');
+    expect(concreteClassForFc(27.58).klass).toBe('AA');
+  });
+
+  it('rounds UP to the next class, never down', () => {
+    // 21 MPa is the everyday Philippine spec and sits just above Class A.
+    expect(concreteClassForFc(21).klass).toBe('AA');
+    expect(concreteClassForFc(17.25).klass).toBe('A');
+    expect(concreteClassForFc(13.8).klass).toBe('B');
+  });
+
+  it('lands exactly on a class boundary without floating-point drift', () => {
+    // 20.68 must give A, not AA — a bare >= on binary floats is the bug here.
+    for (const [klass, fc] of Object.entries(CONCRETE_CLASS_FC)) {
+      expect(concreteClassForFc(fc).klass).toBe(klass);
+      expect(concreteClassForFc(fc).adequate).toBe(true);
+    }
+  });
+
+  it('flags a design above Class AA instead of pretending', () => {
+    const r = concreteClassForFc(35);
+    expect(r.klass).toBe('AA');       // still totals, so the BOQ is not blank
+    expect(r.adequate).toBe(false);   // but says a designed mix is required
+    expect(r.classFc).toBeCloseTo(27.58, 2);
+  });
+
+  it('a weak f′c does not fall through to nothing', () => {
+    expect(concreteClassForFc(10)).toEqual({ klass: 'C', classFc: 13.79, adequate: true });
+  });
+
+  it('every class the picker offers has both a strength and a cement factor', () => {
+    expect(Object.keys(CONCRETE_CLASS_FC).sort()).toEqual(Object.keys(CONCRETE_CLASS_FACTORS).sort());
   });
 });

--- a/webapp/src/engine/quantities.ts
+++ b/webapp/src/engine/quantities.ts
@@ -12,6 +12,41 @@ export type ConcreteClass = 'AA' | 'A' | 'B' | 'C' | 'custom';
 export const CONCRETE_CLASS_FACTORS: Record<Exclude<ConcreteClass, 'custom'>, number> = {
   AA: 12, A: 9, B: 7.5, C: 6,
 };
+
+/**
+ * Specified 28-day cylinder strength of each standard class, MPa
+ * (DPWH Standard Specifications Item 405 — the 4000 / 3000 / 2500 / 2000 psi
+ * mixes the NSCP class letters correspond to).
+ */
+export const CONCRETE_CLASS_FC: Record<Exclude<ConcreteClass, 'custom'>, number> = {
+  AA: 27.58, A: 20.68, B: 17.24, C: 13.79,
+};
+
+export interface ClassForFc {
+  klass: Exclude<ConcreteClass, 'custom'>;
+  /** The class's own specified strength, MPa. */
+  classFc: number;
+  /** False when the design f'c is above Class AA — a designed mix is needed. */
+  adequate: boolean;
+}
+
+/**
+ * The standard mix class that delivers a given design f'c: the WEAKEST class
+ * whose specified strength still reaches it, since a stronger class only
+ * costs cement.
+ *
+ * Above Class AA (27.58 MPa) no standard class qualifies. The strongest is
+ * returned anyway so the take-off still totals, with `adequate` false — a
+ * take-off that silently prices a 12-bag mix for f'c 35 concrete is worse
+ * than one that prices it and says so.
+ */
+export function concreteClassForFc(fc: number): ClassForFc {
+  const ascending: Exclude<ConcreteClass, 'custom'>[] = ['C', 'B', 'A', 'AA'];
+  for (const klass of ascending) {
+    if (CONCRETE_CLASS_FC[klass] >= fc - 1e-9) return { klass, classFc: CONCRETE_CLASS_FC[klass], adequate: true };
+  }
+  return { klass: 'AA', classFc: CONCRETE_CLASS_FC.AA, adequate: false };
+}
 const STEEL_DENSITY = 7850;   // kg/m³
 const BAR_LENGTH = 6;         // m, commercial length
 const TIE_WIRE_ROLL = 2385;   // m per roll

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -33,7 +33,7 @@ import { useSolver } from '../lib/useSolver'
 import type { SolveProgress } from '../engine/progress'
 import { TABLE_204_1, TABLE_204_2, sdlItemKPa, sdlTotal, type SdlItem } from '../engine/deadLoads'
 import { TABLE_205_1, TABLE_206 } from '../engine/liveLoads'
-import type { ConcreteClass } from '../engine/quantities'
+import { concreteClassForFc, type ConcreteClass } from '../engine/quantities'
 import { computeSeismic, buildECases, type SeismicResult, type DriftRow } from '../engine/seismic'
 import type { IrregularityFlag } from '../engine/irregularity'
 import { columnKFactors, type ColumnK } from '../engine/effectiveLength'
@@ -1125,7 +1125,16 @@ export default function ModelSpace() {
   const [lh, setLh] = useState<LetterheadState>(() => initialLetterhead(''))
   const [exporting, setExporting] = useState(false)               // PDF build in flight
   const [ioMenu, setIoMenu] = useState(false)                     // Import/Export dropdown
-  const [concreteClass, setConcreteClass] = useState<ConcreteClass>((si.concreteClass as ConcreteClass) ?? 'A')   // mix class for the take-off
+  // Mix class for the take-off. It FOLLOWS the design f′c rather than sitting
+  // at a hard-coded 'A' — a model designed for 28 MPa was being priced with a
+  // 9-bag Class A mix, which is not the concrete that was designed. The user
+  // can still override it, and once they do the override sticks: `classPin`
+  // holds their choice, `null` means "track f′c". A saved project that already
+  // carries a class is treated as an override, so reopening it does not
+  // silently reprice.
+  const [classPin, setClassPin] = useState<ConcreteClass | null>((si.concreteClass as ConcreteClass) ?? null)
+  const fcClass = useMemo(() => concreteClassForFc(fc), [fc])
+  const concreteClass = useMemo<ConcreteClass>(() => classPin ?? fcClass.klass, [classPin, fcClass])
   const [prices, setPrices] = useState<PriceList>((si.prices as PriceList) ?? {   // unit prices for the costed bill (PHP)
     cementBag: 260, sandM3: 1500, gravelM3: 1600, steelKg: 65, tieWireRoll: 2500, plywoodSheet: 700, lumberM: 25, structuralSteelKg: 120, timberBdFt: 55,
   })
@@ -1205,7 +1214,7 @@ export default function ModelSpace() {
         fc, fy, barDia, tieDia, cover, slabThk, gammaC, qD, qL,
         qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs, methodB, accTor, orth30, evOn, rsaRegular,
         Vw, expo, Kzt, wDirs, assembly, pDelta, cracked, shearDef, tryBars,
-        concreteClass, prices, planSel,
+        concreteClass: classPin ?? undefined, prices, planSel,
         material, colFam, girFam, beaFam, colShape, girShape, beaShape, steelFy, steelFu,
         woodSpeciesId, woodGrade, woodWet, matSource, customId,
       }))
@@ -1214,7 +1223,7 @@ export default function ModelSpace() {
     fc, fy, barDia, tieDia, cover, slabThk, gammaC, qD, qL,
     qa, Hf, gammaSoil, Ca, Cv, Rw, Ie, Zf, Nv, eDirs, methodB, accTor, orth30, evOn, rsaRegular,
     Vw, expo, Kzt, wDirs, assembly, pDelta, cracked, shearDef, tryBars,
-    concreteClass, prices, planSel,
+    classPin, prices, planSel,
     material, colFam, girFam, beaFam, colShape, girShape, beaShape, steelFy, steelFu,
     woodSpeciesId, woodGrade, woodWet, matSource, customId])
 
@@ -5571,17 +5580,40 @@ export default function ModelSpace() {
             <h2 className="text-xl font-extrabold tracking-tight text-[#0f4c92]">
               Material take-off — Bill of Quantities &amp; Materials
             </h2>
-            <label className="no-print flex items-center gap-2 text-sm">
-              <span className="font-medium text-slate-600">Concrete class</span>
-              <select value={concreteClass} onChange={(e) => setConcreteClass(e.target.value as ConcreteClass)}
-                className="rounded-md border border-slate-300 px-2 py-1 text-sm">
-                <option value="AA">AA (12 bags/m³)</option>
-                <option value="A">A (9)</option>
-                <option value="B">B (7.5)</option>
-                <option value="C">C (6)</option>
-              </select>
-            </label>
+            <div className="no-print flex flex-wrap items-center justify-end gap-x-2 gap-y-1 text-sm">
+              <label className="flex items-center gap-2">
+                <span className="font-medium text-slate-600">Concrete class</span>
+                <select value={concreteClass} onChange={(e) => setClassPin(e.target.value as ConcreteClass)}
+                  className="rounded-md border border-slate-300 px-2 py-1 text-sm">
+                  <option value="AA">AA (12 bags/m³)</option>
+                  <option value="A">A (9)</option>
+                  <option value="B">B (7.5)</option>
+                  <option value="C">C (6)</option>
+                </select>
+              </label>
+              {/* Which of the two it is has to be visible, or an overridden
+                  class looks the same as a derived one and the bill quietly
+                  stops matching the design. */}
+              {classPin === null ? (
+                <span className="text-[11.5px] text-slate-500">
+                  from f′c = {f2(fc)} MPa
+                </span>
+              ) : (
+                <button type="button" onClick={() => setClassPin(null)}
+                  className="text-[11.5px] font-semibold text-[#0f4c92] underline underline-offset-2">
+                  overridden — match f′c ({fcClass.klass})
+                </button>
+              )}
+            </div>
           </div>
+
+          {!fcClass.adequate && classPin === null && (
+            <p className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] text-amber-900">
+              f′c = {f2(fc)} MPa is above Class AA ({f2(fcClass.classFc)} MPa), so no standard NSCP mix
+              class reaches it. The bill below is priced at Class AA — a DESIGNED mix is required, and its
+              cement content will be higher than the 12 bags/m³ assumed here.
+            </p>
+          )}
 
           {/* BOM summary */}
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">


### PR DESCRIPTION
Item 7 of the to-do list. **Layer 9** (quantities) plus its Model Space UI.

## The defect

The Bill of Quantities priced a hard-coded **Class A** mix regardless of what the structure was designed for. On the app's own default — f′c = 28 MPa — that is 9 bags/m³ against the 12 the concrete actually needs. On the model I drove for verification the cement line reads **437 bags**; the old behaviour would have billed **328**, a third under.

## The derivation

`concreteClassForFc(fc)` returns the **weakest** standard class whose specified strength still reaches f′c — a stronger class only costs cement. Strengths are the DPWH Standard Specifications Item 405 values the NSCP class letters correspond to:

| Class | f′c (MPa) | psi | Cement |
|---|---|---|---|
| AA | 27.58 | 4000 | 12 bags/m³ |
| A | 20.68 | 3000 | 9 |
| B | 17.24 | 2500 | 7.5 |
| C | 13.79 | 2000 | 6 |

**Above Class AA no standard class qualifies.** The strongest is returned anyway so the take-off still totals, with `adequate: false`, and the BOQ states plainly that a designed mix is required and its cement content will exceed the 12 bags/m³ assumed. A bill that silently prices a standard mix for concrete no standard mix can deliver is worse than one that prices it and admits it. (The app's default 28 MPa is in exactly this band, so the notice is not hypothetical.)

## Still editable, and it says which it is

- Unpinned: the picker reads **"from f′c = 28.00 MPa"**.
- Pick a class: it reads **"overridden — match f′c (AA)"**, as a button that hands control back.

Without that, an overridden class looks identical to a derived one and the bill quietly stops matching the design.

The session snapshot stores the **override**, not the effective class — so reopening a project that never had one keeps tracking f′c rather than freezing at whatever the class happened to be that day.

## Tests

Boundary cases at each class's exact specified strength (a bare float `>=` is the bug there), that it rounds **up** and never down, that above-AA flags rather than silently clamps, and that the strength table and the cement-factor table cover the same set of classes.

## Verification

- `npx tsc -b` clean, `npm run lint` clean, **3842 tests / 214 files green**.
- Driven end to end in headless Chromium — generate grid → analyse → design all → BOQ — through all three states: derived (`Class AA: 12 cement bags/m³`), overridden to B (`Class B: 7.5`), and reset back to derived (`Class AA: 12`).

## Remaining from the list

One item left: the Model Space walkthrough's demo template + state restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmPbtTVsjNBXVpiQVBYBnz)_