### PR TITLE
feat(tour): the Model Space guide gets a demo model, and the buttons nobody finds

### DIFF
--- a/webapp/src/lib/modelTour.ts
+++ b/webapp/src/lib/modelTour.ts
@@ -17,10 +17,20 @@
 //     explicitly, because the tab label points the wrong way and a model with
 //     no restraints does not give a wrong answer — it does not solve at all.
 //
-// The three tabs the tour SKIPS — Modal, Pushover, Nonlinear — are advanced
-// analyses, not steps on the path to a designed structure. Walking a beginner
-// through a pushover before they have a static solve is how a walkthrough
-// becomes something people close.
+// Pushover and Nonlinear are SKIPPED: advanced analyses, not steps on the path
+// to a designed structure, and walking a beginner through a pushover before
+// they have a static solve is how a walkthrough becomes something people close.
+//
+// MODAL IS NOT SKIPPED, for one reason: its mode-shape animation is started by
+// clicking a ROW in the results table, and nothing on screen suggests the rows
+// are clickable. A control that cannot be found by looking is precisely what a
+// walkthrough is for. The same goes for the results sub-tabs (Schedules /
+// BOQ / Construction Schedule), which only appear once a design exists and by
+// then are a long way down the page.
+//
+// The tour also needs something to POINT AT. On a first visit every panel here
+// is empty, so `ModelSpace` gives the guide a demo grid on open and clears it
+// on close — see the `useTour` hooks there.
 // ─────────────────────────────────────────────────────────────────────────
 
 import type { Tour, TourStep } from './tour'
@@ -73,6 +83,14 @@ export const MODEL_STEPS: readonly TourStep[] = [
     why: 'Cracked sections (ACI §6.6.3.1.1) are on by default here and off at the API level, so closed-form benchmarks stay gross-section.',
   },
   {
+    id: 'modal',
+    tab: 'modal',
+    anchor: 'modal-panel',
+    title: 'Modal — and the mode shape you have to click for',
+    body: 'Run the modal analysis, then CLICK A MODE ROW in the results table. The 3D canvas animates that mode as a purple skeleton, and it keeps animating while you work on other tabs.',
+    why: 'Nothing on screen says the rows are clickable, which is why it is worth saying here. Check the mass participation reaches 90% (NSCP §208.5.5) before trusting a response-spectrum run.',
+  },
+  {
     id: 'design',
     tab: 'design',
     anchor: 'design-button',
@@ -80,11 +98,25 @@ export const MODEL_STEPS: readonly TourStep[] = [
     body: 'The pipeline takes the governing combination and sizes slabs, beams, columns and footings, each with a utilisation and a code clause. It consumes analysis results, so it has nothing to work from until the previous step has run.',
   },
   {
+    id: 'results-tabs',
+    tab: 'design',
+    anchor: 'results-tabs',
+    title: 'The results have three tabs of their own',
+    body: 'Under the design: Schedules (bar-by-bar), Bill of Quantities (materials and cost) and Construction Schedule. They are easy to miss — the page is long by the time they appear.',
+    why: 'The bill’s concrete mix class follows the design f′c, and says so; override it there if the specification differs.',
+  },
+  {
     id: 'plans',
     tab: 'plans',
     anchor: 'plans-panel',
     title: 'Take the drawings and the take-off',
     body: 'Framing and foundation plans, footing details and the bill of quantities are generated from the model and the design — not redrawn. Every sheet exports to SVG.',
+  },
+  {
+    id: 'io',
+    anchor: 'io-menu',
+    title: 'Save the model before you close the tab',
+    body: 'Import / Export writes the whole model to a JSON file and reads it back. The autosave only survives the browser session — it is not a saved project.',
   },
 ]
 

