### PR TITLE
feat(steel): an LRFD / ASD design-basis toggle on all four steel pages

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1824,10 +1824,94 @@ not the symptoms.
 
 ## Left open, deliberately
 
-- **Bolted Connection exists twice**: the standalone page computes client-side, the
-  Steel Design tab computes remotely through the protected calc API. That is a fork
-  tied to plan gating, not simple duplication — merging them is a product decision.
+- ~~**Bolted Connection exists twice**~~ — resolved in #564/#565, see below.
 - Steel Design's 3D card is unnumbered, so the card counter skips a number between
   the inputs and the worked solution.
 - The `docs/ValidationMap.md` X001–X004 external cross-checks (ETABS/STAAD/PCA/Excel)
   still need licences.
+
+---
+
+# Steel: four pages, one dual-format engine (PRs #564, #565, and the basis toggle)
+
+## The shape of it now
+
+| Route | What |
+|---|---|
+| `/steel/beam` | §F2 flexure + LTB, §G2.1 shear, L/360 & L/240 deflection |
+| `/steel/column` | §E3 compression, §F6 weak axis, §H1-1 combined |
+| `/bolted-connection` | elastic bolt group, §J3.6/§J3.10, §J4.3 block shear, §J3.7, §J3.9 |
+| `/welded-connection` | eccentric weld group by the weld-as-a-line method, §J2.4 |
+
+`/steel` redirects to `/steel/beam`. Each page holds **its own trial allowance** —
+five free runs each, which is what the pricing page always promised a
+"single-purpose calculator".
+
+Shared: `components/steelUi.tsx` (widgets) and `lib/steelShapes.ts` (catalogue,
+grades). They are separate files because a module exporting **both** components and
+plain values breaks Fast Refresh — the lint rule enforces it, so don't merge them.
+
+## The bolted/welded question, settled
+
+The bolt group used to be solved twice. Steel Design's tab won on completeness
+(φRn per bolt, block shear, a worked solution) and the standalone was deleted —
+then the three things it did better were rebuilt on the survivor: **free-form
+(x, y) bolt patterns**, **double shear**, and the **maximum applied load**.
+
+The weld pair went the *other* way: Steel Design's weld tab was a three-row
+fillet-length check against a full eccentric weld-group solver, so the tab went and
+the standalone stayed, gaining the electrode-class picker the tab had.
+
+`engine/boltedConnection.ts` **is not dead code** — no page imports it, but it is
+the L9 validation benchmark: an independent allowable-stress statement of the
+elastic method cross-checking the `eccentricBoltGroup` path the page runs. Its
+header says so. It also still holds the free-form solver.
+
+## LRFD / ASD — the part to be careful with
+
+`engine/designBasis.ts` owns the φ/Ω pair **per limit state**, split by factor and
+not by chapter: §G2.1(a) rolled webs are 1.00/1.50, slender webs 0.90/1.67.
+
+**The basis changes both sides.** A capacity converted to Rn/Ω but still checked
+against a factored load is conservative by ~1.5; the reverse is unconservative by
+the same, and neither looks wrong on screen. So the load combination travels with
+the basis — `requiredFromDL` — not just the resistance factor.
+
+**The engine did not move to a basis.** `steelDesign.ts` still returns LRFD `phi…`
+fields, so the design pipeline, Model Space, pushover and the validation benchmarks
+— all LRFD-only — are untouched. What is new is that every result also carries its
+**nominal** strength (`Vn`, `Pn`, `Mny`, `Rn_shear`, `Rn_bearing`, `Rn`, `Rnw`), so
+the basis layer states Rn/Ω from Rn rather than dividing φ back out of φRn. The
+available strengths live under honest names on the **calc** result (`avail.…`),
+which only these four pages consume.
+
+Two checks are **re-derived, not rescaled** — the factor is inside the formula:
+
+- **§J3.7** — LRFD divides by φFnv where ASD multiplies by ΩFnt/Fnv. A test asserts
+  the ASD answer is *not* the LRFD one times (1/Ω)/φ, which is what it would be if
+  someone had treated it as a multiplier.
+- **§J3.9 prying** — the plate-flexure factor moves, so a thinner allowable means
+  *more* required thickness.
+
+Deflection has no basis: it is a service check either way.
+
+## Traps
+
+- **A page badge must not name the basis.** The toggle lives inside the calculator,
+  so a header reading "AISC 360-16 LRFD" while the sheet computes ASD would print
+  on the report. The badges say "AISC 360-16" and the basis is stated in the card.
+- **`capacityLabel(basis, 'M', 'x')`** puts the axis on the strength — `Mnx/Ω`, not
+  `Mn/Ωx`.
+- **Verifying a bolt-pattern change needs an eccentricity.** With the load through
+  the centroid there is no torsion, every bolt carries Vu/n, and moving a bolt
+  changes nothing — a check written that way passes without testing anything.
+- **The connection calc endpoint is bolted-only.** The weld fields were removed
+  from `ConnectionCalcInput`/`Result`; welds are solved client-side on their own
+  page.
+
+## Still true, and worth knowing
+
+`VITE_API_URL` is unset — it is not even in `.env.example` — so `calcApi` always
+takes `localFallback` and runs the identical engine **in the browser**. The live
+gate is the route-level trial counter, not the API. Getting the engine genuinely
+off the client is a deployment task, not a code one.

--- a/webapp/src/components/steelUi.tsx
+++ b/webapp/src/components/steelUi.tsx
@@ -12,6 +12,7 @@
 // ─────────────────────────────────────────────────────────────────────────
 
 import { W_SHAPES } from '../lib/steelShapes'