--- a/webapp/src/lib/tour.ts
+++ b/webapp/src/lib/tour.ts
@@ -68,3 +68,22 @@ export const stepAt = (steps: readonly TourStep[], i: number): TourStep | undefi
 /** Every distinct anchor a tour points at. */
 export const anchorsOf = (steps: readonly TourStep[]): string[] =>
   [...new Set(steps.map((s) => s.anchor).filter((a): a is string => Boolean(a)))]
+
+/**
+ * Whether a start/close transition owes a lifecycle hook, and the flag that
+ * results. Extracted from `useTour` so the pairing rule can be tested without
+ * rendering: a page uses these hooks to LOAD AND UNLOAD A DEMO MODEL, so
+ * "fires `end` exactly once, and only after a `start`" is a data-loss rule
+ * rather than a cosmetic one.
+ *
+ *   start while stopped  → fire 'start'   (set up the demo)
+ *   start while started  → fire nothing   (re-opening must not re-load it)
+ *   close while started  → fire 'end'     (tear it down)
+ *   close while stopped  → fire nothing   (a stray close must not tear down
+ *                                          a model the tour never created)
+ */
+export function tourLifecycle(started: boolean, action: 'start' | 'close'):
+  { started: boolean; fire: 'start' | 'end' | null } {
+  if (action === 'start') return started ? { started: true, fire: null } : { started: true, fire: 'start' }
+  return started ? { started: false, fire: 'end' } : { started: false, fire: null }
+}

--- a/webapp/src/lib/tours.test.ts
+++ b/webapp/src/lib/tours.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { TOURS } from './tours'
-import { anchorsOf, nextIndex, prevIndex, isLast, stepAt } from './tour'
+import { anchorsOf, nextIndex, prevIndex, isLast, stepAt, tourLifecycle } from './tour'
 import { SOILS_STEPS } from './soilsTour'
 import { MODEL_STEPS } from './modelTour'
 
@@ -107,13 +107,25 @@ describe('the sequences that trip people up', () => {
     expect(at('analyse')).toBeLessThan(at('design'))
   })
 
-  it('model space skips the advanced analyses', () => {
-    // Modal, pushover and nonlinear are not steps on the way to a designed
-    // structure, and walking a beginner through them is how a guide gets shut.
+  it('model space still skips pushover and nonlinear', () => {
+    // Those two are not steps on the way to a designed structure, and walking
+    // a beginner through them is how a guide gets shut. MODAL is different and
+    // is now included: its mode-shape animation is started by clicking a row
+    // in a table that gives no sign of being clickable, so it is exactly the
+    // kind of thing a walkthrough is for.
     const tabs = MODEL_STEPS.map((s) => s.tab)
-    expect(tabs).not.toContain('modal')
     expect(tabs).not.toContain('pushover')
     expect(tabs).not.toContain('nonlinear')
+    expect(tabs).toContain('modal')
+  })
+
+  it('model space visits modal between the analysis and the design', () => {
+    // Modal needs a solved model and the design does not need modal, so it
+    // belongs after `analyse` and before `design` — which is also its position
+    // in the tab bar, keeping the tour walking forwards.
+    const at = (id: string) => MODEL_STEPS.findIndex((s) => s.id === id)
+    expect(at('analyse')).toBeLessThan(at('modal'))
+    expect(at('modal')).toBeLessThan(at('design'))
   })
 })
 
@@ -133,5 +145,47 @@ describe('navigation stops at the ends rather than wrapping', () => {
   it('never returns undefined for an out-of-range index', () => {
     expect(stepAt(SOILS_STEPS, -5)).toBe(SOILS_STEPS[0])
     expect(stepAt(SOILS_STEPS, 999)).toBe(SOILS_STEPS[SOILS_STEPS.length - 1])
+  })
+})
+
+describe('the demo-model lifecycle', () => {
+  // `ModelSpace` hangs a demo grid off these transitions, so getting them
+  // wrong loses the user's model rather than just showing a clumsy tour.
+  // Replayed as a sequence, because the bugs are all about ORDER.
+  const run = (actions: ('start' | 'close')[]) => {
+    let started = false
+    const fired: string[] = []
+    for (const a of actions) {
+      const t = tourLifecycle(started, a)
+      started = t.started
+      if (t.fire) fired.push(t.fire)
+    }
+    return fired
+  }
+
+  it('pairs one start with one end', () => {
+    expect(run(['start', 'close'])).toEqual(['start', 'end'])
+  })
+
+  it('does not re-load the demo when the guide is reopened mid-tour', () => {
+    expect(run(['start', 'start', 'start', 'close'])).toEqual(['start', 'end'])
+  })
+
+  it('never tears down a model the tour did not create', () => {
+    // A close with no start — a stray Esc, or a close handler that fires twice
+    // — must not reach `save(null)`.
+    expect(run(['close'])).toEqual([])
+    expect(run(['start', 'close', 'close'])).toEqual(['start', 'end'])
+  })
+
+  it('a second run of the guide sets up and tears down again', () => {
+    expect(run(['start', 'close', 'start', 'close'])).toEqual(['start', 'end', 'start', 'end'])
+  })
+
+  it('leaves nothing owed at the end of any balanced sequence', () => {
+    for (const seq of [['start', 'close'], ['start', 'start', 'close', 'close'], ['close', 'start', 'close']] as const) {
+      const fired = run([...seq])
+      expect(fired.filter((f) => f === 'start').length).toBe(fired.filter((f) => f === 'end').length)
+    }
   })
 })

--- a/webapp/src/lib/useTour.ts
+++ b/webapp/src/lib/useTour.ts
@@ -11,8 +11,25 @@
 // own `setTab`. There is no way to advance without navigating.
 // ─────────────────────────────────────────────────────────────────────────
 