+import type { DesignBasis } from '../engine/designBasis'
 
 /** Pass/fail value with a tick or a cross. */
 export function Verdict({ pass, value }: { pass: boolean; value: string }) {
@@ -46,5 +47,37 @@ export function ShapePick({ value, onChange }: { value: string; onChange: (v: st
         {W_SHAPES.map(s => <option key={s.name} value={s.name}>{s.name}</option>)}
       </select>
     </label>
+  )
+}
+
+/**
+ * LRFD / ASD. AISC 360 is a dual-format specification and the choice changes
+ * BOTH sides of every check — the resistance side (φRn vs Rn/Ω) and the demand
+ * side (factored vs service load combinations). It is deliberately one control
+ * per page rather than a global setting: a report mixing the two would be
+ * wrong, and a preference the user cannot see on the sheet is one they forget
+ * they set.
+ */
+export function BasisPick({ value, onChange }: { value: DesignBasis; onChange: (v: DesignBasis) => void }) {
+  return (
+    <label className="flex flex-col text-sm">
+      <span className="mb-1 text-[11.5px] font-semibold text-[#5c6675]">Design basis</span>
+      <select value={value} onChange={e => onChange(e.target.value as DesignBasis)}
+        className="rounded-md border border-[#d6d3c9] px-2.5 py-1.5 text-[13px] text-slate-800 focus:border-[#0f4c92] focus:outline-none">
+        <option value="LRFD">LRFD — φRn vs 1.2D + 1.6L</option>
+        <option value="ASD">ASD — Rn/Ω vs D + L</option>
+      </select>
+    </label>
+  )
+}
+
+/** The basis stated where the report will print it. */
+export function BasisNote({ basis }: { basis: DesignBasis }) {
+  return (
+    <p className="col-span-full text-[10px] text-slate-500">
+      {basis === 'LRFD'
+        ? 'LRFD: capacities are φRn, compared against the governing factored combination max(1.4D, 1.2D + 1.6L).'
+        : 'ASD: capacities are the allowable Rn/Ω, compared against the service combination D + L. Do not compare these against factored loads.'}
+    </p>
   )
 }

--- a/webapp/src/engine/designBasis.test.ts
+++ b/webapp/src/engine/designBasis.test.ts
@@ -1,0 +1,109 @@
+// The dual format's failure mode is not a crash — it is a plausible number on
+// the wrong basis. An ASD allowable strength checked against a factored load
+// passes things it should not by ~1.5, and the reverse fails things it should
+// not. So these tests are about the PAIRING as much as the arithmetic.
+
+import { describe, it, expect } from 'vitest'
+import {
+  SAFETY, basisFactor, available, requiredFromDL,
+  capacityLabel, demandLabel, factorLabel, comboLabel,
+  type LimitState, type DesignBasis,
+} from './designBasis'
+
+const ALL: LimitState[] = ['flexure', 'shearRolled', 'shearSlender', 'compression', 'connection', 'plateFlexure']
+
+describe('the φ / Ω table matches AISC 360-16', () => {
+  it('carries the specification values', () => {
+    expect(SAFETY.flexure).toEqual({ phi: 0.90, omega: 1.67 })        // §F1
+    expect(SAFETY.shearRolled).toEqual({ phi: 1.00, omega: 1.50 })    // §G2.1(a)
+    expect(SAFETY.shearSlender).toEqual({ phi: 0.90, omega: 1.67 })   // §G2.1(b)
+    expect(SAFETY.compression).toEqual({ phi: 0.90, omega: 1.67 })    // §E1
+    expect(SAFETY.connection).toEqual({ phi: 0.75, omega: 2.00 })     // §J
+  })
+
+  it('keeps Ω ≈ 1.5/φ, the calibration between the two formats', () => {
+    // Not how the values are produced — they are written out to match the book
+    // — but if a future edit breaks this relation it is a typo, not a change.
+    for (const ls of ALL) {
+      const { phi, omega } = SAFETY[ls]
+      expect(omega, ls).toBeCloseTo(1.5 / phi, 2)
+    }
+  })
+})
+
+describe('available strength', () => {
+  it('is φRn under LRFD and Rn/Ω under ASD', () => {
+    expect(available(100, 'LRFD', 'flexure')).toBeCloseTo(90, 9)
+    expect(available(100, 'ASD', 'flexure')).toBeCloseTo(100 / 1.67, 9)
+    expect(available(100, 'LRFD', 'connection')).toBeCloseTo(75, 9)
+    expect(available(100, 'ASD', 'connection')).toBeCloseTo(50, 9)
+  })
+
+  it('is always lower under ASD, for every limit state', () => {
+    // The ASD allowable is the more conservative NUMBER; it is compared against
+    // a smaller demand. Neither format is "safer" — but if ASD ever came out
+    // higher, the pairing has been inverted somewhere.
+    for (const ls of ALL) {
+      expect(available(100, 'ASD', ls), ls).toBeLessThan(available(100, 'LRFD', ls))
+    }
+  })
+
+  it('scales linearly, so a doubled nominal doubles the available', () => {
+    for (const basis of ['LRFD', 'ASD'] as DesignBasis[]) {
+      expect(available(200, basis, 'compression')).toBeCloseTo(2 * available(100, basis, 'compression'), 9)
+    }
+  })
+
+  it('rolled and slender webs differ on BOTH sides of the format', () => {
+    // §G2.1(a) is the one place φ is 1.00, and its Ω is 1.50 rather than 1.67.
+    // Using the flexure pair for shear would be wrong in both formats.
+    expect(basisFactor('LRFD', 'shearRolled')).toBe(1.0)
+    expect(basisFactor('LRFD', 'shearSlender')).toBe(0.9)
+    expect(available(100, 'ASD', 'shearRolled')).toBeGreaterThan(available(100, 'ASD', 'shearSlender'))
+  })
+})
+
+describe('load combinations travel with the basis', () => {
+  it('factors under LRFD and sums under ASD', () => {
+    expect(requiredFromDL('LRFD', 10, 25)).toBeCloseTo(1.2 * 10 + 1.6 * 25, 9)
+    expect(requiredFromDL('ASD', 10, 25)).toBeCloseTo(35, 9)
+  })
+
+  it('LRFD takes 1.4D when the live load is small', () => {
+    // 1.4D governs below L ≈ 0.125D; the max() is not decoration.
+    expect(requiredFromDL('LRFD', 100, 0)).toBeCloseTo(140, 9)
+    expect(requiredFromDL('LRFD', 100, 5)).toBeCloseTo(140, 9)
+    expect(requiredFromDL('LRFD', 100, 50)).toBeCloseTo(200, 9)
+  })
+
+  it('the ASD demand is always the smaller of the two', () => {
+    // This is the whole reason the two must not be mixed: an ASD demand against
+    // an LRFD capacity is unconservative in exactly this ratio.
+    for (const [D, L] of [[10, 25], [100, 0], [40, 40], [0, 60]]) {
+      expect(requiredFromDL('ASD', D, L)).toBeLessThanOrEqual(requiredFromDL('LRFD', D, L))
+    }
+  })
+})
+
+describe('the labels say which basis is on the page', () => {
+  it('names the capacity and the demand consistently', () => {
+    expect(capacityLabel('LRFD', 'M')).toBe('φMn')
+    expect(capacityLabel('ASD', 'M')).toBe('Mn/Ω')
+    // The axis suffix belongs on the strength, not on the omega.
+    expect(capacityLabel('ASD', 'M', 'x')).toBe('Mnx/Ω')
+    expect(capacityLabel('LRFD', 'M', 'x')).toBe('φMnx')
+    expect(demandLabel('LRFD', 'V')).toBe('Vu')
+    expect(demandLabel('ASD', 'V')).toBe('Va')
+  })
+
+  it('quotes the factor that was actually applied', () => {
+    expect(factorLabel('LRFD', 'connection')).toBe('φ = 0.75')
+    expect(factorLabel('ASD', 'connection')).toBe('Ω = 2.00')
+    expect(factorLabel('LRFD', 'shearRolled')).toBe('φ = 1.00')
+  })
+
+  it('states the combination, not just the format name', () => {
+    expect(comboLabel('LRFD')).toContain('1.6L')
+    expect(comboLabel('ASD')).toBe('D + L')
+  })
+})

--- a/webapp/src/engine/designBasis.ts
+++ b/webapp/src/engine/designBasis.ts
@@ -1,0 +1,99 @@
+// ─────────────────────────────────────────────────────────────────────────
+// LRFD vs ASD — AISC 360-16 §B3.1 / §B3.2. Layer 6/7 support.
+//
+// AISC is a DUAL-FORMAT specification. Every limit state gives one nominal
+// strength Rn, and then two ways to use it:
+//
+//   LRFD   design strength    = φRn      vs required strength from 1.2D + 1.6L
+//   ASD    allowable strength = Rn / Ω   vs required strength from D + L
+//
+// Both are called the AVAILABLE STRENGTH. They are not two accuracies of the
+// same answer — they are two bookkeeping systems, and mixing them is a real
+// error: an ASD allowable strength compared against a factored load is
+// conservative by roughly 1.5, and the reverse is unconservative by the same.
+// That is why the basis travels with the LOAD COMBINATION here and not just
+// with the resistance factor.
+//
+// WHY THIS IS A SEPARATE MODULE. The φ values were scattered as `PHI_B`,
+// `PHI_C`, `PHI_J` constants inside `steelDesign.ts`, each used at the point a
+// capacity was returned. Adding Ω beside each one would have put the choice in
+// a dozen places. Here the pair lives once per limit state, and the engine
+// functions keep returning NOMINAL strengths for this module to convert.
+//
+// Ω = 1.5/φ for every pair below, which is not a coincidence — it is how the
+// specification calibrates the two formats against each other — but the values
+// are written out rather than derived, because the specification tabulates them
+// and a reader checking against the book should find the book's numbers.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type DesignBasis = 'LRFD' | 'ASD'
+
+/**
+ * The limit states these pages check. Split by RESISTANCE FACTOR, not by
+ * chapter: §G2.1 rolled webs and slender webs carry different φ, so they are
+ * different entries even though both are "shear".
+ */
+export type LimitState =
+  | 'flexure'        // §F1
+  | 'shearRolled'    // §G2.1(a) — h/tw ≤ 2.24√(E/Fy)
+  | 'shearSlender'   // §G2.1(b)
+  | 'compression'    // §E1
+  | 'connection'     // §J — bolts, welds, block shear
+  | 'plateFlexure'   // §F1 applied to a fitting flange (prying)
+
+export const SAFETY: Record<LimitState, { phi: number; omega: number }> = {
+  flexure:      { phi: 0.90, omega: 1.67 },
+  shearRolled:  { phi: 1.00, omega: 1.50 },
+  shearSlender: { phi: 0.90, omega: 1.67 },
+  compression:  { phi: 0.90, omega: 1.67 },
+  connection:   { phi: 0.75, omega: 2.00 },
+  plateFlexure: { phi: 0.90, omega: 1.67 },
+}
+
+/** The multiplier that turns a nominal strength into an available one. */
+export function basisFactor(basis: DesignBasis, ls: LimitState): number {
+  const { phi, omega } = SAFETY[ls]
+  return basis === 'LRFD' ? phi : 1 / omega
+}
+
+/** Available strength: φRn under LRFD, Rn/Ω under ASD. */
+export function available(Rn: number, basis: DesignBasis, ls: LimitState): number {
+  return Rn * basisFactor(basis, ls)
+}
+
+/**
+ * Required strength from service dead and live load.
+ *
+ * LRFD takes the governing factored combination (NSCP 203.3.1 / ASCE 7 2.3);
+ * ASD sums them unfactored (NSCP 203.4.1 / ASCE 7 2.4). Both omit the other
+ * combinations — wind, seismic, roof live — because these pages take one dead
+ * and one live load and nothing else; a combination involving W or E has to
+ * come from the model, not from two numbers.
+ */
+export function requiredFromDL(basis: DesignBasis, D: number, L: number): number {
+  return basis === 'LRFD' ? Math.max(1.4 * D, 1.2 * D + 1.6 * L) : D + L
+}
+
+/** How the governing combination reads, for the worked solution. */
+export function comboLabel(basis: DesignBasis): string {
+  return basis === 'LRFD' ? 'max(1.4D, 1.2D + 1.6L)' : 'D + L'
+}
+
+/**
+ * `φRn` or `Rn/Ω`, for a results-table row label. `sub` is an axis suffix that
+ * belongs on the STRENGTH, not on the omega — "Mnx/Ω", never "Mn/Ωx".
+ */
+export function capacityLabel(basis: DesignBasis, symbol: string, sub = ''): string {
+  return basis === 'LRFD' ? `φ${symbol}n${sub}` : `${symbol}n${sub}/Ω`
+}
+
+/** `φ = 0.90` or `Ω = 1.67`, for the sub-label under a capacity. */
+export function factorLabel(basis: DesignBasis, ls: LimitState): string {
+  const { phi, omega } = SAFETY[ls]
+  return basis === 'LRFD' ? `φ = ${phi.toFixed(2)}` : `Ω = ${omega.toFixed(2)}`
+}
+
+/** Demand symbol: Vu/Mu/Pu are factored, Va/Ma/Pa are service. */
+export function demandLabel(basis: DesignBasis, symbol: string): string {
+  return `${symbol}${basis === 'LRFD' ? 'u' : 'a'}`
+}

--- a/webapp/src/engine/steelDesign.ts
+++ b/webapp/src/engine/steelDesign.ts
@@ -3,9 +3,13 @@
 // Sections are AiscShape from aiscSections (W-family only for beam/column).
 
 import type { AiscShape } from './aiscSections'
+import { basisFactor, requiredFromDL, type DesignBasis } from './designBasis'
 
 export const E_STEEL = 200_000  // MPa
 
+// The phi values below are the LRFD half of the dual format. Every result type
+// also carries the NOMINAL strength, because `designBasis.ts` needs Rn to state
+// the ASD allowable Rn/Omega — see that module for why the two must not mix.
 const PHI_B = 0.90   // §F1 flexure
 const PHI_C = 0.90   // §E1 compression
 const PHI_J = 0.75   // §J connections
@@ -104,6 +108,11 @@ export function beamFlexure(
 
 export interface BeamShearResult {
   Aw: number; Cv1: number; phiV: number; phiVn: number; hwTw: number
+  /** Nominal shear strength 0.6·Fy·Aw·Cv1, kN. */
+  Vn: number
+  /** True when §G2.1(b) governs, which changes BOTH phi (1.00→0.90) and
+   *  Omega (1.50→1.67) — the basis layer needs to know which pair to use. */
+  slenderWeb: boolean
 }
 
 export function beamShear(s: AiscShape, p: DerivedBeamProps, Fy: number): BeamShearResult {
@@ -120,7 +129,8 @@ export function beamShear(s: AiscShape, p: DerivedBeamProps, Fy: number): BeamSh
     Cv1  = hwTw <= lim1 ? 1.0 : hwTw <= lim2 ? lim1 / hwTw : (1.51 * kv * E) / (Fy * hwTw * hwTw)
     phiV = 0.9
   }
-  return { Aw, Cv1, phiV, phiVn: (phiV * 0.6 * Fy * Aw * Cv1) / 1000, hwTw }
+  const Vn = (0.6 * Fy * Aw * Cv1) / 1000
+  return { Aw, Cv1, phiV, phiVn: phiV * Vn, hwTw, Vn, slenderWeb: phiV !== 1.0 }
 }
 
 // ─── Column axial §E3 ──────────────────────────────────────────────────────
@@ -130,6 +140,8 @@ export function beamShear(s: AiscShape, p: DerivedBeamProps, Fy: number): BeamSh
 export interface ColumnAxialResult {
   slendernessX: number; slendernessY: number; slenderness: number
   Fcr: number; phiPn: number; slenderOK: boolean
+  /** Nominal compressive strength Fcr·Ag, kN. */
+  Pn: number
 }
 
 export function columnAxial(
@@ -143,9 +155,10 @@ export function columnAxial(
   const limit = 4.71 * Math.sqrt(E / Fy)
   const Fe  = (Math.PI ** 2 * E) / slenderness ** 2
   const Fcr = slenderness <= limit ? Math.pow(0.658, Fy / Fe) * Fy : 0.877 * Fe
+  const Pn = (Fcr * s.A) / 1000
   return {
     slendernessX, slendernessY, slenderness, Fcr,
-    phiPn: (PHI_C * Fcr * s.A) / 1000,
+    phiPn: PHI_C * Pn, Pn,
     slenderOK: slenderness <= 200,
   }
 }
@@ -153,12 +166,17 @@ export function columnAxial(
 // ─── Weak-axis flexure §F6 ────────────────────────────────────────────────
 // Compact W-shapes, no LTB about weak axis → Mny = Mp_y = Fy·Zy ≤ 1.6·Fy·Sy.
 
-export interface WeakAxisResult { Sy: number; Zy: number; phiMny: number }
+export interface WeakAxisResult {
+  Sy: number; Zy: number; phiMny: number
+  /** Nominal weak-axis flexural strength, kN·m. */
+  Mny: number
+}
 
 export function weakAxisFlexure(s: AiscShape, p: DerivedBeamProps, Fy: number): WeakAxisResult {
   const Sy  = (2 * p.Iy) / s.bf!
   const cap = Math.min(p.Zy, 1.6 * Sy)   // §F6-1 cap
-  return { Sy, Zy: p.Zy, phiMny: (PHI_B * Fy * cap) / 1e6 }
+  const Mny = (Fy * cap) / 1e6
+  return { Sy, Zy: p.Zy, phiMny: PHI_B * Mny, Mny }
 }
 
 // ─── Combined loading §H1-1 ───────────────────────────────────────────────
@@ -192,6 +210,9 @@ export interface BoltResult {
   phiRn_bearing: number // kN per bolt
   phiRn: number         // governing
   n_reqd: number        // bolts required for Vu
+  /** Nominal strengths, kN per bolt — what `designBasis.available()` needs to
+   *  state the ASD allowable Rn/Ω rather than back it out of φRn. */
+  Rn_shear: number; Rn_bearing: number; Rn: number
 }
 
 /**
@@ -211,10 +232,15 @@ export function boltShear(
   const Fnv = grade === 'A325M'
     ? (threadsInPlane ? 310 : 372)
     : (threadsInPlane ? 372 : 457)   // Table J3.2
-  const phiRn_shear   = (PHI_J * Fnv * Ab * nShear) / 1000
-  const phiRn_bearing = (PHI_J * 2.4 * Fu_conn * db * t_conn) / 1000
+  const Rn_shear   = (Fnv * Ab * nShear) / 1000
+  const Rn_bearing = (2.4 * Fu_conn * db * t_conn) / 1000
+  const phiRn_shear   = PHI_J * Rn_shear
+  const phiRn_bearing = PHI_J * Rn_bearing
   const phiRn  = Math.min(phiRn_shear, phiRn_bearing)
-  return { Ab, Fnv, phiRn_shear, phiRn_bearing, phiRn, n_reqd: Math.ceil(Vu / phiRn) }
+  return {
+    Ab, Fnv, phiRn_shear, phiRn_bearing, phiRn, n_reqd: Math.ceil(Vu / phiRn),
+    Rn_shear, Rn_bearing, Rn: Math.min(Rn_shear, Rn_bearing),
+  }
 }
 
 // ─── Fillet weld §J2.4 ────────────────────────────────────────────────────
@@ -227,6 +253,8 @@ export interface WeldResult {
   Fexx: number
   phiRnw: number   // kN/mm per mm of weld length
   L_reqd: number   // mm total weld length for Vu
+  /** Nominal strength per unit length 0.6·Fexx·0.707·w, kN/mm. */
+  Rnw: number
 }
 
 /** Nominal electrode tensile strength, MPa. Exported because the eccentric
@@ -237,8 +265,9 @@ export const FEXX_BY_CLASS: Record<ElectrodeClass, number> = { E70: 482, E80: 55
 
 export function weldStrength(electrode: ElectrodeClass, wSize: number, Vu: number): WeldResult {
   const Fex  = FEXX_BY_CLASS[electrode]
-  const phiRnw = (PHI_J * 0.6 * Fex * 0.707 * wSize) / 1000   // kN/mm
-  return { Fexx: Fex, phiRnw, L_reqd: phiRnw > 0 ? Vu / phiRnw : Infinity }
+  const Rnw    = (0.6 * Fex * 0.707 * wSize) / 1000            // kN/mm
+  const phiRnw = PHI_J * Rnw
+  return { Fexx: Fex, phiRnw, L_reqd: phiRnw > 0 ? Vu / phiRnw : Infinity, Rnw }
 }
 
 // ─── Beam loading (simple span, uniform load) → Mu, Vu, deflections ───────
@@ -247,7 +276,7 @@ export function weldStrength(electrode: ElectrodeClass, wSize: number, Vu: numbe
 export interface BeamLoadInput { wDead: number; wLive: number; L: number }
 
 export interface BeamLoadsResult {
-  wu: number   // kN/m, factored (max of 1.4D, 1.2D+1.6L)
+  wu: number   // kN/m, required — factored under LRFD, service sum under ASD
   Mu: number   // kN·m
   Vu: number   // kN
   deltaD: number  // mm, dead-load deflection (unfactored)
@@ -256,9 +285,16 @@ export interface BeamLoadsResult {
   limL240: number // mm, L/240
 }
 
-export function beamLoadingSimple(bl: BeamLoadInput, Ix_mm4: number): BeamLoadsResult {
+export function beamLoadingSimple(
+  bl: BeamLoadInput, Ix_mm4: number,
+  /** ASD sums the service loads instead of factoring them. Comparing an ASD
+   *  allowable strength against a FACTORED demand — or the reverse — is the
+   *  error the whole dual format exists to keep apart, so the combination
+   *  travels with the basis rather than being fixed here. */
+  basis: DesignBasis = 'LRFD',
+): BeamLoadsResult {
   const { wDead, wLive, L } = bl
-  const wu   = Math.max(1.4 * wDead, 1.2 * wDead + 1.6 * wLive)
+  const wu   = requiredFromDL(basis, wDead, wLive)
   const Mu   = (wu * L * L) / 8
   const Vu   = (wu * L) / 2
   const Lmm  = L * 1000
@@ -441,9 +477,19 @@ export function outOfPlaneBoltGroup(
   Vu: number,           // kN, applied shear
   boltGrade: BoltGrade,
   db: number,           // mm
-  threadInPlane: boolean
+  threadInPlane: boolean,
+  /**
+   * §J3.7 is written twice in the specification:
+   *   LRFD  F'nt = 1.3Fnt − (Fnt / (φ Fnv)) frv ≤ Fnt
+   *   ASD   F'nt = 1.3Fnt − (Ω Fnt / Fnv)   frv ≤ Fnt
+   * Both are "Fnt over the AVAILABLE shear stress", so one expression covers
+   * them once the factor is chosen — which is why this takes a basis rather
+   * than rescaling an LRFD answer. Rescaling would be wrong here: the factor
+   * is inside the reduction, not outside the result.
+   */
+  basis: DesignBasis = 'LRFD',
 ): OutOfPlaneResult {
-  const phi = PHI_J
+  const k = basisFactor(basis, 'connection')   // φ, or 1/Ω
   const Fnt = BOLT_Fnt[boltGrade]
   const Fnv = boltGrade === 'A325M'
     ? (threadInPlane ? 310 : 372)
@@ -461,8 +507,8 @@ export function outOfPlaneBoltGroup(
     const T   = sumYi2 > 0 ? (M_op * yi) / sumYi2 : 0
     const frv = inPlaneBolts.find(ip => ip.id === b.id)?.fv ?? 0
     const frt = (T * 1000) / Ab
-    const phiFnt_prime = Math.max(0, Math.min(1.3 * Fnt - (Fnt / (phi * Fnv)) * frv, Fnt))
-    const phiTn = (phi * phiFnt_prime * Ab) / 1000
+    const phiFnt_prime = Math.max(0, Math.min(1.3 * Fnt - (Fnt / (k * Fnv)) * frv, Fnt))
+    const phiTn = (k * phiFnt_prime * Ab) / 1000
     const util = phiTn > 0 ? T / phiTn : (T > 0 ? Infinity : 0)
     return { id: b.id, yi, T, frt, frv, phiFnt_prime, phiTn, util, ok: util <= 1.0 }
   })
@@ -510,9 +556,12 @@ export interface PryingResult {
 export function pryingAction(
   T_req: number, phi_Bn: number,
   b: number, a: number, p: number,
-  _tf: number, db: number, Fy: number
+  _tf: number, db: number, Fy: number,
+  /** Affects the PLATE-flexure factor in t_req and t_0 only — `phi_Bn` is
+   *  already the available bolt tension on the caller's basis. */
+  basis: DesignBasis = 'LRFD',
 ): PryingResult {
-  const phi_f = 0.90
+  const phi_f = basisFactor(basis, 'plateFlexure')
   const dh     = db + 2
   const b_prime = b - db / 2
   const a_prime = Math.min(a, 1.25 * b)

--- a/webapp/src/lib/calcApi.ts
+++ b/webapp/src/lib/calcApi.ts
@@ -9,6 +9,18 @@ import type {
   BoltResult, BoltGroupGeom, EccentricBoltResult,
   OutOfPlaneResult, PryingResult, BlockShearCase,
 } from '../engine/steelDesign'
+import type { DesignBasis } from '../engine/designBasis'
+
+/**
+ * AVAILABLE STRENGTHS, on the basis the request asked for: φRn under LRFD,
+ * Rn/Ω under ASD (AISC §B3). These are separate from the engine's `phi…`
+ * fields, which stay LRFD-always so the design pipeline and Model Space — both
+ * LRFD-only — keep reading the numbers they always read. A field named `phiMn`
+ * holding Mn/Ω would be a lie in a structural report.
+ */
+export interface AvailableBeam { Mn: number; Vn: number }
+export interface AvailableColumn { Pn: number; Mnx: number; Mny: number }
+export interface AvailableBolt { shear: number; bearing: number; governing: number }
 
 // Base URL from the build env. Empty ⇒ same-origin (run the api service on the
 // same host, or set VITE_API_URL in .env.local for local dev with split servers).
@@ -66,12 +78,16 @@ export interface BeamCalcInput {
   shapeName: string; Fy: number
   span: number; Lb: number; Cb: number
   wDead: number; wLive: number
+  /** Defaults to LRFD when absent, so an older caller is unaffected. */
+  basis?: DesignBasis
 }
 export interface BeamCalcResult {
   props: DerivedBeamProps
   flex: BeamFlexureResult
   shear: BeamShearResult
   loads: BeamLoadsResult
+  basis: DesignBasis
+  avail: AvailableBeam
 }
 export const calcBeam = (input: BeamCalcInput) =>
   post<BeamCalcResult>('/api/steel/beam', input)
@@ -82,6 +98,7 @@ export interface ColumnCalcInput {
   shapeName: string; Fy: number
   L: number; Kx: number; Ky: number
   Pu: number; Mux: number; Muy: number
+  basis?: DesignBasis
 }
 export interface ColumnCalcResult {
   props: DerivedBeamProps
@@ -89,6 +106,8 @@ export interface ColumnCalcResult {
   flexX: BeamFlexureResult
   weak: WeakAxisResult
   comb: CombinedResult
+  basis: DesignBasis
+  avail: AvailableColumn
 }
 export const calcColumn = (input: ColumnCalcInput) =>
   post<ColumnCalcResult>('/api/steel/column', input)
@@ -110,6 +129,7 @@ export interface ConnectionCalcInput {
   bolts?: { id: string; x: number; y: number }[]
   /** Shear planes crossing each bolt: 1 single, 2 double (§J3.6). */
   nShear?: number
+  basis?: DesignBasis
   threads: boolean
   tPlate: number; FuPlate: number; FyPlate: number
   ex_load: number; ey_load: number; e_out: number; b_gage: number
@@ -133,8 +153,12 @@ export interface ConnectionCalcResult {
    */
   maxVu: number
   /** Shear stress on the critical bolt, MPa — Rmax over the bolt area times
-   *  the shear planes. Reported, not a check: the check is phiRn above. */
+   *  the shear planes. Reported, not a check: the check is the capacity above. */
   tauMax: number
+  basis: DesignBasis
+  avail: AvailableBolt
+  /** Available block-shear strength per case, kN, in `blockShear` order. */
+  availBlockShear: number[]
 }
 export const calcConnection = (input: ConnectionCalcInput) =>
   post<ConnectionCalcResult>('/api/steel/connection', input)

--- a/webapp/src/lib/calcLocal.test.ts
+++ b/webapp/src/lib/calcLocal.test.ts
@@ -11,7 +11,7 @@
 // ─────────────────────────────────────────────────────────────────────────
 
 import { describe, it, expect } from 'vitest'
-import { localConnection } from './calcLocal'
+import { localBeam, localColumn, localConnection } from './calcLocal'
 import type { ConnectionCalcInput } from './calcApi'
 
 const BASE: ConnectionCalcInput = {
@@ -93,5 +93,122 @@ describe('localConnection — the maximum applied load', () => {
   it('τmax is the critical bolt force over the bolt area', () => {
     const r = localConnection({ ...BASE, ex_load: 90 })
     expect(r.tauMax).toBeCloseTo((r.eccentric.Rmax * 1000) / r.phiRnBolt.Ab, 9)
+  })
+})
+
+// ── LRFD / ASD ────────────────────────────────────────────────────────────
+// The dual format is where a wrong answer looks right. These tests check the
+// two things that make it wrong: a capacity converted on one basis while the
+// demand stays on the other, and a φ left hard-coded somewhere downstream.
+
+const BEAM = { shapeName: 'W310x38.7', Fy: 345, span: 6, Lb: 2, Cb: 1, wDead: 15, wLive: 25 }
+const COL  = { shapeName: 'W250x67', Fy: 345, L: 4, Kx: 1, Ky: 1, Pu: 900, Mux: 60, Muy: 0 }
+
+describe('localBeam — design basis', () => {
+  it('defaults to LRFD, unchanged from before the basis existed', () => {
+    const r = localBeam(BEAM)
+    expect(r.basis).toBe('LRFD')
+    expect(r.avail.Mn).toBeCloseTo(r.flex.phiMn, 9)
+    expect(r.avail.Vn).toBeCloseTo(r.shear.phiVn, 9)
+    expect(r.loads.wu).toBeCloseTo(Math.max(1.4 * 15, 1.2 * 15 + 1.6 * 25), 9)
+  })
+
+  it('moves BOTH sides when switched to ASD', () => {
+    const lrfd = localBeam(BEAM)
+    const asd = localBeam({ ...BEAM, basis: 'ASD' })
+    // capacity down…
+    expect(asd.avail.Mn).toBeCloseTo(lrfd.flex.Mn / 1.67, 9)
+    // …and demand down too. A capacity-only switch would be the classic error.
+    expect(asd.loads.wu).toBeCloseTo(15 + 25, 9)
+    expect(asd.loads.Mu).toBeLessThan(lrfd.loads.Mu)
+  })
+
+  it('leaves the nominal strength alone — only the factor changes', () => {
+    expect(localBeam({ ...BEAM, basis: 'ASD' }).flex.Mn)
+      .toBeCloseTo(localBeam(BEAM).flex.Mn, 9)
+  })
+
+  it('uses the §G2.1(a) shear pair for a rolled web', () => {
+    const r = localBeam(BEAM)
+    expect(r.shear.slenderWeb).toBe(false)
+    // φv = 1.00 ⇒ the LRFD available equals the nominal
+    expect(r.avail.Vn).toBeCloseTo(r.shear.Vn, 9)
+    // and Ω = 1.50, not the 1.67 that flexure uses
+    expect(localBeam({ ...BEAM, basis: 'ASD' }).avail.Vn).toBeCloseTo(r.shear.Vn / 1.5, 9)
+  })
+
+  it('deflection is a SERVICE check and does not move with the basis', () => {
+    const lrfd = localBeam(BEAM), asd = localBeam({ ...BEAM, basis: 'ASD' })
+    expect(asd.loads.deltaL).toBeCloseTo(lrfd.loads.deltaL, 9)
+    expect(asd.loads.limL360).toBeCloseTo(lrfd.loads.limL360, 9)
+  })
+})
+
+describe('localColumn — design basis', () => {
+  it('checks §H1-1 against the available strengths, not the LRFD ones', () => {
+    const asd = localColumn({ ...COL, basis: 'ASD' })
+    // Rebuild the interaction by hand from the reported available values.
+    const pr = COL.Pu / asd.avail.Pn
+    const mr = COL.Mux / asd.avail.Mnx
+    const expected = pr >= 0.2 ? pr + (8 / 9) * mr : pr / 2 + mr
+    expect(asd.comb.ratio).toBeCloseTo(expected, 9)
+  })
+
+  it('reports a higher utilisation under ASD for the SAME entered load', () => {
+    // Same Pu against a smaller allowable — which is why the page relabels the
+    // input Pu → Pa: entering a factored load under ASD is the user's error to
+    // avoid, and the ratio has to move so it is visible.
+    expect(localColumn({ ...COL, basis: 'ASD' }).comb.ratio)
+      .toBeGreaterThan(localColumn(COL).comb.ratio)
+  })
+
+  it('defaults to LRFD with the pre-existing numbers', () => {
+    const r = localColumn(COL)
+    expect(r.basis).toBe('LRFD')
+    expect(r.avail.Pn).toBeCloseTo(r.axial.phiPn, 9)
+    expect(r.avail.Mnx).toBeCloseTo(r.flexX.phiMn, 9)
+  })
+})
+
+describe('localConnection — design basis', () => {
+  it('converts every capacity, including block shear', () => {
+    const lrfd = localConnection(BASE)
+    const asd = localConnection({ ...BASE, basis: 'ASD' })
+    expect(asd.avail.governing).toBeCloseTo(lrfd.phiRnBolt.Rn / 2.0, 9)
+    for (let k = 0; k < lrfd.blockShear.length; k++) {
+      expect(asd.availBlockShear[k]).toBeCloseTo(lrfd.availBlockShear[k] * (0.5 / 0.75), 9)
+    }
+  })
+
+  it('lowers the maximum applied load with the capacity', () => {
+    const inp = { ...BASE, ex_load: 90 }
+    expect(localConnection({ ...inp, basis: 'ASD' }).maxVu)
+      .toBeCloseTo(localConnection(inp).maxVu * (0.5 / 0.75), 6)
+  })
+
+  it('§J3.7 is re-derived, not rescaled', () => {
+    // The factor sits INSIDE the reduction: F'nt = 1.3Fnt − (Fnt / available
+    // Fnv)·frv. So the ASD tension capacity is NOT the LRFD one times
+    // (1/Ω)/φ — if it were, the formula had been treated as a multiplier.
+    const inp = { ...BASE, Vu: 60, e_out: 80, b_gage: 45, ex_load: 20 }
+    const lrfd = localConnection(inp)
+    const asd = localConnection({ ...inp, basis: 'ASD' })
+    // Both must be in the ACTIVE range of the reduction — a group loaded until
+    // F'nt clamps to zero gives 0 on both bases and proves nothing.
+    expect(lrfd.outOfPlane!.phiTn_crit).toBeGreaterThan(0)
+    expect(asd.outOfPlane!.phiTn_crit).toBeGreaterThan(0)
+    const naiveRescale = lrfd.outOfPlane!.phiTn_crit * (0.5 / 0.75)
+    expect(asd.outOfPlane!.phiTn_crit).not.toBeCloseTo(naiveRescale, 3)
+    // …and it is still lower than the LRFD value, as an allowable must be.
+    expect(asd.outOfPlane!.phiTn_crit).toBeLessThan(lrfd.outOfPlane!.phiTn_crit)
+  })
+
+  it('prying uses the ASD plate-flexure factor in the required thickness', () => {
+    const inp = { ...BASE, Vu: 60, e_out: 80, b_gage: 45, ex_load: 20 }
+    const lrfd = localConnection(inp)
+    const asd = localConnection({ ...inp, basis: 'ASD' })
+    expect(lrfd.prying).not.toBeNull()
+    // A thinner allowable plate-flexure capacity means MORE thickness needed.
+    expect(asd.prying!.t_req).toBeGreaterThan(lrfd.prying!.t_req)
   })
 })

--- a/webapp/src/lib/calcLocal.ts
+++ b/webapp/src/lib/calcLocal.ts
@@ -10,6 +10,7 @@ import {
   pryingAction, shearTabBlockShear, boltGeomFromPositions,
 } from '../engine/steelDesign'
 import { shapeByName } from '../engine/aiscSections'
+import { available, type DesignBasis } from '../engine/designBasis'
 import type {
   BeamCalcInput, BeamCalcResult,
   ColumnCalcInput, ColumnCalcResult,
@@ -25,11 +26,18 @@ const shapeOf = (name: string) => {
 export function localBeam(i: BeamCalcInput): BeamCalcResult {
   const s = shapeOf(i.shapeName)
   const props = deriveWSection(s)
+  const basis: DesignBasis = i.basis ?? 'LRFD'
+  const flex = beamFlexure(s, props, i.Fy, i.Lb, i.Cb)
+  const shear = beamShear(s, props, i.Fy)
   return {
-    props,
-    flex: beamFlexure(s, props, i.Fy, i.Lb, i.Cb),
-    shear: beamShear(s, props, i.Fy),
-    loads: beamLoadingSimple({ wDead: i.wDead, wLive: i.wLive, L: i.span }, props.Ix),
+    props, flex, shear, basis,
+    loads: beamLoadingSimple({ wDead: i.wDead, wLive: i.wLive, L: i.span }, props.Ix, basis),
+    avail: {
+      Mn: available(flex.Mn, basis, 'flexure'),
+      // §G2.1(a) and (b) carry different pairs — 1.00/1.50 and 0.90/1.67 — so
+      // the web slenderness picks the limit state, not just the phi.
+      Vn: available(shear.Vn, basis, shear.slenderWeb ? 'shearSlender' : 'shearRolled'),
+    },
   }
 }
 
@@ -40,9 +48,19 @@ export function localColumn(i: ColumnCalcInput): ColumnCalcResult {
   // strong-axis flexure with Lb = member length, Cb = 1 (uniform moment — conservative)
   const flexX = beamFlexure(s, props, i.Fy, i.L, 1.0)
   const weak = weakAxisFlexure(s, props, i.Fy)
+  const basis: DesignBasis = i.basis ?? 'LRFD'
+  const avail = {
+    Pn:  available(axial.Pn,  basis, 'compression'),
+    Mnx: available(flexX.Mn,  basis, 'flexure'),
+    Mny: available(weak.Mny,  basis, 'flexure'),
+  }
   return {
-    props, axial, flexX, weak,
-    comb: combinedLoading(i.Pu, axial.phiPn, i.Mux, flexX.phiMn, i.Muy, weak.phiMny),
+    props, axial, flexX, weak, basis, avail,
+    // §H1-1 is a ratio of demand to AVAILABLE strength, so it is basis-agnostic
+    // once both sides are on the same basis — which is exactly the trap the
+    // dual format sets, and why the available values are passed rather than
+    // the phi ones.
+    comb: combinedLoading(i.Pu, avail.Pn, i.Mux, avail.Mnx, i.Muy, avail.Mny),
   }
 }
 
@@ -52,23 +70,32 @@ export function localConnection(i: ConnectionCalcInput): ConnectionCalcResult {
     ? boltGeomFromPositions(i.bolts!)
     : boltGroupGeom(i.nRows, i.nCols, i.sx, i.sy, i.ex_edge, i.ey)
   const nShear = i.nShear ?? 1
+  const basis: DesignBasis = i.basis ?? 'LRFD'
   const phiRnBolt = boltShear(i.boltGrade, i.db, i.Vu, i.tPlate, i.FuPlate, i.threads, nShear)
-  const eccentric = eccentricBoltGroup(geom, i.Vu, i.Hu, i.ex_load, i.ey_load, phiRnBolt.phiRn, i.db, i.tPlate)
+  const avail = {
+    shear:     available(phiRnBolt.Rn_shear,   basis, 'connection'),
+    bearing:   available(phiRnBolt.Rn_bearing, basis, 'connection'),
+    governing: available(phiRnBolt.Rn,         basis, 'connection'),
+  }
+  const eccentric = eccentricBoltGroup(geom, i.Vu, i.Hu, i.ex_load, i.ey_load, avail.governing, i.db, i.tPlate)
   const outOfPlane = i.e_out > 0
-    ? outOfPlaneBoltGroup(geom, eccentric.bolts, i.e_out, i.Vu, i.boltGrade, i.db, i.threads)
+    ? outOfPlaneBoltGroup(geom, eccentric.bolts, i.e_out, i.Vu, i.boltGrade, i.db, i.threads, basis)
     : null
   const prying = outOfPlane && i.b_gage > 0
-    ? pryingAction(outOfPlane.Tmax, outOfPlane.phiTn_crit, i.b_gage, i.ex_edge, i.sy, i.tPlate, i.db, i.FyPlate)
+    ? pryingAction(outOfPlane.Tmax, outOfPlane.phiTn_crit, i.b_gage, i.ex_edge, i.sy, i.tPlate, i.db, i.FyPlate, basis)
     : null
+  // A free-form pattern has no single bolt line to tear out along, so the
+  // shear-tab paths do not apply; the page says so rather than printing a
+  // number derived from a geometry that is not there.
+  const blockShear = custom
+    ? []
+    : shearTabBlockShear(i.nRows, i.sy, i.ey, i.ey, i.ex_edge, i.db, i.tPlate, i.FyPlate, i.FuPlate)
   return {
-    geom, phiRnBolt, eccentric, outOfPlane, prying,
-    // A free-form pattern has no single bolt line to tear out along, so the
-    // shear-tab paths do not apply; the page says so rather than printing a
-    // number derived from a geometry that is not there.
-    blockShear: custom
-      ? []
-      : shearTabBlockShear(i.nRows, i.sy, i.ey, i.ey, i.ex_edge, i.db, i.tPlate, i.FyPlate, i.FuPlate),
-    maxVu: eccentric.Rmax > 1e-9 ? (i.Vu * phiRnBolt.phiRn) / eccentric.Rmax : Infinity,
+    geom, phiRnBolt, eccentric, outOfPlane, prying, blockShear,
+    maxVu: eccentric.Rmax > 1e-9 ? (i.Vu * avail.governing) / eccentric.Rmax : Infinity,
     tauMax: (eccentric.Rmax * 1000) / (phiRnBolt.Ab * nShear),
+    basis, avail,
+    availBlockShear: blockShear.map((c) =>
+      available(Math.min(c.Rn_fract, c.Rn_cap), basis, 'connection')),
   }
 }

--- a/webapp/src/pages/BoltedConnection.tsx
+++ b/webapp/src/pages/BoltedConnection.tsx
@@ -12,7 +12,8 @@ import type { SolutionStep } from '../lib/solution'
 import { f1, f2, f3 } from '../lib/format'
 import { sn1, sn2 } from '../lib/solution'
 import { PageHeader } from '../components/calc'
-import { CalcBadge, Spinner, Verdict } from '../components/steelUi'
+import { CalcBadge, Spinner, Verdict, BasisPick, BasisNote } from '../components/steelUi'
+import { capacityLabel, demandLabel, factorLabel, SAFETY, type DesignBasis } from '../engine/designBasis'
 
 const ConnectionViewer3D = lazy(() => import('../components/SteelViewer3D').then(m => ({ default: m.ConnectionViewer3D })))
 
@@ -36,6 +37,7 @@ function BoltedConnectionCalc() {
   const [e_out,      setEOut]       = useState(0)
   const [b_gage,     setBGage]      = useState(0)
   const [nShear,     setNShear]     = useState<1 | 2>(1)
+  const [basis,      setBasis]      = useState<DesignBasis>('LRFD')
   // Free-form pattern. `null` means "use the grid above"; the editor seeds
   // itself FROM the grid on the way in, so switching to custom starts from the
   // pattern already on screen rather than from an empty table.
@@ -62,23 +64,29 @@ function BoltedConnectionCalc() {
       threads: threads === 'yes',
       tPlate, FuPlate, FyPlate,
       ex_load, ey_load, e_out, b_gage,
-      nShear, ...(custom && custom.length > 0 ? { bolts: custom } : {}),
+      nShear, basis, ...(custom && custom.length > 0 ? { bolts: custom } : {}),
     }),
     [Vu, Hu, boltGrade, db, nRows, nCols, sy, sx, ey, ex_edge, threads,
-     tPlate, FuPlate, FyPlate, ex_load, ey_load, e_out, b_gage, nShear, custom]
+     tPlate, FuPlate, FyPlate, ex_load, ey_load, e_out, b_gage, nShear, basis, custom]
   )
   const { data: res, loading, error } = useCalcResult<ConnectionCalcResult>(
     () => calcConnection(input), [input]
   )
 
-  const govBlockShear = res && res.blockShear.length
-    ? res.blockShear.reduce((mn, c) => c.phiRn < mn.phiRn ? c : mn, res.blockShear[0])
+  // The governing path on the CHOSEN basis. Picking it off the LRFD `phiRn`
+  // and then printing an ASD number beside it would name the wrong case
+  // whenever the two orders differ.
+  const govAvailBlockShear = res && res.availBlockShear.length
+    ? Math.min(...res.availBlockShear)
     : null
 
   const boltSteps = useMemo((): SolutionStep[] => {
     if (!res) return []
     const { phiRnBolt, geom, eccentric, outOfPlane, prying, blockShear } = res
-    const { Fnv, Ab, phiRn_shear, phiRn_bearing, phiRn } = phiRnBolt
+    const { Fnv, Ab, Rn_shear, Rn_bearing } = phiRnBolt
+    const { basis, avail } = res
+    const F = basis === 'LRFD' ? SAFETY.connection.phi : 1 / SAFETY.connection.omega
+    const fTex = basis === 'LRFD' ? `\\phi` : `1/\\Omega`
     const { n, Ip } = geom
     const M = eccentric.M
     return [
@@ -87,14 +95,15 @@ function BoltedConnectionCalc() {
         lines: [
           { tex: `A_b = \\frac{\\pi}{4} d_b^2 = \\frac{\\pi}{4}(${db})^2 = ${Ab.toFixed(0)}\\text{ mm}^2` },
           { tex: `F_{nv} = ${Fnv}\\text{ MPa}\\quad (${threads==='yes'?'threads in shear plane, N':'threads excluded, X'})` },
-          { tex: `\\phi R_{n,\\text{shear}} = 0.75 F_{nv} A_b = 0.75 \\times ${Fnv} \\times ${Ab.toFixed(0)} / 1000 = ${sn2(phiRn_shear)}\\text{ kN/bolt}` },
+          { tex: `R_{n,\\text{shear}} = F_{nv} A_b n_s = ${sn2(Rn_shear)}\\text{ kN/bolt}` },
+          { tex: `${fTex} R_{n,\\text{shear}} = ${F.toFixed(3)} \\times ${sn2(Rn_shear)} = ${sn2(avail.shear)}\\text{ kN/bolt}\\quad(${basis})` },
         ],
       },
       {
         title: `Bearing on plate §J3.10 — t = ${tPlate} mm, F_u = ${FuPlate} MPa`,
         lines: [
-          { tex: `\\phi R_{n,\\text{br}} = 0.75 \\times 2.4 F_u d_b t = 0.75 \\times 2.4 \\times ${FuPlate} \\times ${db} \\times ${tPlate} / 1000 = ${sn2(phiRn_bearing)}\\text{ kN/bolt}` },
-          { tex: `\\phi R_n\\text{ (governing)} = \\min(${sn2(phiRn_shear)},\\;${sn2(phiRn_bearing)}) = ${sn2(phiRn)}\\text{ kN/bolt}` },
+          { tex: `R_{n,\\text{br}} = 2.4 F_u d_b t = 2.4 \\times ${FuPlate} \\times ${db} \\times ${tPlate} / 1000 = ${sn2(Rn_bearing)}\\text{ kN/bolt}` },
+          { tex: `\\text{Available (governing)} = \\min(${sn2(avail.shear)},\\;${sn2(avail.bearing)}) = ${sn2(avail.governing)}\\text{ kN/bolt}` },
         ],
       },
       {
@@ -105,7 +114,7 @@ function BoltedConnectionCalc() {
           { text: `Direct shear per bolt: Vx = Hu/n = ${(Hu/n).toFixed(2)} kN,  Vy = Vu/n = ${(Vu/n).toFixed(2)} kN` },
           { tex: `V_{x,i} = H_u/n - M y_i / I_p\\quad V_{y,i} = V_u/n + M x_i / I_p` },
           { tex: `R_{\\max} = ${sn2(eccentric.Rmax)}\\text{ kN on bolt }\\textit{${eccentric.critical}}` },
-          { tex: `\\text{Utilisation} = R_{\\max} / (\\phi R_n) = ${sn2(eccentric.Rmax)} / ${sn2(phiRn)} = ${sn2(eccentric.Rmax/phiRn)}\\quad ${eccentric.Rmax<=phiRn?'\\checkmark':'\\times'}` },
+          { tex: `\\text{Utilisation} = ${sn2(eccentric.Rmax)} / ${sn2(avail.governing)} = ${sn2(eccentric.Rmax/avail.governing)}\\quad ${eccentric.Rmax<=avail.governing?'\\checkmark':'\\times'}` },
         ],
       },
       {
@@ -115,8 +124,8 @@ function BoltedConnectionCalc() {
           if (!crit) return []
           const Ab2 = (Math.PI/4)*db*db
           return [
-            { tex: `f_{br} = \\frac{R_{\\max}}{d_b \\cdot t} = \\frac{${sn2(eccentric.Rmax)} \\times 1000}{${db} \\times ${tPlate}} = ${sn1(crit.fbr)}\\text{ MPa}\\quad \\phi F_{br} = 0.75 \\times 2.4 \\times ${FuPlate} = ${sn1(0.75*2.4*FuPlate)}\\text{ MPa}\\quad ${crit.fbr <= 0.75*2.4*FuPlate ? '\\checkmark':'\\times'}` },
-            { tex: `f_v = \\frac{R_{\\max}}{A_b} = \\frac{${sn2(eccentric.Rmax)} \\times 1000}{${Ab2.toFixed(0)}} = ${sn1(crit.fv)}\\text{ MPa}\\quad \\phi F_{nv} = 0.75 \\times ${Fnv} = ${sn1(0.75*Fnv)}\\text{ MPa}\\quad ${crit.fv <= 0.75*Fnv ? '\\checkmark':'\\times'}` },
+            { tex: `f_{br} = \\frac{R_{\\max}}{d_b \\cdot t} = \\frac{${sn2(eccentric.Rmax)} \\times 1000}{${db} \\times ${tPlate}} = ${sn1(crit.fbr)}\\text{ MPa}\\quad \\text{available } F_{br} = ${F.toFixed(3)} \\times 2.4 \\times ${FuPlate} = ${sn1(F*2.4*FuPlate)}\\text{ MPa}\\quad ${crit.fbr <= F*2.4*FuPlate ? '\\checkmark':'\\times'}` },
+            { tex: `f_v = \\frac{R_{\\max}}{A_b} = \\frac{${sn2(eccentric.Rmax)} \\times 1000}{${Ab2.toFixed(0)}} = ${sn1(crit.fv)}\\text{ MPa}\\quad \\text{available } F_{nv} = ${F.toFixed(3)} \\times ${Fnv} = ${sn1(F*Fnv)}\\text{ MPa}\\quad ${crit.fv <= F*Fnv ? '\\checkmark':'\\times'}` },
           ]
         })(),
       },
@@ -147,12 +156,12 @@ function BoltedConnectionCalc() {
       }] : [])] : []),
       {
         title: 'Block shear §J4.3 (shear tab, single bolt line)',
-        lines: blockShear.flatMap(c => [
+        lines: blockShear.flatMap((c, k) => [
           { text: c.label },
           { tex: `A_{gv} = ${c.Agv.toFixed(0)}\\text{ mm}^2\\quad A_{nv} = ${c.Anv.toFixed(0)}\\text{ mm}^2\\quad A_{nt} = ${c.Ant.toFixed(0)}\\text{ mm}^2` },
           { tex: `R_{n,\\text{fract}} = 0.6 F_u A_{nv} + U_{bs} F_u A_{nt} = ${sn1(c.Rn_fract)}\\text{ kN}` },
           { tex: `\\text{cap } = 0.6 F_y A_{gv} + U_{bs} F_u A_{nt} = ${sn1(c.Rn_cap)}\\text{ kN}` },
-          { tex: `\\phi R_n = 0.75 \\times ${sn1(Math.min(c.Rn_fract,c.Rn_cap))} = ${sn1(c.phiRn)}\\text{ kN}\\quad ${Vu<=c.phiRn?'\\checkmark':'\\times'}` },
+          { tex: `${fTex} R_n = ${F.toFixed(3)} \\times ${sn1(Math.min(c.Rn_fract,c.Rn_cap))} = ${sn1(res.availBlockShear[k])}\\text{ kN}\\quad ${Vu<=res.availBlockShear[k]?'\\checkmark':'\\times'}` },
         ]),
       },
     ]
@@ -164,8 +173,14 @@ function BoltedConnectionCalc() {
       {/* ── inputs ── */}
       <div className="space-y-5">
         <Card title={<>Applied load<CalcBadge loading={loading} error={error} /></>}>
-          <Num label="Applied Vu" unit="kN" value={Vu} onChange={setVu} />
-          <Num label="Applied Hu (horizontal)" unit="kN" value={Hu} onChange={setHu} />
+          <BasisPick value={basis} onChange={setBasis} />
+          <Num label={`Applied ${demandLabel(basis, 'V')}`} unit="kN" value={Vu} onChange={setVu} />
+          <Num label={`Applied ${demandLabel(basis, 'H')} (horizontal)`} unit="kN" value={Hu} onChange={setHu} />
+          <BasisNote basis={basis} />
+          <p className="col-span-full text-[10px] text-slate-500">
+            The load is entered directly here, so it is on you to enter a demand that matches the
+            basis — factored for LRFD, service for ASD.
+          </p>
         </Card>
         <Card title="Bolt properties">
             <Pick label="Grade" value={boltGrade} onChange={v => setBoltGrade(v as BoltGrade)}
@@ -286,21 +301,21 @@ function BoltedConnectionCalc() {
       <div className="space-y-4 lg:sticky lg:top-4 lg:max-h-[calc(100vh-2rem)] lg:self-start lg:overflow-y-auto lg:pr-1">
         {res && (<>
           <ResultCard title="Bolt capacity / bolt">
-            <Row label="φRn shear" value={`${f2(res.phiRnBolt.phiRn_shear)} kN`} />
-            <Row label="φRn bearing" value={`${f2(res.phiRnBolt.phiRn_bearing)} kN`} />
-            <Row label="φRn governing" value={<b>{f2(res.phiRnBolt.phiRn)} kN</b>}
-              sub={nShear === 2 ? 'double shear — 2 planes' : 'single shear — 1 plane'} />
+            <Row label={`${capacityLabel(res.basis, 'R')} shear`} value={`${f2(res.avail.shear)} kN`} />
+            <Row label={`${capacityLabel(res.basis, 'R')} bearing`} value={`${f2(res.avail.bearing)} kN`} />
+            <Row label={`${capacityLabel(res.basis, 'R')} governing`} value={<b>{f2(res.avail.governing)} kN</b>}
+              sub={`${nShear === 2 ? 'double shear' : 'single shear'} · ${factorLabel(res.basis, 'connection')}`} />
           </ResultCard>
           <ResultCard title={`Eccentric group (${res.geom.n} bolts)`}>
             <Row label="Ip" value={`${res.geom.Ip.toFixed(0)} mm²`} />
             <Row label="In-plane M" value={`${res.eccentric.M.toFixed(0)} kN·mm`} />
             <Row label="Critical bolt" value={res.eccentric.critical} sub={`R = ${f2(res.eccentric.Rmax)} kN`} />
-            <Row alert={res.eccentric.Rmax > res.phiRnBolt.phiRn}
-              label="Rmax / φRn"
-              value={<Verdict pass={res.eccentric.Rmax <= res.phiRnBolt.phiRn} value={`${(res.eccentric.Rmax/res.phiRnBolt.phiRn*100).toFixed(0)} %`} />} />
+            <Row alert={res.eccentric.Rmax > res.avail.governing}
+              label={`Rmax / ${capacityLabel(res.basis, 'R')}`}
+              value={<Verdict pass={res.eccentric.Rmax <= res.avail.governing} value={`${(res.eccentric.Rmax/res.avail.governing*100).toFixed(0)} %`} />} />
             <Row label="Bolt shear stress τmax" value={`${f1(res.tauMax)} MPa`}
               sub={`Rmax / (Ab × ${nShear})`} />
-            <Row label="Maximum applied Vu" value={<b>{f2(res.maxVu)} kN</b>}
+            <Row label={`Maximum applied ${demandLabel(res.basis, 'V')}`} value={<b>{f2(res.maxVu)} kN</b>}
               sub="at this eccentricity — the method is linear in the load" />
           </ResultCard>
           <ResultCard title="Per-bolt forces">
@@ -332,15 +347,16 @@ function BoltedConnectionCalc() {
                 tear-out by hand against the pattern you have.
               </p>
             )}
-            {res.blockShear.map(c => (
-              <Row key={c.label} alert={Vu > c.phiRn}
+            {res.blockShear.map((c, k) => (
+              <Row key={c.label} alert={Vu > res.availBlockShear[k]}
                 label={<span className="text-[10px]">{c.label.replace('§J4.3 ', '')}</span>}
-                value={<Verdict pass={Vu <= c.phiRn} value={`φRn = ${f1(c.phiRn)} kN`} />} />
+                value={<Verdict pass={Vu <= res.availBlockShear[k]}
+                  value={`${capacityLabel(res.basis, 'R')} = ${f1(res.availBlockShear[k])} kN`} />} />
             ))}
-            {govBlockShear && (
-              <Row alert={Vu > govBlockShear.phiRn}
+            {govAvailBlockShear !== null && (
+              <Row alert={Vu > govAvailBlockShear}
                 label="Governing block shear"
-                value={<Verdict pass={Vu <= govBlockShear.phiRn} value={`${f1(govBlockShear.phiRn)} kN`} />} />
+                value={<Verdict pass={Vu <= govAvailBlockShear} value={`${f1(govAvailBlockShear)} kN`} />} />
             )}
           </ResultCard>
 
@@ -413,7 +429,7 @@ function BoltedConnectionCalc() {
 export default function BoltedConnection() {
   return (
     <div>
-      <PageHeader title="Bolted Connection" badges={['AISC 360-16 LRFD']} />
+      <PageHeader title="Bolted Connection" badges={['AISC 360-16']} />
       <div className="mx-auto max-w-[1500px] px-5 py-5 sm:px-7">
         <p className="no-print mt-1 text-slate-600">
           Eccentrically-loaded bolt group by the elastic method — φRn per bolt in shear and

--- a/webapp/src/pages/SteelBeam.tsx
+++ b/webapp/src/pages/SteelBeam.tsx
@@ -10,7 +10,8 @@ import type { SolutionStep } from '../lib/solution'
 import { f1, f2 } from '../lib/format'
 import { sn1, sn2 } from '../lib/solution'
 import { PageHeader } from '../components/calc'
-import { ShapePick, CalcBadge, Spinner, Verdict, ZoneBadge } from '../components/steelUi'
+import { ShapePick, CalcBadge, Spinner, Verdict, ZoneBadge, BasisPick, BasisNote } from '../components/steelUi'
+import { capacityLabel, demandLabel, factorLabel, comboLabel, SAFETY, type DesignBasis } from '../engine/designBasis'
 import { GRADES, shapeOrFirst, type Grade } from '../lib/steelShapes'
 
 const BeamViewer3D = lazy(() => import('../components/SteelViewer3D').then(m => ({ default: m.BeamViewer3D })))
@@ -28,16 +29,22 @@ function BeamTab() {
   // Shape geometry stays client-side: needed by 3D viewer and section dimensions in steps.
   const shape = useMemo(() => shapeOrFirst(shapeName), [shapeName])
 
+  const [basis, setBasis] = useState<DesignBasis>('LRFD')
+
   const input = useMemo(
-    () => ({ shapeName, Fy, span, Lb, Cb, wDead: wD, wLive: wL }),
-    [shapeName, Fy, span, Lb, Cb, wD, wL]
+    () => ({ shapeName, Fy, span, Lb, Cb, wDead: wD, wLive: wL, basis }),
+    [shapeName, Fy, span, Lb, Cb, wD, wL, basis]
   )
   const { data: res, loading, error } = useCalcResult<BeamCalcResult>(
     () => calcBeam(input), [input]
   )
 
-  const utilM = res ? res.loads.Mu / res.flex.phiMn : 0
-  const utilV = res ? res.loads.Vu / res.shear.phiVn : 0
+  // Against the AVAILABLE strength on the chosen basis, never the phi one:
+  // the demand above is factored under LRFD and service under ASD, so the two
+  // sides have to come from the same basis or the ratio is meaningless.
+  const utilM = res ? res.loads.Mu / res.avail.Mn : 0
+  const utilV = res ? res.loads.Vu / res.avail.Vn : 0
+  const shearLS = res?.shear.slenderWeb ? 'shearSlender' as const : 'shearRolled' as const
 
   const steps = useMemo((): SolutionStep[] => {
     if (!res) return []
@@ -45,9 +52,14 @@ function BeamTab() {
     const E = 200000
     return [
       {
-        title: 'Factored loads (NSCP/AISC load combos)',
+        title: res.basis === 'LRFD'
+          ? 'Required strength — factored loads (NSCP/AISC LRFD combos)'
+          : 'Required strength — service loads (ASD combination)',
         lines: [
-          { tex: `w_u = \\max(1.4 \\times ${sn1(wD)},\\; 1.2 \\times ${sn1(wD)} + 1.6 \\times ${sn1(wL)}) = ${sn1(loads.wu)}\\text{ kN/m}` },
+          { text: `Load combination: ${comboLabel(res.basis)}.` },
+          { tex: res.basis === 'LRFD'
+              ? `w_u = \\max(1.4 \\times ${sn1(wD)},\\; 1.2 \\times ${sn1(wD)} + 1.6 \\times ${sn1(wL)}) = ${sn1(loads.wu)}\\text{ kN/m}`
+              : `w_a = ${sn1(wD)} + ${sn1(wL)} = ${sn1(loads.wu)}\\text{ kN/m}` },
           { tex: `M_u = \\frac{w_u L^2}{8} = \\frac{${sn1(loads.wu)} \\times ${sn1(span)}^2}{8} = ${sn1(loads.Mu)}\\text{ kN·m}` },
           { tex: `V_u = \\frac{w_u L}{2} = ${sn1(loads.Vu)}\\text{ kN}` },
         ],
@@ -67,8 +79,10 @@ function BeamTab() {
           { tex: `L_p = 1.76\\, r_y \\sqrt{E/F_y} = 1.76 \\times ${shape.ry} \\times \\sqrt{${E}/${Fy}} = ${sn1(flex.Lp)}\\text{ mm} = ${sn2(flex.Lp/1000)}\\text{ m}` },
           { tex: `L_r = ${sn1(flex.Lr)}\\text{ mm} = ${sn2(flex.Lr/1000)}\\text{ m}` },
           { text: `L_b = ${Lb} m → zone: ${flex.ltbZone.toUpperCase()}` },
-          { tex: `M_n = ${sn1(flex.Mn)}\\text{ kN·m}\\quad \\phi M_n = 0.90 \\times ${sn1(flex.Mn)} = ${sn1(flex.phiMn)}\\text{ kN·m}` },
-          { tex: `\\text{Utilisation} = \\frac{M_u}{\\phi M_n} = \\frac{${sn1(loads.Mu)}}{${sn1(flex.phiMn)}} = ${sn2(utilM)}\\quad ${utilM <= 1 ? '\\checkmark' : '\\times'}` },
+          { tex: res.basis === 'LRFD'
+              ? `M_n = ${sn1(flex.Mn)}\\text{ kN·m}\\quad \\phi M_n = ${SAFETY.flexure.phi.toFixed(2)} \\times ${sn1(flex.Mn)} = ${sn1(res.avail.Mn)}\\text{ kN·m}`
+              : `M_n = ${sn1(flex.Mn)}\\text{ kN·m}\\quad \\frac{M_n}{\\Omega_b} = \\frac{${sn1(flex.Mn)}}{${SAFETY.flexure.omega.toFixed(2)}} = ${sn1(res.avail.Mn)}\\text{ kN·m}` },
+          { tex: `\\text{Utilisation} = ${sn1(loads.Mu)} / ${sn1(res.avail.Mn)} = ${sn2(utilM)}\\quad ${utilM <= 1 ? '\\checkmark' : '\\times'}` },
         ],
       },
       {
@@ -76,7 +90,7 @@ function BeamTab() {
         lines: [
           { tex: `A_w = d \\cdot t_w = ${shape.d} \\times ${shape.tw} = ${shear.Aw.toFixed(0)}\\text{ mm}^2` },
           { tex: `h/t_w = ${sn1(shear.hwTw)}\\quad 2.24\\sqrt{E/F_y} = ${sn1(2.24 * Math.sqrt(200000 / Fy))}\\quad C_{v1} = ${sn2(shear.Cv1)},\\; \\phi_v = ${shear.phiV}` },
-          { tex: `\\phi V_n = \\phi_v \\cdot 0.6 F_y A_w C_{v1} = ${sn2(shear.phiVn)}\\text{ kN}` },
+          { tex: `V_n = 0.6 F_y A_w C_{v1} = ${sn2(shear.Vn)}\\text{ kN}\\quad\\Rightarrow\\quad ${res.basis === 'LRFD' ? '\\phi V_n' : 'V_n/\\Omega_v'} = ${sn2(res.avail.Vn)}\\text{ kN}\\quad(${factorLabel(res.basis, shearLS)})` },
         ],
       },
       {
@@ -88,7 +102,7 @@ function BeamTab() {
         ],
       },
     ]
-  }, [res, shape, Fy, wD, wL, span, Lb, utilM])
+  }, [res, shape, Fy, wD, wL, span, Lb, utilM, shearLS])
 
   return (
     <div>
@@ -96,6 +110,8 @@ function BeamTab() {
       <div className="space-y-5">
         <Card title={<>Section & grade<CalcBadge loading={loading} error={error} /></>}>
           <ShapePick value={shapeName} onChange={setShapeName} />
+          <BasisPick value={basis} onChange={setBasis} />
+          <BasisNote basis={basis} />
           <Pick label="Steel grade" value={grade} onChange={v => setGrade(v as Grade)}
             options={Object.entries(GRADES).map(([k, v]) => [k as Grade, v.label])} />
         </Card>
@@ -124,12 +140,16 @@ function BeamTab() {
             <Row label="Lp / Lr" value={`${f2(res.flex.Lp/1000)} / ${f2(res.flex.Lr/1000)} m`} />
           </ResultCard>
           <ResultCard title={<>Flexure §F2 <ZoneBadge zone={res.flex.ltbZone} /></>}>
-            <Row label="φMn" value={`${f1(res.flex.phiMn)} kN·m`} />
-            <Row alert={utilM>1} label="Mu / φMn" value={<Verdict pass={utilM<=1} value={`${(utilM*100).toFixed(0)} %`} />} />
+            <Row label={capacityLabel(res.basis, 'M')} value={`${f1(res.avail.Mn)} kN·m`}
+              sub={`Mn = ${f1(res.flex.Mn)} · ${factorLabel(res.basis, 'flexure')}`} />
+            <Row alert={utilM>1} label={`${demandLabel(res.basis, 'M')} / ${capacityLabel(res.basis, 'M')}`}
+              value={<Verdict pass={utilM<=1} value={`${(utilM*100).toFixed(0)} %`} />} />
           </ResultCard>
           <ResultCard title="Shear §G2.1">
-            <Row label="φVn" value={`${f1(res.shear.phiVn)} kN`} sub={`Cv1=${res.shear.Cv1.toFixed(2)}`} />
-            <Row alert={utilV>1} label="Vu / φVn" value={<Verdict pass={utilV<=1} value={`${(utilV*100).toFixed(0)} %`} />} />
+            <Row label={capacityLabel(res.basis, 'V')} value={`${f1(res.avail.Vn)} kN`}
+              sub={`Cv1=${res.shear.Cv1.toFixed(2)} · ${factorLabel(res.basis, shearLS)}`} />
+            <Row alert={utilV>1} label={`${demandLabel(res.basis, 'V')} / ${capacityLabel(res.basis, 'V')}`}
+              value={<Verdict pass={utilV<=1} value={`${(utilV*100).toFixed(0)} %`} />} />
           </ResultCard>
           <ResultCard title="Deflection">
             <Row alert={res.loads.deltaL>res.loads.limL360} label="δL ≤ L/360" value={<Verdict pass={res.loads.deltaL<=res.loads.limL360} value={`${f2(res.loads.deltaL)} mm`} />} />
@@ -152,7 +172,7 @@ function BeamTab() {
 export default function SteelBeam() {
   return (
     <div>
-      <PageHeader title="Steel Beam Design" badges={['AISC 360-16 LRFD']} />
+      <PageHeader title="Steel Beam Design" badges={['AISC 360-16']} />
       <div className="mx-auto max-w-[1500px] px-5 py-5 sm:px-7">
         <p className="no-print mt-1 text-slate-600">AISC 360-16 §F2 flexure with lateral-torsional buckling, §G2.1 shear, and service deflections against L/360 and L/240. 3D scene and a step-by-step solution.</p>
         <ReportControls title="Steel Beam Design Report" />

--- a/webapp/src/pages/SteelColumn.tsx
+++ b/webapp/src/pages/SteelColumn.tsx
@@ -10,7 +10,8 @@ import type { SolutionStep } from '../lib/solution'
 import { f1 } from '../lib/format'
 import { sn1, sn2, sn3 } from '../lib/solution'
 import { PageHeader } from '../components/calc'
-import { ShapePick, CalcBadge, Spinner, Verdict } from '../components/steelUi'
+import { ShapePick, CalcBadge, Spinner, Verdict, BasisPick, BasisNote } from '../components/steelUi'
+import { capacityLabel, demandLabel, factorLabel, comboLabel, requiredFromDL, SAFETY, type DesignBasis } from '../engine/designBasis'
 import { GRADES, shapeOrFirst, type Grade } from '../lib/steelShapes'
 
 const ColumnViewer3D = lazy(() => import('../components/SteelViewer3D').then(m => ({ default: m.ColumnViewer3D })))
@@ -31,11 +32,14 @@ function ColumnTab() {
   const { Fy } = GRADES[grade]
   const shape  = useMemo(() => shapeOrFirst(shapeName), [shapeName])
   // Factor axial demand client-side (trivial arithmetic, not proprietary)
-  const Pu     = dlMode === 'DL' ? Math.max(1.4*dead, 1.2*dead+1.6*live) : PuDir
+  const [basis, setBasis] = useState<DesignBasis>('LRFD')
+  // The demand side of the dual format: factored under LRFD, the service sum
+  // under ASD. A direct entry is taken as already being on the chosen basis.
+  const Pu     = dlMode === 'DL' ? requiredFromDL(basis, dead, live) : PuDir
 
   const input = useMemo(
-    () => ({ shapeName, Fy, L, Kx, Ky, Pu, Mux, Muy }),
-    [shapeName, Fy, L, Kx, Ky, Pu, Mux, Muy]
+    () => ({ shapeName, Fy, L, Kx, Ky, Pu, Mux, Muy, basis }),
+    [shapeName, Fy, L, Kx, Ky, Pu, Mux, Muy, basis]
   )
   const { data: res, loading, error } = useCalcResult<ColumnCalcResult>(
     () => calcColumn(input), [input]
@@ -43,13 +47,16 @@ function ColumnTab() {
 
   const steps = useMemo((): SolutionStep[] => {
     if (!res) return []
-    const { axial, flexX, weak, comb } = res
+    const { axial, flexX, comb } = res
     const E = 200000
     return [
       {
         title: 'Factored axial load',
         lines: dlMode === 'DL' ? [
-          { tex: `P_u = \\max(1.4D,\\;1.2D+1.6L) = \\max(${sn1(1.4*dead)},\\;${sn1(1.2*dead+1.6*live)}) = ${sn1(Pu)}\\text{ kN}` },
+          { text: `Load combination: ${comboLabel(res.basis)}.` },
+          { tex: res.basis === 'LRFD'
+              ? `P_u = \\max(1.4D,\\;1.2D+1.6L) = \\max(${sn1(1.4*dead)},\\;${sn1(1.2*dead+1.6*live)}) = ${sn1(Pu)}\\text{ kN}`
+              : `P_a = D + L = ${sn1(dead)} + ${sn1(live)} = ${sn1(Pu)}\\text{ kN}` },
         ] : [{ tex: `P_u = ${sn1(Pu)}\\text{ kN (direct input)}` }],
       },
       {
@@ -58,24 +65,27 @@ function ColumnTab() {
           { tex: `KL/r_x = \\frac{${Kx}\\times${L*1000}}{${shape.rx}} = ${sn1(axial.slendernessX)}` },
           { tex: `KL/r_y = \\frac{${Ky}\\times${L*1000}}{${shape.ry}} = ${sn1(axial.slendernessY)}\\quad \\text{(governing = }${sn1(axial.slenderness)})` },
           { tex: `4.71\\sqrt{E/F_y} = 4.71\\sqrt{${E}/${Fy}} = ${sn1(4.71*Math.sqrt(E/Fy))}` },
-          { tex: `F_{cr} = ${sn2(axial.Fcr)}\\text{ MPa}\\quad \\phi P_n = 0.90 \\times ${sn2(axial.Fcr)} \\times ${shape.A} / 1000 = ${sn1(axial.phiPn)}\\text{ kN}` },
+          { tex: `F_{cr} = ${sn2(axial.Fcr)}\\text{ MPa}\\quad P_n = F_{cr} A_g = ${sn1(axial.Pn)}\\text{ kN}` },
+          { tex: res.basis === 'LRFD'
+              ? `\\phi_c P_n = ${SAFETY.compression.phi.toFixed(2)} \\times ${sn1(axial.Pn)} = ${sn1(res.avail.Pn)}\\text{ kN}`
+              : `\\frac{P_n}{\\Omega_c} = \\frac{${sn1(axial.Pn)}}{${SAFETY.compression.omega.toFixed(2)}} = ${sn1(res.avail.Pn)}\\text{ kN}` },
         ],
         note: axial.slenderOK ? undefined : 'KL/r > 200 — slenderness exceeds §E2 advisory limit.',
       },
       {
         title: 'Flexural capacities',
         lines: [
-          { tex: `\\phi M_{nx} = ${sn1(flexX.phiMn)}\\text{ kN·m}\\quad (\\text{${flexX.ltbZone} zone, §F2})` },
-          { tex: `\\phi M_{ny} = 0.90 F_y Z_y = ${sn1(weak.phiMny)}\\text{ kN·m}\\quad (\\text{§F6, weak-axis})` },
+          { tex: `${res.basis === 'LRFD' ? '\\phi M_{nx}' : 'M_{nx}/\\Omega_b'} = ${sn1(res.avail.Mnx)}\\text{ kN·m}\\quad (\\text{${flexX.ltbZone} zone, §F2})` },
+          { tex: `${res.basis === 'LRFD' ? '\\phi M_{ny}' : 'M_{ny}/\\Omega_b'} = ${sn1(res.avail.Mny)}\\text{ kN·m}\\quad (\\text{§F6, weak-axis})` },
         ],
       },
       {
         title: `Combined loading §H1-1 (equation ${comb.equation})`,
         lines: comb.equation === 'H1-1a' ? [
-          { tex: `P_u/\\phi P_n = ${sn3(Pu/axial.phiPn)} \\geq 0.2 \\Rightarrow \\text{use §H1-1a}` },
-          { tex: `\\frac{P_u}{\\phi P_n} + \\frac{8}{9}\\!\\left(\\frac{M_{ux}}{\\phi M_{nx}} + \\frac{M_{uy}}{\\phi M_{ny}}\\right) = ${sn3(Pu/axial.phiPn)} + \\frac{8}{9}(${sn3(Mux/flexX.phiMn)} + ${sn3(Muy > 0 ? Muy/weak.phiMny : 0)}) = ${sn3(comb.ratio)}\\quad${comb.ok?'\\checkmark':'\\times'}` },
+          { tex: `P_u/\\phi P_n = ${sn3(Pu/res.avail.Pn)} \\geq 0.2 \\Rightarrow \\text{use §H1-1a}` },
+          { tex: `\\frac{P_u}{\\phi P_n} + \\frac{8}{9}\\!\\left(\\frac{M_{ux}}{\\phi M_{nx}} + \\frac{M_{uy}}{\\phi M_{ny}}\\right) = ${sn3(Pu/res.avail.Pn)} + \\frac{8}{9}(${sn3(Mux/res.avail.Mnx)} + ${sn3(Muy > 0 ? Muy/res.avail.Mny : 0)}) = ${sn3(comb.ratio)}\\quad${comb.ok?'\\checkmark':'\\times'}` },
         ] : [
-          { tex: `P_u/\\phi P_n = ${sn3(Pu/axial.phiPn)} < 0.2 \\Rightarrow \\text{use §H1-1b}` },
+          { tex: `P_u/\\phi P_n = ${sn3(Pu/res.avail.Pn)} < 0.2 \\Rightarrow \\text{use §H1-1b}` },
           { tex: `\\frac{P_u}{2\\phi P_n} + \\left(\\frac{M_{ux}}{\\phi M_{nx}} + \\frac{M_{uy}}{\\phi M_{ny}}\\right) = ${sn3(comb.ratio)}\\quad${comb.ok?'\\checkmark':'\\times'}` },
         ],
       },
@@ -88,6 +98,8 @@ function ColumnTab() {
       <div className="space-y-5">
         <Card title={<>Section & grade<CalcBadge loading={loading} error={error} /></>}>
           <ShapePick value={shapeName} onChange={setShapeName} />
+          <BasisPick value={basis} onChange={setBasis} />
+          <BasisNote basis={basis} />
           <Pick label="Steel grade" value={grade} onChange={v => setGrade(v as Grade)}
             options={Object.entries(GRADES).map(([k, v]) => [k as Grade, v.label])} />
         </Card>
@@ -98,11 +110,11 @@ function ColumnTab() {
         </Card>
         <Card title="Loads">
           <Pick label="Axial input" value={dlMode} onChange={v => setDlMode(v as 'DL'|'direct')}
-            options={[['DL','Service D & L'],['direct','Factored Pu']]} />
+            options={[['DL','Service D & L'],['direct', basis === 'LRFD' ? 'Factored Pu' : 'Service Pa']]} />
           {dlMode === 'DL' ? <>
             <Num label="Dead D" unit="kN" value={dead} onChange={setDead} />
             <Num label="Live L" unit="kN" value={live} onChange={setLive} />
-          </> : <Num label="Pu" unit="kN" value={PuDir} onChange={setPuDir} />}
+          </> : <Num label={demandLabel(basis, 'P')} unit="kN" value={PuDir} onChange={setPuDir} />}
           <Num label="Mux (strong-axis)" unit="kN·m" value={Mux} onChange={setMux} />
           <Num label="Muy (weak-axis)" unit="kN·m" value={Muy} onChange={setMuy} />
         </Card>
@@ -118,11 +130,12 @@ function ColumnTab() {
             <Row label="KL/ry" value={f1(res.axial.slendernessY)} sub="governing" />
             <Row alert={!res.axial.slenderOK} label="KL/r" value={`${f1(res.axial.slenderness)}${res.axial.slenderOK?'':' > 200 ✗'}`} />
             <Row label="Fcr" value={`${f1(res.axial.Fcr)} MPa`} />
-            <Row label="φPn" value={`${f1(res.axial.phiPn)} kN`} />
+            <Row label={capacityLabel(res.basis, 'P')} value={`${f1(res.avail.Pn)} kN`}
+              sub={`Pn = ${f1(res.axial.Pn)} · ${factorLabel(res.basis, 'compression')}`} />
           </ResultCard>
           <ResultCard title="Flexure">
-            <Row label="φMnx" value={`${f1(res.flexX.phiMn)} kN·m`} sub={res.flexX.ltbZone} />
-            <Row label="φMny §F6" value={`${f1(res.weak.phiMny)} kN·m`} />
+            <Row label={capacityLabel(res.basis, 'M', 'x')} value={`${f1(res.avail.Mnx)} kN·m`} sub={res.flexX.ltbZone} />
+            <Row label={`${capacityLabel(res.basis, 'M', 'y')} §F6`} value={`${f1(res.avail.Mny)} kN·m`} />
           </ResultCard>
           <ResultCard title={`Combined §${res.comb.equation}`}>
             <Row alert={!res.comb.ok} label="Combined ratio" value={<Verdict pass={res.comb.ok} value={`${(res.comb.ratio*100).toFixed(0)} %`} />} />
@@ -144,7 +157,7 @@ function ColumnTab() {
 export default function SteelColumn() {
   return (
     <div>
-      <PageHeader title="Steel Column Design" badges={['AISC 360-16 LRFD']} />
+      <PageHeader title="Steel Column Design" badges={['AISC 360-16']} />
       <div className="mx-auto max-w-[1500px] px-5 py-5 sm:px-7">
         <p className="no-print mt-1 text-slate-600">AISC 360-16 §E3 flexural buckling, weak-axis flexure, and the §H1-1 combined axial-plus-bending interaction. 3D scene and a step-by-step solution.</p>
         <ReportControls title="Steel Column Design Report" />

--- a/webapp/src/pages/WeldedConnection.tsx
+++ b/webapp/src/pages/WeldedConnection.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { solveWeldedConnection, weldedConnectionSolution, type WeldSegment } from '../engine/weldedConnection'
 import { FEXX_BY_CLASS, type ElectrodeClass } from '../engine/steelDesign'
+import { basisFactor, SAFETY, demandLabel, type DesignBasis } from '../engine/designBasis'
 import { WorkedSolution } from '../components/WorkedSolution'
 import { ReportControls } from '../components/ReportControls'
 import { PageHeader } from '../components/calc'
@@ -57,7 +58,12 @@ export default function WeldedConnection() {
   // moves here. 'custom' keeps the raw entry for a filler not in the table.
   const [electrode, setElectrode] = useState<ElectrodeClass | 'custom'>('E70')
   const [FEXX, setFEXX] = useState(FEXX_BY_CLASS.E70)
-  const [phi, setPhi] = useState(0.75)
+  // The raw phi box is gone: 0.75 is the LRFD resistance factor for §J2, and
+  // typing 0.5 into it was the only way to get an ASD answer — with nothing on
+  // the sheet saying which basis the number belonged to. The basis is now the
+  // control, and it sets the factor (phi = 0.75, or 1/Omega = 1/2.00).
+  const [basis, setBasis] = useState<DesignBasis>('LRFD')
+  const phi = basisFactor(basis, 'connection')
 
   const r = solveWeldedConnection({ segments: segs, size, FEXX, phi, load: { P, angleDeg: angle, px, py } })
 
@@ -74,8 +80,10 @@ export default function WeldedConnection() {
       <p className="mt-2 max-w-3xl text-sm text-slate-600">
         Elastic (weld-as-a-line) method for an eccentrically-loaded fillet weld group. Each unit length
         carries the direct share P/L_w plus a torsional share T·ρ/(J/t), T = Pᵧ·eₓ − Pₓ·e_y and
-        J/t = Σ[L³/12 + L·ρ_c²]. The fillet throat is 0.707·w (NSCP 510.2.2 / AISC J2.2), so the design
-        strength per unit length is φ·0.60·F_EXX·0.707·w. Add straight segments anywhere.
+        J/t = Σ[L³/12 + L·ρ_c²]. The fillet throat is 0.707·w (NSCP 510.2.2 / AISC J2.2), so the
+        available strength per unit length is φ·0.60·F_EXX·0.707·w for LRFD, or the same over Ω for
+        ASD. The applied load must be on the same basis: factored for LRFD, service for ASD.
+        Add straight segments anywhere.
       </p>
 
       <div className="mt-6 grid gap-5 lg:grid-cols-[1.1fr_1fr]">
@@ -105,6 +113,14 @@ export default function WeldedConnection() {
           <h2 className="mb-2 mt-4 text-[13.5px] font-bold text-[#0f1b2a]">Load &amp; weld</h2>
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
             <label className="flex flex-col text-sm">
+              <span className="mb-1 text-slate-600">Design basis</span>
+              <select value={basis} onChange={(e) => setBasis(e.target.value as DesignBasis)}
+                className="rounded-md border border-slate-300 px-2.5 py-1.5">
+                <option value="LRFD">LRFD — φ = {SAFETY.connection.phi.toFixed(2)}</option>
+                <option value="ASD">ASD — Ω = {SAFETY.connection.omega.toFixed(2)}</option>
+              </select>
+            </label>
+            <label className="flex flex-col text-sm">
               <span className="mb-1 text-slate-600">Electrode</span>
               <select value={electrode}
                 onChange={(e) => {
@@ -119,10 +135,10 @@ export default function WeldedConnection() {
                 <option value="custom">Custom F_EXX…</option>
               </select>
             </label>
-            {([['Load P (kN)', P, setP], ['Angle (° from +X)', angle, setAngle], ['Fillet leg w (mm)', size, setSize],
+            {([[`Load ${demandLabel(basis, 'P')} (kN)`, P, setP], ['Angle (° from +X)', angle, setAngle], ['Fillet leg w (mm)', size, setSize],
               ['Load at x (mm)', px, setPx], ['Load at y (mm)', py, setPy],
               ...(electrode === 'custom' ? [['F_EXX (MPa)', FEXX, setFEXX] as const] : []),
-              ['φ (LRFD)', phi, setPhi]] as const).map(([lbl, val, set]) => (
+             ] as const).map(([lbl, val, set]) => (
               <label key={lbl} className="flex flex-col text-sm">
                 <span className="mb-1 text-slate-600">{lbl}</span>
                 <input type="number" value={val} onChange={(e) => set(num(e.target.value))} className="rounded-md border border-slate-300 px-2.5 py-1.5" />
@@ -144,7 +160,10 @@ export default function WeldedConnection() {
               ['Torsion T = Pᵧ·eₓ − Pₓ·e_y', `${f2(r.T / 1000)} kN·m`],
               ['Polar inertia J/t = Σ[L³/12 + Lρ²]', `${f2(r.Jt / 1e6)} ×10⁶ mm³`],
               ['Effective throat 0.707·w', `${f2(r.throat)} mm`],
-              ['Design strength / length', `${f2(r.capacityPerLen)} N/mm`]].map(([k, v]) => (
+              // "Design strength" is the LRFD name for it; under ASD the same
+              // number is the ALLOWABLE strength. AISC calls both the available
+              // strength, which is the one word that is true either way.
+              [`Available strength / length (${basis})`, `${f2(r.capacityPerLen)} N/mm`]].map(([k, v]) => (
               <div key={k} className="flex justify-between border-t border-slate-100 py-1"><span className="text-slate-500">{k}</span><span className="font-mono">{v}</span></div>
             ))}
             <div className="flex justify-between border-t border-slate-100 py-1">
@@ -156,7 +175,7 @@ export default function WeldedConnection() {
               <span className="font-mono">{f2(r.reqSize)} mm</span>
             </div>
             <div className="mt-2 flex items-baseline justify-between rounded-lg bg-blue-50 p-2">
-              <span className="text-sm font-semibold text-[#0056b3]">Max allowable load P</span>
+              <span className="text-sm font-semibold text-[#0056b3]">Maximum {demandLabel(basis, 'P')}</span>
               <span className="font-mono text-lg font-bold text-[#0056b3]">{f2(r.maxP)} kN</span>
             </div>
           </div>


### PR DESCRIPTION
Two commits: the toggle, then `HANDOFF.md` brought up to date to describe it.

## The gap

AISC 360 is a **dual-format** specification and the app only spoke half of it. Every capacity was φRn and every demand was 1.2D + 1.6L, with no way to produce an allowable-stress check — which is exactly what the standalone bolted page did before #564 folded it in, and why I declined to bring its allowable-stress numbers across at the time.

## The basis changes *both* sides

That is the whole point, and the reason this isn't just a factor swap:

| | Capacity | Demand |
|---|---|---|
| LRFD | φRn | max(1.4D, 1.2D + 1.6L) |
| ASD | Rn/Ω | D + L |

A capacity converted to Rn/Ω but still checked against a **factored** load is conservative by ~1.5; the reverse is unconservative by the same — and **neither looks wrong on the page**. So the load combination travels with the basis (`requiredFromDL`), not just the resistance factor.

`engine/designBasis.ts` holds the φ/Ω pair **per limit state**, split by factor rather than by chapter: §G2.1(a) rolled webs carry 1.00/1.50 while slender webs carry 0.90/1.67, so using the flexure pair for shear is wrong in *both* formats.

## The engine did not move to a basis

Deliberately. `steelDesign.ts` still returns LRFD `phi…` fields, so **the design pipeline, Model Space, pushover and the validation benchmarks — all LRFD-only — read exactly the numbers they read before.** All 50 pre-existing engine tests pass untouched.

What's new is that every result also carries its **nominal** strength (`Vn`, `Pn`, `Mny`, `Rn_shear`, `Rn_bearing`, `Rn`, `Rnw`), so the basis layer states Rn/Ω *from Rn* rather than dividing φ back out of φRn. The available strengths appear under honest names (`avail.…`) on the **calc** result, which only these four pages consume — a field called `phiMn` holding Mn/Ω would be a lie in a structural report.

## Two checks are re-derived, not rescaled

The factor sits *inside* these formulas, so treating them as multipliers would be wrong:

- **§J3.7** — LRFD divides by φFnv where ASD multiplies by ΩFnt/Fnv. A test asserts the ASD answer is **not** the LRFD one times (1/Ω)/φ, which is what it would be if someone had rescaled it. (Writing that test caught its own trap: my first fixture loaded the group hard enough that F′nt clamped to zero on *both* bases, so it proved nothing. The fixture now checks both are in the active range first.)
- **§J3.9 prying** — the plate-flexure factor moves, so a thinner allowable means *more* required thickness, and the test checks that direction.

**Deflection stays put**: it is a service check and has no basis.

## Also

The page badges drop "LRFD". The basis is a control *inside* the calculator, so a header claiming LRFD while the sheet computes ASD is the one place this could mislead on a printed report.

The welded page's raw **φ input box is gone** — typing 0.5 into it was previously the only way to get an ASD answer, with nothing on the sheet saying which basis the number belonged to.

## Verification

- `npx tsc -b` clean, `npm run lint` clean, **3889 tests / 216 files green** (from 3865 / 215).
- All four pages toggled in headless Chromium. Capacities fall by exactly the expected ratios:
  - flexure & compression **(1/1.67)/0.90 = 0.665** — φMn 187.3 → Mn/Ω 124.6 kN·m; φPn 1701.7 → 1132.2 kN
  - §G2.1(a) shear **(1/1.50)/1.00 = 0.667** — φVn 372.2 → Vn/Ω 248.1 kN
  - connections & welds **(1/2.00)/0.75 = 0.667** — φRn 73.04 → Rn/Ω 48.69 kN; weld 920.09 → 613.39 N/mm
- The beam's combination line switches to `D + L`, its labels to `Ma / Mn/Ω`, its utilisation moves 139% → 144% as the two ratios compose, and **the deflection check does not move at all**.

## HANDOFF

Second commit records the steel split, the bolted/welded resolution and this toggle — written as the things a fresh session would get wrong, including why `engine/boltedConnection.ts` has no importers and must not be deleted, and the vacuous-verification trap I hit twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmPbtTVsjNBXVpiQVBYBnz)_