-import { useCallback, useState } from 'react'
-import { nextIndex, prevIndex, type TourStep } from './tour'
+import { useCallback, useRef, useState } from 'react'
+import { nextIndex, prevIndex, tourLifecycle, type TourStep } from './tour'
+
+/**
+ * Optional lifecycle for a tour that has to SET SOMETHING UP to be worth
+ * running. The 3D Model Space is the case that forced it: its walkthrough
+ * points at a tab bar, a properties table and a design button, and on a first
+ * visit every one of those is empty — a guided tour of a blank canvas.
+ *
+ * `onStart` may load a demo; `onEnd` puts things back. They are paired: `onEnd`
+ * runs only if `onStart` ran, exactly once, whether the tour ended at the last
+ * step, by Esc, or by the close button. A tour that leaves a demo model behind
+ * when the user dismisses it has destroyed their work, which is a far worse
+ * failure than an unhelpful tour.
+ */
+export interface TourHooks {
+  onStart?: () => void
+  onEnd?: () => void
+}
 
 export interface TourController {
   /** Whether the overlay is showing. */
@@ -36,9 +53,16 @@ export interface TourController {
 export function useTour(
   steps: readonly TourStep[],
   setTab: (tab: string) => void,
+  hooks?: TourHooks,
 ): TourController {
   const [on, setOn] = useState(false)
   const [at, setAt] = useState(0)
+  // Whether `onStart` has run and `onEnd` is therefore owed. A ref, not state:
+  // it must be readable and writable inside the same handler that flips `on`,
+  // and it must never trigger a render of its own.
+  const started = useRef(false)
+  const onStart = hooks?.onStart
+  const onEnd = hooks?.onEnd
 
   const go = useCallback((i: number) => {
     setAt(i)
@@ -49,9 +73,19 @@ export function useTour(
   return {
     on, at, total: steps.length,
     step: steps[Math.min(at, steps.length - 1)],
-    start: useCallback(() => { setOn(true); go(0) }, [go]),
+    start: useCallback(() => {
+      const t = tourLifecycle(started.current, 'start')
+      started.current = t.started
+      if (t.fire === 'start') onStart?.()
+      setOn(true); go(0)
+    }, [go, onStart]),
     next: useCallback(() => go(nextIndex(at, steps.length)), [at, go, steps.length]),
     prev: useCallback(() => go(prevIndex(at)), [at, go]),
-    close: useCallback(() => setOn(false), []),
+    close: useCallback(() => {
+      setOn(false)
+      const t = tourLifecycle(started.current, 'close')
+      started.current = t.started
+      if (t.fire === 'end') onEnd?.()
+    }, [onEnd]),
   }
 }

--- a/webapp/src/pages/ModelSpace.tsx
+++ b/webapp/src/pages/ModelSpace.tsx
@@ -1143,8 +1143,6 @@ export default function ModelSpace() {
   const [sdlMatT, setSdlMatT] = useState(50)                       // 204-2 thickness, mm
   const [liveOccId, setLiveOccId] = useState('')                   // NSCP 205-1 occupancy ('' = default LL)
   const [tab, setTab] = useState<Tab>('geometry')                 // right-panel tab
-  // The walkthrough. Advancing a step switches the tab too — see `useTour`.
-  const tour = useTour(MODEL_STEPS, (t) => setTab(t as Tab))
   const [orphans, setOrphans] = useState(0)
   // footing plan: base node → '' (isolated) or partner node id (combined)
   const [planSel, setPlanSel] = useState<Record<string, string>>((si.planSel as Record<string, string>) ?? {})
@@ -1826,6 +1824,28 @@ export default function ModelSpace() {
     save(m)
   }
 
+  // The walkthrough. Advancing a step switches the tab too — see `useTour`.
+  //
+  // On a first visit every panel the tour points at is EMPTY, so without this
+  // the guide is a tour of a blank canvas: "assign sections to each member
+  // family" beside a table with no members in it. If there is no model when
+  // the guide opens, it generates the standard grid from the inputs already on
+  // the Geometry tab as a demo, and clears it again on close.
+  //
+  // A model the user ALREADY HAS is never touched. The guide then runs against
+  // their own structure — better than a demo anyway — and there is nothing to
+  // restore, which is the only version of "restore" that cannot lose work.
+  const demoModel = useRef(false)
+  const tour = useTour(MODEL_STEPS, (t) => setTab(t as Tab), {
+    onStart: () => { if (!model) { demoModel.current = true; generate() } },
+    onEnd: () => {
+      if (!demoModel.current) return
+      demoModel.current = false
+      setModeShapeIdx(null)   // stop the mode-shape animation with its model
+      save(null)              // clears the model, results and the autosave key
+    },
+  })
+
   const nodePos = useMemo(() => {
     const map = new Map<string, THREE.Vector3>()
     model?.nodes.forEach((n) => map.set(n.id, new THREE.Vector3(n.x, n.y, n.z)))
@@ -2006,7 +2026,7 @@ export default function ModelSpace() {
         </div>
         <div className="no-print ml-auto flex flex-wrap items-center gap-2">
           {/* Import / Export dropdown (mockup header: one combined button) */}
-          <div className="relative" onMouseLeave={() => setIoMenu(false)}>
+          <div className="relative" onMouseLeave={() => setIoMenu(false)} data-tour="io-menu">
             <button type="button" onClick={() => setIoMenu((v) => !v)}
               className="rounded-md border border-[#d6d3c9] bg-white px-3 py-2 text-[12.5px] font-semibold text-[#3d4a5c] hover:border-[#0f4c92] hover:text-[#0f4c92]">
               Import / Export ▾
@@ -3816,7 +3836,7 @@ export default function ModelSpace() {
                   Lumped-mass free vibration ([K]−ω²[M]). Mass from member &amp; slab self-weight (dead). Request enough
                   modes to accumulate ≥90% of the lateral mass (NSCP 208.5.5).
                 </p>
-                <div className="col-span-full">
+                <div className="col-span-full" data-tour="modal-panel">
                   <button type="button" onClick={runModal} disabled={!model || !!busy || meshErrors} className={btn}>
                     {busy === 'modal' ? '⏳ Solving modes…' : '〰 Run modal analysis'}
                   </button>
@@ -4435,7 +4455,7 @@ export default function ModelSpace() {
           )}
           <LetterheadCard lh={lh} onChange={(p) => setLh((s) => ({ ...s, ...p }))} />
           {/* Results tabs — Schedules · Bill of Quantities · Construction Schedule */}
-          <div className="no-print flex flex-wrap items-center gap-1.5 border-b border-slate-200">
+          <div className="no-print flex flex-wrap items-center gap-1.5 border-b border-slate-200" data-tour="results-tabs">
             {([['schedules', 'Schedules'], ['boq', 'Bill of Quantities'], ['schedule', 'Construction Schedule']] as const).map(([id, label]) => (
               <button key={id} type="button" onClick={() => setResultsTab(id)}
                 className={`rounded-t-md px-3.5 py-2 text-[13px] font-semibold ${resultsTab === id ? 'border-b-2 border-[#0f4c92] text-[#0f4c92]' : 'text-slate-500 hover:text-[#0f4c92]'}`}>


### PR DESCRIPTION
The last item on the to-do list. View-support layer (`lib/tour.ts`, `lib/useTour.ts`, `lib/modelTour.ts`) plus anchors in `ModelSpace`.

Two problems with the walkthrough as it shipped.

## It had nothing to point at

On a first visit — the only visit where a guide matters — every panel it spotlights is empty: *"assign sections to each member family"* beside a table with no members in it.

`useTour` now takes optional `onStart` / `onEnd` hooks. Model Space uses them to generate the standard grid from the inputs already sitting on the Geometry tab, and clear it again on close.

**A model the user already has is never touched.** The guide runs against their own structure instead — better than a demo anyway — and there is nothing to put back, which is the only version of "restore" that cannot lose work.

The pairing is the part worth being careful about: `onEnd` fires only after an `onStart`, exactly once, whether the tour ended at the last step, by Esc, or by the close button. Reopening mid-tour must not re-load the demo, and a stray close must not tear down a model the tour never created. A guide that leaves a demo behind — or clears real work on the way out — is a far worse failure than an unhelpful guide.

`tourLifecycle` in `tour.ts` is that rule as a pure function, so it is tested by replaying sequences (`start,start,start,close` → one setup, one teardown; `close` alone → nothing) rather than by rendering.

## It skipped the controls people actually miss

Three steps added:

- **Modal**, which the tour previously skipped as an advanced analysis. Its mode-shape animation is started by **clicking a row** in the results table, and nothing on screen suggests the rows are clickable — a control that cannot be found by looking is precisely what a walkthrough is for. It sits between Analysis and Design, which is both its tab position and its place in the work.
- **The results sub-tabs** — Schedules / Bill of Quantities / Construction Schedule — which only appear once a design exists and are a long way down the page by then.
- **Import / Export**, with the point that the autosave is a session, not a saved project.

Pushover and Nonlinear stay out.

`tours.test.ts` previously asserted *"model space skips the advanced analyses"*. That test now states the new rule — modal in, pushover and nonlinear out — plus a new one pinning modal's position between analysis and design, so the tour still never walks backwards through the tab bar.

## Verification

- `npx tsc -b` clean, `npm run lint` clean, **3848 tests / 214 files green**.
- Driven in headless Chromium **both ways**:
  - **From empty** — demo appears on open (canvas present, empty-state gone), all 11 steps spotlight with the card inside the viewport, and `Done` leaves the canvas empty with the autosave key cleared.
  - **With a 24-node model already there** — opening the guide and dismissing it with **Esc mid-tour** leaves the stored model byte-identical, still 24 nodes.

## The list is done

All seven items from the to-do list have shipped: the narrow pages (#558), the legacy cards and Truss header (#558), the worked solutions (#559), the Steel Design 3D scenes (#560), the BOQ mix class (#561), and this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmPbtTVsjNBXVpiQVBYBnz)_